### PR TITLE
doc: specified primitive arguments mutability

### DIFF
--- a/doc/primitives/batch_normalization.md
+++ b/doc/primitives/batch_normalization.md
@@ -111,21 +111,24 @@ requires different inputs and outputs.  For clarity, a summary is shown below.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive Input/Output    | Execution Argument Index |
-|---------------------------|--------------------------|
-| \src                      | DNNL_ARG_SRC             |
-| \f$\src_1\f$              | DNNL_ARG_SRC_1           |
-| \f$\gamma\f$              | DNNL_ARG_SCALE           |
-| \f$\beta\f$               | DNNL_ARG_SHIFT           |
-| mean (\f$\mu\f$)          | DNNL_ARG_MEAN            |
-| variance (\f$\sigma^2\f$) | DNNL_ARG_VARIANCE        |
-| \dst                      | DNNL_ARG_DST             |
-| workspace                 | DNNL_ARG_WORKSPACE       |
-| \diffdst                  | DNNL_ARG_DIFF_DST        |
-| \diffsrc                  | DNNL_ARG_DIFF_SRC        |
-| \f$\diffsrc_1\f$          | DNNL_ARG_DIFF_SRC_1      |
-| \f$\diffgamma\f$          | DNNL_ARG_DIFF_SCALE      |
-| \f$\diffbeta\f$           | DNNL_ARG_DIFF_SHIFT      |
+| Argument                  | Index                    | Type         |
+|---------------------------|--------------------------|--------------|
+| \src                      | DNNL_ARG_SRC             | Input        |
+| \f$\src_1\f$              | DNNL_ARG_SRC_1           | Input        |
+| \f$\gamma\f$              | DNNL_ARG_SCALE           | Input        |
+| \f$\beta\f$               | DNNL_ARG_SHIFT           | Input        |
+| mean (\f$\mu\f$)          | DNNL_ARG_MEAN            | Input/Output |
+| variance (\f$\sigma^2\f$) | DNNL_ARG_VARIANCE        | Input/Output |
+| \dst                      | DNNL_ARG_DST             | Output       |
+| workspace                 | DNNL_ARG_WORKSPACE       | Input/Output |
+| \diffdst                  | DNNL_ARG_DIFF_DST        | Input        |
+| \diffsrc                  | DNNL_ARG_DIFF_SRC        | Output       |
+| \f$\diffsrc_1\f$          | DNNL_ARG_DIFF_SRC_1      | Output       |
+| \f$\diffgamma\f$          | DNNL_ARG_DIFF_SCALE      | Output       |
+| \f$\diffbeta\f$           | DNNL_ARG_DIFF_SHIFT      | Output       |
+| [scratchpad]              | DNNL_ARG_SCRATCHPAD      | Output       |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/binary.md
+++ b/doc/primitives/binary.md
@@ -36,16 +36,19 @@ The binary primitive does not have a notion of forward or backward propagations.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \f$\src_0\f$                | DNNL_ARG_SRC_0                                                            |
-| \f$\src_1\f$                | DNNL_ARG_SRC_1                                                            |
-| \f$\src_2\f$                | DNNL_ARG_SRC_2                                                            |
-| \dst                        | DNNL_ARG_DST                                                              |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
-| \f$binary scale0\f$         | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC_0                                    |
-| \f$binary scale1\f$         | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC_1                                    |
+| Argument                    | Index                                                                     | Type   |
+|-----------------------------|---------------------------------------------------------------------------|--------|
+| \f$\src_0\f$                | DNNL_ARG_SRC_0                                                            | Input  |
+| \f$\src_1\f$                | DNNL_ARG_SRC_1                                                            | Input  |
+| \f$\src_2\f$                | DNNL_ARG_SRC_2                                                            | Input  |
+| \dst                        | DNNL_ARG_DST                                                              | Output |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input  |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input  |
+| \f$binary scale0\f$         | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC_0                                    | Input  |
+| \f$binary scale1\f$         | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC_1                                    | Input  |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/concat.md
+++ b/doc/primitives/concat.md
@@ -27,10 +27,13 @@ simply an identity operation.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output | Execution argument index |
-|------------------------|--------------------------|
-| \src                   | DNNL_ARG_MULTIPLE_SRC    |
-| \dst                   | DNNL_ARG_DST             |
+| Argument     | Index                 | Type   |
+|--------------|-----------------------|--------|
+| \src         | DNNL_ARG_MULTIPLE_SRC | Input  |
+| \dst         | DNNL_ARG_DST          | Output |
+| [scratchpad] | DNNL_ARG_SCRATCHPAD   | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -141,20 +141,23 @@ update.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                   |
-|-----------------------------|----------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                               |
-| \weights                    | DNNL_ARG_WEIGHTS                                                           |
-| \bias                       | DNNL_ARG_BIAS                                                              |
-| \dst                        | DNNL_ARG_DST                                                               |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                          |
-| \diffweights                | DNNL_ARG_DIFF_WEIGHTS                                                      |
-| \diffbias                   | DNNL_ARG_DIFF_BIAS                                                         |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                          |
-| \f$depthwise\f$             | DNNL_ARG_ATTR_POST_OP_DW                                                   |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1, |
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  |
-| \f$\text{prelu post-op}\f$  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS |
+| Argument                    | Index                                                                      | Type   |
+|-----------------------------|----------------------------------------------------------------------------|:-------|
+| \src                        | DNNL_ARG_SRC                                                               | Input  |
+| \weights                    | DNNL_ARG_WEIGHTS                                                           | Input  |
+| \bias                       | DNNL_ARG_BIAS                                                              | Input  |
+| \dst                        | DNNL_ARG_DST                                                               | Output |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                          | Output |
+| \diffweights                | DNNL_ARG_DIFF_WEIGHTS                                                      | Output |
+| \diffbias                   | DNNL_ARG_DIFF_BIAS                                                         | Output |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                          | Input  |
+| \f$depthwise\f$             | DNNL_ARG_ATTR_POST_OP_DW                                                   | Input  |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1  | Input  |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  | Input  |
+| \f$\text{prelu post-op}\f$  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS | Input  |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                        | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/eltwise.md
+++ b/doc/primitives/eltwise.md
@@ -78,14 +78,17 @@ propagation.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                              |
-| \dst                        | DNNL_ARG_DST                                                              |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
+| Argument                    | Index                                                                     | Type   |
+|-----------------------------|---------------------------------------------------------------------------|--------|
+| \src                        | DNNL_ARG_SRC                                                              | Input  |
+| \dst                        | DNNL_ARG_DST                                                              | Output |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         | Output |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                         | Input  |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input  |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input  |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/group_normalization.md
+++ b/doc/primitives/group_normalization.md
@@ -97,20 +97,23 @@ requires different inputs and outputs.  For clarity, a summary is shown below.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive Input/Output      | Execution Argument Index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                              |
-| \f$\gamma\f$                | DNNL_ARG_SCALE                                                            |
-| \f$\beta\f$                 | DNNL_ARG_SHIFT                                                            |
-| mean (\f$\mu\f$)            | DNNL_ARG_MEAN                                                             |
-| variance (\f$\sigma^2\f$)   | DNNL_ARG_VARIANCE                                                         |
-| \dst                        | DNNL_ARG_DST                                                              |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
-| \f$\diffgamma\f$            | DNNL_ARG_DIFF_SCALE                                                       |
-| \f$\diffbeta\f$             | DNNL_ARG_DIFF_SHIFT                                                       |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
+| Argument                    | Index                                                                     | Type         |
+|-----------------------------|---------------------------------------------------------------------------|--------------|
+| \src                        | DNNL_ARG_SRC                                                              | Input        |
+| \f$\gamma\f$                | DNNL_ARG_SCALE                                                            | Input        |
+| \f$\beta\f$                 | DNNL_ARG_SHIFT                                                            | Input        |
+| mean (\f$\mu\f$)            | DNNL_ARG_MEAN                                                             | Input/Output |
+| variance (\f$\sigma^2\f$)   | DNNL_ARG_VARIANCE                                                         | Input/Output |
+| \dst                        | DNNL_ARG_DST                                                              | Output       |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                         | Input        |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         | Output       |
+| \f$\diffgamma\f$            | DNNL_ARG_DIFF_SCALE                                                       | Output       |
+| \f$\diffbeta\f$             | DNNL_ARG_DIFF_SHIFT                                                       | Output       |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input        |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input        |
+| [scratchpad][]              | DNNL_ARG_SCRATCHPAD                                                       | Output       |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/inner_product.md
+++ b/doc/primitives/inner_product.md
@@ -49,19 +49,22 @@ update.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                   |
-|-----------------------------|----------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                               |
-| \weights                    | DNNL_ARG_WEIGHTS                                                           |
-| \bias                       | DNNL_ARG_BIAS                                                              |
-| \dst                        | DNNL_ARG_DST                                                               |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                          |
-| \diffweights                | DNNL_ARG_DIFF_WEIGHTS                                                      |
-| \diffbias                   | DNNL_ARG_DIFF_BIAS                                                         |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                          |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1, |
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  |
-| \f$\text{prelu post-op}\f$  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS |
+| Argument                    | Index                                                                      | Type   |
+|-----------------------------|----------------------------------------------------------------------------|--------|
+| \src                        | DNNL_ARG_SRC                                                               | Input  |
+| \weights                    | DNNL_ARG_WEIGHTS                                                           | Input  |
+| \bias                       | DNNL_ARG_BIAS                                                              | Input  |
+| \dst                        | DNNL_ARG_DST                                                               | Output |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                          | Output |
+| \diffweights                | DNNL_ARG_DIFF_WEIGHTS                                                      | Output |
+| \diffbias                   | DNNL_ARG_DIFF_BIAS                                                         | Output |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                          | Input  |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1  | Input  |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  | Input  |
+| \f$\text{prelu post-op}\f$  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS | Input  |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                        | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/layer_normalization.md
+++ b/doc/primitives/layer_normalization.md
@@ -114,22 +114,25 @@ requires different inputs and outputs. For clarity, a summary is shown below.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                              |
-| \f$\gamma\f$                | DNNL_ARG_SCALE                                                            |
-| \f$\beta\f$                 | DNNL_ARG_SHIFT                                                            |
-| mean (\f$\mu\f$)            | DNNL_ARG_MEAN                                                             |
-| variance* (\f$\sigma\f$)    | DNNL_ARG_VARIANCE                                                         |
-| \dst                        | DNNL_ARG_DST                                                              |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
-| \diffgamma                  | DNNL_ARG_DIFF_SCALE                                                       |
-| \diffbeta                   | DNNL_ARG_DIFF_SHIFT                                                       |
-| \f$src scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC                                      |
-| \f$dst scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_DST                                      |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
+| Argument                    | Index                                                                     | Type         |
+|-----------------------------|---------------------------------------------------------------------------|--------------|
+| \src                        | DNNL_ARG_SRC                                                              | Input        |
+| \f$\gamma\f$                | DNNL_ARG_SCALE                                                            | Input        |
+| \f$\beta\f$                 | DNNL_ARG_SHIFT                                                            | Input        |
+| mean (\f$\mu\f$)            | DNNL_ARG_MEAN                                                             | Input/Output |
+| variance* (\f$\sigma\f$)    | DNNL_ARG_VARIANCE                                                         | Input/Output |
+| \dst                        | DNNL_ARG_DST                                                              | Output       |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                         | Input        |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         | Output       |
+| \diffgamma                  | DNNL_ARG_DIFF_SCALE                                                       | Output       |
+| \diffbeta                   | DNNL_ARG_DIFF_SHIFT                                                       | Output       |
+| \f$src scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC                                      | Input        |
+| \f$dst scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_DST                                      | Input        |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input        |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input        |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output       |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 The variance is marked with an asterisk because, for RMS normalization, the root
 mean square statistic is computed in place of the variance.

