### PR TITLE
cpu: aarch64: simplify uni reorder stack

### DIFF
--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -44,11 +44,10 @@ struct trans_wrapper_t {
         , nb_y_(ysize / 8)
         , x_tail_(xsize % 8)
         , y_tail_(ysize % 8) {
-        using namespace cpu::aarch64::tr;
 
         auto create_ker = [=](dim_t ys, dim_t y_inp_str, dim_t y_out_str,
                                   dim_t xs, dim_t x_inp_str, dim_t x_out_str) {
-            tr::prb_t prb;
+            prb_t prb;
             jit_uni_reorder_kernel_t::desc_t desc;
 
             prb.ndims = 2;
@@ -98,9 +97,9 @@ struct trans_wrapper_t {
         dim_t x_blocked = nb_x_ * 8;
         dim_t y_blocked = nb_y_ * 8;
 
-        auto call_ker = [&](tr::jit_uni_reorder_kernel_t &ker, dim_t inp_y,
+        auto call_ker = [&](jit_uni_reorder_kernel_t &ker, dim_t inp_y,
                                 dim_t inp_x, dim_t out_y, dim_t out_x) {
-            tr::jit_uni_reorder_kernel_t::call_param_t cp;
+            jit_uni_reorder_kernel_t::call_param_t cp;
             cp.src_scales = nullptr;
             cp.dst_scales = nullptr;
 
@@ -124,9 +123,9 @@ struct trans_wrapper_t {
     ~trans_wrapper_t() = default;
 
 private:
-    std::unique_ptr<tr::jit_uni_reorder_kernel_t> ker_;
-    std::unique_ptr<tr::jit_uni_reorder_kernel_t> ker_x_tail_;
-    std::unique_ptr<tr::jit_uni_reorder_kernel_t> ker_y_tail_;
+    std::unique_ptr<jit_uni_reorder_kernel_t> ker_;
+    std::unique_ptr<jit_uni_reorder_kernel_t> ker_x_tail_;
+    std::unique_ptr<jit_uni_reorder_kernel_t> ker_y_tail_;
 
     const size_t inp_dt_size_;
     const size_t out_dt_size_;

--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2017 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include "common/type_helpers.hpp"
 
 #include "cpu/aarch64/jit_uni_pooling.hpp"
-#include "cpu/aarch64/reorder/jit_uni_reorder.hpp"
+#include "cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -49,7 +49,7 @@ struct trans_wrapper_t {
         auto create_ker = [=](dim_t ys, dim_t y_inp_str, dim_t y_out_str,
                                   dim_t xs, dim_t x_inp_str, dim_t x_out_str) {
             tr::prb_t prb;
-            kernel_t::desc_t desc;
+            jit_uni_reorder_kernel_t::desc_t desc;
 
             prb.ndims = 2;
             prb.ioff = 0;
@@ -72,8 +72,8 @@ struct trans_wrapper_t {
 
             prb.full_ndims = prb.ndims;
 
-            kernel_t::desc_init(desc, prb, 2);
-            return kernel_t::create(desc);
+            jit_uni_reorder_kernel_t::desc_init(desc, prb, 2);
+            return jit_uni_reorder_kernel_t::create_handle(desc);
         };
 
         if (nb_x_ * nb_y_ > 0)
@@ -98,9 +98,9 @@ struct trans_wrapper_t {
         dim_t x_blocked = nb_x_ * 8;
         dim_t y_blocked = nb_y_ * 8;
 
-        auto call_ker = [&](tr::kernel_t &ker, dim_t inp_y, dim_t inp_x,
-                                dim_t out_y, dim_t out_x) {
-            tr::call_param_t cp;
+        auto call_ker = [&](tr::jit_uni_reorder_kernel_t &ker, dim_t inp_y,
+                                dim_t inp_x, dim_t out_y, dim_t out_x) {
+            tr::jit_uni_reorder_kernel_t::call_param_t cp;
             cp.src_scales = nullptr;
             cp.dst_scales = nullptr;
 
@@ -124,9 +124,9 @@ struct trans_wrapper_t {
     ~trans_wrapper_t() = default;
 
 private:
-    std::unique_ptr<tr::kernel_t> ker_;
-    std::unique_ptr<tr::kernel_t> ker_x_tail_;
-    std::unique_ptr<tr::kernel_t> ker_y_tail_;
+    std::unique_ptr<tr::jit_uni_reorder_kernel_t> ker_;
+    std::unique_ptr<tr::jit_uni_reorder_kernel_t> ker_x_tail_;
+    std::unique_ptr<tr::jit_uni_reorder_kernel_t> ker_y_tail_;
 
     const size_t inp_dt_size_;
     const size_t out_dt_size_;

--- a/src/cpu/aarch64/reorder/jit_blk_reorder.cpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2022-2025 Arm Ltd. and affiliates
+* Copyright 2022-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
         const memory_desc_t *dst_md) {
     if (!impl::is_dense_format_kind({src_md, dst_md}))
         return status::unimplemented;
-    auto prb = tr::prb_t();
+    auto prb = prb_t();
     // For shapes with dimension greater than thres it is found that jit:uni is better that jit:blk
     auto upper_thres = 1920 * 4096;
     auto src_d = memory_desc_wrapper(src_md);
@@ -85,7 +85,7 @@ status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
                 verbose_t::debuginfo, "tile : %s\n", prb_dump(prb).c_str());
     });
 
-    if (!tr::jit_single_blk_kernel_t::applicable(prb)) {
+    if (!jit_single_blk_kernel_t::applicable(prb)) {
         return status::unimplemented;
     }
 
@@ -99,7 +99,7 @@ status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
     return safe_ptr_assign(*reorder_pd, _pd.release());
 }
 
-void jit_blk_reorder_t::pd_t::prb_tile_normalize(tr::prb_t &p) {
+void jit_blk_reorder_t::pd_t::prb_tile_normalize(prb_t &p) {
     if (!utils::one_of(p.nodes[0].n, 4ul, 8ul, 16ul, 32ul, 64ul)
             && utils::one_of(p.nodes[1].n, 4ul, 8ul, 16ul, 32ul, 64ul)) {
         nstl::swap(p.nodes[0], p.nodes[1]);
@@ -110,7 +110,7 @@ jit_blk_reorder_t::jit_blk_reorder_t(const pd_t *apd) : primitive_t(apd) {}
 jit_blk_reorder_t::~jit_blk_reorder_t() = default;
 
 status_t jit_blk_reorder_t::init(engine_t *engine) {
-    kernel_ = utils::make_unique<tr::jit_single_blk_kernel_t>(pd()->prb_);
+    kernel_ = utils::make_unique<jit_single_blk_kernel_t>(pd()->prb_);
     return kernel_->create_kernel();
 }
 

--- a/src/cpu/aarch64/reorder/jit_blk_reorder.hpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ struct jit_blk_reorder_t : public primitive_t {
         using cpu_reorder_pd_t::cpu_reorder_pd_t;
         DECLARE_COMMON_PD_T("jit:blk", jit_blk_reorder_t);
 
-        tr::prb_t prb_;
+        prb_t prb_;
 
     private:
         static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
@@ -46,7 +46,7 @@ struct jit_blk_reorder_t : public primitive_t {
                 const memory_desc_t *dst_md);
 
         // Swap last two nodes, put block 4, 8, 16 nodes to first
-        static void prb_tile_normalize(tr::prb_t &p);
+        static void prb_tile_normalize(prb_t &p);
         friend dnnl::impl::impl_list_item_t;
     };
 
@@ -58,7 +58,7 @@ struct jit_blk_reorder_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<tr::jit_single_blk_kernel_t> kernel_;
+    std::unique_ptr<jit_single_blk_kernel_t> kernel_;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
@@ -28,7 +28,6 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-namespace tr {
 using namespace Xbyak_aarch64;
 using namespace dnnl::impl::types;
 
@@ -555,8 +554,6 @@ void jit_single_blk_kernel_t::gen_ker64x64_in_32x32(int i_off, int o_off,
                 output_stride, sub_lane, u_tail);
     }
 }
-
-} // namespace tr
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/reorder/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder.cpp
@@ -50,12 +50,12 @@ namespace cpu {
 namespace aarch64 {
 
 status_t jit_uni_reorder_t::pd_t::init(engine_t *engine, engine_t *src_engine,
-        engine_t *dst_engine, const tr::prb_t &prb,
-        const tr::jit_uni_reorder_kernel_t::desc_t &ker_desc) {
+        engine_t *dst_engine, const prb_t &prb,
+        const jit_uni_reorder_kernel_t::desc_t &ker_desc) {
     prb_ = prb;
     ker_desc_ = ker_desc;
     nthr_ = dnnl_get_max_threads();
-    with_groups_ = prb_.compensation_mask == tr::prb_t::comp_mask_with_groups;
+    with_groups_ = prb_.compensation_mask == prb_t::comp_mask_with_groups;
 
     CHECK(cpu_reorder_pd_t::init(engine, src_engine, dst_engine));
     CHECK(init_scratchpad());
@@ -107,12 +107,12 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
         return status::unimplemented;
 
     // Create problem descriptor
-    auto prb = tr::prb_t();
+    auto prb = prb_t();
     status_t prb_init_status = prb_init(prb, *src_md, *dst_md, attr);
     if (prb_init_status != status::success) return prb_init_status;
 
     // Cache optimisation
-    tr::prb_block_for_cache(prb);
+    prb_block_for_cache(prb);
     DEBUG({
         verbose_printf(
                 verbose_t::debuginfo, "cache: %s\n", prb_dump(prb).c_str());
@@ -121,14 +121,14 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
     // Driver-kernel load balancing
     int ndims_ker_max {};
     int nthr = dnnl_get_max_threads();
-    tr::prb_thread_kernel_balance(prb, ndims_ker_max, nthr);
+    prb_thread_kernel_balance(prb, ndims_ker_max, nthr);
 
     if (prb.is_tail_present) prb_node_dependency(prb);
 
     // Kernel descriptor creation
-    tr::jit_uni_reorder_kernel_t::desc_t ker_desc;
-    status_t ker_init_status = tr::jit_uni_reorder_kernel_t::desc_init(
-            ker_desc, prb, ndims_ker_max);
+    jit_uni_reorder_kernel_t::desc_t ker_desc;
+    status_t ker_init_status
+            = jit_uni_reorder_kernel_t::desc_init(ker_desc, prb, ndims_ker_max);
     if (ker_init_status != status::success) return ker_init_status;
 
     const int ndims_driver = prb.ndims - ker_desc.prb.ndims;
@@ -153,9 +153,9 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
 void jit_uni_reorder_t::omp_driver_0d(int off, const char *in, char *out,
         const float *src_scales, const float *dst_scales, int src_zp,
         int dst_zp, int32_t *compensation_scratch) const {
-    const tr::prb_t &prb = pd()->prb_;
+    const prb_t &prb = pd()->prb_;
 
-    tr::jit_uni_reorder_kernel_t::call_param_t base_params;
+    jit_uni_reorder_kernel_t::call_param_t base_params;
     base_params.in = in;
     base_params.out = out;
     base_params.src_scales = src_scales;
@@ -165,7 +165,7 @@ void jit_uni_reorder_t::omp_driver_0d(int off, const char *in, char *out,
     base_params.compensation_scratch = compensation_scratch;
 
     if (prb.is_tail_present) {
-        tr::jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
+        jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
         tail_params.base_params = base_params;
 
         static constexpr int omp_ndims = 0;
@@ -181,10 +181,10 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
         const char *in, char *out, const float *src_scales,
         const float *dst_scales, int src_zp, int dst_zp,
         int32_t *compensation_scratch) const {
-    const tr::prb_t &prb = pd()->prb_;
-    const tr::node_t *ns = prb.nodes + off;
+    const prb_t &prb = pd()->prb_;
+    const node_t *ns = prb.nodes + off;
     for_nd(ithr, nthr, (ptrdiff_t)ns[0].n, [&](ptrdiff_t d0) {
-        tr::jit_uni_reorder_kernel_t::call_param_t base_params;
+        jit_uni_reorder_kernel_t::call_param_t base_params;
         base_params.in = in + d0 * ns[0].is * data_type_size(prb.itype);
         base_params.out = out + d0 * ns[0].os * data_type_size(prb.otype);
         base_params.src_scales = src_scales + d0 * ns[0].ss;
@@ -194,7 +194,7 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
         base_params.compensation_scratch = compensation_scratch + d0 * ns[0].cs;
 
         if (prb.is_tail_present) {
-            tr::jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
+            jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 1;
@@ -213,11 +213,11 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
         const char *in, char *out, const float *src_scales,
         const float *dst_scales, int src_zp, int dst_zp,
         int32_t *compensation_scratch) const {
-    const tr::prb_t &prb = pd()->prb_;
-    const tr::node_t *ns = prb.nodes + off;
+    const prb_t &prb = pd()->prb_;
+    const node_t *ns = prb.nodes + off;
     for_nd(ithr, nthr, (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
             [&](ptrdiff_t d1, ptrdiff_t d0) {
-        tr::jit_uni_reorder_kernel_t::call_param_t base_params;
+        jit_uni_reorder_kernel_t::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is) * data_type_size(prb.itype);
         base_params.out = out
@@ -230,7 +230,7 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
                 = compensation_scratch + d0 * ns[0].cs + d1 * ns[1].cs;
 
         if (prb.is_tail_present) {
-            tr::jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
+            jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 2;
@@ -249,11 +249,11 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
         const char *in, char *out, const float *src_scales,
         const float *dst_scales, int src_zp, int dst_zp,
         int32_t *compensation_scratch) const {
-    const tr::prb_t &prb = pd()->prb_;
-    const tr::node_t *ns = prb.nodes + off;
+    const prb_t &prb = pd()->prb_;
+    const node_t *ns = prb.nodes + off;
     for_nd(ithr, nthr, (ptrdiff_t)ns[2].n, (ptrdiff_t)ns[1].n,
             (ptrdiff_t)ns[0].n, [&](ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
-        tr::jit_uni_reorder_kernel_t::call_param_t base_params;
+        jit_uni_reorder_kernel_t::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is)
                         * data_type_size(prb.itype);
@@ -270,7 +270,7 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
                 + d1 * ns[1].cs + d2 * ns[2].cs;
 
         if (prb.is_tail_present) {
-            tr::jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
+            jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 3;
@@ -289,12 +289,12 @@ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
         const char *in, char *out, const float *src_scales,
         const float *dst_scales, int src_zp, int dst_zp,
         int32_t *compensation_scratch) const {
-    const tr::prb_t &prb = pd()->prb_;
-    const tr::node_t *ns = prb.nodes + off;
+    const prb_t &prb = pd()->prb_;
+    const node_t *ns = prb.nodes + off;
     for_nd(ithr, nthr, (ptrdiff_t)ns[3].n, (ptrdiff_t)ns[2].n,
             (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
             [&](ptrdiff_t d3, ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
-        tr::jit_uni_reorder_kernel_t::call_param_t base_params;
+        jit_uni_reorder_kernel_t::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is
                           + d3 * ns[3].is)
@@ -313,7 +313,7 @@ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
                 + d1 * ns[1].cs + d2 * ns[2].cs + d3 * ns[3].cs;
 
         if (prb.is_tail_present) {
-            tr::jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
+            jit_uni_reorder_kernel_t::tail_call_param_t tail_params;
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 4;
@@ -337,11 +337,11 @@ void jit_uni_reorder_t::omp_driver(const char *in, char *out,
 
     DEBUG({
         verbose_printf(verbose_t::debuginfo, "prb : %s\n",
-                tr::prb_dump(pd()->prb_).c_str());
+                prb_dump(pd()->prb_).c_str());
     });
     DEBUG({
         verbose_printf(verbose_t::debuginfo, "ker : %s\n",
-                tr::prb_dump(pd()->ker_desc_.prb).c_str());
+                prb_dump(pd()->ker_desc_.prb).c_str());
     });
 
     int ndims = pd()->prb_.ndims;
@@ -446,9 +446,9 @@ void jit_uni_reorder_t::reduce_compensation(char *out,
     });
 }
 
-void jit_uni_reorder_t::fill_curr_data_chunks(const tr::prb_t &prb,
-        const int off, const ptrdiff_t *omp_data_chunks, const int omp_ndims,
-        tr::jit_uni_reorder_kernel_t::tail_call_param_t &c) const {
+void jit_uni_reorder_t::fill_curr_data_chunks(const prb_t &prb, const int off,
+        const ptrdiff_t *omp_data_chunks, const int omp_ndims,
+        jit_uni_reorder_kernel_t::tail_call_param_t &c) const {
     // Chunks are backwards numered i.e:
     // [0] -> [node_size]
     // [1] -> [node_size - 1]
@@ -500,8 +500,8 @@ void jit_uni_reorder_t::fill_curr_data_chunks(const tr::prb_t &prb,
 status_t jit_uni_reorder_t::init(engine_t *engine) {
     // We could inject the correct implementer of the kernel_t interface at this
     // point.
-    CHECK(safe_ptr_assign(kernel_,
-            tr::jit_uni_reorder_kernel_t::create_handle(pd()->ker_desc_)));
+    CHECK(safe_ptr_assign(
+            kernel_, jit_uni_reorder_kernel_t::create_handle(pd()->ker_desc_)));
     return kernel_->create_kernel();
 }
 

--- a/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,8 +44,9 @@ struct jit_uni_reorder_t : public primitive_t {
         bool with_groups_ = false;
         dim_t D_mask_ = 0;
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(engine_t *engine, engine_t *src_engine,
+                engine_t *dst_engine, const tr::prb_t &prb,
+                const tr::kernel_t::desc_t &ker_desc);
 
     private:
         status_t init_scratchpad();

--- a/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
@@ -38,15 +38,15 @@ struct jit_uni_reorder_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_reorder_t);
 
-        tr::prb_t prb_;
-        tr::jit_uni_reorder_kernel_t::desc_t ker_desc_;
+        prb_t prb_;
+        jit_uni_reorder_kernel_t::desc_t ker_desc_;
         int nthr_;
         bool with_groups_ = false;
         dim_t D_mask_ = 0;
 
         status_t init(engine_t *engine, engine_t *src_engine,
-                engine_t *dst_engine, const tr::prb_t &prb,
-                const tr::jit_uni_reorder_kernel_t::desc_t &ker_desc);
+                engine_t *dst_engine, const prb_t &prb,
+                const jit_uni_reorder_kernel_t::desc_t &ker_desc);
 
     private:
         status_t init_scratchpad();
@@ -85,16 +85,16 @@ private:
             const int32_t *dst_zero_points,
             const memory_tracking::grantor_t &scratchpad) const;
 
-    void fill_curr_data_chunks(const tr::prb_t &prb, const int off,
+    void fill_curr_data_chunks(const prb_t &prb, const int off,
             const ptrdiff_t *omp_data_chunks, const int omp_ndims,
-            tr::jit_uni_reorder_kernel_t::tail_call_param_t &c) const;
+            jit_uni_reorder_kernel_t::tail_call_param_t &c) const;
 
     void reduce_compensation(char *out,
             const int32_t *compensation_reduce_scratch, const int nthr,
             const dim_t wspace_per_thr_size) const;
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<tr::jit_uni_reorder_kernel_t> kernel_;
+    std::unique_ptr<jit_uni_reorder_kernel_t> kernel_;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
@@ -39,14 +39,14 @@ struct jit_uni_reorder_t : public primitive_t {
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_reorder_t);
 
         tr::prb_t prb_;
-        tr::kernel_t::desc_t ker_desc_;
+        tr::jit_uni_reorder_kernel_t::desc_t ker_desc_;
         int nthr_;
         bool with_groups_ = false;
         dim_t D_mask_ = 0;
 
         status_t init(engine_t *engine, engine_t *src_engine,
                 engine_t *dst_engine, const tr::prb_t &prb,
-                const tr::kernel_t::desc_t &ker_desc);
+                const tr::jit_uni_reorder_kernel_t::desc_t &ker_desc);
 
     private:
         status_t init_scratchpad();
@@ -87,14 +87,14 @@ private:
 
     void fill_curr_data_chunks(const tr::prb_t &prb, const int off,
             const ptrdiff_t *omp_data_chunks, const int omp_ndims,
-            tr::tail_call_param_t &c) const;
+            tr::jit_uni_reorder_kernel_t::tail_call_param_t &c) const;
 
     void reduce_compensation(char *out,
             const int32_t *compensation_reduce_scratch, const int nthr,
             const dim_t wspace_per_thr_size) const;
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<tr::kernel_t> kernel_;
+    std::unique_ptr<tr::jit_uni_reorder_kernel_t> kernel_;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.cpp
@@ -32,7 +32,6 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
-namespace tr {
 
 using namespace Xbyak_aarch64;
 using namespace dnnl::impl::types;
@@ -1848,7 +1847,6 @@ void jit_uni_reorder_kernel_t::generate() {
 
 #undef TAIL_PARAM
 #undef PARAM
-} //namespace tr
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
@@ -31,54 +31,59 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 namespace tr {
-struct call_param_t {
-    const void *in = nullptr;
-    void *out = nullptr;
-    const float *src_scales = nullptr;
-    const float *dst_scales = nullptr;
-    int32_t src_zp = 0;
-    int32_t dst_zp = 0;
-    int32_t *compensation_scratch = nullptr;
-};
-
-// The additional structure is needed because
-// using a data structure with tail processing
-// data for non-tail cases reduces kernel
-// performance. This is because there is too
-// much data that has to be transferred to the kernel.
-struct tail_call_param_t {
-    call_param_t base_params;
-    int64_t curr_data_chunks[DNNL_MAX_NDIMS] = {-1};
-    int64_t zeroing_data = static_cast<int64_t>(false);
-    int64_t skip_kernel_execution = static_cast<int64_t>(false);
-};
-
-struct kernel_t {
+/* kernel */
+class jit_uni_reorder_kernel_t : public jit_generator_t {
+public:
     struct desc_t {
         int id;
         prb_t prb;
+        // TODO: Add kernel name field here?
+        // const char* name;
     };
 
-    kernel_t(const desc_t &desc)
-        : desc_(desc)
-        , prb_(desc_.prb)
-        , compensation_needed_(
-                  desc.prb.req_s8s8_comp || desc.prb.req_asymmetric_comp) {}
-    virtual void operator()(const call_param_t *c) const = 0;
-    virtual void operator()(const tail_call_param_t *c) const = 0;
-    virtual status_t create_kernel() = 0;
-    virtual ~kernel_t() = default;
+    struct call_param_t {
+        const void *in = nullptr;
+        void *out = nullptr;
+        const float *src_scales = nullptr;
+        const float *dst_scales = nullptr;
+        int32_t src_zp = 0;
+        int32_t dst_zp = 0;
+        int32_t *compensation_scratch = nullptr;
+    };
+
+    // The additional structure is needed because
+    // using a data structure with tail processing
+    // data for non-tail cases reduces kernel
+    // performance. This is because there is too
+    // much data that has to be transferred to the kernel.
+    struct tail_call_param_t {
+        call_param_t base_params;
+        int64_t curr_data_chunks[DNNL_MAX_NDIMS] = {-1};
+        int64_t zeroing_data = static_cast<int64_t>(false);
+        int64_t skip_kernel_execution = static_cast<int64_t>(false);
+    };
+
+    jit_uni_reorder_kernel_t(const desc_t &desc);
+    ~jit_uni_reorder_kernel_t() override = default;
 
     /** inits kernel descriptor:
      *      desc            -- kernel descriptor (output)
-     *      prb             -- transposition problem (input)
+     *      prb             -- problem descriptor (input)
      *      ndims_ker_max   -- limit the maximum number of dimensions kernel
      *                         will process (optional, 0 -- no limitation) */
     static status_t desc_init(
             desc_t &desc, const prb_t &prb, int ndims_ker_max = 0);
 
-    /** creates kernel for the problem described in desc */
-    static kernel_t *create(const desc_t &desc);
+    /** selects kernel for the problem described in desc */
+    static jit_uni_reorder_kernel_t *create_handle(const desc_t &desc);
+
+    void operator()(const call_param_t *c) const {
+        return jit_generator_t::operator()(c);
+    }
+
+    void operator()(const tail_call_param_t *c) const {
+        return jit_generator_t::operator()(c);
+    }
 
     /** Minimal reasonable/desirable kernel size.
     * The constant might be used to determine how a problem should be split
@@ -86,15 +91,6 @@ struct kernel_t {
     static constexpr size_t ker_prb_size_min = 64;
 
 protected:
-    const desc_t desc_;
-    const prb_t &prb_;
-    bool compensation_needed_;
-};
-
-/* kernel */
-struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_reorder_kernel_f32)
-
     using XReg = Xbyak_aarch64::XReg;
     using WReg = Xbyak_aarch64::WReg;
     using ZReg = Xbyak_aarch64::ZReg;
@@ -102,11 +98,6 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     using VReg = Xbyak_aarch64::VReg;
     using VReg4S = Xbyak_aarch64::VReg4S;
     using PReg = Xbyak_aarch64::PReg;
-
-    void operator()(const call_param_t *c) const override;
-    void operator()(const tail_call_param_t *c) const override;
-
-    status_t create_kernel() override;
 
     enum class scale_arg_t { NONE, SRC, DST };
 
@@ -122,63 +113,17 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         int len_unroll = 0;
     };
 
-    static bool impl_desc_init(const prb_t &prb, impl_desc_t *desc);
-
-    static bool applicable(const prb_t &p);
-
-    XReg o_addr(int o_off, bool with_type_multiplier = true);
-
-    XReg src_s_addr(int s_off);
-
-    XReg dst_s_addr(int s_off);
-
-    XReg c_addr(int c_off);
-
-    XReg data_chunk_addr(int node_id);
-
-    void step(int off, int prev_i_off, int prev_o_off, int prev_s_off,
-            int prev_c_off, int &i_off, int &o_off, int &s_off, int &c_off,
-            int step_size = 1);
-
-    void step(int off, int prev_i_off, int prev_o_off, int &i_off, int &o_off,
-            int step_size = 1);
-
-    bool can_do_tr4x8();
-    bool process_unroll_tr4x8(const int ndims, const int len);
-    void tr4x8_sve256(int i_off, int o_off);
-
-    void tr8x8_sve256(int i_off, int o_off);
-
-    bool can_do_tr8x8();
-
-    bool process_unroll_tr8x8(const int ndims, const int len);
-
-    void process_unroll_generic_step(int reg_unroll, const int *i_off,
-            const int *o_off, const int *s_off, const int *c_off,
-            const int *zero_padding, const bool tail_processing);
-
     static bool interim_f32_needed(const prb_t &prb, bool compensation_needed);
 
-    void process_unroll_generic(
-            const int ndims, int len, const bool tail_processing);
-
-    void compute_ker(
-            const int ndims, const int len_unroll, const bool tail_processing);
-
-    void check_if_this_is_last_chunk(const XReg reg_curr_chunk, int node_id);
-
+    // Common data
+    XReg o_addr(int o_off, bool with_type_multiplier = true);
+    XReg src_s_addr(int s_off);
+    XReg dst_s_addr(int s_off);
+    XReg c_addr(int c_off);
+    XReg data_chunk_addr(int node_id);
     void zero_dst_memory(const int bytes_to_zeroing);
 
-    void finalize_tail_loop(int i_step, int o_step, int s_step, int c_step,
-            const int curr_node_id);
-
-    void compute_blk_ker(const impl_desc_t &desc);
-
-    void create_loops(const impl_desc_t &desc,
-            const std::array<const XReg, 3> &reg_cnt, int jit_loop);
-
-    bool impl();
-
+    // Common dt conversion utils
     void cvt_z_s32_f32(const size_t startIdx, const size_t regNum);
     void cvt_v_s32_f32(const size_t startIdx, const size_t regNum);
     void cvt_z_f32_s32(const size_t startIdx, const size_t regNum);
@@ -206,13 +151,30 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     void cvt_z_s8_u8(const size_t startIdx, const size_t regNum);
     void cvt_v_s8_u8(const size_t startIdx, const size_t regNum);
 
-    jit_uni_reorder_kernel_f32_t(const desc_t &desc);
-
+    // Common scaffolding (create loops, set up tail handling, etc.)
+    static bool impl_desc_init(const prb_t &prb, impl_desc_t *desc);
     void generate() override;
+    bool impl();
+    void create_loops(const impl_desc_t &desc,
+            const std::array<const XReg, 3> &reg_cnt, int jit_loop);
+    void check_if_this_is_last_chunk(const XReg reg_curr_chunk, int node_id);
+    void finalize_tail_loop(int i_step, int o_step, int s_step, int c_step,
+            const int curr_node_id);
+    void inject_kernel_body(const impl_desc_t &desc);
+    void step(int off, int prev_i_off, int prev_o_off, int prev_s_off,
+            int prev_c_off, int &i_off, int &o_off, int &s_off, int &c_off,
+            int step_size = 1);
+    void step(int off, int prev_i_off, int prev_o_off, int &i_off, int &o_off,
+            int step_size = 1);
 
-    ~jit_uni_reorder_kernel_f32_t() override = default;
+    // This is where it gets specific. This function is overriden by each
+    // specialised kernel to produce its unrolled code.
+    virtual void compute(int ndims, int len_unroll, bool tail_processing) = 0;
 
-private:
+    const desc_t desc_;
+    const prb_t &prb_;
+    bool compensation_needed_;
+
     static constexpr int64_t with_tail_info_ = static_cast<int64_t>(true);
     static constexpr int64_t without_tail_info_ = static_cast<int64_t>(false);
 
@@ -278,6 +240,113 @@ private:
     const std::vector<ZReg> z_tmp_vec
             = {z_tmp0, z_tmp1, z_tmp2, z_tmp3, z_tmp4, z_tmp5, z_tmp6, z_tmp7};
     constexpr static int z_tmp_vec_size = 8;
+};
+
+class generic_kernel_t : public jit_uni_reorder_kernel_t {
+public:
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(generic_kernel_t)
+
+    using jit_uni_reorder_kernel_t::jit_uni_reorder_kernel_t;
+
+    static bool applicable(const prb_t &prb) {
+        using namespace data_type;
+
+        bool bf16_ok
+                = (mayiuse_bf16() && (prb.itype == bf16) && (prb.otype == bf16)
+                          && !interim_f32_needed(prb, false) && prb.beta == 0.f)
+                || (prb.itype != bf16 && prb.otype != bf16)
+                || (prb.itype == f32 && prb.otype == bf16 && mayiuse_bf16()
+                        && prb.beta == 0.f)
+                || (prb.itype == bf16 && prb.otype == f32 && mayiuse_bf16()
+                        && prb.beta == 0.f);
+
+        bool is_f16 = (prb.itype == f16 || prb.otype == f16);
+        bool f16_ok = (prb.itype == f32 && prb.otype == f16 && prb.beta == 0.f)
+                || (prb.itype == f16 && prb.otype == f32 && prb.beta == 0.f)
+                || (prb.itype == f16 && prb.otype == f16 && prb.beta == 0.f);
+
+        bool ok = true && prb.ndims > 0
+                && utils::one_of(
+                        prb.itype, f32, f16, bf16, s32, data_type::s8, u8)
+                && utils::one_of(
+                        prb.otype, f32, f16, bf16, s32, data_type::s8, u8)
+                && utils::everyone_is(
+                        0, prb.ioff, prb.ooff) /* do we need this? */
+                && utils::one_of(prb.beta, 0.f, 1.f) /* anything else? */
+                && impl_desc_init(prb, nullptr) && prb_has_small_strides(prb)
+                && bf16_ok && IMPLICATION(is_f16, f16_ok);
+
+        return ok;
+    }
+
+private:
+    void compute(int ndims, int len, bool tail_processing) override;
+    void process_unroll_generic_step(int reg_unroll, const int *i_off,
+            const int *o_off, const int *s_off, const int *c_off,
+            const int *zero_padding, const bool tail_processing);
+};
+
+class tr8x8_kernel_t : public jit_uni_reorder_kernel_t {
+public:
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(tr8x8_kernel_t)
+
+    using jit_uni_reorder_kernel_t::jit_uni_reorder_kernel_t;
+
+    static bool applicable(const prb_t &prb) {
+        using namespace data_type;
+
+        static constexpr int desirable_node_size = 8;
+        static constexpr int desirable_stride = 1;
+
+        // This process relies on swapping the two innermost dimensions.
+        // Therefore, the input stride in the second node and output stride in
+        // first node have to be equal to 1.
+        bool ok = mayiuse(sve_256) && prb.ndims >= 2
+                && ((utils::one_of(prb.itype, u8, data_type::s8, s32, f32)
+                        && utils::one_of(
+                                prb.otype, u8, data_type::s8, s32, f32)))
+                && utils::everyone_is(desirable_node_size, prb.n(0), prb.n(1))
+                && utils::everyone_is(desirable_stride, prb.os(0), prb.is(1))
+                && !prb.is_tail_present
+                && prb.src_scale_type == scale_type_t::NONE
+                && prb.dst_scale_type == scale_type_t::NONE && prb.beta == 0.f
+                && !(prb.req_s8s8_comp || prb.req_asymmetric_comp);
+
+        return ok;
+    }
+
+private:
+    void compute(int ndims, int len, bool) override;
+    void tr8x8_core(int i_off, int o_off);
+};
+
+// TODO: Combine this with tr8x8_kernel_t?
+class tr4x8_kernel_t : public jit_uni_reorder_kernel_t {
+public:
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(tr4x8_kernel_t)
+
+    using jit_uni_reorder_kernel_t::jit_uni_reorder_kernel_t;
+
+    static bool applicable(const prb_t &prb) {
+        using namespace data_type;
+
+        // The kernel is specialised for f32 -> bf16 reorders.
+        //
+        // This process relies on swapping the two innermost dimensions.
+        // Therefore, the input stride in the second node and output stride in
+        // first node have to be equal to 1.
+        return mayiuse(sve_256) && prb.ndims >= 2
+                && (prb.itype == f32 && prb.otype == bf16) && prb.n(0) == 4
+                && prb.n(1) == 8 && utils::everyone_is(1, prb.os(0), prb.is(1))
+                && !prb.is_tail_present
+                && prb.src_scale_type == scale_type_t::NONE
+                && prb.dst_scale_type == scale_type_t::NONE && prb.beta == 0.f
+                && !(prb.req_s8s8_comp || prb.req_asymmetric_comp);
+    }
+
+private:
+    void compute(int ndims, int len, bool) override;
+    void tr4x8_core(int i_off, int o_off);
 };
 
 /* TODO: add trans_t class */

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
@@ -30,7 +30,6 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
-namespace tr {
 /* kernel */
 class jit_uni_reorder_kernel_t : public jit_generator_t {
 public:
@@ -432,7 +431,7 @@ private:
 
     void postamble();
 
-    const tr::prb_t &prb_;
+    const prb_t &prb_;
 
     int itype_sz_;
     int otype_sz_;
@@ -473,8 +472,6 @@ private:
             = {z_tmp0, z_tmp1, z_tmp2, z_tmp3, z_tmp4, z_tmp5, z_tmp6, z_tmp7};
     constexpr static int z_tmp_vec_size = 8;
 };
-
-} // namespace tr
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
@@ -817,7 +817,7 @@ void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr) {
      * (less than tr::ker_prb_size_min). In that case try to split the
      * innermost driver dimension into two, to increase size_ker_cur. */
     const bool want_borrow_ker_from_drv = kdims < prb.ndims
-            && size_ker_cur < kernel_t::ker_prb_size_min
+            && size_ker_cur < jit_uni_reorder_kernel_t::ker_prb_size_min
             && size_drv_cur > size_drv_min;
     if (want_borrow_ker_from_drv) {
         /* size_want_borrow is the minimal size, so that:
@@ -829,8 +829,8 @@ void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr) {
          *  In the worst case the minimal size_want_borrow is equal
          *  to the innermost driver dimension itself. In that case
          *  we will sacrifice it in favor of kernel (is it fine?). */
-        size_t size_want_borrow
-                = utils::div_up(kernel_t::ker_prb_size_min, size_ker_cur);
+        size_t size_want_borrow = utils::div_up(
+                jit_uni_reorder_kernel_t::ker_prb_size_min, size_ker_cur);
         for (; prb.nodes[kdims].n % size_want_borrow; ++size_want_borrow)
             ;
 
@@ -844,7 +844,7 @@ void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr) {
      * try to split the outermost kernel dimension into two, to increase
      * size_drv_cur. */
     const bool want_borrow_drv_from_ker
-            = size_ker_cur > kernel_t::ker_prb_size_min
+            = size_ker_cur > jit_uni_reorder_kernel_t::ker_prb_size_min
             && size_drv_cur < size_drv_min;
     if (want_borrow_drv_from_ker) {
         size_t size_want_borrow = utils::div_up(size_drv_min, size_drv_cur);

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
@@ -50,8 +50,6 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-namespace tr {
-
 namespace {
 inline bool is_direct_copy(const prb_t &prb) {
     return prb.ndims == 1 && prb.nodes[0].is == 1 && prb.nodes[0].os == 1;
@@ -490,10 +488,10 @@ void prb_normalize(prb_t &p) {
 
 void prb_node_dependency(prb_t &prb) {
     for (int i = 0; i < prb.ndims; i++) {
-        tr::node_t &node = prb.nodes[i];
+        node_t &node = prb.nodes[i];
         node.parent_node_id = node_t::empty_field;
         for (int j = i + 1; j < prb.ndims; j++) {
-            const tr::node_t &potential_parent_node = prb.nodes[j];
+            const node_t &potential_parent_node = prb.nodes[j];
             if (!potential_parent_node.is_dim_id_empty()
                     && potential_parent_node.dim_id == node.dim_id) {
                 node.parent_node_id = j;
@@ -693,7 +691,7 @@ void prb_block_for_cache(prb_t &prb) {
         // Changes the order of traversal of the tile from column-wise to
         // row-wise. This makes the reads more cache-friendly at the cost of
         // the writes being separated by some stride.
-        tr::prb_node_move(prb, 2, 3);
+        prb_node_move(prb, 2, 3);
     }
 
     // performance improvement for shapes with large inner-most dimension
@@ -758,7 +756,7 @@ void prb_block_for_cache(prb_t &prb) {
             const auto dim_two_it = dim_beg_it + new_position;
             const auto dim_last_it = dim_beg_it + prb.ndims;
             const auto min_n_node_it = std::min_element(dim_two_it, dim_last_it,
-                    [](const tr::node_t &lhs, const tr::node_t &rhs) {
+                    [](const node_t &lhs, const node_t &rhs) {
                 return lhs.n < rhs.n;
             });
             const auto min_idx = std::distance(dim_beg_it, min_n_node_it);
@@ -814,14 +812,14 @@ void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr) {
     /* Initially kdims is chosen so that size_drv_cur >= size_drv_min.
      *
      * It might happen that for chosen kdims the size_ker_cur is too small
-     * (less than tr::ker_prb_size_min). In that case try to split the
+     * (less than ker_prb_size_min). In that case try to split the
      * innermost driver dimension into two, to increase size_ker_cur. */
     const bool want_borrow_ker_from_drv = kdims < prb.ndims
             && size_ker_cur < jit_uni_reorder_kernel_t::ker_prb_size_min
             && size_drv_cur > size_drv_min;
     if (want_borrow_ker_from_drv) {
         /* size_want_borrow is the minimal size, so that:
-         *  o) size_ker_cur * size_want_borrow >= tr::ker_prb_size_min
+         *  o) size_ker_cur * size_want_borrow >= ker_prb_size_min
          *  o) current innermost driver dimension is divisible by
          *     size_want_borrow (so that we can evenly split that
          *     dimension into two)
@@ -868,7 +866,6 @@ void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr) {
     }
 }
 
-} // namespace tr
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -869,7 +869,6 @@ void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr) {
 }
 
 } // namespace tr
-
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_utils.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_utils.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-namespace tr {
 struct node_t {
     static constexpr int64_t empty_field = -1;
 
@@ -157,8 +156,6 @@ void prb_block_for_cache(prb_t &prb);
  * optionally splits one of the dimension to achieve better balance between
  * parallel driver and the kernel. */
 void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr);
-
-} // namespace tr
 
 } // namespace aarch64
 } // namespace cpu


### PR DESCRIPTION
# Description

The previous design had a pure interface that was only implemented by a monolithic class that had every method copied in. This means that as new assembly kernels (and their helper functions) are added, the size of this class would grow indefinitely. There's also the overhead for a new reader of figuring out which methods are shared helpers vs. which ones are kernel-specific.

This refactor groups all the common functionality (creating loops, data conversion, call operators, etc.) into `jit_uni_reorder_kernel_t`. Developers can then add their specialised kernels by inheriting and overriding the `compute()` method.

I have deliberately not made any changes that would affect the dispatch logic or the generated assembly. This patch is just to provide a framework for those future improvements to be made.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?