### PR TITLE
benchdnn: graph: check for usm memory kind

### DIFF
--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -589,10 +589,26 @@ int skip_unimplemented_partitions(const std::vector<partition> &partitions,
     return OK;
 }
 
+int skip_unimplemented_memory_kind(res_t *res) {
+    // currently, only USM memory is supported by graph driver, skip other
+    // memory kinds (eg., buffer).
+    if (memory_kind != memory_kind_ext_t::usm) {
+        BENCHDNN_PRINT(2, "%s\n",
+                "[INFO]: only USM memory is supported by graph driver");
+        res->state = SKIPPED;
+        res->reason = skip_reason::case_not_supported;
+    }
+
+    return OK;
+}
+
 int doit(const prb_t *prb, res_t *res) {
     if (bench_mode == bench_mode_t::list) return res->state = LISTED, OK;
 
     skip_start(res);
+    if (res->state == SKIPPED) return OK;
+
+    skip_unimplemented_memory_kind(res);
     if (res->state == SKIPPED) return OK;
 
     const auto &dg = prb->dg;


### PR DESCRIPTION
Before the changes:

```
$ ./tests/benchdnn/benchdnn --graph --engine=gpu --memory-kind=buffer --case=complex_fusion/mha/GQA-f32.json
Segmentation fault from GPU at 0x6266340b2000, ctx_id: 1 (CCS) type: 0 (NotPresent), level: 3 (PML4), access: 0 (Read), banned: 1, aborting.
Segmentation fault from GPU at 0x6266340b2000, ctx_id: 1 (CCS) type: 0 (NotPresent), level: 3 (PML4), access: 0 (Read), banned: 1, aborting.
Abort was called at 288 line in file:
./shared/source/os_interface/linux/drm_neo.cpp
Aborted (core dumped)
```

After the changes:

```
$ ./tests/benchdnn/benchdnn --graph --engine=gpu --memory-kind=buffer --case=complex_fusion/mha/GQA-f32.json
[INFO]: only USM memory is supported for graph driver
0:SKIPPED (Case not supported) (0 ms) __REPRO: --graph --engine=gpu --memory-kind=buffer --case=complex_fusion/mha/GQA-f32.json
tests:1 passed:0 skipped:1 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.03s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.00s (0%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```

Fixes MFDNN-14639