### PR TITLE
xe: reduce build time with Xe3p

### DIFF
--- a/src/gpu/intel/gemm/jit/CMakeLists.txt
+++ b/src/gpu/intel/gemm/jit/CMakeLists.txt
@@ -73,11 +73,22 @@ if(DPCPP_HOST_COMPILER_KIND STREQUAL "DEFAULT")
     endif()
 
     foreach(isa ${DNNL_GPU_ISA_LIST})
-        set(GENERATOR_LIB generator${isa})
-        add_library(${GENERATOR_LIB} OBJECT ${GENERATOR_SOURCES})
-        target_compile_definitions(${GENERATOR_LIB} PRIVATE DNNL_GPU_ISA_${isa})
-        set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
-                        $<TARGET_OBJECTS:${GENERATOR_LIB}>)
+        if(${isa} STREQUAL "XE3P")
+            foreach(subvariant 35_10 35_11 UNKNOWN)
+                set(GENERATOR_LIB generatorXE3P_${subvariant})
+                add_library(${GENERATOR_LIB} OBJECT ${GENERATOR_SOURCES})
+                target_compile_definitions(${GENERATOR_LIB} PRIVATE DNNL_GPU_ISA_XE3P)
+                target_compile_definitions(${GENERATOR_LIB} PRIVATE DNNL_GPU_ISA_XE3P_${subvariant})
+                set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
+                                $<TARGET_OBJECTS:${GENERATOR_LIB}>)
+            endforeach()
+        else()
+            set(GENERATOR_LIB generator${isa})
+            add_library(${GENERATOR_LIB} OBJECT ${GENERATOR_SOURCES})
+            target_compile_definitions(${GENERATOR_LIB} PRIVATE DNNL_GPU_ISA_${isa})
+            set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
+                            $<TARGET_OBJECTS:${GENERATOR_LIB}>)
+        endif()
     endforeach()
 endif()
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/hw_template_instantiations.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/hw_template_instantiations.cxx
@@ -31,6 +31,14 @@ REG_XEHPC_ISA(template class Generator<HW::XeHPC>);
 REG_XE2_ISA(template class Generator<HW::Xe2>);
 #elif defined(DNNL_GPU_ISA_XE3)
 REG_XE3_ISA(template class Generator<HW::Xe3>);
+#elif defined(DNNL_GPU_ISA_XE3P)
+#if defined(DNNL_GPU_ISA_XE3P_35_10)
+REG_XE3P_ISA(template class Generator<HW::XE3P_35_10>);
+#elif defined(DNNL_GPU_ISA_XE3P_35_11)
+REG_XE3P_ISA(template class Generator<HW::XE3P_35_11>);
+#else
+REG_XE3P_ISA(template class Generator<HW::XE3P_UNKNOWN>);
+#endif
 #else
 // Default to instantiating all classes
 REG_XELP_ISA(template class Generator<HW::Gen12LP>);


### PR DESCRIPTION
This reduces ~5.5 minutes build time down to ~2.5 minutes (on my machine) by parallelizing Xe3p GEMM generator sub-targets.

In the long term we need to unify all these sub-targets: [MFDNN-14690](https://jira.devtools.intel.com/browse/MFDNN-14690)