### PR TITLE
cpu: x64: do not clobber rsp in autogenerated GEMM kernels

### DIFF
--- a/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
@@ -126,6 +126,7 @@ struct xbyak_gemm_t : public jit_generator_t {
         auto ALPHA = qword[rsp + 48];
         auto BETA = qword[rsp + 64];
         auto ORIG_A = qword[rsp + 80];
+        auto WS_BUF = qword[rsp + 96];
         auto ORIG_SP = qword[rsp + 120];
 
         auto ZSTRIDE = zmm4;
@@ -147,7 +148,8 @@ struct xbyak_gemm_t : public jit_generator_t {
             Label pack2, pack3, pack4, pack10;
 
             mov(BO1, A);
-            lea(AO1, ptr[rsp + 128 + OFFSET * SIZE]);
+            mov(AO1, WS_BUF);
+            lea(AO1, ptr[AO1 + OFFSET * SIZE]);
             mov(LL, K);
             sar(LL, 2);
             jle(pack3, T_NEAR);
@@ -833,13 +835,15 @@ struct xbyak_gemm_t : public jit_generator_t {
         auto kernel = [&](int unroll_m, int unroll_n, bool isDirect,
                               bool isCopy, bool isUnmasked = true) {
             if (!isDirect) {
-                lea(AO1, ptr[rsp + 128 + OFFSET * SIZE]);
+                mov(AO1, WS_BUF);
+                lea(AO1, ptr[AO1 + OFFSET * SIZE]);
             } else {
                 mov(AO1, A);
             }
 
             if (isCopy) {
-                lea(LDA4, ptr[rsp + 128 + OFFSET * SIZE]);
+                mov(LDA4, WS_BUF);
+                lea(LDA4, ptr[LDA4 + OFFSET * SIZE]);
             } else {
                 auto step = 2;
                 lea(LDA4, ptr[LDA * step + (16 - 1 - OFFSET) * SIZE]);
@@ -1454,18 +1458,22 @@ struct xbyak_gemm_t : public jit_generator_t {
         cmp(K, STACK_K_CAPACITY);
         jg(buffer_in_ws, T_NEAR);
 
-        // Create buffer and align to 4kB page
+        // Using 4kB aligned buffer on stack as workspace
         lea(rax, ptr[K * SIZE]);
         imul(rax, rax, 0x30);
         add(rax, 256);
         sub(rsp, rax);
         and_(rsp, -PAGE_4K);
+        lea(rax, ptr[rsp + 128]);
         jmp(buffer_allocated, T_NEAR);
 
         L(buffer_in_ws);
-        mov(rsp, ARG_WS);
+        // Using buffer in heap as workspace
+        mov(rax, ARG_WS);
+        sub(rsp, 256);
 
         L(buffer_allocated);
+        mov(WS_BUF, rax);
 
         mov(ORIG_SP, rbp);
         mov(M, ARG_M);

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -811,13 +811,15 @@ struct xbyak_gemm_t : public jit_generator_t {
             const Ymm &reg18, const Ymm &reg19, const Ymm &reg20,
             const Ymm &reg21, const Ymm &reg22, const Ymm &reg23) {
         if (!isDirect) {
-            lea(AO1, ptr[rsp + 256 + OFFSET * SIZE]);
+            mov(AO1, WS_BUF);
+            lea(AO1, ptr[AO1 + OFFSET * SIZE]);
         } else {
             mov(AO1, A);
         }
 
         if (isCopy) {
-            lea(LDA4, ptr[rsp + 256 + OFFSET * SIZE]);
+            mov(LDA4, WS_BUF);
+            lea(LDA4, ptr[LDA4 + OFFSET * SIZE]);
         } else {
             lea(LDA4, ptr[LDA * 8 + (8 - 1 - OFFSET) * SIZE]);
         }
@@ -1313,7 +1315,8 @@ struct xbyak_gemm_t : public jit_generator_t {
         Reg64 reg;
 
         mov(BO1, A);
-        lea(AO1, ptr[rsp + 256 + OFFSET * SIZE]);
+        mov(AO1, WS_BUF);
+        lea(AO1, ptr[AO1 + OFFSET * SIZE]);
 
         if (isTransA) {
             lea(BO2, ptr[BO1 + LDA * 4]);
@@ -1983,18 +1986,22 @@ struct xbyak_gemm_t : public jit_generator_t {
         cmp(K, STACK_K_CAPACITY);
         jg(buffer_in_ws, T_NEAR);
 
-        // Create buffer and align to 4kB page
+        // Using 4kB aligned buffer on stack as workspace
         lea(rax, ptr[K * SIZE]);
         sal(rax, math::ilog2q(UNROLL_M));
         add(rax, 256);
         sub(rsp, rax);
         and_(rsp, -PAGE_4K);
+        lea(rax, ptr[rsp + 256]);
         jmp(buffer_allocated, T_NEAR);
 
         L(buffer_in_ws);
-        mov(rsp, ARG_WS);
+        // Using buffer in heap as workspace
+        mov(rax, ARG_WS);
+        sub(rsp, 256);
 
         L(buffer_allocated);
+        mov(WS_BUF, rax);
 
         mov(ORIG_SP, rbp);
         mov(M, ARG_M);
@@ -2162,8 +2169,10 @@ private:
     const Address BETA = qword[rsp + 64];
     const Address ORIG_A = qword[rsp + 80];
     const Address MASK = dword[rsp + 88];
+    // STRIDE requires padding to 32 bytes to accomodate ymm loads/stores
     const Address STRIDE = qword[rsp + 120];
-    const Address ORIG_SP = qword[rsp + 152];
+    const Address WS_BUF = qword[rsp + 152];
+    const Address ORIG_SP = qword[rsp + 160];
 
     const Ymm VALPHA = ymm1;
     const Ymm VBETA = ymm2;


### PR DESCRIPTION
Our autogenerated GEMM kernels are updating `rsp` register with an address in heap in some cases. This results in heap corruption when execution of the kernel is interrupted with a signal. This PR updates both AVX2 and AVX512 implementations to use local variable as a pointer to workspace buffer and preserve `rsp` register.

Confirmed that `test_{matmul|ip}_all` lists pass with disabled BRGEMM kernels on Intel AVX2 and Intel AVX512.
```
ONEDNN_MAX_CPU_ISA=AVX2 $ ./benchdnn --ip --batch=test_ip_all
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| x64:gemm_s8u8s32:jit : 1848 (40%)                        |
|              ref:any : 952 (21%)                         |
| x64:gemm_s8s8s32:jit : 922 (20%)                         |
|         x64:gemm:jit : 722 (16%)                         |
|             gemm:jit : 148 (3%)                          |
============================================================
tests:15573 passed:4328 skipped:10981 mistrusted:264 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 46.43s; create_pd: 0.12s (0%); create_prim: 0.69s (1%); fill: 15.01s (32%); execute: 12.68s (27%); compute_ref: 1.12s (2%); compare: 3.10s (7%);

ONEDNN_MAX_CPU_ISA=AVX512_CORE $ ./benchdnn --ip --batch=test_ip_all
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
|              ref:any : 3203 (40%)                        |
|         x64:gemm:jit : 2039 (25%)                        |
| x64:gemm_s8u8s32:jit : 1848 (23%)                        |
| x64:gemm_s8s8s32:jit : 922 (12%)                         |
============================================================
tests:15573 passed:7692 skipped:7561 mistrusted:320 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 114.69s; create_pd: 0.27s (0%); create_prim: 0.88s (1%); fill: 36.54s (32%); execute: 35.35s (31%); compute_ref: 9.83s (9%); compare: 9.05s (8%);

ONEDNN_MAX_CPU_ISA=AVX2 $ ./benchdnn --matmul --batch=test_matmul_all
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
|      ref:any : 11414 (46%)                               |
| ref_int8:any : 6688 (27%)                                |
|     gemm:jit : 5021 (20%)                                |
| gemm:jit:f32 : 1782 (7%)                                 |
============================================================
tests:41896 passed:24737 skipped:16991 mistrusted:168 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 243.44s; create_pd: 0.45s (0%); create_prim: 1.35s (1%); fill: 4.53s (2%); execute: 213.89s (88%); compute_ref: 9.55s (4%); compare: 2.75s (1%);


ONEDNN_MAX_CPU_ISA=AVX512_CORE $ ./benchdnn --matmul --batch=test_matmul_all
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
|       ref:any : 14373 (44%)                              |
|  ref_int8:any : 6688 (20%)                               |
| gemm:jit:bf16 : 5059 (15%)                               |
|      gemm:jit : 5021 (15%)                               |
|  gemm:jit:f32 : 1782 (5%)                                |
============================================================
tests:41896 passed:32755 skipped:8973 mistrusted:168 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 248.51s; create_pd: 0.57s (0%); create_prim: 1.57s (1%); fill: 5.70s (2%); execute: 213.83s (86%); compute_ref: 9.92s (4%); compare: 3.39s (1%);

```
Orphan CI: [link](https://intel-ci.intel.com/f1234fde-84ce-f109-bafd-a4bf010d0e2d).

Fixes #4845.
