### PR TITLE
cpu: aarch64: add f16 support to JIT softmax

### DIFF
--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -126,6 +126,7 @@ struct jit_softmax_base_t : public jit_generator_t {
             const int disp = 0);
     XReg src_ptr(size_t offt = 0);
     XReg dst_ptr(size_t offt = 0);
+    XReg interim_ptr(size_t offt = 0);
 
     template <typename body_t>
     void axis_loop(body_t body);
@@ -220,6 +221,10 @@ XReg jit_softmax_base_t::dst_ptr(size_t offt) {
     return xreg_addr(reg_dst, reg_dst_spat_offt, offt);
 }
 
+XReg jit_softmax_base_t::interim_ptr(size_t offt) {
+    return xreg_addr(reg_interim, reg_interim_spat_offt, offt);
+}
+
 template <typename body_t>
 void jit_softmax_base_t::axis_loop(body_t body) {
     Label main_loop, tail_loop, tail_axis;
@@ -291,10 +296,9 @@ jit_softmax_base_t::jit_softmax_base_t(const softmax_pd_t *pd, int vlen)
     , diff_dst_d_(pd_->diff_dst_md())
     , need_scratchpad_(pd_->is_fwd()
               && utils::one_of(dst_d_.data_type(), data_type::u8, data_type::s8,
-                      data_type::bf16))
+                      data_type::bf16, data_type::f16))
     , vlen_(vlen)
