### PR TITLE
[GPU] Fix convolution issue with mad layouts (backport to rls-v3.10)

### DIFF
--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -1459,6 +1459,9 @@ struct fma_context_t {
                       auto &b0 = layout[0];
                       if (b0.idx != dim) return false;
                       if (b0.size % block != 0) return false;
+                      bool stride_ok = (b0.stride == 1)
+                              || (layout.type().is_x16() && b0.stride == 2);
+                      if (!stride_ok) return false;
                       return true;
                   };
         if (a_vec_idx != -1 && !is_blocked_by(a, a_vec_idx, vec_size))


### PR DESCRIPTION
Jira: MFDNN-14678

Backport of commit 2cd8a351de0eded6f76c1c4434d78903a83dc0f1 ([PR #4717](https://github.com/uxlfoundation/oneDNN/pull/4717)) to `rls-v3.10`.

The issue is due to a non-unit stride in `mad`. In general, the expected A/B layouts are either:

- Unit-strided
- Strided by two - in case of `s16` and `u16`

The fix adds a `stride_ok` guard in `is_blocked_by` (inside `fma_context_t::is_mad_compatible`) so that layouts with non-conforming strides are not assigned to MAD vector operations, preventing NaN values and large numerical errors in the convolution output.

Verified on `rls-v3.10`:
- **Before fix:** `FAILED` (errors:16077 total:18816)
- **After fix:** `PASSED`

Reproduction command:
```
benchdnn --conv --engine=gpu --allow-enum-tags-only=false --dir=FWD_I --bia-dt=f32 --stag=abcd --dtag=abcd --attr-scratchpad=user g192mb1ic192ih14oc384oh7kh3sh2ph1
```