### PR TITLE
cpu: x64: matmul: fix initialization of use_buffer_c in amx blocking

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1054,7 +1054,8 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
     current_lda_ = get_actual_lda();
 
     // Need a temp C buffer if a BRGEMM creates partial results
-    need_buf_c_ = (nthr_k_ != 1) || (k_blk_ != K && acc_dt != dst_dt);
+    need_buf_c_
+            = (nthr_k_ != 1) || (k_blk_ != K && (with_sum || acc_dt != dst_dt));
 
     efficiency_score_ = calculate_blocking_scores();
 


### PR DESCRIPTION
Fixes MFDNN-14444

Incorrect initialization of use_buffer_c causes failure for the case with sum.