### PR TITLE
matmul, benchdnn: support more scaling formats for grouped matmul

### DIFF
--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -422,9 +422,12 @@ The following are supported:
   - Weight Scales: column-wise (`mask = (1 << 0) | (1 << 2)`) and
     K-grouped (`mask = (1 << 0) | (1 << 1) | (1 << 2)`) with group specification
     are supported.
-  - Scale data type can be `f32`, `bf16`, `f16`, or `e8m0` (for MXFP8 and MXFP4
-    types following the OCP MX specification).
+  - Scale data type includes: `f32`, `bf16`, `f16`, `e8m0` for MXFP8 and MXFP4,
+    `f8_e4m3` for NVFP4 block scales.
 - Zero points attribute for weights tensors with the same masks as scales.
+- Post-ops: binary post-ops are supported (e.g., binary `mul` with a scalar
+  `f32` tensor can be used to apply a global scale factor, as needed for NVFP4
+  two-level scaling).
 - Bias supports per-expert shape.
 - Supported on CPU and GPU engines.
 

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -166,11 +166,10 @@ status_t grouped_matmul_attr_check(
     if (attr == nullptr) return status::success;
     if (attr->has_default_values()) return status::success;
 
-    // Grouped matmul supports scales, zero points and woq
-    // no other attributes or post-ops for now
+    // Grouped matmul supports scales, zero points, woq, and post-ops
     auto allowed_mask = smask_t::scales_data_type | smask_t::scales_groups
             | smask_t::fpmath_mode | smask_t::zero_points_data_type
-            | smask_t::zero_points_groups;
+            | smask_t::zero_points_groups | smask_t::post_ops;
     VCHECK_MATMUL_UNIMPL(
             attr->has_default_values(allowed_mask, desc.dst_desc.data_type),
             VERBOSE_UNSUPPORTED_ATTR);

--- a/src/cpu/matmul/ref_grouped_gemm.cpp
+++ b/src/cpu/matmul/ref_grouped_gemm.cpp
@@ -110,6 +110,8 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
                     data_type::s4, data_type::u4)
             && pd()->attr()->fpmath_.apply_to_int_;
 
+    const bool with_post_ops = !pd()->attr()->post_ops_.has_default_values();
+
     // Parallelize over groups (experts in MoE)
     // Expectation is to see 128-256+ groups, with varying M per group
     // and possibly some empty groups (M == 0)
@@ -269,6 +271,18 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
                 }
 
                 const dim_t dst_idx = dst_base_idx + m * N + n;
+
+                // Apply post-ops (binary mul for NVFP4 global scale)
+                if (with_post_ops) {
+                    ref_post_ops_t::args_t args;
+                    args.dst_val
+                            = io::load_float_value(dst_dt, dst_data, dst_idx);
+                    args.ctx = &ctx;
+                    args.l_offset = dst_idx;
+                    args.dst_md = pd()->dst_md();
+                    ref_post_ops->execute(result, args);
+                }
+
                 io::store_float_value(dst_dt, result, dst_data, dst_idx);
             }
         }

--- a/src/cpu/matmul/ref_grouped_gemm.hpp
+++ b/src/cpu/matmul/ref_grouped_gemm.hpp
@@ -28,6 +28,7 @@
 #include "common/utils.hpp"
 
 #include "cpu/matmul/cpu_matmul_pd.hpp"
