### PR TITLE
cpu: aarch64: prevent large post-op kernel generation

### DIFF
--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -26,7 +26,6 @@
 #include "cpu/cpu_primitive.hpp"
 #include "cpu/scale_utils.hpp"
 
-#include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/aarch64/jit_brgemm_conv.hpp"
 
 namespace dnnl {
@@ -485,20 +484,6 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     brgemm_descriptors_->resize(brgs_sz_);
 
     const auto &p = attr()->post_ops_;
-
-    // TODO: fix failing post ops for bf16 on sve 128
-    const bool is_bf16
-            = src_type == data_type::bf16 && wei_type == data_type::bf16;
-    if (is_bf16 && get_max_cpu_isa() == sve_128) {
-        for (auto const &entry : p.entry_) {
-            const bool is_failing_po = entry.is_eltwise()
-                    && one_of(entry.eltwise.alg,
-                            // these fail due to label offset being too large
-                            alg_kind::eltwise_tanh, alg_kind::eltwise_gelu_tanh,
-                            alg_kind::eltwise_gelu_erf);
-            VDISPATCH_CONV(!is_failing_po, VERBOSE_BAD_ALGORITHM);
-        }
-    }
 
     const int sum_idx = p.find(primitive_kind::sum);
     with_sum = (sum_idx != -1);

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -21,13 +21,11 @@
 #include <memory>
 
 #include "common/c_types_map.hpp"
-#include "common/memory_tracking.hpp"
 #include "common/utils.hpp"
 
 #include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/aarch64/jit_brgemm_primitive_conf.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
-#include "cpu/cpu_engine.hpp"
 
 using namespace Xbyak_aarch64;
 
@@ -995,7 +993,14 @@ private:
             }
         }
 
-        for (int mb_ = 0; mb_ < mb; mb_++) {
+        // Unrolling over mb can result in very large post-op assembly being
+        // generated (see Issue #4089), so branch and loop instead.
+        if (mb > 0) {
+            Label mb_loop;
+            mov_imm(x16, mb);
+
+            L(mb_loop);
+
             loop_by_N(m_block, nb2, nb2_tail, nb_tail);
 
             if (brg.alpha != 0)
@@ -1003,7 +1008,11 @@ private:
                         X_TMP_0);
             add_imm(reg_out, reg_out, out_typesize_ * (m_block * LDD_),
                     X_TMP_0);
+
+            subs(x16, x16, 1);
+            bgt(mb_loop);
         }
+
         if (mb_tail > 0) loop_by_N(mb_tail, nb2, nb2_tail, nb_tail);
 
         add_imm(X_SP, X_SP, stack_space_needed_, X_TMP_0);


### PR DESCRIPTION
# Description

Prevents very large post-op kernels from being created. These were causing exceptions to be thrown.

Fixes: Issue #4089

# Benchmarks
Generated the test set with `./build/tests/benchdnn/benchdnn --conv --dt=bf16,f32 --stag=axb --dtag=axb --attr-post-ops=sum,sum+tanh,exp,sum+exp,gelu_erf --impl=brgconv:sve --batch=shapes_gemm` and filtered for changes of more than +/- 10%.

## SVE-256:
_No changes observed_

## SVE-128:
Speedups are mostly due to us being able to run [previously skipped post-ops](https://github.com/uxlfoundation/oneDNN/blob/80cdf7e8211655e69fe3d5a0e573b4d6ae2aefd9/src/cpu/aarch64/jit_brgemm_conv.cpp#L489-L501) as they don't crash after this patch.

|old impl|new impl|prb|old avg|new avg|speedup ratio (old avg / new avg)|
|---------|---------|---------|---------|---------|---------|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=gelu_erf g1ic16id5oc16od3kd3pd4dd4n"big_padding_and_dilation_w.r.t._kernel_size-1"|0.0131649|0.00278983|4.7189x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=gelu_erf g1ic16ih5oc16oh3kh3ph4dh4n"big_padding_and_dilation_w.r.t._kernel_size-1"|0.00653319|0.00258148|2.5308x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=gelu_erf g1ic16iw5oc16ow3kw3pw4dw4n"big_padding_and_dilation_w.r.t._kernel_size-1"|0.0053604|0.00244591|2.1916x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=gelu_erf g1mb1ic64ih1000oc64oh1000kh3ph128dh127|8831.42|40.7008|216.9839x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=gelu_erf g3mb4ic3id5oc48od3kd3pd0n"ic%simd_width_!=0_with_im2col"|0.0816859|0.00491753|16.6112x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=gelu_erf g3mb4ic3ih5oc48oh3kh3ph0n"ic%simd_width_!=0_with_im2col"|0.0174365|0.00297653|5.8580x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=gelu_erf g3mb4ic3iw5oc48ow3kw3pw0n"ic%simd_width_!=0_with_im2col"|0.0067145|0.00258478|2.5977x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh g1ic16id5oc16od3kd3pd4dd4n"big_padding_and_dilation_w.r.t._kernel_size-1"|0.013488|0.00274914|4.9063x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh g1ic16ih5oc16oh3kh3ph4dh4n"big_padding_and_dilation_w.r.t._kernel_size-1"|0.00657586|0.00256887|2.5598x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh g1ic16iw5oc16ow3kw3pw4dw4n"big_padding_and_dilation_w.r.t._kernel_size-1"|0.00502907|0.0024492|2.0534x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh g1mb1ic64ih1000oc64oh1000kh3ph128dh127|8844.93|36.3443|243.3650x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh g3mb4ic3id5oc48od3kd3pd0n"ic%simd_width_!=0_with_im2col"|0.0835807|0.00474915|17.5991x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh g3mb4ic3ih5oc48oh3kh3ph0n"ic%simd_width_!=0_with_im2col"|0.0184007|0.00294531|6.2475x|
|ref:any|brgconv:sve_128|--mode=P --conv --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh g3mb4ic3iw5oc48ow3kw3pw0n"ic%simd_width_!=0_with_im2col"|0.00696479|0.00255392|2.7271x|
|brgconv:sve_128|brgconv:sve_128|--mode=P --conv --stag=axb --dtag=axb --attr-post-ops=sum+tanh g1ic16ih5oc16oh3kh3ph4dh4n"big_padding_and_dilation_w.r.t._kernel_size-1"|0.00251713|0.00280959|0.8959x|

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?