### PR TITLE
benchdnn: replace memset with random fill in mode=F to prevent data compression

### DIFF
--- a/src/gpu/intel/fill_random.cl
+++ b/src/gpu/intel/fill_random.cl
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/include/philox.h"
+
+// Fills a buffer with pseudo-random data using Philox RNG and subgroup block
+// writes. Each subgroup (16 work-items) writes 256 bytes.
+#define SG_SIZE 16
+#define BYTES_PER_SG (SG_SIZE * 4 * 4)
+
+__attribute__((intel_reqd_sub_group_size(SG_SIZE))) __kernel void fill_random(
+        __global uchar *buf, uint seed, ulong byte_count) {
+    const ulong base = (get_global_id(0) / SG_SIZE) * BYTES_PER_SG;
+    if (base >= byte_count) return;
+
+    const uint b = (uint)get_global_id(0) * 4;
+    uchar16 rnd
+            = as_uchar16(philox_4x32_vec4(b, b ^ seed) & (uint4)(0xEEEEEEEEu));
+
+    if (base + BYTES_PER_SG <= byte_count) {
+        intel_sub_group_block_write_uc16(buf + base, rnd);
+        return;
+    }
+
+    const uint lid = get_sub_group_local_id();
+    unroll_for(int i = 0; i < 16; i++) {
+        ulong off = base + lid + (ulong)i * SG_SIZE;
+        if (off < byte_count) buf[off] = rnd[i];
+    }
+}

--- a/src/gpu/intel/fill_random.cpp
+++ b/src/gpu/intel/fill_random.cpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <mutex>
+#include <unordered_map>
+
+#include "common/c_types_map.hpp"
+#include "common/utils.hpp"
+
+#include "gpu/intel/compute/kernel.hpp"
+#include "gpu/intel/compute/kernel_ctx.hpp"
+#include "gpu/intel/engine.hpp"
+#include "gpu/intel/stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+
+static status_t get_cached_kernel(
+        intel::engine_t *engine, compute::kernel_t &kernel) {
+    static std::unordered_map<engine_id_t, compute::kernel_t> cache;
+    static std::mutex mutex;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    auto it = cache.find(engine->engine_id());
+    if (it != cache.end()) {
+        kernel = it->second;
+        return status::success;
+    }
+
+    compute::kernel_ctx_t ctx;
+    std::vector<compute::kernel_t> kernels;
+    CHECK(engine->create_kernels(&kernels, {"fill_random"}, ctx));
+    kernel = cache.emplace(engine->engine_id(), kernels[0]).first->second;
+    return status::success;
+}
+
+status_t fill_random(impl::stream_t *stream, size_t size,
+        impl::memory_t *memory, int buffer_index, uint32_t seed) {
+    if (size == 0) return status::success;
+
+    auto *intel_stream = utils::downcast<intel::stream_t *>(stream);
+    auto *intel_engine = utils::downcast<intel::engine_t *>(stream->engine());
+    compute::kernel_t kernel;
+    CHECK(get_cached_kernel(intel_engine, kernel));
+
+    // Each subgroup (16 work-items) processes 256 bytes (16 * 4 * sizeof(uint)).
+    static constexpr size_t subgroup_size = 16;
+    static constexpr size_t bytes_per_subgroup
+            = subgroup_size * 4 * sizeof(uint32_t);
+    size_t num_subgroups = utils::div_up(size, bytes_per_subgroup);
+    compute::nd_range_t nd_range({num_subgroups * subgroup_size, 1, 1});
+    compute::kernel_arg_list_t arg_list;
+    arg_list.set(0, *memory->memory_storage(buffer_index));
+    arg_list.set(1, seed);
+    arg_list.set(2, static_cast<uint64_t>(size));
+
+    CHECK(kernel.parallel_for(*stream, nd_range, arg_list,
+            intel_stream->ctx().get_deps(), intel_stream->ctx().get_deps()));
+    return status::success;
+}
+
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+extern "C" dnnl::impl::status_t DNNL_API dnnl_impl_gpu_fill_random(
+        dnnl::impl::stream_t *stream, size_t size, dnnl::impl::memory_t *memory,
+        int buffer_index, uint32_t seed) {
+    return dnnl::impl::gpu::intel::fill_random(
+            stream, size, memory, buffer_index, seed);
+}

