### PR TITLE
update xbyak library to  v7.35.3

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -46,6 +46,15 @@
 #define XBYAK_NO_EXCEPTION
 #endif
 
+// Several JIT kernels intentionally or unintentionally use size-mismatched memory operands
+// (e.g. zword[]-annotated addresses with 64-bit GPR instructions, or dword[] fields loaded into
+// Reg64 registers). These are architecturally correct on x86-64 but trigger this check. Until all
+// call sites are updated to use properly-sized operands or stripped annotations, set this to 0 to
+// suppress the false-positive errors.
+#if !defined(XBYAK_STRICT_CHECK_MEM_REG_SIZE)
+#define XBYAK_STRICT_CHECK_MEM_REG_SIZE 0
+#endif
+
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 /* turn off `size_t to other-type implicit casting` warning
  * currently we have a lot of jit-generated instructions that

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_copy_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_copy_kern.cpp
@@ -502,8 +502,7 @@ jit_avx512_core_amx_copy_kern_t::jit_avx512_core_amx_copy_kern_t(
     , is_a_(is_a)
     , is_trans_(is_trans)
     , size_(isize)
-    , isize_(isize)
-    , arg_b_(0) {
+    , isize_(isize) {
 
     assert(utils::one_of(isize_, 2, 1));
     assert(isize_ == size_);

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_gemm_bf16bf16f32_kern.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_gemm_bf16bf16f32_kern.cpp
@@ -429,13 +429,7 @@ jit_avx512_core_gemm_bf16bf16f32_kern_t::
     : jit_generator_t(jit_name())
     , beta_zero_(beta_zero)
     , alpha_one_(alpha_one)
-    , bfloat16_(mayiuse(avx512_core_bf16))
-    , arg_a_(0)
-    , arg_b_(0)
-    , arg_c_(0)
-    , arg_ldc_(0)
-    , arg_coffset_c_(0)
-    , arg_coffset_r_(0) {
+    , bfloat16_(mayiuse(avx512_core_bf16)) {
 
     assert(mayiuse(avx512_core));
     assert(IMPLICATION(!use_zmm, bfloat16_));

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_gemv_bf16bf16f32_kern.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_gemv_bf16bf16f32_kern.cpp
@@ -517,12 +517,7 @@ jit_avx512_core_gemv_bf16bf16f32_kern_t::
         jit_avx512_core_gemv_bf16bf16f32_kern_t(bool trans)
     : jit_generator_t(jit_name())
     , trans_(trans)
-    , bfloat16_(mayiuse(avx512_core_bf16))
-    , arg_lda_(0)
-    , arg_x_(0)
-    , arg_incx_(0)
-    , arg_y_(0)
-    , arg_incy_(0) {
+    , bfloat16_(mayiuse(avx512_core_bf16)) {
 
     assert(mayiuse(avx512_core));
 

--- a/src/cpu/x64/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
@@ -313,12 +313,7 @@ jit_avx_gemv_t_f32_kern_t::jit_avx_gemv_t_f32_kern_t()
     , AO_(r14)
     , XO_(r15)
     , YO_(rbx)
-    , YO2_(rbp)
-    , arg_lda_(0)
-    , arg_x_(0)
-    , arg_incx_(0)
-    , arg_y_(0)
-    , arg_incy_(0) {
+    , YO2_(rbp) {
 
     // Assign integer registers
     M_ = abi_param1;

--- a/src/cpu/x64/gemm/f32/jit_sse41_gemv_n_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_gemv_n_f32_kern.cpp
@@ -318,12 +318,7 @@ jit_sse41_gemv_n_f32_kern_t::jit_sse41_gemv_n_f32_kern_t(void)
     , has_avx512_(mayiuse(avx512_core) && __BUILD_GEMM_AVX512)
     , has_avx2_(mayiuse(avx2) && __BUILD_GEMM_AVX2)
     , has_avx_(mayiuse(avx) && __BUILD_GEMM_AVX2)
-    , has_sse41_(mayiuse(sse41) && __BUILD_GEMM_SSE41)
-    , arg_lda_(0)
-    , arg_x_(0)
-    , arg_incx_(0)
-    , arg_y_(0)
-    , arg_incy_(0) {
+    , has_sse41_(mayiuse(sse41) && __BUILD_GEMM_SSE41) {
 
     int unroll_m = 0;
     int unroll_n = 0;

--- a/src/cpu/x64/gemm/f32/jit_sse41_gemv_t_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_gemv_t_f32_kern.cpp
@@ -283,12 +283,7 @@ jit_sse41_gemv_t_f32_kern_t::jit_sse41_gemv_t_f32_kern_t()
     , AO_(r14)
     , XO_(r15)
     , YO_(rbx)
-    , YO2_(rbp)
-    , arg_lda_(0)
-    , arg_x_(0)
-    , arg_incx_(0)
-    , arg_y_(0)
-    , arg_incy_(0) {
+    , YO2_(rbp) {
 
     // Assign integer registers
     M_ = abi_param1;

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_gemm_s8u8s32_kern.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_gemm_s8u8s32_kern.cpp
@@ -459,19 +459,7 @@ jit_avx2_gemm_s8u8s32_kern_t::jit_avx2_gemm_s8u8s32_kern_t(bool beta_zero,
     , enable_offset_c_(enable_offset_c)
     , enable_offset_r_(enable_offset_r)
     , vnni_(mayiuse(avx2_vnni))
-    , unroll_m_(unroll_m)
-    , arg_a_(0)
-    , arg_b_(0)
-    , arg_c_(0)
-    , arg_ldc_(0)
-    , arg_coffset_c_(0)
-    , arg_coffset_r_(0)
-    , coffset_cx_(0)
-    , coffset_cy_(0)
-    , coffset_rx_(0)
-    , coffset_ry_(0)
-    , bcast_k2_(0)
-    , bcast_k1_(0) {
+    , unroll_m_(unroll_m) {
 
     assert(utils::one_of(unroll_m, 24, 16, 8, 4, 2, 1));
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_gemm_s8u8s32_kern.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_gemm_s8u8s32_kern.cpp
@@ -511,18 +511,7 @@ jit_avx512_core_gemm_s8u8s32_kern_t::jit_avx512_core_gemm_s8u8s32_kern_t(
     , AA_(is_windows ? rdi : rcx)
     // Assign vector registers
     , dp_scratch_(zmm6)
-    , ones_(zmm7)
-    // Zero-initialize
-    , arg_a_(0)
-    , arg_b_(0)
-    , arg_c_(0)
-    , arg_ldc_(0)
-    , arg_coffset_c_(0)
-    , arg_coffset_r_(0)
-    , coffset_cx_(0)
-    , coffset_cy_(0)
-    , coffset_rx_(0)
-    , coffset_ry_(0) {
+    , ones_(zmm7) {
 
     for (int i = 0; i < (max_unroll_m_ >> 4); i++)
         a_regs_[i] = Zmm(i);

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -588,8 +588,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     static const Vmm zero_vmm(0);
     if (post_op.is_prelu() && is_avx512_) push_opmask(host_, get_aux_kmask());
 
-    Xbyak::Address rhs1_arg_addr(0);
-    Xbyak::Address rhs2_arg_addr(0);
+    Xbyak::Address rhs1_arg_addr {};
+    Xbyak::Address rhs2_arg_addr {};
 
     // Phase 3 Apply binary post-op over all vmms.
     for (const auto vmm_idx : vmm_idxs) {

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -237,7 +237,7 @@ private:
             case arg_t::scale: return scale_ptr(off);
             default: assert(!"unsupported arg_num"); break;
         }
-        return Xbyak::Address(0);
+        return Xbyak::Address {};
     }
 
     Xbyak::Reg64 get_reg_address(const arg_t arg_num) {

--- a/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
@@ -72,7 +72,7 @@ Xbyak::Address jit_prelu_backward_kernel_t::data_ptr(int arg_num, size_t offt) {
 
         default: assert(!"unsupported arg_num"); break;
     }
-    return Xbyak::Address(0);
+    return Xbyak::Address {};
 }
 
 bool jit_prelu_backward_kernel_t::any_tensor_bf16() const {

--- a/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
@@ -61,7 +61,7 @@ Xbyak::Address jit_prelu_forward_kernel_t::data_ptr(int arg_num, size_t offt) {
         case DNNL_ARG_DST: return get_addr(reg_dst_, dst_dt_);
         default: assert(!"unsupported arg_num"); break;
     }
-    return Xbyak::Address(0);
+    return Xbyak::Address {};
 }
 
 bool jit_prelu_forward_kernel_t::any_tensor_bf16() const {

--- a/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
@@ -46,12 +46,6 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
         , cstate_dt_size_(types::data_type_size(rnn.src_iter_c_dt))
         , is_avx512(mayiuse(avx512_core))
         , is_avx2(mayiuse(avx2))
-        , dscale_off_addr(0)
-        , dshift_off_addr(0)
-        , ymm_perm_mask_addr(0)
-        , zmm_perm_mask_addr(0)
-        , zero_addr(0)
-        , u8_saturation_addr(0)
         , weights_scales_reg(r13)
         , qtable(r14)
         // implementations avoids to preserve Vmm(0) because of potential

--- a/third_party/xbyak/xbyak.h
+++ b/third_party/xbyak/xbyak.h
@@ -82,8 +82,19 @@
 	#define XBYAK_GNUC_PREREQ(major, minor) 0
 #endif
 
+// User defined (must define all 3)
+#if defined(XBYAK_STD_UNORDERED_SET) || defined(XBYAK_STD_UNORDERED_MAP) || defined(XBYAK_STD_UNORDERED_MULTIMAP)
+	#ifndef XBYAK_STD_UNORDERED_SET
+		#error "Define XBYAK_STD_UNORDERED_SET"
+	#endif
+	#ifndef XBYAK_STD_UNORDERED_MAP
+		#error "Define XBYAK_STD_UNORDERED_MAP"
+	#endif
+	#ifndef XBYAK_STD_UNORDERED_MULTIMAP
+		#error "Define XBYAK_STD_UNORDERED_MULTIMAP"
+	#endif
 // This covers -std=(gnu|c)++(0x|11|1y), -stdlib=libc++, and modern Microsoft.
-#if ((defined(_MSC_VER) && (_MSC_VER >= 1600)) || defined(_LIBCPP_VERSION) ||\
+#elif ((defined(_MSC_VER) && (_MSC_VER >= 1600)) || defined(_LIBCPP_VERSION) ||\
 	 			 ((__cplusplus >= 201103) || defined(__GXX_EXPERIMENTAL_CXX0X__)))
 	#include <unordered_set>
 	#define XBYAK_STD_UNORDERED_SET std::unordered_set
@@ -168,8 +179,10 @@
 	#define XBYAK_TLS thread_local
 	#define XBYAK_VARIADIC_TEMPLATE
 	#define XBYAK_NOEXCEPT noexcept
+	#define XBYAK_OVERRIDE override
 #else
 	#define XBYAK_NOEXCEPT throw()
+	#define XBYAK_OVERRIDE
 #endif
 
 // require c++14 or later
@@ -196,11 +209,17 @@
 	#pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
+// Define this macro as 0 to disable strict checking of memory operand and register size matching.
+// This macro may be removed in future versions.
+#ifndef XBYAK_STRICT_CHECK_MEM_REG_SIZE
+	#define XBYAK_STRICT_CHECK_MEM_REG_SIZE 1
+#endif
+
 namespace Xbyak {
 
 enum {
 	DEFAULT_MAX_CODE_SIZE = 4096,
-	VERSION = 0x7231 /* 0xABCD = A.BC(.D) */
+	VERSION = 0x7353 /* 0xABCD = A.BC(.D) */
 };
 
 #ifndef MIE_INTEGER_TYPE_DEFINED
@@ -278,6 +297,9 @@ enum {
 	ERR_INVALID_DFV,
 	ERR_INVALID_REG_IDX,
 	ERR_BAD_ENCODING_MODE,
+	ERR_CANT_USE_ABCDH,
+	ERR_CANT_INIT_CPUTOPOLOGY,
+	ERR_INVALID_CPUMASK_INDEX,
 	ERR_INTERNAL // Put it at last.
 };
 
@@ -337,6 +359,9 @@ inline const char *ConvertErrorToString(int err)
 		"invalid dfv",
 		"invalid reg index",
 		"bad encoding mode",
+		"can't use [abcd]h with rex",
+		"can't init CpuTopology",
+		"invalid cpumask index",
 		"internal error"
 	};
 	assert(ERR_INTERNAL + 1 == sizeof(errTbl) / sizeof(*errTbl));
@@ -377,7 +402,7 @@ public:
 		}
 	}
 	operator int() const { return err_; }
-	const char *what() const XBYAK_NOEXCEPT
+	const char *what() const XBYAK_NOEXCEPT XBYAK_OVERRIDE
 	{
 		return ConvertErrorToString(err_);
 	}
@@ -421,11 +446,6 @@ inline void AlignedFree(void *p)
 #endif
 }
 
-template<class To, class From>
-inline const To CastTo(From p) XBYAK_NOEXCEPT
-{
-	return (const To)(size_t)(p);
-}
 namespace inner {
 
 #ifdef _WIN32
@@ -469,6 +489,14 @@ enum LabelMode {
 	LasIs, // as is
 	Labs, // absolute
 	LaddTop // (addr + top) for mov(reg, label) with AutoGrow
+};
+
+enum AddressMode {
+	M_none,
+	M_ModRM,
+	M_64bitDisp,
+	M_rip,
+	M_ripAddr
 };
 
 } // inner
@@ -524,7 +552,7 @@ class MmapAllocator : public Allocator {
 	AllocationList allocList_;
 public:
 	explicit MmapAllocator(const std::string& name = "xbyak") : name_(name) {}
-	uint8_t *alloc(size_t size)
+	uint8_t *alloc(size_t size) XBYAK_OVERRIDE
 	{
 		const size_t alignedSizeM1 = inner::getPageSize() - 1;
 		size = (size + alignedSizeM1) & ~alignedSizeM1;
@@ -550,7 +578,13 @@ public:
 			}
 		}
 #endif
