### PR TITLE
xe: sdpa: restrict block2d_stores to rows(unroll_m_vs) < 64

### DIFF
--- a/src/gpu/intel/include/tile_ops.h
+++ b/src/gpu/intel/include/tile_ops.h
@@ -235,8 +235,6 @@ DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 8, 16, u16_m4k32v1, 32, 4)
 DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 16, 16, u16_m8k32v1, 32, 8)
 
 DEF_BLOCK2D_LOAD_STORE(float, uint, 8, 16, u32_m8k16v1, 16, 8)
-DEF_BLOCK2D_LOAD_STORE(float, uint, 8, 16, u32_m4k32v1, 32, 4)
-DEF_BLOCK2D_LOAD_STORE(float, uint, 16, 16, u32_m8k32v1, 32, 8)
 
 #define tile_fill(t, v) \
     do { \

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -502,7 +502,7 @@ status_t micro_t::pd_t::init_conf(impl::engine_t *engine) {
         conf.block_q = (ldq % 4 == 0);
         conf.block_a = (lda % 16 == 0 && v_full);
     } else if (pd->arch() >= compute::gpu_arch_t::xe_hpc
-            && config.unroll_m_vs < 64) {
+            && (config.unroll_m_vs * dst_mdw.data_type_size()) <= 64) {
         auto vbytes = d->values() * val_mdw.data_type_size();
         if (lda % 16 == 0 && vbytes % 4 == 0) conf.block_2d_a = true;
     }


### PR DESCRIPTION

# Description

Block 2D loads/stores can only read one cache line worth of rows, the current restriction on 2d blocks assumed we would only transfer halfs but this caused issues when the return type if float. The new restrictions prevent the use of 2d block stores in these cases.



Fixes # [MFDNN-14397](https://jira.devtools.intel.com/browse/MFDNN-14397)
