### PR TITLE
[GPU] Restore remainder calculation from upstream

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
@@ -444,18 +444,12 @@ void Generator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState
     state.ra.safeRelease(idM);
     state.ra.safeRelease(idN);
     state.ra.safeRelease(idK);
-    if (!strategy.persistentLoop()) {
-        state.ra.safeRelease(state.inputs.localSizeM);
-        state.ra.safeRelease(state.inputs.localSizeN);
-    }
     if (anyKParallelFixed) {
         state.ra.safeRelease(state.inputs.localIDK);
         if (!strategy.persistentLoop())
             state.ra.safeRelease(state.inputs.localSizeK);
     }
     if (strategy.linearOrder() || strategy.persistentLoop()) {
-        state.ra.safeRelease(state.inputs.groupIDM);
-        state.ra.safeRelease(state.inputs.groupIDN);
         state.ra.claim(state.nextGroupIDM);
         state.ra.claim(state.nextGroupIDN);
     }
@@ -498,8 +492,6 @@ void Generator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState
             state.ra.safeRelease(state.inputs.k0);
     }
 
-    state.ra.safeRelease(state.inputs.localIDM);
-    state.ra.safeRelease(state.inputs.localIDN);
     if (!strategy.needsMNLocalIDs())
         state.lidM = state.lidN = invalid;
 
@@ -578,6 +570,17 @@ void Generator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState
 
     gemmSetupABC(problem, strategy, state);
     gemmSubkernel(problem, strategy, state);
+
+    if (strategy.linearOrder() || strategy.persistentLoop()) {
+        state.ra.safeRelease(state.inputs.groupIDM);
+        state.ra.safeRelease(state.inputs.groupIDN);
+    }
+    if (!strategy.persistentLoop()) {
+        state.ra.safeRelease(state.inputs.localSizeM);
+        state.ra.safeRelease(state.inputs.localSizeN);
+    }
+    state.ra.safeRelease(state.inputs.localIDM);
+    state.ra.safeRelease(state.inputs.localIDN);
 
     mark(lKernelDone);
 
@@ -843,6 +846,8 @@ void Generator<hw>::gemmSubkernel(GEMMProblem &problem, GEMMStrategy &strategy, 
         auto modStrategy = strategy;
 
         gemmDowngradeAccess(problem, modStrategy, state);
+        gemmCalcWGIndices(problem, modStrategy, state);
+        gemmCalcWGRemainders(problem, modStrategy, state);
 
         status << "Unaligned A/B" << status_stream::endl;
         if (!gemmMEdge(problem, modStrategy, state)) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -980,6 +980,32 @@ void Generator<hw>::gemmCalcWGRemainders(const GEMMProblem &problem, const GEMMS
     if (strategy.coopB != CoopSplit::FullK) state.ra.safeRelease(state.wgJ0);
 }
 
+// Calculate workgroup m/n indices.
+template <HW hw>
+void Generator<hw>::gemmCalcWGIndices(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
+{
+    Subregister idM, idN;
+
+    idM = state.ra.alloc_sub<uint32_t>(getHint(HintType::TempComp1, strategy));
+    idN = state.ra.alloc_sub<uint32_t>(getHint(HintType::TempComp0, strategy));
+
+    if (strategy.fixedWG(problem)) {
+        mulConstant(1, idM, state.inputs.groupIDM, strategy.wg[LoopM]);
+        mulConstant(1, idN, state.inputs.groupIDN, strategy.wg[LoopN]);
+    } else {
+        mul(1, idM, state.inputs.groupIDM, state.inputs.localSizeM.uw());
+        mul(1, idN, state.inputs.groupIDN, state.inputs.localSizeN.uw());
+    }
+    bool gemmtBarriers = problem.gemmt() && strategy.needsBarrier();
+    if (wgRemCheck(problem, strategy) || gemmtBarriers) {
+        state.wgI0 = state.ra.alloc_sub<uint32_t>(getHint(HintType::TempComp0, strategy));
+        state.wgJ0 = state.ra.alloc_sub<uint32_t>(getHint(HintType::TempComp1, strategy));
+        mulConstant(1, state.wgI0, idM, strategy.unroll[LoopM]);
+        mulConstant(1, state.wgJ0, idN, strategy.unroll[LoopN]);
+    }
+    state.ra.safeRelease(idM);
+    state.ra.safeRelease(idN);
+}
 // Cache multiples of lda/ldb for later address calculations.
 template <HW hw>
 void Generator<hw>::gemmCacheLDABMultiples(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state, bool doA, bool doB)

--- a/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
@@ -341,6 +341,7 @@ protected:
     void gemmReverseLoops(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmScaleInputs(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmCalcWGRemainders(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
+    void gemmCalcWGIndices(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
 
     void gemmGetBatchIDs(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmReleaseBatchIDs(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);


### PR DESCRIPTION
# Description

Restore dropped commit from upstream during unembargo, resolves multiple fails as part of [MFDNN-14735](https://jira.devtools.intel.com/browse/MFDNN-14735).

Dropped from unembargo PR due to correctness concerns but [CI clean](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f123bcf3-11ce-f145-a710-a4bf010d0e2d)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?