### PR TITLE
cpu: x64: conv: remove unnecessary work around - backport

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1428,13 +1428,6 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
         btc.inp_buffer = (jcp.exec_type == exec_trans && jcp.copy_input)
                 ? inp_p_buffer + src_dsz * ithr * jcp.inp_buffer_size
                 : nullptr;
-        if (is_amx && btc.inp_buffer) {
-            // Workaround: for some machines SEGFAULT possible on tile load
-            // if the page was not touched before it
-            for (dim_t i = 0; i < jcp.inp_buffer_size;
-                    i += brgemm_convolution_utils::P4K)
-                btc.inp_buffer[i] = 0;
-        }
 
         btc.inp_buffer_mask = (jcp.exec_type == exec_trans)
                 ? inp_p_buffer_mask + ithr * jcp.inp_buffer_mask_size

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -780,14 +780,6 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                 ? out_p_buffer + dst_dsz * ithr * jcp.out_buffer_size
                 : nullptr;
 
-        if (is_amx && inp_buffer) {
-            // Workaround: for some machines SEGFAULT possible on tile load
-            // if the page was not touched before it
-            for (dim_t i = 0; i < jcp.inp_buffer_size;
-                    i += brgemm_convolution_bwd_utils::P4K)
-                inp_buffer[i] = 0;
-        }
-
         uint8_t *__restrict inp_buffer_mask = (jcp.exec_type == exec_trans)
                 ? inp_p_buffer_mask + ithr * jcp.inp_buffer_mask_size
                 : nullptr;


### PR DESCRIPTION
Remove unnecessary flow that touches every page in the input buffer in conv layer.
Related to jira: https://jira.devtools.intel.com/browse/MFDNN-14582
backport of: https://github.com/uxlfoundation/oneDNN/pull/4700