-    , simd_w_(vlen / sizeof(float)) // bf16 works on ymms
-{}
+    , simd_w_(vlen / sizeof(float)) {}
 
 // SVE JIT softmax generator
 struct jit_softmax_sve_t : public jit_softmax_base_t {
@@ -323,7 +327,6 @@ struct jit_softmax_sve_t : public jit_softmax_base_t {
     void uni_fmax(const ZReg &dst, const ZReg &src, const ZReg &src2,
             const PReg &mask = PReg(DUMMY_IDX));
     XReg diff_src_ptr(size_t offt = 0);
-    XReg interim_ptr(size_t offt = 0);
     XReg diff_dst_ptr(size_t offt = 0);
     void prepare_tail_mask();
     void accumulate_vsbr();
@@ -365,10 +368,6 @@ XReg jit_softmax_sve_t::diff_src_ptr(size_t offt) {
     return xreg_addr(reg_diff_src, reg_src_spat_offt, offt);
 }
 
-XReg jit_softmax_sve_t::interim_ptr(size_t offt) {
-    return xreg_addr(reg_interim, reg_interim_spat_offt, offt);
-}
-
 XReg jit_softmax_sve_t::diff_dst_ptr(size_t offt) {
     return xreg_addr(reg_diff_dst, reg_diff_dst_spat_offt, offt);
 }
@@ -381,7 +380,8 @@ void jit_softmax_sve_t::store(
     ZReg src_vmm = vmm;
 
     if (tail) {
-        if (utils::one_of(dt, data_type::f32, data_type::bf16)) {
+        if (utils::one_of(
+                    dt, data_type::f32, data_type::bf16, data_type::f16)) {
             if (axis_is_blocked_) {
                 src_vmm = vzero;
                 eor(vzero.d, vzero.d, vzero.d);
@@ -404,6 +404,10 @@ void jit_softmax_sve_t::store(
             break;
         case data_type::bf16:
             bfcvt(src_vmm.h, P_ALL_ONE / T_m, src_vmm.s);
+            st1h(src_vmm.s, opmask, ptr(effective_addr));
+            break;
+        case data_type::f16:
+            fcvt(src_vmm.h, P_ALL_ONE / T_m, src_vmm.s);
             st1h(src_vmm.s, opmask, ptr(effective_addr));
             break;
         case data_type::u8:
@@ -447,6 +451,10 @@ void jit_softmax_sve_t::load(
             ld1h(effective_vmm, tmp_mask / T_z, ptr(addr));
             lsl(effective_vmm, effective_vmm,
                     0x10); // Shift left by 16 bits
+            break;
+        case data_type::f16:
+            ld1h(effective_vmm, tmp_mask / T_z, ptr(addr));
+            fcvt(effective_vmm, P_ALL_ONE / T_m, ZRegH(effective_vmm.getIdx()));
             break;
         case data_type::u8:
             ld1b(effective_vmm, tmp_mask / T_z, ptr(addr));
@@ -701,8 +709,10 @@ struct jit_softmax_asimd_t : public jit_softmax_base_t {
     const VReg vmax = VReg(vmax_idx);
     const VReg vzero = VReg(vzero_idx);
 
-    void store(const XReg &addr, const VReg &vmm, bool tail);
-    void load(const VReg &vmm, const XReg &addr, bool tail, const VReg &fill);
+    void store(
+            const XReg &addr, const VReg &vmm, const data_type_t dt, bool tail);
+    void load(const VReg &vmm, const XReg &addr, const data_type_t dt,
+            bool tail, const VReg &fill);
     void get_horizontal_op(const VReg &v, op_t op);
     void accumulate_vmax() override;
     void accumulate_vsum() override;
@@ -715,19 +725,46 @@ struct jit_softmax_asimd_t : public jit_softmax_base_t {
     jit_softmax_asimd_t(const softmax_pd_t *pd);
 };
 
-void jit_softmax_asimd_t::load(
-        const VReg &vmm, const XReg &addr, bool tail, const VReg &fill) {
+void jit_softmax_asimd_t::load(const VReg &vmm, const XReg &addr,
+        const data_type_t dt, bool tail, const VReg &fill) {
     if (!tail) {
-        ldr(QReg(vmm.getIdx()), ptr(addr));
+        switch (dt) {
+            case data_type::f32: ldr(QReg(vmm.getIdx()), ptr(addr)); break;
+            case data_type::f16:
+                ld1(VReg4H(vmm.getIdx()), ptr(addr));
+                fcvtl(VReg4S(vmm.getIdx()), VReg4H(vmm.getIdx()));
+                break;
+            default: assert(!"unsupported"); break;
+        }
         return;
     }
 
     mov(VReg16B(vmm.getIdx()), VReg16B(fill.getIdx()));
     mov(X_TMP_0, addr);
-    ld1(VReg4S(vmm.getIdx())[0], ptr(X_TMP_0));
-    for (size_t i = 1; i < axis_simd_tail_; i++) {
-        add_imm(X_TMP_1, X_TMP_0, i * sizeof(float), X_TMP_2);
-        ld1(VReg4S(vmm.getIdx())[i], ptr(X_TMP_1));
+
+    if (dt == data_type::f32) {
+        // Handle tail lane 0 separately.
+        ld1(VReg4S(vmm.getIdx())[0], ptr(X_TMP_0));
+        // Fill lanes [1, axis_simd_tail_) with per-lane loads.
+        for (size_t i = 1; i < axis_simd_tail_; i++) {
+            add_imm(X_TMP_1, X_TMP_0, i * sizeof(float), X_TMP_2);
+            ld1(VReg4S(vmm.getIdx())[i], ptr(X_TMP_1));
+        }
+    } else if (dt == data_type::f16) {
+        HReg cvt_vmm = HReg(24);
+        // Handle tail lane 0 separately.
+        ldr(cvt_vmm, ptr(X_TMP_0));
+        fcvt(SReg(cvt_vmm.getIdx()), cvt_vmm);
+        mov(VReg4S(vmm.getIdx())[0], VReg4S(cvt_vmm.getIdx())[0]);
+        // Fill lanes [1, axis_simd_tail_) with per-lane loads.
+        for (size_t i = 1; i < axis_simd_tail_; i++) {
+            add_imm(X_TMP_1, X_TMP_0, i * sizeof(float16_t), X_TMP_2);
+            ldr(cvt_vmm, ptr(X_TMP_1));
+            fcvt(SReg(cvt_vmm.getIdx()), cvt_vmm);
+            mov(VReg4S(vmm.getIdx())[i], VReg4S(cvt_vmm.getIdx())[0]);
+        }
+    } else {
+        assert(!"unsupported");
     }
 }
 
@@ -737,17 +774,40 @@ void jit_softmax_asimd_t::clear_unused_tail_lanes(const VReg &vmm) {
         mov(vmm.s[lane], vzero.s[0]);
 }
 
-void jit_softmax_asimd_t::store(const XReg &addr, const VReg &vmm, bool tail) {
+void jit_softmax_asimd_t::store(
+        const XReg &addr, const VReg &vmm, const data_type_t dt, bool tail) {
     if (!tail || axis_is_blocked_) {
-        str(QReg(vmm.getIdx()), ptr(addr));
+        switch (dt) {
+            case data_type::f32: str(QReg(vmm.getIdx()), ptr(addr)); break;
+            case data_type::f16:
+                fcvtn(VReg4H(vmm.getIdx()), vmm.s);
+                st1(VReg4H(vmm.getIdx()), ptr(addr));
+                break;
+            default: assert(!"unsupported"); break;
+        }
         return;
     }
 
     mov(X_TMP_0, addr);
-    st1(VReg4S(vmm.getIdx())[0], ptr(X_TMP_0));
-    for (size_t i = 1; i < axis_simd_tail_; i++) {
-        add_imm(X_TMP_1, X_TMP_0, i * sizeof(float), X_TMP_2);
-        st1(VReg4S(vmm.getIdx())[i], ptr(X_TMP_1));
+    if (dt == data_type::f32) {
+        // Handle tail lane 0 separately.
+        st1(VReg4S(vmm.getIdx())[0], ptr(X_TMP_0));
+        // Store lanes [1, axis_simd_tail_) with per-lane stores.
+        for (size_t i = 1; i < axis_simd_tail_; i++) {
+            add_imm(X_TMP_1, X_TMP_0, i * sizeof(float), X_TMP_2);
+            st1(VReg4S(vmm.getIdx())[i], ptr(X_TMP_1));
+        }
+    } else if (dt == data_type::f16) {
+        fcvtn(VReg4H(vmm.getIdx()), vmm.s);
+        // Handle tail lane 0 separately.
+        st1(VReg4H(vmm.getIdx())[0], ptr(X_TMP_0));
+        // Store lanes [1, axis_simd_tail_) with per-lane stores.
+        for (size_t i = 1; i < axis_simd_tail_; i++) {
+            add_imm(X_TMP_1, X_TMP_0, i * sizeof(float16_t), X_TMP_2);
+            st1(VReg4H(vmm.getIdx())[i], ptr(X_TMP_1));
+        }
+    } else {
+        assert(!"unsupported");
     }
 }
 
@@ -768,8 +828,8 @@ void jit_softmax_asimd_t::accumulate_vmax() {
     axis_loop([&](int unroll, bool tail) {
         for (int i = 0; i < unroll; i++) {
             VReg vreg_tmp_src = VReg(data_vreg_start_idx + i);
-            load(vreg_tmp_src, src_ptr(src_axis_stride_ * i), tail,
-                    vneg_flt_max);
+            load(vreg_tmp_src, src_ptr(src_axis_stride_ * i),
+                    src_d_.data_type(), tail, vneg_flt_max);
             fmax(vmax.s, vmax.s, vreg_tmp_src.s);
         }
     });
@@ -787,7 +847,8 @@ void jit_softmax_asimd_t::accumulate_vsum() {
 
         for (int i = 0; i < unroll; i++) {
             VReg vreg_tmp_src = VReg(data_vreg_start_idx + i);
-            load(vreg_tmp_src, src_ptr(src_axis_stride_ * i), tail, vzero);
+            load(vreg_tmp_src, src_ptr(src_axis_stride_ * i),
+                    src_d_.data_type(), tail, vzero);
             fsub(vreg_tmp_src.s, vreg_tmp_src.s, vmax.s);
         }
 
@@ -797,7 +858,13 @@ void jit_softmax_asimd_t::accumulate_vsum() {
             VReg vreg_tmp_src = VReg(data_vreg_start_idx + i);
             if (tail) clear_unused_tail_lanes(vreg_tmp_src);
             fadd(vsum.s, vsum.s, vreg_tmp_src.s);
-            store(dst_ptr(dst_axis_stride_ * i), vreg_tmp_src, tail);
+            if (need_scratchpad_) {
+                store(interim_ptr(interim_axis_stride_ * i), vreg_tmp_src,
+                        data_type::f32, tail);
+            } else {
+                store(dst_ptr(dst_axis_stride_ * i), vreg_tmp_src,
+                        dst_d_.data_type(), tail);
+            }
         }
     });
 
@@ -809,7 +876,13 @@ void jit_softmax_asimd_t::compute_dst() {
     axis_loop([&](int unroll, bool tail) {
         for (int i = 0; i < unroll; i++) {
             VReg vreg_tmp_src = VReg(data_vreg_start_idx + i);
-            load(vreg_tmp_src, dst_ptr(dst_axis_stride_ * i), tail, vzero);
+            if (need_scratchpad_) {
+                load(vreg_tmp_src, interim_ptr(interim_axis_stride_ * i),
+                        data_type::f32, tail, vzero);
+            } else {
+                load(vreg_tmp_src, dst_ptr(dst_axis_stride_ * i),
+                        dst_d_.data_type(), tail, vzero);
+            }
             fmul(vreg_tmp_src.s, vreg_tmp_src.s, vsum.s);
 
             if (need_src_scale_) {
@@ -824,7 +897,8 @@ void jit_softmax_asimd_t::compute_dst() {
                 fmul(vreg_tmp_src.s, vreg_tmp_src.s, v_dst_scale.s);
             }
 
-            store(dst_ptr(dst_axis_stride_ * i), vreg_tmp_src, tail);
+            store(dst_ptr(dst_axis_stride_ * i), vreg_tmp_src,
+                    dst_d_.data_type(), tail);
         }
     });
 }

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -76,12 +76,14 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
             const auto src_dt = src_md()->data_type;
             const auto dst_dt = dst_md()->data_type;
             bool ok = mayiuse(isa) && is_fwd() && !has_zero_dim_memory()
-                    && utils::one_of(src_dt, f32, bf16, s8, u8)
-                    && utils::one_of(dst_dt, f32, bf16, s8, u8)
+                    && utils::one_of(src_dt, f32, bf16, f16, s8, u8)
+                    && utils::one_of(dst_dt, f32, bf16, f16, s8, u8)
                     && IMPLICATION(
                             utils::one_of(bf16, src_dt, dst_dt), mayiuse_bf16())
                     && IMPLICATION(isa == asimd,
-                            src_dt == f32 && dst_dt == f32 && is_softmax())
+                            utils::one_of(src_dt, f32, f16)
+                                    && utils::one_of(dst_dt, f32, f16)
+                                    && is_softmax())
                     && attr()->has_default_values(skip_mask_t::scales)
                     && attr_scales_ok()
                     && set_default_formats() == status::success;
@@ -103,7 +105,7 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
     private:
         void init_scratchpad() {
             if (utils::one_of(dst_md()->data_type, data_type::u8, data_type::s8,
-                        data_type::bf16)) {
+                        data_type::bf16, data_type::f16)) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.template book<char>(
                         memory_tracking::names::key_softmax_interim_store,


### PR DESCRIPTION
# Description

This commit adds f16 support to both `sve` and `asimd` JIT softmax implementations. Like bf16 (#4736), scratchpad memory is used to skip the downcast and upcast steps between the `accumulate_vsum` and `compute_dst` stages, instead directly storing and loading the f32 intermediate results.

## Performance improvements
### c6g

| Shape     | Threads | jit:asimd (ms) | acl (ms) | Speedup |
| --------- | ------- | -------------- | -------- | ------- |
| 1539x387  | 1  | 1.27331   | 1.392     | 1.09 |
| 1539x387  | 4  | 0.32673   | 0.350008  | 1.07 |
| 1539x387  | 16 | 0.0855566 | 0.0934482 | 1.09 |
| 1539x387  | 64 | 0.0312224 | 0.0476928 | 1.53 |
| 1024x4096 | 1  | 8.39337   | 8.72097   | 1.04 |
| 1024x4096 | 4  | 2.10112   | 2.16244   | 1.03 |
| 1024x4096 | 16 | 0.525929  | 0.555301  | 1.06 |
| 1024x4096 | 64 | 0.153722  | 0.1694    | 1.10 |
| 4096x4096 | 1  | 33.6363   | 34.8734   | 1.04 |
| 4096x4096 | 4  | 8.40803   | 8.72652   | 1.04 |
| 4096x4096 | 16 | 2.10091   | 2.1819    | 1.04 |
| 4096x4096 | 64 | 0.5464    | 0.576469  | 1.06 |

### c7g

| Shape     | Threads | jit:sve_256 (ms) | acl (ms) | Speedup |
| --------- | ------- | ------------------- | -------------------- | ------- |
| 1539x387  | 1  | 0.520005  | 0.886423  | 1.70 |
| 1539x387  | 4  | 0.136949  | 0.225167  | 1.64 |
| 1539x387  | 16 | 0.0411082 | 0.0600836 | 1.46 |
| 1539x387  | 64 | 0.0183688 | 0.0365855 | 1.99 |
| 1024x4096 | 1  | 3.27242   | 5.97288   | 1.83 |
| 1024x4096 | 4  | 0.821882  | 1.49474   | 1.82 |
| 1024x4096 | 16 | 0.208002  | 0.37318   | 1.79 |
| 1024x4096 | 64 | 0.0664772 | 0.116497  | 1.75 |
| 4096x4096 | 1  | 13.4423   | 24.4346   | 1.82 |
| 4096x4096 | 4  | 3.36215   | 6.00421   | 1.79 |
| 4096x4096 | 16 | 0.854854  | 1.51097   | 1.77 |
| 4096x4096 | 64 | 0.24823   | 0.39427   | 1.59 |

### c8g

| Shape     | Threads | jit:sve_128 (ms) | acl (ms) | Speedup |
| --------- | ------- | ------------------- | -------------------- | ------- |
| 1539x387  | 1  | 0.641119  | 0.738752  | 1.15 |
| 1539x387  | 4  | 0.165582  | 0.186646  | 1.13 |
| 1539x387  | 16 | 0.0440275 | 0.0504332 | 1.15 |
| 1539x387  | 64 | 0.0176629 | 0.0256207 | 1.45 |
| 1024x4096 | 1  | 4.30367   | 4.90276   | 1.14 |
| 1024x4096 | 4  | 1.07575   | 1.2346    | 1.15 |
| 1024x4096 | 16 | 0.270289  | 0.30645   | 1.13 |
| 1024x4096 | 64 | 0.0834595 | 0.0892428 | 1.07 |
| 4096x4096 | 1  | 17.5693   | 20.0301   | 1.14 |
| 4096x4096 | 4  | 4.39784   | 5.02197   | 1.14 |
| 4096x4096 | 16 | 1.08913   | 1.26287   | 1.16 |
| 4096x4096 | 64 | 0.307255  | 0.316733  | 1.03 |