### PR TITLE
xe: gemm: jit: revert 2d group disabling

### DIFF
--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -418,22 +418,6 @@ bool pd_t::scales_ok() {
             return false;
 
         if (!x_scales.has_default_groups()) {
-            const memory_desc_t *md = nullptr;
-            switch (s) {
-                // Swap descriptors to follow column major format
-                case DNNL_ARG_A: md = &desc()->b_desc; break;
-                case DNNL_ARG_B: md = &desc()->a_desc; break;
-                case DNNL_ARG_C: md = &desc()->c_desc; break;
-            }
-            if (!md) gpu_error_not_expected();
-            int count = 0;
-            for (int i = 0; i < 2; i++) {
-                int gs = x_scales.get_group(i);
-                int dim = md->dims[md->ndims - 2 + i];
-                if (1 < gs && gs < dim) count++;
-            }
-            if (count > 1) return false;
-
             // Dynamic Dst Quant only supported with `1x32` groups.
             if (s == DNNL_ARG_C && with_mx_scale()
                     && (x_scales.get_group(0) != 1


### PR DESCRIPTION
# Description

Revert changes from 1c09d15c0ea570845709257c209d8547cc205b1c that disabled 2d grouped scales (enabled in #4478 ). 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?