### PR TITLE
cpu: x64: guard APX extended GPRs on OS XCR0 bit 19 support

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -390,6 +390,21 @@ inline int get_max_palette_size() {
 
 } // namespace amx
 
+namespace apx {
+
+// Returns true if the OS has enabled APX Extended General Purpose Register
+// (EGR) state save/restore (XCR0 bit 19). Without this, any instruction that
+// accesses extended registers r16-r31 via the REX2 prefix will raise #UD.
+inline bool egr_available() {
+    // XSAVE feature must be supported in order to check APX EGR state.
+    const bool xsave_supported = cpu().has(Xbyak::util::Cpu::tOSXSAVE);
+    if (!xsave_supported) return false;
+    constexpr int XSAVE_APX_EGR = 19;
+    return (Xbyak::util::Cpu::getXfeature() >> XSAVE_APX_EGR) & 1;
+}
+
+} // namespace apx
+
 namespace {
 
 inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -95,7 +95,8 @@ public:
     inline jit_generator_t &jit() const { return jit_; }
     inline bool ExtendedRegisters() const {
         return is_superset(isa_, avx512_core)
-                && (mayiuse(avx10_2_512) || mayiuse(avx10_2_512_amx_2));
+                && (mayiuse(avx10_2_512) || mayiuse(avx10_2_512_amx_2))
+                && x64::apx::egr_available();
     }
 
     inline int Size() const { return size_; }


### PR DESCRIPTION
## Problem

Setting `DNNL_MAX_CPU_ISA=AVX10_2_512` caused `Illegal instruction (core
dumped)` for all data types on matmul, brgemm, ip, and conv primitives.
The crash did not occur with `AVX10_1_512` or `AVX512_CORE_FP16`.

## Root cause

`registry_scratchpad_t::ExtendedRegisters()` in `injector_utils.hpp`
returned `true` for `avx10_2_512` because `mayiuse(avx10_2_512)` passed.
This caused JIT kernels (e.g. `jit_brgemm_kernel_t`) to allocate and emit
REX2-prefixed instructions using APX extended GPRs r16–r31.

APX Extended General Purpose Register (EGR) state must be explicitly
enabled by the OS in the XSAVE context-switch area via XCR0 bit 19.
`mayiuse(avx10_2_512)` only checks CPUID feature flags (`tAPX_F`), which
reflect hardware capability, not OS enablement. On the system the error 
occurring the XCR0 bit 19 was 0 — the OS had not opted in to saving and 
restoring the EGR state. Any REX2-prefixed instruction executed in this
configuration raises `#UD` (Undefined Instruction), regardless of hardware
support.

This mirrors the existing situation for AMX, where `amx::is_available()`
is called to verify OS enablement before allowing AMX tile instructions.

## Fix

Add `apx::egr_available()` in `cpu_isa_traits.hpp`, which checks XCR0
bit 19 via `Xbyak::util::Cpu::getXfeature()` after first confirming OSXSAVE
is enabled. Gate `ExtendedRegisters()` on this check so that extended GPRs
r16–r31 are only used when the OS has enabled APX EGR context switching.

The `apx::egr_available()` check was patterned after the `amx::is_available()` 
nstruction for amx