--- a/src/gpu/intel/include/philox.h
+++ b/src/gpu/intel/include/philox.h
@@ -20,7 +20,7 @@
 #define DT_UNDEF 1
 #include "gpu/intel/include/types.h"
 
-uint philox_4x32_s64(ulong idx, ulong seed, ulong offset) {
+uint4 philox_4x32_s64_vec4(ulong idx, ulong seed, ulong offset) {
 #define PHILOX_4UINT_ROUND(mul, ctr, key) \
     as_uint4(convert_ulong2(ctr.s02) * mul).s3210 \
             ^ (uint4)(ctr.s1 ^ key.s0, 0, ctr.s3 ^ key.s1, 0)
@@ -50,7 +50,11 @@ uint philox_4x32_s64(ulong idx, ulong seed, ulong offset) {
     ctr = PHILOX_4UINT_ROUND(PHILOX_M4x32, ctr, key0.sEF);
     ctr = PHILOX_4UINT_ROUND(PHILOX_M4x32, ctr, key1.s01);
     ctr = PHILOX_4UINT_ROUND(PHILOX_M4x32, ctr, key1.s23);
-    return ctr[idx & 3L];
+    return ctr;
+}
+
+uint philox_4x32_s64(ulong idx, ulong seed, ulong offset) {
+    return philox_4x32_s64_vec4(idx, seed, offset)[idx & 3L];
 }
 
 uint philox_4x32(uint idx, uint seed) {
@@ -60,6 +64,14 @@ uint philox_4x32(uint idx, uint seed) {
     ulong offset_64 = ((x + 1) << 32) + x;
     ulong seed_64 = ((ulong)(seed) << 32) + seed;
     return philox_4x32_s64(idx_64, seed_64, offset_64);
+}
+
+uint4 philox_4x32_vec4(uint idx, uint seed) {
+    ulong x = idx & ~3L;
+    ulong idx_64 = ((x + 3) << 32) + (x + 2);
+    ulong offset_64 = ((x + 1) << 32) + x;
+    ulong seed_64 = ((ulong)(seed) << 32) + seed;
+    return philox_4x32_s64_vec4(idx_64, seed_64, offset_64);
 }
 
 ushort philox_8x16(long idx, uint seed) {

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -611,6 +611,29 @@ void dnn_mem_t::memset(int value, size_t size, int buffer_index) const {
     SAFE_V(FAIL);
 }
 
+#if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
+        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
+extern "C" dnnl_status_t dnnl_impl_gpu_fill_random(dnnl_stream_t stream,
+        size_t size, dnnl_memory_t memory, int buffer_index, uint32_t seed);
+
+// Fills buffer with pseudo-random data generated directly on the device.
+// This mitigates GPU driver data compression, which could otherwise yield
+// unrealistically high bandwidth measurements in mode=F (e.g., via memset).
+int dnn_mem_t::gpu_fill_random(size_t size, int buffer_index) const {
+    if (is_cpu(engine_)) {
+        BENCHDNN_PRINT(0, "%s\n", "gpu_fill_random called with CPU engine");
+        return FAIL;
+    }
+    static constexpr uint32_t seed = 123456789;
+    auto mem = m_padded_ ? m_padded_ : m_;
+    stream_t stream(engine_);
+    DNN_SAFE(dnnl_impl_gpu_fill_random(stream, size, mem, buffer_index, seed),
+            WARN);
+    DNN_SAFE(dnnl_stream_wait(stream), WARN);
+    return OK;
+}
+#endif
+
 dnn_mem_t dnn_mem_t::create_from_host_ptr(
         const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr) {
     // Pre-allocated handle_info won't use prefill no matter what.
@@ -955,8 +978,19 @@ int dnn_mem_t::initialize(
             if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
                     || cold_cache_input.cold_cache_mode_
                             != default_cold_cache_input().cold_cache_mode_) {
-                // Fill memory directly with 0x3F3F3F3F (0.747059f) number.
+#if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
+        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
+                if (!is_cpu(engine_))
+                    // Fill memory with pseudo-random data directly on device
+                    // to avoid data compression.
+                    SAFE(this->gpu_fill_random(sz, i), WARN);
+                else
+                    // Fill memory directly with 0x3F3F3F3F (0.747059f).
+                    this->memset(dnnl_mem_default_perf_test_value, sz, i);
+#else
+                // Fill memory directly with 0x3F3F3F3F (0.747059f).
                 this->memset(dnnl_mem_default_perf_test_value, sz, i);
+#endif
             } else {
                 // Fill memory with a magic number (NAN for fp data types)
                 // to catch possible uninitialized access.

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -177,6 +177,10 @@ struct dnn_mem_t {
     void map() const;
     void unmap() const;
     void memset(int value, size_t size, int buffer_index) const;
+#if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
+        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
+    int gpu_fill_random(size_t size, int buffer_index) const;
+#endif
 
     static dnn_mem_t create_from_host_ptr(
             const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr);


### PR DESCRIPTION
### Fix unrealistic performance results in `--mode=F` on GPUs with data compression enabled 
**JIRA:** [MFDNN-12589](https://jira.devtools.intel.com/browse/MFDNN-12589)

---

### Problem Description

Benchdnn's `--mode=F` (fast performance mode) uses `memset(0x3F)` to initialize GPU buffers. This uniform pattern (`0x3F3F3F3F...`) is compressed by modern GPU drivers (particularly Intel BMG/Battlemage on Windows), resulting in **falsely elevated bandwidth measurements** ($\sim3\times$ faster than reality). As a result, the reported bandwidth values are incorrect and do not represent actual hardware performance.

**Evidence (BMG 12GB, eltwise relu fp16 32768×32768)**

| Mode       | Bandwidth (GB/s)               | Fill Time        | Exec Time                    | Total Time |
|------------|--------------------------------|------------------|------------------------------|------------|
| `--mode=F` | $1142.4 \texttt{ GB/s}$ (artificially high ❌) | $0.00 \texttt{s}$ (fast ⚡) | $3.75 \texttt{ms}$ (artificially low ❌) | $0.27 \texttt{s}$ |
| `--mode=P` | $404.3 \texttt{ GB/s}$ (realistic ✅) | $5.87 \texttt{s}$ (slow 🐌) | $10.62 \texttt{ms}$ (realistic ✅) | $11.2 \texttt{s}$ |

> <small> Note: `--mode=P` generates reference data on the CPU and transfers it to the GPU uing host-to-device copy, which introduces significant overhead and slows down benchmarks ($5.87 \texttt{s}$ fill in $11.2 \texttt{s}$ total).</small>


<details>
<summary><small><small>Commands used (click to open)</small></small></summary>

```bash
# mode=F
benchdnn --mode=f --eltwise --perf-template=perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%-Gbw% --engine=gpu --dt=f16 --alg=relu 32768x32768

# mode=P
benchdnn --mode=p --eltwise --perf-template=perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%-Gbw% --engine=gpu --dt=f16 --alg=relu 32768x32768
```

</details>

---

### Proposed Solution

Idea is to replace `memset` with performant **on-device pseudo-random data generation** using a dedicated GPU kernel. This approach:
- Generates non-compressible data directly on the device (zero CPU↔GPU transfer overhead).
- Uses `philox` function with good avalanche properties (modified to return a full uint4 vector).
- Applies universal NaN/Inf filter (`0xEEEEEEEE`) valid for all available FP types.
- Maintains per-call repeatability via constant seed value.
- Achieves high throughput via an optimized vectorized kernel using `intel_sub_group_block_write_uc16`, filling $2 \texttt{GB}$ in $5\texttt{ms}$.
- Falls back to `memset` for non-Intel GPUs and CPU engines.
- Enables filling of buffers larger than $4 \texttt{GB}$ by leveraging 64-bit size logic.

**Modified files**
- `tests/benchdnn/dnnl_memory.hpp` — Added `gpu_fill_random()` declaration.
- `tests/benchdnn/dnnl_memory.cpp` — Added implementation of `gpu_fill_random()`.
- `src/gpu/intel/fill_random.cl` — Added OpenCL kernels for on-device pseudo-random buffer initialization.
- `src/gpu/intel/fill_random.cpp` — Implemented kernel launch logic with cache.
- `src/gpu/intel/include/philox.h` — Philox PRNG extended to generate vector output.

**Kernel Performance**
> Full benchmark results for all implemented kernels are documented in the appendices.
> See **JIRA:** [MFDNN-12589](https://jira.devtools.intel.com/browse/MFDNN-12589) for details.

---

### Results

With this fix, performance numbers were achieved at a realistic bandwidth of $404.2 \texttt{GB/s}$ instead of the previously artificially inflated $1142.4 \texttt{GB/s}$, and realistic execution time `--perf-template=%-time%` of $10.62 \texttt{ms}$ instead of the previously artificially deflated $3.75 \texttt{ms}$. This was accomplished while maintaining very high time efficiency at $0.31 \texttt{s}$, which is only $0.04 \texttt{s}$ slower than the previous very efficient memset ($0.27 \texttt{s}$) and $36 \times$ faster than the host-to-device copy required by `--mode=P` ($11.2 \texttt{s}$).

**Reported numbers comparison (BMG 12GB, eltwise relu fp16 32768×32768)**

| Mode       | Bandwidth (GB/s)               | Fill Time        | Exec Time                    | Total Time |
|------------|--------------------------------|------------------|------------------------------|------------|
| `--mode=F` (before fix) | $1142.4 \texttt{ GB/s}$ (inflated ❌) | $0.00 \texttt{s}$ (fast ⚡) | $3.75 \texttt{ms}$ (deflated ❌) | $0.27 \texttt{s}$ |
| `--mode=P` (before fix) | $404.3 \texttt{ GB/s}$ (realistic ✅) | $5.87 \texttt{s}$ (slow 🐌) | $10.62 \texttt{ms}$ (realistic ✅) | $11.2 \texttt{s}$ |
| `--mode=F` (after fix) | $404.2 \texttt{ GB/s}$ (realistic ✅) | $0.00 \texttt{s}$ (fast ⚡) | $10.62 \texttt{ms}$ (realistic ✅) | $0.31 \texttt{s}$ |

> <small> Note: `--mode=P` generates reference data on the CPU and transfers it to the GPU uing host-to-device copy, which introduces significant overhead and slows down benchmarks ($5.87 \texttt{s}$ fill in $11.2 \texttt{s}$ total).</small>


<details>
<summary><small><small>Commands used (click to open)</small></small></summary>

```bash
# Self-tests
benchdnn.exe --engine=gpu --self

# mode=F
benchdnn.exe --mode=f --eltwise --perf-template=perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%-Gbw% --engine=gpu --dt=f16 --alg=relu 32768x32768

# mode=P
benchdnn.exe --mode=p --eltwise --perf-template=perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%-Gbw% --engine=gpu --dt=f16 --alg=relu 32768x32768
```

</details>

---

### Pull Request Checklist

#### General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

#### Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

#### New features

- [ ] ~~Have you published an RFC for the new feature?~~ (N/A - This is a bug fix, not a new feature)
- [ ] ~~Was the RFC approved?~~ (N/A)
- [ ] ~~Have you added relevant tests?~~ (N/A for new features, but YES for bug fix validation)

#### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests? (Yes, added tests in `tests/benchdnn/self/memory.cpp`)

#### RFC PR

- [ ] ~~Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?~~ (N/A — Not an RFC PR)
- [ ] ~~Have you added a link to the rendered document?~~ (N/A)