### PR TITLE
common: deduce runtime value marker from types

### DIFF
--- a/src/common/gemm_types.hpp
+++ b/src/common/gemm_types.hpp
@@ -91,8 +91,8 @@ struct gemm_desc_t : public op_desc_t {
         // if ndims < 3, it should return 1
         int64_t batch = 1;
         for (int i = 0; i < c_desc.ndims - 2; ++i) {
-            if (c_desc.dims[i] == DNNL_RUNTIME_DIM_VAL)
-                return DNNL_RUNTIME_DIM_VAL;
+            if (is_runtime_value(c_desc.dims[i]))
+                return runtime_value_for<dnnl_dim_t>();
             batch *= c_desc.dims[i];
         }
         return batch;

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -644,11 +644,11 @@ status_t matmul_desc_init(matmul_desc_t *matmul_desc,
         const dim_t b_dim = with_bias ? op_d.bias_desc.dims[d] : 0;
         const dim_t r_dim = with_reduce ? op_d.reduce_desc.dims[d] : 0;
 
-        if (one_of(DNNL_RUNTIME_DIM_VAL, s_dim, w_dim, d_dim, b_dim)) {
+        if (any_runtime_value(s_dim, w_dim, d_dim, b_dim)) {
 
-            VCHECK_MATMUL(everyone_is(DNNL_RUNTIME_DIM_VAL, s_dim, w_dim, d_dim)
+            VCHECK_MATMUL(all_runtime_values(s_dim, w_dim, d_dim)
                             && IMPLICATION((bia_mask & (1 << d)) && with_bias,
-                                    b_dim == DNNL_RUNTIME_DIM_VAL),
+                                    is_runtime_value(b_dim)),
                     VERBOSE_RUNTIMEDIM_INCONSISTENT, d);
         } else {
             // This follows numpy semantics of broadcasting when 0 is involved.

--- a/src/common/memory.cpp
+++ b/src/common/memory.cpp
@@ -48,7 +48,7 @@ namespace {
 // Returns the size required for memory descriptor mapping.
 // Caveats:
 // 1. If memory descriptor with run-time parameters, the mapping cannot be done;
-//    hence return DNNL_RUNTIME_SIZE_VAL
+//    hence return runtime_value_for<size_t>()
 // 2. Otherwise, the size returned includes `offset0` and holes (for the case
 //    of non-trivial strides). Strictly speaking, the mapping should happen only
 //    for elements accessible with `md.off_l(0 .. md.nelems())`. However, for
@@ -59,7 +59,7 @@ namespace {
 size_t memory_desc_map_size(const memory_desc_t *md, int index = 0) {
     auto mdw = memory_desc_wrapper(md);
 
-    if (mdw.has_runtime_dims_or_strides()) return DNNL_RUNTIME_SIZE_VAL;
+    if (mdw.has_runtime_dims_or_strides()) return runtime_value_for<size_t>();
 
     return mdw.size(index, true, true);
 }
@@ -350,7 +350,7 @@ status_t dnnl_memory_map_data_v2(
     if (map_size == 0) {
         *mapped_ptr = nullptr;
         return success;
-    } else if (map_size == DNNL_RUNTIME_SIZE_VAL) {
+    } else if (is_runtime_value(map_size)) {
         return invalid_arguments;
     }
 

--- a/src/common/memory_desc.cpp
+++ b/src/common/memory_desc.cpp
@@ -105,10 +105,9 @@ status_t memory_desc_init_by_strides(memory_desc_t &memory_desc, int ndims,
         bool has_runtime_strides = false;
         default_strides[md.ndims - 1] = 1;
         for (int d = md.ndims - 2; d >= 0; --d) {
-            if (md.padded_dims[d] == DNNL_RUNTIME_DIM_VAL)
-                has_runtime_strides = true;
+            if (is_runtime_value(md.padded_dims[d])) has_runtime_strides = true;
             default_strides[d] = has_runtime_strides
-                    ? DNNL_RUNTIME_DIM_VAL
+                    ? runtime_value_for(default_strides[d])
                     : default_strides[d + 1] * md.padded_dims[d + 1];
         }
         strides = default_strides;
@@ -255,7 +254,7 @@ status_t memory_desc_init_with_grouped_encoding(memory_desc_t &memory_desc,
             "variable_dim_idx");
 
     for (int d = 0; d < ndims; ++d) {
-        VCHECK_MEMORY(dims[d] != DNNL_RUNTIME_DIM_VAL, invalid_arguments,
+        VCHECK_MEMORY(!is_runtime_value(dims[d]), invalid_arguments,
                 VERBOSE_RUNTIMEDIM_UNSUPPORTED);
         VCHECK_MEMORY(
                 dims[d] > 0, invalid_arguments, VERBOSE_BAD_DIM, "dims", d);
@@ -297,9 +296,8 @@ status_t memory_desc_init_submemory(memory_desc_t &memory_desc,
             VERBOSE_UNSUPPORTED_MEM_STRIDE);
 
     for (int d = 0; d < src_d.ndims(); ++d) {
-        VCHECK_MEMORY(
-                !(utils::one_of(DNNL_RUNTIME_DIM_VAL, dims[d], offsets[d])),
-                unimplemented, VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+        VCHECK_MEMORY(!any_runtime_value(dims[d], offsets[d]), unimplemented,
+                VERBOSE_RUNTIMEDIM_UNSUPPORTED);
 
         const bool dim_offsets_oob = (dims[d] < 0 || offsets[d] < 0
                 || (offsets[d] + dims[d] > src_d.dims()[d]));
@@ -346,7 +344,7 @@ status_t memory_desc_reshape(memory_desc_t &out_memory_desc,
     auto volume = [](const dim_t *dims, int ndims) -> dim_t {
         dim_t prod = 1;
         for (int i = 0; i < ndims; ++i) {
-            if (dims[i] == DNNL_RUNTIME_DIM_VAL) return DNNL_RUNTIME_DIM_VAL;
+            if (is_runtime_value(dims[i])) return runtime_value_for(prod);
             prod *= dims[i] > 0 ? dims[i] : 1;
         }
         return prod;
@@ -653,12 +651,12 @@ status_t memory_desc_init_by_string_tag(memory_desc_t &md, int ndims,
             blk.strides[dim_idx] = stride;
 
             dim_t fib = full_inner_blks[dim_idx];
-            dim_t padded_dim = md.dims[dim_idx] == DNNL_RUNTIME_DIM_VAL
-                    ? DNNL_RUNTIME_DIM_VAL
+            const auto padded_dim = is_runtime_value(md.dims[dim_idx])
+                    ? runtime_value_for(md.padded_dims[dim_idx])
                     : (md.dims[dim_idx] + fib - 1) / fib * fib;
             md.padded_dims[dim_idx] = padded_dim;
-            if (one_of(DNNL_RUNTIME_DIM_VAL, padded_dim, stride))
-                stride = DNNL_RUNTIME_DIM_VAL;
+            if (any_runtime_value(padded_dim, stride))
+                stride = runtime_value_for(stride);
             else
                 stride *= (padded_dim / fib);
         } else {

--- a/src/common/memory_desc_wrapper.cpp
+++ b/src/common/memory_desc_wrapper.cpp
@@ -59,8 +59,8 @@ status_t fill_blocked(memory_desc_t &md, std::initializer_list<int> perm,
 
     utils::array_set(md.padded_offsets, 0, md.ndims);
     for (int d = 0; d < md.ndims; ++d)
-        md.padded_dims[d] = md.dims[d] == DNNL_RUNTIME_DIM_VAL
-                ? DNNL_RUNTIME_DIM_VAL
+        md.padded_dims[d] = is_runtime_value(md.dims[d])
+                ? runtime_value_for(md.padded_dims[d])
                 : utils::rnd_up(md.dims[d], blocks[d]);
 
     // setting the strides
@@ -72,8 +72,8 @@ status_t fill_blocked(memory_desc_t &md, std::initializer_list<int> perm,
             blk.strides[d] = stride;
 
             const dim_t pdim = md.padded_dims[d];
-            if (utils::one_of(DNNL_RUNTIME_DIM_VAL, stride, pdim))
-                stride = DNNL_RUNTIME_DIM_VAL;
+            if (any_runtime_value(stride, pdim))
+                stride = runtime_value_for(stride);
             else if (pdim != 0)
                 stride *= pdim / blocks[d];
 

--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -191,7 +191,7 @@ struct memory_desc_wrapper : public c_compatible {
      * is true, and the number of data elements otherwise */
     dim_t nelems(bool with_padding = false) const {
         if (is_zero()) return 0;
-        if (has_runtime_dims()) return DNNL_RUNTIME_DIM_VAL;
+        if (has_runtime_dims()) return runtime_value_for<dim_t>();
         return utils::array_product(
                 with_padding ? padded_dims() : dims(), ndims());
     }
@@ -309,7 +309,7 @@ struct memory_desc_wrapper : public c_compatible {
             return 0;
         }
 
-        if (has_runtime_dims_or_strides()) return DNNL_RUNTIME_SIZE_VAL;
+        if (has_runtime_dims_or_strides()) return runtime_value_for<size_t>();
 
         if (is_wino_desc()) {
             return wino_desc().size;
@@ -459,7 +459,7 @@ struct memory_desc_wrapper : public c_compatible {
     /** returns true if at least one dim is not known */
     bool has_runtime_dims() const {
         for (int d = 0; d < ndims(); ++d)
-            if (dims()[d] == DNNL_RUNTIME_DIM_VAL) return true;
+            if (is_runtime_value(dims()[d])) return true;
         return false;
     }
 
@@ -467,7 +467,7 @@ struct memory_desc_wrapper : public c_compatible {
     bool has_runtime_strides() const {
         if (!is_blocking_desc()) return false;
         for (int d = 0; d < ndims(); ++d)
-            if (blocking_desc().strides[d] == DNNL_RUNTIME_DIM_VAL) return true;
+            if (is_runtime_value(blocking_desc().strides[d])) return true;
         return false;
     }
 

--- a/src/common/memory_zero_pad.cpp
+++ b/src/common/memory_zero_pad.cpp
@@ -199,7 +199,7 @@ status_t typed_zero_pad(const memory_t *memory, const exec_ctx_t &ctx) {
     if (mdw.nelems(false) == mdw.nelems(true)) return success;
 
     const size_t map_size = mdw.size();
-    assert(map_size != DNNL_RUNTIME_SIZE_VAL);
+    assert(!is_runtime_value(map_size));
 
     void *mapped_ptr
             = ctx.map_memory_storage(memory_storage, ctx.stream(), map_size);

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -242,7 +242,7 @@ status_t post_ops_t::validate_binary(alg_kind_t alg,
 
     // Additional check to restrict run-time dimension usage until supported.
     for (int d = 0; d < user_src1_desc->ndims; ++d) {
-        VCHECK_ATTR(user_src1_desc->dims[d] != DNNL_RUNTIME_DIM_VAL,
+        VCHECK_ATTR(!is_runtime_value(user_src1_desc->dims[d]),
                 VERBOSE_RUNTIMEDIM_UNSUPPORTED);
     }
 
@@ -251,7 +251,7 @@ status_t post_ops_t::validate_binary(alg_kind_t alg,
         VCHECK_ATTR(memory_desc_sanity_check(*user_src2_desc),
                 VERBOSE_MEM_DESC_CHECK_FAIL);
         for (int d = 0; d < user_src2_desc->ndims; ++d) {
-            VCHECK_ATTR(user_src2_desc->dims[d] != DNNL_RUNTIME_DIM_VAL,
+            VCHECK_ATTR(!is_runtime_value(user_src2_desc->dims[d]),
                     VERBOSE_RUNTIMEDIM_UNSUPPORTED);
         }
     }

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -1109,8 +1109,8 @@ inline bool memory_desc_strides_check(
         if (md.padded_dims[d] == 0) return true;
 
         // no strides verification for runtime dims
-        const bool has_runtime_dim = utils::one_of(
-                DNNL_RUNTIME_DIM_VAL, strides[d], md.padded_dims[d]);
+        const bool has_runtime_dim
+                = any_runtime_value(strides[d], md.padded_dims[d]);
         if (has_runtime_dim) return true;
 
         perm[d] = d;
@@ -1238,8 +1238,10 @@ inline status_t memory_desc_init_by_blocking_desc(
 
     utils::simultaneous_sort(
             mblk.strides, ou_blocks, perm, ndims, [](stride_t a, stride_t b) {
-        if (utils::one_of(DNNL_RUNTIME_DIM_VAL, a, b))
-            return DNNL_RUNTIME_DIM_VAL;
+        static_assert(runtime_value_for<stride_t>() < 0,
+                "negative value is expected");
+        if (any_runtime_value(a, b))
+            return runtime_value_for<stride_t>(); // negative: preserves order
         return b - a;
     });
 
@@ -1318,21 +1320,6 @@ format_tag_t memory_desc_matches_one_of_tag(
     return format_tag::undef;
 }
 
-/** returns true if fp32 value denotes DNNL_RUNTIME_F32_VAL */
-inline bool is_runtime_value(float val) {
-    return utils::bit_cast<unsigned>(val) == DNNL_RUNTIME_F32_VAL_REP.u;
-}
-
-/** returns true if s32 value denotes DNNL_RUNTIME_S32_VAL */
-inline bool is_runtime_value(int val) {
-    return val == DNNL_RUNTIME_S32_VAL;
-}
-
-/** returns true if dim_t value denotes DNNL_RUNTIME_DIM_VAL */
-inline bool is_runtime_value(dim_t val) {
-    return val == DNNL_RUNTIME_DIM_VAL;
-}
-
 inline bool memory_desc_sanity_check(int ndims, const dims_t dims,
         data_type_t data_type, format_kind_t format_kind) {
     using namespace data_type;
@@ -1346,8 +1333,8 @@ inline bool memory_desc_sanity_check(int ndims, const dims_t dims,
 
     bool has_runtime_dims = false;
     for (int d = 0; d < ndims; ++d) {
-        if (dims[d] != DNNL_RUNTIME_DIM_VAL && dims[d] < 0) return false;
-        if (dims[d] == DNNL_RUNTIME_DIM_VAL) has_runtime_dims = true;
+        if (!is_runtime_value(dims[d]) && dims[d] < 0) return false;
+        if (is_runtime_value(dims[d])) has_runtime_dims = true;
     }
 
     if (has_runtime_dims) {

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -970,6 +970,76 @@ public:
     }
 };
 
+/** returns true if fp32 value denotes DNNL_RUNTIME_F32_VAL */
+inline bool is_runtime_value(float val) {
+    return utils::bit_cast<unsigned>(val) == DNNL_RUNTIME_F32_VAL_REP.u;
+}
+
+/** returns true if s32 value denotes DNNL_RUNTIME_S32_VAL */
+inline bool is_runtime_value(int val) {
+    return val == DNNL_RUNTIME_S32_VAL;
+}
+
+/** returns true if dim_t value denotes DNNL_RUNTIME_DIM_VAL */
+inline bool is_runtime_value(dim_t val) {
+    return val == DNNL_RUNTIME_DIM_VAL;
+}
+
+/** returns true if size_t value denotes DNNL_RUNTIME_SIZE_VAL */
+inline bool is_runtime_value(size_t val) {
+    return val == DNNL_RUNTIME_SIZE_VAL;
+}
+
+template <typename T>
+constexpr bool any_runtime_value(T item) {
+    return is_runtime_value(item);
+}
+template <typename T, typename... Args>
+bool any_runtime_value(T item, Args... item_others) {
+    return is_runtime_value(item) || any_runtime_value(item_others...);
+}
+
+template <typename T>
+constexpr bool all_runtime_values(T item) {
+    return is_runtime_value(item);
+}
+template <typename T, typename... Args>
+constexpr bool all_runtime_values(T item, Args... item_others) {
+    return is_runtime_value(item) && all_runtime_values(item_others...);
+}
+
+template <typename T>
+constexpr T runtime_value_for() {
+    static_assert(sizeof(T) == 0, "no runtime value defined for this type");
+    return T {};
+}
+
+template <>
+inline float runtime_value_for<float>() {
+    return DNNL_RUNTIME_F32_VAL;
+}
+
+template <>
+constexpr int runtime_value_for<int>() {
+    return DNNL_RUNTIME_S32_VAL;
+}
+
+template <>
+constexpr dim_t runtime_value_for<dim_t>() {
+    return DNNL_RUNTIME_DIM_VAL;
+}
+
+template <>
+constexpr size_t runtime_value_for<size_t>() {
+    return DNNL_RUNTIME_SIZE_VAL;
+}
+
+/** returns the runtime placeholder constant for the argument type T */
+template <typename T>
+inline T runtime_value_for(T) {
+    return runtime_value_for<typename utils::remove_reference<T>::type>();
+}
+
 } // namespace impl
 } // namespace dnnl
 

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -637,7 +637,7 @@ namespace {
 int get_runtime_mask(const memory_desc_t *md) {
     int mask = 0;
     for (int d = md->ndims - 1; d >= 0; --d) {
-        mask += md->dims[d] == DNNL_RUNTIME_DIM_VAL ? 1 << d : 0;
+        mask += is_runtime_value(md->dims[d]) ? 1 << d : 0;
     }
     return mask;
 }

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -119,7 +119,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad
-            if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
+            if (is_runtime_value(N())) ok = false;
         }
 
         if (!attr()->post_ops_.sum_with_default_dt()) return false;

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -1,4 +1,5 @@
 /*******************************************************************************
+* Copyright 2026 Intel Corporation
 * Copyright 2025 FUJITSU LIMITED
 * Copyright 2025-2026 Arm Ltd. and affiliates
 *
@@ -815,7 +816,7 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
         if (is_src_scl && is_wei_scl && wei_scl_msk > 0) {
             // This case requires scratchpad.
-            if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
+            if (is_runtime_value(N())) ok = false;
         }
         return ok;
     };

--- a/src/cpu/gemm_inner_product_utils.hpp
+++ b/src/cpu/gemm_inner_product_utils.hpp
@@ -91,8 +91,8 @@ protected:
         return (!runtime_oc()) && (OC_ == (size_t)dst_mb_stride_);
     }
     bool do_bias() const { return bias_data_type_ != data_type::undef; }
-    bool runtime_oc() const { return OC_ == (size_t)DNNL_RUNTIME_DIM_VAL; }
-    bool runtime_mb() const { return MB_ == (size_t)DNNL_RUNTIME_DIM_VAL; }
+    bool runtime_oc() const { return is_runtime_value(OC_); }
+    bool runtime_mb() const { return is_runtime_value(MB_); }
 };
 
 inline const bcast_set_t &gemm_default_strategies() {

--- a/src/cpu/matmul/gemm_based_common.hpp
+++ b/src/cpu/matmul/gemm_based_common.hpp
@@ -111,7 +111,7 @@ inline bool check_gemm_binary_per_oc_compatible_formats(const matmul_pd_t &pd) {
     const int ndims = dst_d.ndims();
 
     for (auto d : dims)
-        if (d == DNNL_RUNTIME_DIM_VAL) return false;
+        if (is_runtime_value(d)) return false;
 
     // check d, h, w... (b2, m, n... for matmul) dimensions are continuous
     bool ok = true;

--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -111,7 +111,7 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
-            if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
+            if (is_runtime_value(N())) ok = false;
         }
         return ok;
     };
@@ -138,7 +138,7 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
                 && IMPLICATION(is_binary_po_per_oc,
                         gemm_based::check_gemm_binary_per_oc_compatible_formats(
                                 *this))
-                && IMPLICATION(N() == DNNL_RUNTIME_DIM_VAL, !has_prelu);
+                && IMPLICATION(is_runtime_value(N()), !has_prelu);
     };
 
     // check basic attributes

--- a/src/cpu/matmul/gemm_bf16_matmul.hpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.hpp
@@ -63,7 +63,7 @@ struct gemm_bf16_matmul_t : public primitive_t {
 
             // mb value is calculated based on work-sharing using
             // balance211 in execute()
-            dim_t mb = DNNL_RUNTIME_DIM_VAL;
+            auto mb = runtime_value_for<dim_t>();
             if (!has_runtime_dims && ((batch * M) % nthr == 0)) {
                 const dim_t m_per_thr = nstl::max<dim_t>(1, (batch * M) / nthr);
                 if (m_per_thr >= M && m_per_thr % M == 0) {

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -54,7 +54,7 @@ status_t gemm_f32_matmul_t::pd_t::init(engine_t *engine) {
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
-            if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
+            if (is_runtime_value(N())) ok = false;
         }
         return ok;
     };
@@ -81,7 +81,7 @@ status_t gemm_f32_matmul_t::pd_t::init(engine_t *engine) {
                 && IMPLICATION(is_binary_po_per_oc,
                         gemm_based::check_gemm_binary_per_oc_compatible_formats(
                                 *this))
-                && IMPLICATION(N() == DNNL_RUNTIME_DIM_VAL, !has_prelu);
+                && IMPLICATION(is_runtime_value(N()), !has_prelu);
     };
 
     const bool problem_dt_correct = src_md()->data_type == src_type
@@ -160,8 +160,8 @@ status_t gemm_f32_matmul_t::pd_t::configure_attributes() {
                     data_type::undef);
 
     // `C_is_abx` limitation comes from `extended_sgemm`.
-    const bool C_is_abx = helper.ldc() >= helper.N()
-            && helper.ldc() != DNNL_RUNTIME_DIM_VAL;
+    const bool C_is_abx
+            = !is_runtime_value(helper.ldc()) && helper.ldc() >= helper.N();
     params_.dst_is_acc_ = C_is_abx
             && IMPLICATION(attr()->post_ops_.find(primitive_kind::sum) != -1,
                     sum_po_via_gemm_beta);

--- a/src/cpu/matmul/gemm_f32_matmul.hpp
+++ b/src/cpu/matmul/gemm_f32_matmul.hpp
@@ -61,7 +61,7 @@ struct gemm_f32_matmul_t : public primitive_t {
 
             // mb value is calculated based on work-sharing using
             // balance211 in execute()
-            dim_t mb = DNNL_RUNTIME_DIM_VAL;
+            auto mb = runtime_value_for<dim_t>();
             if (!has_runtime_dims && ((batch * M) % nthr == 0)) {
                 const dim_t m_per_thr = nstl::max<dim_t>(1, (batch * M) / nthr);
                 if (m_per_thr >= M && m_per_thr % M == 0) {

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -65,7 +65,7 @@ status_t gemm_x8s8s32x_matmul_t::pd_t::init(engine_t *engine) {
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
-            if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
+            if (is_runtime_value(N())) ok = false;
         }
         return ok;
     };
@@ -105,7 +105,7 @@ status_t gemm_x8s8s32x_matmul_t::pd_t::init(engine_t *engine) {
                 && IMPLICATION(is_binary_po_per_oc,
                         gemm_based::check_gemm_binary_per_oc_compatible_formats(
                                 *this))
-                && IMPLICATION(N() == DNNL_RUNTIME_DIM_VAL, !has_prelu);
+                && IMPLICATION(is_runtime_value(N()), !has_prelu);
     };
 
     VDISPATCH_MATMUL(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.hpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.hpp
@@ -62,7 +62,7 @@ struct gemm_x8s8s32x_matmul_t : public primitive_t {
 
             // mb value is calculated based on work-sharing using
             // balance211 in execute()
-            dim_t mb = DNNL_RUNTIME_DIM_VAL;
+            auto mb = runtime_value_for<dim_t>();
             if (!has_runtime_dims && ((batch * M) % nthr == 0)) {
                 const dim_t m_per_thr = nstl::max<dim_t>(1, (batch * M) / nthr);
                 if (m_per_thr >= M && m_per_thr % M == 0) {

--- a/src/cpu/matmul/matmul_utils.hpp
+++ b/src/cpu/matmul/matmul_utils.hpp
@@ -213,7 +213,8 @@ private:
         dim_t batch_size = 1;
         for (int b_idx = 0; b_idx < batch_dims; b_idx++) {
             dim_t batch_dim = tensor_md.dims()[b_idx];
-            if (DNNL_RUNTIME_DIM_VAL == batch_dim) return DNNL_RUNTIME_DIM_VAL;
+            if (is_runtime_value(batch_dim))
+                return runtime_value_for(batch_size);
 
             batch_size *= batch_dim;
         }

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -217,7 +217,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                 && !asc.has_default_values(DNNL_ARG_WEIGHTS)
                 && asc.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad
-            if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
+            if (is_runtime_value(N())) ok = false;
         }
         // Impl suppports f32 scales only for non-weight decompression
         if (!(is_bf16_with_int_wei || is_f16_with_int_wei


### PR DESCRIPTION
The PR removes explicit use of constants the `DNNL_RUNTIME_DIM_VAL`, `DNNL_RUNTIME_SIZE_VAL`, `DNNL_RUNTIME_S32_VAL`, `DNNL_RUNTIME_F32_VAL` in CPU-related part of the library.
We already had overloads of the `is_runtime_value` functions, but they weren't used in many places.
New variadic function templates have also been added to check whether at least one or all values in a set are equal to the corresponding runtime placeholder value, taking into account the type of values.
E.g., the call
```
all_runtime_values(
    DNNL_RUNTIME_DIM_VAL,
    DNNL_RUNTIME_SIZE_VAL,
    DNNL_RUNTIME_S32_VAL,
    DNNL_RUNTIME_F32_VAL,
    runtime_value_for<int>(),
    runtime_value_for<dim_t>(),
    runtime_value_for<float>(),
    runtime_value_for<size_t>())
```
returns `true`.
Functions to deduce runtime placeholder values from a variable's type have also been added. This can help avoid bugs when, for example, the type of a structure member has changed. If the type has changed, we need to find all occurrences of that member and update all assignments and conditional uses of runtime value placeholders.

Functions are placed in utils.hpp (not type_helpers.hpp) to avoid circular dependencies with files included in type_helpers.hpp. One another option is to place them in a separate file.
