### PR TITLE
github: workflows: stopped linters from triggering on PR edits

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -20,7 +20,7 @@ name: "Clang-Tidy"
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/automation/aarch64/**"
       - ".github/automation/x64/**"

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -20,7 +20,7 @@ name: "PR Linters"
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
`pr-linters` and `clang-tidy` workflows are now triggering on PR description edits. This is a waste as neither of these are looking at the description. This PR removes the trigger responsible for this behavior. 
