### PR TITLE
xe: lnorm: use uniform pointer with block read

### DIFF
--- a/src/gpu/intel/lnorm/reusable_vectorized.cl
+++ b/src/gpu/intel/lnorm/reusable_vectorized.cl
@@ -75,10 +75,10 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
 
     if (USE_SCALE)
         scale = GWS_GET_BUFFER_POS(SS, gws_params, scale)
-                + ((greads - 1) * SG_STRIDE);
+                - get_sub_group_local_id() + ((greads - 1) * SG_STRIDE);
     if (USE_SHIFT)
         shift = GWS_GET_BUFFER_POS(SS, gws_params, shift)
-                + ((greads - 1) * SG_STRIDE);
+                - get_sub_group_local_id() + ((greads - 1) * SG_STRIDE);
 
     /// Normalize layer
     FLT_ACC_DATA_T sqrt_variance = rsqrt(local_variance + eps);


### PR DESCRIPTION
`intel_sub_group_block_read()` must be called with a uniform pointer across the subgroup:
https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups.html#_add_a_new_section_6_13_x_sub_group_read_and_write_functions

LNorm kernel has this adjustment for `dst_vect` but it's missing for shift/scale.