--- a/doc/primitives/lrn.md
+++ b/doc/primitives/lrn.md
@@ -52,14 +52,16 @@ The backward propagation computes \f$\diffsrc(n, c, h, w)\f$, based on
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output | Execution argument index |
-|------------------------|--------------------------|
-| \src                   | DNNL_ARG_SRC             |
-| \dst                   | DNNL_ARG_DST             |
-| workspace              | DNNL_ARG_WORKSPACE       |
-| \diffsrc               | DNNL_ARG_DIFF_SRC        |
-| \diffdst               | DNNL_ARG_DIFF_DST        |
+| Argument     | Index               | Type         |
+|--------------|---------------------|--------------|
+| \src         | DNNL_ARG_SRC        | Input        |
+| \dst         | DNNL_ARG_DST        | Output       |
+| workspace    | DNNL_ARG_WORKSPACE  | Input/Output |
+| \diffsrc     | DNNL_ARG_DIFF_SRC   | Output       |
+| \diffdst     | DNNL_ARG_DIFF_DST   | Input        |
+| [scratchpad] | DNNL_ARG_SCRATCHPAD | Output       |
 
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -44,18 +44,21 @@ dimension, the following constraint must hold true:
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output           | Execution argument index                                                   |
-|----------------------------------|----------------------------------------------------------------------------|
-| \src                             | #DNNL_ARG_SRC                                                               |
-| \weights                         | #DNNL_ARG_WEIGHTS                                                           |
-| \bias                            | #DNNL_ARG_BIAS                                                              |
-| \dst                             | #DNNL_ARG_DST                                                               |
-| \f$\text{dropout output mask}\f$ | #DNNL_ARG_ATTR_DROPOUT_MASK                                                 |
-| \f$\text{dropout probability}\f$ | #DNNL_ARG_ATTR_DROPOUT_PROBABILITY                                          |
-| \f$\text{dropout rng seed}\f$    | #DNNL_ARG_ATTR_DROPOUT_SEED                                                 |
-| \f$\text{binary post-op}\f$      | #DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| #DNNL_ARG_SRC_1, |
-|                                  | #DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| #DNNL_ARG_SRC_2  |
-| \f$\text{prelu post-op}\f$       | #DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| #DNNL_ARG_WEIGHTS |
+| Argument                         | Index                                                                      | Type   |
+|----------------------------------|----------------------------------------------------------------------------|--------|
+| \src                             | DNNL_ARG_SRC                                                               | Input  |
+| \weights                         | DNNL_ARG_WEIGHTS                                                           | Input  |
+| \bias                            | DNNL_ARG_BIAS                                                              | Input  |
+| \dst                             | DNNL_ARG_DST                                                               | Output |
+| \f$\text{dropout output mask}\f$ | DNNL_ARG_ATTR_DROPOUT_MASK                                                 | Output |
+| \f$\text{dropout probability}\f$ | DNNL_ARG_ATTR_DROPOUT_PROBABILITY                                          | Input  |
+| \f$\text{dropout rng seed}\f$    | DNNL_ARG_ATTR_DROPOUT_SEED                                                 | Input  |
+| \f$\text{binary post-op}\f$      | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1  | Input  |
+|                                  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  | Input  |
+| \f$\text{prelu post-op}\f$       | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS | Input  |
+| [scratchpad]                     | DNNL_ARG_SCRATCHPAD                                                        | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/pooling.md
+++ b/doc/primitives/pooling.md
@@ -61,15 +61,18 @@ case of max pooling) `workspace`.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                              |
-| \dst                        | DNNL_ARG_DST                                                              |
-| workspace                   | DNNL_ARG_WORKSPACE                                                        |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
+| Argument                    | Index                                                                     | Type         |
+|-----------------------------|---------------------------------------------------------------------------|--------------|
+| \src                        | DNNL_ARG_SRC                                                              | Input        |
+| \dst                        | DNNL_ARG_DST                                                              | Output       |
+| workspace                   | DNNL_ARG_WORKSPACE                                                        | Input/Output |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         | Output       |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                         | Input        |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input        |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input        |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output       |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/prelu.md
+++ b/doc/primitives/prelu.md
@@ -77,14 +77,17 @@ dimensions, since \f$\diffweights\f$ tensor must match \f$\weights\f$ tensor.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output | Execution argument index |
-|------------------------|--------------------------|
-| \f$\src\f$             | DNNL_ARG_SRC             |
-| \f$\dst\f$             | DNNL_ARG_DST             |
-| \f$\weights\f$         | DNNL_ARG_WEIGHTS         |
-| \f$\diffsrc\f$         | DNNL_ARG_DIFF_SRC        |
-| \f$\diffdst\f$         | DNNL_ARG_DIFF_DST        |
-| \f$\diffweights\f$     | DNNL_ARG_DIFF_WEIGHTS    |
+| Argument           | Index                 | Type   |
+|--------------------|-----------------------|--------|
+| \f$\src\f$         | DNNL_ARG_SRC          | Input  |
+| \f$\weights\f$     | DNNL_ARG_WEIGHTS      | Input  |
+| \f$\dst\f$         | DNNL_ARG_DST          | Output |
+| \f$\diffsrc\f$     | DNNL_ARG_DIFF_SRC     | Output |
+| \f$\diffdst\f$     | DNNL_ARG_DIFF_DST     | Input  |
+| \f$\diffweights\f$ | DNNL_ARG_DIFF_WEIGHTS | Output |
+| [scratchpad]       | DNNL_ARG_SCRATCHPAD   | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 
 ## Implementation Details

