### PR TITLE
cpu: x64: brgemm_conv: fix scratchpad

### DIFF
--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -158,7 +158,8 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
 
     brgemm_convolution_utils::set_amx_wsp_per_thread(jcp_);
     auto scratchpad = scratchpad_registry().registrar();
-    brgemm_convolution_utils::init_scratchpad(scratchpad, jcp_);
+    CHECK(brgemm_convolution_utils::init_scratchpad(
+            scratchpad, jcp_, *src_md(), *weights_md(), *dst_md()));
 
     return status::success;
 }

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -676,7 +676,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
 
     brgemm_convolution_utils::set_amx_wsp_per_thread(jcp_);
     auto scratchpad = scratchpad_registry().registrar();
-    brgemm_convolution_utils::init_scratchpad(scratchpad, jcp_);
+    CHECK(brgemm_convolution_utils::init_scratchpad(
+            scratchpad, jcp_, *src_md(), *weights_md(), *dst_md()));
 
     return status::success;
 }

--- a/src/cpu/x64/jit_brgemm_conv_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.hpp
@@ -53,8 +53,9 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
 void set_amx_wsp_per_thread(jit_brgemm_conv_conf_t &jcp);
 
-void init_scratchpad(memory_tracking::registrar_t &scratchpad,
-        const jit_brgemm_conv_conf_t &jcp);
+status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
+        const jit_brgemm_conv_conf_t &jcp, const memory_desc_t &src_md,
+        const memory_desc_t &weights_md, const memory_desc_t &dst_md);
 
 status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
         const convolution_desc_t &cd, memory_desc_t &src_md,


### PR DESCRIPTION
[MFDNN-14170](https://jira.devtools.intel.com/browse/MFDNN-14170)

Added a check that sets a 32 GB threshold when creating a scratchpad. This is similar to[ the forward propagation logic in the same file](https://github.com/uxlfoundation/oneDNN/blob/757dbcdfbf6212664bccbc547b13e09dbfd66569/src/cpu/x64/jit_brgemm_conv_utils.cpp#L3513C2-L3530C28). 

It is inside the if (jcp.exec_type == exec_trans) block because inp_buffer is allocated only for exec_trans.

