### PR TITLE
[rls-v3.11] xe: conv: jit: fix incorrect get_fma_friendly_layout

### DIFF
--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -2496,7 +2496,10 @@ private:
         auto c_layout = get_c_layout(a_layout, b_layout, c_blk_layout);
         bmnk_block_mapper_t c_mapper(mapper);
         c_mapper.push_blocks(abc_kind_t::a, x2r.a_layout.blocks());
-        c_mapper.push_blocks(abc_kind_t::b, x2r.b_layout.blocks());
+        for (auto &block : x2r.b_layout.blocks()) {
+            if (mapper.bmnk_kind(abc_kind_t::b, block.idx) == bmnk_kind_t::n)
+                c_mapper.push_block(abc_kind_t::b, block);
+        }
         auto c_prb_layout = c_mapper.map_from_bmnk(abc_kind_t::c,
                 {bmnk_kind_t::b, bmnk_kind_t::m, bmnk_kind_t::n}, c_layout);
 

--- a/src/gpu/intel/jit/ir/gemm_schedule.cpp
+++ b/src/gpu/intel/jit/ir/gemm_schedule.cpp
@@ -59,9 +59,7 @@ void bmnk_block_mapper_t::push_block(
         abc_kind_t abc_kind, const layout_block_t &b) {
     auto bmnk_kind = bmnk_mapper_.bmnk_kind(abc_kind, b.idx);
     switch (bmnk_kind) {
-        case bmnk_kind_t::b:
-            if (abc_kind == abc_kind_t::a) b_blocks_.emplace_back(abc_kind, b);
-            break;
+        case bmnk_kind_t::b: b_blocks_.emplace_back(abc_kind, b); break;
         case bmnk_kind_t::m: m_blocks_.emplace_back(abc_kind, b); break;
         case bmnk_kind_t::n: n_blocks_.emplace_back(abc_kind, b); break;
         case bmnk_kind_t::k: k_blocks_.emplace_back(abc_kind, b); break;


### PR DESCRIPTION
For grouped BWD_W, b_blocks_ did not include the group dimension for the dst buffer, causing get_fma_friendly_layout to fail as that is the vectorized dimension.

Backport #4688.
