### PR TITLE
benchdnn: fix cold cache buffers allocation

### DIFF
--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -32,6 +32,9 @@
 #define dnnl_mem_default_value 0xFF
 #define dnnl_mem_default_perf_test_value 0x3F
 
+static constexpr size_t dnnl_mem_default_alignment = 2u * 1024u * 1024u;
+static constexpr size_t dnnl_mem_page_size = 4096u;
+
 struct dnn_mem_t {
     struct handle_info_t {
         bool is_host_ptr;
@@ -46,7 +49,8 @@ struct dnn_mem_t {
 
     dnn_mem_t() { map(); }
     dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_engine_t engine, bool prefill,
-            const handle_info_t &handle_info = handle_info_t::allocate());
+            const handle_info_t &handle_info = handle_info_t::allocate(),
+            size_t alignment = dnnl_mem_default_alignment);
 
     dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_data_type_t dt,
             const std::string &tag, dnnl_engine_t engine, bool prefill);
@@ -230,6 +234,7 @@ private:
 
     mutable bool is_mapped_ = false;
     mutable std::vector<void *> mapped_ptrs_;
+    size_t alignment_ {dnnl_mem_default_alignment};
 
     int initialize_memory_create_sycl(const handle_info_t &handle_info);
     int initialize_memory_create_opencl(const handle_info_t &handle_info);

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -178,7 +178,8 @@ cold_cache_t::cold_cache_t(
             // Note: despite `gpu_n_buffers_top_limit_` is taken as a limit, it
             // applies for CPU as well to avoid numerous reorders.
             const bool prefill = n_mem_pool_buffers > gpu_n_buffers_top_limit_;
-            cc_entry[i] = dnn_mem_t(orig_cc_mem_md, get_test_engine(), prefill);
+            cc_entry[i] = dnn_mem_t(orig_cc_mem_md, get_test_engine(), prefill,
+                    dnn_mem_t::handle_info_t::allocate(), dnnl_mem_page_size);
 
             // Sparse memories require this call to replicate the exact original
             // data distribution because the data structure affects performance


### PR DESCRIPTION
Benchdnn with cold-cache may create up 10000 buffers. Because each buffer is aligned to 2Mb size it leads to dozens Gb memory usage. In particular it prevents multi instance testing (like inference RT): 16 instances each eating dozens gigabytes are going to OOM.

This pull request introduces memory alignment handling in the `dnn_mem_t` class within the benchdnn: it makes memory alignment configurable.
Updated cold cache buffer creation to explicitly specify smaller value (4K) as the alignment for cold cache buffers allocations.