### PR TITLE
benchdnn: respect accumulation mode in safe digits calculation

### DIFF
--- a/tests/benchdnn/brgemm/cfg.cpp
+++ b/tests/benchdnn/brgemm/cfg.cpp
@@ -18,7 +18,8 @@
 
 namespace brgemm {
 
-cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
+cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds)
+    : base_cfg_t {prb->attr.acc_mode} {
     for (const auto kind : kinds) {
         auto orig_data_type = prb->get_dt(kind);
         auto data_type = deduce_cfg_data_type(orig_data_type, prb->attr, kind);

--- a/tests/benchdnn/conv/cfg.cpp
+++ b/tests/benchdnn/conv/cfg.cpp
@@ -30,6 +30,15 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
                         kind, orig_data_type, data_type, get_cfg_map(kind)});
     }
 
+    acc_mode_ = prb->attr.acc_mode;
+    bool inputs_f16 = true;
+    for (auto dk : {SRC, WEI, DST}) {
+        if (dk == output_data_kind_) continue;
+        inputs_f16 = inputs_f16 && get_dt(dk) == dnnl_f16;
+    }
+    // XXX: GPU convolution can use f16 accumulator when both inputs are f16.
+    if (is_gpu() && inputs_f16) acc_mode_ = dnnl_accumulation_mode_f16;
+
     // Keep legacy filling for Wino.
     if (prb->alg == WINO) {
         if (prb->dt[0] == dnnl_f32) {

--- a/tests/benchdnn/deconv/cfg.cpp
+++ b/tests/benchdnn/deconv/cfg.cpp
@@ -30,6 +30,15 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
                         kind, orig_data_type, data_type, get_cfg_map(kind)});
     }
 
+    acc_mode_ = prb->attr.acc_mode;
+    bool inputs_f16 = true;
+    for (auto dk : {SRC, WEI, DST}) {
+        if (dk == output_data_kind_) continue;
+        inputs_f16 = inputs_f16 && get_dt(dk) == dnnl_f16;
+    }
+    // XXX: GPU deconvolution can use f16 accumulator when both inputs are f16.
+    if (is_gpu() && inputs_f16) acc_mode_ = dnnl_accumulation_mode_f16;
+
     adjust_ranges();
     print_fill_cfg_verbose();
 }