+#include "cpu/primitive_attr_postops.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -99,7 +100,7 @@ struct ref_grouped_t : public primitive_t {
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
                 VDISPATCH_MATMUL(
                         utils::one_of(attr_scales.get_data_type(DNNL_ARG_SRC),
-                                f32, bf16, f16, e8m0),
+                                f32, bf16, f16, e8m0, f8_e4m3, f8_e5m2),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
                 if (!attr_scales.get(DNNL_ARG_SRC).has_default_groups()) {
                     // K-grouped src scales supported with int and fp types
@@ -118,9 +119,10 @@ struct ref_grouped_t : public primitive_t {
                 const int colwise_mask = wei_qmask_N();
                 const int blocked_mask = wei_qmask_K() | wei_qmask_N();
                 // Allow column-wise or blocked (K grouping) scales for weights
-                VDISPATCH_MATMUL(utils::one_of(attr_scales.get_data_type(
-                                                       DNNL_ARG_WEIGHTS),
-                                         f32, bf16, f16, e8m0),
+                VDISPATCH_MATMUL(
+                        utils::one_of(
+                                attr_scales.get_data_type(DNNL_ARG_WEIGHTS),
+                                f32, bf16, f16, e8m0, f8_e4m3, f8_e5m2),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
                 VDISPATCH_MATMUL(
                         wei_mask == colwise_mask || wei_mask == blocked_mask,
@@ -193,8 +195,17 @@ struct ref_grouped_t : public primitive_t {
                         (int)zp_gK);
             }
 
-            // No post-ops
-            VDISPATCH_MATMUL(attr()->post_ops_.has_default_values(),
+            // Post-ops: only binary mul is supported (for NVFP4 global scale)
+            const auto &po = attr()->post_ops_;
+            bool po_ok = true;
+            for (int i = 0; i < po.len(); ++i) {
+                const auto &e = po.entry_[i];
+                po_ok = po_ok && e.is_binary()
+                        && e.binary.alg == alg_kind::binary_mul;
+            }
+            VDISPATCH_MATMUL(po_ok, VERBOSE_UNSUPPORTED_POSTOP);
+            VDISPATCH_MATMUL(attr_.post_ops_.set_default_formats(dst_md(0))
+                            == status::success,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             return status::success;
@@ -203,10 +214,19 @@ struct ref_grouped_t : public primitive_t {
 
     ref_grouped_t(const pd_t *apd) : primitive_t(apd) {}
 
+    status_t init(engine_t *engine) override {
+        ref_post_ops
+                = utils::make_unique<ref_post_ops_t>(pd()->attr()->post_ops_);
+        if (!ref_post_ops) return status::out_of_memory;
+        CHECK(ref_post_ops->init(pd()->dst_md()));
+        return status::success;
+    }
+
     status_t execute(const exec_ctx_t &ctx) const override;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::unique_ptr<ref_post_ops_t> ref_post_ops;
 };
 
 } // namespace matmul

--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
@@ -20,6 +20,11 @@
 # - Grouped weight zero points: --attr-zero-points=wei:7:s8:32x1 (grouped along K)
 # - WOQ (weight-only quantization) with f16 activations and s4/u4/8-bit weights
 # - Transposed weights: --wtag=acb (weights layout [num_experts, N, K] vs abc [num_experts, K, N])
+# - FP8 row-wise: f8_e5m2/f8_e4m3 dtypes with row-wise src + column-wise wei f32 scales
+# - MXFP8: f8_e4m3 dtypes, e8m0 block scales, block size 32
+# - MXFP4: f4_e2m1 dtypes, e8m0 block scales, block size 32
+# - NVFP4: f4_e2m1 dtypes, f8_e4m3 block scales (block size 16) + global f32 scale via
+#           binary mul post-op (--attr-post-ops=mul:f32:0)
 
 --reset
 
@@ -157,4 +162,13 @@
 --wtag=abc,acb
 --grouped=0:4:8,8,8,8
 --attr-scales=src:3:e8m0:1x32+wei:7:e8m0:32x1
+32x128:4x128x64
+
+# NVFP4: f4_e2m1 dt with f8_e4m3 block scales + global f32 scale via binary mul
+--reset
+--dt=f4_e2m1:f4_e2m1:bf16
+--wtag=abc,acb
+--grouped=0:4:8,8,8,8
+--attr-scales=src:3:f8_e4m3:1x16+wei:7:f8_e4m3:16x1
+--attr-post-ops=mul:f32:0
 32x128:4x128x64


### PR DESCRIPTION
Second part of [MFDNN-14729](https://jira.devtools.intel.com/browse/MFDNN-14729), should cover the next configurations for CPU ref and testing:
- fp8 row-wise src/col-wise wei scales
- mxfp4,8 src/wei scales (stored as `[M, K/32]`)
- nvfp4 src/wei scales (stored as `[M, K/16]` + extra f32 global scale, that is stored on the device)