### PR TITLE
[GPU] Tweak convolution plan

### DIFF
--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -1978,17 +1978,17 @@ public:
         }
         if (status == plan_status_t::success) return status::success;
 
-        if (a_direct_view_ || b_direct_view_) {
-            gpu_trace() << "Retry plan initialization without direct view";
-            enable_direct_view(false);
-            status = try_init_plan();
-            if (status == plan_status_t::success) return status::success;
-        }
-
         if ((use_slm(abc_kind_t::a) || use_slm(abc_kind_t::b))
                 && !cfg_.slm().is_overridden()) {
             gpu_trace() << "Retry plan initialization without SLM";
             enable_slm(false);
+            status = try_init_plan();
+            if (status == plan_status_t::success) return status::success;
+        }
+
+        if (a_direct_view_ || b_direct_view_) {
+            gpu_trace() << "Retry plan initialization without direct view";
+            enable_direct_view(false);
             status = try_init_plan();
             if (status == plan_status_t::success) return status::success;
         }


### PR DESCRIPTION
Jira: [MFDNN-14766](https://jira.devtools.intel.com/browse/MFDNN-14766)

The original regression is due to the layout normalization changes. This resulted in some previously rejected configs to be enabled which caused the regression.

The PR includes two changes:

- Convolution plan tweak to prioritize the direct view optimization higher than SLM during retries
- Relaxed `mad` layout check for f16/bf16 types
    - In particular for "direct view" layouts we usually have overlapped blocks (same stride). Any of these two blocks are now checked during the vectorized dimension check