### PR TITLE
gpu: intel: gemm: bump register claim for sdpa col_max

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -53,7 +53,7 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
     // The host side arguments with 32 byte size registers (DG2)
     // use 16 registers include padding bytes (aligned with 128 bytes)
     // r0, r4 are reserved for system threads
-    state.ra.claim((GRF::bytes(hw) >= 64) ? r0-r6 : r0-r15);
+    state.ra.claim((GRF::bytes(hw) >= 64) ? r0-r9 : r0-r15);
 
     state.fullK = state.inputs.k;
 


### PR DESCRIPTION
# Description

This PR bumps the claimed registers to account for additional register demands from the new training logic in the SDPA forward pass.