### PR TITLE
    cpu: aarch64: optimize jit depthwise convolution

### DIFF
--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
-* Copyright 2024-2025 Arm Ltd. and affiliates
+* Copyright 2024-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,26 +46,33 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
+        // adjust the src offset so it's always within the range expected by LD_MUL_VL.
+        if (this->jcp.with_sum) {
+            add_imm(reg_tmp_addr, reg_output,
+                    (ch * ocb_stride) * jcp.typesize_out, reg_tmp_imm);
+        }
+        int b_off = ch * ch_blk;
+        if (this->jcp.with_bias) {
+            LD_MUL_VL(ld1w, ZRegS(1), P_ALL_ONE, reg_bias,
+                    b_off * sizeof(float), sizeof(float));
+        }
         for (int ow = 0; ow < ur_w; ow++) {
             ZRegS zregs_acc = get_acc_reg_s(ch * ur_w + ow);
 
-            int b_off = ch * ch_blk;
-            if (this->jcp.with_bias) {
-                add_imm(reg_tmp_addr, reg_bias, b_off * sizeof(float),
-                        reg_tmp_imm);
-                ld1w(zregs_acc, P_ALL_ONE, ptr(reg_tmp_addr));
+            if (this->jcp.with_bias && zregs_acc.getIdx() != 1) {
+                mov(zregs_acc, P_ALL_ONE, ZRegS(1));
             } else
                 fmov(zregs_acc); // zero clear
 
-            int o_off = ch * ocb_stride + ow * ow_stride;
+            int o_off = ow * ow_stride;
             if (this->jcp.with_sum) {
-                add_imm(reg_tmp_addr, reg_output, o_off * jcp.typesize_out,
-                        reg_tmp_imm);
                 if (jcp.dst_dt == data_type::f32) {
-                    ld1w(ZRegS(0), P_ALL_ONE, ptr(reg_tmp_addr));
+                    LD_MUL_VL(ld1w, ZRegS(0), P_ALL_ONE, reg_tmp_addr,
+                            o_off * jcp.typesize_out, jcp.typesize_out);
                     fadd(zregs_acc, zregs_acc, ZRegS(0));
                 } else if (jcp.dst_dt == data_type::bf16) {
-                    ld1h(ZRegS(0), P_ALL_ONE, ptr(reg_tmp_addr));
+                    LD_MUL_VL(ld1h, ZRegS(0), P_ALL_ONE, reg_tmp_addr,
+                            o_off * jcp.typesize_out, jcp.typesize_out);
                     // Convert BF16 input to FP32
                     lsl(ZRegS(0), ZRegS(0), 16);
                     fadd(zregs_acc, zregs_acc, ZRegS(0));
@@ -108,17 +115,21 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
         }
 
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
+            // adjust the src offset so it's always within the range expected by LD_MUL_VL.
+            add_imm(reg_tmp_addr, aux_reg_input,
+                    (ch * icb_stride) * jcp.typesize_in, reg_tmp_imm);
+            add_imm(reg_tmp2_addr, aux_reg_kernel,
+                    (ch * jcp.kh * jcp.kw * ch_blk) * jcp.typesize_in,
+                    reg_tmp_imm);
             for (int kw = 0; kw < jcp.kw; kw++) {
-                int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
-
+                int ker_off = kw * ch_blk;
                 ZReg zregs_ker = get_ker_reg(0);
-                add_imm(reg_tmp_addr, aux_reg_kernel, ker_off * jcp.typesize_in,
-                        reg_tmp_imm);
-
                 if (jcp.dst_dt == data_type::f32) {
-                    ld1w(zregs_ker.s, P_ALL_ONE, ptr(reg_tmp_addr));
+                    LD_MUL_VL(ld1w, zregs_ker.s, P_ALL_ONE, reg_tmp2_addr,
+                            ker_off * jcp.typesize_in, jcp.typesize_in);
                 } else if (jcp.dst_dt == data_type::bf16) {
-                    ld1h(zregs_ker.s, P_ALL_ONE, ptr(reg_tmp_addr));
+                    LD_MUL_VL(ld1h, zregs_ker.s, P_ALL_ONE, reg_tmp2_addr,
+                            ker_off * jcp.typesize_in, jcp.typesize_in);
                 } else {
                     assert(!"Unsupported: data type");
                 }
@@ -126,20 +137,17 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
                 int ow_start = get_ow_start(kw, pad_l);
                 int ow_end = get_ow_end(ur_w, kw, pad_r);
                 for (int ow = ow_start; ow < ow_end; ow++) {
-                    int inp_off = ch * icb_stride
-                            + (ow * stride_w - pad_l) * iw_stride
+                    int inp_off = (ow * stride_w - pad_l) * iw_stride
                             + kw * dilate_w * iw_stride;
-
                     ZReg zregs_src = get_src_reg(0);
-                    add_imm(reg_tmp_addr, aux_reg_input,
-                            inp_off * jcp.typesize_in, reg_tmp_imm);
-
                     if (jcp.dst_dt == data_type::f32) {
-                        ld1w(zregs_src.s, P_ALL_ONE, ptr(reg_tmp_addr));
+                        LD_MUL_VL(ld1w, zregs_src.s, P_ALL_ONE, reg_tmp_addr,
+                                inp_off * jcp.typesize_in, jcp.typesize_in);
                         ZRegS zregs_acc = get_acc_reg_s(ch * ur_w + ow);
                         fmla(zregs_acc, P_ALL_ONE, zregs_src.s, zregs_ker.s);
                     } else if (jcp.dst_dt == data_type::bf16) {
-                        ld1h(zregs_src.s, P_ALL_ONE, ptr(reg_tmp_addr));
+                        LD_MUL_VL(ld1h, zregs_src.s, P_ALL_ONE, reg_tmp_addr,
+                                inp_off * jcp.typesize_in, jcp.typesize_in);
                         ZRegS zregs_acc = get_acc_reg_s(ch * ur_w + ow);
                         bfmlalb(zregs_acc, zregs_src.h, zregs_ker.h);
                     } else {
@@ -185,19 +193,22 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
 
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
+        // adjust the output offset so it's always within the range expected by ST_MUL_VL.
+        add_imm(reg_tmp_addr, reg_output, (ch * ocb_stride) * jcp.typesize_out,
+                reg_tmp_imm);
         for (int ow = 0; ow < ur_w; ow++) {
-            const int o_off = ch * ocb_stride + ow * ow_stride;
-            add_imm(reg_tmp_addr, reg_output, o_off * jcp.typesize_out,
-                    reg_tmp_imm);
+            const int o_off = ow * ow_stride;
             if (jcp.dst_dt == data_type::f32) {
                 ZRegS zreg_dst = get_acc_reg_s(ch * ur_w + ow);
-                st1w(zreg_dst, P_ALL_ONE, ptr(reg_tmp_addr));
+                ST_MUL_VL(st1w, zreg_dst, P_ALL_ONE, reg_tmp_addr,
+                        o_off * jcp.typesize_out, jcp.typesize_out);
             } else if (jcp.dst_dt == data_type::bf16) {
                 ZReg zreg_dst = get_acc_reg(ch * ur_w + ow);
                 // Convert fp32 to bf16
                 bfcvt(zreg_dst.h, P_ALL_ONE, zreg_dst.s);
                 // Store the bf16 value doing the downcast
-                st1h(zreg_dst.s, P_ALL_ONE, ptr(reg_tmp_addr));
+                ST_MUL_VL(st1h, zreg_dst.s, P_ALL_ONE, reg_tmp_addr,
+                        o_off * jcp.typesize_out, jcp.typesize_out);
             } else {
                 assert(!"Unsupported: data type");
             }

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ private:
     reg64_t reg_output_stack = x27;
     reg64_t reg_bias_stack = x19;
     reg64_t reg_tmp_addr = x20;
+    reg64_t reg_tmp2_addr = x18;
 
     inline void load_src(int ur_ch_blocks, int ur_w);
     inline void compute_loop(int ur_w, int ur_ch_blocks, int pad_l, int pad_r);


### PR DESCRIPTION
# Description

Optimise JIT depthwise convolution using `LD_MUL_VL` and `ST_MUL_VL`, and adjust offsets to remain within the expected range. This reduces the number of instructions generated by the kernel and yields a significant speedup across all threads.

Additionally, a small improvement is to load the bias from a previously loaded register to avoid unnecessary memory access.

Before

```
    add	x20, x2, x15
    ld1w	{z1.s}, p0/z, [x20]
    fmla	z13.s, p0/m, z1.s, z0.s
    mov	x15, #0x16c0                	// #5824
    add	x20, x2, x15
    ld1w	{z1.s}, p0/z, [x20]
    fmla	z14.s, p0/m, z1.s, z0.s
    mov	x15, #0x16d0                	// #5840
    add	x20, x2, x15
    ld1w	{z1.s}, p0/z, [x20]
    fmla	z15.s, p0/m, z1.s, z0.s
    mov	x15, #0x16e0                	// #5856
    add	x20, x2, x15
    ld1w	{z1.s}, p0/z, [x20]
    fmla	z16.s, p0/m, z1.s, z0.s
    mov	x15, #0x16f0                	// #5872
    add	x20, x2, x15
    ld1w	{z1.s}, p0/z, [x20]
    fmla	z17.s, p0/m, z1.s, z0.s
    mov	x15, #0x1700                	// #5888
    add	x20, x2, x15
    ld1w	{z1.s}, p0/z, [x20]
    fmla	z18.s, p0/m, z1.s, z0.s
    mov	x15, #0x1710                	// #5904
    add	x20, x2, x15
    ld1w	{z1.s}, p0/z, [x20]
    fmla	z19.s, p0/m, z1.s, z0.s
```

After 

```
     ld1w	{z1.s}, p0/z, [x20, #1, mul vl]
     fmla	z13.s, p0/m, z1.s, z0.s
     ld1w	{z1.s}, p0/z, [x20, #2, mul vl]
     fmla	z14.s, p0/m, z1.s, z0.s
     ld1w	{z1.s}, p0/z, [x20, #3, mul vl]
     fmla	z15.s, p0/m, z1.s, z0.s
     ld1w	{z1.s}, p0/z, [x20, #4, mul vl]
     fmla	z16.s, p0/m, z1.s, z0.s
     ld1w	{z1.s}, p0/z, [x20, #5, mul vl]
     fmla	z17.s, p0/m, z1.s, z0.s
     ld1w	{z1.s}, p0/z, [x20, #6, mul vl]
     fmla	z18.s, p0/m, z1.s, z0.s
     ld1w	{z1.s}, p0/z, [x20, #7, mul vl]
     fmla	z19.s, p0/m, z1.s, z0.s
```

For SVE 128, the enhancement in performance resulting from these modifications

```
threads                                1     8     16    32    64
DESC                                                             
g1024mb1ic1024ih7oc1024oh7kh3ph1     0.91  0.91  0.85  1.04  0.90
g1024mb8ic1024ih10oc1024oh10kh3ph1   0.91  0.88  0.90  0.92  1.01
g1152mb1ic1152ih16oc1152oh16kh3ph1   0.70  0.75  0.75  0.83  0.76
g1152mb1ic1152ih16oc1152oh16kh5ph2   0.69  0.77  0.76  0.82  0.57
g128mb1ic128ih56oc128oh28kh3sh2ph1   0.76  0.83  0.87  0.87  1.23
g128mb1ic128ih56oc128oh56kh3ph1      0.62  0.71  0.74  0.76  0.69
g128mb8ic128ih75oc128oh38kh3sh2ph1   0.74  0.79  0.82  0.83  0.72
g128mb8ic128ih75oc128oh75kh3ph1      0.65  0.67  0.74  0.71  0.65
g144mb1ic144ih128oc144oh128kh3ph1    0.64  0.69  0.75  0.77  0.67
g144mb1ic144ih128oc144oh64kh5sh2ph1  0.73  0.76  0.78  0.80  0.74
g240mb1ic240ih64oc240oh32kh3sh2ph0   0.84  0.79  0.78  0.85  0.79
g240mb1ic240ih64oc240oh64kh5ph2      0.61  0.68  0.75  0.76  0.67
g256mb1ic256ih28oc256oh14kh3sh2ph1   0.79  0.89  0.90  0.93  0.99
g256mb1ic256ih28oc256oh28kh3ph1      0.67  0.76  0.77  0.83  0.83
g256mb8ic256ih38oc256oh19kh3sh2ph1   0.85  0.82  0.88  0.88  0.73
g256mb8ic256ih38oc256oh38kh3ph1      0.68  0.71  0.78  0.79  0.65
g32mb1ic32ih112oc32oh112kh3ph1       0.63  0.66  0.75  0.74  0.70
g32mb1ic32ih256oc32oh256kh3ph1       0.65  0.72  0.75  0.77  0.66
g32mb8ic32ih150oc32oh150kh3ph1       0.69  0.71  0.73  0.72  0.74
g480mb1ic480ih32oc480oh32kh3ph1      0.71  0.78  0.86  0.83  0.79
g480mb1ic480ih32oc480oh32kh5ph2      0.69  0.75  0.82  0.77  0.70
g512mb1ic512ih14oc512oh14kh3ph1      0.82  0.83  0.84  0.93  0.83
g512mb1ic512ih14oc512oh7kh3sh2ph1    0.90  0.96  0.93  0.88  0.88
g512mb8ic512ih19oc512oh10kh3sh2ph1   0.88  0.87  0.84  0.89  0.92
g512mb8ic512ih19oc512oh19kh3ph1      0.67  0.75  0.79  0.83  0.96
g64mb1ic64ih112oc64oh56kh3sh2ph1     0.79  0.79  0.79  0.78  0.75
g64mb1ic64ih16oc64oh16kh3ph1         0.73  0.82  0.84  0.94  1.16
g64mb1ic64ih32oc64oh32kh3ph1         0.71  0.80  0.91  0.90  0.92
g64mb1ic64ih4oc64oh4kh3ph1           0.96  0.95  0.92  0.98  0.86
g64mb1ic64ih64oc64oh64kh3ph1         0.64  0.68  0.78  0.74  0.80
g64mb1ic64ih8oc64oh8kh3ph1           0.89  1.00  1.10  1.11  0.67
g64mb8ic64ih150oc64oh75kh3sh2ph1     0.85  0.93  0.90  0.83  0.78
g672mb1ic672ih32oc672oh16kh5sh2ph1   0.81  0.80  0.85  0.83  1.10
g672mb1ic672ih32oc672oh32kh5ph2      0.69  0.75  0.82  0.79  0.74
g96mb1ic96ih256oc96oh128kh3sh2ph0    0.79  0.89  0.81  0.85  0.77

overall speedup: +24.27%

per-thread mean ratios:

  threads= 1: ratio=0.751703, overall speedup=+33.03%
  threads= 8: ratio=0.795492, overall speedup=+25.71%
  threads=16: ratio=0.824567, overall speedup=+21.28%
  threads=32: ratio=0.843328, overall speedup=+18.58%
  threads=64: ratio=0.808298, overall speedup=+23.72%
```

For SVE 256, the enhancement in performance resulting from these modifications

```
threads                                1     8     16    32    64
DESC                                                             
g1024mb1ic1024ih7oc1024oh7kh3ph1     0.94  0.97  1.04  0.99  0.87
g1024mb8ic1024ih10oc1024oh10kh3ph1   0.96  0.97  0.93  0.93  0.97
g1152mb1ic1152ih16oc1152oh16kh3ph1   0.94  0.92  0.90  0.92  0.85
g1152mb1ic1152ih16oc1152oh16kh5ph2   0.97  0.94  0.91  0.97  0.92
g128mb1ic128ih56oc128oh28kh3sh2ph1   0.96  0.96  0.84  0.94  1.03
g128mb1ic128ih56oc128oh56kh3ph1      0.86  0.86  0.85  0.84  0.87
g128mb8ic128ih75oc128oh38kh3sh2ph1   0.94  1.09  0.84  0.89  0.98
g128mb8ic128ih75oc128oh75kh3ph1      0.86  0.86  0.85  0.83  0.94
g144mb1ic144ih128oc144oh128kh3ph1    0.84  0.83  0.84  0.82  0.90
g144mb1ic144ih128oc144oh64kh5sh2ph1  0.96  0.95  0.90  0.91  0.84
g240mb1ic240ih64oc240oh32kh3sh2ph0   0.90  0.91  0.88  0.90  0.85
g240mb1ic240ih64oc240oh64kh5ph2      0.90  0.86  0.86  0.87  0.68
g256mb1ic256ih28oc256oh14kh3sh2ph1   0.96  0.93  0.97  0.86  0.99
g256mb1ic256ih28oc256oh28kh3ph1      0.95  0.96  0.90  0.90  0.97
g256mb8ic256ih38oc256oh19kh3sh2ph1   0.95  1.03  0.93  0.94  0.90
g256mb8ic256ih38oc256oh38kh3ph1      0.92  0.90  0.87  0.87  0.90
g32mb1ic32ih112oc32oh112kh3ph1       0.85  0.84  0.85  0.85  1.10
g32mb1ic32ih256oc32oh256kh3ph1       0.95  0.95  0.93  0.92  1.00
g32mb8ic32ih150oc32oh150kh3ph1       0.85  0.82  0.84  0.82  0.88
g480mb1ic480ih32oc480oh32kh3ph1      0.93  0.90  0.86  0.93  1.00
g480mb1ic480ih32oc480oh32kh5ph2      0.94  0.93  0.88  0.88  0.90
g512mb1ic512ih14oc512oh14kh3ph1      0.96  0.95  0.91  0.96  0.87
g512mb1ic512ih14oc512oh7kh3sh2ph1    1.03  0.92  0.97  1.00  1.16
g512mb8ic512ih19oc512oh10kh3sh2ph1   0.96  1.00  0.94  0.94  1.14
g512mb8ic512ih19oc512oh19kh3ph1      0.94  0.95  0.90  0.92  0.77
g64mb1ic64ih112oc64oh56kh3sh2ph1     0.91  0.88  0.90  0.93  0.89
g64mb1ic64ih16oc64oh16kh3ph1         0.93  0.92  1.09  1.17  0.70
g64mb1ic64ih32oc64oh32kh3ph1         0.93  0.89  0.87  0.96  1.05
g64mb1ic64ih4oc64oh4kh3ph1           0.91  1.06  1.22  1.15  1.02
g64mb1ic64ih64oc64oh64kh3ph1         0.90  0.86  0.83  0.87  0.94
g64mb1ic64ih8oc64oh8kh3ph1           0.93  0.96  1.07  0.93  1.43
g64mb8ic64ih150oc64oh75kh3sh2ph1     0.93  1.01  1.07  0.96  0.83
g672mb1ic672ih32oc672oh16kh5sh2ph1   0.97  0.96  0.92  0.92  1.10
g672mb1ic672ih32oc672oh32kh5ph2      0.95  0.91  0.88  0.88  1.01
g96mb1ic96ih256oc96oh128kh3sh2ph0    0.95  1.06  0.62  0.91  0.99

overall speedup: +7.59%

per-thread mean ratios:

  threads= 1: ratio=0.929663, overall speedup=+7.57%
  threads= 8: ratio=0.934846, overall speedup=+6.97%
  threads=16: ratio=0.911086, overall speedup=+9.76%
  threads=32: ratio=0.921998, overall speedup=+8.46%
  threads=64: ratio=0.949626, overall speedup=+5.30%

```
# Detailed list of changes

- Add LD_MUL_VL to the bias and source data load, and adjust the offset to ensure it remains within the expected range.
- Always, if possible, load the bias from a previously loaded register to avoid unnecessary memory access.
- Add LD_MUL_VL to the hot loop to load the weights and adjust the offset so it stays within the expected range. This greatly reduced the number of 'add' instructions previously used in the hot loop, cutting the kernel's total instruction count by nearly one third.
- Add ST_MUL_VL to the storage function and modify the offset to ensure it always remains within the expected range.

This PR was inspired by @jondea's work [here](https://github.com/uxlfoundation/oneDNN/pull/4807).
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?