-		void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, fd, 0);
+		int prot = PROT_READ | PROT_WRITE;
+#ifdef PROT_MPROTECT
+		// Some NetBSD systems have this protection turned on by default
+		// https://man.netbsd.org/mprotect.2
+		prot |= PROT_MPROTECT(PROT_READ | PROT_WRITE | PROT_EXEC);
+#endif
+		void *p = mmap(NULL, size, prot, mode, fd, 0);
 		if (p == MAP_FAILED) {
 			if (fd != -1) close(fd);
 			XBYAK_THROW_RET(ERR_CANT_ALLOC, 0)
@@ -563,7 +597,7 @@ public:
 #endif
 		return (uint8_t*)p;
 	}
-	void free(uint8_t *p)
+	void free(uint8_t *p) XBYAK_OVERRIDE
 	{
 		if (p == 0) return;
 		AllocationList::iterator i = allocList_.find((uintptr_t)p);
@@ -686,7 +720,7 @@ public:
 	}
 	void setRounding(int idx)
 	{
-		if (mask_ && (mask_ != unsigned(idx))) XBYAK_THROW(ERR_OPMASK_IS_ALREADY_SET)
+		if (rounding_ && (rounding_ != unsigned(idx))) XBYAK_THROW(ERR_ROUNDING_IS_ALREADY_SET)
 		rounding_ = idx;
 	}
 	void setZero() { zero_ = true; }
@@ -940,30 +974,6 @@ struct Reg64 : public Reg32e {
 	explicit XBYAK_CONSTEXPR Reg64(int idx = 0) : Reg32e(idx, 64) {}
 };
 struct RegRip {
-	int64_t disp_;
-	const Label* label_;
-	bool isAddr_;
-	explicit XBYAK_CONSTEXPR RegRip(int64_t disp = 0, const Label* label = 0, bool isAddr = false) : disp_(disp), label_(label), isAddr_(isAddr) {}
-	friend const RegRip operator+(const RegRip& r, int disp) {
-		return RegRip(r.disp_ + disp, r.label_, r.isAddr_);
-	}
-	friend const RegRip operator-(const RegRip& r, int disp) {
-		return RegRip(r.disp_ - disp, r.label_, r.isAddr_);
-	}
-	friend const RegRip operator+(const RegRip& r, int64_t disp) {
-		return RegRip(r.disp_ + disp, r.label_, r.isAddr_);
-	}
-	friend const RegRip operator-(const RegRip& r, int64_t disp) {
-		return RegRip(r.disp_ - disp, r.label_, r.isAddr_);
-	}
-	friend const RegRip operator+(const RegRip& r, const Label& label) {
-		if (r.label_ || r.isAddr_) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegRip());
-		return RegRip(r.disp_, &label);
-	}
-	friend const RegRip operator+(const RegRip& r, const void *addr) {
-		if (r.label_ || r.isAddr_) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegRip());
-		return RegRip(r.disp_ + (int64_t)addr, 0, true);
-	}
 };
 #endif
 
@@ -1024,17 +1034,30 @@ public:
 };
 #endif
 
+/*
+	pattern
+	[base]? [+index[*scale]]? [+/-disp]* [+label]?
+	rip [+/-disp]* [+label]?
+	  rip+disp if backward reference then use label.getAddress()
+	  rip+label if forward reference
+	[&var]?[+/-disp]*
+*/
 class RegExp {
+	friend class Address;
 public:
 #ifdef XBYAK64
 	enum { i32e = 32 | 64 };
 #else
 	enum { i32e = 32 };
 #endif
-	XBYAK_CONSTEXPR RegExp(size_t disp = 0) : scale_(0), disp_(disp) { }
+	XBYAK_CONSTEXPR RegExp() : scale_(0), disp_(0), label_(0), rip_(false), asPtr_(false) { }
+	XBYAK_CONSTEXPR RegExp(size_t disp) : scale_(0), disp_(disp), label_(0), rip_(false), asPtr_(false) { }
 	XBYAK_CONSTEXPR RegExp(const Reg& r, int scale = 1)
 		: scale_(scale)
 		, disp_(0)
+		, label_(0)
+		, rip_(false)
+		, asPtr_(false)
 	{
 		if (!r.isREG(i32e) && !r.is(Reg::XMM|Reg::YMM|Reg::ZMM|Reg::TMM)) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER)
 		if (scale == 0) return;
@@ -1045,6 +1068,27 @@ public:
 			base_ = r;
 		}
 	}
+	RegExp(Label& label);
+
+	// can't use constexpr to const void *
+	explicit RegExp(const void *addr)
+		: scale_(0)
+		, disp_(size_t(addr))
+		, label_(0)
+		, rip_(false)
+		, asPtr_(true)
+	{
+	}
+#ifdef XBYAK64
+	XBYAK_CONSTEXPR RegExp(const RegRip& /*rip*/)
+		: scale_(0)
+		, disp_(0)
+		, label_(0)
+		, rip_(true)
+		, asPtr_(false)
+	{
+	}
+#endif
 	bool isVsib(int bit = 128 | 256 | 512) const { return index_.isBit(bit); }
 	RegExp optimize() const
 	{
@@ -1062,6 +1106,8 @@ public:
 	}
 	const Reg& getBase() const { return base_; }
 	const Reg& getIndex() const { return index_; }
+	const Label *getLabel() const { return label_; }
+	bool isOnlyDisp() const { return !base_.getBit() && !index_.getBit(); } // for mov eax
 	int getScale() const { return scale_; }
 	size_t getDisp() const { return disp_; }
 	XBYAK_CONSTEXPR void verify() const
@@ -1073,6 +1119,7 @@ public:
 		}
 	}
 	friend RegExp operator+(const RegExp& a, const RegExp& b);
