### PR TITLE
[GPU][NVL-P] Use atomic spec generation for atomic loads

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
@@ -105,9 +105,10 @@ void Generator<hw>::loadMatrixBlock(const Register &dest, const RegisterBlock &b
         case AccessType::ChannelScattered: {
             auto spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Read);
             if(hw >= HW::XE3P_35_10) spec |= Overfetch;
-            if (astrategy.atomic && hw >= HW::Xe2)
+            if (astrategy.atomic && hw >= HW::Xe2) {
+                spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Atomic);
                 atomic(AtomicOp::load, mod, dest, spec, astrategy.base, getAddress(addr, block, astrategy));
-            else if (block.descAssigned) {
+            } else if (block.descAssigned) {
                 MessageDescriptor desc;
                 ExtendedMessageDescriptor exdesc;
                 encodeLoadDescriptors(hw, desc, exdesc, block.simdSize, r0, spec, astrategy.base, null);


### PR DESCRIPTION
# Description

Currently atomic loads use a spec generated with the READ parameter rather than ATOMIC which can generate in invalid cache setting for NVL-P Atomic Loads.

Fixes # [MFDNN-14736](https://jira.devtools.intel.com/browse/MFDNN-14736)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?