--- a/doc/primitives/reduction.md
+++ b/doc/primitives/reduction.md
@@ -57,12 +57,15 @@ where \f$eps\_op\f$ can be max and sum.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                              |
-| \dst                        | DNNL_ARG_DST                                                              |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
+| Argument                    | Index                                                                     | Type         |
+|-----------------------------|---------------------------------------------------------------------------|--------------|
+| \src                        | DNNL_ARG_SRC                                                              | Input        |
+| \dst                        | DNNL_ARG_DST                                                              | Output       |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input        |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input        |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output       |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/reorder.md
+++ b/doc/primitives/reorder.md
@@ -30,12 +30,15 @@ quantize the data (and if necessary change the memory format simultaneously).
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output | Execution argument index              |
-|------------------------|---------------------------------------|
-| \src                   | DNNL_ARG_FROM                         |
-| \dst                   | DNNL_ARG_TO                           |
-| \f$src scale\f$        | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_FROM |
-| \f$dst scale\f$        | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_TO   |
+| Argument        | Index                                 | Type   |
+|-----------------|---------------------------------------|--------|
+| \src            | DNNL_ARG_FROM                         | Input  |
+| \dst            | DNNL_ARG_TO                           | Output |
+| \f$src scale\f$ | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_FROM | Input  |
+| \f$dst scale\f$ | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_TO   | Input  |
+| [scratchpad]    | DNNL_ARG_SCRATCHPAD                   | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/resampling.md
+++ b/doc/primitives/resampling.md
@@ -84,14 +84,17 @@ The backward propagation computes \diffsrc based on \diffdst.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                              |
-| \dst                        | DNNL_ARG_DST                                                              |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
+| Argument                    | Index                                                                     | Type   |
+|-----------------------------|---------------------------------------------------------------------------|--------|
+| \src                        | DNNL_ARG_SRC                                                              | Input  |
+| \dst                        | DNNL_ARG_DST                                                              | Output |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         | Output |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                         | Input  |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input  |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input  |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/rnn.md
+++ b/doc/primitives/rnn.md
@@ -350,33 +350,36 @@ flag is set weight gradients will be initialized by zeros by the RNN primitive.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output | Execution argument index          |
-|------------------------|-----------------------------------|
-| \srclayer              | DNNL_ARG_SRC_LAYER                |
-| \srclayerattention     | DNNL_ARG_SRC_LAYER_ATTENTION      |
-| \srciter               | DNNL_ARG_SRC_ITER                 |
-| \srciterc              | DNNL_ARG_SRC_ITER_C               |
-| \weightslayer          | DNNL_ARG_WEIGHTS_LAYER            |
-| \weightsiter           | DNNL_ARG_WEIGHTS_ITER             |
-| \weightspeephole       | DNNL_ARG_WEIGHTS_PEEPHOLE         |
-| \weightsprojection     | DNNL_ARG_WEIGHTS_PROJECTION       |
-| \bias                  | DNNL_ARG_BIAS                     |
-| \dstlayer              | DNNL_ARG_DST_LAYER                |
-| \dstiter               | DNNL_ARG_DST_ITER                 |
-| \dstiterc              | DNNL_ARG_DST_ITER_C               |
-| \workspace             | DNNL_WORKSPACE                    |
-| \diffsrclayer          | DNNL_ARG_DIFF_SRC_LAYER           |
-| \diffsrclayerattention | DNNL_ARG_DIFF_SRC_LAYER_ATTENTION |
-| \diffsrciter           | DNNL_ARG_DIFF_SRC_ITER            |
-| \diffsrciterc          | DNNL_ARG_DIFF_SRC_ITER_C          |
-| \diffweightslayer      | DNNL_ARG_DIFF_WEIGHTS_LAYER       |
-| \diffweightsiter       | DNNL_ARG_DIFF_WEIGHTS_ITER        |
-| \diffweightspeephole   | DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE    |
-| \diffweightsprojection | DNNL_ARG_DIFF_WEIGHTS_PROJECTION  |
-| \diffbias              | DNNL_ARG_DIFF_BIAS                |
-| \diffdstlayer          | DNNL_ARG_DIFF_DST_LAYER           |
-| \diffdstiter           | DNNL_ARG_DIFF_DST_ITER            |
-| \diffdstiterc          | DNNL_ARG_DIFF_DST_ITER_C          |
+| Argument               | Index                             | Type         |
+|------------------------|-----------------------------------|--------------|
+| \srclayer              | DNNL_ARG_SRC_LAYER                | Input        |
+| \srclayerattention     | DNNL_ARG_SRC_LAYER_ATTENTION      | Input        |
+| \srciter               | DNNL_ARG_SRC_ITER                 | Input        |
+| \srciterc              | DNNL_ARG_SRC_ITER_C               | Input        |
+| \weightslayer          | DNNL_ARG_WEIGHTS_LAYER            | Input        |
+| \weightsiter           | DNNL_ARG_WEIGHTS_ITER             | Input        |
+| \weightspeephole       | DNNL_ARG_WEIGHTS_PEEPHOLE         | Input        |
+| \weightsprojection     | DNNL_ARG_WEIGHTS_PROJECTION       | Input        |
+| \bias                  | DNNL_ARG_BIAS                     | Input        |
+| \dstlayer              | DNNL_ARG_DST_LAYER                | Output       |
+| \dstiter               | DNNL_ARG_DST_ITER                 | Output       |
+| \dstiterc              | DNNL_ARG_DST_ITER_C               | Output       |
+| \workspace             | DNNL_WORKSPACE                    | Input/Output |
+| \diffsrclayer          | DNNL_ARG_DIFF_SRC_LAYER           | Output       |
+| \diffsrclayerattention | DNNL_ARG_DIFF_SRC_LAYER_ATTENTION | Output       |
+| \diffsrciter           | DNNL_ARG_DIFF_SRC_ITER            | Output       |
+| \diffsrciterc          | DNNL_ARG_DIFF_SRC_ITER_C          | Output       |
+| \diffweightslayer      | DNNL_ARG_DIFF_WEIGHTS_LAYER       | Output       |
+| \diffweightsiter       | DNNL_ARG_DIFF_WEIGHTS_ITER        | Output       |
+| \diffweightspeephole   | DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE    | Output       |
+| \diffweightsprojection | DNNL_ARG_DIFF_WEIGHTS_PROJECTION  | Output       |
+| \diffbias              | DNNL_ARG_DIFF_BIAS                | Output       |
+| \diffdstlayer          | DNNL_ARG_DIFF_DST_LAYER           | Input        |
+| \diffdstiter           | DNNL_ARG_DIFF_DST_ITER            | Input        |
+| \diffdstiterc          | DNNL_ARG_DIFF_DST_ITER_C          | Input        |
+| [scratchpad]           | DNNL_ARG_SCRATCHPAD               | Output       |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/shuffle.md
+++ b/doc/primitives/shuffle.md
@@ -60,12 +60,15 @@ Essentially, backward propagation is the same as forward propagation with
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output | Execution argument index |
-|------------------------|--------------------------|
-| \src                   | DNNL_ARG_SRC             |
-| \dst                   | DNNL_ARG_DST             |
-| \diffsrc               | DNNL_ARG_DIFF_SRC        |
-| \diffdst               | DNNL_ARG_DIFF_DST        |
+| Argument               | Index                    | Type         |
+|------------------------|--------------------------|--------------|
+| \src                   | DNNL_ARG_SRC             | Input        |
+| \dst                   | DNNL_ARG_DST             | Output       |
+| \diffsrc               | DNNL_ARG_DIFF_SRC        | Output       |
+| \diffdst               | DNNL_ARG_DIFF_DST        | Input        |
+| [scratchpad]           | DNNL_ARG_SCRATCHPAD      | Output       |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Data Types
 

