### PR TITLE
cpu: rv64: brgemm: add jit brgemm kernel for f32

### DIFF
--- a/src/cpu/rv64/brgemm/brgemm.cpp
+++ b/src/cpu/rv64/brgemm/brgemm.cpp
@@ -1,0 +1,159 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/rv64/brgemm/brgemm.hpp"
+#include "cpu/rv64/brgemm/jit_brgemm_kernel.hpp"
+
+#include "xbyak_riscv/xbyak_riscv_util.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace dnnl::impl::utils;
+
+status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
+        brgemm_batch_kind_t type, data_type_t dt_a, data_type_t dt_b,
+        brgemm_layout_t layout, float alpha, float beta, dim_t LDA, dim_t LDB,
+        dim_t LDC, dim_t M, dim_t N, dim_t K, const brgemm_strides_t *strides) {
+
+    if (!brg) return status::invalid_arguments;
+    if (M <= 0 || K <= 0) return status::invalid_arguments;
+
+    // Only f32 → f32 supported in the MVP.
+    if (!everyone_is(data_type::f32, dt_a, dt_b)) return status::unimplemented;
+
+    *brg = utils::zero<brgemm_desc_t>();
+
+    brg->bcast_dim = M;
+    brg->load_dim = N;
+    brg->reduce_dim = K;
+    brg->LDA = LDA;
+    brg->LDB = LDB;
+    brg->LDC = LDC;
+    brg->alpha = alpha;
+    brg->beta = beta;
+    brg->type = type;
+    brg->layout = layout;
+    brg->isa_impl = isa;
+
+    brg->dt_a = dt_a;
+    brg->dt_b = dt_b;
+    brg->dt_c = data_type::f32;
+    brg->typesize_A = static_cast<int>(types::data_type_size(dt_a));
+    brg->typesize_B = static_cast<int>(types::data_type_size(dt_b));
+    brg->typesize_C = static_cast<int>(types::data_type_size(brg->dt_c));
+    brg->is_f32 = true;
+
+    if (strides) {
+        brg->stride_a = strides->stride_a;
+        brg->stride_b = strides->stride_b;
+    }
+
+    // Determine bd_block from VLEN. Using LMUL=m4 so that each logical
+    // vector register holds VLEN*4/32 f32 elements.
+    const uint32_t vlen_bits
+            = Xbyak_riscv::CPU::getInstance().getVlen(); // e.g. 128
+    const int vlen_f32 = static_cast<int>(vlen_bits) / 32; // elements per m1
+    brg->bd_block = vlen_f32 * 4; // LMUL=m4 → 4× elements
+
+    brg->bdb = static_cast<int>(M) / brg->bd_block;
+    brg->bdb_tail = static_cast<int>(M) % brg->bd_block;
+
+    brg->n_step = 4; // process 4 output columns per inner iteration
+    brg->rd_block = 4; // K unroll factor
+    brg->rdb = static_cast<int>(K) / brg->rd_block;
+    brg->rdb_tail = static_cast<int>(K) % brg->rd_block;
+
+    return status::success;
+}
+
+status_t brgemm_kernel_create(
+        brgemm_kernel_t **brg_kernel, const brgemm_desc_t &brg) {
+    if (!brg_kernel) return status::invalid_arguments;
+    *brg_kernel = nullptr;
+
+    auto *kernel = new brgemm_kernel_common_t(brg);
+    status_t st = kernel->create_kernel();
+    if (st != status::success) {
+        delete kernel;
+        return st;
+    }
+    *brg_kernel = kernel;
+    return status::success;
+}
+
+void brgemm_kernel_destroy(brgemm_kernel_t *brg_kernel) {
+    delete brg_kernel;
+}
+
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, const void *ptr_A,
+        const void *ptr_B, void *ptr_C, dim_t N, float beta) {
+
+    const auto &brg = brg_kernel->get_brg();
+    const int ts = brg.typesize_C; // sizeof(float) = 4
+    const int bd = brg.bd_block;
+    const dim_t K = brg.reduce_dim;
+    const dim_t LDA_bytes = brg.LDA * ts;
+
+    const auto *A_base = reinterpret_cast<const char *>(ptr_A);
+    const auto *B_base = reinterpret_cast<const char *>(ptr_B);
+    auto *C_base = reinterpret_cast<char *>(ptr_C);
+
+    // K-blocking: split the reduction dimension into chunks of BK to keep
+    // the A working-set (bd_block × BK × 4 bytes) inside the L1D cache.
+    const dim_t BK = BRGEMM_BK;
+
+    for (dim_t kb = 0; kb < K; kb += BK) {
+        const dim_t K_inner = nstl::min(BK, K - kb);
+        const float beta_kb = (kb == 0) ? beta : 1.0f;
+
+        const char *A_kb = A_base + kb * LDA_bytes;
+        const char *B_kb = B_base + kb * ts;
+
+        brgemm_kernel_params_t p;
+        p.ptr_B = B_kb;
+        p.N = N;
+        p.K = K_inner;
+        p.beta = beta_kb;
+
+        // Process full bd_block tiles.
+        for (int m = 0; m < brg.bdb; m++) {
+            p.ptr_A = A_kb + static_cast<dim_t>(m) * bd * ts;
+            p.ptr_C = C_base + static_cast<dim_t>(m) * bd * ts;
+            p.M = bd;
+            (*brg_kernel)(&p);
+        }
+
+        // Process M tail (if any).
+        if (brg.bdb_tail > 0) {
+            p.ptr_A = A_kb + static_cast<dim_t>(brg.bdb) * bd * ts;
+            p.ptr_C = C_base + static_cast<dim_t>(brg.bdb) * bd * ts;
+            p.M = brg.bdb_tail;
+            (*brg_kernel)(&p);
+        }
+    }
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/brgemm/brgemm.hpp
+++ b/src/cpu/rv64/brgemm/brgemm.hpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_BRGEMM_BRGEMM_HPP
+#define CPU_RV64_BRGEMM_BRGEMM_HPP
+
+#include "cpu/rv64/brgemm/brgemm_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
+        brgemm_batch_kind_t type, data_type_t dt_a, data_type_t dt_b,
+        brgemm_layout_t layout, float alpha, float beta, dim_t LDA, dim_t LDB,
+        dim_t LDC, dim_t M, dim_t N, dim_t K,
+        const brgemm_strides_t *strides = nullptr);
+
+status_t brgemm_kernel_create(
+        brgemm_kernel_t **brg_kernel, const brgemm_desc_t &brg);
+
+void brgemm_kernel_destroy(brgemm_kernel_t *brg_kernel);
+
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, const void *ptr_A,
+        const void *ptr_B, void *ptr_C, dim_t N, float beta);
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_BRGEMM_BRGEMM_HPP

