### PR TITLE
xe: conv: avoid non-deterministic IR generation

### DIFF
--- a/src/gpu/intel/jit/pass/hoist.cpp
+++ b/src/gpu/intel/jit/pass/hoist.cpp
@@ -425,7 +425,7 @@ private:
 
         object_eq_map_t<expr_t, expr_t> and_ops;
         object_eq_map_t<expr_t, expr_t> mask_exprs;
-        for (auto &kv : hoisted_masks_) {
+        for (auto &kv : sort_var_map_by_value(hoisted_masks_)) {
             if (split_by_and_) {
                 auto e = split_by_and_ops(kv.first, and_ops);
                 mask_exprs.emplace(e, kv.second);


### PR DESCRIPTION
Found while investigating [MFDNN-14746](https://jira.devtools.intel.com/browse/MFDNN-14746). Without sorting `std::unordered_map` may result in different iterator order between Linux/Windows.