### PR TITLE
benchdnn: graph: remove obsolete verbose print

### DIFF
--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -426,8 +426,6 @@ int ref_partition_t::check_partition_correctness(
                 res->reason = skip_reason::case_not_supported;
                 return OK;
             }
-            BENCHDNN_PRINT(
-                    2, "Op failed: {(%zu) %s}\n", op_id, op_kind.c_str());
             return FAIL;
         }
 


### PR DESCRIPTION
The printed op is always the last op of a partition. But usually it's not the cause of the correctness failure. The message is misleading.