### PR TITLE
revert: cpu: x86: deconv fallback to older deconv on brgemm failure

### DIFF
--- a/src/cpu/x64/jit_brgemm_deconv.cpp
+++ b/src/cpu/x64/jit_brgemm_deconv.cpp
@@ -199,7 +199,6 @@ status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                 reinterpret_cast<const op_desc_t *>(&conv_d), attr(), nullptr);
         if (!it.is_initialized()) return status::out_of_memory;
 
-        // First pass: try to find BRGEMM backward strided implementation
         while (++it != it.end()) {
             conv_pd_ = *it;
             if (check_embedded_impl_init<
@@ -208,39 +207,9 @@ status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     == status::success)
                 break;
         }
-
-        // Second pass: fallback to any other backward data convolution implementation
-        // This allows non-BRGEMM kernels (like jit_avx512_core_bf16) to handle
-        // cases with uneven spatial dimensions
-        // If bias is present, only fallback if the direction is FWD_I, this is the only
-        // combination where fallback implementations handle bias correctly.
-        if (it == it.end()) {
-            const bool has_bias = with_bias();
-            const bool is_fwd_inference
-                    = fwd_deconv_d->prop_kind == prop_kind::forward_inference;
-            const bool allow_fallback
-                    = !has_bias || (has_bias && is_fwd_inference);
-
-            if (allow_fallback) {
-                primitive_desc_iterator_t it2(engine,
-                        reinterpret_cast<const op_desc_t *>(&conv_d), attr(),
-                        nullptr);
-                if (!it2.is_initialized()) return status::out_of_memory;
-                while (++it2 != it2.end()) {
-                    conv_pd_ = *it2;
-                    if ((*it2)->kind() == primitive_kind::convolution) break;
-                }
-                if (it2 == it2.end())
-                    VDISPATCH_DECONVOLUTION_IC(false,
-                            "no suitable implementation found for strided "
-                            "deconvolution");
-            } else {
-                // Block fallback when bias is present but not FWD_I direction
-                VDISPATCH_DECONVOLUTION_IC(false,
-                        "no suitable implementation found for strided "
-                        "deconvolution with bias in non-FWD_I direction");
-            }
-        }
+        if (it == it.end())
+            VDISPATCH_DECONVOLUTION_IC(false,
+                    "brgemm implementation not found for strided convolution");
     } else {
         CHECK(fwd_conv_desc_create(fwd_deconv_d, &conv_d));
 


### PR DESCRIPTION
[MFDNN-14627](https://jira.devtools.intel.com/browse/MFDNN-14627)

This reverts commit fcb57d030d3793e9d298af4b59ddb98ef8d87f01.

https://github.com/uxlfoundation/oneDNN/pull/4656

The fallback code is failing in two situations.
When the bias data type does not match the destination data type.
It also fails when trying to fall back for s8:s8:s32 data types on a system without vnni.

I created a PR that resolved both those issues https://github.com/uxlfoundation/oneDNN/pull/4697 only to discover it would prevent the code catching the original shapes from [MFDNN-14380](https://jira.devtools.intel.com/browse/MFDNN-14380).

I will need more time to investigate an additional fix for MFDNN-14380 in the meantime to prevent nightly build failures I am reverting this change.
