### PR TITLE
cpu: x64: xbyak fix ModRM encoding for prefetchrst2

### DIFF
--- a/third_party/xbyak/xbyak_mnemonic.h
+++ b/third_party/xbyak/xbyak_mnemonic.h
@@ -896,7 +896,7 @@ void prefetcht1(const Address& addr) { opMR(addr, Reg32(2), T_0F, 0x18); }
 void prefetcht2(const Address& addr) { opMR(addr, Reg32(3), T_0F, 0x18); }
 void prefetchw(const Address& addr) { opMR(addr, Reg32(1), T_0F, 0x0D); }
 void prefetchwt1(const Address& addr) { opMR(addr, Reg32(2), T_0F, 0x0D); }
-void prefetchrst2(const Address& addr) { opMR(addr, Reg32(11), T_0F, 0x18); }
+void prefetchrst2(const Address& addr) { opMR(addr, Reg32(4), T_0F, 0x18); }
 void psadbw(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0xF6); }
 void pshufb(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0x00, T_0F38, T_66); }
 void pshufd(const Mmx& mmx, const Operand& op, uint8_t imm8) { opMMX(mmx, op, 0x70, T_0F, T_66, imm8); }


### PR DESCRIPTION
Fix incorrect ModRM.reg field for PREFETCHRST2 instruction

`PREFETCHRST2` was encoded with `Reg32(11)` as the ModRM.reg operand,
which is incorrect for two reasons:

1. `Reg32(11)` ≥ `8`, causing xbyak to emit a spurious REX prefix with
   REX.R=1, which is invalid for this instruction.
2. The effective ModRM.reg value would be 11 & 7 = 3, colliding with
   `PREFETCHT2` (0F 18 /3).

Per the Intel XED ISA specification, PREFETCHRST2 uses opcode
NP 0F 18 /4 (ModRM.reg = REG[0b100]). This is consistent with the
0F 18 group encoding:

  /0 = PREFETCHNTA
  /1 = PREFETCHT0
  /2 = PREFETCHT1
  /3 = PREFETCHT2
  **/4 = PREFETCHRST2  ← fixed**
  /6 = PREFETCHIT1
  /7 = PREFETCHIT0

Fix: replace Reg32(11) with Reg32(4).

I think when this was originally entered the Mod7,6 bits which are shown as  `!(11)` was mistaken for the ModR/M bits which should be `0b100` or `4`

A quick search of the code base and the only kernel using this instruction is the jit_brgemm_kernel. 

As currently encoded, when calling `prefetchrst2` the actual instruction being called is `prefetcht2` see reason 2 above.

Reference:
[intel architecture instruction set extensions programming reference](https://www.intel.com/content/www/us/en/content-details/869288/intel-architecture-instruction-set-extensions-programming-reference.html) page version 60 page 105 

And the Opcode Extension Tables from the [Intel Software Development Manual vol 2d](https://www.intel.com/content/www/us/en/content-details/874247/intel-64-and-ia-32-architectures-software-developer-s-manual-volume-2d-instruction-set-reference-w-z.html) version 90 page 177