### PR TITLE
gpu: intel: gemm: fix GRF register size for dqk cases

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -50,7 +50,10 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
     state.isNested = true;
 
     /* Leave some space for host kernel arguments */
-    state.ra.claim((GRF::bytes(hw) >= 64) ? r0-r6 : r0-r8);
+    // The host side arguments with 32 byte size registers (DG2)
+    // use 16 registers include padding bytes (aligned with 128 bytes)
+    // r0, r4 are reserved for system threads
+    state.ra.claim((GRF::bytes(hw) >= 64) ? r0-r6 : r0-r15);
 
     state.fullK = state.inputs.k;
 


### PR DESCRIPTION
# Description

This is a temp fix for the correction issues appearing sometimes in s8/f16 cases in SDPA for DG2 machines due to small register sizes. Yet to see what are the performance implications for it.

Jira: https://jira.devtools.intel.com/browse/MFDNN-14243