--- a/doc/primitives/softmax.md
+++ b/doc/primitives/softmax.md
@@ -74,16 +74,19 @@ The backward propagation computes \f$\diffsrc(ou, c, in)\f$, based on
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| Primitive input/output      | Execution argument index                                                  |
-|-----------------------------|---------------------------------------------------------------------------|
-| \src                        | DNNL_ARG_SRC                                                              |
-| \dst                        | DNNL_ARG_DST                                                              |
-| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
-| \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \f$src scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC                                      |
-| \f$dst scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_DST                                      |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
-|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
+| Argument                    | Index                                                                     | Type   |
+|-----------------------------|---------------------------------------------------------------------------|--------|
+| \src                        | DNNL_ARG_SRC                                                              | Input  |
+| \dst                        | DNNL_ARG_DST                                                              | Output |
+| \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         | Output |
+| \diffdst                    | DNNL_ARG_DIFF_DST                                                         | Input  |
+| \f$src scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC                                      | Input  |
+| \f$dst scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_DST                                      | Input  |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input  |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input  |
+| [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 

--- a/doc/primitives/sum.md
+++ b/doc/primitives/sum.md
@@ -25,10 +25,13 @@ The backward propagation for the sum operation is simply an identity operation.
 When executed, the inputs and outputs should be mapped to an execution
 argument index as specified by the following table.
 
-| primitive input/output | execution argument index |
-|------------------------|--------------------------|
-| \src                   | DNNL_ARG_MULTIPLE_SRC    |
-| \dst                   | DNNL_ARG_DST             |
+| Argument     | Index                 | Type   |
+|--------------|-----------------------|--------|
+| \src         | DNNL_ARG_MULTIPLE_SRC | Input  |
+| \dst         | DNNL_ARG_DST          | Output |
+| [scratchpad] | DNNL_ARG_SCRATCHPAD   | Output |
+
+[scratchpad]: @ref dev_guide_attributes_scratchpad
 
 ## Implementation Details
 


### PR DESCRIPTION
This PR updates primitives documentation Developer Guide to specify role of every execution argument as input or output.

We have a few cases where the answer is "It's complicated", in particularly with mean and variance arguments for convolution. This seems to be sufficiently covered in accompanying tables explaining impact of flags.
