### PR TITLE
cpu: aarch64: improve bf16 SVE softmax performance

### DIFF
--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -102,8 +102,8 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
 
     private:
         void init_scratchpad() {
-            if (utils::one_of(
-                        dst_md()->data_type, data_type::u8, data_type::s8)) {
+            if (utils::one_of(dst_md()->data_type, data_type::u8, data_type::s8,
+                        data_type::bf16)) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.template book<char>(
                         memory_tracking::names::key_softmax_interim_store,


### PR DESCRIPTION
# Description
This commit improves bf16 SVE softmax performance by eliminating a register dependency chain issue caused by merging predication being used on the common bf16 conversion destination register `ZReg(24)`, which led to unrolled `bfcvt` calls executing sequentialy instead of in parallel.

Also, the bf16 forward path now uses scratchpad memory to store and load intermediate results in f32 (after `exp()` and before normalisation by the sum), instead of downcasting them to bf16, storing in the `dst` buffer, then loading and upcasting back to f32.

## Performance improvements
### c7g

| Threads     | Shape | jit:sve_256 (after) | jit:sve_256 (before) | Speedup |
| --------- | ------- | ------------------- | -------------------- | ------- |
| 1               | 1539x387  | 0.517138           | 0.643011           | 1.24    |
| 4               | 1539x387  | 0.135158           | 0.161282           | 1.19    |
| 16              | 1539x387  | 0.037364           | 0.0424671          | 1.14    |
| 64              | 1539x387  | 0.018423           | 0.0202958          | 1.10    |
| 1               | 1024x4096 | 3.23311            | 3.96083            | 1.23    |
| 4               | 1024x4096 | 0.811217           | 1.002              | 1.24    |
| 16              | 1024x4096 | 0.205826           | 0.273722           | 1.33    |
| 64              | 1024x4096 | 0.068614           | 0.0811805          | 1.18    |
| 1               | 4096x4096 | 13.3045            | 16.1861            | 1.22    |
| 4               | 4096x4096 | 3.32634            | 4.10402            | 1.23    |
| 16              | 4096x4096 | 0.845478           | 1.12217            | 1.33    |
| 64              | 4096x4096 | 0.246503           | 0.305913           | 1.24    |

### c8g

| Threads     | Shape | jit:sve_128 (after) | jit:sve_128 (before) | Speedup |
| --------- | ------- | ------------------- | -------------------- | ------- |
| 1               | 1539x387  | 0.637679           | 0.844137           | 1.32    |
| 4               | 1539x387  | 0.163335           | 0.21236            | 1.30    |
| 16              | 1539x387  | 0.043211           | 0.055138           | 1.28    |
| 64              | 1539x387  | 0.017306           | 0.019105           | 1.10    |
| 1               | 1024x4096 | 4.27456            | 5.86007            | 1.37    |
| 4               | 1024x4096 | 1.06883            | 1.47111            | 1.38    |
| 16              | 1024x4096 | 0.268515           | 0.368239           | 1.37    |
| 64              | 1024x4096 | 0.083284           | 0.097609           | 1.17    |
| 1               | 4096x4096 | 17.4665            | 23.7653            | 1.36    |
| 4               | 4096x4096 | 4.37045            | 5.9495             | 1.36    |
| 16              | 4096x4096 | 1.08261            | 1.49593            | 1.38    |
| 64              | 4096x4096 | 0.306393           | 0.372924           | 1.22    |