### PR TITLE
cpu: rv64: conv: add rvv winograd kernel

### DIFF
--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -77,6 +77,7 @@ using namespace dnnl::impl::cpu::aarch64;
 #include "cpu/rv64/jit_rvv_1x1_convolution.hpp"
 #include "cpu/rv64/rvv_brgemm_conv.hpp"
 #include "cpu/rv64/rvv_gemm_convolution.hpp"
+#include "cpu/rv64/rvv_winograd_convolution.hpp"
 using namespace dnnl::impl::cpu::rv64;
 #endif // DNNL_RISCV_USE_RVV_INTRINSICS
 #endif
@@ -171,6 +172,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64(jit_sve_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_fwd_t)
             CPU_INSTANCE_RV64GCV(jit_rvv_1x1_convolution_fwd_t)
+            CPU_INSTANCE_RV64GCV(rvv_wino_convolution_fwd_t)
             CPU_INSTANCE_RV64GCV(rvv_brgemm_convolution_fwd_t)
             CPU_INSTANCE_RV64GCV(riscv_gemm_convolution_fwd_t)
             CPU_INSTANCE(gemm_convolution_fwd_t)

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -1,0 +1,646 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <vector>
+#include <riscv_vector.h>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
+#include "cpu/rv64/rvv_winograd_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::utils;
+using namespace dnnl::impl::data_type;
+using namespace dnnl::impl::memory_tracking::names;
+
+namespace {
+// Winograd F(2x2, 3x3) transform matrices
+// Input transform matrix B^T (4x4)
+constexpr float BT[4][4] = {{1.0f, 0.0f, -1.0f, 0.0f}, {0.0f, 1.0f, 1.0f, 0.0f},
+        {0.0f, -1.0f, 1.0f, 0.0f}, {0.0f, -1.0f, 0.0f, 1.0f}};
+
+// B matrix (transpose of B^T)
+constexpr float B[4][4] = {{1.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, -1.0f, -1.0f},
+        {-1.0f, 1.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 1.0f}};
+
+// Output transform matrix A^T (2x4)
+constexpr float AT[2][4]
+        = {{1.0f, 1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, -1.0f, 1.0f}};
+
+// A matrix (transpose of A^T, which is 4x2)
+constexpr float A[4][2]
+        = {{1.0f, 0.0f}, {1.0f, 1.0f}, {1.0f, -1.0f}, {0.0f, 1.0f}};
+
+// Filter transform matrix G (4x3)
+constexpr float G[4][3] = {{1.0f, 0.0f, 0.0f}, {0.5f, 0.5f, 0.5f},
+        {0.5f, -0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}};
+
+// Pre-compute filter transform: 3x3 -> 4x4
+// Transform = G * filter * G^T
+// Output layout: [oc][ic][16]
+__attribute__((unused)) static void compute_filter_transform_3x3_to_4x4(
+        const float *filter, float *transformed, int oc, int ic) {
+    for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
+        for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
+            const float *f = &filter[(oc_idx * ic + ic_idx) * 9];
+            float *out = &transformed[(oc_idx * ic + ic_idx) * 16];
+
+            float temp[4][3];
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 3; j++) {
+                    float sum = 0.0f;
+                    for (int k = 0; k < 3; k++) {
+                        sum += G[i][k] * f[k * 3 + j];
+                    }
+                    temp[i][j] = sum;
+                }
+            }
+
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 4; j++) {
+                    float sum = 0.0f;
+                    for (int k = 0; k < 3; k++) {
+                        sum += temp[i][k] * G[j][k];
+                    }
+                    out[i * 4 + j] = sum;
+                }
+            }
+        }
+    }
+}
+
+// Pre-compute filter transform with GEMM-layout: 3x3 -> 4x4
+// Transform = G * filter * G^T
+// Output layout: [16][ic_rounded][oc_rounded] for efficient aligned memory access
+// Pads with zeros for non-multiple-of-4 dimensions
+void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
+        float *transformed, int oc, int ic, int ic_rounded, int oc_rounded) {
+
+    for (size_t i = 0; i < static_cast<size_t>(16 * ic_rounded * oc_rounded);
+            i++) {
+        transformed[i] = 0.0f;
+    }
+
+    float *temp_std = new float[oc * ic * 16];
+
+    // Step 1: Compute Winograd transform into standard [oc][ic][16] layout
+    for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
+        for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
+            const float *f = &filter[(oc_idx * ic + ic_idx) * 9];
+            float *out = &temp_std[(oc_idx * ic + ic_idx) * 16];
+
+            float temp[4][3];
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 3; j++) {
+                    float sum = 0.0f;
+                    for (int k = 0; k < 3; k++) {
+                        sum += G[i][k] * f[k * 3 + j];
+                    }
+                    temp[i][j] = sum;
+                }
+            }
+
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 4; j++) {
+                    float sum = 0.0f;
+                    for (int k = 0; k < 3; k++) {
+                        sum += temp[i][k] * G[j][k];
+                    }
+                    out[i * 4 + j] = sum;
+                }
+            }
+        }
+    }
+
+    // B[oc_idx * ldb + ic_idx] where ldb = number of columns = ic_rounded
+    for (int elem = 0; elem < 16; elem++) {
+        for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
+            for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
+                // Store as [elem][oc][ic] row-major: B[oc_idx][ic_idx]
+                transformed[elem * oc_rounded * ic_rounded + oc_idx * ic_rounded
+                        + ic_idx]
+                        = temp_std[oc_idx * ic * 16 + ic_idx * 16 + elem];
+            }
+        }
+    }
+
+    delete[] temp_std;
+}
+
+// RVV-optimized Winograd input transform: d = B^T * input_tile * B (4x4 -> 4x4)
+inline void winograd_input_transform_4x4(
+        const float *input_tile, float *output_tile) {
+    const dim_t vl_max = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+    float temp[16];
+
+    // Step 1: input_tile * B
+    for (int i = 0; i < 4; i++) {
+        vfloat32m1_t v_in_row
+                = __riscv_vle32_v_f32m1(input_tile + i * 4, vl_max);
+        for (int j = 0; j < 4; j++) {
+            float B_col[4] = {B[0][j], B[1][j], B[2][j], B[3][j]};
+            vfloat32m1_t v_b_col = __riscv_vle32_v_f32m1(B_col, vl_max);
+            vfloat32m1_t v_prod
+                    = __riscv_vfmul_vv_f32m1(v_in_row, v_b_col, vl_max);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+            vfloat32m1_t v_sum
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+            temp[i * 4 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
+        }
+    }
+
+    // Step 2: B^T * temp
+    for (int i = 0; i < 4; i++) {
+        float BT_row[4] = {BT[i][0], BT[i][1], BT[i][2], BT[i][3]};
+        vfloat32m1_t v_bt_row = __riscv_vle32_v_f32m1(BT_row, vl_max);
+        for (int j = 0; j < 4; j++) {
+            float temp_col[4] = {temp[0 * 4 + j], temp[1 * 4 + j],
+                    temp[2 * 4 + j], temp[3 * 4 + j]};
+            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl_max);
+            vfloat32m1_t v_prod
+                    = __riscv_vfmul_vv_f32m1(v_bt_row, v_temp_col, vl_max);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+            vfloat32m1_t v_sum
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+            output_tile[i * 4 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
+        }
+    }
+}
+
+// RVV-optimized Winograd output transform: m = A^T * winograd_domain * A (4x4 -> 2x2)
+inline void winograd_output_transform_2x2(
+        const float *winograd_domain, float *output_tile) {
+    const dim_t vl_max = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+    float temp[8];
+
+    // Step 1: winograd_domain * A
+    for (int i = 0; i < 4; i++) {
+        vfloat32m1_t v_wino_row
+                = __riscv_vle32_v_f32m1(winograd_domain + i * 4, vl_max);
+        for (int j = 0; j < 2; j++) {
+            float A_col[4] = {A[0][j], A[1][j], A[2][j], A[3][j]};
+            vfloat32m1_t v_a_col = __riscv_vle32_v_f32m1(A_col, vl_max);
+            vfloat32m1_t v_prod
+                    = __riscv_vfmul_vv_f32m1(v_wino_row, v_a_col, vl_max);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+            vfloat32m1_t v_sum
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+            temp[i * 2 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
+        }
+    }
+
+    // Step 2: A^T * temp
+    for (int i = 0; i < 2; i++) {
+        float AT_row[4] = {AT[i][0], AT[i][1], AT[i][2], AT[i][3]};
+        vfloat32m1_t v_at_row = __riscv_vle32_v_f32m1(AT_row, vl_max);
+        for (int j = 0; j < 2; j++) {
+            float temp_col[4] = {temp[0 * 2 + j], temp[1 * 2 + j],
+                    temp[2 * 2 + j], temp[3 * 2 + j]};
+            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl_max);
+            vfloat32m1_t v_prod
+                    = __riscv_vfmul_vv_f32m1(v_at_row, v_temp_col, vl_max);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+            vfloat32m1_t v_sum
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+            output_tile[i * 2 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
+        }
+    }
+}
+
+} // namespace
+
+// Helper: round up to multiple of n (for alignment)
+static inline dim_t round_up(dim_t x, dim_t n) {
+    return ((x + n - 1) / n) * n;
+}
+
+status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
+        memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,
+        const memory_desc_t &src_md, const memory_desc_t &weights_md,
+        const memory_desc_t &dst_md, const memory_desc_t &bias_md,
+        const primitive_attr_t &attr, int max_threads) {
+    using namespace prop_kind;
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bias_d(&bias_md);
+
+    const dim_t mb = src_d.dims()[0];
+    conf.mb = mb;
+
+    conf.ih = src_d.dims()[2];
+    conf.iw = src_d.dims()[3];
+    conf.oh = dst_d.dims()[2];
+    conf.ow = dst_d.dims()[3];
+
+    conf.ic = src_d.dims()[1];
+    conf.oc = dst_d.dims()[1];
+
+    conf.kh = weights_d.dims()[2];
+    conf.kw = weights_d.dims()[3];
+
+    conf.stride_h = cd.strides[0];
+    conf.stride_w = cd.strides[1];
+
+    conf.pad_t = cd.padding[0][0];
+    conf.pad_l = cd.padding[0][1];
+    conf.pad_b = cd.padding[1][0];
+    conf.pad_r = cd.padding[1][1];
+
+    conf.with_bias = cd.bias_desc.data_type != data_type::undef;
+
+    conf.nthr = max_threads;
+
+    // Compute Winograd domain specification for GEMM-based execution
+    constexpr dim_t CACHE_LINE_SIZE = 64;
+    constexpr dim_t CACHE_LINE_FLOATS = CACHE_LINE_SIZE / sizeof(float); // 16
+
+    // Matrix dimensions: C[M][N] = A[M][K] * B[K][N]
+    conf.wspec.M = ((conf.oh + 1) / 2) * ((conf.ow + 1) / 2); // Total 2x2 tiles
+    conf.wspec.K = conf.ic; // Input channels
+    conf.wspec.N = conf.oc; // Output channels
+    conf.wspec.n_gemms = 16; // Winograd F(2×2, 3×3)
+    conf.wspec.n_batches = conf.mb;
+
+    // 64-byte aligned leading dimensions (for efficient vectorization)
+    // Weight matrix: B[N][K] where N=OC, K=IC (row-major for GEMM)
+    // For weight transform, we need separate rounded dimensions
+    conf.wspec.weight_oc_rounded = round_up(conf.wspec.N, CACHE_LINE_FLOATS);
+    conf.wspec.weight_ic_rounded = round_up(conf.wspec.K, CACHE_LINE_FLOATS);
+
+    // weight_ld_row is the leading dimension (stride) for B[N][K] row-major
+    // B[oc_idx][ic_idx] = B[oc_idx * ldb + ic_idx], so ldb = number of columns = ic_rounded
+    conf.wspec.weight_ld_row = conf.wspec.weight_ic_rounded;
+    conf.wspec.weight_ld_matrix
+            = conf.wspec.weight_oc_rounded * conf.wspec.weight_ic_rounded;
+
+    // Input matrix: A[K][M] column-major where K=IC, M=tiles
+    // A[k][m] stored as A[m * lda + k] where lda = round_up(K, CACHE_LINE_FLOATS)
+    conf.wspec.input_ld_row
+            = round_up(conf.wspec.K, CACHE_LINE_FLOATS); // lda = K rounded
+    conf.wspec.input_ld_batch
+            = conf.wspec.input_ld_row * conf.wspec.M; // M columns per batch
+    conf.wspec.input_ld_matrix
+            = conf.wspec.input_ld_batch * conf.wspec.n_batches;
+
+    // Output matrix: C^T[M][N] row-major where M=tiles, N=OC
+    // GEMM computes C^T where C^T[m][n] = C[n][m]
+    // C^T[m][n] stored as C^T[m * N + n]
+    conf.wspec.output_ld_row = conf.wspec.N; // N columns per row of C^T
+    conf.wspec.output_ld_batch
+            = conf.wspec.output_ld_row * conf.wspec.M; // M rows per batch
+    conf.wspec.output_ld_matrix
+            = conf.wspec.output_ld_batch * conf.wspec.n_batches;
+
+    // Matrix sizes in floats
+    conf.wspec.weight_matrix_size
+            = conf.wspec.n_gemms * conf.wspec.weight_ld_matrix;
+    conf.wspec.input_matrix_size
+            = conf.wspec.n_gemms * conf.wspec.input_ld_matrix;
+    conf.wspec.output_matrix_size
+            = conf.wspec.n_gemms * conf.wspec.output_ld_matrix;
+
+    // GEMM-layout scratchpad allocation
+    using namespace memory_tracking::names;
+
+    scratchpad.book<float>(key_wino_U, conf.wspec.weight_matrix_size);
+    scratchpad.book<float>(key_wino_V, conf.wspec.input_matrix_size);
+    scratchpad.book<float>(key_wino_M, conf.wspec.output_matrix_size);
+
+    return status::success;
+}
+
+status_t rvv_wino_convolution_fwd_t::execute_forward(
+        const exec_ctx_t &ctx) const {
+
+    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+    auto bias = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
+    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+
+    const auto &conf = pd()->conf_;
+    const auto scratchpad = ctx.get_scratchpad_grantor();
+
+    using namespace memory_tracking::names;
+    float *transformed_weights = scratchpad.template get<float>(key_wino_U);
+    float *transformed_input = scratchpad.template get<float>(key_wino_V);
+    float *winograd_output = scratchpad.template get<float>(key_wino_M);
+
+    // Phase 1: Weight transform
+    compute_filter_transform_3x3_to_4x4_gemm_layout(weights,
+            transformed_weights, conf.wspec.N, conf.wspec.K,
+            conf.wspec.weight_ic_rounded, conf.wspec.weight_oc_rounded);
+
+    // Phase 2: Input transform
+    CHECK(execute_input_transform(src, transformed_input));
+
+    // Phase 3: Batched GEMM (16 independent matrix multiplications)
+    CHECK(execute_gemm_batched(
+            transformed_input, transformed_weights, winograd_output));
+
+    // Phase 4: Output transform
+    CHECK(execute_output_transform(winograd_output, bias, dst));
+
+    return status::success;
+}
+
+status_t rvv_wino_convolution_fwd_t::execute_input_transform(
+        const data_t *src, float *transformed_input) const {
+
+    const auto &conf = pd()->conf_;
+    const dim_t nb_oh = (conf.oh + 1) / 2;
+    const dim_t nb_ow = (conf.ow + 1) / 2;
+    const dim_t total_tiles = nb_oh * nb_ow;
+
+    // Parallelize over tiles
+    parallel(conf.nthr, [&](const int ithr, const int nthr) {
+        dim_t start = 0, end = 0;
+        balance211(conf.mb * total_tiles, nthr, ithr, start, end);
+
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            const dim_t mb_idx = iwork / total_tiles;
+            const dim_t tile_idx = iwork % total_tiles;
+            const dim_t oh_tile = tile_idx / nb_ow;
+            const dim_t ow_tile = tile_idx % nb_ow;
+            const dim_t oh_start = oh_tile * 2;
+            const dim_t ow_start = ow_tile * 2;
+
+            const float *src_base = src + mb_idx * conf.ic * conf.ih * conf.iw;
+
+            // Transform each input channel's 4x4 tile
+            // Output layout: transformed_input[elem][batch][k][m]
+            for (dim_t ic_idx = 0; ic_idx < conf.ic; ic_idx++) {
+                float input_tile[16];
+                for (dim_t i = 0; i < 4; i++) {
+                    dim_t ih_idx = oh_start + i - conf.pad_t;
+                    for (dim_t j = 0; j < 4; j++) {
+                        dim_t iw_idx = ow_start + j - conf.pad_l;
+                        if (ih_idx >= 0 && ih_idx < conf.ih && iw_idx >= 0
+                                && iw_idx < conf.iw) {
+                            size_t offset = ic_idx * conf.ih * conf.iw
+                                    + ih_idx * conf.iw + iw_idx;
+                            input_tile[i * 4 + j] = src_base[offset];
+                        } else {
+                            input_tile[i * 4 + j] = 0.0f;
+                        }
+                    }
+                }
+
+                // Winograd transform this 4x4 tile
+                float transformed[16];
+                winograd_input_transform_4x4(input_tile, transformed);
+
+                // Store in GEMM layout: transformed_input[elem][batch][m][k]
+                // where m=tile_idx, k=ic_idx
+                const dim_t vl_max
+                        = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+                for (int elem = 0; elem < 16; elem += vl_max) {
+                    const dim_t vl
+                            = (elem + vl_max <= 16) ? vl_max : (16 - elem);
+
+                    float *dst_base = transformed_input
+                            + elem * conf.wspec.input_ld_matrix
+                            + mb_idx * conf.wspec.input_ld_batch
+                            + tile_idx * conf.wspec.input_ld_row + ic_idx;
+
+                    for (dim_t i = 0; i < vl; i++) {
+                        dst_base[i * conf.wspec.input_ld_matrix]
+                                = transformed[elem + i];
+                    }
+                }
+            }
+        }
+    });
+
+    return status::success;
+}
+
+status_t rvv_wino_convolution_fwd_t::execute_gemm_batched(
+        const float *transformed_input, const float *transformed_weights,
+        float *winograd_output) const {
+
+    const auto &conf = pd()->conf_;
+
+    // Execute 16 GEMMs in parallel (each Winograd element is independent)
+    const int n_gemms_threads
+            = static_cast<int>(std::min(static_cast<dim_t>(16), conf.nthr));
+
+    parallel(n_gemms_threads, [&](const int ithr, const int nthr) {
+        for (int elem = ithr; elem < 16; elem += nthr) {
+            for (dim_t batch = 0; batch < conf.mb; batch++) {
+                const float *A = transformed_input
+                        + elem * conf.wspec.input_ld_matrix
+                        + batch * conf.wspec.input_ld_batch;
+                const dim_t lda = conf.wspec.input_ld_row;
+
+                const float *B = transformed_weights
+                        + elem * conf.wspec.weight_ld_matrix;
+                const dim_t ldb = conf.wspec.weight_ld_row;
+
+                float *C = winograd_output + elem * conf.wspec.output_ld_matrix
+                        + batch * conf.wspec.output_ld_batch;
+
+                // RVV GEMM: C^T[M×N] where C^T[m][n] = sum_k A[m][k] * B[n][k]
+                const dim_t M = conf.wspec.M;
+                const dim_t N = conf.wspec.N;
+                const dim_t K = conf.wspec.K;
+                const dim_t vl_max
+                        = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+
+                // Initialize C to zero
+                for (dim_t m = 0; m < M; m++) {
+                    float *C_row = C + m * N;
+                    for (dim_t n = 0; n < N; n++) {
+                        C_row[n] = 0.0f;
+                    }
+                }
+
+                // RVV vectorized GEMM: for each m, compute all n in parallel
+                for (dim_t m = 0; m < M; m++) {
+                    const float *A_row = A + m * lda;
+                    float *C_row = C + m * N;
+
+                    dim_t n_vec_base = 0;
+                    for (; n_vec_base + vl_max <= N; n_vec_base += vl_max) {
+                        vfloat32m1_t vacc
+                                = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+
+                        for (dim_t k = 0; k < K; k++) {
+                            float a_scalar = A_row[k];
+                            float B_local[16];
+                            for (dim_t i = 0; i < vl_max; i++) {
+                                B_local[i] = B[(n_vec_base + i) * ldb + k];
+                            }
+                            vfloat32m1_t vb
+                                    = __riscv_vle32_v_f32m1(B_local, vl_max);
+                            vacc = __riscv_vfmacc_vf_f32m1(
+                                    vacc, a_scalar, vb, vl_max);
+                        }
+
+                        __riscv_vse32_v_f32m1(C_row + n_vec_base, vacc, vl_max);
+                    }
+
+                    // Handle remaining channels
+                    if (n_vec_base < N) {
+                        const dim_t n_remain = N - n_vec_base;
+                        vfloat32m1_t vacc
+                                = __riscv_vfmv_v_f_f32m1(0.0f, n_remain);
+
+                        for (dim_t k = 0; k < K; k++) {
+                            float a_scalar = A_row[k];
+                            float B_local[16];
+                            for (dim_t i = 0; i < n_remain; i++) {
+                                B_local[i] = B[(n_vec_base + i) * ldb + k];
+                            }
+                            vfloat32m1_t vb
+                                    = __riscv_vle32_v_f32m1(B_local, n_remain);
+                            vacc = __riscv_vfmacc_vf_f32m1(
+                                    vacc, a_scalar, vb, n_remain);
+                        }
+
+                        __riscv_vse32_v_f32m1(
+                                C_row + n_vec_base, vacc, n_remain);
+                    }
+                }
+            }
+        }
+    });
+
+    return status::success;
+}
+
+status_t rvv_wino_convolution_fwd_t::execute_output_transform(
+        const float *winograd_output, const data_t *bias, data_t *dst) const {
+
+    const auto &conf = pd()->conf_;
+    const dim_t nb_oh = (conf.oh + 1) / 2;
+    const dim_t nb_ow = (conf.ow + 1) / 2;
+    const dim_t total_tiles = nb_oh * nb_ow;
+
+    // Zero initialize dst
+    const dim_t dst_size = conf.mb * conf.oc * conf.oh * conf.ow;
+    for (dim_t i = 0; i < dst_size; i++) {
+        dst[i] = 0.0f;
+    }
+
+    // Parallelize over tiles
+    parallel(conf.nthr, [&](const int ithr, const int nthr) {
+        dim_t start = 0, end = 0;
+        balance211(conf.mb * total_tiles, nthr, ithr, start, end);
+
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            const dim_t mb_idx = iwork / total_tiles;
+            const dim_t tile_idx = iwork % total_tiles;
+            const dim_t oh_tile = tile_idx / nb_ow;
+            const dim_t ow_tile = tile_idx % nb_ow;
+            const dim_t oh_start = oh_tile * 2;
+            const dim_t ow_start = ow_tile * 2;
+
+            // For each output channel, extract 16 Winograd elements and inverse transform
+            const dim_t vl_max = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+
+            for (dim_t oc_idx = 0; oc_idx < conf.oc; oc_idx++) {
+                float winograd_domain_tile[16];
+
+                for (int elem = 0; elem < 16; elem += vl_max) {
+                    const dim_t vl
+                            = (elem + vl_max <= 16) ? vl_max : (16 - elem);
+                    const float *src_base = winograd_output
+                            + elem * conf.wspec.output_ld_matrix
+                            + mb_idx * conf.wspec.output_ld_batch
+                            + tile_idx * conf.wspec.output_ld_row + oc_idx;
+
+                    for (dim_t i = 0; i < vl; i++) {
+                        winograd_domain_tile[elem + i]
+                                = src_base[i * conf.wspec.output_ld_matrix];
+                    }
+                }
+
+                float output_tile_2x2[4];
+                winograd_output_transform_2x2(
+                        winograd_domain_tile, output_tile_2x2);
+
+                data_t *dst_base = dst + mb_idx * conf.oc * conf.oh * conf.ow
+                        + oc_idx * conf.oh * conf.ow;
+                for (dim_t i = 0; i < 2; i++) {
+                    dim_t oh = oh_start + i;
+                    if (oh >= conf.oh) continue;
+                    dim_t row_start = oh * conf.ow + ow_start;
+                    for (dim_t j = 0; j < 2; j++) {
+                        dim_t ow = ow_start + j;
+                        if (ow >= conf.ow) continue;
+                        dst_base[row_start + j] = output_tile_2x2[i * 2 + j];
+                    }
+                }
+            }
+
+            // Add bias if present (once per tile, for all OC)
+            if (conf.with_bias && bias) {
+                for (dim_t oc_idx = 0; oc_idx < conf.oc; oc_idx++) {
+                    float bias_val = bias[oc_idx];
+                    data_t *dst_base = dst
+                            + mb_idx * conf.oc * conf.oh * conf.ow
+                            + oc_idx * conf.oh * conf.ow;
+
+                    vfloat32m1_t v_bias
+                            = __riscv_vfmv_v_f_f32m1(bias_val, vl_max);
+
+                    for (dim_t i = 0; i < 2; i++) {
+                        dim_t oh = oh_start + i;
+                        if (oh >= conf.oh) continue;
+                        dim_t row_start = oh * conf.ow + ow_start;
+
+                        if (ow_start + 2 <= conf.ow) {
+                            vfloat32m1_t v_data = __riscv_vle32_v_f32m1(
+                                    dst_base + row_start, vl_max);
+                            v_data = __riscv_vfadd_vv_f32m1(
+                                    v_data, v_bias, vl_max);
+                            __riscv_vse32_v_f32m1(
+                                    dst_base + row_start, v_data, vl_max);
+                        } else {
+                            // Scalar fallback for partial row
+                            for (dim_t j = 0; j < 2; j++) {
+                                dim_t ow = ow_start + j;
+                                if (ow >= conf.ow) continue;
+                                dst_base[row_start + j] += bias_val;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    return status::success;
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <vector>
 #include <riscv_vector.h>
 
 #include "common/c_types_map.hpp"
@@ -25,7 +24,6 @@
 #include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
-#include "cpu/gemm/gemm.hpp"
 #include "cpu/platform.hpp"
 #include "cpu/rv64/rvv_winograd_convolution.hpp"
 
@@ -100,26 +98,18 @@ __attribute__((unused)) static void compute_filter_transform_3x3_to_4x4(
 
 // Pre-compute filter transform with GEMM-layout: 3x3 -> 4x4
 // Transform = G * filter * G^T
-// Output layout: [16][ic_rounded][oc_rounded] for BLAS N,N column-major access
-// Column-major interpretation: OC x IC matrix with ld = oc_rounded
-// Pads with zeros for non-multiple-of-n dimensions
+// Output layout: [16][ic_rounded][oc_rounded] for brgemm col-major access
+// Computes directly without intermediate allocation.
 void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
         float *transformed, int oc, int ic, int ic_rounded, int oc_rounded) {
 
-    for (size_t i = 0; i < static_cast<size_t>(16 * ic_rounded * oc_rounded);
-            i++) {
-        transformed[i] = 0.0f;
-    }
+    std::memset(transformed, 0, 16 * ic_rounded * oc_rounded * sizeof(float));
 
-    float *temp_std = static_cast<float *>(
-            impl::malloc(oc * ic * 16 * sizeof(float), 64));
-
-    // Step 1: Compute Winograd transform into standard [oc][ic][16] layout
     for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
         for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
             const float *f = &filter[(oc_idx * ic + ic_idx) * 9];
-            float *out = &temp_std[(oc_idx * ic + ic_idx) * 16];
 
+            // Step 1: temp = G * filter (4x3)
             float temp[4][3];
             for (int i = 0; i < 4; i++) {
                 for (int j = 0; j < 3; j++) {
@@ -131,31 +121,22 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
                 }
             }
 
+            // Step 2: result = temp * G^T, store directly to GEMM layout
+            // Layout: [elem][ic_idx * oc_rounded + oc_idx]
             for (int i = 0; i < 4; i++) {
                 for (int j = 0; j < 4; j++) {
                     float sum = 0.0f;
                     for (int k = 0; k < 3; k++) {
                         sum += temp[i][k] * G[j][k];
                     }
-                    out[i * 4 + j] = sum;
+                    int elem = i * 4 + j;
+                    transformed[elem * oc_rounded * ic_rounded
+                            + ic_idx * oc_rounded + oc_idx]
+                            = sum;
                 }
             }
         }
     }
-
-    // Step 2: Rearrange to [elem][ic][oc] row-major layout
-    // Column-major: OC x IC with ld = oc_rounded (for BLAS N,N path)
-    for (int elem = 0; elem < 16; elem++) {
-        for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
-            for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
-                transformed[elem * oc_rounded * ic_rounded + ic_idx * oc_rounded
-                        + oc_idx]
-                        = temp_std[oc_idx * ic * 16 + ic_idx * 16 + elem];
-            }
-        }
-    }
-
-    impl::free(temp_std);
 }
 
 // RVV-optimized Winograd input transform: d = B^T * input_tile * B (4x4 -> 4x4)
@@ -247,7 +228,7 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
         memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,
         const memory_desc_t &src_md, const memory_desc_t &weights_md,
         const memory_desc_t &dst_md, const memory_desc_t &bias_md,
-        const primitive_attr_t &attr, int max_threads) {
+        const primitive_attr_t &attr) {
     using namespace prop_kind;
 
     const memory_desc_wrapper src_d(&src_md);
@@ -279,8 +260,6 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
 
     conf.with_bias = cd.bias_desc.data_type != data_type::undef;
 
-    conf.nthr = max_threads;
-
     // Compute Winograd domain specification for GEMM-based execution
     constexpr dim_t CACHE_LINE_SIZE = platform::get_cache_line_size();
     constexpr dim_t CACHE_LINE_FLOATS = CACHE_LINE_SIZE / sizeof(float); // 16
@@ -305,37 +284,29 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
             = conf.wspec.weight_oc_rounded * conf.wspec.weight_ic_rounded;
 
     // Input matrix: A[K][M] column-major where K=IC, M=tiles
-    // A[k][m] stored as A[m * lda + k] where lda = round_up(K, CACHE_LINE_FLOATS)
+    // Input buffer per thread: [16][tile_chunk × IC_rounded] per element
     conf.wspec.input_ld_row
-            = round_up(conf.wspec.K, CACHE_LINE_FLOATS); // lda = K rounded
+            = round_up(conf.wspec.K, CACHE_LINE_FLOATS); // LDB = IC_rounded
     conf.wspec.input_ld_batch
-            = conf.wspec.input_ld_row * conf.wspec.M; // M columns per batch
-    conf.wspec.input_ld_matrix
-            = conf.wspec.input_ld_batch * conf.wspec.n_batches;
+            = conf.wspec.input_ld_row * conf.wspec.M; // per-elem stride
 
-    // Output matrix: C^T[M][N] row-major where M=tiles, N=OC
-    // GEMM computes C^T where C^T[m][n] = C[n][m]
-    // C^T[m][n] stored as C^T[m * N + n]
-    conf.wspec.output_ld_row = conf.wspec.N; // N columns per row of C^T
+    // Output buffer per thread: [16][tiles x OC] per element
+    conf.wspec.output_ld_row = conf.wspec.N; // LDC = OC
     conf.wspec.output_ld_batch
-            = conf.wspec.output_ld_row * conf.wspec.M; // M rows per batch
-    conf.wspec.output_ld_matrix
-            = conf.wspec.output_ld_batch * conf.wspec.n_batches;
+            = conf.wspec.output_ld_row * conf.wspec.M; // per-elem stride
 
-    // Matrix sizes in floats
+    // Buffer sizes in floats
     conf.wspec.weight_matrix_size
             = conf.wspec.n_gemms * conf.wspec.weight_ld_matrix;
-    conf.wspec.input_matrix_size
-            = conf.wspec.n_gemms * conf.wspec.input_ld_matrix;
-    conf.wspec.output_matrix_size
-            = conf.wspec.n_gemms * conf.wspec.output_ld_matrix;
+    conf.wspec.V_buffer_size = conf.wspec.n_gemms * conf.wspec.input_ld_batch;
+    conf.wspec.M_buffer_size = conf.wspec.n_gemms * conf.wspec.output_ld_batch;
 
-    // GEMM-layout scratchpad allocation
+    // Scratchpad: V and M buffers for single-thread execution
+    // Weight buffer is in persistent resource_t (not scratchpad)
     using namespace memory_tracking::names;
 
-    scratchpad.book<float>(key_wino_U, conf.wspec.weight_matrix_size);
-    scratchpad.book<float>(key_wino_V, conf.wspec.input_matrix_size);
-    scratchpad.book<float>(key_wino_M, conf.wspec.output_matrix_size);
+    scratchpad.book<float>(key_wino_V, conf.wspec.V_buffer_size);
+    scratchpad.book<float>(key_wino_M, conf.wspec.M_buffer_size);
 
     return status::success;
 }
@@ -350,236 +321,116 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
 
     const auto &conf = pd()->conf_;
     const auto scratchpad = ctx.get_scratchpad_grantor();
+    const auto *brg_kernel = pd()->brg_kernel_.get();
+
+    // Get persistent weight buffer from resource (cached across execute calls)
+    auto *wino_resource
+            = ctx.get_resource_mapper()->get<rvv_wino_resource_t>(this);
+    float *transformed_weights = wino_resource->get_weight_buffer();
+
+    // Transform weights on first execute, cache for subsequent calls
+    if (!wino_resource->weights_valid()) {
+        compute_filter_transform_3x3_to_4x4_gemm_layout(weights,
+                transformed_weights, conf.wspec.N, conf.wspec.K,
+                conf.wspec.weight_ic_rounded, conf.wspec.weight_oc_rounded);
+        wino_resource->set_weights_valid();
+    }
 
     using namespace memory_tracking::names;
-    float *transformed_weights = scratchpad.template get<float>(key_wino_U);
-    float *transformed_input = scratchpad.template get<float>(key_wino_V);
-    float *winograd_output = scratchpad.template get<float>(key_wino_M);
+    float *V = scratchpad.template get<float>(key_wino_V);
+    float *M = scratchpad.template get<float>(key_wino_M);
 
-    // Phase 1: Weight transform
-    compute_filter_transform_3x3_to_4x4_gemm_layout(weights,
-            transformed_weights, conf.wspec.N, conf.wspec.K,
-            conf.wspec.weight_ic_rounded, conf.wspec.weight_oc_rounded);
-
-    // Phase 2: Input transform
-    CHECK(execute_input_transform(src, transformed_input));
-
-    // Phase 3: Batched GEMM (16 independent matrix multiplications)
-    CHECK(execute_gemm_batched(
-            transformed_input, transformed_weights, winograd_output));
-
-    // Phase 4: Output transform
-    CHECK(execute_output_transform(winograd_output, bias, dst));
-
-    return status::success;
-}
-
-status_t rvv_wino_convolution_fwd_t::execute_input_transform(
-        const data_t *src, float *transformed_input) const {
-
-    const auto &conf = pd()->conf_;
+    // Sequential batch processing: input transform → GEMM → output transform
+    // per batch, keeping working set in L2 cache.
     const dim_t nb_oh = (conf.oh + 1) / 2;
     const dim_t nb_ow = (conf.ow + 1) / 2;
     const dim_t total_tiles = nb_oh * nb_ow;
+    const dim_t input_ld_row = conf.wspec.input_ld_row;
+    const dim_t V_elem_stride = conf.wspec.input_ld_batch;
+    const dim_t M_elem_stride = conf.wspec.output_ld_batch;
 
-    // Parallelize over tiles
-    parallel(conf.nthr, [&](const int ithr, const int nthr) {
-        dim_t start = 0, end = 0;
-        balance211(conf.mb * total_tiles, nthr, ithr, start, end);
+    for (dim_t mb_idx = 0; mb_idx < conf.mb; mb_idx++) {
+        const float *src_batch = src + mb_idx * conf.ic * conf.ih * conf.iw;
 
-        for (dim_t iwork = start; iwork < end; ++iwork) {
-            const dim_t mb_idx = iwork / total_tiles;
-            const dim_t tile_idx = iwork % total_tiles;
+        // Step 1: Input transform for this batch
+        for (dim_t tile_idx = 0; tile_idx < total_tiles; tile_idx++) {
             const dim_t oh_tile = tile_idx / nb_ow;
             const dim_t ow_tile = tile_idx % nb_ow;
-            const dim_t oh_start = oh_tile * 2;
-            const dim_t ow_start = ow_tile * 2;
+            const dim_t oh_s = oh_tile * 2;
+            const dim_t ow_s = ow_tile * 2;
 
-            const float *src_base = src + mb_idx * conf.ic * conf.ih * conf.iw;
-
-            // Transform each input channel's 4x4 tile
-            // Output layout: transformed_input[elem][batch][k][m]
             for (dim_t ic_idx = 0; ic_idx < conf.ic; ic_idx++) {
                 float input_tile[16];
                 for (dim_t i = 0; i < 4; i++) {
-                    dim_t ih_idx = oh_start + i - conf.pad_t;
+                    dim_t ih_idx = oh_s + i - conf.pad_t;
                     for (dim_t j = 0; j < 4; j++) {
-                        dim_t iw_idx = ow_start + j - conf.pad_l;
+                        dim_t iw_idx = ow_s + j - conf.pad_l;
                         if (ih_idx >= 0 && ih_idx < conf.ih && iw_idx >= 0
                                 && iw_idx < conf.iw) {
-                            size_t offset = ic_idx * conf.ih * conf.iw
-                                    + ih_idx * conf.iw + iw_idx;
-                            input_tile[i * 4 + j] = src_base[offset];
+                            input_tile[i * 4 + j]
+                                    = src_batch[ic_idx * conf.ih * conf.iw
+                                            + ih_idx * conf.iw + iw_idx];
                         } else {
                             input_tile[i * 4 + j] = 0.0f;
                         }
                     }
                 }
 
-                // Winograd transform this 4x4 tile
                 float transformed[16];
                 winograd_input_transform_4x4(input_tile, transformed);
 
-                // Store in GEMM layout: transformed_input[elem][batch][m][k]
-                // where m=tile_idx, k=ic_idx
-                const dim_t vl_max
-                        = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
-                for (int elem = 0; elem < 16; elem += vl_max) {
-                    const dim_t vl
-                            = (elem + vl_max <= 16) ? vl_max : (16 - elem);
-
-                    float *dst_base = transformed_input
-                            + elem * conf.wspec.input_ld_matrix
-                            + mb_idx * conf.wspec.input_ld_batch
-                            + tile_idx * conf.wspec.input_ld_row + ic_idx;
-
-                    // Scatter: source is contiguous but dest is strided
-                    // Use scalar loop since scatter cannot be vectorized
-                    for (dim_t i = 0; i < vl; i++) {
-                        dst_base[i * conf.wspec.input_ld_matrix]
-                                = transformed[elem + i];
-                    }
+                for (int elem = 0; elem < 16; elem++) {
+                    V[elem * V_elem_stride + tile_idx * input_ld_row + ic_idx]
+                            = transformed[elem];
                 }
             }
         }
-    });
 
-    return status::success;
-}
-
-status_t rvv_wino_convolution_fwd_t::execute_gemm_batched(
-        const float *transformed_input, const float *transformed_weights,
-        float *winograd_output) const {
-
-    const auto &conf = pd()->conf_;
-
-    // Combine all batches into one large GEMM per Winograd element.
-    // BLAS column-major: C = A * B (transa='N', transb='N')
-    //   A = weights: OC×IC col-major with lda = oc_rounded
-    //   B = input:   IC×M_total col-major with ldb = ic_rounded
-    //   C = output:  OC×M_total col-major with ldc = OC
-    const dim_t M_total = conf.wspec.M * conf.mb;
-    const dim_t K = conf.wspec.K;
-    const dim_t N = conf.wspec.N;
-    const float alpha = 1.0f;
-    const float beta = 0.0f;
-    const dim_t lda = conf.wspec.weight_ld_row;
-    const dim_t ldb = conf.wspec.input_ld_row;
-    const dim_t ldc = N;
-
-    // Tile-partitioned parallelism: partition the tile dimension (M_total)
-    // across threads. Each thread processes ALL 16 Winograd elements for its
-    // tile chunk. This gives:
-    // 1. Single parallel region (vs 16 separate multi-threaded GEMM calls
-    //    with 16× barrier overhead)
-    // 2. Weight matrix (A) reused across all 16 elements → stays in cache
-    // 3. No cross-thread contention on output buffers
-    // 4. Good scaling for both small and large GEMM sizes
-    status_t st = status::success;
-    parallel(conf.nthr, [&](const int ithr, const int nthr) {
-        dim_t n_start = 0, n_end = 0;
-        balance211(M_total, nthr, ithr, n_start, n_end);
-        const dim_t my_n = n_end - n_start;
-        if (my_n <= 0) return;
-
+        // Step 2: GEMM using brgemm kernel (16 elements)
         for (int elem = 0; elem < 16; elem++) {
             const float *A_weights
                     = transformed_weights + elem * conf.wspec.weight_ld_matrix;
-            const float *B_input = transformed_input
-                    + elem * conf.wspec.input_ld_matrix + n_start * ldb;
-            float *C_output = winograd_output
-                    + elem * conf.wspec.output_ld_matrix + n_start * ldc;
+            const float *B_input = V + elem * V_elem_stride;
+            float *C_output = M + elem * M_elem_stride;
 
-            auto ret = extended_sgemm("N", "N", &N, &my_n, &K, &alpha,
-                    A_weights, &lda, B_input, &ldb, &beta, C_output, &ldc);
-            if (ret != status::success) st = ret;
+            brgemm_kernel_execute(brg_kernel, A_weights, B_input, C_output,
+                    total_tiles, 0.0f);
         }
-    });
 
-    return st;
-}
-
-status_t rvv_wino_convolution_fwd_t::execute_output_transform(
-        const float *winograd_output, const data_t *bias, data_t *dst) const {
-
-    const auto &conf = pd()->conf_;
-    const dim_t nb_oh = (conf.oh + 1) / 2;
-    const dim_t nb_ow = (conf.ow + 1) / 2;
-    const dim_t total_tiles = nb_oh * nb_ow;
-
-    // Each output pixel is written exactly once by its owning tile,
-    // so no zero-initialization is needed.
-
-    // Parallelize over tiles
-    parallel(conf.nthr, [&](const int ithr, const int nthr) {
-        dim_t start = 0, end = 0;
-        balance211(conf.mb * total_tiles, nthr, ithr, start, end);
-
-        for (dim_t iwork = start; iwork < end; ++iwork) {
-            const dim_t mb_idx = iwork / total_tiles;
-            const dim_t tile_idx = iwork % total_tiles;
+        // Step 3: Output transform for this batch
+        data_t *dst_batch = dst + mb_idx * conf.oc * conf.oh * conf.ow;
+        for (dim_t tile_idx = 0; tile_idx < total_tiles; tile_idx++) {
             const dim_t oh_tile = tile_idx / nb_ow;
             const dim_t ow_tile = tile_idx % nb_ow;
-            const dim_t oh_start = oh_tile * 2;
-            const dim_t ow_start = ow_tile * 2;
-
-            // For each output channel, extract 16 Winograd elements and inverse transform
-            const dim_t vl_max = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+            const dim_t oh_s = oh_tile * 2;
+            const dim_t ow_s = ow_tile * 2;
 
             for (dim_t oc_idx = 0; oc_idx < conf.oc; oc_idx++) {
-                float winograd_domain_tile[16];
-
-                for (int elem = 0; elem < 16; elem += vl_max) {
-                    const dim_t vl
-                            = (elem + vl_max <= 16) ? vl_max : (16 - elem);
-                    const float *src_base = winograd_output
-                            + elem * conf.wspec.output_ld_matrix
-                            + mb_idx * conf.wspec.output_ld_batch
-                            + tile_idx * conf.wspec.output_ld_row + oc_idx;
-
-                    if (vl == vl_max) {
-                        // Vectorized gather: load to temp buffer, then vector store
-                        float gather_buf[MAX_VL_FLOATS];
-                        for (dim_t i = 0; i < vl; i++) {
-                            gather_buf[i]
-                                    = src_base[i * conf.wspec.output_ld_matrix];
-                        }
-                        vfloat32m1_t v_data
-                                = __riscv_vle32_v_f32m1(gather_buf, vl);
-                        __riscv_vse32_v_f32m1(
-                                winograd_domain_tile + elem, v_data, vl);
-                    } else {
-                        // Scalar fallback for remaining elements
-                        for (dim_t i = 0; i < vl; i++) {
-                            winograd_domain_tile[elem + i]
-                                    = src_base[i * conf.wspec.output_ld_matrix];
-                        }
-                    }
+                float wino_tile[16];
+                for (int elem = 0; elem < 16; elem++) {
+                    wino_tile[elem] = M[elem * M_elem_stride
+                            + tile_idx * conf.wspec.N + oc_idx];
                 }
 
-                float output_tile_2x2[4];
-                winograd_output_transform_2x2(
-                        winograd_domain_tile, output_tile_2x2);
+                float output_2x2[4];
+                winograd_output_transform_2x2(wino_tile, output_2x2);
 
-                // Write output tile with optional bias fusion
                 const float bias_val
                         = (conf.with_bias && bias) ? bias[oc_idx] : 0.0f;
-                data_t *dst_base = dst + mb_idx * conf.oc * conf.oh * conf.ow
-                        + oc_idx * conf.oh * conf.ow;
                 for (dim_t i = 0; i < 2; i++) {
-                    dim_t oh = oh_start + i;
+                    dim_t oh = oh_s + i;
                     if (oh >= conf.oh) continue;
-                    dim_t row_start = oh * conf.ow + ow_start;
                     for (dim_t j = 0; j < 2; j++) {
-                        dim_t ow = ow_start + j;
+                        dim_t ow = ow_s + j;
                         if (ow >= conf.ow) continue;
-                        dst_base[row_start + j]
-                                = output_tile_2x2[i * 2 + j] + bias_val;
+                        dst_batch[oc_idx * conf.oh * conf.ow + oh * conf.ow
+                                + ow]
+                                = output_2x2[i * 2 + j] + bias_val;
                     }
                 }
             }
         }
-    });
+    }
 
     return status::success;
 }

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -25,6 +25,7 @@
 #include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
+#include "cpu/gemm/gemm.hpp"
 #include "cpu/platform.hpp"
 #include "cpu/rv64/rvv_winograd_convolution.hpp"
 
@@ -99,8 +100,9 @@ __attribute__((unused)) static void compute_filter_transform_3x3_to_4x4(
 
 // Pre-compute filter transform with GEMM-layout: 3x3 -> 4x4
 // Transform = G * filter * G^T
-// Output layout: [16][ic_rounded][oc_rounded] for efficient aligned memory access
-// Pads with zeros for non-multiple-of-4 dimensions
+// Output layout: [16][ic_rounded][oc_rounded] for BLAS N,N column-major access
+// Column-major interpretation: OC x IC matrix with ld = oc_rounded
+// Pads with zeros for non-multiple-of-n dimensions
 void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
         float *transformed, int oc, int ic, int ic_rounded, int oc_rounded) {
 
@@ -109,7 +111,8 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
         transformed[i] = 0.0f;
     }
 
-    float *temp_std = new float[oc * ic * 16];
+    float *temp_std = static_cast<float *>(
+            impl::malloc(oc * ic * 16 * sizeof(float), 64));
 
     // Step 1: Compute Winograd transform into standard [oc][ic][16] layout
     for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
@@ -140,19 +143,19 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
         }
     }
 
-    // B[oc_idx * ldb + ic_idx] where ldb = number of columns = ic_rounded
+    // Step 2: Rearrange to [elem][ic][oc] row-major layout
+    // Column-major: OC x IC with ld = oc_rounded (for BLAS N,N path)
     for (int elem = 0; elem < 16; elem++) {
-        for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
-            for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
-                // Store as [elem][oc][ic] row-major: B[oc_idx][ic_idx]
-                transformed[elem * oc_rounded * ic_rounded + oc_idx * ic_rounded
-                        + ic_idx]
+        for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
+            for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
+                transformed[elem * oc_rounded * ic_rounded + ic_idx * oc_rounded
+                        + oc_idx]
                         = temp_std[oc_idx * ic * 16 + ic_idx * 16 + elem];
             }
         }
     }
 
-    delete[] temp_std;
+    impl::free(temp_std);
 }
 
 // RVV-optimized Winograd input transform: d = B^T * input_tile * B (4x4 -> 4x4)
@@ -295,9 +298,9 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
     conf.wspec.weight_oc_rounded = round_up(conf.wspec.N, CACHE_LINE_FLOATS);
     conf.wspec.weight_ic_rounded = round_up(conf.wspec.K, CACHE_LINE_FLOATS);
 
-    // weight_ld_row is the leading dimension (stride) for B[N][K] row-major
-    // B[oc_idx][ic_idx] = B[oc_idx * ldb + ic_idx], so ldb = number of columns = ic_rounded
-    conf.wspec.weight_ld_row = conf.wspec.weight_ic_rounded;
+    // weight_ld_row is the leading dimension for column-major OC x IC matrix
+    // A[oc_idx + ic_idx * lda], so lda = oc_rounded
+    conf.wspec.weight_ld_row = conf.wspec.weight_oc_rounded;
     conf.wspec.weight_ld_matrix
             = conf.wspec.weight_oc_rounded * conf.wspec.weight_ic_rounded;
 
@@ -450,92 +453,50 @@ status_t rvv_wino_convolution_fwd_t::execute_gemm_batched(
 
     const auto &conf = pd()->conf_;
 
-    // Execute 16 GEMMs in parallel (each Winograd element is independent)
-    const int n_gemms_threads
-            = static_cast<int>(std::min(static_cast<dim_t>(16), conf.nthr));
+    // Combine all batches into one large GEMM per Winograd element.
+    // BLAS column-major: C = A * B (transa='N', transb='N')
+    //   A = weights: OC×IC col-major with lda = oc_rounded
+    //   B = input:   IC×M_total col-major with ldb = ic_rounded
+    //   C = output:  OC×M_total col-major with ldc = OC
+    const dim_t M_total = conf.wspec.M * conf.mb;
+    const dim_t K = conf.wspec.K;
+    const dim_t N = conf.wspec.N;
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    const dim_t lda = conf.wspec.weight_ld_row;
+    const dim_t ldb = conf.wspec.input_ld_row;
+    const dim_t ldc = N;
 
-    parallel(n_gemms_threads, [&](const int ithr, const int nthr) {
-        for (int elem = ithr; elem < 16; elem += nthr) {
-            for (dim_t batch = 0; batch < conf.mb; batch++) {
-                const float *A = transformed_input
-                        + elem * conf.wspec.input_ld_matrix
-                        + batch * conf.wspec.input_ld_batch;
-                const dim_t lda = conf.wspec.input_ld_row;
+    // Tile-partitioned parallelism: partition the tile dimension (M_total)
+    // across threads. Each thread processes ALL 16 Winograd elements for its
+    // tile chunk. This gives:
+    // 1. Single parallel region (vs 16 separate multi-threaded GEMM calls
+    //    with 16× barrier overhead)
+    // 2. Weight matrix (A) reused across all 16 elements → stays in cache
+    // 3. No cross-thread contention on output buffers
+    // 4. Good scaling for both small and large GEMM sizes
+    status_t st = status::success;
+    parallel(conf.nthr, [&](const int ithr, const int nthr) {
+        dim_t n_start = 0, n_end = 0;
+        balance211(M_total, nthr, ithr, n_start, n_end);
+        const dim_t my_n = n_end - n_start;
+        if (my_n <= 0) return;
 
-                const float *B = transformed_weights
-                        + elem * conf.wspec.weight_ld_matrix;
-                const dim_t ldb = conf.wspec.weight_ld_row;
+        for (int elem = 0; elem < 16; elem++) {
+            const float *A_weights
+                    = transformed_weights + elem * conf.wspec.weight_ld_matrix;
+            const float *B_input = transformed_input
+                    + elem * conf.wspec.input_ld_matrix + n_start * ldb;
+            float *C_output = winograd_output
+                    + elem * conf.wspec.output_ld_matrix + n_start * ldc;
 
-                float *C = winograd_output + elem * conf.wspec.output_ld_matrix
-                        + batch * conf.wspec.output_ld_batch;
-
-                // RVV GEMM: C^T[M×N] where C^T[m][n] = sum_k A[m][k] * B[n][k]
-                const dim_t M = conf.wspec.M;
-                const dim_t N = conf.wspec.N;
-                const dim_t K = conf.wspec.K;
-                const dim_t vl_max
-                        = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
-
-                // Initialize C to zero
-                for (dim_t m = 0; m < M; m++) {
-                    float *C_row = C + m * N;
-                    for (dim_t n = 0; n < N; n++) {
-                        C_row[n] = 0.0f;
-                    }
-                }
-
-                // RVV vectorized GEMM: for each m, compute all n in parallel
-                for (dim_t m = 0; m < M; m++) {
-                    const float *A_row = A + m * lda;
-                    float *C_row = C + m * N;
-
-                    dim_t n_vec_base = 0;
-                    for (; n_vec_base + vl_max <= N; n_vec_base += vl_max) {
-                        vfloat32m1_t vacc
-                                = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
-
-                        for (dim_t k = 0; k < K; k++) {
-                            float a_scalar = A_row[k];
-                            float B_local[MAX_VL_FLOATS];
-                            for (dim_t i = 0; i < vl_max; i++) {
-                                B_local[i] = B[(n_vec_base + i) * ldb + k];
-                            }
-                            vfloat32m1_t vb
-                                    = __riscv_vle32_v_f32m1(B_local, vl_max);
-                            vacc = __riscv_vfmacc_vf_f32m1(
-                                    vacc, a_scalar, vb, vl_max);
-                        }
-
-                        __riscv_vse32_v_f32m1(C_row + n_vec_base, vacc, vl_max);
-                    }
-
-                    // Handle remaining channels
-                    if (n_vec_base < N) {
-                        const dim_t n_remain = N - n_vec_base;
-                        vfloat32m1_t vacc
-                                = __riscv_vfmv_v_f_f32m1(0.0f, n_remain);
-
-                        for (dim_t k = 0; k < K; k++) {
-                            float a_scalar = A_row[k];
-                            float B_local[MAX_VL_FLOATS];
-                            for (dim_t i = 0; i < n_remain; i++) {
-                                B_local[i] = B[(n_vec_base + i) * ldb + k];
-                            }
-                            vfloat32m1_t vb
-                                    = __riscv_vle32_v_f32m1(B_local, n_remain);
-                            vacc = __riscv_vfmacc_vf_f32m1(
-                                    vacc, a_scalar, vb, n_remain);
-                        }
-
-                        __riscv_vse32_v_f32m1(
-                                C_row + n_vec_base, vacc, n_remain);
-                    }
-                }
-            }
+            auto ret = extended_sgemm("N", "N", &N, &my_n, &K, &alpha,
+                    A_weights, &lda, B_input, &ldb, &beta, C_output, &ldc);
+            if (ret != status::success) st = ret;
         }
     });
 
-    return status::success;
+    return st;
 }
 
 status_t rvv_wino_convolution_fwd_t::execute_output_transform(
@@ -546,11 +507,8 @@ status_t rvv_wino_convolution_fwd_t::execute_output_transform(
     const dim_t nb_ow = (conf.ow + 1) / 2;
     const dim_t total_tiles = nb_oh * nb_ow;
 
-    // Zero initialize dst
-    const dim_t dst_size = conf.mb * conf.oc * conf.oh * conf.ow;
-    for (dim_t i = 0; i < dst_size; i++) {
-        dst[i] = 0.0f;
-    }
+    // Each output pixel is written exactly once by its owning tile,
+    // so no zero-initialization is needed.
 
     // Parallelize over tiles
     parallel(conf.nthr, [&](const int ithr, const int nthr) {
@@ -603,6 +561,9 @@ status_t rvv_wino_convolution_fwd_t::execute_output_transform(
                 winograd_output_transform_2x2(
                         winograd_domain_tile, output_tile_2x2);
 
+                // Write output tile with optional bias fusion
+                const float bias_val
+                        = (conf.with_bias && bias) ? bias[oc_idx] : 0.0f;
                 data_t *dst_base = dst + mb_idx * conf.oc * conf.oh * conf.ow
                         + oc_idx * conf.oh * conf.ow;
                 for (dim_t i = 0; i < 2; i++) {
@@ -612,42 +573,8 @@ status_t rvv_wino_convolution_fwd_t::execute_output_transform(
                     for (dim_t j = 0; j < 2; j++) {
                         dim_t ow = ow_start + j;
                         if (ow >= conf.ow) continue;
-                        dst_base[row_start + j] = output_tile_2x2[i * 2 + j];
-                    }
-                }
-            }
-
-            // Add bias if present (once per tile, for all OC)
-            if (conf.with_bias && bias) {
-                for (dim_t oc_idx = 0; oc_idx < conf.oc; oc_idx++) {
-                    float bias_val = bias[oc_idx];
-                    data_t *dst_base = dst
-                            + mb_idx * conf.oc * conf.oh * conf.ow
-                            + oc_idx * conf.oh * conf.ow;
-
-                    vfloat32m1_t v_bias
-                            = __riscv_vfmv_v_f_f32m1(bias_val, vl_max);
-
-                    for (dim_t i = 0; i < 2; i++) {
-                        dim_t oh = oh_start + i;
-                        if (oh >= conf.oh) continue;
-                        dim_t row_start = oh * conf.ow + ow_start;
-
-                        if (ow_start + 2 <= conf.ow) {
-                            vfloat32m1_t v_data = __riscv_vle32_v_f32m1(
-                                    dst_base + row_start, vl_max);
-                            v_data = __riscv_vfadd_vv_f32m1(
-                                    v_data, v_bias, vl_max);
-                            __riscv_vse32_v_f32m1(
-                                    dst_base + row_start, v_data, vl_max);
-                        } else {
-                            // Scalar fallback for partial row
-                            for (dim_t j = 0; j < 2; j++) {
-                                dim_t ow = ow_start + j;
-                                if (ow >= conf.ow) continue;
-                                dst_base[row_start + j] += bias_val;
-                            }
-                        }
+                        dst_base[row_start + j]
+                                = output_tile_2x2[i * 2 + j] + bias_val;
                     }
                 }
             }

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -158,21 +158,19 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
 // RVV-optimized Winograd input transform: d = B^T * input_tile * B (4x4 -> 4x4)
 inline void winograd_input_transform_4x4(
         const float *input_tile, float *output_tile) {
-    const dim_t vl_max = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+    constexpr dim_t vl = 4; // Fixed size for 4x4 matrix operations
     float temp[16];
 
     // Step 1: input_tile * B
     for (int i = 0; i < 4; i++) {
-        vfloat32m1_t v_in_row
-                = __riscv_vle32_v_f32m1(input_tile + i * 4, vl_max);
+        vfloat32m1_t v_in_row = __riscv_vle32_v_f32m1(input_tile + i * 4, vl);
         for (int j = 0; j < 4; j++) {
             float B_col[4] = {B[0][j], B[1][j], B[2][j], B[3][j]};
-            vfloat32m1_t v_b_col = __riscv_vle32_v_f32m1(B_col, vl_max);
-            vfloat32m1_t v_prod
-                    = __riscv_vfmul_vv_f32m1(v_in_row, v_b_col, vl_max);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+            vfloat32m1_t v_b_col = __riscv_vle32_v_f32m1(B_col, vl);
+            vfloat32m1_t v_prod = __riscv_vfmul_vv_f32m1(v_in_row, v_b_col, vl);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
             vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
             temp[i * 4 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
         }
     }
@@ -180,16 +178,16 @@ inline void winograd_input_transform_4x4(
     // Step 2: B^T * temp
     for (int i = 0; i < 4; i++) {
         float BT_row[4] = {BT[i][0], BT[i][1], BT[i][2], BT[i][3]};
-        vfloat32m1_t v_bt_row = __riscv_vle32_v_f32m1(BT_row, vl_max);
+        vfloat32m1_t v_bt_row = __riscv_vle32_v_f32m1(BT_row, vl);
         for (int j = 0; j < 4; j++) {
             float temp_col[4] = {temp[0 * 4 + j], temp[1 * 4 + j],
                     temp[2 * 4 + j], temp[3 * 4 + j]};
-            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl_max);
+            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl);
             vfloat32m1_t v_prod
-                    = __riscv_vfmul_vv_f32m1(v_bt_row, v_temp_col, vl_max);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+                    = __riscv_vfmul_vv_f32m1(v_bt_row, v_temp_col, vl);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
             vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
             output_tile[i * 4 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
         }
     }
@@ -198,21 +196,21 @@ inline void winograd_input_transform_4x4(
 // RVV-optimized Winograd output transform: m = A^T * winograd_domain * A (4x4 -> 2x2)
 inline void winograd_output_transform_2x2(
         const float *winograd_domain, float *output_tile) {
-    const dim_t vl_max = static_cast<dim_t>(__riscv_vsetvlmax_e32m1());
+    constexpr dim_t vl = 4; // Fixed size for 4-element matrix operations
     float temp[8];
 
     // Step 1: winograd_domain * A
     for (int i = 0; i < 4; i++) {
         vfloat32m1_t v_wino_row
-                = __riscv_vle32_v_f32m1(winograd_domain + i * 4, vl_max);
+                = __riscv_vle32_v_f32m1(winograd_domain + i * 4, vl);
         for (int j = 0; j < 2; j++) {
             float A_col[4] = {A[0][j], A[1][j], A[2][j], A[3][j]};
-            vfloat32m1_t v_a_col = __riscv_vle32_v_f32m1(A_col, vl_max);
+            vfloat32m1_t v_a_col = __riscv_vle32_v_f32m1(A_col, vl);
             vfloat32m1_t v_prod
-                    = __riscv_vfmul_vv_f32m1(v_wino_row, v_a_col, vl_max);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+                    = __riscv_vfmul_vv_f32m1(v_wino_row, v_a_col, vl);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
             vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
             temp[i * 2 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
         }
     }
@@ -220,16 +218,16 @@ inline void winograd_output_transform_2x2(
     // Step 2: A^T * temp
     for (int i = 0; i < 2; i++) {
         float AT_row[4] = {AT[i][0], AT[i][1], AT[i][2], AT[i][3]};
-        vfloat32m1_t v_at_row = __riscv_vle32_v_f32m1(AT_row, vl_max);
+        vfloat32m1_t v_at_row = __riscv_vle32_v_f32m1(AT_row, vl);
         for (int j = 0; j < 2; j++) {
             float temp_col[4] = {temp[0 * 2 + j], temp[1 * 2 + j],
                     temp[2 * 2 + j], temp[3 * 2 + j]};
-            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl_max);
+            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl);
             vfloat32m1_t v_prod
-                    = __riscv_vfmul_vv_f32m1(v_at_row, v_temp_col, vl_max);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl_max);
+                    = __riscv_vfmul_vv_f32m1(v_at_row, v_temp_col, vl);
+            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
             vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl_max);
+                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
             output_tile[i * 2 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
         }
     }
@@ -432,6 +430,8 @@ status_t rvv_wino_convolution_fwd_t::execute_input_transform(
                             + mb_idx * conf.wspec.input_ld_batch
                             + tile_idx * conf.wspec.input_ld_row + ic_idx;
 
+                    // Scatter: source is contiguous but dest is strided
+                    // Use scalar loop since scatter cannot be vectorized
                     for (dim_t i = 0; i < vl; i++) {
                         dst_base[i * conf.wspec.input_ld_matrix]
                                 = transformed[elem + i];
@@ -517,7 +517,7 @@ status_t rvv_wino_convolution_fwd_t::execute_gemm_batched(
 
                         for (dim_t k = 0; k < K; k++) {
                             float a_scalar = A_row[k];
-                            float B_local[16];
+                            float B_local[MAX_VL_FLOATS];
                             for (dim_t i = 0; i < n_remain; i++) {
                                 B_local[i] = B[(n_vec_base + i) * ldb + k];
                             }
@@ -579,9 +579,23 @@ status_t rvv_wino_convolution_fwd_t::execute_output_transform(
                             + mb_idx * conf.wspec.output_ld_batch
                             + tile_idx * conf.wspec.output_ld_row + oc_idx;
 
-                    for (dim_t i = 0; i < vl; i++) {
-                        winograd_domain_tile[elem + i]
-                                = src_base[i * conf.wspec.output_ld_matrix];
+                    if (vl == vl_max) {
+                        // Vectorized gather: load to temp buffer, then vector store
+                        float gather_buf[MAX_VL_FLOATS];
+                        for (dim_t i = 0; i < vl; i++) {
+                            gather_buf[i]
+                                    = src_base[i * conf.wspec.output_ld_matrix];
+                        }
+                        vfloat32m1_t v_data
+                                = __riscv_vle32_v_f32m1(gather_buf, vl);
+                        __riscv_vse32_v_f32m1(
+                                winograd_domain_tile + elem, v_data, vl);
+                    } else {
+                        // Scalar fallback for remaining elements
+                        for (dim_t i = 0; i < vl; i++) {
+                            winograd_domain_tile[elem + i]
+                                    = src_base[i * conf.wspec.output_ld_matrix];
+                        }
                     }
                 }
 

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -14,14 +14,11 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <algorithm>
 #include <cstring>
 #include <riscv_vector.h>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
-#include "common/nstl.hpp"
-#include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 #include "cpu/platform.hpp"
 #include "cpu/rv64/rvv_winograd_convolution.hpp"
@@ -42,17 +39,9 @@ namespace {
 constexpr float BT[4][4] = {{1.0f, 0.0f, -1.0f, 0.0f}, {0.0f, 1.0f, 1.0f, 0.0f},
         {0.0f, -1.0f, 1.0f, 0.0f}, {0.0f, -1.0f, 0.0f, 1.0f}};
 
-// B matrix (transpose of B^T)
-constexpr float B[4][4] = {{1.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, -1.0f, -1.0f},
-        {-1.0f, 1.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 1.0f}};
-
 // Output transform matrix A^T (2x4)
 constexpr float AT[2][4]
         = {{1.0f, 1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, -1.0f, 1.0f}};
-
-// A matrix (transpose of A^T, which is 4x2)
-constexpr float A[4][2]
-        = {{1.0f, 0.0f}, {1.0f, 1.0f}, {1.0f, -1.0f}, {0.0f, 1.0f}};
 
 // Filter transform matrix G (4x3)
 constexpr float G[4][3] = {{1.0f, 0.0f, 0.0f}, {0.5f, 0.5f, 0.5f},
@@ -102,11 +91,6 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
 }
 
 } // namespace
-
-// Helper: round up to multiple of n (for alignment)
-static inline dim_t round_up(dim_t x, dim_t n) {
-    return ((x + n - 1) / n) * n;
-}
 
 status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
         memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,
@@ -158,8 +142,8 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
     // 64-byte aligned leading dimensions (for efficient vectorization)
     // Weight matrix: B[N][K] where N=OC, K=IC (row-major for GEMM)
     // For weight transform, we need separate rounded dimensions
-    conf.wspec.weight_oc_rounded = round_up(conf.wspec.N, CACHE_LINE_FLOATS);
-    conf.wspec.weight_ic_rounded = round_up(conf.wspec.K, CACHE_LINE_FLOATS);
+    conf.wspec.weight_oc_rounded = rnd_up(conf.wspec.N, CACHE_LINE_FLOATS);
+    conf.wspec.weight_ic_rounded = rnd_up(conf.wspec.K, CACHE_LINE_FLOATS);
 
     // weight_ld_row is the leading dimension for column-major OC x IC matrix
     // A[oc_idx + ic_idx * lda], so lda = oc_rounded
@@ -170,7 +154,7 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
     // Input matrix: A[K][M] column-major where K=IC, M=tiles
     // Input buffer per thread: [16][tile_chunk × IC_rounded] per element
     conf.wspec.input_ld_row
-            = round_up(conf.wspec.K, CACHE_LINE_FLOATS); // LDB = IC_rounded
+            = rnd_up(conf.wspec.K, CACHE_LINE_FLOATS); // LDB = IC_rounded
     conf.wspec.input_ld_batch
             = conf.wspec.input_ld_row * conf.wspec.M; // per-elem stride
 

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -15,12 +15,11 @@
 *******************************************************************************/
 
 #include <cstring>
-#include <riscv_vector.h>
 
 #include "common/c_types_map.hpp"
-#include "common/dnnl_thread.hpp"
 #include "common/utils.hpp"
 #include "cpu/platform.hpp"
+#include "cpu/rv64/jit_generator.hpp"
 #include "cpu/rv64/rvv_winograd_convolution.hpp"
 
 namespace dnnl {
@@ -34,15 +33,7 @@ using namespace dnnl::impl::data_type;
 using namespace dnnl::impl::memory_tracking::names;
 
 namespace {
-// Winograd F(2x2, 3x3) transform matrices
-// Input transform matrix B^T (4x4)
-constexpr float BT[4][4] = {{1.0f, 0.0f, -1.0f, 0.0f}, {0.0f, 1.0f, 1.0f, 0.0f},
-        {0.0f, -1.0f, 1.0f, 0.0f}, {0.0f, -1.0f, 0.0f, 1.0f}};
-
-// Output transform matrix A^T (2x4)
-constexpr float AT[2][4]
-        = {{1.0f, 1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, -1.0f, 1.0f}};
-
+// Winograd F(2x2, 3x3) filter transform matrix
 // Filter transform matrix G (4x3)
 constexpr float G[4][3] = {{1.0f, 0.0f, 0.0f}, {0.5f, 0.5f, 0.5f},
         {0.5f, -0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}};
@@ -90,7 +81,477 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
     }
 }
 
+// -----------------------------------------------------------------------
+// JIT input transform kernel: tile loop + IC loop in one kernel call
+// Processes all tiles for one batch, eliminating per-tile call overhead.
+// -----------------------------------------------------------------------
+struct jit_wino_input_transform_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_wino_input_transform_t)
+
+    struct call_params_t {
+        const float *src_batch;
+        float *V;
+        dim_t ic_spatial_stride;
+        dim_t nb_oh;
+        dim_t nb_ow;
+    };
+
+    dim_t ic_, ih_, iw_, pad_t_, pad_l_;
+    dim_t input_ld_row_, V_elem_stride_;
+
+    jit_wino_input_transform_t(const rvv_winograd_conf_t &conf)
+        : jit_generator_t("wino_input_xform")
+        , ic_(conf.ic)
+        , ih_(conf.ih)
+        , iw_(conf.iw)
+        , pad_t_(conf.pad_t)
+        , pad_l_(conf.pad_l)
+        , input_ld_row_(conf.wspec.input_ld_row)
+        , V_elem_stride_(conf.wspec.input_ld_batch) {}
+
+    void generate() override {
+        using namespace Xbyak_riscv;
+
+        // --- Scalar register allocation ---
+        const Reg reg_src = a1; // src_batch base
+        const Reg reg_V = a2; // V buffer base
+        const Reg reg_ic_base = a3; // IC loop counter
+        const Reg reg_vl = a4; // current VL
+        const Reg reg_ic_total = a5; // ic_ (baked)
+        const Reg reg_ic_spb = a6; // ic_spatial_stride * 4 (bytes)
+        const Reg reg_oh_s = a7; // oh_s (computed per tile)
+        const Reg reg_ow_s = t5; // ow_s (computed per tile)
+        const Reg reg_tile_voff = t6; // tile offset in bytes (per tile)
+        // Saved: baked constants + tile loop state
+        const Reg reg_ih = s0, reg_iw = s1, reg_pad_t = s2, reg_pad_l = s3;
+        const Reg reg_nb_oh = Xbyak_riscv::s4, reg_nb_ow = Xbyak_riscv::s5;
+        const Reg reg_oh_tile = Xbyak_riscv::s6, reg_ow_tile = Xbyak_riscv::s7;
+
+        // --- Vector registers (LMUL=1) ---
+        const VReg vr0(0), vr1(1), vr2(2), vr3(3);
+        const VReg vt0(4), vt1(5), vt2(6), vt3(7);
+        const VReg vm0(8), vm1(9), vm2(10), vm3(11);
+
+        // --- Prologue: save s0-s7 ---
+        addi(sp, sp, -64);
+        sd(reg_ih, sp, 0);
+        sd(reg_iw, sp, 8);
+        sd(reg_pad_t, sp, 16);
+        sd(reg_pad_l, sp, 24);
+        sd(reg_nb_oh, sp, 32);
+        sd(reg_nb_ow, sp, 40);
+        sd(reg_oh_tile, sp, 48);
+        sd(reg_ow_tile, sp, 56);
+
+        // Load params
+        ld(reg_src, a0, 0); // src_batch
+        ld(reg_V, a0, 8); // V
+        ld(t0, a0, 16); // ic_spatial_stride
+        ld(reg_nb_oh, a0, 24); // nb_oh
+        ld(reg_nb_ow, a0, 32); // nb_ow
+
+        slli(reg_ic_spb, t0, 2); // ic_spat_bytes
+
+        // Bake constants
+        li(reg_ic_total, ic_);
+        li(reg_ih, ih_);
+        li(reg_iw, iw_);
+        li(reg_pad_t, pad_t_);
+        li(reg_pad_l, pad_l_);
+
+        // ---- Outer tile loop: oh_tile ----
+        mv(reg_oh_tile, x0);
+        Label lbl_oh_loop, lbl_oh_done;
+        L(lbl_oh_loop);
+        bge(reg_oh_tile, reg_nb_oh, lbl_oh_done);
+
+        // oh_s = oh_tile * 2
+        slli(reg_oh_s, reg_oh_tile, 1);
+
+        // ---- Inner tile loop: ow_tile ----
+        mv(reg_ow_tile, x0);
+        Label lbl_ow_loop, lbl_ow_done;
+        L(lbl_ow_loop);
+        bge(reg_ow_tile, reg_nb_ow, lbl_ow_done);
+
+        // ow_s = ow_tile * 2
+        slli(reg_ow_s, reg_ow_tile, 1);
+
+        // tile_voff = (oh_tile * nb_ow + ow_tile) * input_ld_row * 4
+        mul(reg_tile_voff, reg_oh_tile, reg_nb_ow);
+        add(reg_tile_voff, reg_tile_voff, reg_ow_tile);
+        li(t0, input_ld_row_);
+        mul(reg_tile_voff, reg_tile_voff, t0);
+        slli(reg_tile_voff, reg_tile_voff, 2);
+
+        // ---- IC loop ----
+        mv(reg_ic_base, x0);
+        Label lbl_ic_loop, lbl_ic_end;
+        L(lbl_ic_loop);
+        bge(reg_ic_base, reg_ic_total, lbl_ic_end);
+
+        sub(t0, reg_ic_total, reg_ic_base);
+        vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
+
+        // src_row_base = src + ic_base * ic_spb
+        mul(a0, reg_ic_base, reg_ic_spb);
+        add(a0, a0, reg_src);
+
+        // Lambda: load one k row, B-sparse, accumulate
+        auto emit_load_k = [&](int k, bool positive) {
+            addi(t1, reg_oh_s, k);
+            sub(t1, t1, reg_pad_t);
+
+            Label lbl_zero_row, lbl_row_done;
+            blt(t1, x0, lbl_zero_row);
+            bge(t1, reg_ih, lbl_zero_row);
+
+            mul(t2, t1, reg_iw);
+            slli(t2, t2, 2);
+            add(t2, t2, a0);
+
+            auto emit_col_load = [&](int j, const VReg &vt) {
+                addi(t3, reg_ow_s, j);
+                sub(t3, t3, reg_pad_l);
+                Label lbl_skip_col, lbl_col_done;
+                blt(t3, x0, lbl_skip_col);
+                bge(t3, reg_iw, lbl_skip_col);
+                slli(t4, t3, 2);
+                add(t4, t4, t2);
+                vlse32_v(vt, t4, reg_ic_spb);
+                j_(lbl_col_done);
+                L(lbl_skip_col);
+                vmv_v_i(vt, 0);
+                L(lbl_col_done);
+            };
+
+            emit_col_load(0, vt0);
+            emit_col_load(1, vt1);
+            emit_col_load(2, vt2);
+            emit_col_load(3, vt3);
+
+            j_(lbl_row_done);
+            L(lbl_zero_row);
+            vmv_v_i(vt0, 0);
+            vmv_v_i(vt1, 0);
+            vmv_v_i(vt2, 0);
+            vmv_v_i(vt3, 0);
+            L(lbl_row_done);
+
+            vfsub_vv(vm0, vt0, vt2);
+            vfadd_vv(vm1, vt1, vt2);
+            vfsub_vv(vm2, vt2, vt1);
+            vfsub_vv(vm3, vt3, vt1);
+
+            if (positive) {
+                vfadd_vv(vr0, vr0, vm0);
+                vfadd_vv(vr1, vr1, vm1);
+                vfadd_vv(vr2, vr2, vm2);
+                vfadd_vv(vr3, vr3, vm3);
+            } else {
+                vfsub_vv(vr0, vr0, vm0);
+                vfsub_vv(vr1, vr1, vm1);
+                vfsub_vv(vr2, vr2, vm2);
+                vfsub_vv(vr3, vr3, vm3);
+            }
+        };
+
+        // Lambda: zero accum, 2 k values, store 4 results
+        auto emit_out_i
+                = [&](int out_i, int k_a, bool k_a_pos, int k_b, bool k_b_pos) {
+            vmv_v_i(vr0, 0);
+            vmv_v_i(vr1, 0);
+            vmv_v_i(vr2, 0);
+            vmv_v_i(vr3, 0);
+
+            emit_load_k(k_a, k_a_pos);
+            emit_load_k(k_b, k_b_pos);
+
+            // Store to V buffer
+            slli(t0, reg_ic_base, 2);
+            add(t0, t0, reg_tile_voff);
+            add(t0, t0, reg_V);
+            li(t1, static_cast<uint64_t>(out_i) * 4 * V_elem_stride_ * 4);
+            add(t0, t0, t1);
+            li(t1, V_elem_stride_ * 4);
+
+            vse32_v(vr0, t0);
+            add(t0, t0, t1);
+            vse32_v(vr1, t0);
+            add(t0, t0, t1);
+            vse32_v(vr2, t0);
+            add(t0, t0, t1);
+            vse32_v(vr3, t0);
+        };
+
+        emit_out_i(0, 0, true, 2, false);
+        emit_out_i(1, 1, true, 2, true);
+        emit_out_i(2, 1, false, 2, true);
+        emit_out_i(3, 1, false, 3, true);
+
+        add(reg_ic_base, reg_ic_base, reg_vl);
+        j_(lbl_ic_loop);
+        L(lbl_ic_end);
+
+        // Advance ow_tile
+        addi(reg_ow_tile, reg_ow_tile, 1);
+        j_(lbl_ow_loop);
+        L(lbl_ow_done);
+
+        // Advance oh_tile
+        addi(reg_oh_tile, reg_oh_tile, 1);
+        j_(lbl_oh_loop);
+        L(lbl_oh_done);
+
+        // --- Epilogue: restore s0-s7 ---
+        ld(reg_ih, sp, 0);
+        ld(reg_iw, sp, 8);
+        ld(reg_pad_t, sp, 16);
+        ld(reg_pad_l, sp, 24);
+        ld(reg_nb_oh, sp, 32);
+        ld(reg_nb_ow, sp, 40);
+        ld(reg_oh_tile, sp, 48);
+        ld(reg_ow_tile, sp, 56);
+        addi(sp, sp, 64);
+        ret();
+    }
+};
+
+// -----------------------------------------------------------------------
+// JIT output transform kernel: tile loop + OC loop in one kernel call
+// Processes all tiles for one batch, eliminating per-tile call overhead.
+// -----------------------------------------------------------------------
+struct jit_wino_output_transform_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_wino_output_transform_t)
+
+    struct call_params_t {
+        const float *M;
+        const float *bias;
+        float *dst_batch;
+        dim_t nb_oh;
+        dim_t nb_ow;
+    };
+
+    dim_t oc_, oh_, ow_, N_;
+    dim_t M_elem_stride_, oc_spatial_stride_;
+    bool with_bias_;
+
+    jit_wino_output_transform_t(const rvv_winograd_conf_t &conf)
+        : jit_generator_t("wino_output_xform")
+        , oc_(conf.oc)
+        , oh_(conf.oh)
+        , ow_(conf.ow)
+        , N_(conf.wspec.N)
+        , M_elem_stride_(conf.wspec.output_ld_batch)
+        , oc_spatial_stride_(conf.oh * conf.ow)
+        , with_bias_(conf.with_bias) {}
+
+    void generate() override {
+        using namespace Xbyak_riscv;
+
+        const Reg reg_M = a1;
+        const Reg reg_dst = a2;
+        const Reg reg_oc_base = a3;
+        const Reg reg_vl = a4;
+        const Reg reg_oc_total = a5;
+        const Reg reg_bias = a6;
+        const Reg reg_oc_spb = a7;
+        const Reg reg_oh_s = t4;
+        const Reg reg_ow_s = t5;
+        const Reg reg_tile_moff = t6;
+        // Saved
+        const Reg reg_oh_lim = s0, reg_ow_lim = s1;
+        const Reg reg_M_eb = s2, reg_N = s3;
+        const Reg reg_nb_oh = Xbyak_riscv::s4, reg_nb_ow = Xbyak_riscv::s5;
+        const Reg reg_oh_tile = Xbyak_riscv::s6, reg_ow_tile = Xbyak_riscv::s7;
+
+        // --- Vector registers (LMUL=1) ---
+        const VReg vr0(0), vr1(1);
+        const VReg vw0(4), vw1(5), vw2(6), vw3(7);
+        const VReg vtmp0(8), vtmp1(9);
+        const VReg v_bias(10);
+
+        // --- Prologue: save s0-s7 ---
+        addi(sp, sp, -64);
+        sd(reg_oh_lim, sp, 0);
+        sd(reg_ow_lim, sp, 8);
+        sd(reg_M_eb, sp, 16);
+        sd(reg_N, sp, 24);
+        sd(reg_nb_oh, sp, 32);
+        sd(reg_nb_ow, sp, 40);
+        sd(reg_oh_tile, sp, 48);
+        sd(reg_ow_tile, sp, 56);
+
+        // Load params
+        ld(reg_M, a0, 0);
+        ld(reg_bias, a0, 8);
+        ld(reg_dst, a0, 16);
+        ld(reg_nb_oh, a0, 24);
+        ld(reg_nb_ow, a0, 32);
+
+        // Bake constants
+        li(reg_oc_total, oc_);
+        li(reg_oh_lim, oh_);
+        li(reg_ow_lim, ow_);
+        li(reg_N, N_);
+        li(reg_M_eb, M_elem_stride_ * 4);
+        li(reg_oc_spb, oc_spatial_stride_ * 4);
+
+        // Lambda: load w0-w3 and accumulate for one k
+        auto emit_load_k = [&](int k, bool positive) {
+            slli(t0, reg_oc_base, 2);
+            add(t0, t0, reg_tile_moff);
+            add(t0, t0, reg_M);
+            if (k > 0) {
+                li(t1, static_cast<uint64_t>(k) * 4);
+                mul(t1, t1, reg_M_eb);
+                add(t0, t0, t1);
+            }
+
+            vle32_v(vw0, t0);
+            add(t0, t0, reg_M_eb);
+            vle32_v(vw1, t0);
+            add(t0, t0, reg_M_eb);
+            vle32_v(vw2, t0);
+            add(t0, t0, reg_M_eb);
+            vle32_v(vw3, t0);
+
+            vfadd_vv(vtmp0, vw0, vw1);
+            vfadd_vv(vtmp0, vtmp0, vw2);
+            vfsub_vv(vtmp1, vw1, vw2);
+            vfadd_vv(vtmp1, vtmp1, vw3);
+
+            if (positive) {
+                vfadd_vv(vr0, vr0, vtmp0);
+                vfadd_vv(vr1, vr1, vtmp1);
+            } else {
+                vfsub_vv(vr0, vr0, vtmp0);
+                vfsub_vv(vr1, vr1, vtmp1);
+            }
+        };
+
+        // Lambda: zero accum, 3 k values, bias, store
+        auto emit_out_i = [&](int out_i, int k0, bool pos0, int k1, bool pos1,
+                                  int k2, bool pos2) {
+            vmv_v_i(vr0, 0);
+            vmv_v_i(vr1, 0);
+
+            emit_load_k(k0, pos0);
+            emit_load_k(k1, pos1);
+            emit_load_k(k2, pos2);
+
+            if (with_bias_) {
+                vfadd_vv(vr0, vr0, v_bias);
+                vfadd_vv(vr1, vr1, v_bias);
+            }
+
+            // Store with boundary checks
+            addi(t0, reg_oh_s, out_i);
+            Label lbl_store_done;
+            bge(t0, reg_oh_lim, lbl_store_done);
+
+            mul(t1, reg_oc_base, reg_oc_spb);
+            add(t1, t1, reg_dst);
+            mul(t2, t0, reg_ow_lim);
+            slli(t2, t2, 2);
+            add(t2, t2, t1);
+            slli(t3, reg_ow_s, 2);
+            add(t2, t2, t3);
+
+            vsse32_v(vr0, t2, reg_oc_spb);
+
+            addi(t3, reg_ow_s, 1);
+            bge(t3, reg_ow_lim, lbl_store_done);
+            addi(t2, t2, 4);
+            vsse32_v(vr1, t2, reg_oc_spb);
+
+            L(lbl_store_done);
+        };
+
+        // ---- Outer tile loop: oh_tile ----
+        mv(reg_oh_tile, x0);
+        Label lbl_oh_loop, lbl_oh_done;
+        L(lbl_oh_loop);
+        bge(reg_oh_tile, reg_nb_oh, lbl_oh_done);
+
+        slli(reg_oh_s, reg_oh_tile, 1);
+
+        // ---- Inner tile loop: ow_tile ----
+        mv(reg_ow_tile, x0);
+        Label lbl_ow_loop, lbl_ow_done;
+        L(lbl_ow_loop);
+        bge(reg_ow_tile, reg_nb_ow, lbl_ow_done);
+
+        slli(reg_ow_s, reg_ow_tile, 1);
+
+        // tile_moff = (oh_tile * nb_ow + ow_tile) * N * 4
+        mul(reg_tile_moff, reg_oh_tile, reg_nb_ow);
+        add(reg_tile_moff, reg_tile_moff, reg_ow_tile);
+        mul(reg_tile_moff, reg_tile_moff, reg_N);
+        slli(reg_tile_moff, reg_tile_moff, 2);
+
+        // ---- OC loop ----
+        mv(reg_oc_base, x0);
+        Label lbl_oc_loop, lbl_oc_end;
+        L(lbl_oc_loop);
+        bge(reg_oc_base, reg_oc_total, lbl_oc_end);
+
+        sub(t0, reg_oc_total, reg_oc_base);
+        vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
+
+        // Load bias once per OC chunk
+        if (with_bias_) {
+            slli(t0, reg_oc_base, 2);
+            add(t0, reg_bias, t0);
+            vle32_v(v_bias, t0);
+        }
+
+        emit_out_i(0, 0, true, 1, true, 2, true);
+        emit_out_i(1, 1, true, 2, false, 3, true);
+
+        add(reg_oc_base, reg_oc_base, reg_vl);
+        j_(lbl_oc_loop);
+        L(lbl_oc_end);
+
+        addi(reg_ow_tile, reg_ow_tile, 1);
+        j_(lbl_ow_loop);
+        L(lbl_ow_done);
+
+        addi(reg_oh_tile, reg_oh_tile, 1);
+        j_(lbl_oh_loop);
+        L(lbl_oh_done);
+
+        // --- Epilogue: restore s0-s7 ---
+        ld(reg_oh_lim, sp, 0);
+        ld(reg_ow_lim, sp, 8);
+        ld(reg_M_eb, sp, 16);
+        ld(reg_N, sp, 24);
+        ld(reg_nb_oh, sp, 32);
+        ld(reg_nb_ow, sp, 40);
+        ld(reg_oh_tile, sp, 48);
+        ld(reg_ow_tile, sp, 56);
+        addi(sp, sp, 64);
+        ret();
+    }
+};
+
 } // namespace
+
+status_t rvv_wino_resource_t::configure(
+        size_t weight_buf_size, const rvv_winograd_conf_t &conf) {
+    weight_buf_.reset(new float[weight_buf_size]);
+    if (!weight_buf_) return status::out_of_memory;
+
+    auto *input = new jit_wino_input_transform_t(conf);
+    input->create_kernel();
+    input_xform_.reset(input);
+
+    auto *output = new jit_wino_output_transform_t(conf);
+    output->create_kernel();
+    output_xform_.reset(output);
+
+    return status::success;
+}
 
 status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
         memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,
@@ -102,7 +563,6 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
     const memory_desc_wrapper src_d(&src_md);
     const memory_desc_wrapper weights_d(&weights_md);
     const memory_desc_wrapper dst_d(&dst_md);
-    const memory_desc_wrapper bias_d(&bias_md);
 
     const dim_t mb = src_d.dims()[0];
     conf.mb = mb;
@@ -208,12 +668,15 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
     float *V = scratchpad.template get<float>(key_wino_V);
     float *M = scratchpad.template get<float>(key_wino_M);
 
+    // JIT kernels created in create_resource(), retrieved from resource
+    auto *input_xform = wino_resource->get_input_xform();
+    auto *output_xform = wino_resource->get_output_xform();
+
     // Sequential batch processing: input transform -> GEMM -> output transform
     // per batch, keeping working set in L2 cache.
     const dim_t nb_oh = (conf.oh + 1) / 2;
     const dim_t nb_ow = (conf.ow + 1) / 2;
     const dim_t total_tiles = nb_oh * nb_ow;
-    const dim_t input_ld_row = conf.wspec.input_ld_row;
     const dim_t V_elem_stride = conf.wspec.input_ld_batch;
     const dim_t M_elem_stride = conf.wspec.output_ld_batch;
     const dim_t ic_spatial_stride = conf.ih * conf.iw;
@@ -222,126 +685,15 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
     for (dim_t mb_idx = 0; mb_idx < conf.mb; mb_idx++) {
         const float *src_batch = src + mb_idx * conf.ic * ic_spatial_stride;
 
-        // Step 1: Input transform - vectorized across IC channels
-        // Row-by-row approach: for each output row out_i of B^T * tile * B,
-        // compute fused result using at most 9 vector registers.
-        // result[out_i][j] = Σ_k BT[out_i][k] * Σ_m tile[k][m]*B[m][j]
-        for (dim_t tile_idx = 0; tile_idx < total_tiles; tile_idx++) {
-            const dim_t oh_tile = tile_idx / nb_ow;
-            const dim_t ow_tile = tile_idx % nb_ow;
-            const dim_t oh_s = oh_tile * 2;
-            const dim_t ow_s = ow_tile * 2;
-
-            dim_t vl = __riscv_vsetvl_e32m1(conf.ic);
-            for (dim_t ic_base = 0; ic_base < conf.ic; ic_base += vl) {
-                vl = __riscv_vsetvl_e32m1(conf.ic - ic_base);
-
-                // Load 4x4 input tile: 4 rows of 4 strided loads
-                // tile[i][j] = src at (oh_s+i, ow_s+j) for each IC channel
-                // Using 4 variables for the 4 values in current row i.
-                // We process one output row at a time: for each out_i,
-                // we load row k=0..3 on the fly and accumulate.
-                for (int out_i = 0; out_i < 4; out_i++) {
-                    // Accumulators for 4 columns of result[out_i][*]
-                    vfloat32m1_t res0 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                    vfloat32m1_t res1 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                    vfloat32m1_t res2 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                    vfloat32m1_t res3 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-
-                    for (int k = 0; k < 4; k++) {
-                        // Exploit BT sparsity: skip when BT[out_i][k] == 0
-                        // BT = [1,0,-1,0; 0,1,1,0; 0,-1,1,0; 0,-1,0,1]
-                        float bt_val = BT[out_i][k];
-                        if (bt_val == 0.0f) continue;
-
-                        dim_t ih_idx = oh_s + k - conf.pad_t;
-                        // Load tile[k][0..3] for this IC chunk
-                        vfloat32m1_t t0, t1, t2, t3;
-                        if (ih_idx >= 0 && ih_idx < conf.ih) {
-                            dim_t iw0 = ow_s + 0 - conf.pad_l;
-                            dim_t iw1 = ow_s + 1 - conf.pad_l;
-                            dim_t iw2 = ow_s + 2 - conf.pad_l;
-                            dim_t iw3 = ow_s + 3 - conf.pad_l;
-                            t0 = (iw0 >= 0 && iw0 < conf.iw)
-                                    ? __riscv_vlse32_v_f32m1(src_batch
-                                                      + ic_base
-                                                              * ic_spatial_stride
-                                                      + ih_idx * conf.iw + iw0,
-                                              ic_spatial_stride * sizeof(float),
-                                              vl)
-                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                            t1 = (iw1 >= 0 && iw1 < conf.iw)
-                                    ? __riscv_vlse32_v_f32m1(src_batch
-                                                      + ic_base
-                                                              * ic_spatial_stride
-                                                      + ih_idx * conf.iw + iw1,
-                                              ic_spatial_stride * sizeof(float),
-                                              vl)
-                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                            t2 = (iw2 >= 0 && iw2 < conf.iw)
-                                    ? __riscv_vlse32_v_f32m1(src_batch
-                                                      + ic_base
-                                                              * ic_spatial_stride
-                                                      + ih_idx * conf.iw + iw2,
-                                              ic_spatial_stride * sizeof(float),
-                                              vl)
-                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                            t3 = (iw3 >= 0 && iw3 < conf.iw)
-                                    ? __riscv_vlse32_v_f32m1(src_batch
-                                                      + ic_base
-                                                              * ic_spatial_stride
-                                                      + ih_idx * conf.iw + iw3,
-                                              ic_spatial_stride * sizeof(float),
-                                              vl)
-                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                        } else {
-                            t0 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                            t1 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                            t2 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                            t3 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                        }
-
-                        // Exploit B sparsity: B*[t0,t1,t2,t3]^T =
-                        // [t0-t2, t1+t2, t2-t1, t3-t1]
-                        // (B = [1,0,0,0; 0,1,-1,-1; -1,1,1,0; 0,0,0,1])
-                        vfloat32m1_t tmp0 = __riscv_vfsub_vv_f32m1(t0, t2, vl);
-                        vfloat32m1_t tmp1 = __riscv_vfadd_vv_f32m1(t1, t2, vl);
-                        vfloat32m1_t tmp2 = __riscv_vfsub_vv_f32m1(t2, t1, vl);
-                        vfloat32m1_t tmp3 = __riscv_vfsub_vv_f32m1(t3, t1, vl);
-
-                        // Accumulate: res += bt_val * tmp
-                        // bt_val is always 1.0f or -1.0f here
-                        if (bt_val > 0.0f) {
-                            res0 = __riscv_vfadd_vv_f32m1(res0, tmp0, vl);
-                            res1 = __riscv_vfadd_vv_f32m1(res1, tmp1, vl);
-                            res2 = __riscv_vfadd_vv_f32m1(res2, tmp2, vl);
-                            res3 = __riscv_vfadd_vv_f32m1(res3, tmp3, vl);
-                        } else {
-                            res0 = __riscv_vfsub_vv_f32m1(res0, tmp0, vl);
-                            res1 = __riscv_vfsub_vv_f32m1(res1, tmp1, vl);
-                            res2 = __riscv_vfsub_vv_f32m1(res2, tmp2, vl);
-                            res3 = __riscv_vfsub_vv_f32m1(res3, tmp3, vl);
-                        }
-                    }
-
-                    // Store result[out_i][0..3] to V buffer
-                    int base_elem = out_i * 4;
-                    __riscv_vse32_v_f32m1(V + (base_elem + 0) * V_elem_stride
-                                    + tile_idx * input_ld_row + ic_base,
-                            res0, vl);
-                    __riscv_vse32_v_f32m1(V + (base_elem + 1) * V_elem_stride
-                                    + tile_idx * input_ld_row + ic_base,
-                            res1, vl);
-                    __riscv_vse32_v_f32m1(V + (base_elem + 2) * V_elem_stride
-                                    + tile_idx * input_ld_row + ic_base,
-                            res2, vl);
-                    __riscv_vse32_v_f32m1(V + (base_elem + 3) * V_elem_stride
-                                    + tile_idx * input_ld_row + ic_base,
-                            res3, vl);
-                }
-
-                vl = __riscv_vsetvl_e32m1(conf.ic);
-            }
+        // Step 1: Input transform via JIT kernel (tile loop is inside JIT)
+        {
+            jit_wino_input_transform_t::call_params_t params;
+            params.src_batch = src_batch;
+            params.V = V;
+            params.ic_spatial_stride = ic_spatial_stride;
+            params.nb_oh = nb_oh;
+            params.nb_ow = nb_ow;
+            (*input_xform)(&params);
         }
 
         // Step 2: GEMM using brgemm kernel (16 elements)
@@ -355,103 +707,16 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
                     total_tiles, 0.0f);
         }
 
-        // Step 3: Output transform - vectorized across OC channels
-        // Row-by-row approach: for each output row out_i of A^T * wino * A,
-        // compute fused result using at most 7 vector registers.
-        // output[out_i][j] = Σ_k AT[out_i][k] * Σ_m wino[k][m]*A[m][j]
-        data_t *dst_batch = dst + mb_idx * conf.oc * oc_spatial_stride;
-        for (dim_t tile_idx = 0; tile_idx < total_tiles; tile_idx++) {
-            const dim_t oh_tile = tile_idx / nb_ow;
-            const dim_t ow_tile = tile_idx % nb_ow;
-            const dim_t oh_s = oh_tile * 2;
-            const dim_t ow_s = ow_tile * 2;
-
-            dim_t vl = __riscv_vsetvl_e32m1(conf.oc);
-            for (dim_t oc_base = 0; oc_base < conf.oc; oc_base += vl) {
-                vl = __riscv_vsetvl_e32m1(conf.oc - oc_base);
-
-                for (int out_i = 0; out_i < 2; out_i++) {
-                    // Accumulators for 2 columns of output[out_i][*]
-                    vfloat32m1_t res0 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                    vfloat32m1_t res1 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-
-                    for (int k = 0; k < 4; k++) {
-                        // Exploit AT sparsity: skip when AT[out_i][k] == 0
-                        // AT = [1,1,1,0; 0,1,-1,1]
-                        float at_val = AT[out_i][k];
-                        if (at_val == 0.0f) continue;
-
-                        // Load wino[k][0..3]
-                        vfloat32m1_t w0 = __riscv_vle32_v_f32m1(M
-                                        + (k * 4 + 0) * M_elem_stride
-                                        + tile_idx * conf.wspec.N + oc_base,
-                                vl);
-                        vfloat32m1_t w1 = __riscv_vle32_v_f32m1(M
-                                        + (k * 4 + 1) * M_elem_stride
-                                        + tile_idx * conf.wspec.N + oc_base,
-                                vl);
-                        vfloat32m1_t w2 = __riscv_vle32_v_f32m1(M
-                                        + (k * 4 + 2) * M_elem_stride
-                                        + tile_idx * conf.wspec.N + oc_base,
-                                vl);
-                        vfloat32m1_t w3 = __riscv_vle32_v_f32m1(M
-                                        + (k * 4 + 3) * M_elem_stride
-                                        + tile_idx * conf.wspec.N + oc_base,
-                                vl);
-
-                        // Exploit A sparsity: A*[w0,w1,w2,w3]^T =
-                        // [w0+w1+w2, w1-w2+w3]
-                        // (A = [1,0; 1,1; 1,-1; 0,1])
-                        vfloat32m1_t tmp0 = __riscv_vfadd_vv_f32m1(
-                                __riscv_vfadd_vv_f32m1(w0, w1, vl), w2, vl);
-                        vfloat32m1_t tmp1 = __riscv_vfadd_vv_f32m1(
-                                __riscv_vfsub_vv_f32m1(w1, w2, vl), w3, vl);
-
-                        // Accumulate: res += at_val * tmp
-                        // at_val is 1.0f or -1.0f here
-                        if (at_val > 0.0f) {
-                            res0 = __riscv_vfadd_vv_f32m1(res0, tmp0, vl);
-                            res1 = __riscv_vfadd_vv_f32m1(res1, tmp1, vl);
-                        } else {
-                            res0 = __riscv_vfsub_vv_f32m1(res0, tmp0, vl);
-                            res1 = __riscv_vfsub_vv_f32m1(res1, tmp1, vl);
-                        }
-                    }
-
-                    // Add bias
-                    vfloat32m1_t v_bias = (conf.with_bias && bias)
-                            ? __riscv_vle32_v_f32m1(bias + oc_base, vl)
-                            : __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                    res0 = __riscv_vfadd_vv_f32m1(res0, v_bias, vl);
-                    res1 = __riscv_vfadd_vv_f32m1(res1, v_bias, vl);
-
-                    // Store to dst using strided stores
-                    // dst layout: [OC][OH][OW], stride between OC = OH*OW
-                    {
-                        dim_t oh = oh_s + out_i;
-                        if (oh < conf.oh) {
-                            dim_t ow = ow_s + 0;
-                            if (ow < conf.ow) {
-                                __riscv_vsse32_v_f32m1(dst_batch
-                                                + oc_base * oc_spatial_stride
-                                                + oh * conf.ow + ow,
-                                        oc_spatial_stride * sizeof(float), res0,
-                                        vl);
-                            }
-                            ow = ow_s + 1;
-                            if (ow < conf.ow) {
-                                __riscv_vsse32_v_f32m1(dst_batch
-                                                + oc_base * oc_spatial_stride
-                                                + oh * conf.ow + ow,
-                                        oc_spatial_stride * sizeof(float), res1,
-                                        vl);
-                            }
-                        }
-                    }
-                }
-
-                vl = __riscv_vsetvl_e32m1(conf.oc);
-            }
+        // Step 3: Output transform via JIT kernel (tile loop is inside JIT)
+        {
+            data_t *dst_batch = dst + mb_idx * conf.oc * oc_spatial_stride;
+            jit_wino_output_transform_t::call_params_t params;
+            params.M = M;
+            params.bias = bias;
+            params.dst_batch = dst_batch;
+            params.nb_oh = nb_oh;
+            params.nb_ow = nb_ow;
+            (*output_xform)(&params);
         }
     }
 

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -80,471 +80,442 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
         }
     }
 }
-
-// -----------------------------------------------------------------------
-// JIT input transform kernel: tile loop + IC loop in one kernel call
-// Processes all tiles for one batch, eliminating per-tile call overhead.
-// -----------------------------------------------------------------------
-struct jit_wino_input_transform_t : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_wino_input_transform_t)
-
-    struct call_params_t {
-        const float *src_batch;
-        float *V;
-        dim_t ic_spatial_stride;
-        dim_t nb_oh;
-        dim_t nb_ow;
-    };
-
-    dim_t ic_, ih_, iw_, pad_t_, pad_l_;
-    dim_t input_ld_row_, V_elem_stride_;
-
-    jit_wino_input_transform_t(const rvv_winograd_conf_t &conf)
-        : jit_generator_t("wino_input_xform")
-        , ic_(conf.ic)
-        , ih_(conf.ih)
-        , iw_(conf.iw)
-        , pad_t_(conf.pad_t)
-        , pad_l_(conf.pad_l)
-        , input_ld_row_(conf.wspec.input_ld_row)
-        , V_elem_stride_(conf.wspec.input_ld_batch) {}
-
-    void generate() override {
-        using namespace Xbyak_riscv;
-
-        // --- Scalar register allocation ---
-        const Reg reg_src = a1; // src_batch base
-        const Reg reg_V = a2; // V buffer base
-        const Reg reg_ic_base = a3; // IC loop counter
-        const Reg reg_vl = a4; // current VL
-        const Reg reg_ic_total = a5; // ic_ (baked)
-        const Reg reg_ic_spb = a6; // ic_spatial_stride * 4 (bytes)
-        const Reg reg_oh_s = a7; // oh_s (computed per tile)
-        const Reg reg_ow_s = t5; // ow_s (computed per tile)
-        const Reg reg_tile_voff = t6; // tile offset in bytes (per tile)
-        // Saved: baked constants + tile loop state
-        const Reg reg_ih = s0, reg_iw = s1, reg_pad_t = s2, reg_pad_l = s3;
-        const Reg reg_nb_oh = Xbyak_riscv::s4, reg_nb_ow = Xbyak_riscv::s5;
-        const Reg reg_oh_tile = Xbyak_riscv::s6, reg_ow_tile = Xbyak_riscv::s7;
-
-        // --- Vector registers (LMUL=1) ---
-        const VReg vr0(0), vr1(1), vr2(2), vr3(3);
-        const VReg vt0(4), vt1(5), vt2(6), vt3(7);
-        const VReg vm0(8), vm1(9), vm2(10), vm3(11);
-
-        // --- Prologue: save s0-s7 ---
-        addi(sp, sp, -64);
-        sd(reg_ih, sp, 0);
-        sd(reg_iw, sp, 8);
-        sd(reg_pad_t, sp, 16);
-        sd(reg_pad_l, sp, 24);
-        sd(reg_nb_oh, sp, 32);
-        sd(reg_nb_ow, sp, 40);
-        sd(reg_oh_tile, sp, 48);
-        sd(reg_ow_tile, sp, 56);
-
-        // Load params
-        ld(reg_src, a0, 0); // src_batch
-        ld(reg_V, a0, 8); // V
-        ld(t0, a0, 16); // ic_spatial_stride
-        ld(reg_nb_oh, a0, 24); // nb_oh
-        ld(reg_nb_ow, a0, 32); // nb_ow
-
-        slli(reg_ic_spb, t0, 2); // ic_spat_bytes
-
-        // Bake constants
-        li(reg_ic_total, ic_);
-        li(reg_ih, ih_);
-        li(reg_iw, iw_);
-        li(reg_pad_t, pad_t_);
-        li(reg_pad_l, pad_l_);
-
-        // ---- Outer tile loop: oh_tile ----
-        mv(reg_oh_tile, x0);
-        Label lbl_oh_loop, lbl_oh_done;
-        L(lbl_oh_loop);
-        bge(reg_oh_tile, reg_nb_oh, lbl_oh_done);
-
-        // oh_s = oh_tile * 2
-        slli(reg_oh_s, reg_oh_tile, 1);
-
-        // ---- Inner tile loop: ow_tile ----
-        mv(reg_ow_tile, x0);
-        Label lbl_ow_loop, lbl_ow_done;
-        L(lbl_ow_loop);
-        bge(reg_ow_tile, reg_nb_ow, lbl_ow_done);
-
-        // ow_s = ow_tile * 2
-        slli(reg_ow_s, reg_ow_tile, 1);
-
-        // tile_voff = (oh_tile * nb_ow + ow_tile) * input_ld_row * 4
-        mul(reg_tile_voff, reg_oh_tile, reg_nb_ow);
-        add(reg_tile_voff, reg_tile_voff, reg_ow_tile);
-        li(t0, input_ld_row_);
-        mul(reg_tile_voff, reg_tile_voff, t0);
-        slli(reg_tile_voff, reg_tile_voff, 2);
-
-        // ---- IC loop ----
-        mv(reg_ic_base, x0);
-        Label lbl_ic_loop, lbl_ic_end;
-        L(lbl_ic_loop);
-        bge(reg_ic_base, reg_ic_total, lbl_ic_end);
-
-        sub(t0, reg_ic_total, reg_ic_base);
-        vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
-
-        // src_row_base = src + ic_base * ic_spb
-        mul(a0, reg_ic_base, reg_ic_spb);
-        add(a0, a0, reg_src);
-
-        // Lambda: load one k row, B-sparse, accumulate
-        auto emit_load_k = [&](int k, bool positive) {
-            addi(t1, reg_oh_s, k);
-            sub(t1, t1, reg_pad_t);
-
-            Label lbl_zero_row, lbl_row_done;
-            blt(t1, x0, lbl_zero_row);
-            bge(t1, reg_ih, lbl_zero_row);
-
-            mul(t2, t1, reg_iw);
-            slli(t2, t2, 2);
-            add(t2, t2, a0);
-
-            auto emit_col_load = [&](int j, const VReg &vt) {
-                addi(t3, reg_ow_s, j);
-                sub(t3, t3, reg_pad_l);
-                Label lbl_skip_col, lbl_col_done;
-                blt(t3, x0, lbl_skip_col);
-                bge(t3, reg_iw, lbl_skip_col);
-                slli(t4, t3, 2);
-                add(t4, t4, t2);
-                vlse32_v(vt, t4, reg_ic_spb);
-                j_(lbl_col_done);
-                L(lbl_skip_col);
-                vmv_v_i(vt, 0);
-                L(lbl_col_done);
-            };
-
-            emit_col_load(0, vt0);
-            emit_col_load(1, vt1);
-            emit_col_load(2, vt2);
-            emit_col_load(3, vt3);
-
-            j_(lbl_row_done);
-            L(lbl_zero_row);
-            vmv_v_i(vt0, 0);
-            vmv_v_i(vt1, 0);
-            vmv_v_i(vt2, 0);
-            vmv_v_i(vt3, 0);
-            L(lbl_row_done);
-
-            vfsub_vv(vm0, vt0, vt2);
-            vfadd_vv(vm1, vt1, vt2);
-            vfsub_vv(vm2, vt2, vt1);
-            vfsub_vv(vm3, vt3, vt1);
-
-            if (positive) {
-                vfadd_vv(vr0, vr0, vm0);
-                vfadd_vv(vr1, vr1, vm1);
-                vfadd_vv(vr2, vr2, vm2);
-                vfadd_vv(vr3, vr3, vm3);
-            } else {
-                vfsub_vv(vr0, vr0, vm0);
-                vfsub_vv(vr1, vr1, vm1);
-                vfsub_vv(vr2, vr2, vm2);
-                vfsub_vv(vr3, vr3, vm3);
-            }
-        };
-
-        // Lambda: zero accum, 2 k values, store 4 results
-        auto emit_out_i
-                = [&](int out_i, int k_a, bool k_a_pos, int k_b, bool k_b_pos) {
-            vmv_v_i(vr0, 0);
-            vmv_v_i(vr1, 0);
-            vmv_v_i(vr2, 0);
-            vmv_v_i(vr3, 0);
-
-            emit_load_k(k_a, k_a_pos);
-            emit_load_k(k_b, k_b_pos);
-
-            // Store to V buffer
-            slli(t0, reg_ic_base, 2);
-            add(t0, t0, reg_tile_voff);
-            add(t0, t0, reg_V);
-            li(t1, static_cast<uint64_t>(out_i) * 4 * V_elem_stride_ * 4);
-            add(t0, t0, t1);
-            li(t1, V_elem_stride_ * 4);
-
-            vse32_v(vr0, t0);
-            add(t0, t0, t1);
-            vse32_v(vr1, t0);
-            add(t0, t0, t1);
-            vse32_v(vr2, t0);
-            add(t0, t0, t1);
-            vse32_v(vr3, t0);
-        };
-
-        emit_out_i(0, 0, true, 2, false);
-        emit_out_i(1, 1, true, 2, true);
-        emit_out_i(2, 1, false, 2, true);
-        emit_out_i(3, 1, false, 3, true);
-
-        add(reg_ic_base, reg_ic_base, reg_vl);
-        j_(lbl_ic_loop);
-        L(lbl_ic_end);
-
-        // Advance ow_tile
-        addi(reg_ow_tile, reg_ow_tile, 1);
-        j_(lbl_ow_loop);
-        L(lbl_ow_done);
-
-        // Advance oh_tile
-        addi(reg_oh_tile, reg_oh_tile, 1);
-        j_(lbl_oh_loop);
-        L(lbl_oh_done);
-
-        // --- Epilogue: restore s0-s7 ---
-        ld(reg_ih, sp, 0);
-        ld(reg_iw, sp, 8);
-        ld(reg_pad_t, sp, 16);
-        ld(reg_pad_l, sp, 24);
-        ld(reg_nb_oh, sp, 32);
-        ld(reg_nb_ow, sp, 40);
-        ld(reg_oh_tile, sp, 48);
-        ld(reg_ow_tile, sp, 56);
-        addi(sp, sp, 64);
-        ret();
-    }
-};
-
-// -----------------------------------------------------------------------
-// JIT output transform kernel: tile loop + OC loop in one kernel call
-// Processes all tiles for one batch, eliminating per-tile call overhead.
-// -----------------------------------------------------------------------
-struct jit_wino_output_transform_t : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_wino_output_transform_t)
-
-    struct call_params_t {
-        const float *M;
-        const float *bias;
-        float *dst_batch;
-        dim_t nb_oh;
-        dim_t nb_ow;
-    };
-
-    dim_t oc_, oh_, ow_, N_;
-    dim_t M_elem_stride_, oc_spatial_stride_;
-    bool with_bias_;
-
-    jit_wino_output_transform_t(const rvv_winograd_conf_t &conf)
-        : jit_generator_t("wino_output_xform")
-        , oc_(conf.oc)
-        , oh_(conf.oh)
-        , ow_(conf.ow)
-        , N_(conf.wspec.N)
-        , M_elem_stride_(conf.wspec.output_ld_batch)
-        , oc_spatial_stride_(conf.oh * conf.ow)
-        , with_bias_(conf.with_bias) {}
-
-    void generate() override {
-        using namespace Xbyak_riscv;
-
-        const Reg reg_M = a1;
-        const Reg reg_dst = a2;
-        const Reg reg_oc_base = a3;
-        const Reg reg_vl = a4;
-        const Reg reg_oc_total = a5;
-        const Reg reg_bias = a6;
-        const Reg reg_oc_spb = a7;
-        const Reg reg_oh_s = t4;
-        const Reg reg_ow_s = t5;
-        const Reg reg_tile_moff = t6;
-        // Saved
-        const Reg reg_oh_lim = s0, reg_ow_lim = s1;
-        const Reg reg_M_eb = s2, reg_N = s3;
-        const Reg reg_nb_oh = Xbyak_riscv::s4, reg_nb_ow = Xbyak_riscv::s5;
-        const Reg reg_oh_tile = Xbyak_riscv::s6, reg_ow_tile = Xbyak_riscv::s7;
-
-        // --- Vector registers (LMUL=1) ---
-        const VReg vr0(0), vr1(1);
-        const VReg vw0(4), vw1(5), vw2(6), vw3(7);
-        const VReg vtmp0(8), vtmp1(9);
-        const VReg v_bias(10);
-
-        // --- Prologue: save s0-s7 ---
-        addi(sp, sp, -64);
-        sd(reg_oh_lim, sp, 0);
-        sd(reg_ow_lim, sp, 8);
-        sd(reg_M_eb, sp, 16);
-        sd(reg_N, sp, 24);
-        sd(reg_nb_oh, sp, 32);
-        sd(reg_nb_ow, sp, 40);
-        sd(reg_oh_tile, sp, 48);
-        sd(reg_ow_tile, sp, 56);
-
-        // Load params
-        ld(reg_M, a0, 0);
-        ld(reg_bias, a0, 8);
-        ld(reg_dst, a0, 16);
-        ld(reg_nb_oh, a0, 24);
-        ld(reg_nb_ow, a0, 32);
-
-        // Bake constants
-        li(reg_oc_total, oc_);
-        li(reg_oh_lim, oh_);
-        li(reg_ow_lim, ow_);
-        li(reg_N, N_);
-        li(reg_M_eb, M_elem_stride_ * 4);
-        li(reg_oc_spb, oc_spatial_stride_ * 4);
-
-        // Lambda: load w0-w3 and accumulate for one k
-        auto emit_load_k = [&](int k, bool positive) {
-            slli(t0, reg_oc_base, 2);
-            add(t0, t0, reg_tile_moff);
-            add(t0, t0, reg_M);
-            if (k > 0) {
-                li(t1, static_cast<uint64_t>(k) * 4);
-                mul(t1, t1, reg_M_eb);
-                add(t0, t0, t1);
-            }
-
-            vle32_v(vw0, t0);
-            add(t0, t0, reg_M_eb);
-            vle32_v(vw1, t0);
-            add(t0, t0, reg_M_eb);
-            vle32_v(vw2, t0);
-            add(t0, t0, reg_M_eb);
-            vle32_v(vw3, t0);
-
-            vfadd_vv(vtmp0, vw0, vw1);
-            vfadd_vv(vtmp0, vtmp0, vw2);
-            vfsub_vv(vtmp1, vw1, vw2);
-            vfadd_vv(vtmp1, vtmp1, vw3);
-
-            if (positive) {
-                vfadd_vv(vr0, vr0, vtmp0);
-                vfadd_vv(vr1, vr1, vtmp1);
-            } else {
-                vfsub_vv(vr0, vr0, vtmp0);
-                vfsub_vv(vr1, vr1, vtmp1);
-            }
-        };
-
-        // Lambda: zero accum, 3 k values, bias, store
-        auto emit_out_i = [&](int out_i, int k0, bool pos0, int k1, bool pos1,
-                                  int k2, bool pos2) {
-            vmv_v_i(vr0, 0);
-            vmv_v_i(vr1, 0);
-
-            emit_load_k(k0, pos0);
-            emit_load_k(k1, pos1);
-            emit_load_k(k2, pos2);
-
-            if (with_bias_) {
-                vfadd_vv(vr0, vr0, v_bias);
-                vfadd_vv(vr1, vr1, v_bias);
-            }
-
-            // Store with boundary checks
-            addi(t0, reg_oh_s, out_i);
-            Label lbl_store_done;
-            bge(t0, reg_oh_lim, lbl_store_done);
-
-            mul(t1, reg_oc_base, reg_oc_spb);
-            add(t1, t1, reg_dst);
-            mul(t2, t0, reg_ow_lim);
-            slli(t2, t2, 2);
-            add(t2, t2, t1);
-            slli(t3, reg_ow_s, 2);
-            add(t2, t2, t3);
-
-            vsse32_v(vr0, t2, reg_oc_spb);
-
-            addi(t3, reg_ow_s, 1);
-            bge(t3, reg_ow_lim, lbl_store_done);
-            addi(t2, t2, 4);
-            vsse32_v(vr1, t2, reg_oc_spb);
-
-            L(lbl_store_done);
-        };
-
-        // ---- Outer tile loop: oh_tile ----
-        mv(reg_oh_tile, x0);
-        Label lbl_oh_loop, lbl_oh_done;
-        L(lbl_oh_loop);
-        bge(reg_oh_tile, reg_nb_oh, lbl_oh_done);
-
-        slli(reg_oh_s, reg_oh_tile, 1);
-
-        // ---- Inner tile loop: ow_tile ----
-        mv(reg_ow_tile, x0);
-        Label lbl_ow_loop, lbl_ow_done;
-        L(lbl_ow_loop);
-        bge(reg_ow_tile, reg_nb_ow, lbl_ow_done);
-
-        slli(reg_ow_s, reg_ow_tile, 1);
-
-        // tile_moff = (oh_tile * nb_ow + ow_tile) * N * 4
-        mul(reg_tile_moff, reg_oh_tile, reg_nb_ow);
-        add(reg_tile_moff, reg_tile_moff, reg_ow_tile);
-        mul(reg_tile_moff, reg_tile_moff, reg_N);
-        slli(reg_tile_moff, reg_tile_moff, 2);
-
-        // ---- OC loop ----
-        mv(reg_oc_base, x0);
-        Label lbl_oc_loop, lbl_oc_end;
-        L(lbl_oc_loop);
-        bge(reg_oc_base, reg_oc_total, lbl_oc_end);
-
-        sub(t0, reg_oc_total, reg_oc_base);
-        vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
-
-        // Load bias once per OC chunk
-        if (with_bias_) {
-            slli(t0, reg_oc_base, 2);
-            add(t0, reg_bias, t0);
-            vle32_v(v_bias, t0);
-        }
-
-        emit_out_i(0, 0, true, 1, true, 2, true);
-        emit_out_i(1, 1, true, 2, false, 3, true);
-
-        add(reg_oc_base, reg_oc_base, reg_vl);
-        j_(lbl_oc_loop);
-        L(lbl_oc_end);
-
-        addi(reg_ow_tile, reg_ow_tile, 1);
-        j_(lbl_ow_loop);
-        L(lbl_ow_done);
-
-        addi(reg_oh_tile, reg_oh_tile, 1);
-        j_(lbl_oh_loop);
-        L(lbl_oh_done);
-
-        // --- Epilogue: restore s0-s7 ---
-        ld(reg_oh_lim, sp, 0);
-        ld(reg_ow_lim, sp, 8);
-        ld(reg_M_eb, sp, 16);
-        ld(reg_N, sp, 24);
-        ld(reg_nb_oh, sp, 32);
-        ld(reg_nb_ow, sp, 40);
-        ld(reg_oh_tile, sp, 48);
-        ld(reg_ow_tile, sp, 56);
-        addi(sp, sp, 64);
-        ret();
-    }
-};
-
 } // namespace
 
-status_t rvv_wino_resource_t::configure(const rvv_winograd_conf_t &conf) {
-    auto *input = new jit_wino_input_transform_t(conf);
-    input->create_kernel();
-    input_xform_.reset(input);
+// -----------------------------------------------------------------------
+// jit_wino_input_transform_t implementation
+// -----------------------------------------------------------------------
+jit_wino_input_transform_t::jit_wino_input_transform_t(
+        const rvv_winograd_conf_t &conf)
+    : jit_generator_t("wino_input_xform")
+    , ic_(conf.ic)
+    , ih_(conf.ih)
+    , iw_(conf.iw)
+    , pad_t_(conf.pad_t)
+    , pad_l_(conf.pad_l)
+    , input_ld_row_(conf.wspec.input_ld_row)
+    , V_elem_stride_(conf.wspec.input_ld_batch) {}
 
-    auto *output = new jit_wino_output_transform_t(conf);
-    output->create_kernel();
+void jit_wino_input_transform_t::generate() {
+    using namespace Xbyak_riscv;
+
+    // --- Scalar register allocation ---
+    const Reg reg_src = a1; // src_batch base
+    const Reg reg_V = a2; // V buffer base
+    const Reg reg_ic_base = a3; // IC loop counter
+    const Reg reg_vl = a4; // current VL
+    const Reg reg_ic_total = a5; // ic_ (baked)
+    const Reg reg_ic_spb = a6; // ic_spatial_stride * 4 (bytes)
+    const Reg reg_oh_s = a7; // oh_s (computed per tile)
+    const Reg reg_ow_s = t5; // ow_s (computed per tile)
+    const Reg reg_tile_voff = t6; // tile offset in bytes (per tile)
+    // Saved: baked constants + tile loop state
+    const Reg reg_ih = s0, reg_iw = s1, reg_pad_t = s2, reg_pad_l = s3;
+    const Reg reg_nb_oh = Xbyak_riscv::s4, reg_nb_ow = Xbyak_riscv::s5;
+    const Reg reg_oh_tile = Xbyak_riscv::s6, reg_ow_tile = Xbyak_riscv::s7;
+
+    // --- Vector registers (LMUL=1) ---
+    const VReg vr0(0), vr1(1), vr2(2), vr3(3);
+    const VReg vt0(4), vt1(5), vt2(6), vt3(7);
+    const VReg vm0(8), vm1(9), vm2(10), vm3(11);
+
+    // --- Prologue: save s0-s7 ---
+    addi(sp, sp, -64);
+    sd(reg_ih, sp, 0);
+    sd(reg_iw, sp, 8);
+    sd(reg_pad_t, sp, 16);
+    sd(reg_pad_l, sp, 24);
+    sd(reg_nb_oh, sp, 32);
+    sd(reg_nb_ow, sp, 40);
+    sd(reg_oh_tile, sp, 48);
+    sd(reg_ow_tile, sp, 56);
+
+    // Load params
+    ld(reg_src, a0, 0); // src_batch
+    ld(reg_V, a0, 8); // V
+    ld(t0, a0, 16); // ic_spatial_stride
+    ld(reg_nb_oh, a0, 24); // nb_oh
+    ld(reg_nb_ow, a0, 32); // nb_ow
+
+    slli(reg_ic_spb, t0, 2); // ic_spat_bytes
+
+    // Bake constants
+    li(reg_ic_total, ic_);
+    li(reg_ih, ih_);
+    li(reg_iw, iw_);
+    li(reg_pad_t, pad_t_);
+    li(reg_pad_l, pad_l_);
+
+    // ---- Outer tile loop: oh_tile ----
+    mv(reg_oh_tile, x0);
+    Label lbl_oh_loop, lbl_oh_done;
+    L(lbl_oh_loop);
+    bge(reg_oh_tile, reg_nb_oh, lbl_oh_done);
+
+    // oh_s = oh_tile * 2
+    slli(reg_oh_s, reg_oh_tile, 1);
+
+    // ---- Inner tile loop: ow_tile ----
+    mv(reg_ow_tile, x0);
+    Label lbl_ow_loop, lbl_ow_done;
+    L(lbl_ow_loop);
+    bge(reg_ow_tile, reg_nb_ow, lbl_ow_done);
+
+    // ow_s = ow_tile * 2
+    slli(reg_ow_s, reg_ow_tile, 1);
+
+    // tile_voff = (oh_tile * nb_ow + ow_tile) * input_ld_row * 4
+    mul(reg_tile_voff, reg_oh_tile, reg_nb_ow);
+    add(reg_tile_voff, reg_tile_voff, reg_ow_tile);
+    li(t0, input_ld_row_);
+    mul(reg_tile_voff, reg_tile_voff, t0);
+    slli(reg_tile_voff, reg_tile_voff, 2);
+
+    // ---- IC loop ----
+    mv(reg_ic_base, x0);
+    Label lbl_ic_loop, lbl_ic_end;
+    L(lbl_ic_loop);
+    bge(reg_ic_base, reg_ic_total, lbl_ic_end);
+
+    sub(t0, reg_ic_total, reg_ic_base);
+    vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
+
+    // src_row_base = src + ic_base * ic_spb
+    mul(a0, reg_ic_base, reg_ic_spb);
+    add(a0, a0, reg_src);
+
+    // Lambda: load one k row, B-sparse, accumulate
+    auto emit_load_k = [&](int k, bool positive) {
+        addi(t1, reg_oh_s, k);
+        sub(t1, t1, reg_pad_t);
+
+        Label lbl_zero_row, lbl_row_done;
+        blt(t1, x0, lbl_zero_row);
+        bge(t1, reg_ih, lbl_zero_row);
+
+        mul(t2, t1, reg_iw);
+        slli(t2, t2, 2);
+        add(t2, t2, a0);
+
+        auto emit_col_load = [&](int j, const VReg &vt) {
+            addi(t3, reg_ow_s, j);
+            sub(t3, t3, reg_pad_l);
+            Label lbl_skip_col, lbl_col_done;
+            blt(t3, x0, lbl_skip_col);
+            bge(t3, reg_iw, lbl_skip_col);
+            slli(t4, t3, 2);
+            add(t4, t4, t2);
+            vlse32_v(vt, t4, reg_ic_spb);
+            j_(lbl_col_done);
+            L(lbl_skip_col);
+            vmv_v_i(vt, 0);
+            L(lbl_col_done);
+        };
+
+        emit_col_load(0, vt0);
+        emit_col_load(1, vt1);
+        emit_col_load(2, vt2);
+        emit_col_load(3, vt3);
+
+        j_(lbl_row_done);
+        L(lbl_zero_row);
+        vmv_v_i(vt0, 0);
+        vmv_v_i(vt1, 0);
+        vmv_v_i(vt2, 0);
+        vmv_v_i(vt3, 0);
+        L(lbl_row_done);
+
+        vfsub_vv(vm0, vt0, vt2);
+        vfadd_vv(vm1, vt1, vt2);
+        vfsub_vv(vm2, vt2, vt1);
+        vfsub_vv(vm3, vt3, vt1);
+
+        if (positive) {
+            vfadd_vv(vr0, vr0, vm0);
+            vfadd_vv(vr1, vr1, vm1);
+            vfadd_vv(vr2, vr2, vm2);
+            vfadd_vv(vr3, vr3, vm3);
+        } else {
+            vfsub_vv(vr0, vr0, vm0);
+            vfsub_vv(vr1, vr1, vm1);
+            vfsub_vv(vr2, vr2, vm2);
+            vfsub_vv(vr3, vr3, vm3);
+        }
+    };
+
+    // Lambda: zero accum, 2 k values, store 4 results
+    auto emit_out_i
+            = [&](int out_i, int k_a, bool k_a_pos, int k_b, bool k_b_pos) {
+        vmv_v_i(vr0, 0);
+        vmv_v_i(vr1, 0);
+        vmv_v_i(vr2, 0);
+        vmv_v_i(vr3, 0);
+
+        emit_load_k(k_a, k_a_pos);
+        emit_load_k(k_b, k_b_pos);
+
+        // Store to V buffer
+        slli(t0, reg_ic_base, 2);
+        add(t0, t0, reg_tile_voff);
+        add(t0, t0, reg_V);
+        li(t1, static_cast<uint64_t>(out_i) * 4 * V_elem_stride_ * 4);
+        add(t0, t0, t1);
+        li(t1, V_elem_stride_ * 4);
+
+        vse32_v(vr0, t0);
+        add(t0, t0, t1);
+        vse32_v(vr1, t0);
+        add(t0, t0, t1);
+        vse32_v(vr2, t0);
+        add(t0, t0, t1);
+        vse32_v(vr3, t0);
+    };
+
+    emit_out_i(0, 0, true, 2, false);
+    emit_out_i(1, 1, true, 2, true);
+    emit_out_i(2, 1, false, 2, true);
+    emit_out_i(3, 1, false, 3, true);
+
+    add(reg_ic_base, reg_ic_base, reg_vl);
+    j_(lbl_ic_loop);
+    L(lbl_ic_end);
+
+    // Advance ow_tile
+    addi(reg_ow_tile, reg_ow_tile, 1);
+    j_(lbl_ow_loop);
+    L(lbl_ow_done);
+
+    // Advance oh_tile
+    addi(reg_oh_tile, reg_oh_tile, 1);
+    j_(lbl_oh_loop);
+    L(lbl_oh_done);
+
+    // --- Epilogue: restore s0-s7 ---
+    ld(reg_ih, sp, 0);
+    ld(reg_iw, sp, 8);
+    ld(reg_pad_t, sp, 16);
+    ld(reg_pad_l, sp, 24);
+    ld(reg_nb_oh, sp, 32);
+    ld(reg_nb_ow, sp, 40);
+    ld(reg_oh_tile, sp, 48);
+    ld(reg_ow_tile, sp, 56);
+    addi(sp, sp, 64);
+    ret();
+}
+
+// -----------------------------------------------------------------------
+// jit_wino_output_transform_t implementation
+// -----------------------------------------------------------------------
+jit_wino_output_transform_t::jit_wino_output_transform_t(
+        const rvv_winograd_conf_t &conf)
+    : jit_generator_t("wino_output_xform")
+    , oc_(conf.oc)
+    , oh_(conf.oh)
+    , ow_(conf.ow)
+    , N_(conf.wspec.N)
+    , M_elem_stride_(conf.wspec.output_ld_batch)
+    , oc_spatial_stride_(conf.oh * conf.ow)
+    , with_bias_(conf.with_bias) {}
+
+void jit_wino_output_transform_t::generate() {
+    using namespace Xbyak_riscv;
+
+    const Reg reg_M = a1;
+    const Reg reg_dst = a2;
+    const Reg reg_oc_base = a3;
+    const Reg reg_vl = a4;
+    const Reg reg_oc_total = a5;
+    const Reg reg_bias = a6;
+    const Reg reg_oc_spb = a7;
+    const Reg reg_oh_s = t4;
+    const Reg reg_ow_s = t5;
+    const Reg reg_tile_moff = t6;
+    // Saved
+    const Reg reg_oh_lim = s0, reg_ow_lim = s1;
+    const Reg reg_M_eb = s2, reg_N = s3;
+    const Reg reg_nb_oh = Xbyak_riscv::s4, reg_nb_ow = Xbyak_riscv::s5;
+    const Reg reg_oh_tile = Xbyak_riscv::s6, reg_ow_tile = Xbyak_riscv::s7;
+
+    // --- Vector registers (LMUL=1) ---
+    const VReg vr0(0), vr1(1);
+    const VReg vw0(4), vw1(5), vw2(6), vw3(7);
+    const VReg vtmp0(8), vtmp1(9);
+    const VReg v_bias(10);
+
+    // --- Prologue: save s0-s7 ---
+    addi(sp, sp, -64);
+    sd(reg_oh_lim, sp, 0);
+    sd(reg_ow_lim, sp, 8);
+    sd(reg_M_eb, sp, 16);
+    sd(reg_N, sp, 24);
+    sd(reg_nb_oh, sp, 32);
+    sd(reg_nb_ow, sp, 40);
+    sd(reg_oh_tile, sp, 48);
+    sd(reg_ow_tile, sp, 56);
+
+    // Load params
+    ld(reg_M, a0, 0);
+    ld(reg_bias, a0, 8);
+    ld(reg_dst, a0, 16);
+    ld(reg_nb_oh, a0, 24);
+    ld(reg_nb_ow, a0, 32);
+
+    // Bake constants
+    li(reg_oc_total, oc_);
+    li(reg_oh_lim, oh_);
+    li(reg_ow_lim, ow_);
+    li(reg_N, N_);
+    li(reg_M_eb, M_elem_stride_ * 4);
+    li(reg_oc_spb, oc_spatial_stride_ * 4);
+
+    // Lambda: load w0-w3 and accumulate for one k
+    auto emit_load_k = [&](int k, bool positive) {
+        slli(t0, reg_oc_base, 2);
+        add(t0, t0, reg_tile_moff);
+        add(t0, t0, reg_M);
+        if (k > 0) {
+            li(t1, static_cast<uint64_t>(k) * 4);
+            mul(t1, t1, reg_M_eb);
+            add(t0, t0, t1);
+        }
+
+        vle32_v(vw0, t0);
+        add(t0, t0, reg_M_eb);
+        vle32_v(vw1, t0);
+        add(t0, t0, reg_M_eb);
+        vle32_v(vw2, t0);
+        add(t0, t0, reg_M_eb);
+        vle32_v(vw3, t0);
+
+        vfadd_vv(vtmp0, vw0, vw1);
+        vfadd_vv(vtmp0, vtmp0, vw2);
+        vfsub_vv(vtmp1, vw1, vw2);
+        vfadd_vv(vtmp1, vtmp1, vw3);
+
+        if (positive) {
+            vfadd_vv(vr0, vr0, vtmp0);
+            vfadd_vv(vr1, vr1, vtmp1);
+        } else {
+            vfsub_vv(vr0, vr0, vtmp0);
+            vfsub_vv(vr1, vr1, vtmp1);
+        }
+    };
+
+    // Lambda: zero accum, 3 k values, bias, store
+    auto emit_out_i = [&](int out_i, int k0, bool pos0, int k1, bool pos1,
+                              int k2, bool pos2) {
+        vmv_v_i(vr0, 0);
+        vmv_v_i(vr1, 0);
+
+        emit_load_k(k0, pos0);
+        emit_load_k(k1, pos1);
+        emit_load_k(k2, pos2);
+
+        if (with_bias_) {
+            vfadd_vv(vr0, vr0, v_bias);
+            vfadd_vv(vr1, vr1, v_bias);
+        }
+
+        // Store with boundary checks
+        addi(t0, reg_oh_s, out_i);
+        Label lbl_store_done;
+        bge(t0, reg_oh_lim, lbl_store_done);
+
+        mul(t1, reg_oc_base, reg_oc_spb);
+        add(t1, t1, reg_dst);
+        mul(t2, t0, reg_ow_lim);
+        slli(t2, t2, 2);
+        add(t2, t2, t1);
+        slli(t3, reg_ow_s, 2);
+        add(t2, t2, t3);
+
+        vsse32_v(vr0, t2, reg_oc_spb);
+
+        addi(t3, reg_ow_s, 1);
+        bge(t3, reg_ow_lim, lbl_store_done);
+        addi(t2, t2, 4);
+        vsse32_v(vr1, t2, reg_oc_spb);
+
+        L(lbl_store_done);
+    };
+
+    // ---- Outer tile loop: oh_tile ----
+    mv(reg_oh_tile, x0);
+    Label lbl_oh_loop, lbl_oh_done;
+    L(lbl_oh_loop);
+    bge(reg_oh_tile, reg_nb_oh, lbl_oh_done);
+
+    slli(reg_oh_s, reg_oh_tile, 1);
+
+    // ---- Inner tile loop: ow_tile ----
+    mv(reg_ow_tile, x0);
+    Label lbl_ow_loop, lbl_ow_done;
+    L(lbl_ow_loop);
+    bge(reg_ow_tile, reg_nb_ow, lbl_ow_done);
+
+    slli(reg_ow_s, reg_ow_tile, 1);
+
+    // tile_moff = (oh_tile * nb_ow + ow_tile) * N * 4
+    mul(reg_tile_moff, reg_oh_tile, reg_nb_ow);
+    add(reg_tile_moff, reg_tile_moff, reg_ow_tile);
+    mul(reg_tile_moff, reg_tile_moff, reg_N);
+    slli(reg_tile_moff, reg_tile_moff, 2);
+
+    // ---- OC loop ----
+    mv(reg_oc_base, x0);
+    Label lbl_oc_loop, lbl_oc_end;
+    L(lbl_oc_loop);
+    bge(reg_oc_base, reg_oc_total, lbl_oc_end);
+
+    sub(t0, reg_oc_total, reg_oc_base);
+    vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
+
+    // Load bias once per OC chunk
+    if (with_bias_) {
+        slli(t0, reg_oc_base, 2);
+        add(t0, reg_bias, t0);
+        vle32_v(v_bias, t0);
+    }
+
+    emit_out_i(0, 0, true, 1, true, 2, true);
+    emit_out_i(1, 1, true, 2, false, 3, true);
+
+    add(reg_oc_base, reg_oc_base, reg_vl);
+    j_(lbl_oc_loop);
+    L(lbl_oc_end);
+
+    addi(reg_ow_tile, reg_ow_tile, 1);
+    j_(lbl_ow_loop);
+    L(lbl_ow_done);
+
+    addi(reg_oh_tile, reg_oh_tile, 1);
+    j_(lbl_oh_loop);
+    L(lbl_oh_done);
+
+    // --- Epilogue: restore s0-s7 ---
+    ld(reg_oh_lim, sp, 0);
+    ld(reg_ow_lim, sp, 8);
+    ld(reg_M_eb, sp, 16);
+    ld(reg_N, sp, 24);
+    ld(reg_nb_oh, sp, 32);
+    ld(reg_nb_ow, sp, 40);
+    ld(reg_oh_tile, sp, 48);
+    ld(reg_ow_tile, sp, 56);
+    addi(sp, sp, 64);
+    ret();
+}
+
+// -----------------------------------------------------------------------
+// rvv_wino_convolution_fwd_t implementation
+// -----------------------------------------------------------------------
+status_t rvv_wino_convolution_fwd_t::init(engine_t *engine) {
+    auto *input = new jit_wino_input_transform_t(pd()->conf_);
+    input_xform_.reset(input);
+    CHECK(input->create_kernel());
+
+    auto *output = new jit_wino_output_transform_t(pd()->conf_);
     output_xform_.reset(output);
+    CHECK(output->create_kernel());
 
     return status::success;
 }
@@ -592,7 +563,7 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
     conf.wspec.M = ((conf.oh + 1) / 2) * ((conf.ow + 1) / 2); // Total 2x2 tiles
     conf.wspec.K = conf.ic; // Input channels
     conf.wspec.N = conf.oc; // Output channels
-    conf.wspec.n_gemms = 16; // Winograd F(2×2, 3×3)
+    conf.wspec.n_gemms = 16; // Winograd F(2x2, 3x3)
     conf.wspec.n_batches = conf.mb;
 
     // 64-byte aligned leading dimensions (for efficient vectorization)
@@ -608,7 +579,7 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
             = conf.wspec.weight_oc_rounded * conf.wspec.weight_ic_rounded;
 
     // Input matrix: A[K][M] column-major where K=IC, M=tiles
-    // Input buffer per thread: [16][tile_chunk × IC_rounded] per element
+    // Input buffer per thread: [16][tile_chunk x IC_rounded] per element
     conf.wspec.input_ld_row
             = rnd_up(conf.wspec.K, CACHE_LINE_FLOATS); // LDB = IC_rounded
     conf.wspec.input_ld_batch
@@ -658,11 +629,8 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
     float *V = scratchpad.template get<float>(key_wino_V);
     float *M = scratchpad.template get<float>(key_wino_M);
 
-    // JIT kernels persisted in resource across execute() calls
-    auto *wino_resource
-            = ctx.get_resource_mapper()->get<rvv_wino_resource_t>(this);
-    auto *input_xform = wino_resource->get_input_xform();
-    auto *output_xform = wino_resource->get_output_xform();
+    auto *input_xform = input_xform_.get();
+    auto *output_xform = output_xform_.get();
 
     // Sequential batch processing: input transform -> GEMM -> output transform
     // per batch, keeping working set in L2 cache.

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -15,7 +15,6 @@
 *******************************************************************************/
 
 #include <algorithm>
-#include <cmath>
 #include <cstring>
 #include <riscv_vector.h>
 
@@ -59,43 +58,6 @@ constexpr float A[4][2]
 constexpr float G[4][3] = {{1.0f, 0.0f, 0.0f}, {0.5f, 0.5f, 0.5f},
         {0.5f, -0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}};
 
-// Maximum supported vector length in floats (for VLEN=1024: 1024/32=32)
-constexpr dim_t MAX_VL_FLOATS = 32;
-
-// Pre-compute filter transform: 3x3 -> 4x4
-// Transform = G * filter * G^T
-// Output layout: [oc][ic][16]
-__attribute__((unused)) static void compute_filter_transform_3x3_to_4x4(
-        const float *filter, float *transformed, int oc, int ic) {
-    for (int oc_idx = 0; oc_idx < oc; oc_idx++) {
-        for (int ic_idx = 0; ic_idx < ic; ic_idx++) {
-            const float *f = &filter[(oc_idx * ic + ic_idx) * 9];
-            float *out = &transformed[(oc_idx * ic + ic_idx) * 16];
-
-            float temp[4][3];
-            for (int i = 0; i < 4; i++) {
-                for (int j = 0; j < 3; j++) {
-                    float sum = 0.0f;
-                    for (int k = 0; k < 3; k++) {
-                        sum += G[i][k] * f[k * 3 + j];
-                    }
-                    temp[i][j] = sum;
-                }
-            }
-
-            for (int i = 0; i < 4; i++) {
-                for (int j = 0; j < 4; j++) {
-                    float sum = 0.0f;
-                    for (int k = 0; k < 3; k++) {
-                        sum += temp[i][k] * G[j][k];
-                    }
-                    out[i * 4 + j] = sum;
-                }
-            }
-        }
-    }
-}
-
 // Pre-compute filter transform with GEMM-layout: 3x3 -> 4x4
 // Transform = G * filter * G^T
 // Output layout: [16][ic_rounded][oc_rounded] for brgemm col-major access
@@ -135,84 +97,6 @@ void compute_filter_transform_3x3_to_4x4_gemm_layout(const float *filter,
                             = sum;
                 }
             }
-        }
-    }
-}
-
-// RVV-optimized Winograd input transform: d = B^T * input_tile * B (4x4 -> 4x4)
-inline void winograd_input_transform_4x4(
-        const float *input_tile, float *output_tile) {
-    constexpr dim_t vl = 4; // Fixed size for 4x4 matrix operations
-    float temp[16];
-
-    // Step 1: input_tile * B
-    for (int i = 0; i < 4; i++) {
-        vfloat32m1_t v_in_row = __riscv_vle32_v_f32m1(input_tile + i * 4, vl);
-        for (int j = 0; j < 4; j++) {
-            float B_col[4] = {B[0][j], B[1][j], B[2][j], B[3][j]};
-            vfloat32m1_t v_b_col = __riscv_vle32_v_f32m1(B_col, vl);
-            vfloat32m1_t v_prod = __riscv_vfmul_vv_f32m1(v_in_row, v_b_col, vl);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
-            temp[i * 4 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
-        }
-    }
-
-    // Step 2: B^T * temp
-    for (int i = 0; i < 4; i++) {
-        float BT_row[4] = {BT[i][0], BT[i][1], BT[i][2], BT[i][3]};
-        vfloat32m1_t v_bt_row = __riscv_vle32_v_f32m1(BT_row, vl);
-        for (int j = 0; j < 4; j++) {
-            float temp_col[4] = {temp[0 * 4 + j], temp[1 * 4 + j],
-                    temp[2 * 4 + j], temp[3 * 4 + j]};
-            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl);
-            vfloat32m1_t v_prod
-                    = __riscv_vfmul_vv_f32m1(v_bt_row, v_temp_col, vl);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
-            output_tile[i * 4 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
-        }
-    }
-}
-
-// RVV-optimized Winograd output transform: m = A^T * winograd_domain * A (4x4 -> 2x2)
-inline void winograd_output_transform_2x2(
-        const float *winograd_domain, float *output_tile) {
-    constexpr dim_t vl = 4; // Fixed size for 4-element matrix operations
-    float temp[8];
-
-    // Step 1: winograd_domain * A
-    for (int i = 0; i < 4; i++) {
-        vfloat32m1_t v_wino_row
-                = __riscv_vle32_v_f32m1(winograd_domain + i * 4, vl);
-        for (int j = 0; j < 2; j++) {
-            float A_col[4] = {A[0][j], A[1][j], A[2][j], A[3][j]};
-            vfloat32m1_t v_a_col = __riscv_vle32_v_f32m1(A_col, vl);
-            vfloat32m1_t v_prod
-                    = __riscv_vfmul_vv_f32m1(v_wino_row, v_a_col, vl);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
-            temp[i * 2 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
-        }
-    }
-
-    // Step 2: A^T * temp
-    for (int i = 0; i < 2; i++) {
-        float AT_row[4] = {AT[i][0], AT[i][1], AT[i][2], AT[i][3]};
-        vfloat32m1_t v_at_row = __riscv_vle32_v_f32m1(AT_row, vl);
-        for (int j = 0; j < 2; j++) {
-            float temp_col[4] = {temp[0 * 2 + j], temp[1 * 2 + j],
-                    temp[2 * 2 + j], temp[3 * 2 + j]};
-            vfloat32m1_t v_temp_col = __riscv_vle32_v_f32m1(temp_col, vl);
-            vfloat32m1_t v_prod
-                    = __riscv_vfmul_vv_f32m1(v_at_row, v_temp_col, vl);
-            vfloat32m1_t v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            vfloat32m1_t v_sum
-                    = __riscv_vfredusum_vs_f32m1_f32m1(v_prod, v_zero, vl);
-            output_tile[i * 2 + j] = __riscv_vfmv_f_s_f32m1_f32(v_sum);
         }
     }
 }
@@ -340,7 +224,7 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
     float *V = scratchpad.template get<float>(key_wino_V);
     float *M = scratchpad.template get<float>(key_wino_M);
 
-    // Sequential batch processing: input transform → GEMM → output transform
+    // Sequential batch processing: input transform -> GEMM -> output transform
     // per batch, keeping working set in L2 cache.
     const dim_t nb_oh = (conf.oh + 1) / 2;
     const dim_t nb_ow = (conf.ow + 1) / 2;
@@ -348,41 +232,131 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
     const dim_t input_ld_row = conf.wspec.input_ld_row;
     const dim_t V_elem_stride = conf.wspec.input_ld_batch;
     const dim_t M_elem_stride = conf.wspec.output_ld_batch;
+    const dim_t ic_spatial_stride = conf.ih * conf.iw;
+    const dim_t oc_spatial_stride = conf.oh * conf.ow;
 
     for (dim_t mb_idx = 0; mb_idx < conf.mb; mb_idx++) {
-        const float *src_batch = src + mb_idx * conf.ic * conf.ih * conf.iw;
+        const float *src_batch = src + mb_idx * conf.ic * ic_spatial_stride;
 
-        // Step 1: Input transform for this batch
+        // Step 1: Input transform - vectorized across IC channels
+        // Row-by-row approach: for each output row out_i of B^T * tile * B,
+        // compute fused result using at most 9 vector registers.
+        // result[out_i][j] = Σ_k BT[out_i][k] * Σ_m tile[k][m]*B[m][j]
         for (dim_t tile_idx = 0; tile_idx < total_tiles; tile_idx++) {
             const dim_t oh_tile = tile_idx / nb_ow;
             const dim_t ow_tile = tile_idx % nb_ow;
             const dim_t oh_s = oh_tile * 2;
             const dim_t ow_s = ow_tile * 2;
 
-            for (dim_t ic_idx = 0; ic_idx < conf.ic; ic_idx++) {
-                float input_tile[16];
-                for (dim_t i = 0; i < 4; i++) {
-                    dim_t ih_idx = oh_s + i - conf.pad_t;
-                    for (dim_t j = 0; j < 4; j++) {
-                        dim_t iw_idx = ow_s + j - conf.pad_l;
-                        if (ih_idx >= 0 && ih_idx < conf.ih && iw_idx >= 0
-                                && iw_idx < conf.iw) {
-                            input_tile[i * 4 + j]
-                                    = src_batch[ic_idx * conf.ih * conf.iw
-                                            + ih_idx * conf.iw + iw_idx];
+            dim_t vl = __riscv_vsetvl_e32m1(conf.ic);
+            for (dim_t ic_base = 0; ic_base < conf.ic; ic_base += vl) {
+                vl = __riscv_vsetvl_e32m1(conf.ic - ic_base);
+
+                // Load 4x4 input tile: 4 rows of 4 strided loads
+                // tile[i][j] = src at (oh_s+i, ow_s+j) for each IC channel
+                // Using 4 variables for the 4 values in current row i.
+                // We process one output row at a time: for each out_i,
+                // we load row k=0..3 on the fly and accumulate.
+                for (int out_i = 0; out_i < 4; out_i++) {
+                    // Accumulators for 4 columns of result[out_i][*]
+                    vfloat32m1_t res0 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                    vfloat32m1_t res1 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                    vfloat32m1_t res2 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                    vfloat32m1_t res3 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+
+                    for (int k = 0; k < 4; k++) {
+                        // Exploit BT sparsity: skip when BT[out_i][k] == 0
+                        // BT = [1,0,-1,0; 0,1,1,0; 0,-1,1,0; 0,-1,0,1]
+                        float bt_val = BT[out_i][k];
+                        if (bt_val == 0.0f) continue;
+
+                        dim_t ih_idx = oh_s + k - conf.pad_t;
+                        // Load tile[k][0..3] for this IC chunk
+                        vfloat32m1_t t0, t1, t2, t3;
+                        if (ih_idx >= 0 && ih_idx < conf.ih) {
+                            dim_t iw0 = ow_s + 0 - conf.pad_l;
+                            dim_t iw1 = ow_s + 1 - conf.pad_l;
+                            dim_t iw2 = ow_s + 2 - conf.pad_l;
+                            dim_t iw3 = ow_s + 3 - conf.pad_l;
+                            t0 = (iw0 >= 0 && iw0 < conf.iw)
+                                    ? __riscv_vlse32_v_f32m1(src_batch
+                                                      + ic_base
+                                                              * ic_spatial_stride
+                                                      + ih_idx * conf.iw + iw0,
+                                              ic_spatial_stride * sizeof(float),
+                                              vl)
+                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                            t1 = (iw1 >= 0 && iw1 < conf.iw)
+                                    ? __riscv_vlse32_v_f32m1(src_batch
+                                                      + ic_base
+                                                              * ic_spatial_stride
+                                                      + ih_idx * conf.iw + iw1,
+                                              ic_spatial_stride * sizeof(float),
+                                              vl)
+                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                            t2 = (iw2 >= 0 && iw2 < conf.iw)
+                                    ? __riscv_vlse32_v_f32m1(src_batch
+                                                      + ic_base
+                                                              * ic_spatial_stride
+                                                      + ih_idx * conf.iw + iw2,
+                                              ic_spatial_stride * sizeof(float),
+                                              vl)
+                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                            t3 = (iw3 >= 0 && iw3 < conf.iw)
+                                    ? __riscv_vlse32_v_f32m1(src_batch
+                                                      + ic_base
+                                                              * ic_spatial_stride
+                                                      + ih_idx * conf.iw + iw3,
+                                              ic_spatial_stride * sizeof(float),
+                                              vl)
+                                    : __riscv_vfmv_v_f_f32m1(0.0f, vl);
                         } else {
-                            input_tile[i * 4 + j] = 0.0f;
+                            t0 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                            t1 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                            t2 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                            t3 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                        }
+
+                        // Exploit B sparsity: B*[t0,t1,t2,t3]^T =
+                        // [t0-t2, t1+t2, t2-t1, t3-t1]
+                        // (B = [1,0,0,0; 0,1,-1,-1; -1,1,1,0; 0,0,0,1])
+                        vfloat32m1_t tmp0 = __riscv_vfsub_vv_f32m1(t0, t2, vl);
+                        vfloat32m1_t tmp1 = __riscv_vfadd_vv_f32m1(t1, t2, vl);
+                        vfloat32m1_t tmp2 = __riscv_vfsub_vv_f32m1(t2, t1, vl);
+                        vfloat32m1_t tmp3 = __riscv_vfsub_vv_f32m1(t3, t1, vl);
+
+                        // Accumulate: res += bt_val * tmp
+                        // bt_val is always 1.0f or -1.0f here
+                        if (bt_val > 0.0f) {
+                            res0 = __riscv_vfadd_vv_f32m1(res0, tmp0, vl);
+                            res1 = __riscv_vfadd_vv_f32m1(res1, tmp1, vl);
+                            res2 = __riscv_vfadd_vv_f32m1(res2, tmp2, vl);
+                            res3 = __riscv_vfadd_vv_f32m1(res3, tmp3, vl);
+                        } else {
+                            res0 = __riscv_vfsub_vv_f32m1(res0, tmp0, vl);
+                            res1 = __riscv_vfsub_vv_f32m1(res1, tmp1, vl);
+                            res2 = __riscv_vfsub_vv_f32m1(res2, tmp2, vl);
+                            res3 = __riscv_vfsub_vv_f32m1(res3, tmp3, vl);
                         }
                     }
+
+                    // Store result[out_i][0..3] to V buffer
+                    int base_elem = out_i * 4;
+                    __riscv_vse32_v_f32m1(V + (base_elem + 0) * V_elem_stride
+                                    + tile_idx * input_ld_row + ic_base,
+                            res0, vl);
+                    __riscv_vse32_v_f32m1(V + (base_elem + 1) * V_elem_stride
+                                    + tile_idx * input_ld_row + ic_base,
+                            res1, vl);
+                    __riscv_vse32_v_f32m1(V + (base_elem + 2) * V_elem_stride
+                                    + tile_idx * input_ld_row + ic_base,
+                            res2, vl);
+                    __riscv_vse32_v_f32m1(V + (base_elem + 3) * V_elem_stride
+                                    + tile_idx * input_ld_row + ic_base,
+                            res3, vl);
                 }
 
-                float transformed[16];
-                winograd_input_transform_4x4(input_tile, transformed);
-
-                for (int elem = 0; elem < 16; elem++) {
-                    V[elem * V_elem_stride + tile_idx * input_ld_row + ic_idx]
-                            = transformed[elem];
-                }
+                vl = __riscv_vsetvl_e32m1(conf.ic);
             }
         }
 
@@ -397,37 +371,102 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
                     total_tiles, 0.0f);
         }
 
-        // Step 3: Output transform for this batch
-        data_t *dst_batch = dst + mb_idx * conf.oc * conf.oh * conf.ow;
+        // Step 3: Output transform - vectorized across OC channels
+        // Row-by-row approach: for each output row out_i of A^T * wino * A,
+        // compute fused result using at most 7 vector registers.
+        // output[out_i][j] = Σ_k AT[out_i][k] * Σ_m wino[k][m]*A[m][j]
+        data_t *dst_batch = dst + mb_idx * conf.oc * oc_spatial_stride;
         for (dim_t tile_idx = 0; tile_idx < total_tiles; tile_idx++) {
             const dim_t oh_tile = tile_idx / nb_ow;
             const dim_t ow_tile = tile_idx % nb_ow;
             const dim_t oh_s = oh_tile * 2;
             const dim_t ow_s = ow_tile * 2;
 
-            for (dim_t oc_idx = 0; oc_idx < conf.oc; oc_idx++) {
-                float wino_tile[16];
-                for (int elem = 0; elem < 16; elem++) {
-                    wino_tile[elem] = M[elem * M_elem_stride
-                            + tile_idx * conf.wspec.N + oc_idx];
-                }
+            dim_t vl = __riscv_vsetvl_e32m1(conf.oc);
+            for (dim_t oc_base = 0; oc_base < conf.oc; oc_base += vl) {
+                vl = __riscv_vsetvl_e32m1(conf.oc - oc_base);
 
-                float output_2x2[4];
-                winograd_output_transform_2x2(wino_tile, output_2x2);
+                for (int out_i = 0; out_i < 2; out_i++) {
+                    // Accumulators for 2 columns of output[out_i][*]
+                    vfloat32m1_t res0 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                    vfloat32m1_t res1 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
 
-                const float bias_val
-                        = (conf.with_bias && bias) ? bias[oc_idx] : 0.0f;
-                for (dim_t i = 0; i < 2; i++) {
-                    dim_t oh = oh_s + i;
-                    if (oh >= conf.oh) continue;
-                    for (dim_t j = 0; j < 2; j++) {
-                        dim_t ow = ow_s + j;
-                        if (ow >= conf.ow) continue;
-                        dst_batch[oc_idx * conf.oh * conf.ow + oh * conf.ow
-                                + ow]
-                                = output_2x2[i * 2 + j] + bias_val;
+                    for (int k = 0; k < 4; k++) {
+                        // Exploit AT sparsity: skip when AT[out_i][k] == 0
+                        // AT = [1,1,1,0; 0,1,-1,1]
+                        float at_val = AT[out_i][k];
+                        if (at_val == 0.0f) continue;
+
+                        // Load wino[k][0..3]
+                        vfloat32m1_t w0 = __riscv_vle32_v_f32m1(M
+                                        + (k * 4 + 0) * M_elem_stride
+                                        + tile_idx * conf.wspec.N + oc_base,
+                                vl);
+                        vfloat32m1_t w1 = __riscv_vle32_v_f32m1(M
+                                        + (k * 4 + 1) * M_elem_stride
+                                        + tile_idx * conf.wspec.N + oc_base,
+                                vl);
+                        vfloat32m1_t w2 = __riscv_vle32_v_f32m1(M
+                                        + (k * 4 + 2) * M_elem_stride
+                                        + tile_idx * conf.wspec.N + oc_base,
+                                vl);
+                        vfloat32m1_t w3 = __riscv_vle32_v_f32m1(M
+                                        + (k * 4 + 3) * M_elem_stride
+                                        + tile_idx * conf.wspec.N + oc_base,
+                                vl);
+
+                        // Exploit A sparsity: A*[w0,w1,w2,w3]^T =
+                        // [w0+w1+w2, w1-w2+w3]
+                        // (A = [1,0; 1,1; 1,-1; 0,1])
+                        vfloat32m1_t tmp0 = __riscv_vfadd_vv_f32m1(
+                                __riscv_vfadd_vv_f32m1(w0, w1, vl), w2, vl);
+                        vfloat32m1_t tmp1 = __riscv_vfadd_vv_f32m1(
+                                __riscv_vfsub_vv_f32m1(w1, w2, vl), w3, vl);
+
+                        // Accumulate: res += at_val * tmp
+                        // at_val is 1.0f or -1.0f here
+                        if (at_val > 0.0f) {
+                            res0 = __riscv_vfadd_vv_f32m1(res0, tmp0, vl);
+                            res1 = __riscv_vfadd_vv_f32m1(res1, tmp1, vl);
+                        } else {
+                            res0 = __riscv_vfsub_vv_f32m1(res0, tmp0, vl);
+                            res1 = __riscv_vfsub_vv_f32m1(res1, tmp1, vl);
+                        }
+                    }
+
+                    // Add bias
+                    vfloat32m1_t v_bias = (conf.with_bias && bias)
+                            ? __riscv_vle32_v_f32m1(bias + oc_base, vl)
+                            : __riscv_vfmv_v_f_f32m1(0.0f, vl);
+                    res0 = __riscv_vfadd_vv_f32m1(res0, v_bias, vl);
+                    res1 = __riscv_vfadd_vv_f32m1(res1, v_bias, vl);
+
+                    // Store to dst using strided stores
+                    // dst layout: [OC][OH][OW], stride between OC = OH*OW
+                    {
+                        dim_t oh = oh_s + out_i;
+                        if (oh < conf.oh) {
+                            dim_t ow = ow_s + 0;
+                            if (ow < conf.ow) {
+                                __riscv_vsse32_v_f32m1(dst_batch
+                                                + oc_base * oc_spatial_stride
+                                                + oh * conf.ow + ow,
+                                        oc_spatial_stride * sizeof(float), res0,
+                                        vl);
+                            }
+                            ow = ow_s + 1;
+                            if (ow < conf.ow) {
+                                __riscv_vsse32_v_f32m1(dst_batch
+                                                + oc_base * oc_spatial_stride
+                                                + oh * conf.ow + ow,
+                                        oc_spatial_stride * sizeof(float), res1,
+                                        vl);
+                            }
+                        }
                     }
                 }
+
+                vl = __riscv_vsetvl_e32m1(conf.oc);
             }
         }
     }

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -537,11 +537,7 @@ struct jit_wino_output_transform_t : public jit_generator_t {
 
 } // namespace
 
-status_t rvv_wino_resource_t::configure(
-        size_t weight_buf_size, const rvv_winograd_conf_t &conf) {
-    weight_buf_.reset(new float[weight_buf_size]);
-    if (!weight_buf_) return status::out_of_memory;
-
+status_t rvv_wino_resource_t::configure(const rvv_winograd_conf_t &conf) {
     auto *input = new jit_wino_input_transform_t(conf);
     input->create_kernel();
     input_xform_.reset(input);
@@ -629,10 +625,10 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
     conf.wspec.V_buffer_size = conf.wspec.n_gemms * conf.wspec.input_ld_batch;
     conf.wspec.M_buffer_size = conf.wspec.n_gemms * conf.wspec.output_ld_batch;
 
-    // Scratchpad: V and M buffers for single-thread execution
-    // Weight buffer is in persistent resource_t (not scratchpad)
+    // Scratchpad: U (transformed weights), V (transformed input), M (GEMM output)
     using namespace memory_tracking::names;
 
+    scratchpad.book<float>(key_wino_U, conf.wspec.weight_matrix_size);
     scratchpad.book<float>(key_wino_V, conf.wspec.V_buffer_size);
     scratchpad.book<float>(key_wino_M, conf.wspec.M_buffer_size);
 
@@ -651,24 +647,20 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
     const auto scratchpad = ctx.get_scratchpad_grantor();
     const auto *brg_kernel = pd()->brg_kernel_.get();
 
-    // Get persistent weight buffer from resource (cached across execute calls)
-    auto *wino_resource
-            = ctx.get_resource_mapper()->get<rvv_wino_resource_t>(this);
-    float *transformed_weights = wino_resource->get_weight_buffer();
-
-    // Transform weights on first execute, cache for subsequent calls
-    if (!wino_resource->weights_valid()) {
-        compute_filter_transform_3x3_to_4x4_gemm_layout(weights,
-                transformed_weights, conf.wspec.N, conf.wspec.K,
-                conf.wspec.weight_ic_rounded, conf.wspec.weight_oc_rounded);
-        wino_resource->set_weights_valid();
-    }
-
     using namespace memory_tracking::names;
+
+    // Transform weights into scratchpad buffer every execute (like x64 brgemm)
+    float *transformed_weights = scratchpad.template get<float>(key_wino_U);
+    compute_filter_transform_3x3_to_4x4_gemm_layout(weights,
+            transformed_weights, conf.wspec.N, conf.wspec.K,
+            conf.wspec.weight_ic_rounded, conf.wspec.weight_oc_rounded);
+
     float *V = scratchpad.template get<float>(key_wino_V);
     float *M = scratchpad.template get<float>(key_wino_M);
 
-    // JIT kernels created in create_resource(), retrieved from resource
+    // JIT kernels persisted in resource across execute() calls
+    auto *wino_resource
+            = ctx.get_resource_mapper()->get<rvv_wino_resource_t>(this);
     auto *input_xform = wino_resource->get_input_xform();
     auto *output_xform = wino_resource->get_output_xform();
 

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -1,0 +1,226 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_RVV_WINOGRAD_CONVOLUTION_HPP
+#define CPU_RV64_RVV_WINOGRAD_CONVOLUTION_HPP
+
+#include "common/broadcast_strategy.hpp"
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/binary_injector_utils.hpp"
+#include "cpu/cpu_convolution_pd.hpp"
+#include "cpu/primitive_attr_postops.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+// Winograd domain specification (ARM-style)
+struct WinogradDomainSpec {
+    // Matrix dimensions for GEMM: C[M][N] = A[M][K] * B[K][N]
+    dim_t M; // Total tiles = ceil(oh/2) * ceil(ow/2)
+    dim_t K; // Input channels (IC)
+    dim_t N; // Output channels (OC)
+
+    dim_t n_gemms; // = 16 (Winograd F(2×2, 3×3) has 16 transformed elements)
+    dim_t n_batches; // = mb (batch size)
+
+    // 64-byte aligned strides (16 floats per cache line)
+    dim_t input_ld_row; // Leading dimension for input rows
+    dim_t input_ld_batch; // Leading dimension for batches
+    dim_t input_ld_matrix; // Leading dimension for matrices (16 GEMMs)
+
+    dim_t weight_ld_row; // Leading dimension for weight rows
+    dim_t weight_ld_matrix; // Leading dimension for matrices (16 GEMMs)
+
+    // Rounded dimensions for weight transform buffer allocation
+    dim_t weight_ic_rounded; // Round up K for IC dimension
+    dim_t weight_oc_rounded; // Round up N for OC dimension
+
+    dim_t output_ld_row; // Leading dimension for output rows
+    dim_t output_ld_batch; // Leading dimension for batches
+    dim_t output_ld_matrix; // Leading dimension for matrices (16 GEMMs)
+
+    // Matrix sizes in bytes
+    size_t input_matrix_size; // Size of transformed input buffer
+    size_t weight_matrix_size; // Size of transformed weights buffer
+    size_t output_matrix_size; // Size of Winograd domain output buffer
+};
+
+struct rvv_winograd_conf_t {
+    // Convolution parameters
+    bool with_bias;
+    dim_t ih, iw; // Input spatial dimensions
+    dim_t ic, oc; // Input/output channels
+    dim_t kh, kw; // Kernel size (should be 3x3)
+    dim_t stride_h, stride_w; // Stride (should be 1x1)
+    dim_t pad_t, pad_b; // Top/bottom padding
+    dim_t pad_l, pad_r; // Left/right padding
+
+    // Output dimensions
+    dim_t oh, ow;
+
+    // Winograd transform parameters
+    dim_t mb; // Batch size
+    dim_t nthr; // Number of threads
+
+    // Winograd domain specification for GEMM-based execution
+    WinogradDomainSpec wspec;
+};
+
+status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
+        memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,
+        const memory_desc_t &src_md, const memory_desc_t &weights_md,
+        const memory_desc_t &dst_md, const memory_desc_t &bias_md,
+        const primitive_attr_t &attr, int max_threads);
+
+struct rvv_wino_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        using cpu_convolution_fwd_pd_t::cpu_convolution_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                "wino:rvv", rvv_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
+
+            // Check data types: f32 only
+            VDISPATCH_CONV(with_bias()
+                            ? expect_data_types(f32, f32, f32, f32, f32)
+                            : expect_data_types(
+                                      f32, f32, data_type::undef, f32, f32),
+                    VERBOSE_UNSUPPORTED_DT_CFG);
+
+            VDISPATCH_CONV(
+                    attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, f32),
+                    VERBOSE_UNSUPPORTED_ATTR);
+
+            VDISPATCH_CONV(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
+
+            VDISPATCH_CONV(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+
+            // Set default formats if format_kind == any
+            // IMPORTANT: Must do this BEFORE creating memory_desc_wrapper!
+            if (src_md_.format_kind == format_kind::any) set_default_formats();
+
+            const memory_desc_wrapper src_d(&src_md_);
+            const memory_desc_wrapper weights_d(&weights_md_);
+            const memory_desc_wrapper dst_d(&dst_md_);
+
+            // Check kernel size: 3x3 only
+            VDISPATCH_CONV(weights_d.dims()[2] == 3 && weights_d.dims()[3] == 3,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "only 3x3 kernel is supported for winograd");
+
+            // Check stride: must be 1x1
+            VDISPATCH_CONV(desc()->strides[0] == 1 && desc()->strides[1] == 1,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "only stride 1x1 is supported for winograd");
+
+            // Check padding: <= 1
+            VDISPATCH_CONV(desc()->padding[0][0] <= 1
+                            && desc()->padding[0][1] <= 1
+                            && desc()->padding[1][0] <= 1
+                            && desc()->padding[1][1] <= 1,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "padding must be <= 1 for winograd");
+
+            // Check dilation: no dilation
+            VDISPATCH_CONV(desc()->dilates[0] == 0 && desc()->dilates[1] == 0,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "dilation is not supported for winograd");
+
+            // Check spatial dims: <= 112
+            VDISPATCH_CONV(src_d.dims()[2] <= 112 && src_d.dims()[3] <= 112,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "input spatial dimensions must be <= 112 for winograd");
+
+            // Check channels: ic >= 64, oc >= 64
+            VDISPATCH_CONV(src_d.dims()[1] >= 64 && dst_d.dims()[1] >= 64,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "ic and oc must be >= 64 for winograd");
+
+            // Initialize configuration
+            const int max_threads = dnnl_get_max_threads();
+            auto scratchpad = scratchpad_registry().registrar();
+            CHECK(rvv_winograd_init_conf(conf_, scratchpad, *desc(), src_md_,
+                    weights_md_, dst_md_, bias_md_, attr_, max_threads));
+
+            if (desc()->alg_kind == alg_kind::convolution_auto) {
+                set_default_alg_kind(alg_kind::convolution_winograd);
+            }
+
+            return status::success;
+        }
+
+        rvv_winograd_conf_t conf_ = {};
+
+    protected:
+        bool set_default_formats() {
+            using namespace format_tag;
+            const int n = ndims();
+            const bool g = with_groups();
+            const auto dat_tag = utils::pick(n - 3, nwc, nchw, ncdhw);
+            const auto wei_tag = utils::pick(2 * n - 6 + (g ? 1 : 0), oiw, goiw,
+                    oihw, goihw, oidhw, goidhw);
+
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+
+        bool post_ops_ok() const {
+            // Winograd doesn't support post-ops currently
+            return attr()->post_ops_.len() == 0;
+        }
+    };
+
+    rvv_wino_convolution_fwd_t(const pd_t *apd)
+        : primitive_t(apd), post_ops_(nullptr) {}
+
+    using data_t = typename prec_traits_t<data_type::f32>::type;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+
+    // GEMM-based execution: process all tiles in batch
+    status_t execute_input_transform(
+            const data_t *src, float *transformed_input) const;
+    status_t execute_gemm_batched(const float *transformed_input,
+            const float *transformed_weights, float *winograd_output) const;
+    status_t execute_output_transform(const float *winograd_output,
+            const data_t *bias, data_t *dst) const;
+
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<ref_post_ops_t> post_ops_;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -17,51 +17,57 @@
 #ifndef CPU_RV64_RVV_WINOGRAD_CONVOLUTION_HPP
 #define CPU_RV64_RVV_WINOGRAD_CONVOLUTION_HPP
 
+#include <memory>
+
 #include "common/broadcast_strategy.hpp"
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
+#include "common/resource.hpp"
 #include "common/utils.hpp"
 
 #include "cpu/binary_injector_utils.hpp"
 #include "cpu/cpu_convolution_pd.hpp"
 #include "cpu/primitive_attr_postops.hpp"
 
+#include "cpu/rv64/brgemm/brgemm.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace rv64 {
 
-// Winograd domain specification (ARM-style)
+// Winograd domain specification for GEMM-based Winograd convolution.
+// Single-core execution: processes batches sequentially with
+// local input/output buffers to keep working set in cache.
 struct WinogradDomainSpec {
-    // Matrix dimensions for GEMM: C[M][N] = A[M][K] * B[K][N]
-    dim_t M; // Total tiles = ceil(oh/2) * ceil(ow/2)
+    // Matrix dimensions for brgemm: C[OC×tiles] = A[OC×IC] × B[IC×tiles]
+    dim_t M; // Total tiles per batch = ceil(oh/2) * ceil(ow/2)
     dim_t K; // Input channels (IC)
     dim_t N; // Output channels (OC)
 
     dim_t n_gemms; // = 16 (Winograd F(2×2, 3×3) has 16 transformed elements)
     dim_t n_batches; // = mb (batch size)
 
-    // 64-byte aligned strides (16 floats per cache line)
-    dim_t input_ld_row; // Leading dimension for input rows
-    dim_t input_ld_batch; // Leading dimension for batches
-    dim_t input_ld_matrix; // Leading dimension for matrices (16 GEMMs)
+    // Weight layout: [16][IC_rounded × OC_rounded] col-major per element
+    dim_t weight_ld_row; // LDA for brgemm = oc_rounded
+    dim_t weight_ld_matrix; // Per-element size = oc_rounded × ic_rounded
+    dim_t weight_ic_rounded; // Round up IC for cache-line alignment
+    dim_t weight_oc_rounded; // Round up OC for cache-line alignment
 
-    dim_t weight_ld_row; // Leading dimension for weight rows
-    dim_t weight_ld_matrix; // Leading dimension for matrices (16 GEMMs)
+    // Input buffer: [16][tiles × IC_rounded] per element
+    dim_t input_ld_row; // LDB for brgemm = ic_rounded
+    dim_t input_ld_batch; // Per-element stride = tiles × ic_rounded
 
-    // Rounded dimensions for weight transform buffer allocation
-    dim_t weight_ic_rounded; // Round up K for IC dimension
-    dim_t weight_oc_rounded; // Round up N for OC dimension
+    // Output buffer: [16][tiles × OC] per element
+    dim_t output_ld_row; // LDC for brgemm = OC
+    dim_t output_ld_batch; // Per-element stride = tiles × OC
 
-    dim_t output_ld_row; // Leading dimension for output rows
-    dim_t output_ld_batch; // Leading dimension for batches
-    dim_t output_ld_matrix; // Leading dimension for matrices (16 GEMMs)
-
-    // Matrix sizes in bytes
-    size_t input_matrix_size; // Size of transformed input buffer
-    size_t weight_matrix_size; // Size of transformed weights buffer
-    size_t output_matrix_size; // Size of Winograd domain output buffer
+    // Buffer sizes in floats
+    size_t weight_matrix_size; // Total weight buffer = 16 × weight_ld_matrix
+    size_t V_buffer_size; // Input buffer size
+    size_t M_buffer_size; // Output buffer size
 };
 
 struct rvv_winograd_conf_t {
@@ -79,7 +85,6 @@ struct rvv_winograd_conf_t {
 
     // Winograd transform parameters
     dim_t mb; // Batch size
-    dim_t nthr; // Number of threads
 
     // Winograd domain specification for GEMM-based execution
     WinogradDomainSpec wspec;
@@ -89,7 +94,29 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
         memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,
         const memory_desc_t &src_md, const memory_desc_t &weights_md,
         const memory_desc_t &dst_md, const memory_desc_t &bias_md,
-        const primitive_attr_t &attr, int max_threads);
+        const primitive_attr_t &attr);
+
+// Resource for persistent weight transform buffer.
+// Weights are transformed on first execute() and cached for reuse.
+struct rvv_wino_resource_t : public resource_t {
+    rvv_wino_resource_t() = default;
+
+    status_t configure(size_t weight_buf_size) {
+        weight_buf_.reset(new float[weight_buf_size]);
+        if (!weight_buf_) return status::out_of_memory;
+        return status::success;
+    }
+
+    float *get_weight_buffer() const { return weight_buf_.get(); }
+    bool weights_valid() const { return weights_valid_; }
+    void set_weights_valid() const { weights_valid_ = true; }
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(rvv_wino_resource_t);
+
+private:
+    std::unique_ptr<float[]> weight_buf_;
+    mutable bool weights_valid_ = false;
+};
 
 struct rvv_wino_convolution_fwd_t : public primitive_t {
     struct pd_t : public cpu_convolution_fwd_pd_t {
@@ -101,6 +128,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
         status_t init(engine_t *engine) {
             using namespace data_type;
 
+            VDISPATCH_CONV(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
 
             // Check data types: f32 only
@@ -155,29 +183,44 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "input spatial dimensions must be <= 112 for winograd");
 
-            // Check channels: ic >= 128, oc >= 128
+            // Check channels: IC >= 128 && OC >= 128
             // Small channels (e.g. IC=OC=64) cause regression vs gemm:rvv
             // due to Winograd transform overhead and small GEMM dimensions.
+            // Layers with IC or OC < 128 (e.g. VGG conv3_1 IC=128/OC=96)
+            // regress vs brgemm:rvv, so threshold stays at 128.
             VDISPATCH_CONV(src_d.dims()[1] >= 128 && dst_d.dims()[1] >= 128,
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "ic and oc must be >= 128 for winograd");
 
-            // Thread-count-adaptive output spatial check.
-            // Single-core: Winograd's 2.25x FLOPs reduction dominates for
-            //   all layers with sufficient channels. Dispatch with oh >= 7.
-            // Multi-core: Winograd's 16 small GEMMs (K=IC) have lower
-            //   arithmetic intensity than im2col's single GEMM (K=IC*9).
-            //   Only large-spatial layers (oh >= 14) have enough tiles per
-            //   thread to compensate via the FLOPs advantage.
-            const int max_threads = dnnl_get_max_threads();
-            const dim_t min_spatial = (max_threads > 1) ? 14 : 7;
-            VDISPATCH_CONV(dst_d.dims()[2] >= min_spatial
-                            && dst_d.dims()[3] >= min_spatial,
+            // Winograd dispatch is restricted to single-core execution.
+            // Sequential batch processing keeps working set in L2 cache and
+            // gives 1.1-1.4x speedup over brgemm:rvv on single-core.
+            // On multi-core, brgemm's spatial parallelism is superior.
+            VDISPATCH_CONV(dnnl_get_max_threads() <= 1,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "winograd only beneficial for single-thread execution");
+
+            // Minimum output spatial dimensions for Winograd benefit
+            VDISPATCH_CONV(dst_d.dims()[2] >= 7 && dst_d.dims()[3] >= 7,
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "output spatial dimensions too small for winograd");
             auto scratchpad = scratchpad_registry().registrar();
             CHECK(rvv_winograd_init_conf(conf_, scratchpad, *desc(), src_md_,
-                    weights_md_, dst_md_, bias_md_, attr_, max_threads));
+                    weights_md_, dst_md_, bias_md_, attr_));
+
+            // Create brgemm kernel for Winograd GEMM.
+            // col-major: C[OC×tiles] = A[OC×IC] × B[IC×tiles]
+            {
+                brgemm_desc_t brg_desc;
+                CHECK(brgemm_desc_init(&brg_desc, v, brgemm_strd,
+                        data_type::f32, data_type::f32, brgemm_col_major, 1.0f,
+                        0.0f, conf_.wspec.weight_ld_row,
+                        conf_.wspec.input_ld_row, conf_.wspec.N, conf_.wspec.N,
+                        conf_.wspec.M, conf_.wspec.K));
+                brgemm_kernel_t *kernel = nullptr;
+                CHECK(brgemm_kernel_create(&kernel, brg_desc));
+                brg_kernel_.reset(kernel);
+            }
 
             if (desc()->alg_kind == alg_kind::convolution_auto) {
                 set_default_alg_kind(alg_kind::convolution_winograd);
@@ -187,6 +230,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
         }
 
         rvv_winograd_conf_t conf_ = {};
+        std::shared_ptr<brgemm_kernel_t> brg_kernel_;
 
     protected:
         bool set_default_formats() {
@@ -206,10 +250,19 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
         }
     };
 
-    rvv_wino_convolution_fwd_t(const pd_t *apd)
-        : primitive_t(apd), post_ops_(nullptr) {}
+    rvv_wino_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
     using data_t = typename prec_traits_t<data_type::f32>::type;
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const override {
+        if (mapper.has_resource(this)) return status::success;
+        auto r = utils::make_unique<rvv_wino_resource_t>();
+        if (!r) return status::out_of_memory;
+        CHECK(r->configure(pd()->conf_.wspec.weight_matrix_size));
+        mapper.add(this, std::move(r));
+        return status::success;
+    }
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -218,17 +271,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
 
-    // GEMM-based execution: process all tiles in batch
-    status_t execute_input_transform(
-            const data_t *src, float *transformed_input) const;
-    status_t execute_gemm_batched(const float *transformed_input,
-            const float *transformed_weights, float *winograd_output) const;
-    status_t execute_output_transform(const float *winograd_output,
-            const data_t *bias, data_t *dst) const;
-
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-
-    std::unique_ptr<ref_post_ops_t> post_ops_;
 };
 
 } // namespace rv64

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -155,13 +155,26 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "input spatial dimensions must be <= 112 for winograd");
 
-            // Check channels: ic >= 64, oc >= 64
-            VDISPATCH_CONV(src_d.dims()[1] >= 64 && dst_d.dims()[1] >= 64,
+            // Check channels: ic >= 128, oc >= 128
+            // Small channels (e.g. IC=OC=64) cause regression vs gemm:rvv
+            // due to Winograd transform overhead and small GEMM dimensions.
+            VDISPATCH_CONV(src_d.dims()[1] >= 128 && dst_d.dims()[1] >= 128,
                     VERBOSE_UNSUPPORTED_FEATURE,
-                    "ic and oc must be >= 64 for winograd");
+                    "ic and oc must be >= 128 for winograd");
 
-            // Initialize configuration
+            // Thread-count-adaptive output spatial check.
+            // Single-core: Winograd's 2.25x FLOPs reduction dominates for
+            //   all layers with sufficient channels. Dispatch with oh >= 7.
+            // Multi-core: Winograd's 16 small GEMMs (K=IC) have lower
+            //   arithmetic intensity than im2col's single GEMM (K=IC*9).
+            //   Only large-spatial layers (oh >= 14) have enough tiles per
+            //   thread to compensate via the FLOPs advantage.
             const int max_threads = dnnl_get_max_threads();
+            const dim_t min_spatial = (max_threads > 1) ? 14 : 7;
+            VDISPATCH_CONV(dst_d.dims()[2] >= min_spatial
+                            && dst_d.dims()[3] >= min_spatial,
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "output spatial dimensions too small for winograd");
             auto scratchpad = scratchpad_registry().registrar();
             CHECK(rvv_winograd_init_conf(conf_, scratchpad, *desc(), src_md_,
                     weights_md_, dst_md_, bias_md_, attr_, max_threads));

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -24,7 +24,6 @@
 #include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
-#include "common/resource.hpp"
 #include "common/utils.hpp"
 
 #include "cpu/binary_injector_utils.hpp"
@@ -98,20 +97,44 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
         const memory_desc_t &dst_md, const memory_desc_t &bias_md,
         const primitive_attr_t &attr);
 
-// Resource for JIT kernel persistence across execute() calls.
-struct rvv_wino_resource_t : public resource_t {
-    rvv_wino_resource_t() = default;
+// JIT transform kernels for Winograd convolution
+struct jit_wino_input_transform_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_wino_input_transform_t)
 
-    status_t configure(const rvv_winograd_conf_t &conf);
+    struct call_params_t {
+        const float *src_batch;
+        float *V;
+        dim_t ic_spatial_stride;
+        dim_t nb_oh;
+        dim_t nb_ow;
+    };
 
-    jit_generator_t *get_input_xform() const { return input_xform_.get(); }
-    jit_generator_t *get_output_xform() const { return output_xform_.get(); }
+    dim_t ic_, ih_, iw_, pad_t_, pad_l_;
+    dim_t input_ld_row_, V_elem_stride_;
 
-    DNNL_DISALLOW_COPY_AND_ASSIGN(rvv_wino_resource_t);
+    jit_wino_input_transform_t(const rvv_winograd_conf_t &conf);
 
-private:
-    std::unique_ptr<jit_generator_t> input_xform_;
-    std::unique_ptr<jit_generator_t> output_xform_;
+    void generate() override;
+};
+
+struct jit_wino_output_transform_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_wino_output_transform_t)
+
+    struct call_params_t {
+        const float *M;
+        const float *bias;
+        float *dst_batch;
+        dim_t nb_oh;
+        dim_t nb_ow;
+    };
+
+    dim_t oc_, oh_, ow_, N_;
+    dim_t M_elem_stride_, oc_spatial_stride_;
+    bool with_bias_;
+
+    jit_wino_output_transform_t(const rvv_winograd_conf_t &conf);
+
+    void generate() override;
 };
 
 struct rvv_wino_convolution_fwd_t : public primitive_t {
@@ -244,15 +267,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
 
     using data_t = typename prec_traits_t<data_type::f32>::type;
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override {
-        if (mapper.has_resource(this)) return status::success;
-        auto r = utils::make_unique<rvv_wino_resource_t>();
-        if (!r) return status::out_of_memory;
-        CHECK(r->configure(pd()->conf_));
-        mapper.add(this, std::move(r));
-        return status::success;
-    }
+    status_t init(engine_t *engine) override;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -262,6 +277,9 @@ private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_generator_t> input_xform_;
+    std::unique_ptr<jit_generator_t> output_xform_;
 };
 
 } // namespace rv64

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -21,6 +21,7 @@
 
 #include "common/broadcast_strategy.hpp"
 #include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
 #include "common/resource.hpp"
@@ -32,6 +33,7 @@
 
 #include "cpu/rv64/brgemm/brgemm.hpp"
 #include "cpu/rv64/cpu_isa_traits.hpp"
+#include "cpu/rv64/jit_generator.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -101,13 +103,11 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
 struct rvv_wino_resource_t : public resource_t {
     rvv_wino_resource_t() = default;
 
-    status_t configure(size_t weight_buf_size) {
-        weight_buf_.reset(new float[weight_buf_size]);
-        if (!weight_buf_) return status::out_of_memory;
-        return status::success;
-    }
+    status_t configure(size_t weight_buf_size, const rvv_winograd_conf_t &conf);
 
     float *get_weight_buffer() const { return weight_buf_.get(); }
+    jit_generator_t *get_input_xform() const { return input_xform_.get(); }
+    jit_generator_t *get_output_xform() const { return output_xform_.get(); }
     bool weights_valid() const { return weights_valid_; }
     void set_weights_valid() const { weights_valid_ = true; }
 
@@ -115,6 +115,8 @@ struct rvv_wino_resource_t : public resource_t {
 
 private:
     std::unique_ptr<float[]> weight_buf_;
+    std::unique_ptr<jit_generator_t> input_xform_;
+    std::unique_ptr<jit_generator_t> output_xform_;
     mutable bool weights_valid_ = false;
 };
 
@@ -253,7 +255,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
         if (mapper.has_resource(this)) return status::success;
         auto r = utils::make_unique<rvv_wino_resource_t>();
         if (!r) return status::out_of_memory;
-        CHECK(r->configure(pd()->conf_.wspec.weight_matrix_size));
+        CHECK(r->configure(pd()->conf_.wspec.weight_matrix_size, pd()->conf_));
         mapper.add(this, std::move(r));
         return status::success;
     }

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -183,18 +183,12 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "input spatial dimensions must be <= 112 for winograd");
 
-            // Check channels: IC >= 128 && OC >= 128
-            // Small channels (e.g. IC=OC=64) cause regression vs gemm:rvv
-            // due to Winograd transform overhead and small GEMM dimensions.
-            // Layers with IC or OC < 128 (e.g. VGG conv3_1 IC=128/OC=96)
-            // regress vs brgemm:rvv, so threshold stays at 128.
-            VDISPATCH_CONV(src_d.dims()[1] >= 128 && dst_d.dims()[1] >= 128,
+            // Check channels: IC >= 96 && OC >= 96
+            VDISPATCH_CONV(src_d.dims()[1] >= 96 && dst_d.dims()[1] >= 96,
                     VERBOSE_UNSUPPORTED_FEATURE,
-                    "ic and oc must be >= 128 for winograd");
+                    "ic and oc must be >= 96 for winograd");
 
             // Winograd dispatch is restricted to single-core execution.
-            // Sequential batch processing keeps working set in L2 cache and
-            // gives 1.1-1.4x speedup over brgemm:rvv on single-core.
             // On multi-core, brgemm's spatial parallelism is superior.
             VDISPATCH_CONV(dnnl_get_max_threads() <= 1,
                     VERBOSE_UNSUPPORTED_FEATURE,

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -42,7 +42,7 @@ namespace rv64 {
 // Winograd domain specification for GEMM-based Winograd convolution.
 // Single-core execution: processes batches sequentially with
 // local input/output buffers to keep working set in cache.
-struct WinogradDomainSpec {
+struct WinogradDomainSpec_t {
     // Matrix dimensions for brgemm: C[OC×tiles] = A[OC×IC] × B[IC×tiles]
     dim_t M; // Total tiles per batch = ceil(oh/2) * ceil(ow/2)
     dim_t K; // Input channels (IC)
@@ -88,7 +88,7 @@ struct rvv_winograd_conf_t {
     dim_t mb; // Batch size
 
     // Winograd domain specification for GEMM-based execution
-    WinogradDomainSpec wspec;
+    WinogradDomainSpec_t wspec;
 };
 
 status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
@@ -278,8 +278,8 @@ private:
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_generator_t> input_xform_;
-    std::unique_ptr<jit_generator_t> output_xform_;
+    std::unique_ptr<jit_wino_input_transform_t> input_xform_;
+    std::unique_ptr<jit_wino_output_transform_t> output_xform_;
 };
 
 } // namespace rv64

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -98,26 +98,20 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
         const memory_desc_t &dst_md, const memory_desc_t &bias_md,
         const primitive_attr_t &attr);
 
-// Resource for persistent weight transform buffer.
-// Weights are transformed on first execute() and cached for reuse.
+// Resource for JIT kernel persistence across execute() calls.
 struct rvv_wino_resource_t : public resource_t {
     rvv_wino_resource_t() = default;
 
-    status_t configure(size_t weight_buf_size, const rvv_winograd_conf_t &conf);
+    status_t configure(const rvv_winograd_conf_t &conf);
 
-    float *get_weight_buffer() const { return weight_buf_.get(); }
     jit_generator_t *get_input_xform() const { return input_xform_.get(); }
     jit_generator_t *get_output_xform() const { return output_xform_.get(); }
-    bool weights_valid() const { return weights_valid_; }
-    void set_weights_valid() const { weights_valid_ = true; }
 
     DNNL_DISALLOW_COPY_AND_ASSIGN(rvv_wino_resource_t);
 
 private:
-    std::unique_ptr<float[]> weight_buf_;
     std::unique_ptr<jit_generator_t> input_xform_;
     std::unique_ptr<jit_generator_t> output_xform_;
-    mutable bool weights_valid_ = false;
 };
 
 struct rvv_wino_convolution_fwd_t : public primitive_t {
@@ -255,7 +249,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
         if (mapper.has_resource(this)) return status::success;
         auto r = utils::make_unique<rvv_wino_resource_t>();
         if (!r) return status::out_of_memory;
-        CHECK(r->configure(pd()->conf_.wspec.weight_matrix_size, pd()->conf_));
+        CHECK(r->configure(pd()->conf_));
         mapper.add(this, std::move(r));
         return status::success;
     }


### PR DESCRIPTION
## Description

This PR introduces the implementation of Winograd convolution optimization for RISC-V architectures using RVV intrinsics. The Winograd algorithm (F(2×2, 3×3)) reduces the number of arithmetic operations for 3×3 convolutions by transforming the computation into the Winograd domain.

This implementation provides:

1. Winograd F(2×2, 3×3) transform functions with full RVV vectorization
2. RVV-optimized GEMM computation for Winograd domain
3. Support for plain memory formats (nchw, oihw)
4. Bias addition support with RVV vectorization

## Key Features

1. **Filter Transform**: Pre-compute transformed weights: G × W × G^T (3×3 → 4×4)
2. **Input Transform**: Extract 4×4 tiles and transform: B^T × tile × B (4×4 → 4×4) with RVV vectorization
3. **Batched GEMM**: RVV-optimized matrix multiplication in Winograd domain
4. **Output Transform**: Transform back: A^T × result × A (4×4 → 2×2) with RVV vectorization
5. **Bias Addition**: Add bias using RVV vectorization

### Dispatch Conditions

The Winograd primitive is dispatched when all conditions are met:
- Data type: f32
- Kernel size: 3×3
- Stride: 1×1
- Padding: ≤ 1
- Dilation: None (0)
- Input/output channels: ≥ 64
- Spatial dimensions: ≤ 112×112
- Max threads: ≤ 28

## Performance improvements

**Test Platform**: SG2044 (RV64GCV, VLEN=128, using 8 cores)

**Baseline**: upstream main branch (gemm:rvv implementation)
**Comparison**: Current branch with Winograd F(2×2, 3×3) implementation

#### 1. Dispatch Coverage Analysis

| Test Set | 3×3 Conv Layers | Winograd Dispatch | Coverage | Rejection Reasons |
|----------|----------------|-------------------|----------|-------------------|
| **shapes_resnet_50** | 4 | 4 | **100%**  | - |
| **shapes_vgg_11** | 10 | 8 | **80%**  | conv1_1, conv1_2 (IC<64) |
| **shapes_mobilenet** | 1 | 0 | 0% | stride=2 |
| **shapes_googlenet_v3** | multiple | few | low | stride=2 or IC<64 |

**Dispatch Analysis**:
- All eligible 3×3 convolutions (stride=1, IC≥64, OC≥64) successfully dispatch to Winograd
- Rejection reason: *stride=2* or *IC/OC < 64*

#### 2. Winograd Layer Performance Comparison (shapes_resnet_50)

| Layer | Main (gemm:rvv) | Winograd RVV | Speedup |
|-------|----------------|--------------|---------|
| res2a_branch2b*3 | **196.32 ms** | **9.81 ms** | **20.0×** |
| res3a_branch2b*4 | **173.04 ms** | **10.83 ms** | **16.0×** |
| res4a_branch2b*6 | **138.56 ms** | **11.00 ms** | **12.6×** |
| res5a_branch2b*3 | **210.82 ms** | **6.46 ms** | **32.6×** |
| **Average** | **179.69 ms** | **9.53 ms** | **18.9×** |

#### 3. Winograd Layer Performance Comparison (shapes_vgg_11)

| Layer | Main (gemm:rvv) | Winograd RVV | Speedup |
|-------|----------------|--------------|---------|
| conv2_1 | **197.36 ms** | **9.79 ms** | **20.2×** |
| conv2_2 | **336.31 ms** | **10.39 ms** | **32.4×** |
| conv3_1 | **129.30 ms** | **9.71 ms** | **13.3×** |
| conv3_2 | **174.90 ms** | **9.90 ms** | **17.7×** |
| conv4_1 | **69.28 ms** | **8.95 ms** | **7.7×** |
| conv4_2 | **83.66 ms** | **9.04 ms** | **9.3×** |
| conv5_1 | **35.92 ms** | **7.19 ms** | **5.0×** |
| conv5_2 | **42.06 ms** | **7.29 ms** | **5.8×** |
| **Average** | **133.60 ms** | **9.16 ms** | **14.6×** |

## Why Winograd Achieves Significant Speedup

### 1. Reduced Arithmetic Operations

The Winograd algorithm F(2×2, 3×3) minimizes the number of multiplications required for 3×3 convolutions:

**Direct Convolution (per output pixel)**:
- Multiplications: 3×3×IC = 9×IC
- For 2×2 output block (4 pixels): 9×IC×4 = **36×IC multiplications**

**Winograd F(2×2, 3×3) (per 2×2 output block)**:
- Input transform (4×4 → 4×4): 16×IC multiplications per tile
- Winograd domain GEMM: 4×4×IC = 16×IC multiplications
- Output transform (4×4 → 2×2): 4×OC multiplications
- **Total: ~32×IC multiplications (theoretical reduction: ~12.5%)**

More importantly, Winograd transforms **independent element-wise operations** into **dense matrix multiplications**, which are much more efficiently computed using RVV vectorization.

### 2. Lower Transformation Overhead vs im2col

**im2col + GEMM (gemm:rvv approach)**:
- im2col expands input into large temporary buffer
- Memory overhead: **~9× expansion** (each input pixel replicated 9 times)
- Huge memory bandwidth consumption
- Large GEMM operations

**Winograd F(2×2, 3×3)**:
- Input transform: 4×4 tiles → 4×4 Winograd domain (small, fixed-size)
- **No memory expansion**: transform is in-place computation
- Output transform: 4×4 → 2×2 (small, fixed-size)
- Smaller, more cache-friendly batched GEMMs (16 independent 4×4×IC GEMMs)

### 3. Better Computation-to-Memory Ratio

- Winograd transforms are **compute-bound** (dense matrix operations on small matrices)
- im2col is **memory-bound** (data rearrangement with massive replication)
- RVV vectorization benefits from regular, predictable memory access patterns in Winograd domain

### Summary

The massive speedup (14-19×) comes from:
1. **Algorithmic advantage**: Winograd reduces arithmetic operations and transforms element-wise convolution into dense GEMM
2. **Memory efficiency**: Minimal transformation overhead compared to im2col's 9× memory expansion
3. **Vectorization synergy**: Full RVV vectorization across all stages
4. **Cache friendliness**: Small fixed-size transforms with excellent locality

---

## References

- ARM Compute Library Winograd implementation
- oneDNN x64/aarch64 Winograd primitives
- wincnn (https://github.com/andravin/wincnn)

---
