### PR TITLE
oneDNN v3.11.1 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.11.0")
+set(PROJECT_VERSION "3.11.1")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.11:
* Fixed performance regression in `bf16` matmul with `int4` weights on Intel GPUs based on Xe2 architecture (d4d4d7aebf68d3ee730d1a246a08da5170f76a87)
* Fixed performance regression in inner product primitive with transposed weights on x64 CPUs (c5d2d090113c9798a8117d221b14d785ee693082)
* Updated benchdnn input files for matmul and convolution performance benchmarking (e80a1a8396b69fd126436235491f51f505b7da89, 96d72a9327f1e18b057562171a546fa083d32712, b9c9bcebef49835e71b7619f5d1e67184de7755d)
* Fixed an out of registers issue in SDPA fusion with Graph API on Intel GPUs (ba81382bb70b3fdda262d60f8f245e44620cd6f6)
* Fixed integer overflow in softmax primitive implementation for Intel GPUs (4a711d79e475eee2d50045188cf5b5397d9df1a6, b02cfa0deb54119c9293391bccd82ba293c4a29d, c557f33171d08b5842abc6b33b76420e89b191ab, ab64a9bf3cf31a128921ba31c35c6b4756635101)
* Fixed incorrect results in `f64` convolution weight gradient on Intel GPUs based on Xe-LPG architecture (adcb323e24b7e8c351f389757309c27d2256e88e, 3d1a7e47f323993c617ebd305a76b83008ff0d80)
* Removed in-place optimization for reorder in Graph API to avoid correctness issues (a6c3630674dacb8149296a8d7197b8f172642d34)
* Improved performance of `int8`, `f16`, and `bf16` convolution on processors with Intel AMX support (a418949386e401f462a339c08cdb0cda2fe7ddb4)
* Fixed a correctness issue in `f32` convolution with small number of input channels (3d1d9b49957c1d6f569986a12a890424ba8786f0, ada85c5d9a84e30167435a4e411d9e39a08b8070)
* Fixed a correctenss issue in matmul with binary post-op and non-trivial strides on x64 CPUs (f49f470314fbeab3d34eea8cdea132f9f2b7447a, 265df18f7a16f83be4b97618bda93e59e48d1dd0, 58925706d735cc8a021c59081e2b27014d4eb203)
* Fixed benchdnn graph driver test to support non-trivial strides (0232763f649b5ff069fbe79ed38b5998390f9c10, 662cbb38706b942b23081d1e1b06c5224252a545)
* Fixed a correctness issue in 3D grouped convolution weight gradient on Intel GPUs (8a7996b582cec0d7d71cb076c98f5bbee26828fe)
* Fixed a page fault issue in `f32` SDPA subgraph on Intel GPUs (98845e571f102e8a241a03d10816f0bc7af9cb56)
* Fixed a performance regression in `bf16` matmul on x64 CPUs with Intel AMX instruction set support (5b886e87c3a7d0846e7161b028dad88abd5a4d85, f3a79e7528dbde8c4312caa2a13e34b50b48cf8b, 52cc90014604e39307f8a10b4f4d291f7fed7acf, cf9a11e44f598bdf1802dd9346418c99b486b2ae)
* Fixed a segmentation fault in matmul on x64 processors with Intel AVX 10.2 and Intel AMX instruction set support (98aea2f2265d7a73b8f95b02e42b98fc60aa612e)
* Fixed correctness issue in SDPA subgraph with non-trivial strides for mask on Intel GPUs (0ccdfba1ded1010b4705e2724ac5f3862dba3785)
