### PR TITLE
benchdnn: add per-type NaN-safe mask to `gpu_fill_random`

### DIFF
--- a/src/gpu/intel/fill_random.cl
+++ b/src/gpu/intel/fill_random.cl
@@ -16,28 +16,23 @@
 
 #include "gpu/intel/include/philox.h"
 
-// Fills a buffer with pseudo-random data using Philox RNG and subgroup block
-// writes. Each subgroup (16 work-items) writes 256 bytes.
-#define SG_SIZE 16
-#define BYTES_PER_SG (SG_SIZE * 4 * 4)
+// Fills a buffer with pseudo-random data using Philox RNG.
+// Each work-item generates 4 × uint32 (16 bytes) via vstore4.
+// The mask clears exponent LSBs to prevent NaN/Inf for FP types.
+__kernel void fill_random(
+        __global uint *buf, uint seed, ulong byte_count, uint mask) {
+    const ulong start = (ulong)get_global_id(0) * 16;
+    if (start >= byte_count) return;
 
-__attribute__((intel_reqd_sub_group_size(SG_SIZE))) __kernel void fill_random(
-        __global uchar *buf, uint seed, ulong byte_count) {
-    const ulong base = (get_global_id(0) / SG_SIZE) * BYTES_PER_SG;
-    if (base >= byte_count) return;
+    uint b = (uint)(start >> 2);
+    uint4 rnd = philox_4x32_vec4(b, b ^ seed) & (uint4)(mask);
 
-    const uint b = (uint)get_global_id(0) * 4;
-    uchar16 rnd
-            = as_uchar16(philox_4x32_vec4(b, b ^ seed) & (uint4)(0xEEEEEEEEu));
-
-    if (base + BYTES_PER_SG <= byte_count) {
-        intel_sub_group_block_write_uc16(buf + base, rnd);
-        return;
-    }
-
-    const uint lid = get_sub_group_local_id();
-    unroll_for(int i = 0; i < 16; i++) {
-        ulong off = base + lid + (ulong)i * SG_SIZE;
-        if (off < byte_count) buf[off] = rnd[i];
+    if (start + 16 <= byte_count) {
+        vstore4(rnd, get_global_id(0), buf);
+    } else {
+        __global uchar *p = (__global uchar *)buf;
+        uchar16 bytes = as_uchar16(rnd);
+        for (ulong i = 0; i < byte_count - start; i++)
+            p[start + i] = bytes[i];
     }
 }

--- a/src/gpu/intel/fill_random.cpp
+++ b/src/gpu/intel/fill_random.cpp
@@ -49,6 +49,19 @@ static status_t get_cached_kernel(
     return status::success;
 }
 
+static uint32_t nan_safe_mask(data_type_t dt) {
+    switch (dt) {
+        case data_type::f32: return 0xFF7FFFFFu;
+        case data_type::f16: return 0xFBFFFBFFu;
+        case data_type::bf16: return 0xFF7FFF7Fu;
+        case data_type::f8_e5m2: return 0xFBFBFBFBu;
+        case data_type::f8_e4m3: return 0xF7F7F7F7u;
+        case data_type::e8m0: return 0xFEFEFEFEu;
+        case data_type::f64: return 0xFFEFFFFFu;
+        default: return 0xFFFFFFFFu;
+    }
+}
+
 status_t fill_random(impl::stream_t *stream, size_t size,
         impl::memory_t *memory, int buffer_index, uint32_t seed) {
     if (size == 0) return status::success;
@@ -58,17 +71,15 @@ status_t fill_random(impl::stream_t *stream, size_t size,
     compute::kernel_t kernel;
     CHECK(get_cached_kernel(intel_engine, kernel));
 
-    // Each subgroup (16 work-items) processes 256 bytes (16 * 4 * sizeof(uint)).
-    static constexpr size_t subgroup_size = 16;
-    static constexpr size_t bytes_per_subgroup
-            = subgroup_size * 4 * sizeof(uint32_t);
-    size_t num_subgroups = utils::div_up(size, bytes_per_subgroup);
+    // Each work-item writes 16 bytes (4 × uint32) via vstore4.
+    static constexpr size_t bytes_per_item = 16;
     compute::nd_range_t nd_range(
-            compute::range_t(num_subgroups * subgroup_size, 1, 1));
+            compute::range_t(utils::div_up(size, bytes_per_item), 1, 1));
     compute::kernel_arg_list_t arg_list;
     arg_list.set(0, *memory->memory_storage(buffer_index));
     arg_list.set(1, seed);
     arg_list.set(2, static_cast<uint64_t>(size));
+    arg_list.set(3, nan_safe_mask(memory->md()->data_type));
 
     CHECK(kernel.parallel_for(*stream, nd_range, arg_list,
             intel_stream->ctx().get_deps(), intel_stream->ctx().get_deps()));


### PR DESCRIPTION
### This PR modifies logic in `fill_random.cl` kernel to use custom per-type masks instead of single universal `0xEEEEEEEEu` mask.

JIRA: [MFDNN-14789](https://jira.devtools.intel.com/browse/MFDNN-14789)

---

### Problem

The existing `gpu_fill_random` kernel applied a hardcoded `0xEEEEEEEE` universal mask to "Philox PRNG" output. This mask only allowed even nibbles, compressing e.g. `FP16` from $65536$ to $4096$ unique values and severely limiting the dynamic range of generated data.

#### Limitations of "sub_group_block_write"

Philox PRNG always generates vector of $4$ `uint` values. The kernel uses `intel_sub_group_block_write_uc16`, which **transposes bytes** across work-items: byte `rnd[c]` from work-item `j` lands at address `base + c*16 + j`. Each FP element in memory is therefore assembled from bytes at the *same* `rnd[]` index across adjacent work-items. This means the NaN-safe mask must be **byte-uniform** (identical pattern in every byte). A non-uniform mask like `0xFBFFFBFF` would leave some bytes at `0xFF` providing no masking and allowing NaN/Inf values. For this reason, at least $1$ bit must be reserved in every byte, so, for example, for the `FP16` type, we are left with a limit of $2^{14} = 16384$ unique values even though, in theory, reserving just $1$ bit would suffice in this case.

---

### Proposed Solution
The direct `vstore4`-based approach has been restored. Expanding the range of samples generated is possible by switching from a static mask to a dynamic one determined by the buffor data type. 

- Compute a per-type byte-uniform mask that clears the exponent LSB position within each byte, preventing all-ones exponent (`NaN`/`Inf`).
- Pass that custom per-type mask as a kernel argument (`uint mask`).
- Data type retrived via `memory->md()->data_type)` which restricts the generation of valid masks to `--mode=F` only. It cannot be used in `--mode=C`.
- Restore initial `vstore4`-based approach.

#### Masks used:
```c++
switch (dt) {
    case data_type::f32: return 0xFF7FFFFFu;
    case data_type::f16: return 0xFBFFFBFFu;
    case data_type::bf16: return 0xFF7FFF7Fu;
    case data_type::f8_e5m2: return 0xFBFBFBFBu;
    case data_type::f8_e4m3: return 0xF7F7F7F7u;
    case data_type::e8m0: return 0xFEFEFEFEu;
    case data_type::f64: return 0xFFEFFFFFu;
    default: return 0xFFFFFFFFu;
}
```

#### Modified Files
- **fill_random.cl** - added `uint mask` kernel parameter, applied to PRNG output. Logic restored to `vstore4`.
- **fill_random.cpp** - `nan_safe_mask()` function, additional kernel argument.

---

### Results
For one million generated samples:
| Data Type | Before (unique samples) | After (unique sample) | Change | Limit ($2^{20}$ samples) |
|---|---|---|---|---|
| `dnnl_f32`         | 1,016,560 | **1,048,318**  | ×1.03 ↑ | 1 048 576 |
| `dnnl_f16`         | 4,096        | **32,768**       | ×8 ↑ | 32768 |
| `dnnl_f8_e5m2` | 64            | **128**            | ×2 ↑ | 128 |

> [!WARNING]
> After merging this PR, testing the generator via `tests/benchdnn/self/memory.cpp` is no longer possible.
> The `memory.cpp` tests run in `mode_bit_t::corr` mode, which uses `m_padded`. Function `gpu_fill_random` is 
> restricted to `mode=f` only.
