### PR TITLE
cpu: x64: matmul: No prefetches when B is transformed - bug fix

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1037,7 +1037,7 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
         is_a_nt_ = true;
         is_b_nt_ = false;
         need_prefetch_a_ = false;
-        need_prefetch_b_ = (n_per_thread / n_blk_) >= 2;
+        need_prefetch_b_ = ((n_per_thread / n_blk_) >= 2) && !use_buffer_b;
         use_fused_copy_a_ = false;
 
         extendable_k_ = K % wei_k_blk != 0 && !skip_extendable_k();


### PR DESCRIPTION
This change avoids issuing prefetches when B transformation is used, as they access out-of-bounds addresses, leading to performance degradation without causing a segfault.
Related to jira: https://jira.devtools.intel.com/browse/MFDNN-14571