--- a/src/cpu/rv64/brgemm/brgemm_types.hpp
+++ b/src/cpu/rv64/brgemm/brgemm_types.hpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_BRGEMM_BRGEMM_TYPES_HPP
+#define CPU_RV64_BRGEMM_BRGEMM_TYPES_HPP
+
+#include "common/c_types_map.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+enum brgemm_batch_kind_t {
+    brgemm_batch_kind_undef = 0,
+    brgemm_addr = 1,
+    brgemm_offs = 2,
+    brgemm_strd = 3,
+};
+
+enum brgemm_layout_t {
+    brgemm_layout_undef = 0,
+    brgemm_col_major = 1,
+    brgemm_row_major = 2,
+};
+
+struct brgemm_strides_t {
+    dim_t stride_a;
+    dim_t stride_b;
+};
+
+struct brgemm_batch_element_t {
+    union {
+        struct {
+            const void *A;
+            const void *B;
+        } ptr;
+        struct {
+            dim_t A;
+            dim_t B;
+        } offset;
+    };
+};
+
+// K-blocking tile size.  Chosen so that the A working set per M-tile
+// fits comfortably in the 32 KB L1D cache:
+//   bd_block(8) * BK(256) * 4 bytes = 8 KB.
+static constexpr int BRGEMM_BK = 256;
+
+// BRGEMM descriptor: configured at init time, constants baked into JIT kernel.
+struct brgemm_desc_t {
+    dim_t bcast_dim; // M
+    dim_t load_dim; // N (informational; actual N is a runtime parameter)
+    dim_t reduce_dim; // K
+
+    dim_t LDA, LDB, LDC;
+
+    float alpha, beta;
+
+    cpu_isa_t isa_impl;
+    data_type_t dt_a, dt_b, dt_c;
+    int typesize_A, typesize_B, typesize_C;
+
+    brgemm_batch_kind_t type;
+    brgemm_layout_t layout;
+    dim_t stride_a, stride_b;
+
+    // Blocking parameters (computed by brgemm_desc_init).
+    int bd_block; // M tile per vector (LMUL-dependent)
+    int bdb; // number of full bd_block tiles in M
+    int bdb_tail; // remaining M rows
+
+    int n_step; // N columns processed per inner iteration (4)
+    int rd_block; // K unroll factor (4)
+    int rdb; // K / rd_block
+    int rdb_tail; // K % rd_block
+
+    bool is_f32;
+};
+
+// Runtime parameters passed to the JIT micro-kernel for one M-tile.
+struct brgemm_kernel_params_t {
+    const void *ptr_A; // offset 0
+    const void *ptr_B; // offset 8
+    void *ptr_C; // offset 16
+    dim_t N; // offset 24: number of output columns
+    dim_t M; // offset 32: actual rows in this tile
+    dim_t K; // offset 40: reduction dimension (runtime, for K-blocking)
+    float beta; // offset 48: 0.0f or 1.0f
+};
+
+// Abstract JIT kernel base.
+struct brgemm_kernel_t {
+    virtual ~brgemm_kernel_t() = default;
+    virtual status_t create_kernel() = 0;
+    virtual void operator()(brgemm_kernel_params_t *) const = 0;
+    virtual const brgemm_desc_t &get_brg() const = 0;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_BRGEMM_BRGEMM_TYPES_HPP

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -1,0 +1,368 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/rv64/brgemm/jit_brgemm_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+struct jit_brgemm_kernel_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_t)
+
+    jit_brgemm_kernel_t(const brgemm_desc_t &brg)
+        : jit_generator_t("rv64_brgemm_kernel_f32_jit"), brg_(brg) {}
+
+    void operator()(brgemm_kernel_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+    const brgemm_desc_t &get_brg() const { return brg_; }
+
+protected:
+    void generate() override;
+
+private:
+    brgemm_desc_t brg_;
+};
+
+void jit_brgemm_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const dim_t LDA_bytes = brg_.LDA * brg_.typesize_A;
+    const dim_t LDB_bytes = brg_.LDB * brg_.typesize_B;
+    const dim_t LDC_bytes = brg_.LDC * brg_.typesize_C;
+    const dim_t N_stride_B = 4 * LDB_bytes; // B advance per 4-col group
+    const dim_t N_stride_C = 4 * LDC_bytes; // C advance per 4-col group
+
+    const Reg reg_param = a0;
+    const Reg reg_tmp0 = a0; // reused after param loads
+
+    const Reg reg_A = a1; // A running pointer (advances per K step)
+    const Reg reg_n = a2; // N loop counter
+    const Reg reg_C = a3; // C column pointer (advances per N group)
+    const Reg reg_k = a4; // K loop counter
+    const Reg reg_K_main = a5; // (K/4)*4, computed at runtime
+    const Reg reg_B0 = a6; // B column-0 running pointer
+    const Reg reg_B1 = a7; // B column-1 running pointer
+
+    const Reg reg_lda = t0; // LDA in bytes (baked immediate)
+    const Reg reg_ldb = t1; // LDB in bytes (baked immediate)
+    const Reg reg_ldc = t2; // LDC in bytes (baked immediate)
+    const Reg reg_K_val = t3; // K (runtime, from params)
+    const Reg reg_N = t4; // N (from params)
+    const Reg reg_beta = t5; // beta raw bits (from params)
+    const Reg reg_tmp1 = t6; // scratch
+
+    const Reg reg_A_base = s0; // A base pointer (survives N iterations)
+    const Reg reg_B_base = s1; // B group base pointer
+    const Reg reg_B2 = s2; // B column-2 running pointer
+    const Reg reg_B3 = s3; // B column-3 running pointer
+
+    const FReg freg_b0 = fa0;
+    const FReg freg_b1 = fa1;
+    const FReg freg_b2 = fa2;
+    const FReg freg_b3 = fa3;
+
+    // Vector registers (LMUL=m4: each logical register = 4 physical).
+    // 4 accumulators + 2 A-buffers + 1 scratch = 7 groups (28 of 32 phys)
+    const VReg v_c0(0); // accum col 0
+    const VReg v_c1(4); // accum col 1
+    const VReg v_c2(8); // accum col 2
+    const VReg v_c3(12); // accum col 3
+    const VReg v_a0(16); // A double-buffer 0
+    const VReg v_a1(20); // A double-buffer 1
+    const VReg v_tmp(24); // scratch for C load/update
+
+    addi(sp, sp, -32);
+    sd(reg_A_base, sp, 0);
+    sd(reg_B_base, sp, 8);
+    sd(reg_B2, sp, 16);
+    sd(reg_B3, sp, 24);
+
+    ld(reg_A_base, reg_param, 0); // A base
+    ld(reg_B_base, reg_param, 8); // B base
+    ld(reg_C, reg_param, 16); // C base
+    ld(reg_N, reg_param, 24); // N
+    ld(reg_tmp1, reg_param, 32); // M (for vsetvli)
+    ld(reg_K_val, reg_param, 40); // K (runtime)
+    lw(reg_beta, reg_param, 48); // beta bits
+
+    vsetvli(x0, reg_tmp1, SEW::e32, LMUL::m4);
+
+    li(reg_lda, LDA_bytes);
+    li(reg_ldb, LDB_bytes);
+    li(reg_ldc, LDC_bytes);
+
+    // ---- Compute K_main = (K / 4) * 4 for 4× unrolled loop ----
+    srli(reg_K_main, reg_K_val, 2);
+    slli(reg_K_main, reg_K_main, 2);
+
+    // ================================================================
+    // N outer loop: process 4 columns per iteration
+    // ================================================================
+    mv(reg_n, x0); // n = 0
+
+    Label lbl_n_loop, lbl_n_tail, lbl_n_tail_loop, lbl_n_end;
+
+    L(lbl_n_loop);
+    // Check: n + 4 <= N ?
+    addi(reg_tmp0, reg_n, 4);
+    blt(reg_N, reg_tmp0, lbl_n_tail); // if N < n+4, go to tail
+
+    mv(reg_A, reg_A_base);
+
+    // ---- Setup 4 B column pointers for current N group ----
+    mv(reg_B0, reg_B_base);
+    add(reg_B1, reg_B_base, reg_ldb);
+    add(reg_B2, reg_B1, reg_ldb); // B_base + 2*LDB
+    add(reg_B3, reg_B2, reg_ldb); // B_base + 3*LDB
+
+    vmv_v_i(v_c0, 0);
+    vmv_v_i(v_c1, 0);
+    vmv_v_i(v_c2, 0);
+    vmv_v_i(v_c3, 0);
+
+    // ---- K main loop (4× unrolled, double-buffered A loads) ----
+    mv(reg_k, x0);
+    Label lbl_k_main_end, lbl_k_tail, lbl_k_tail_end;
+
+    // Helper: load 4 B scalars (all independent, no address chains).
+    auto emit_b_load = [&]() {
+        flw(freg_b0, reg_B0, 0);
+        flw(freg_b1, reg_B1, 0);
+        flw(freg_b2, reg_B2, 0);
+        flw(freg_b3, reg_B3, 0);
+    };
+
+    // Helper: advance all 4 B pointers to the next k row.
+    auto emit_b_advance = [&]() {
+        addi(reg_B0, reg_B0, 4);
+        addi(reg_B1, reg_B1, 4);
+        addi(reg_B2, reg_B2, 4);
+        addi(reg_B3, reg_B3, 4);
+    };
+
+    // Pipelined K step: prefetch next A into v_next while computing
+    // FMAs with the already-loaded v_cur.
+    auto emit_pipelined_step = [&](const VReg &v_next, const VReg &v_cur) {
+        vle32_v(v_next, reg_A); // prefetch next A
+        add(reg_A, reg_A, reg_lda);
+        emit_b_load(); // 4 independent scalar loads
+        vfmacc_vf(v_c0, freg_b0, v_cur);
+        vfmacc_vf(v_c1, freg_b1, v_cur);
+        vfmacc_vf(v_c2, freg_b2, v_cur);
+        vfmacc_vf(v_c3, freg_b3, v_cur);
+        emit_b_advance();
+    };
+
+    // Drain step: FMA with v_cur, no prefetch (avoids OOB A read).
+    auto emit_drain_step = [&](const VReg &v_cur) {
+        emit_b_load();
+        vfmacc_vf(v_c0, freg_b0, v_cur);
+        vfmacc_vf(v_c1, freg_b1, v_cur);
+        vfmacc_vf(v_c2, freg_b2, v_cur);
+        vfmacc_vf(v_c3, freg_b3, v_cur);
+        emit_b_advance();
+    };
+
+    // Guard: skip pipelined section if K_main == 0 (K < 4).
+    beq(reg_K_main, x0, lbl_k_tail);
+
+    // Compute K_pipe = K_main - 4 (loop bound for fully-pipelined phase).
+    addi(reg_tmp1, reg_K_main, -4); // reg_tmp1 = K_pipe
+
+    // Initial preload of A[0] into v_a0.
+    vle32_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+
+    {
+        Label lbl_pipe, lbl_pipe_end;
+        L(lbl_pipe);
+        bge(reg_k, reg_tmp1, lbl_pipe_end); // k >= K_pipe → exit
+
+        emit_pipelined_step(v_a1, v_a0); // step 0
+        emit_pipelined_step(v_a0, v_a1); // step 1
+        emit_pipelined_step(v_a1, v_a0); // step 2
+        emit_pipelined_step(v_a0, v_a1); // step 3 (prefetch for next iter)
+
+        addi(reg_k, reg_k, 4);
+        j_(lbl_pipe);
+        L(lbl_pipe_end);
+    }
+
+    // v_a0 holds A[K_pipe] (from initial preload or last step-3).
+    emit_pipelined_step(v_a1, v_a0); // rem step 0
+    emit_pipelined_step(v_a0, v_a1); // rem step 1
+    emit_pipelined_step(v_a1, v_a0); // rem step 2 (last access: A[K_main-1])
+    emit_drain_step(v_a1); // rem step 3 (no prefetch → no OOB)
+    addi(reg_k, reg_k, 4); // k = K_main
+
+    L(lbl_k_main_end);
+
+    // ---- K tail (1 step at a time, no pipelining needed) ----
+    L(lbl_k_tail);
+    bge(reg_k, reg_K_val, lbl_k_tail_end);
+
+    vle32_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+    emit_b_load();
+    vfmacc_vf(v_c0, freg_b0, v_a0);
+    vfmacc_vf(v_c1, freg_b1, v_a0);
+    vfmacc_vf(v_c2, freg_b2, v_a0);
+    vfmacc_vf(v_c3, freg_b3, v_a0);
+    emit_b_advance();
+    addi(reg_k, reg_k, 1);
+    j_(lbl_k_tail);
+
+    L(lbl_k_tail_end);
+
+    // ---- Store accumulators to C (single beta branch for all cols) ----
+    {
+        mv(reg_tmp0, reg_C);
+        Label lbl_bz, lbl_store_done;
+        beq(reg_beta, x0, lbl_bz);
+
+        // beta != 0 path: C[col] = C[col] + accum
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c1);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c2);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c3);
+        vse32_v(v_tmp, reg_tmp0);
+
+        j_(lbl_store_done);
+
+        // beta == 0 path: C[col] = accum (overwrite)
+        L(lbl_bz);
+        vse32_v(v_c0, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c1, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c2, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c3, reg_tmp0);
+
+        L(lbl_store_done);
+    }
+
+    // ---- Advance B_base and C for next 4-column group ----
+    li(reg_tmp1, N_stride_B);
+    add(reg_B_base, reg_B_base, reg_tmp1);
+
+    li(reg_tmp1, N_stride_C);
+    add(reg_C, reg_C, reg_tmp1);
+
+    addi(reg_n, reg_n, 4);
+    j_(lbl_n_loop);
+
+    // ================================================================
+    // N tail: process 1 column at a time
+    // ================================================================
+    L(lbl_n_tail);
+
+    L(lbl_n_tail_loop);
+    bge(reg_n, reg_N, lbl_n_end);
+
+    // Reset A, setup B0 for single column.
+    mv(reg_A, reg_A_base);
+    mv(reg_B0, reg_B_base);
+
+    vmv_v_i(v_c0, 0);
+
+    mv(reg_k, x0);
+    Label lbl_kt2, lbl_kt2_end;
+
+    L(lbl_kt2);
+    bge(reg_k, reg_K_val, lbl_kt2_end);
+
+    vle32_v(v_a0, reg_A);
+    flw(freg_b0, reg_B0, 0);
+    vfmacc_vf(v_c0, freg_b0, v_a0);
+    add(reg_A, reg_A, reg_lda);
+    addi(reg_B0, reg_B0, 4);
+    addi(reg_k, reg_k, 1);
+    j_(lbl_kt2);
+
+    L(lbl_kt2_end);
+
+    // Store single column.
+    {
+        Label lbl_bz2, lbl_done2;
+        beq(reg_beta, x0, lbl_bz2);
+        vle32_v(v_tmp, reg_C);
+        vfadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_C);
+        j_(lbl_done2);
+        L(lbl_bz2);
+        vse32_v(v_c0, reg_C);
+        L(lbl_done2);
+    }
+
+    // Advance B_base by 1 column, C by 1 column.
+    add(reg_B_base, reg_B_base, reg_ldb);
+    add(reg_C, reg_C, reg_ldc);
+
+    addi(reg_n, reg_n, 1);
+    j_(lbl_n_tail_loop);
+
+    L(lbl_n_end);
+
+    ld(reg_A_base, sp, 0);
+    ld(reg_B_base, sp, 8);
+    ld(reg_B2, sp, 16);
+    ld(reg_B3, sp, 24);
+    addi(sp, sp, 32);
+    ret();
+#else
+    // RVV JIT is disabled at build time.
+    ret();
+#endif
+}
+
+brgemm_kernel_common_t::brgemm_kernel_common_t(const brgemm_desc_t &brg)
+    : brg_(brg), jit_kernel_(new jit_brgemm_kernel_t(brg)) {}
+
+brgemm_kernel_common_t::~brgemm_kernel_common_t() {
+    delete jit_kernel_;
+}
+
+status_t brgemm_kernel_common_t::create_kernel() {
+    return jit_kernel_->create_kernel();
+}
+
+void brgemm_kernel_common_t::operator()(brgemm_kernel_params_t *p) const {
+    (*jit_kernel_)(p);
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_BRGEMM_JIT_BRGEMM_KERNEL_HPP
+#define CPU_RV64_BRGEMM_JIT_BRGEMM_KERNEL_HPP
+
+#include "cpu/rv64/brgemm/brgemm_types.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_brgemm_kernel_t;
+
+struct brgemm_kernel_common_t : public brgemm_kernel_t {
+    brgemm_kernel_common_t(const brgemm_desc_t &brg);
+    ~brgemm_kernel_common_t() override;
+
+    status_t create_kernel() override;
+    void operator()(brgemm_kernel_params_t *) const override;
+    const brgemm_desc_t &get_brg() const override { return brg_; }
+
+private:
+    brgemm_desc_t brg_;
+    jit_brgemm_kernel_t *jit_kernel_ = nullptr;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_BRGEMM_JIT_BRGEMM_KERNEL_HPP

--- a/src/cpu/rv64/rvv_brgemm_conv.cpp
+++ b/src/cpu/rv64/rvv_brgemm_conv.cpp
@@ -21,7 +21,7 @@
 #include "common/utils.hpp"
 #include "common/verbose.hpp"
 
-#include "cpu/gemm/gemm.hpp"
+#include "cpu/rv64/brgemm/brgemm.hpp"
 #include "cpu/rv64/rvv_brgemm_conv.hpp"
 
 namespace dnnl {
@@ -68,6 +68,24 @@ status_t rvv_brgemm_convolution_fwd_t::pd_t::init(engine_t *engine) {
                               src_md_, weights_md_, dst_md_, bias_md_, attr_,
                               dnnl_get_max_threads()),
             VERBOSE_PRIMITIVE_CREATION_FAIL, "brgemm_conv");
+
+    // Create the JIT BRGEMM kernel for the convolution's GEMM shape.
+    const dim_t M = jcp_.oc;
+    const dim_t K = jcp_.ic;
+    const dim_t OC_all = static_cast<dim_t>(jcp_.ngroups) * jcp_.oc;
+    const dim_t IC_all = static_cast<dim_t>(jcp_.ngroups) * jcp_.ic;
+    const dim_t LDA = OC_all;
+    const dim_t LDB = static_cast<dim_t>(jcp_.stride_w) * IC_all;
+    const dim_t LDC = OC_all;
+
+    brgemm_desc_t brg_desc;
+    CHECK(brgemm_desc_init(&brg_desc, v, brgemm_strd, data_type::f32,
+            data_type::f32, brgemm_col_major, 1.0f, 1.0f, LDA, LDB, LDC, M,
+            jcp_.ow, K));
+
+    brgemm_kernel_t *kernel = nullptr;
+    CHECK(brgemm_kernel_create(&kernel, brg_desc));
+    brg_kernel_.reset(kernel);
 
     return status::success;
 }
@@ -125,100 +143,11 @@ status_t rvv_brgemm_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
     // Weight strides (hwio / dhwio / hwigo / dhwigo).
     const dim_t wei_kpos_str = static_cast<dim_t>(IC) * OC_all;
 
-    // GEMM leading dimensions (column-major / BLAS convention).
-    const dim_t LDA = OC_all; // weight: M=OC, K=IC
-    const dim_t LDB = static_cast<dim_t>(SW) * IC_all; // source
-    const dim_t LDC = OC_all; // destination
+    const auto *brg_kernel = pd()->brg_kernel_.get();
 
-    const float one = 1.0f;
-
-    // When SH=SW=1 and IW=OW (padding-preserved spatial), consecutive
-    // output rows correspond to contiguous source/dst in nhwc layout.
-    const bool can_batch_rows = (SH == 1 && SW == 1 && IW == OW);
-
-    if (can_batch_rows) {
-        // Parallel over (mb, groups, od) — each thread handles all OH rows.
-        parallel_nd(jcp.mb, G, OD, [&](dim_t n, dim_t g, dim_t od) {
-            float *dst_base = dst + n * dst_mb_str + od * dst_d_str + g * OC;
-
-            // Zero entire output slice for this (n, g, od).
-            if (!jcp.with_sum) {
-                for (dim_t s = 0; s < OH * OW; s++) {
-                    float *d = dst_base + s * OC_all;
-                    for (dim_t oc = 0; oc < OC; oc++)
-                        d[oc] = 0.0f;
-                }
-            }
-
-            for (int kd = 0; kd < KD; kd++) {
-                const int id = od * SD + kd * DD - FP;
-                if (id < 0 || id >= ID) continue;
-
-                for (int kh = 0; kh < KH; kh++) {
-                    // Valid oh range: need 0 <= oh + kh*DH - TP < IH.
-                    const int oh_s
-                            = nstl::max(0, TP - kh * DH); // DH already +1
-                    const int oh_e = nstl::min(OH, IH + TP - kh * DH);
-                    if (oh_s >= oh_e) continue;
-                    const int ih_start = oh_s + kh * DH - TP; // SH=1
-
-                    for (int kw = 0; kw < KW; kw++) {
-                        const int iw_base = kw * DW - LP;
-                        int ow_s = iw_base < 0 ? -iw_base : 0;
-                        int ow_e = nstl::min(OW, IW - iw_base);
-                        const dim_t valid_ow = ow_e - ow_s;
-                        if (valid_ow <= 0) continue;
-                        const int iw_start = iw_base + ow_s; // SW=1
-
-                        const float *A = wei
-                                + ((kd * KH + kh) * KW + kw) * wei_kpos_str
-                                + g * OC;
-
-                        if (ow_s == 0 && ow_e == OW) {
-                            // Full-width: source/dst contiguous across rows.
-                            dim_t num_rows = oh_e - oh_s;
-                            dim_t N = num_rows * OW;
-                            const float *B = src + n * src_mb_str
-                                    + id * src_d_str + ih_start * src_h_str
-                                    + iw_start * src_w_str + g * IC;
-                            float *C = dst_base + oh_s * dst_h_str
-                                    + ow_s * OC_all;
-                            dim_t M = OC, K_dim = IC;
-                            status_t st = extended_sgemm("N", "N", &M, &N,
-                                    &K_dim, &one, A, &LDA, B, &LDB, &one, C,
-                                    &LDC);
-                            if (st != status::success) return;
-                        } else {
-                            // Edge (partial width): per-row GEMM.
-                            for (int oh = oh_s; oh < oh_e; oh++) {
-                                const int ih = oh + kh * DH - TP;
-                                const float *B = src + n * src_mb_str
-                                        + id * src_d_str + ih * src_h_str
-                                        + iw_start * src_w_str + g * IC;
-                                float *C = dst_base + oh * dst_h_str
-                                        + ow_s * OC_all;
-                                dim_t M = OC, N_dim = valid_ow, K_dim = IC;
-                                status_t st = extended_sgemm("N", "N", &M,
-                                        &N_dim, &K_dim, &one, A, &LDA, B, &LDB,
-                                        &one, C, &LDC);
-                                if (st != status::success) return;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (jcp.with_bias) {
-                const float *bia_g = bia + g * OC;
-                for (dim_t s = 0; s < OH * OW; s++) {
-                    float *d = dst_base + s * OC_all;
-                    for (dim_t oc = 0; oc < OC; oc++)
-                        d[oc] += bia_g[oc];
-                }
-            }
-        });
-    } else {
-        // Strided convolutions: parallel over (mb, groups, od, oh).
+    {
+        // Parallel over (mb, groups, od, oh) for good multi-core scaling.
+        // Each thread handles one or more output rows independently.
         const dim_t work = static_cast<dim_t>(jcp.mb) * G * OD * OH;
 
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -237,6 +166,8 @@ status_t rvv_brgemm_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                         for (int oc = 0; oc < OC; oc++)
                             dst_row[ow * OC_all + oc] = 0.0f;
                 }
+
+                bool first_kpos = !jcp.with_sum;
 
                 for (int kd = 0; kd < KD; kd++) {
                     const int id = od * SD + kd * DD - FP;
@@ -264,11 +195,10 @@ status_t rvv_brgemm_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                                     + iw_start * src_w_str + g * IC;
                             float *C = dst_row + ow_s * OC_all;
 
-                            dim_t M = OC, N = valid_ow, K_dim = IC;
-                            status_t st = extended_sgemm("N", "N", &M, &N,
-                                    &K_dim, &one, A, &LDA, B, &LDB, &one, C,
-                                    &LDC);
-                            if (st != status::success) return;
+                            const float beta_val = first_kpos ? 0.0f : 1.0f;
+                            brgemm_kernel_execute(
+                                    brg_kernel, A, B, C, valid_ow, beta_val);
+                            first_kpos = false;
                         }
                     }
                 }

--- a/src/cpu/rv64/rvv_brgemm_conv.hpp
+++ b/src/cpu/rv64/rvv_brgemm_conv.hpp
@@ -17,6 +17,8 @@
 #ifndef CPU_RV64_RVV_BRGEMM_CONV_HPP
 #define CPU_RV64_RVV_BRGEMM_CONV_HPP
 
+#include <memory>
+
 #include "common/c_types_map.hpp"
 #include "common/primitive.hpp"
 #include "common/verbose.hpp"
@@ -24,6 +26,7 @@
 #include "cpu/cpu_convolution_pd.hpp"
 #include "cpu/cpu_engine.hpp"
 
+#include "cpu/rv64/brgemm/brgemm.hpp"
 #include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/rvv_brgemm_conv_utils.hpp"
 
@@ -42,6 +45,7 @@ struct rvv_brgemm_convolution_fwd_t : public primitive_t {
         status_t init(engine_t *engine);
 
         brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
+        std::shared_ptr<brgemm_kernel_t> brg_kernel_;
     };
 
     rvv_brgemm_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}


### PR DESCRIPTION
# Description

This PR introduces an optimized JIT BRGEMM (Batched Reduce GEMM) micro-kernel for RV64 architectures using `xbyak_riscv_v` JIT code generation. It replaces the generic `extended_sgemm` calls in `rvv_brgemm_conv` with a dedicated JIT-compiled kernel, eliminating GEMM driver overhead (matrix packing, generic tiling, dynamic dispatch) and delivering a direct JIT call path from convolution to the micro-kernel.

- Releted PR: #4770 

This version provides:

1. Minimal viable JIT BRGEMM infrastructure with full correctness on ResNet-50, GoogleNet-v3, and VGG-11
2. K-blocking (BK=256) for improved L1D cache locality
3. Software pipelining with double-buffered A loads
4. Dedicated B column pointers for independent scalar loads
5. Single-core performance improvements of 3-10% on CNN workloads

## Key Features

- **JIT BRGEMM Micro-kernel**: A dedicated JIT-compiled kernel via `xbyak_riscv_v` that processes C[M_tile, 0:N] += A[M_tile, 0:K] * B[0:K, 0:N] with column-major layout and LMUL=m4 vectorization along the M (output channel) dimension.

- **K-blocking (BK=256)**: The reduction dimension K is split into 256-element blocks at runtime, ensuring the A working set (bd_block × 256 × 4B = 8KB) fits comfortably in the 32KB L1D cache.

- **Software Pipelining**: Two-phase K-loop design with double-buffered A vector registers (`v_a0`/`v_a1`).

## Implementation Details

### Design Choices

- **LMUL = m4**: Vectorization along M (OC) dimension with `bd_block = VLEN × 4 / 32` (8 for VLEN=128). Runtime `vsetvli` handles M-tails naturally.

- **N loop inside JIT**: Process 4 columns per iteration + 1-column tail, reducing function-call overhead vs. tiling N in C code.

- **K loop 4× unrolled**: Matching the existing `jit_rvv_gemm_kernel` pattern, with double-buffered A loads for latency hiding.

- **No packing**: Operate directly on NHWC source/weight data. For typical IC ≤ 512, the weight matrix fits in L2 without packing.

- **Callee-saved registers**: `s0`/`s1` for A_base and B_group_base survive across N iterations; `s2`/`s3` for B2/B3 column pointers enable independent scalar loads.

- **Dispatch threshold**: BRGEMM path is used when `ow >= 20` and `ic >= 16`, routing convolutions with sufficient output width to the JIT kernel for per-kernel-position GEMM efficiency, while smaller shapes fall back to packed GEMM.



# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on SG2044 platform with VLEN=128. We draw comparisons between:

1. Upstream main reference GEMM-based convolution using `extended_sgemm` with RVV intrinsics
2. This PR with dedicated JIT BRGEMM micro-kernel

### Single-Core Performance

| Cases | Dispatch Precentage | Baseline (main) Time | This PR Time | Speedup |
|---------|---------------------|----------------------|--------------|-------------|
| **shapes_gemm** | 5% | 5342.42 ms | 3324.12 ms | **1.61×** |
| **shapes_googlenet_v3** | 14% | 10698.7 ms | 9249.15 ms | **1.16×** |
| **shapes_resnet_50** | 20% | 15823.6 ms | 13929.8 ms | **1.14×** |
| **shapes_vgg_11** | 50% | 7389.52 ms | 6035.79 ms | **1.22×** |

| Layer Type | Baseline (main) Time | This PR Time | Speedup |
|------------|----------------------|--------------|---------|
| gemm:last shape | 5339.3 ms | 3327.08 ms | **1.60×** |
| googlenet_v3:conv_1_1_conv2d | 596.111 ms | 484.13 ms | **1.23×** |
| googlenet_v3:conv_2_2_conv2d | 1599.64 ms | 1003.11 ms | **1.59×** |
| googlenet_v3:conv_4_4_conv2d | 2066.64 ms | 1850.16 ms | **1.12×** |
| googlenet_v3:mixed_tower_conv_1_conv2d*3 | 240.09 ms | 191.471 ms | **1.25×** |
| googlenet_v3:mixed_tower_1_conv_1_conv2d*4 | 180.226 ms | 156.51 ms | **1.15×** |
| googlenet_v3:mixed_tower_1_conv_2_conv2d*3 | 249.787 ms | 228.208 ms | **1.09×** |
| resnet_50:res2a_branch2b*3 | 726.939 ms | 578.896 ms | **1.26×** |
| resnet_50:res3a_branch1 | 1460.05 ms | 1139.11 ms | **1.28×** |
| resnet_50:res3a_branch2a | 325.254 ms | 281.975 ms | **1.15×** |
| resnet_50:res3a_branch2b*4 | 792.465 ms | 814.943 ms | **0.97×** |
| vgg_11:conv1_2 | 2155.19 ms | 1316.3 ms | **1.64×** |
| vgg_11:conv2_1 | 695.531 ms | 592.101 ms | **1.17×** |
| vgg_11:conv2_2 | 1513.8 ms | 1270.69 ms | **1.19×** |
| vgg_11:conv3_1 | 456.857 ms | 462.722 ms | **0.99×** |
| vgg_11:conv3_2 | 776.491 ms | 713.153 ms | **1.09×** |

### Multi-Core Performance (8 cores)

| Cases | Dispatch Precentage | Baseline (main) Time | This PR Time | Speedup |
|---------|---------------------|----------------------|--------------|-------------|
| **shapes_gemm** | 5% | 952.053 ms | 650.274 ms | **1.46×** |
| **shapes_googlenet_v3** | 14% | 1830.65 ms | 1669.01 ms | **1.10×** |
| **shapes_resnet_50** | 20% | 2517.14 ms | 2480.61 ms | **1.01×** |
| **shapes_vgg_11** | 50% | 1130.94 ms | 818.857 ms | **1.38×** |


### Future Work

- **Post-ops fusion**: Bias addition, ReLU inside the JIT store path to avoid a second pass over output.
- **Weight reorder / packing**: Optional packed weight layout for large-IC layers.
- **Batch support (BS>1)**: Batch multiple kernel positions into one brgemm call with in-register accumulators.
