### PR TITLE
fix: common: memory_desc: add upper bounds check for md tensor dimensions

### DIFF
--- a/src/common/memory_desc_wrapper.cpp
+++ b/src/common/memory_desc_wrapper.cpp
@@ -63,6 +63,10 @@ status_t fill_blocked(memory_desc_t &md, std::initializer_list<int> perm,
                 ? runtime_value_for(md.padded_dims[d])
                 : utils::rnd_up(md.dims[d], blocks[d]);
 
+    // tracks max stride for integral overflow checks
+    dim_t max_stride = 1;
+    int max_stride_d = 0;
+
     // setting the strides
     {
         dim_t stride = block_size;
@@ -77,7 +81,24 @@ status_t fill_blocked(memory_desc_t &md, std::initializer_list<int> perm,
             else if (pdim != 0)
                 stride *= pdim / blocks[d];
 
+            if (max_stride <= stride) {
+                max_stride = stride;
+                max_stride_d = d;
+            }
+
         } while (iter_d != perm.begin());
+    }
+
+    const size_t dt_size = types::data_type_size(md.data_type);
+
+    // guard against integral overflow due to strides exceeding numeric limits
+    if (!is_runtime_value(md.padded_dims[max_stride_d])) {
+        size_t dim_val = static_cast<size_t>(
+                md.padded_dims[max_stride_d] / blocks[max_stride_d]);
+        dim_val = dim_val == (size_t)max_stride ? 1 : dim_val;
+        if (dim_val > SIZE_MAX / max_stride) return status::invalid_arguments;
+        if (dt_size && ((dim_val * max_stride) > SIZE_MAX / dt_size))
+            return status::invalid_arguments;
     }
 
     return status::success;

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -1135,6 +1135,10 @@ inline bool memory_desc_strides_check(
     };
     std::sort(perm, perm + md.ndims, idx_sorter);
 
+    // tracks max stride for integral overflow checks
+    dim_t max_stride = 1;
+    int max_stride_d = 0;
+
     dim_t min_stride = block_size;
     for (int idx = 0; idx < md.ndims; ++idx) {
         const int d = perm[idx];
@@ -1154,6 +1158,22 @@ inline bool memory_desc_strides_check(
         // update min_stride for next iteration
         const auto padded_dim = md.padded_dims[d];
         min_stride = block_size * strides[d] * (padded_dim / blocks[d]);
+        if (max_stride <= strides[d]) {
+            max_stride = strides[d];
+            max_stride_d = d;
+        }
+    }
+
+    const size_t dt_size = types::data_type_size(md.data_type);
+
+    // guard against integral overflow due to strides exceeding numeric limits
+    if (!is_runtime_value(md.padded_dims[max_stride_d])) {
+        size_t dim_val = static_cast<size_t>(
+                md.padded_dims[max_stride_d] / blocks[max_stride_d]);
+        dim_val = dim_val == (size_t)max_stride ? 1 : dim_val;
+        if (dim_val > SIZE_MAX / max_stride) return false;
+        if (dt_size && ((dim_val * max_stride) > SIZE_MAX / dt_size))
+            return false;
     }
     return true;
 }
@@ -1331,9 +1351,22 @@ inline bool memory_desc_sanity_check(int ndims, const dims_t dims,
                     f8_e4m3, f16, bf16, f32, f64, s64, s32, s8, u8, s4, u4);
     if (!ok) return false;
 
+    // A bounds check on the dimensions ensures that the tensor size
+    // computation does not trigger a overflow during memory creation.
+    dim_t prod = 1;
+    for (int d = 0; d < ndims; ++d) {
+        if (dims[d] != DNNL_RUNTIME_DIM_VAL) {
+            if (dims[d] < 0) return false;
+            if (dims[d] > 0) {
+                if (prod > std::numeric_limits<dim_t>::max() / dims[d])
+                    return false;
+                prod *= dims[d];
+            }
+        }
+    }
+
     bool has_runtime_dims = false;
     for (int d = 0; d < ndims; ++d) {
-        if (!is_runtime_value(dims[d]) && dims[d] < 0) return false;
         if (is_runtime_value(dims[d])) has_runtime_dims = true;
     }
 

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <locale>
 #include <sstream>
 #include <string>
@@ -296,8 +297,11 @@ constexpr T array_product(const T *arr) {
 template <typename T, typename R = T>
 inline R array_product(const T *arr, size_t size) {
     R prod = 1;
-    for (size_t i = 0; i < size; ++i)
+    for (size_t i = 0; i < size; ++i) {
+        assert(IMPLICATION(arr[i] > 0 && prod > 0,
+                prod <= std::numeric_limits<R>::max() / arr[i]));
         prod *= arr[i];
+    }
     return prod;
 }
 


### PR DESCRIPTION
# Description

The PR adds out-of-bounds checks for tensor dimensions within `memory_desc_sanity_check()` and `size()` calculations to prevent potential overflow situations during memory creation.
`memory_desc_sanity_check()` has a lower bound check for tensor dimensions `(dims<0)` but not for the case when the product of tensor dimensions exceeds numeric bounds. 

Addresses [MFDNN-14665](https://jira.devtools.intel.com/browse/MFDNN-14665).

#### Test: 
```
DNNL_VERBOSE=all ./tests/benchdnn/benchdnn --matmul 4x4611686018427387905:4611686018427387905x4
```

#### Before fix:
```
onednn_verbose,v1,info,oneDNN v3.12.0 (commit 946487bb0f9b2c5a6f425b4d5c35b1d8d3fd5298)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with float16, Intel DL Boost and bfloat16 support and Intel AMX with bfloat16 and 8-bit integer support
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,create:dispatch,brgemm_matmul,datatype configuration not supported on this isa,src/cpu/x64/matmul/brgemm_matmul_utils.cpp:1369
onednn_verbose,v1,primitive,create:dispatch,brgemm_matmul,datatype configuration not supported on this isa,src/cpu/x64/matmul/brgemm_matmul_utils.cpp:1369
onednn_verbose,v1,primitive,create:dispatch,brgemm_matmul,datatype configuration not supported on this isa,src/cpu/x64/matmul/brgemm_matmul_utils.cpp:1369
onednn_verbose,v1,primitive,create:dispatch,brgemm_matmul,datatype configuration not supported on this isa,src/cpu/x64/matmul/brgemm_matmul_utils.cpp:1369
onednn_verbose,v1,primitive,create:cache_miss,cpu,matmul,brg_matmul:avx512_core,undef,src:f32:a:blocked:ab:4611686018427387905x1:f0 wei:f32:ap:blocked:AB16a64b::f0 dst:f32:a:blocked:ab::f0,,,4x4611686018427387905:4611686018427387905x4,109.795
onednn_verbose,v1,primitive,create:cache_hit,cpu,matmul,brg_matmul:avx512_core,undef,src:f32:a:blocked:ab:4611686018427387905x1:f0 wei:f32:ap:blocked:AB16a64b::f0 dst:f32:a:blocked:ab::f0,,,4x4611686018427387905:4611686018427387905x4,0.126953
AddressSanitizer:DEADLYSIGNAL
=================================================================
==613136==ERROR: AddressSanitizer: SEGV on unknown address 0x52700000c000 (pc 0x634320c247cf bp 0x7ffd91188b30 sp 0x7ffd91188b10 T0)
==613136==The signal is caused by a WRITE memory access.
```

#### After fix:
```
onednn_verbose,v1,info,oneDNN v3.12.0 (commit 946487bb0f9b2c5a6f425b4d5c35b1d8d3fd5298)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with float16, Intel DL Boost and bfloat16 support and Intel AMX with bfloat16 and 8-bit integer support
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
Error: Function 'init_md' at (/nfs/site/proj/mkl/hal9000/amanerik/oneDNN/tests/benchdnn/dnnl_memory.cpp:678) returned 'invalid_arguments'
```