### PR TITLE
revert: gpu: intel: ze: engine: resolve potential module leaks

### DIFF
--- a/src/gpu/intel/ze/engine.cpp
+++ b/src/gpu/intel/ze/engine.cpp
@@ -93,10 +93,13 @@ status_t engine_t::create_kernel(compute::kernel_t &kernel,
 status_t engine_t::convert_to_ze(std::vector<compute::kernel_t> &kernels,
         const std::vector<const char *> &kernel_names,
         xpu::binary_t &binary) const {
-    std::shared_ptr<xpu::ze::wrapper_t<ze_module_handle_t>> ze_module_ptr;
+    ze_module_handle_t ze_module = nullptr;
     std::vector<ze_kernel_handle_t> ze_kernels;
-    CHECK(ze::create_kernels(device(), context(), kernel_names, binary,
-            ze_module_ptr, ze_kernels));
+    CHECK(ze::create_kernels(
+            device(), context(), kernel_names, binary, &ze_module, ze_kernels));
+    auto ze_module_ptr
+            = std::make_shared<xpu::ze::wrapper_t<ze_module_handle_t>>(
+                    ze_module);
     kernels = std::vector<compute::kernel_t>(kernel_names.size());
     for (size_t i = 0; i < kernel_names.size(); i++) {
         if (!ze_kernels[i]) continue;
@@ -157,10 +160,13 @@ status_t engine_t::create_kernel_from_binary(compute::kernel_t &kernel,
         const xpu::binary_t &binary, const char *kernel_name,
         const compute::program_src_t &src) const {
     std::vector<const char *> kernel_names = {kernel_name};
-    std::shared_ptr<xpu::ze::wrapper_t<ze_module_handle_t>> ze_module_ptr;
+    ze_module_handle_t ze_module = nullptr;
     std::vector<ze_kernel_handle_t> ze_kernels;
-    CHECK(ze::create_kernels(device(), context(), kernel_names, binary,
-            ze_module_ptr, ze_kernels));
+    CHECK(ze::create_kernels(
+            device(), context(), kernel_names, binary, &ze_module, ze_kernels));
+    auto ze_module_ptr
+            = std::make_shared<xpu::ze::wrapper_t<ze_module_handle_t>>(
+                    ze_module);
 
     CHECK(kernel_t::make(kernel, ze_module_ptr, ze_kernels[0], kernel_name));
 

--- a/src/gpu/intel/ze/utils.cpp
+++ b/src/gpu/intel/ze/utils.cpp
@@ -246,14 +246,9 @@ status_t compile_ocl_module_to_binary(ze_device_handle_t device,
 
 status_t create_kernels(ze_device_handle_t device, ze_context_handle_t context,
         const std::vector<const char *> &kernel_names,
-        const xpu::binary_t &binary,
-        std::shared_ptr<xpu::ze::wrapper_t<ze_module_handle_t>> &module_ptr,
+        const xpu::binary_t &binary, ze_module_handle_t *module_ptr,
         std::vector<ze_kernel_handle_t> &kernels) {
-    ze_module_handle_t ze_module = nullptr;
-    CHECK(compile_native_module(&ze_module, device, context, binary));
-
-    module_ptr = std::make_shared<xpu::ze::wrapper_t<ze_module_handle_t>>(
-            ze_module);
+    CHECK(compile_native_module(module_ptr, device, context, binary));
 
     kernels.resize(kernel_names.size(), nullptr);
     for (size_t i = 0; i < kernel_names.size(); i++) {

--- a/src/gpu/intel/ze/utils.hpp
+++ b/src/gpu/intel/ze/utils.hpp
@@ -47,8 +47,7 @@ status_t compile_ocl_module_to_binary(ze_device_handle_t device,
 
 status_t create_kernels(ze_device_handle_t device, ze_context_handle_t context,
         const std::vector<const char *> &kernel_names,
-        const xpu::binary_t &binary,
-        std::shared_ptr<xpu::ze::wrapper_t<ze_module_handle_t>> &module_ptr,
+        const xpu::binary_t &binary, ze_module_handle_t *module_ptr,
         std::vector<ze_kernel_handle_t> &kernels);
 
 } // namespace ze


### PR DESCRIPTION
This reverts commit 2dd6b8a7e7b36ecf32aa1dfb0a35f4e3a8c4a836.

Improving the code from potential leaks didn't do good. Will take another attempt later.