### PR TITLE
benchdnn: replace memset with GPU random data generation

### DIFF
--- a/src/gpu/intel/fill_random.cl
+++ b/src/gpu/intel/fill_random.cl
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/include/philox.h"
+
+// Fills a buffer with pseudo-random data using Philox RNG and subgroup block
+// writes. Each subgroup (16 work-items) writes 256 bytes.
+#define SG_SIZE 16
+#define BYTES_PER_SG (SG_SIZE * 4 * 4)
+
+__attribute__((intel_reqd_sub_group_size(SG_SIZE))) __kernel void fill_random(
+        __global uchar *buf, uint seed, ulong byte_count) {
+    const ulong base = (get_global_id(0) / SG_SIZE) * BYTES_PER_SG;
+    if (base >= byte_count) return;
+
+    const uint b = (uint)get_global_id(0) * 4;
+    uchar16 rnd
+            = as_uchar16(philox_4x32_vec4(b, b ^ seed) & (uint4)(0xEEEEEEEEu));
+
+    if (base + BYTES_PER_SG <= byte_count) {
+        intel_sub_group_block_write_uc16(buf + base, rnd);
+        return;
+    }
+
+    const uint lid = get_sub_group_local_id();
+    unroll_for(int i = 0; i < 16; i++) {
+        ulong off = base + lid + (ulong)i * SG_SIZE;
+        if (off < byte_count) buf[off] = rnd[i];
+    }
+}

--- a/src/gpu/intel/fill_random.cpp
+++ b/src/gpu/intel/fill_random.cpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <mutex>
+#include <unordered_map>
+
+#include "common/c_types_map.hpp"
+#include "common/utils.hpp"
+
+#include "gpu/intel/compute/kernel.hpp"
+#include "gpu/intel/compute/kernel_ctx.hpp"
+#include "gpu/intel/engine.hpp"
+#include "gpu/intel/stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+
+static status_t get_cached_kernel(
+        intel::engine_t *engine, compute::kernel_t &kernel) {
+    static std::unordered_map<engine_id_t, compute::kernel_t> cache;
+    static std::mutex mutex;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    auto it = cache.find(engine->engine_id());
+    if (it != cache.end()) {
+        kernel = it->second;
+        return status::success;
+    }
+
+    compute::kernel_ctx_t ctx;
+    std::vector<compute::kernel_t> kernels;
+    CHECK(engine->create_kernels(&kernels, {"fill_random"}, ctx));
+    kernel = cache.emplace(engine->engine_id(), kernels[0]).first->second;
+    return status::success;
+}
+
+status_t fill_random(impl::stream_t *stream, size_t size,
+        impl::memory_t *memory, int buffer_index, uint32_t seed) {
+    if (size == 0) return status::success;
+
+    auto *intel_stream = utils::downcast<intel::stream_t *>(stream);
+    auto *intel_engine = utils::downcast<intel::engine_t *>(stream->engine());
+    compute::kernel_t kernel;
+    CHECK(get_cached_kernel(intel_engine, kernel));
+
+    // Each subgroup (16 work-items) processes 256 bytes (16 * 4 * sizeof(uint)).
+    static constexpr size_t subgroup_size = 16;
+    static constexpr size_t bytes_per_subgroup
+            = subgroup_size * 4 * sizeof(uint32_t);
+    size_t num_subgroups = utils::div_up(size, bytes_per_subgroup);
+    compute::nd_range_t nd_range({num_subgroups * subgroup_size, 1, 1});
+    compute::kernel_arg_list_t arg_list;
+    arg_list.set(0, *memory->memory_storage(buffer_index));
+    arg_list.set(1, seed);
+    arg_list.set(2, static_cast<uint64_t>(size));
+
+    CHECK(kernel.parallel_for(*stream, nd_range, arg_list,
+            intel_stream->ctx().get_deps(), intel_stream->ctx().get_deps()));
+    return status::success;
+}
+
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+extern "C" dnnl::impl::status_t DNNL_API dnnl_impl_gpu_fill_random(
+        dnnl::impl::stream_t *stream, size_t size, dnnl::impl::memory_t *memory,
+        int buffer_index, uint32_t seed) {
+    return dnnl::impl::gpu::intel::fill_random(
+            stream, size, memory, buffer_index, seed);
+}

