### PR TITLE
ci: aarch64: bump performance baseline version to v3.11

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -3,6 +3,6 @@
         "acl": "v52.4.0",
         "gcc": "13",
         "clang": "17",
-        "onednn-base": "v3.9"
+        "onednn-base": "v3.11"
     }
 }


### PR DESCRIPTION
# Description

Bump performance baseline version to v3.11