+	friend RegExp operator+(const RegExp& e, unsigned long long disp);
 	friend RegExp operator-(const RegExp& e, size_t disp);
 private:
 	/*
@@ -1082,13 +1129,22 @@ private:
 	Reg base_;
 	Reg index_;
 	int scale_;
-	size_t disp_;
+	size_t disp_; // absolute address
+	Label *label_;
+	bool rip_;
+	bool asPtr_; // disp_ contains a pointer
 };
 
 inline RegExp operator+(const RegExp& a, const RegExp& b)
 {
 	if (a.index_.getBit() && b.index_.getBit()) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
+	if (a.label_ && b.label_) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
+	if (b.rip_) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
+	if (a.rip_ && !b.isOnlyDisp()) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
+	if (a.asPtr_ && b.asPtr_) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
 	RegExp ret = a;
+	if (ret.label_ == 0) ret.label_ = b.label_;
+	if (ret.asPtr_ == 0) ret.asPtr_ = b.asPtr_;
 	if (!ret.index_.getBit()) { ret.index_ = b.index_; ret.scale_ = b.scale_; }
 	if (b.base_.getBit()) {
 		if (ret.base_.getBit()) {
@@ -1113,6 +1169,24 @@ inline RegExp operator*(int scale, const Reg& r)
 {
 	return r * scale;
 }
+
+// backward compatibility for eax+&x (pointer address)
+inline RegExp operator+(const RegExp& a, const void* b) { return a + RegExp(b); }
+
+// since what size_t is typedef'd to depends on the implementation, use unsigned long long (assume u64) for the implementation.
+inline RegExp operator+(const RegExp& e, unsigned long long disp)
+{
+	RegExp ret = e;
+	ret.disp_ += static_cast<size_t>(disp);
+	return ret;
+}
+// overload for integer literals (e.g. eax+0) to avoid ambiguity with the void* overload
+inline RegExp operator+(const RegExp& e, int disp) { return e + static_cast<unsigned long long>(disp); }
+inline RegExp operator+(const RegExp& e, long disp) { return e + static_cast<unsigned long long>(disp); }
+inline RegExp operator+(const RegExp& e, long long disp) { return e + static_cast<unsigned long long>(disp); }
+inline RegExp operator+(const RegExp& e, unsigned int disp) { return e + static_cast<unsigned long long>(disp); }
+inline RegExp operator+(const RegExp& e, unsigned long disp) { return e + static_cast<unsigned long long>(disp); }
+
 inline RegExp operator-(const RegExp& e, size_t disp)
 {
 	RegExp ret = e;
@@ -1294,7 +1368,7 @@ public:
 	*/
 	void rewrite(size_t offset, uint64_t disp, size_t size)
 	{
-		assert(offset < maxSize_);
+		if (offset >= maxSize_ || size > maxSize_ - offset) XBYAK_THROW(ERR_OFFSET_IS_TOO_BIG)
 		if (size != 1 && size != 2 && size != 4 && size != 8) XBYAK_THROW(ERR_BAD_PARAMETER)
 		uint8_t *const data = top_ + offset;
 		for (size_t i = 0; i < size; i++) {
@@ -1360,33 +1434,39 @@ public:
 
 class Address : public Operand {
 public:
-	enum Mode {
-		M_ModRM,
-		M_64bitDisp,
-		M_rip,
-		M_ripAddr
-	};
+
+	XBYAK_CONSTEXPR Address()
+		: Operand(0, MEM, 0), e_(), label_(NULL), mode_(inner::M_ModRM), immSize(0),
+		  disp8N(0), permitVsib(false), broadcast_(false), optimize_(true) { }
 	XBYAK_CONSTEXPR Address(uint32_t sizeBit, bool broadcast, const RegExp& e)
-		: Operand(0, MEM, sizeBit), e_(e), label_(0), mode_(M_ModRM), immSize(0), disp8N(0), permitVsib(false), broadcast_(broadcast), optimize_(true)
+		: Operand(0, MEM, sizeBit), e_(e), label_(e.label_), mode_(), immSize(0),
+		  disp8N(0), permitVsib(false), broadcast_(broadcast), optimize_(true)
 	{
+		if (e.rip_) {
+			mode_ = (e.label_ || e.asPtr_) ? inner::M_ripAddr : inner::M_rip;
+		} else {
+#ifdef XBYAK64
+			uint64_t disp = e.getDisp();
+			if (e.isOnlyDisp() && ((0x80000000 <= disp && disp <= 0xffffffff80000000) || e.getLabel())) {
+				mode_ = inner::M_64bitDisp;
+			} else
+#endif
+			{
+				mode_ = inner::M_ModRM;
+			}
+		}
 		e_.verify();
 	}
-#ifdef XBYAK64
-	explicit XBYAK_CONSTEXPR Address(size_t disp)
-		: Operand(0, MEM, 64), e_(disp), label_(0), mode_(M_64bitDisp), immSize(0), disp8N(0), permitVsib(false), broadcast_(false), optimize_(true) { }
-	XBYAK_CONSTEXPR Address(uint32_t sizeBit, bool broadcast, const RegRip& addr)
-		: Operand(0, MEM, sizeBit), e_(addr.disp_), label_(addr.label_), mode_(addr.isAddr_ ? M_ripAddr : M_rip), immSize(0), disp8N(0), permitVsib(false), broadcast_(broadcast), optimize_(true) { }
-#endif
 	RegExp getRegExp() const
 	{
 		return optimize_ ? e_.optimize() : e_;
 	}
 	Address cloneNoOptimize() const { Address addr = *this; addr.optimize_ = false; return addr; }
-	Mode getMode() const { return mode_; }
+	inner::AddressMode getMode() const { return mode_; }
 	bool is32bit() const { return e_.getBase().getBit() == 32 || e_.getIndex().getBit() == 32; }
-	bool isOnlyDisp() const { return !e_.getBase().getBit() && !e_.getIndex().getBit(); } // for mov eax
+	bool isOnlyDisp() const { return e_.isOnlyDisp(); }
 	size_t getDisp() const { return e_.getDisp(); }
-	bool is64bitDisp() const { return mode_ == M_64bitDisp; } // for moffset
+	bool is64bitDisp() const { return mode_ == inner::M_64bitDisp; } // for moffset
 	bool isBroadcast() const { return broadcast_; }
 	bool hasRex2() const { return e_.getBase().hasRex2() || e_.getIndex().hasRex2(); }
 	const Label* getLabel() const { return label_; }
@@ -1399,7 +1479,7 @@ public:
 private:
 	RegExp e_;
 	const Label* label_;
-	Mode mode_;
+	inner::AddressMode mode_;
 public:
 	int immSize; // the size of immediate value of nmemonics (0, 1, 2, 4)
 	int disp8N; // 0(normal), 1(force disp32), disp8N = {2, 4, 8}
@@ -1443,21 +1523,17 @@ public:
 	{
 		return Address(bit_, broadcast_, e);
 	}
-	Address operator[](const void *disp) const
+	Address operator[](const void *addr) const
 	{
-		return Address(bit_, broadcast_, RegExp(reinterpret_cast<size_t>(disp)));
+		return operator[](RegExp(addr));
 	}
-#ifdef XBYAK64
-	Address operator[](uint64_t disp) const { return Address(disp); }
-	Address operator[](const RegRip& addr) const { return Address(bit_, broadcast_, addr); }
-#endif
 };
 
 struct JmpLabel {
 	size_t endOfJmp; /* offset from top to the end address of jmp */
 	int jmpSize;
 	inner::LabelMode mode;
-	size_t disp; // disp for [rip + disp]
+	size_t disp; // disp for [rip + disp] or [forward ref label + disp]
 	explicit JmpLabel(size_t endOfJmp = 0, int jmpSize = 0, inner::LabelMode mode = inner::LasIs, size_t disp = 0)
 		: endOfJmp(endOfJmp), jmpSize(jmpSize), mode(mode), disp(disp)
 	{
@@ -1477,6 +1553,7 @@ public:
 	~Label();
 	void clear() { mgr = 0; id = 0; }
 	int getId() const { return id; }
+	bool isDefined() const;
 	const uint8_t *getAddress() const;
 
 	// backward compatibility
@@ -1492,6 +1569,22 @@ public:
 		return buf;
 	}
 };
+
+inline RegExp::RegExp(Label& label)
+	: scale_(1)
+	, disp_(0)
+	, label_(0)
+	, rip_(false)
+	, asPtr_(true)
+{
+	const uint8_t *addr = label.getAddress();
+	if (addr) {
+		disp_ = size_t(addr);
+		label_ = 0;
+	} else {
+		label_ = &label;
+	}
+}
 
 class LabelManager {
 	// for string label
@@ -1553,6 +1646,9 @@ class LabelManager {
 				if (jmp->jmpSize <= 4 && !inner::IsInInt32(disp)) XBYAK_THROW(ERR_OFFSET_IS_TOO_BIG)
 #endif
 				if (jmp->jmpSize == 1 && !inner::IsInDisp8((uint32_t)disp)) XBYAK_THROW(ERR_LABEL_IS_TOO_FAR)
+			}
+			if (jmp->mode != inner::LasIs) {
+				disp += jmp->disp;
 			}
 			if (base_->isAutoGrow()) {
 				base_->save(offset, disp, jmp->jmpSize, jmp->mode);
@@ -1710,8 +1806,13 @@ public:
 	bool hasUndefClabel() const { return hasUndefinedLabel_inner(clabelUndefList_); }
 	const uint8_t *getCode() const { return base_->getCode(); }
 	bool isReady() const { return !base_->isAutoGrow() || base_->isCalledCalcJmpAddress(); }
+	bool isDefined(const Label& label) const { return clabelDefList_.find(label.id) != clabelDefList_.end(); }
 };
 
+inline bool Label::isDefined() const
+{
+	return mgr && mgr->isDefined(*this);
+}
 inline Label::Label(const Label& rhs)
 {
 	id = rhs.id;
@@ -1912,9 +2013,10 @@ private:
 	static const uint64_t T_ND1 = 1ull << 35; // ND=1
 	static const uint64_t T_ZU = 1ull << 36; // ND=ZU
 	static const uint64_t T_F2 = 1ull << 37; // pp = 3
-	static const uint64_t T_FP8 = 1ull << 40; // amx bf8 and hf8
-	// T_66 = 1, T_F3 = 2, T_F2 = 3
+	static const uint64_t T_SENTRY = (1ull << 38)-1; // attribute(>=T_SENTRY) is for error check
 	static const uint64_t T_ALLOW_DIFF_SIZE = 1ull << 38; // allow difference reg size
+	static const uint64_t T_ALLOW_ABCDH = 1ull << 39; // allow [abcd]h reg
+	// T_66 = 1, T_F3 = 2, T_F2 = 3
 	static inline uint32_t getPP(uint64_t type) { return (type & T_66) ? 1 : (type & T_F3) ? 2 : (type & T_F2) ? 3 : 0; }
 	// @@@end of avx_type_def.h
 	static inline uint32_t getMap(uint64_t type)
@@ -1979,9 +2081,9 @@ private:
 		int disp8N = 1;
 		if (rounding) {
 			if (rounding == EvexModifierRounding::T_SAE) {
-					verifySAE(base, type); LL = 0;
+				verifySAE(base, type); LL = 0;
 			} else {
-					verifyER(base, type); LL = rounding - 1;
+				verifyER(base, type); LL = rounding - 1;
 			}
 			b = true;
 		} else {
@@ -2046,8 +2148,11 @@ private:
 	{
 		db(static_cast<uint8_t>((mod << 6) | ((r1 & 7) << 3) | (r2 & 7)));
 	}
-	void setSIB(const RegExp& e, int reg, int disp8N = 0)
+	void setSIB(const Address& addr, int reg)
 	{
+		const RegExp& e = addr.getRegExp();
+		const Label *label = e.getLabel();
+		int disp8N = addr.disp8N;
 		uint64_t disp64 = e.getDisp();
 #if defined(XBYAK64) && !defined(__ILP32__)
 #ifdef XBYAK_OLD_DISP_CHECK
@@ -2070,8 +2175,10 @@ private:
 			mod00 = 0, mod01 = 1, mod10 = 2
 		};
 		int mod = mod10; // disp32
-		if (!baseBit || ((baseIdx & 7) != Operand::EBP && disp == 0)) {
+		if (!baseBit || ((baseIdx & 7) != Operand::EBP && (label == 0 && disp == 0))) {
 			mod = mod00;
+		} else if (label) {
+			// always disp32
 		} else {
 			if (disp8N == 0) {
 				if (inner::IsInDisp8(disp)) {
@@ -2105,7 +2212,11 @@ private:
 		if (mod == mod01) {
 			db(disp);
 		} else if (mod == mod10 || (mod == mod00 && !baseBit)) {
-			dd(disp);
+			if (label) {
+				putL_inner(*label, false, e.getDisp() - addr.immSize, 4);
+			} else {
+				dd(disp);
+			}
 		}
 	}
 	LabelManager labelMgr_;
@@ -2120,20 +2231,24 @@ private:
 				db(0x0F); db(0x3A);
 			}
 		}
-		db(code | ((type == 0 || (type & T_CODE1_IF1)) && !r.isBit(8)));
+		db(code | (((type & T_SENTRY) == 0 || (type & T_CODE1_IF1)) && !r.isBit(8)));
 	}
-	void opRR(const Reg& reg1, const Reg& reg2, uint64_t type, int code)
+	void opRR(const Reg& r1, const Reg& r2, uint64_t type, int code)
 	{
-		if (!(type & T_ALLOW_DIFF_SIZE) && reg1.isREG() && reg2.isREG() && reg1.getBit() != reg2.getBit()) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER)
-		bool rex2 = rex(reg2, reg1, type);
-		writeCode(type, reg1, code, rex2);
-		setModRM(3, reg1.getIdx(), reg2.getIdx());
+		if (!(type & T_ALLOW_DIFF_SIZE) && r1.isREG() && r2.isREG() && r1.getBit() != r2.getBit()) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER)
+		if (!(type & T_ALLOW_ABCDH) && (isBadCombination(r1, r2) || isBadCombination(r2, r1))) XBYAK_THROW(ERR_CANT_USE_ABCDH)
+		bool rex2 = rex(r2, r1, type);
+		writeCode(type, r1, code, rex2);
+		setModRM(3, r1.getIdx(), r2.getIdx());
 	}
 	void opMR(const Address& addr, const Reg& r, uint64_t type, int code, uint64_t type2 = 0, int code2 = NONE)
 	{
 		if (code2 == NONE) code2 = code;
 		if (type2 && opROO(Reg(), addr, r, type2, code2)) return;
 		if (addr.is64bitDisp()) XBYAK_THROW(ERR_CANT_USE_64BIT_DISP)
+#if XBYAK_STRICT_CHECK_MEM_REG_SIZE == 1
+		if (!(type & T_ALLOW_DIFF_SIZE) && r.getBit() <= BIT && addr.getBit() > 0 && addr.getBit() != r.getBit()) XBYAK_THROW(ERR_BAD_MEM_SIZE)
+#endif
 		bool rex2 = rex(addr, r, type);
 		writeCode(type, r, code, rex2);
 		opAddr(addr, r.getIdx());
@@ -2151,7 +2266,7 @@ private:
 	// for only MPX(bnd*)
 	void opMIB(const Address& addr, const Reg& reg, uint64_t type, int code)
 	{
-		if (addr.getMode() != Address::M_ModRM) XBYAK_THROW(ERR_INVALID_MIB_ADDRESS)
+		if (addr.getMode() != inner::M_ModRM) XBYAK_THROW(ERR_INVALID_MIB_ADDRESS)
 		opMR(addr.cloneNoOptimize(), reg, type, code);
 	}
 	void makeJmp(uint32_t disp, LabelType type, uint8_t shortCode, uint8_t longCode, uint8_t longPref)
@@ -2220,16 +2335,17 @@ private:
 	void opAddr(const Address &addr, int reg)
 	{
 		if (!addr.permitVsib && addr.isVsib()) XBYAK_THROW(ERR_BAD_VSIB_ADDRESSING)
-		if (addr.getMode() == Address::M_ModRM) {
-			setSIB(addr.getRegExp(), reg, addr.disp8N);
-		} else if (addr.getMode() == Address::M_rip || addr.getMode() == Address::M_ripAddr) {
+		if (addr.getMode() == inner::M_ModRM) {
+			setSIB(addr, reg);
+		} else if (addr.getMode() == inner::M_rip || addr.getMode() == inner::M_ripAddr) {
 			setModRM(0, reg, 5);
 			if (addr.getLabel()) { // [rip + Label]
-				putL_inner(*addr.getLabel(), true, addr.getDisp() - addr.immSize);
+				putL_inner(*addr.getLabel(), true, addr.getDisp() - addr.immSize, 4);
 			} else {
 				size_t disp = addr.getDisp();
-				if (addr.getMode() == Address::M_ripAddr) {
+				if (addr.getMode() == inner::M_ripAddr) {
 					if (isAutoGrow()) XBYAK_THROW(ERR_INVALID_RIP_IN_AUTO_GROW)
+					// compute the relative offset to the pointer address
 					disp -= (size_t)getCurr() + 4 + addr.immSize;
 				}
 				dd(inner::VerifyInInt32(disp));
@@ -2278,6 +2394,13 @@ private:
 			opSSE(mmx, op, T_66 | T_0F3A, code, isXMM_REG32orMEM, imm);
 		}
 	}
+	// r1 is [abcd]h and r2 is reg with rex
+	bool isBadCombination(const Reg& r1, const Reg& r2) const
+	{
+		if (!r1.isHigh8bit()) return false;
+		if (r2.isExt8bit() || r2.getIdx() >= 8) return true;
+		return false;
+	}
 	// (r, r, m) or (r, m, r)
 	bool opROO(const Reg& d, const Operand& op1, const Operand& op2, uint64_t type, int code, int immSize = 0, int sc = NONE)
 	{
@@ -2309,7 +2432,7 @@ private:
 		if (op.isMEM()) {
 			opMR(op.getAddress(immSize), r, type, code);
 		} else if (op.isREG(bit)) {
-			opRR(r, op.getReg().changeBit(opBit), type, code);
+			opRR(r, op.getReg().changeBit(opBit), type | T_ALLOW_ABCDH, code);
 		} else {
 			XBYAK_THROW(ERR_BAD_COMBINATION)
 		}
@@ -2440,7 +2563,7 @@ private:
 				return;
 			}
 			if (op.isMEM()) {
-				opMR(op.getAddress(), Reg(ext, Operand::REG, 32), 0, code);
+				opMR(op.getAddress(), Reg(ext, Operand::REG, 32), T_ALLOW_DIFF_SIZE, code);
 				return;
 			}
 		}
@@ -2473,9 +2596,9 @@ private:
 		return bit / 8;
 	}
 	template<class T>
-	void putL_inner(T& label, bool relative = false, size_t disp = 0)
+	void putL_inner(T& label, bool relative = false, size_t disp = 0, int jmpSize = (int)sizeof(size_t))
 	{
-		const int jmpSize = relative ? 4 : (int)sizeof(size_t);
+		if (relative) jmpSize = 4;
 		if (isAutoGrow() && size_ + 16 >= maxSize_) growMemory();
 		size_t offset = 0;
 		if (labelMgr_.getOffset(&offset, label)) {
@@ -3053,7 +3176,11 @@ public:
 			if (code) {
 				rex(*reg);
 				db(op1.isREG(8) ? 0xA0 : op1.isREG() ? 0xA1 : op2.isREG(8) ? 0xA2 : 0xA3);
-				db(addr->getDisp(), 8);
+				if (addr->getLabel()) {
+					putL_inner(*addr->getLabel(), false, addr->getDisp() - addr->immSize, 8);
+				} else {
+					db(addr->getDisp(), 8);
+				}
 			} else {
 				XBYAK_THROW(ERR_BAD_COMBINATION)
 			}
@@ -3062,7 +3189,11 @@ public:
 		if (code && addr->isOnlyDisp()) {
 			rex(*reg, *addr);
 			db(code | (reg->isBit(8) ? 0 : 1));
-			dd(static_cast<uint32_t>(addr->getDisp()));
+			if (addr->getLabel()) {
+				putL_inner(*addr->getLabel(), false, addr->getDisp() - addr->immSize);
+			} else {
+				dd(static_cast<uint32_t>(addr->getDisp()));
+			}
 		} else
 #endif
 		{
@@ -3162,11 +3293,11 @@ public:
 	}
 	void mov(const Operand& op, const Segment& seg)
 	{
-		opRO(Reg8(seg.getIdx()), op, T_ALLOW_DIFF_SIZE, 0x8C, op.isREG(16|i32e));
+		opRO(Reg8(seg.getIdx()), op, T_ALLOW_DIFF_SIZE | T_ALLOW_ABCDH, 0x8C, op.isREG(16|i32e));
 	}
 	void mov(const Segment& seg, const Operand& op)
 	{
-		opRO(Reg8(seg.getIdx()), op.isREG(16|i32e) ? static_cast<const Operand&>(op.getReg().cvt32()) : op, T_ALLOW_DIFF_SIZE, 0x8E, op.isREG(16|i32e));
+		opRO(Reg8(seg.getIdx()), op.isREG(16|i32e) ? static_cast<const Operand&>(op.getReg().cvt32()) : op, T_ALLOW_DIFF_SIZE | T_ALLOW_ABCDH, 0x8E, op.isREG(16|i32e));
 	}
 #endif
 
@@ -3315,11 +3446,14 @@ public:
 		opAVX10ZeroExt(op1, op2, typeTbl, codeTbl, enc, 16|32|64);
 	}
 	/*
-		use single byte nop if useMultiByteNop = false
+		useMultiByteNop
+		= 0: use only single byte nop
+		= 1: recommended multi-byte
+		= 2: better for newer CPUs
 	*/
-	void nop(size_t size = 1, bool useMultiByteNop = true)
+	void nop(size_t size = 1, int useMultiByteNop = 2)
 	{
-		if (!useMultiByteNop) {
+		if (useMultiByteNop == 0) {
 			for (size_t i = 0; i < size; i++) {
 				db(0x90);
 			}
@@ -3330,8 +3464,9 @@ public:
 			recommended multi-byte sequence of NOP instruction
 			AMD and Intel seem to agree on the same sequences for up to 9 bytes:
 			https://support.amd.com/TechDocs/55723_SOG_Fam_17h_Processors_3.00.pdf
+			10~15 byte nop in Software Optimization Guide for the AMD Zen4 Microarchitecture No. 57647
 		*/
-		static const uint8_t nopTbl[9][9] = {
+		static const uint8_t nopTbl[][15] = {
 			{0x90},
 			{0x66, 0x90},
 			{0x0F, 0x1F, 0x00},
@@ -3340,9 +3475,15 @@ public:
 			{0x66, 0x0F, 0x1F, 0x44, 0x00, 0x00},
 			{0x0F, 0x1F, 0x80, 0x00, 0x00, 0x00, 0x00},
 			{0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
-			{0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
+			{0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}, // 9
+			{0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
+			{0x66, 0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}, // 11
+			{0x66, 0x66, 0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
+			{0x66, 0x66, 0x66, 0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
+			{0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
+			{0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
 		};
-		const size_t n = sizeof(nopTbl) / sizeof(nopTbl[0]);
+		const size_t n = useMultiByteNop == 2 ? sizeof(nopTbl) / sizeof(nopTbl[0]) : 9;
 		while (size > 0) {
 			size_t len = (std::min)(n, size);
 			const uint8_t *seq = nopTbl[len - 1];
@@ -3353,9 +3494,9 @@ public:
 #ifndef XBYAK_DONT_READ_LIST
 #include "xbyak_mnemonic.h"
 	/*
-		use single byte nop if useMultiByteNop = false
+		use single byte nop if useMultiByteNop = 0
 	*/
-	void align(size_t x = 16, bool useMultiByteNop = true)
+	void align(size_t x = 16, int useMultiByteNop = 2)
 	{
 		if (x == 1) return;
 		if (x < 1 || (x & (x - 1))) XBYAK_THROW(ERR_BAD_ALIGN)

--- a/third_party/xbyak/xbyak_mnemonic.h
+++ b/third_party/xbyak/xbyak_mnemonic.h
@@ -42,7 +42,8 @@
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 * THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-const char *getVersionString() const { return "7.23.1"; }
+
+const char *getVersionString() const { return "7.35.3"; }
 void aadd(const Address& addr, const Reg32e &reg) { opMR(addr, reg, T_0F38, 0x0FC, T_APX); }
 void aand(const Address& addr, const Reg32e &reg) { opMR(addr, reg, T_0F38|T_66, 0x0FC, T_APX|T_66); }
 void adc(const Operand& op, uint32_t imm) { opOI(op, imm, 0x10, 2); }
@@ -731,8 +732,8 @@ void movaps(const Address& addr, const Xmm& xmm) { opSSE(xmm, addr, T_0F|T_NONE,
 void movaps(const Xmm& xmm, const Operand& op) { opMMX(xmm, op, 0x28, T_0F, T_NONE); }
 void movbe(const Address& addr, const Reg& reg) { opMR(addr, reg, T_0F38, 0xF1, T_APX, 0x61); }
 void movbe(const Reg& reg, const Address& addr) { opMR(addr, reg, T_0F38, 0xF0, T_APX, 0x60); }
-void movd(const Mmx& mmx, const Operand& op) { if (!(op.isMEM() || op.isREG(32))) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0x66); opSSE(mmx, op, T_0F, 0x6E); }
-void movd(const Operand& op, const Mmx& mmx) { if (!(op.isMEM() || op.isREG(32))) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0x66); opSSE(mmx, op, T_0F, 0x7E); }
+void movd(const Mmx& mmx, const Operand& op) { if (!(op.isMEM() || op.isREG(32))) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0x66); opSSE(mmx, op, T_0F | T_ALLOW_DIFF_SIZE, 0x6E); }
+void movd(const Operand& op, const Mmx& mmx) { if (!(op.isMEM() || op.isREG(32))) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0x66); opSSE(mmx, op, T_0F | T_ALLOW_DIFF_SIZE, 0x7E); }
 void movddup(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_DUP|T_F2|T_0F|T_EW1|T_YMM|T_EVEX, 0x12, isXMM_XMMorMEM, NONE); }
 void movdir64b(const Reg& reg, const Address& addr) { opMR(addr, reg.cvt32(), T_66|T_0F38, 0xF8, T_APX|T_66); }
 void movdiri(const Address& addr, const Reg32e& reg) { opMR(addr, reg, T_0F38, 0xF9, T_APX); }
@@ -755,8 +756,8 @@ void movnti(const Address& addr, const Reg32e& reg) { opMR(addr, reg, T_0F, 0xC3
 void movntpd(const Address& addr, const Xmm& reg) { if (reg.getIdx() >= 16) XBYAK_THROW(ERR_BAD_PARAMETER) opSSE(Reg16(reg.getIdx()), addr, T_0F, 0x2B); }
 void movntps(const Address& addr, const Xmm& xmm) { opSSE(Xmm(xmm.getIdx()), addr, T_0F, 0x2B); }
 void movntq(const Address& addr, const Mmx& mmx) { if (!mmx.isMMX()) XBYAK_THROW(ERR_BAD_COMBINATION) opSSE(mmx, addr, T_0F, 0xE7); }
-void movq(const Address& addr, const Mmx& mmx) { if (mmx.isXMM()) db(0x66); opSSE(mmx, addr, T_0F, mmx.isXMM() ? 0xD6 : 0x7F); }
-void movq(const Mmx& mmx, const Operand& op) { if (!op.isMEM() && mmx.getKind() != op.getKind()) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0xF3); opSSE(mmx, op, T_0F, mmx.isXMM() ? 0x7E : 0x6F); }
+void movq(const Address& addr, const Mmx& mmx) { if (mmx.isXMM()) db(0x66); opSSE(mmx, addr, T_0F | T_ALLOW_DIFF_SIZE, mmx.isXMM() ? 0xD6 : 0x7F); }
+void movq(const Mmx& mmx, const Operand& op) { if (!op.isMEM() && mmx.getKind() != op.getKind()) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0xF3); opSSE(mmx, op, T_0F | T_ALLOW_DIFF_SIZE, mmx.isXMM() ? 0x7E : 0x6F); }
 void movq2dq(const Xmm& xmm, const Mmx& mmx) { opSSE(xmm, mmx, T_F3 | T_0F, 0xD6); }
 void movsb() { db(0xA4); }
 void movsd() { db(0xA5); }
@@ -865,6 +866,7 @@ void pminsd(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_66 | T_0F38, 0
 void pminsw(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0xEA); }
 void pminub(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0xDA); }
 void pminud(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_66 | T_0F38, 0x3B, isXMM_XMMorMEM); }
+void pminuw(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_66 | T_0F38, 0x3A, isXMM_XMMorMEM); }
 void pmovmskb(const Reg32e& reg, const Mmx& mmx) { if (mmx.isXMM()) db(0x66); opSSE(reg, mmx, T_0F, 0xD7); }
 void pmovsxbd(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_N4|T_N_VL|T_66|T_0F38|T_YMM|T_EVEX, 0x21, isXMM_XMMorMEM, NONE); }
 void pmovsxbq(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_N2|T_N_VL|T_66|T_0F38|T_YMM|T_EVEX, 0x22, isXMM_XMMorMEM, NONE); }
@@ -1476,7 +1478,7 @@ void vpermpd(const Ymm& y, const Operand& op, uint8_t imm) { opAVX_X_XM_IMM(y, o
 void vpermpd(const Ymm& y1, const Ymm& y2, const Operand& op) { opAVX_X_X_XM(y1, y2, op, T_66|T_0F38|T_EW1|T_YMM|T_MUST_EVEX|T_B64, 0x16); }
 void vpermps(const Ymm& y1, const Ymm& y2, const Operand& op) { opAVX_X_X_XM(y1, y2, op, T_66|T_0F38|T_W0|T_YMM|T_EVEX|T_B32, 0x16); }
 void vpermq(const Ymm& y, const Operand& op, uint8_t imm) { opAVX_X_XM_IMM(y, op, T_66|T_0F3A|T_W1|T_EW1|T_YMM|T_EVEX|T_B64, 0x00, imm); }
-void vpermq(const Ymm& y1, const Ymm& y2, const Operand& op) { opAVX_X_X_XM(y1, y2, op, T_66|T_0F38|T_W0|T_EW1|T_YMM|T_EVEX|T_B64, 0x36); }
+void vpermq(const Ymm& y1, const Ymm& y2, const Operand& op) { opAVX_X_X_XM(y1, y2, op, T_66|T_0F38|T_EW1|T_YMM|T_EVEX|T_B64, 0x36); }
 void vpextrb(const Operand& op, const Xmm& x, uint8_t imm) { if (!((op.isREG(8|16|i32e) || op.isMEM()) && x.isXMM())) XBYAK_THROW(ERR_BAD_COMBINATION) opVex(x, 0, op, T_0F3A | T_66 | T_EVEX | T_N1, 0x14, imm); }
 void vpextrd(const Operand& op, const Xmm& x, uint8_t imm) { if (!((op.isREG(32) || op.isMEM()) && x.isXMM())) XBYAK_THROW(ERR_BAD_COMBINATION) opVex(x, 0, op, T_0F3A | T_66 | T_W0 | T_EVEX | T_N4, 0x16, imm); }
 void vpextrq(const Operand& op, const Xmm& x, uint8_t imm) { if (!((op.isREG(64) || op.isMEM()) && x.isXMM())) XBYAK_THROW(ERR_BAD_COMBINATION) opVex(x, 0, op, T_0F3A | T_66 | T_W1 | T_EVEX | T_EW1 | T_N8, 0x16, imm); }
@@ -1918,7 +1920,7 @@ void clui() { db(0xF3); db(0x0F); db(0x01); db(0xEE); }
 void stui() { db(0xF3); db(0x0F); db(0x01); db(0xEF); }
 void testui() { db(0xF3); db(0x0F); db(0x01); db(0xED); }
 void uiret() { db(0xF3); db(0x0F); db(0x01); db(0xEC); }
-void cmpxchg16b(const Address& addr) { opMR(addr, Reg64(1), T_0F, 0xC7); }
+void cmpxchg16b(const Address& addr) { opMR(addr, Reg64(1), T_0F|T_ALLOW_DIFF_SIZE, 0xC7); }
 void fxrstor64(const Address& addr) { opMR(addr, Reg64(1), T_0F, 0xAE); }
 void movq(const Reg64& reg, const Mmx& mmx) { if (mmx.isXMM()) db(0x66); opSSE(mmx, reg, T_0F, 0x7E); }
 void movq(const Mmx& mmx, const Reg64& reg) { if (mmx.isXMM()) db(0x66); opSSE(mmx, reg, T_0F, 0x6E); }
@@ -2270,8 +2272,8 @@ void vcvtbiasph2bf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x
 void vcvtbiasph2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
 void vcvtbiasph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
 void vcvtdq2ph(const Xmm& x, const Operand& op) { checkCvt4(x, op); opCvt(x, op, T_N16|T_N_VL|T_MAP5|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x5B); }
+void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_MUST_EVEX | T_F2 | T_MAP5 | T_W0 | T_YMM | T_N1, 0x1E); }
 void vcvtne2ps2bf16(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_F2|T_0F38|T_W0|T_YMM|T_SAE_Z|T_MUST_EVEX|T_B32, 0x72); }
-void vcvthf82ph(const Xmm& x, const Operand& op) { opVex(x, 0, op, T_N8|T_N_VL|T_F2|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x1e); }
 void vcvtpd2ph(const Xmm& x, const Operand& op) { opCvt5(x, op, T_N16|T_N_VL|T_66|T_MAP5|T_EW1|T_ER_Z|T_MUST_EVEX|T_B64, 0x5A); }
 void vcvtpd2qq(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x7B); }
 void vcvtpd2udq(const Xmm& x, const Operand& op) { opCvt2(x, op, T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x79); }
@@ -2729,6 +2731,8 @@ void vucomxsh(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_N2|T_F3
 void vucomxss(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_N4|T_F3|T_0F|T_W0|T_SAE_X|T_MUST_EVEX, 0x2E); }
 #ifdef XBYAK64
 void kmovq(const Reg64& r, const Opmask& k) { opKmov(k, r, true, 64); }
+void tcvtrowd2ps(const Zmm& z, const Tmm& t, const Reg32& r) { opVex(z, &r, t, T_F3|T_0F38|T_W0|T_MUST_EVEX, 0x4A); }
+void tcvtrowd2ps(const Zmm& z, const Tmm& t, uint8_t imm) { opVex(z, 0, t, T_F3|T_0F3A|T_W0|T_MUST_EVEX, 0x07, imm); }
 void tcvtrowps2bf16h(const Zmm& z, const Tmm& t, const Reg32& r) { opVex(z, &r, t, T_F2|T_0F38|T_W0|T_MUST_EVEX, 0x6D); }
 void tcvtrowps2bf16h(const Zmm& z, const Tmm& t, uint8_t imm) { opVex(z, 0, t, T_F2|T_0F3A|T_W0|T_MUST_EVEX, 0x07, imm); }
 void tcvtrowps2bf16l(const Zmm& z, const Tmm& t, const Reg32& r) { opVex(z, &r, t, T_F3|T_0F38|T_W0|T_MUST_EVEX, 0x6D); }

--- a/third_party/xbyak/xbyak_util.h
+++ b/third_party/xbyak/xbyak_util.h
@@ -60,9 +60,11 @@
 #else
 	#define XBYAK_CONSTEXPR
 #endif
+#define XBYAK_CPUMASK_COMPACT 0
 #endif
 #else
 #include <string.h>
+#include <stdio.h>
 
 /**
 	utility class and functions for Xbyak
@@ -131,6 +133,32 @@
 	#define XBYAK_USE_PERF
 #endif
 
+#ifndef XBYAK_CPU_CACHE
+	#define XBYAK_CPU_CACHE 1
+#endif
+#if XBYAK_CPU_CACHE == 1
+#include <vector>
+#ifndef XBYAK_CPUMASK_COMPACT
+	#define XBYAK_CPUMASK_COMPACT 1
+#endif
+#if XBYAK_CPUMASK_COMPACT == 0
+	#include <set>
+#endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
+namespace Xbyak { namespace util {
+class CpuTopology;
+class Cpu;
+namespace impl {
+
+bool initCpuTopology(CpuTopology& cpuTopo);
+
+} // Xbyak::util::impl
+} } // Xbyak::util
+#endif // XBYAK_CPU_CACHE
+
+
 namespace Xbyak { namespace util {
 
 typedef enum {
@@ -159,6 +187,10 @@ inline T min_(T x, T y) { return x < y ? x : y; }
 	CPU detection class
 	@note static inline const member is supported by c++17 or later, so use template hack
 */
+#ifdef _MSC_VER
+	#pragma warning(push)
+	#pragma warning(disable : 4459)
+#endif
 class Cpu {
 public:
 	class Type {
@@ -199,16 +231,15 @@ private:
 	{
 		return (1U << n) - 1;
 	}
-	// [EBX:ECX:EDX] == s?
-	bool isEqualStr(uint32_t EBX, uint32_t ECX, uint32_t EDX, const char s[12]) const
+	// [ebx:ecx:edx] == s?
+	bool isEqualStr(uint32_t ebx, uint32_t ecx, uint32_t edx, const char s[12]) const
 	{
-		return get32bitAsBE(&s[0]) == EBX && get32bitAsBE(&s[4]) == EDX && get32bitAsBE(&s[8]) == ECX;
+		return get32bitAsBE(&s[0]) == ebx && get32bitAsBE(&s[4]) == edx && get32bitAsBE(&s[8]) == ecx;
 	}
 	uint32_t extractBit(uint32_t val, uint32_t base, uint32_t end) const
 	{
 		return (val >> base) & ((1u << (end + 1 - base)) - 1);
 	}
-
 	void setFamily()
 	{
 		uint32_t data[4] = {};
@@ -269,7 +300,7 @@ private:
 			int physicalThreadCount = 0;
 			getCpuid(0x1, data);
 			int logicalProcessorCount = extractBit(data[1], 16, 23);
-			int htt = extractBit(data[3], 28, 28);
+			int htt = extractBit(data[3], 28, 28); // Hyper-threading technology.
 			getCpuid(0x80000000, data);
 			uint32_t highestExtendedLeaf = data[0];
 			if (highestExtendedLeaf >= 0x80000008) {
@@ -295,12 +326,11 @@ private:
 		} else {
 			/*
 				Intel - Legacy Method
-
 			*/
 			int physicalThreadCount = 0;
 			getCpuid(0x1, data);
 			int logicalProcessorCount = extractBit(data[1], 16, 23);
-			int htt = extractBit(data[3], 28, 28);
+			int htt = extractBit(data[3], 28, 28); // Hyper-threading technology.
 			getCpuid(0, data);
 			if (data[0] >= 0x4) {
 				getCpuid(0x4, data);
@@ -464,7 +494,7 @@ public:
 	static inline void getCpuidEx(uint32_t eaxIn, uint32_t ecxIn, uint32_t data[4])
 	{
 #ifdef XBYAK_INTEL_CPU_SPECIFIC
-	#ifdef _WIN32
+	#ifdef _MSC_VER
 		__cpuidex(reinterpret_cast<int*>(data), eaxIn, ecxIn);
 	#else
 		__cpuid_count(eaxIn, ecxIn, data[0], data[1], data[2], data[3]);
@@ -601,6 +631,7 @@ public:
 	XBYAK_DEFINE_TYPE(94, tAMX_MOVRS);
 	XBYAK_DEFINE_TYPE(95, tAMX_FP8);
 	XBYAK_DEFINE_TYPE(96, tMOVRS);
+	XBYAK_DEFINE_TYPE(97, tHYBRID);
 
 #undef XBYAK_SPLIT_ID
 #undef XBYAK_DEFINE_TYPE
@@ -614,173 +645,173 @@ public:
 		, avx10version_(0)
 	{
 		uint32_t data[4] = {};
-		const uint32_t& EAX = data[0];
-		const uint32_t& EBX = data[1];
-		const uint32_t& ECX = data[2];
-		const uint32_t& EDX = data[3];
+		const uint32_t& eax = data[0];
+		const uint32_t& ebx = data[1];
+		const uint32_t& ecx = data[2];
+		const uint32_t& edx = data[3];
 		getCpuid(0, data);
-		const uint32_t maxNum = EAX;
-		if (isEqualStr(EBX, ECX, EDX, "AuthenticAMD")) {
+		const uint32_t maxNum = eax;
+		if (isEqualStr(ebx, ecx, edx, "AuthenticAMD")) {
 			type_ |= tAMD;
 			getCpuid(0x80000001, data);
-			if (EDX & (1U << 31)) {
+			if (edx & (1U << 31)) {
 				type_ |= t3DN;
 				// 3DNow! implies support for PREFETCHW on AMD
 				type_ |= tPREFETCHW;
 			}
 
-			if (EDX & (1U << 29)) {
+			if (edx & (1U << 29)) {
 				// Long mode implies support for PREFETCHW on AMD
 				type_ |= tPREFETCHW;
 			}
-		}
-		if (isEqualStr(EBX, ECX, EDX, "GenuineIntel")) {
+		} else if (isEqualStr(ebx, ecx, edx, "GenuineIntel")) {
 			type_ |= tINTEL;
 		}
 
 		// Extended flags information
 		getCpuid(0x80000000, data);
-		const uint32_t maxExtendedNum = EAX;
+		const uint32_t maxExtendedNum = eax;
 		if (maxExtendedNum >= 0x80000001) {
 			getCpuid(0x80000001, data);
 
-			if (ECX & (1U << 5)) type_ |= tLZCNT;
-			if (ECX & (1U << 6)) type_ |= tSSE4a;
-			if (ECX & (1U << 8)) type_ |= tPREFETCHW;
-			if (EDX & (1U << 15)) type_ |= tCMOV;
-			if (EDX & (1U << 22)) type_ |= tMMX2;
-			if (EDX & (1U << 27)) type_ |= tRDTSCP;
-			if (EDX & (1U << 30)) type_ |= tE3DN;
-			if (EDX & (1U << 31)) type_ |= t3DN;
+			if (ecx & (1U << 5)) type_ |= tLZCNT;
+			if (ecx & (1U << 6)) type_ |= tSSE4a;
+			if (ecx & (1U << 8)) type_ |= tPREFETCHW;
+			if (edx & (1U << 15)) type_ |= tCMOV;
+			if (edx & (1U << 22)) type_ |= tMMX2;
+			if (edx & (1U << 27)) type_ |= tRDTSCP;
+			if (edx & (1U << 30)) type_ |= tE3DN;
+			if (edx & (1U << 31)) type_ |= t3DN;
 		}
 
 		if (maxExtendedNum >= 0x80000008) {
 			getCpuid(0x80000008, data);
-			if (EBX & (1U << 0)) type_ |= tCLZERO;
+			if (ebx & (1U << 0)) type_ |= tCLZERO;
 		}
 
 		getCpuid(1, data);
-		if (ECX & (1U << 0)) type_ |= tSSE3;
-		if (ECX & (1U << 1)) type_ |= tPCLMULQDQ;
-		if (ECX & (1U << 9)) type_ |= tSSSE3;
-		if (ECX & (1U << 19)) type_ |= tSSE41;
-		if (ECX & (1U << 20)) type_ |= tSSE42;
-		if (ECX & (1U << 22)) type_ |= tMOVBE;
-		if (ECX & (1U << 23)) type_ |= tPOPCNT;
-		if (ECX & (1U << 25)) type_ |= tAESNI;
-		if (ECX & (1U << 26)) type_ |= tXSAVE;
-		if (ECX & (1U << 27)) type_ |= tOSXSAVE;
-		if (ECX & (1U << 29)) type_ |= tF16C;
-		if (ECX & (1U << 30)) type_ |= tRDRAND;
+		if (ecx & (1U << 0)) type_ |= tSSE3;
+		if (ecx & (1U << 1)) type_ |= tPCLMULQDQ;
+		if (ecx & (1U << 9)) type_ |= tSSSE3;
+		if (ecx & (1U << 19)) type_ |= tSSE41;
+		if (ecx & (1U << 20)) type_ |= tSSE42;
+		if (ecx & (1U << 22)) type_ |= tMOVBE;
+		if (ecx & (1U << 23)) type_ |= tPOPCNT;
+		if (ecx & (1U << 25)) type_ |= tAESNI;
+		if (ecx & (1U << 26)) type_ |= tXSAVE;
+		if (ecx & (1U << 27)) type_ |= tOSXSAVE;
+		if (ecx & (1U << 29)) type_ |= tF16C;
+		if (ecx & (1U << 30)) type_ |= tRDRAND;
 
-		if (EDX & (1U << 15)) type_ |= tCMOV;
-		if (EDX & (1U << 23)) type_ |= tMMX;
-		if (EDX & (1U << 25)) type_ |= tMMX2 | tSSE;
-		if (EDX & (1U << 26)) type_ |= tSSE2;
+		if (edx & (1U << 15)) type_ |= tCMOV;
+		if (edx & (1U << 23)) type_ |= tMMX;
+		if (edx & (1U << 25)) type_ |= tMMX2 | tSSE;
+		if (edx & (1U << 26)) type_ |= tSSE2;
 
 		if (type_ & tOSXSAVE) {
 			// check XFEATURE_ENABLED_MASK[2:1] = '11b'
 			uint64_t bv = getXfeature();
 			if ((bv & 6) == 6) {
-				if (ECX & (1U << 12)) type_ |= tFMA;
-				if (ECX & (1U << 28)) type_ |= tAVX;
+				if (ecx & (1U << 12)) type_ |= tFMA;
+				if (ecx & (1U << 28)) type_ |= tAVX;
 				// do *not* check AVX-512 state on macOS because it has on-demand AVX-512 support
 #if !defined(__APPLE__)
 				if (((bv >> 5) & 7) == 7)
 #endif
 				{
 					getCpuidEx(7, 0, data);
-					if (EBX & (1U << 16)) type_ |= tAVX512F;
+					if (ebx & (1U << 16)) type_ |= tAVX512F;
 					if (type_ & tAVX512F) {
-						if (EBX & (1U << 17)) type_ |= tAVX512DQ;
-						if (EBX & (1U << 21)) type_ |= tAVX512_IFMA;
-						if (EBX & (1U << 26)) type_ |= tAVX512PF;
-						if (EBX & (1U << 27)) type_ |= tAVX512ER;
-						if (EBX & (1U << 28)) type_ |= tAVX512CD;
-						if (EBX & (1U << 30)) type_ |= tAVX512BW;
-						if (EBX & (1U << 31)) type_ |= tAVX512VL;
-						if (ECX & (1U << 1)) type_ |= tAVX512_VBMI;
-						if (ECX & (1U << 6)) type_ |= tAVX512_VBMI2;
-						if (ECX & (1U << 11)) type_ |= tAVX512_VNNI;
-						if (ECX & (1U << 12)) type_ |= tAVX512_BITALG;
-						if (ECX & (1U << 14)) type_ |= tAVX512_VPOPCNTDQ;
-						if (EDX & (1U << 2)) type_ |= tAVX512_4VNNIW;
-						if (EDX & (1U << 3)) type_ |= tAVX512_4FMAPS;
-						if (EDX & (1U << 8)) type_ |= tAVX512_VP2INTERSECT;
-						if ((type_ & tAVX512BW) && (EDX & (1U << 23))) type_ |= tAVX512_FP16;
+						if (ebx & (1U << 17)) type_ |= tAVX512DQ;
+						if (ebx & (1U << 21)) type_ |= tAVX512_IFMA;
+						if (ebx & (1U << 26)) type_ |= tAVX512PF;
+						if (ebx & (1U << 27)) type_ |= tAVX512ER;
+						if (ebx & (1U << 28)) type_ |= tAVX512CD;
+						if (ebx & (1U << 30)) type_ |= tAVX512BW;
+						if (ebx & (1U << 31)) type_ |= tAVX512VL;
+						if (ecx & (1U << 1)) type_ |= tAVX512_VBMI;
+						if (ecx & (1U << 6)) type_ |= tAVX512_VBMI2;
+						if (ecx & (1U << 11)) type_ |= tAVX512_VNNI;
+						if (ecx & (1U << 12)) type_ |= tAVX512_BITALG;
+						if (ecx & (1U << 14)) type_ |= tAVX512_VPOPCNTDQ;
+						if (edx & (1U << 2)) type_ |= tAVX512_4VNNIW;
+						if (edx & (1U << 3)) type_ |= tAVX512_4FMAPS;
+						if (edx & (1U << 8)) type_ |= tAVX512_VP2INTERSECT;
+						if ((type_ & tAVX512BW) && (edx & (1U << 23))) type_ |= tAVX512_FP16;
 					}
 				}
 			}
 		}
 		if (maxNum >= 7) {
 			getCpuidEx(7, 0, data);
-			const uint32_t maxNumSubLeaves = EAX;
-			if (type_ & tAVX && (EBX & (1U << 5))) type_ |= tAVX2;
-			if (EBX & (1U << 3)) type_ |= tBMI1;
-			if (EBX & (1U << 4)) type_ |= tHLE;
-			if (EBX & (1U << 8)) type_ |= tBMI2;
-			if (EBX & (1U << 9)) type_ |= tENHANCED_REP;
-			if (EBX & (1U << 11)) type_ |= tRTM;
-			if (EBX & (1U << 14)) type_ |= tMPX;
-			if (EBX & (1U << 18)) type_ |= tRDSEED;
-			if (EBX & (1U << 19)) type_ |= tADX;
-			if (EBX & (1U << 20)) type_ |= tSMAP;
-			if (EBX & (1U << 23)) type_ |= tCLFLUSHOPT;
-			if (EBX & (1U << 24)) type_ |= tCLWB;
-			if (EBX & (1U << 29)) type_ |= tSHA;
-			if (ECX & (1U << 0)) type_ |= tPREFETCHWT1;
-			if (ECX & (1U << 5)) type_ |= tWAITPKG;
-			if (ECX & (1U << 8)) type_ |= tGFNI;
-			if (ECX & (1U << 9)) type_ |= tVAES;
-			if (ECX & (1U << 10)) type_ |= tVPCLMULQDQ;
-			if (ECX & (1U << 23)) type_ |= tKEYLOCKER;
-			if (ECX & (1U << 25)) type_ |= tCLDEMOTE;
-			if (ECX & (1U << 27)) type_ |= tMOVDIRI;
-			if (ECX & (1U << 28)) type_ |= tMOVDIR64B;
-			if (EDX & (1U << 5)) type_ |= tUINTR;
-			if (EDX & (1U << 14)) type_ |= tSERIALIZE;
-			if (EDX & (1U << 16)) type_ |= tTSXLDTRK;
-			if (EDX & (1U << 22)) type_ |= tAMX_BF16;
-			if (EDX & (1U << 24)) type_ |= tAMX_TILE;
-			if (EDX & (1U << 25)) type_ |= tAMX_INT8;
+			const uint32_t maxNumSubLeaves = eax;
+			if (type_ & tAVX && (ebx & (1U << 5))) type_ |= tAVX2;
+			if (ebx & (1U << 3)) type_ |= tBMI1;
+			if (ebx & (1U << 4)) type_ |= tHLE;
+			if (ebx & (1U << 8)) type_ |= tBMI2;
+			if (ebx & (1U << 9)) type_ |= tENHANCED_REP;
+			if (ebx & (1U << 11)) type_ |= tRTM;
+			if (ebx & (1U << 14)) type_ |= tMPX;
+			if (ebx & (1U << 18)) type_ |= tRDSEED;
+			if (ebx & (1U << 19)) type_ |= tADX;
+			if (ebx & (1U << 20)) type_ |= tSMAP;
+			if (ebx & (1U << 23)) type_ |= tCLFLUSHOPT;
+			if (ebx & (1U << 24)) type_ |= tCLWB;
+			if (ebx & (1U << 29)) type_ |= tSHA;
+			if (ecx & (1U << 0)) type_ |= tPREFETCHWT1;
+			if (ecx & (1U << 5)) type_ |= tWAITPKG;
+			if (ecx & (1U << 8)) type_ |= tGFNI;
+			if (ecx & (1U << 9)) type_ |= tVAES;
+			if (ecx & (1U << 10)) type_ |= tVPCLMULQDQ;
+			if (ecx & (1U << 23)) type_ |= tKEYLOCKER;
+			if (ecx & (1U << 25)) type_ |= tCLDEMOTE;
+			if (ecx & (1U << 27)) type_ |= tMOVDIRI;
+			if (ecx & (1U << 28)) type_ |= tMOVDIR64B;
+			if (edx & (1U << 5)) type_ |= tUINTR;
+			if (edx & (1U << 14)) type_ |= tSERIALIZE;
+			if (edx & (1U << 15)) type_ |= tHYBRID;
+			if (edx & (1U << 16)) type_ |= tTSXLDTRK;
+			if (edx & (1U << 22)) type_ |= tAMX_BF16;
+			if (edx & (1U << 24)) type_ |= tAMX_TILE;
+			if (edx & (1U << 25)) type_ |= tAMX_INT8;
 			if (maxNumSubLeaves >= 1) {
 				getCpuidEx(7, 1, data);
-				if (EAX & (1U << 0)) type_ |= tSHA512;
-				if (EAX & (1U << 1)) type_ |= tSM3;
-				if (EAX & (1U << 2)) type_ |= tSM4;
-				if (EAX & (1U << 3)) type_ |= tRAO_INT;
-				if (EAX & (1U << 4)) type_ |= tAVX_VNNI;
+				if (eax & (1U << 0)) type_ |= tSHA512;
+				if (eax & (1U << 1)) type_ |= tSM3;
+				if (eax & (1U << 2)) type_ |= tSM4;
+				if (eax & (1U << 3)) type_ |= tRAO_INT;
+				if (eax & (1U << 4)) type_ |= tAVX_VNNI;
 				if (type_ & tAVX512F) {
-					if (EAX & (1U << 5)) type_ |= tAVX512_BF16;
+					if (eax & (1U << 5)) type_ |= tAVX512_BF16;
 				}
-				if (EAX & (1U << 7)) type_ |= tCMPCCXADD;
-				if (EAX & (1U << 21)) type_ |= tAMX_FP16;
-				if (EAX & (1U << 23)) type_ |= tAVX_IFMA;
-				if (EAX & (1U << 31)) type_ |= tMOVRS;
-				if (EDX & (1U << 4)) type_ |= tAVX_VNNI_INT8;
-				if (EDX & (1U << 5)) type_ |= tAVX_NE_CONVERT;
-				if (EDX & (1U << 10)) type_ |= tAVX_VNNI_INT16;
-				if (EDX & (1U << 14)) type_ |= tPREFETCHITI;
-				if (EDX & (1U << 19)) type_ |= tAVX10;
-				if (EDX & (1U << 21)) type_ |= tAPX_F;
+				if (eax & (1U << 7)) type_ |= tCMPCCXADD;
+				if (eax & (1U << 21)) type_ |= tAMX_FP16;
+				if (eax & (1U << 23)) type_ |= tAVX_IFMA;
+				if (eax & (1U << 31)) type_ |= tMOVRS;
+				if (edx & (1U << 4)) type_ |= tAVX_VNNI_INT8;
+				if (edx & (1U << 5)) type_ |= tAVX_NE_CONVERT;
+				if (edx & (1U << 10)) type_ |= tAVX_VNNI_INT16;
+				if (edx & (1U << 14)) type_ |= tPREFETCHITI;
+				if (edx & (1U << 19)) type_ |= tAVX10;
+				if (edx & (1U << 21)) type_ |= tAPX_F;
 
 				getCpuidEx(0x1e, 1, data);
-				if (EAX & (1U << 4)) type_ |= tAMX_FP8;
-				if (EAX & (1U << 5)) type_ |= tAMX_TRANSPOSE;
-				if (EAX & (1U << 6)) type_ |= tAMX_TF32;
-				if (EAX & (1U << 7)) type_ |= tAMX_AVX512;
-				if (EAX & (1U << 8)) type_ |= tAMX_MOVRS;
+				if (eax & (1U << 4)) type_ |= tAMX_FP8;
+				if (eax & (1U << 5)) type_ |= tAMX_TRANSPOSE;
+				if (eax & (1U << 6)) type_ |= tAMX_TF32;
+				if (eax & (1U << 7)) type_ |= tAMX_AVX512;
+				if (eax & (1U << 8)) type_ |= tAMX_MOVRS;
 			}
 		}
 		if (maxNum >= 0x19) {
 			getCpuidEx(0x19, 0, data);
-			if (EBX & (1U << 0)) type_ |= tAESKLE;
-			if (EBX & (1U << 2)) type_ |= tWIDE_KL;
+			if (ebx & (1U << 0)) type_ |= tAESKLE;
+			if (ebx & (1U << 2)) type_ |= tWIDE_KL;
 			if (type_ & (tKEYLOCKER|tAESKLE|tWIDE_KL)) type_ |= tKEYLOCKER_WIDE;
 		}
 		if (has(tAVX10) && maxNum >= 0x24) {
 			getCpuidEx(0x24, 0, data);
-			avx10version_ = EBX & mask(7);
+			avx10version_ = ebx & mask(7);
 		}
 		setFamily();
 		setNumCores();
@@ -800,8 +831,825 @@ public:
 	}
 	int getAVX10version() const { return avx10version_; }
 };
+#ifdef _MSC_VER
+	#pragma warning(pop)
+#endif
 
 #ifndef XBYAK_ONLY_CLASS_CPU
+#if XBYAK_CPU_CACHE == 1
+
+enum CoreType {
+	Unknown,
+	Performance, // P-core (Intel)
+	Efficient, // E-core (Intel)
+	Standard // Non-hybrid
+};
+
+inline const char *getCoreTypeStr(int coreType)
+{
+	switch (coreType) {
+	case Performance: return "P-core";
+	case Efficient: return "E-core";
+	case Standard: return "Standard";
+	default: return "Unknown";
+	}
+}
+
+enum CacheType {
+	L1i,
+	L1d,
+	L2,
+	L3,
+	CACHE_UNKNOWN,
+	CACHE_TYPE_NUM = CACHE_UNKNOWN
+};
+
+inline const char* getCacheTypeStr(int type)
+{
+	switch (type) {
+	case L1i: return "L1i";
+	case L1d: return "L1d";
+	case L2: return "L2";
+	case L3: return "L3";
+	default: return "Unknown";
+	}
+}
+
+namespace impl {
+
+inline void appendStr(std::string& s, uint32_t v)
+{
+#if __cplusplus >= 201103L
+	s += std::to_string(v);
+#else
+	char buf[16];
+	snprintf(buf, sizeof(buf), "%u", v);
+	s += buf;
+#endif
+}
+
+// str = "(int|range)[,(int|range)]*"
+// range = int-int
+// e.g. "1,3,5", "0-3,5-7", ""
+template<class T>
+bool setStr(T& x, const char *str)
+{
+	const char *p = str;
+	while (*p) {
+		if (p != str) {
+			if (*p != ',') return false;
+			p++;
+		}
+		char *endp;
+		uint32_t v = uint32_t(strtoul(p, &endp, 10));
+		if (endp == p) return false;
+		if (*endp == '-') {
+			const char *rangeStart = endp + 1;
+			uint32_t next = uint32_t(strtoul(rangeStart, &endp, 10));
+			if (endp == rangeStart) return false;
+			if (!x.appendRange(v, next)) return false;
+		} else {
+			if (!x.append(v)) return false;
+		}
+		if (*endp == '\0') return true;
+		p = endp;
+	}
+	return true;
+}
+
+} // impl
+
+#ifndef XBYAK_CPUMASK_N
+#define XBYAK_CPUMASK_N 6
+#endif
+#ifndef XBYAK_CPUMASK_BITN
+#define XBYAK_CPUMASK_BITN 10 // max number of logical cpu = 1024
+#endif
+#if XBYAK_CPUMASK_COMPACT == 1
+/*
+	a_ is treated as an array of N elements, each being bitN bits
+	a_ = 1<<bitN and n_ = 0 and range_ = 0 means empty set
+	n_ is length of a_[] - 1
+	When range_ is false (discrete values):
+		Values satisfy a_[i] + 1 < a_[i+1] for all 0 <= i <= n_
+	When range_ is true (intervals):
+		v = a_[i*2] is the start of the interval
+		n = a_[i*2+1] is the interval length - 1
+		Represents the interval [v, v+n]
+	Max number of cpu = 2**bitN - 1
+	Max value that can be stored = N
+	Max interval length = N/2
+*/
+class CpuMask {
+	static const uint32_t N = XBYAK_CPUMASK_N;
+	static const uint32_t bitN = XBYAK_CPUMASK_BITN;
+	static const uint64_t mask = (uint64_t(1) << bitN) - 1;
+	uint64_t a_:N*bitN;
+	uint64_t n_:3;
+	uint64_t range_:1;
+
+	// Set a_[idx] = v
+	void set_a(size_t idx, uint32_t v)
+	{
+		assert(idx < N);
+		assert(v <= mask);
+		a_ &= ~(mask << (idx*bitN));
+		a_ |= (v & mask) << (idx*bitN);
+	}
+	// Get a_[idx]
+	uint32_t get_a(size_t idx) const
+	{
+		assert(idx < N);
+		return (a_ >> (idx*bitN)) & mask;
+	}
+#ifndef NDEBUG
+	// Return true if the idx-th value exists
+	bool hasNext(uint32_t idx) const
+	{
+		if (empty()) return false;
+		if (!range_) return idx <= n_;
+		uint32_t n = 0;
+		for (uint32_t i = 1; i <= n_; i += 2) {
+			n += get_a(i) + 1;
+			if (idx < n) return true;
+		}
+		return false;
+	}
+#endif
+public:
+	CpuMask() { clear(); }
+	class ConstIterator {
+		const CpuMask& parent_;
+		uint32_t idx_;
+		uint32_t size_;
+		friend class CpuMask;
+	public:
+		ConstIterator(const CpuMask& parent)
+			: parent_(parent), idx_(0), size_(uint32_t(parent.size())) {}
+		uint32_t operator*() const { return parent_.get(idx_); }
+		ConstIterator& operator++() { idx_++; return *this; }
+		bool operator==(const ConstIterator& rhs) const { return idx_ == rhs.idx_; }
+		bool operator!=(const ConstIterator& rhs) const { return !operator==(rhs); }
+	};
+	ConstIterator begin() const { return ConstIterator(*this); }
+	ConstIterator end() const {
+		ConstIterator it(*this);
+		it.idx_ = uint32_t(size());
+		return it;
+	}
+	typedef ConstIterator iterator;
+	typedef ConstIterator const_iterator;
+	void clear() { a_ = 1 << bitN; n_ = 0; range_ = 0; }
+	bool empty() const
+	{
+		return a_ == 1 << bitN && n_ == 0 && range_ == 0;
+	}
+	uint64_t to_u64() const { return a_ | (uint64_t(n_) << (N * bitN)) | (uint64_t(range_) << (N * bitN + 3)); }
+	bool operator<(const CpuMask& rhs) const { return to_u64() < rhs.to_u64(); }
+	bool operator>(const CpuMask& rhs) const { return to_u64() > rhs.to_u64(); }
+	bool operator>=(const CpuMask& rhs) const { return !operator<(rhs); }
+	bool operator<=(const CpuMask& rhs) const { return !operator>(rhs); }
+	bool operator==(const CpuMask& rhs) const { return to_u64() == rhs.to_u64(); }
+	bool operator!=(const CpuMask& rhs) const { return !operator==(rhs); }
+	// Add element v
+	// v should be monotonically increasing
+	bool append(uint32_t v)
+	{
+		uint32_t prev = 0, n = 0;
+		if (v > mask) goto ERR;
+		// When adding for the first time, treat as discrete value
+		if (empty()) {
+			a_ = v;
+			n_ = 0;
+			return true;
+		}
+		if (!range_) {
+			prev = get_a(n_);
+			if (v <= prev) goto ERR;
+			// If there's one discrete value and it forms an interval with the new value, switch to interval mode
+			if (n_ == 0 && prev + 1 == v) {
+				set_a(1, 1);
+				range_ = 1;
+				n_ = 1;
+				return true;
+			}
+			if (n_ >= N - 1) goto ERR;
+			// Add discrete value
+			n_++;
+			set_a(n_, v);
+			return true;
+		}
+		// If the value to add is 1 greater than the end of the current interval
+		n = get_a(n_);
+		prev = get_a(n_ - 1) + n;
+		if (prev >= v) goto ERR;
+		if (prev + 1 == v) {
+			// Increase the interval length by one
+			set_a(n_, n + 1);
+			return true;
+		} else {
+			if (n_ >= N - 1) goto ERR;
+			// If not continuous with the previous interval
+			// Add a new interval [v]
+			set_a(n_ + 1, v);
+			n_ += 2;
+			return true;
+		}
+	ERR:
+		XBYAK_THROW_RET(ERR_INVALID_CPUMASK_INDEX, false)
+		return false;
+	}
+	// add range [a, b] which means a, a+1, ..., b
+	bool appendRange(uint32_t a, uint32_t b)
+	{
+		if ((empty() || (range_ && n_ < N - 1)) && (a <= b && b <= mask)) {
+			range_ = true;
+			n_ += n_ == 0 ? 1 : 2;
+			set_a(n_ - 1, a);
+			set_a(n_, b - a);
+			return true;
+		}
+		return false;
+	}
+	// str = "(int|range)[,(int|range)]*"
+	// range = int-int
+	bool setStr(const char *str)
+	{
+		return impl::setStr(*this, str);
+	}
+	bool setStr(const std::string& str) { return setStr(str.c_str()); }
+	std::string getStr() const
+	{
+		std::string s;
+		if (empty()) return s;
+		if (!range_) {
+			for (uint32_t i = 0; i <= n_; i++) {
+				if (!s.empty()) s += ",";
+				impl::appendStr(s, get_a(i));
+			}
+			return s;
+		}
+		for (uint32_t i = 0; i <= n_; i += 2) {
+			uint32_t v = get_a(i);
+			uint32_t len = get_a(i + 1);
+			if (!s.empty()) s += ",";
+			impl::appendStr(s, v);
+			if (len > 0) {
+				s += "-";
+				impl::appendStr(s, v + len);
+			}
+		}
+		return s;
+	}
+	size_t size() const
+	{
+		if (empty()) return 0;
+		if (!range_) return n_ + 1;
+		size_t n = 0;
+		for (uint32_t i = 1; i <= n_; i += 2) {
+			n += get_a(i) + 1;
+		}
+		return n;
+	}
+
+	uint32_t get(uint32_t idx) const
+	{
+		assert(hasNext(idx));
+		if (!range_) return get_a(idx);
+		uint32_t n = 0;
+		for (uint32_t i = 1; i <= n_; i += 2) {
+			uint32_t range = get_a(i) + 1;
+			if (idx < n + range) {
+				return get_a(i - 1) + (idx - n);
+			}
+			n += range;
+		}
+		return false;
+	}
+	void dump() const
+	{
+		printf("a_:");
+		for (int i = int(N) - 1; i >= 0; i--) {
+			printf("%u ", uint32_t((a_ >> (i * bitN)) & mask));
+		}
+		printf("\n");
+		printf("n_: %u\n", (uint32_t)n_);
+		printf("range_: %u\n", (uint32_t)range_);
+	}
+	void put(const char *label = NULL) const
+	{
+		if (label) printf("%s: ", label);
+		printf("%s\n", getStr().c_str());
+	}
+};
+#else
+class CpuMask {
+	typedef std::set<uint32_t> IntSet;
+	IntSet indices_;
+public:
+	CpuMask() : indices_() {}
+	typedef IntSet::const_iterator const_iterator;
+	typedef const_iterator iterator;
+	const_iterator begin() const { return indices_.begin(); }
+	const_iterator end() const { return indices_.end(); }
+
+	void clear() { indices_.clear(); }
+	bool empty() const { return indices_.empty(); }
+	bool operator<(const CpuMask& rhs) const { return indices_ < rhs.indices_; }
+	bool operator>(const CpuMask& rhs) const { return indices_ > rhs.indices_; }
+	bool operator>=(const CpuMask& rhs) const { return !operator<(rhs); }
+	bool operator<=(const CpuMask& rhs) const { return !operator>(rhs); }
+	bool operator==(const CpuMask& rhs) const { return indices_ == rhs.indices_; }
+	bool operator!=(const CpuMask& rhs) const { return !operator==(rhs); }
+	// idx should be monotonically increasing
+	bool append(uint32_t idx)
+	{
+		if (idx >= (1u << XBYAK_CPUMASK_BITN)) return false;
+		if (!indices_.empty() && *indices_.rbegin() >= idx) return false;
+		indices_.insert(idx);
+		return true;
+	}
+	// add range [a, b] which means a, a+1, ..., b
+	bool appendRange(uint32_t a, uint32_t b)
+	{
+		if (a > b) return false;
+		while (a <= b) {
+			if (!append(a)) return false;
+			a++;
+		}
+		return true;
+	}
+	bool setStr(const char *str)
+	{
+		return impl::setStr(*this, str);
+	}
+	bool setStr(const std::string& str) { return setStr(str.c_str()); }
+	std::string getStr() const
+	{
+		std::string s;
+		bool inRange = false;
+		uint32_t prev = 0x80000000;
+		for (const_iterator i = indices_.begin(); i != indices_.end(); ++i) {
+			uint32_t v = *i;
+			if (inRange) {
+				if (prev + 1 != v) {
+					impl::appendStr(s, prev);
+					inRange = false;
+					s += ',';
+					impl::appendStr(s, v);
+				}
+			} else {
+				if (prev + 1 == v) {
+					// start range
+					s += '-';
+					inRange = true;
+				} else {
+					if (!s.empty()) s += ',';
+					impl::appendStr(s, v);
+				}
+			}
+			prev = v;
+		}
+		if (inRange) {
+			impl::appendStr(s, prev);
+		}
+		return s;
+	}
+	size_t size() const { return indices_.size(); }
+	uint32_t get(uint32_t idx) const
+	{
+		assert(idx < size());
+		const_iterator it = indices_.begin();
+		std::advance(it, idx);
+		return *it;
+	}
+	void put(const char *label = NULL) const
+	{
+		if (label) printf("%s: ", label);
+		printf("%s\n", getStr().c_str());
+	}
+};
+#endif
+
+class CpuCache {
+public:
+	CpuCache() : size(0), associativity(0) {}
+
+	// Cache size in bytes
+	uint32_t size;
+
+	// number of ways of associativity
+	uint32_t associativity;
+
+	// Set of logical CPU indices sharing this cache
+	CpuMask sharedCpuIndices;
+
+	// Whether this is a shared cache
+	bool isShared() const { return sharedCpuIndices.size() > 1; }
+
+	// Number of logical CPUs sharing this cache
+	size_t getSharedCpuNum() const { return sharedCpuIndices.size(); }
+
+	void put(const char *label = NULL) const
+	{
+		if (label) printf("%s: ", label);
+		printf("%u KiB, assoc. %u, shared ", size / 1024, associativity);
+		sharedCpuIndices.put();
+	}
+};
+
+struct LogicalCpu {
+	LogicalCpu()
+		: coreId(0)
+		, coreType(Unknown)
+		, cache()
+	{
+	}
+	uint32_t coreId; // index of physical core
+	CoreType coreType; // for hybrid systems
+	CpuCache cache[CACHE_TYPE_NUM];
+	const CpuMask& getSiblings() const { return cache[L1i].sharedCpuIndices; }
+
+	void put(const char *label = NULL) const
+	{
+		if (label) printf("%s: ", label);
+		printf("coreId %u, type %s\n", coreId, getCoreTypeStr(coreType));
+		for (int i = 0; i < CACHE_TYPE_NUM; i++) {
+			cache[i].put(getCacheTypeStr(i));
+		}
+	}
+};
+
+class CpuTopology {
+public:
+	explicit CpuTopology(const Cpu& cpu)
+		: logicalCpus_()
+		, physicalCoreNum_(0)
+		, lineSize_(0)
+		, isHybrid_(cpu.has(cpu.tHYBRID))
+	{
+		if (!impl::initCpuTopology(*this)) {
+			XBYAK_THROW(ERR_CANT_INIT_CPUTOPOLOGY);
+		}
+	}
+
+	// Number of logical CPUs
+	size_t getLogicalCpuNum() const { return logicalCpus_.size(); }
+
+	// Number of physical cores
+	size_t getPhysicalCoreNum() const { return physicalCoreNum_; }
+
+	// Cache line size in bytes
+	uint32_t getLineSize() const { return lineSize_; }
+
+	// Get logical CPU information
+	const LogicalCpu& getLogicalCpu(size_t cpuIdx) const
+	{
+		return logicalCpus_[cpuIdx];
+	}
+
+	// Get cache information for a specific logical CPU
+	const CpuCache& getCache(size_t cpuIdx, CacheType type) const
+	{
+		return logicalCpus_[cpuIdx].cache[type];
+	}
+
+	// Whether this is a hybrid system
+	bool isHybrid() const { return isHybrid_; }
+private:
+	friend bool impl::initCpuTopology(CpuTopology&);
+	std::vector<LogicalCpu> logicalCpus_;
+	size_t physicalCoreNum_;
+	uint32_t lineSize_;
+	bool isHybrid_;
+};
+
+namespace impl {
+
+inline uint32_t popcnt(uint64_t mask)
+{
+#if defined(_M_X64) || defined(_M_AMD64)
+	return (int)__popcnt64(mask);
+#elif defined(__GNUC__) || defined(__clang__)
+	return __builtin_popcountll(mask);
+#else
+	uint32_t count = 0;
+	while (mask) {
+		count += (mask & 1);
+		mask >>= 1;
+	}
+	return count;
+#endif
+}
+
+#ifdef _WIN32
+
+typedef std::vector<uint32_t> U32Vec;
+typedef SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX ProcInfo;
+
+// return total logical cpus if sucessful, 0 if failed
+inline uint32_t getGroupAcc(U32Vec& v)
+{
+	DWORD len = 0;
+	GetLogicalProcessorInformationEx(RelationGroup, NULL, &len);
+	std::vector<char> buf(len);
+	if (!GetLogicalProcessorInformationEx(RelationGroup, reinterpret_cast<ProcInfo*>(buf.data()), &len)) {
+		return 0;
+	}
+	const auto& entry = *reinterpret_cast<const ProcInfo*>(buf.data());
+	const GROUP_RELATIONSHIP& gr = entry.Group;
+
+	const uint32_t n = gr.ActiveGroupCount;
+	if (n == 0) return 0;
+
+	v.resize(n);
+
+	uint32_t acc = 0;
+	for (uint32_t g = 0; g < n; g++) {
+		v[g] = acc;
+		acc += gr.GroupInfo[g].ActiveProcessorCount;
+	}
+	return acc;
+}
+
+// return number of physical cores if successful, 0 if failed
+static inline uint32_t getCores(std::vector<LogicalCpu>& cpus, bool isHybrid, const U32Vec& groupAcc) {
+	DWORD len = 0;
+	GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &len);
+	std::vector<char> buf(len);
+	if (!GetLogicalProcessorInformationEx(RelationProcessorCore, reinterpret_cast<ProcInfo*>(buf.data()), &len)) return 0;
+
+	// get core indices
+	const char *p = buf.data();
+	const char *end = p + len;
+	uint32_t coreIdx = 0;
+
+	while (p < end) {
+		const auto& entry = *reinterpret_cast<const ProcInfo*>(p);
+		if (entry.Relationship == RelationProcessorCore) {
+			const PROCESSOR_RELATIONSHIP& core = entry.Processor;
+			LogicalCpu cpu;
+			cpu.coreId = coreIdx++;
+			if (!isHybrid) {
+				cpu.coreType = Standard;
+			} else if (core.EfficiencyClass > 0) {
+				cpu.coreType = Performance;
+			} else {
+				cpu.coreType = Efficient;
+			}
+
+			const GROUP_AFFINITY* masks = core.GroupMask;
+			for (WORD i = 0; i < core.GroupCount; i++) {
+				const WORD group = masks[i].Group;
+				const KAFFINITY m = masks[i].Mask;
+				const uint32_t base = groupAcc[group];
+
+				for (uint32_t b = 0; b < sizeof(KAFFINITY) * 8; b++) {
+					if (m & (KAFFINITY(1) << b)) {
+						const uint32_t idx = base + b;
+						if (idx >= cpus.size()) return 0;
+						cpus[idx] = cpu;
+					}
+				}
+			}
+		}
+		p += entry.Size;
+	}
+	return coreIdx;
+}
+
+inline bool convertMask(CpuMask& mask, const U32Vec& groupAcc, const CACHE_RELATIONSHIP& cache)
+{
+	const GROUP_AFFINITY* masks = cache.GroupMasks;
+
+	for (WORD i = 0; i < cache.GroupCount; i++) {
+		const WORD group = masks[i].Group;
+		const KAFFINITY m = masks[i].Mask;
+		const uint32_t base = groupAcc[group];
+
+		for (uint32_t b = 0; b < sizeof(KAFFINITY) * 8; b++) {
+			if (m & (KAFFINITY(1) << b)) {
+				if (!mask.append(base + b)) return false;
+			}
+		}
+	}
+	return true;
+}
+
+inline bool initCpuTopology(CpuTopology& cpuTopo)
+{
+	U32Vec groupAcc;
+	const uint32_t logicalCpuNum = getGroupAcc(groupAcc);
+	if (logicalCpuNum == 0) return false;
+	if (logicalCpuNum >= (1u << XBYAK_CPUMASK_BITN)) return false;
+
+	cpuTopo.logicalCpus_.resize(logicalCpuNum);
+	cpuTopo.physicalCoreNum_ = getCores(cpuTopo.logicalCpus_, cpuTopo.isHybrid(), groupAcc);
+	if (cpuTopo.physicalCoreNum_ == 0) return false;
+
+	DWORD len = 0;
+	GetLogicalProcessorInformationEx(RelationCache, NULL, &len);
+	std::vector<char> buf(len);
+	if (!GetLogicalProcessorInformationEx(RelationCache, reinterpret_cast<ProcInfo*>(buf.data()), &len)) return false;
+
+	const char *p = buf.data();
+	const char *end = p + len;
+
+	while (p < end) {
+		const auto& entry = *reinterpret_cast<const ProcInfo*>(p);
+		if (entry.Relationship == RelationCache) {
+			const CACHE_RELATIONSHIP& cache = entry.Cache;
+			uint32_t type = CACHE_UNKNOWN;
+			if (cache.Level == 1) {
+				if (cache.Type == CacheInstruction) {
+					type = L1i;
+				} else if (cache.Type == CacheData) {
+					type = L1d;
+				}
+			} else if (cache.Level == 2) {
+				type = L2;
+			} else if (cache.Level == 3) {
+				type = L3;
+			}
+			if (type != CACHE_UNKNOWN) {
+				CpuMask mask;
+				if (!convertMask(mask, groupAcc, cache)) return false;
+				for (const auto& i : mask) {
+					if (i >= cpuTopo.logicalCpus_.size()) return false;
+					cpuTopo.logicalCpus_[i].cache[type].size = cache.CacheSize;
+					if (cpuTopo.lineSize_ == 0) cpuTopo.lineSize_ = cache.LineSize;
+					cpuTopo.logicalCpus_[i].cache[type].associativity = cache.Associativity;
+					cpuTopo.logicalCpus_[i].cache[type].sharedCpuIndices = mask;
+				}
+			}
+		}
+		p += entry.Size;
+	}
+	return true;
+}
+#elif defined(__linux__) // Linux
+
+struct WrapFILE {
+	FILE *f;
+	explicit WrapFILE(const char *name)
+		: f(fopen(name, "r"))
+	{
+	}
+	~WrapFILE() { if (f) fclose(f); }
+};
+
+inline uint32_t readIntFromFile(const char* path) {
+	WrapFILE wf(path);
+	if (!wf.f) return 0;
+	uint32_t val = 0;
+	int n = fscanf(wf.f, "%u", &val);
+	return (n == 1) ? val : 0;
+}
+
+inline bool parseCpuList(CpuMask& mask, const char* path) {
+	WrapFILE wf(path);
+	if (!wf.f) return false;
+	char buf[1024];
+	if (!fgets(buf, sizeof(buf), wf.f)) return false;
+	size_t n = strlen(buf);
+	if (n > 0 && buf[n - 1] == '\n') buf[n - 1] = '\0';
+	return setStr(mask, buf);
+}
+
+inline bool initCpuTopology(CpuTopology& cpuTopo)
+{
+	const uint32_t logicalCpuNum = sysconf(_SC_NPROCESSORS_ONLN);
+
+	if (logicalCpuNum == 0) return false;
+	if (logicalCpuNum >= (1u << XBYAK_CPUMASK_BITN)) return false;
+
+	cpuTopo.logicalCpus_.resize(logicalCpuNum);
+	uint32_t maxPhisicalIdx = 0;
+
+	for (uint32_t cpuIdx = 0; cpuIdx < logicalCpuNum; cpuIdx++) {
+		char path[256];
+		LogicalCpu& logCpu = cpuTopo.logicalCpus_[cpuIdx];
+
+		snprintf(path, sizeof(path),
+			"/sys/devices/system/cpu/cpu%u/topology/core_id", cpuIdx);
+		logCpu.coreId = readIntFromFile(path);
+		maxPhisicalIdx = (std::max)(maxPhisicalIdx, logCpu.coreId);
+
+		logCpu.coreType = Standard;
+
+		for (uint32_t cacheIdx = 0; cacheIdx < CACHE_TYPE_NUM; cacheIdx++) {
+			CacheType cacheType = CACHE_UNKNOWN;
+
+			// Map cache index to cache type
+			{
+				snprintf(path, sizeof(path),
+					"/sys/devices/system/cpu/cpu%u/cache/index%u/type", cpuIdx, cacheIdx);
+				char typeStr[32];
+				WrapFILE wf(path);
+
+				if (wf.f && fgets(typeStr, sizeof(typeStr), wf.f)) {
+					if (strncmp(typeStr, "Instruction", 11) == 0) {
+						cacheType = L1i;
+					} else if (strncmp(typeStr, "Data", 4) == 0) {
+						// Determine level
+						char path[256];
+						snprintf(path, sizeof(path),
+							"/sys/devices/system/cpu/cpu%u/cache/index%u/level", cpuIdx, cacheIdx);
+						switch (readIntFromFile(path)) {
+						case 1: cacheType = L1d; break;
+						case 2: cacheType = L2; break;
+						case 3: cacheType = L3; break;
+						default: break;;
+						}
+					} else if (strncmp(typeStr, "Unified", 7) == 0) {
+						snprintf(path, sizeof(path),
+							"/sys/devices/system/cpu/cpu%u/cache/index%u/level", cpuIdx, cacheIdx);
+						switch (readIntFromFile(path)) {
+						case 2: cacheType = L2; break;
+						case 3: cacheType = L3; break;
+						default: break;;
+						}
+					}
+				}
+			}
+			if (cacheType == CACHE_UNKNOWN) continue;
+			CpuCache& cache = logCpu.cache[cacheType];
+
+			// Read cache size
+			{
+				snprintf(path, sizeof(path),
+					"/sys/devices/system/cpu/cpu%u/cache/index%u/size", cpuIdx, cacheIdx);
+				char sizeStr[32];
+				WrapFILE wf(path);
+				if (wf.f && fgets(sizeStr, sizeof(sizeStr), wf.f)) {
+					char *endp;
+					uint32_t size = (uint32_t)strtoul(sizeStr, &endp, 10);
+					switch (*endp) {
+					case '\0': case '\n': cache.size = size; break;
+					case 'K': case 'k':   cache.size = size * 1024; break;
+					case 'M': case 'm':   cache.size = size * 1024 * 1024; break;
+					default: break;
+					}
+				}
+			}
+
+			// Read ways of associativity
+			snprintf(path, sizeof(path),
+				"/sys/devices/system/cpu/cpu%u/cache/index%u/ways_of_associativity", cpuIdx, cacheIdx);
+			cache.associativity = readIntFromFile(path);
+
+			// Read shared CPU list
+			snprintf(path, sizeof(path),
+				"/sys/devices/system/cpu/cpu%u/cache/index%u/shared_cpu_list", cpuIdx, cacheIdx);
+			parseCpuList(cache.sharedCpuIndices, path);
+
+		}
+	}
+
+	// Assign core types for hybrid architectures
+	const bool isHybrid = cpuTopo.isHybrid();
+	if (isHybrid) {
+		// For hybrid systems, read P-core and E-core lists from sysfs
+		CpuMask pCoreMask;
+		if (parseCpuList(pCoreMask, "/sys/devices/cpu_core/cpus")) {
+			// Set Performance core types
+			for (CpuMask::const_iterator it = pCoreMask.begin(); it != pCoreMask.end(); ++it) {
+				uint32_t cpuIdx = *it;
+				if (cpuIdx < logicalCpuNum) {
+					cpuTopo.logicalCpus_[cpuIdx].coreType = Performance;
+				}
+			}
+		}
+		CpuMask eCoreMask;
+		if (parseCpuList(eCoreMask, "/sys/devices/cpu_atom/cpus")) {
+			// Set Efficient core types
+			for (CpuMask::const_iterator it = eCoreMask.begin(); it != eCoreMask.end(); ++it) {
+				uint32_t cpuIdx = *it;
+				if (cpuIdx < logicalCpuNum) {
+					cpuTopo.logicalCpus_[cpuIdx].coreType = Efficient;
+				}
+			}
+		}
+	}
+
+	// Read coherency line size
+	cpuTopo.lineSize_ = readIntFromFile("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size");
+
+	cpuTopo.physicalCoreNum_ = maxPhisicalIdx + 1;
+	return true;
+}
+#else // Other OS (e.g., macOS)
+inline bool initCpuTopology(CpuTopology& cpuTopo)
+{
+	// CPU topology detection not yet implemented
+	(void)cpuTopo;
+	return false;
+}
+#endif // _WIN32 / __linux__ / other OS
+
+} // namespace impl
+#endif // XBYAK_CPU_CACHE
+
 class Clock {
 public:
 	static inline uint64_t getRdtsc()
@@ -1210,5 +2058,20 @@ public:
 #endif // XBYAK_ONLY_CLASS_CPU
 
 } } // end of util
+
+#if XBYAK_CPUMASK_COMPACT == 1 && __cplusplus >= 201103
+
+namespace std {
+
+template<>
+struct hash<Xbyak::util::CpuMask> {
+	size_t operator()(const Xbyak::util::CpuMask& m) const noexcept {
+		return std::hash<uint64_t>{}(m.to_u64());
+	}
+};
+
+} // std
+
+#endif
 
 #endif


### PR DESCRIPTION
This updates the Xbyak library to be in sync with the upstream version of Xybak.

This addvances the version from Xybak v7.28 to Xbyak v7.35.3

This PR is broken down into 3 commits.

**1st commit:** Updates Xbyak to v7.35.3:
Changes to oneDNN to build with Xbyak v7.35.3:
- New feature XBYAK_STRICT_CHECK_MEM_REG_SIZE disabled in the
      cpu_isa_traits header. Several oneDNN JIT kernels use
      size-mismatched memory operands that are architecturally correct
      but will cause Xbyak to throw an ERR_BADD_MEM_SIZE error.
- Removed all instances of Xbyak::Address(0) the Address(size_t)
      constructor is removed. The added Xbyak::Address() constructor
      is used instead.
 
**2nd commit:**
- enables `XBYAK_STRICT_CHECK_MEM_REG_SIZE` macro and fixes places in the code that caused the `ERR_BAD_MEM_SIZE` failure.
- This is the highest risk change in this PR since the failures happen at runtime during JIT assembly, not at compile time so have to be caught by unit tests and benchdnn.

--------------------------------

Changes to the Xbyak library:

**Overall themes (v7.29-7.35):** Label and integer-based addressing improvements (RegExp/Address robustness and clarity), the new CpuTopology/CpuMask API for hybrid CPU topology, instruction additions (tcvtrowd2ps, prefetchrst2, extended NOPs), removal of deprecated ISA entries, and portability fixes (UWP, macOS, Clang C++14).

v7.29
- Added **Labels support in addressing**: `ptr[label]` now works. `ptr[integer]` format merged into `RegExp`
v7.30
- Added `tcvtrowd2ps` instruction support
v7.31
- **Major addition:** introduced `util::CpuTopology`, `LogicalCpu`, and `CpuMask` classes. for handling CPU cache and core topology on hybrid systems.
- `util::CpuTopology` uses OS specific methods to populate.
v7.32
- **Removed depricated instrucitons** referenced in Intel manual 319433-059
- Added comparison operators to `CpuMask` class
- added `put()` helper functions to `LogicalCpu` and `Cache` class for debug output
v7.33
- `CpuMask` string format added
- `CpuMask` storage switched from `std::vector<size_t` to `CpuMask`
- Fixed `inline` linkage issues
- `cmpxchg16b` now accepts `xword` operand (e.g., `cmpxchg16b xword[rax]`
v3.34
- Added `prefetchrst2 instruction
- added muti-byte NOP support for 10-15 byte encodings (previously caped at 9 bytes)
- Improved backward compatability for `Address` and `RegExp`
- made `RegExp` constructor explicit to resolve integer literal ambiguity
- Added default `Address` constructor
- Added `CpuMask::appendRange()`
v7.35
- **`RegExp` Addressing fixes**: `RegExp(0)` now treated as normal displacement.
- Removed `constespr` from `RegExp` to fix comilation error with `clang++ -std=c++14`