--- a/src/gpu/intel/include/philox.h
+++ b/src/gpu/intel/include/philox.h
@@ -20,7 +20,7 @@
 #define DT_UNDEF 1
 #include "gpu/intel/include/types.h"
 
-uint philox_4x32_s64(ulong idx, ulong seed, ulong offset) {
+uint4 philox_4x32_s64_vec4(ulong idx, ulong seed, ulong offset) {
 #define PHILOX_4UINT_ROUND(mul, ctr, key) \
     as_uint4(convert_ulong2(ctr.s02) * mul).s3210 \
             ^ (uint4)(ctr.s1 ^ key.s0, 0, ctr.s3 ^ key.s1, 0)
@@ -50,7 +50,11 @@ uint philox_4x32_s64(ulong idx, ulong seed, ulong offset) {
     ctr = PHILOX_4UINT_ROUND(PHILOX_M4x32, ctr, key0.sEF);
     ctr = PHILOX_4UINT_ROUND(PHILOX_M4x32, ctr, key1.s01);
     ctr = PHILOX_4UINT_ROUND(PHILOX_M4x32, ctr, key1.s23);
-    return ctr[idx & 3L];
+    return ctr;
+}
+
+uint philox_4x32_s64(ulong idx, ulong seed, ulong offset) {
+    return philox_4x32_s64_vec4(idx, seed, offset)[idx & 3L];
 }
 
 uint philox_4x32(uint idx, uint seed) {
@@ -60,6 +64,14 @@ uint philox_4x32(uint idx, uint seed) {
     ulong offset_64 = ((x + 1) << 32) + x;
     ulong seed_64 = ((ulong)(seed) << 32) + seed;
     return philox_4x32_s64(idx_64, seed_64, offset_64);
+}
+
+uint4 philox_4x32_vec4(uint idx, uint seed) {
+    ulong x = idx & ~3L;
+    ulong idx_64 = ((x + 3) << 32) + (x + 2);
+    ulong offset_64 = ((x + 1) << 32) + x;
+    ulong seed_64 = ((ulong)(seed) << 32) + seed;
+    return philox_4x32_s64_vec4(idx_64, seed_64, offset_64);
 }
 
 ushort philox_8x16(long idx, uint seed) {

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -629,6 +629,29 @@ void dnn_mem_t::memset(int value, size_t size, int buffer_index) const {
     SAFE_V(FAIL);
 }
 
+#if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
+        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
+extern "C" dnnl_status_t dnnl_impl_gpu_fill_random(dnnl_stream_t stream,
+        size_t size, dnnl_memory_t memory, int buffer_index, uint32_t seed);
+
+// Fills buffer with pseudo-random data generated directly on the device.
+// This mitigates GPU driver data compression, which could otherwise yield
+// unrealistically high bandwidth measurements in mode=F (e.g., via memset).
+int dnn_mem_t::gpu_fill_random(size_t size, int buffer_index) const {
+    if (is_cpu(engine_)) {
+        BENCHDNN_PRINT(0, "%s\n", "gpu_fill_random called with CPU engine");
+        return FAIL;
+    }
+    static constexpr uint32_t seed = 123456789;
+    auto mem = m_padded_ ? m_padded_ : m_;
+    stream_t stream(engine_);
+    DNN_SAFE(dnnl_impl_gpu_fill_random(stream, size, mem, buffer_index, seed),
+            WARN);
+    DNN_SAFE(dnnl_stream_wait(stream), WARN);
+    return OK;
+}
+#endif
+
 dnn_mem_t dnn_mem_t::create_from_host_ptr(
         const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr) {
     // Pre-allocated handle_info won't use prefill no matter what.
@@ -973,8 +996,19 @@ int dnn_mem_t::initialize(
             if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
                     || cold_cache_input.cold_cache_mode_
                             != default_cold_cache_input().cold_cache_mode_) {
-                // Fill memory directly with 0x3F3F3F3F (0.747059f) number.
+#if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
+        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
+                if (!is_cpu(engine_))
+                    // Fill memory with pseudo-random data directly on device
+                    // to avoid data compression.
+                    SAFE(this->gpu_fill_random(sz, i), WARN);
+                else
+                    // Fill memory directly with 0x3F3F3F3F (0.747059f).
+                    this->memset(dnnl_mem_default_perf_test_value, sz, i);
+#else
+                // Fill memory directly with 0x3F3F3F3F (0.747059f).
                 this->memset(dnnl_mem_default_perf_test_value, sz, i);
+#endif
             } else {
                 // Fill memory with a magic number (NAN for fp data types)
                 // to catch possible uninitialized access.

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -176,6 +176,10 @@ struct dnn_mem_t {
     void map() const;
     void unmap() const;
     void memset(int value, size_t size, int buffer_index) const;
+#if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
+        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
+    int gpu_fill_random(size_t size, int buffer_index) const;
+#endif
 
     static dnn_mem_t create_from_host_ptr(
             const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr);


### PR DESCRIPTION
### This PR cherry-picks commit [`benchdnn: replace memset with GPU random data generation`](https://github.com/uxlfoundation/oneDNN/pull/4699/commits/0aa58e812534ca77b3e25f2938f019f2a2854a59) from [PR #4699](https://github.com/uxlfoundation/oneDNN/pull/4699) into the [`rls-v3.11`](https://github.com/uxlfoundation/oneDNN/tree/rls-v3.11) reference branch.

JIRA: [MFDNN-14787](https://jira.devtools.intel.com/browse/MFDNN-14787)

---

### Problem Description

After [PR4699](https://github.com/uxlfoundation/oneDNN/pull/4699) was merged into [`main`](https://github.com/uxlfoundation/oneDNN/tree/main), benchdnn in `mode=f` now reports **realistic performance numbers and bandwidth** instead of previously **artificially inflated results** caused by data compression (uniform `memset` pattern like `0x3F3F3F3F...` is easily compressed by modern GPU drivers).

As a consequence, many `mode=f` benchmarks on [`main`](https://github.com/uxlfoundation/oneDNN/tree/main) now accurately represent **actual hardware performance** and are no longer falsely elevated. However, this creates a problem in CI pipelines: when current ([`main`](https://github.com/uxlfoundation/oneDNN/tree/main)) results are compared against the [`rls-v3.11`](https://github.com/uxlfoundation/oneDNN/tree/rls-v3.11) baseline — which still contains the old compressible `memset`. These regressions are **not real**; they are purely an artifact of comparing correct measurements against an inaccurate baseline.

### Proposed Solution

To eliminate these false regression signals, this PR backports the relevant commit to the [`rls-v3.11`](https://github.com/uxlfoundation/oneDNN/tree/rls-v3.11) reference branch to align the data generation method on both branches. The performance baseline on [`rls-v3.11`](https://github.com/uxlfoundation/oneDNN/tree/rls-v3.11) will also reflect realistic hardware behavior, ensuring that CI comparisons between versions produce **meaningful and accurate regression detection**.

- **Cherry-picked from:** [`0aa58e81`](https://github.com/uxlfoundation/oneDNN/pull/4699/commits/0aa58e812534ca77b3e25f2938f019f2a2854a59) (part of [PR4699](https://github.com/uxlfoundation/oneDNN/pull/4699)).
- **Root cause of false regressions:** `memset`-filled buffers were highly compressible by GPU hardware, resulting in artificially high bandwidth and performance numbers in the baseline.

### Results

| Mode       | Bandwidth (GB/s)               | Fill Time        | Exec Time                    | Total Time |
|------------|--------------------------------|------------------|------------------------------|------------|
| `--mode=F` (v3.11.1) | $1143.8 \texttt{ GB/s}$ (inflated ❌) | $0.00 \texttt{s}$ (fast ⚡) | $3.75 \texttt{ms}$ (deflated ❌) | $0.28 \texttt{s}$ |
| `--mode=F` (v3.11.1 + [cp](https://github.com/uxlfoundation/oneDNN/pull/4699/commits/0aa58e812534ca77b3e25f2938f019f2a2854a59)) | $404.1 \texttt{ GB/s}$ (realistic ✅) | $0.00 \texttt{s}$ (fast ⚡) | $10.62 \texttt{ms}$ (realistic ✅) | $0.31 \texttt{s}$ |

<details>
<summary><small><small>Commands used (click to open)</small></small></summary>

```bash
benchdnn.exe --mode=f --eltwise --perf-template=perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%-Gbw% --engine=gpu --dt=f16 --alg=relu 32768x32768
```

</details>