### PR TITLE
cpu: x64: matmul: nthr_k and nthr_n switched places - bug fix - backport

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -360,8 +360,8 @@ bool matmul_amx_blocking_params_macro_t::find_best_blocking(
         current_blocking.nthr_ = best_blocking.nthr_b_ * best_blocking.nthr_m_
                 * best_blocking.nthr_n_ * best_blocking.nthr_k_;
         current_blocking.set_core_divs(best_blocking.nthr_b_,
-                best_blocking.nthr_m_, best_blocking.nthr_n_,
-                best_blocking.nthr_k_);
+                best_blocking.nthr_m_, best_blocking.nthr_k_,
+                best_blocking.nthr_n_);
         if (current_blocking.set_blocking_parameters(true)
                 && current_blocking > best_blocking) {
             best_blocking = current_blocking;


### PR DESCRIPTION
Bug fix: nthr_k and nthr_n were swapped in a function call
Related to jira: https://jira.devtools.intel.com/browse/MFDNN-14571
Backport of: https://github.com/uxlfoundation/oneDNN/pull/4660