### PR TITLE
[GPU] Fix mx dst kernel selection requirement

### DIFF
--- a/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
@@ -348,8 +348,8 @@ MatchParamsBase::MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isInt
         unrollReq[LoopN] = 8;
     }
  
-    if(problem.hasCMXScale() && unrollReq[LoopN] % 32){
-        unrollReq[LoopN] = 32;
+    if(problem.hasCMXScale()){
+        unrollReq[LoopM] = 32;
     }
 
 


### PR DESCRIPTION
# Description

Fixup unroll requirement for mx dst scales in GEMM. This bug was introduced by 04a8d4b6280f83f649b21a5e59f06ea0483c69d7 but concealed by cases being dispatched to ref. 

Fixes # [MFDNN-14706](https://jira.devtools.intel.com/browse/MFDNN-14706)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?