--- a/tests/benchdnn/ip/cfg.cpp
+++ b/tests/benchdnn/ip/cfg.cpp
@@ -18,7 +18,8 @@
 
 namespace ip {
 
-cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
+cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds)
+    : base_cfg_t {prb->attr.acc_mode} {
     output_data_kind_ = (prb->dir & FLAG_FWD) ? DST
             : (prb->dir & FLAG_WEI)           ? WEI
                                               : SRC;

--- a/tests/benchdnn/matmul/cfg.cpp
+++ b/tests/benchdnn/matmul/cfg.cpp
@@ -18,7 +18,8 @@
 
 namespace matmul {
 
-cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
+cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds)
+    : base_cfg_t {prb->attr.acc_mode} {
     for (const auto kind : kinds) {
         auto orig_data_type = prb->get_dt(kind);
         auto data_type = deduce_cfg_data_type(orig_data_type, prb->attr, kind);

--- a/tests/benchdnn/utils/cfg.hpp
+++ b/tests/benchdnn/utils/cfg.hpp
@@ -149,12 +149,30 @@ struct base_cfg_t {
     }
 
 protected:
+    base_cfg_t() = default;
+    base_cfg_t(dnnl_accumulation_mode_t acc_mode) : acc_mode_(acc_mode) {}
+
     std::unordered_map<data_kind_t, cfg_entry_t, data_kind_hash_t> cfg_entry_;
     data_kind_t output_data_kind_ = DST; // Assume FWD by default.
+    dnnl_accumulation_mode_t acc_mode_ = dnnl_accumulation_mode_strict;
 
     int64_t get_safe_digits() const {
         return MIN2(digits_dt(cfg_entry_.at(output_data_kind_).get_dt()),
-                digits_dt(dnnl_f32));
+                digits_acc_mode(acc_mode_));
+    }
+
+    static int64_t digits_acc_mode(dnnl_accumulation_mode_t acc_mode) {
+        switch (acc_mode) {
+            case dnnl_accumulation_mode_strict:
+            case dnnl_accumulation_mode_f32: return digits_dt(dnnl_f32);
+            case dnnl_accumulation_mode_f16: return digits_dt(dnnl_f16);
+            case dnnl_accumulation_mode_s32: return digits_dt(dnnl_s32);
+            case dnnl_accumulation_mode_relaxed:
+            case dnnl_accumulation_mode_any:
+                // In practice, the minimum accumulation type is f16.
+                return digits_dt(dnnl_f16);
+            default: assert(!"not expected"); return digits_dt(dnnl_f32);
+        }
     }
 
     bool is_int8(data_kind_t dk = WEI) const {


### PR DESCRIPTION
Jira: [MFDNN-14670](https://jira.devtools.intel.com/browse/MFDNN-14670)

PR addresses two issues:

1. benchdnn doesn't respect `acc-mode` during data filling (e.g. see the matmul failure below)
2. GPU convolution/deconvolution is not aligned with documentation and can use `f16` accumulator even when `acc-mode` doesn't allow it: [link](https://github.com/uxlfoundation/oneDNN/blob/fb7fa143e5e6609411c9117fd7f760a61e12b6e3/src/gpu/intel/conv/jit/plan.cpp#L1267)
    - It's a FIXME but at this point it's easier to wait until XeLP/XeLPG are officially deprecated

Matmul failures on XeLP/XeLPG - note `--attr-acc-mode=any`:

```
$ ./build/tests/benchdnn/benchdnn -v5 --matmul --engine=gpu --dt=f16:f16:f32 --attr-acc-mode=any -v5 128x10240:10240x128
create: --matmul --engine=gpu --dt=f16:f16:f32 --attr-acc-mode=any 128x10240:10240x128
oneDNN implementation: jit:gemm:any
CPU reference oneDNN implementation: brg_matmul:avx2
run: --matmul --engine=gpu --dt=f16:f16:f32 --attr-acc-mode=any 128x10240:10240x128
run ref: --matmul --engine=cpu --attr-acc-mode=any 128x10240:10240x128
[   0][DST][0:0] exp_f32:       -2613 exp:       -2613 got:       -2612 diff:       1 rdiff:0.000382702
[   4][DST][0:4] exp_f32:        2365 exp:        2365 got:        2364 diff:       1 rdiff:0.000422833
[  10][DST][0:10] exp_f32:       -2169 exp:       -2169 got:       -2168 diff:       1 rdiff:0.000461042
[  16][DST][0:16] exp_f32:       -3379 exp:       -3379 got:       -3380 diff:       1 rdiff:0.000295946
[  25][DST][0:25] exp_f32:        2821 exp:        2821 got:        2822 diff:       1 rdiff:0.000354484
[  29][DST][0:29] exp_f32:        2707 exp:        2707 got:        2708 diff:       1 rdiff:0.000369413
[  33][DST][0:33] exp_f32:        2263 exp:        2263 got:        2264 diff:       1 rdiff:0.000441891
[  38][DST][0:38] exp_f32:       -5186 exp:       -5186 got:       -5184 diff:       2 rdiff:0.000385654
[  44][DST][0:44] exp_f32:       -2287 exp:       -2287 got:       -2288 diff:       1 rdiff:0.000437254
[  54][DST][0:54] exp_f32:       -2293 exp:       -2293 got:       -2292 diff:       1 rdiff:0.00043611
[COMPARE_STATS][DST]: trh=0 err_max_diff:       6 err_max_rdiff:0.00101868 all_max_diff:       6 all_max_rdiff:0.00101868
[PRIM_REF][INFO]: L2_size:524288 bytes; per_core_L3_size:2359296 bytes; nthr:24; impl_name:brg_matmul:avx2
0:FAILED (errors:3689 total:16384) (627 ms) __REPRO: --matmul --engine=gpu --dt=f16:f16:f32 --attr-acc-mode=any 128x10240:10240x128
```