### PR TITLE
common: verbose: drop extra CSV header column

### DIFF
--- a/doc/performance_considerations/verbose.md
+++ b/doc/performance_considerations/verbose.md
@@ -98,8 +98,8 @@ onednn_verbose,v0,info,cpu,runtime:OpenMP,nthr:128
 onednn_verbose,v0,info,cpu,isa:Intel AVX-512 with Intel DL Boost
 onednn_verbose,v0,info,gpu,runtime:none
 onednn_verbose,v0,info,graph,backend,0:dnnl_backend
-onednn_verbose,v0,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
-onednn_verbose,v0,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,backend,exec_time
+onednn_verbose,v0,primitive,info,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
+onednn_verbose,v0,graph,info,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,backend,exec_time
 onednn_verbose,v0,primitive,create:check,matmul,dimension src:1 is inconsistent with weights:0,src/common/matmul.cpp:144
 ~~~
 
@@ -139,8 +139,8 @@ onednn_verbose,v0,info,cpu,runtime:OpenMP,nthr:128
 onednn_verbose,v0,info,cpu,isa:Intel AVX-512 with Intel DL Boost
 onednn_verbose,v0,info,gpu,runtime:none
 onednn_verbose,v0,info,graph,backend,0:dnnl_backend
-onednn_verbose,v0,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
-onednn_verbose,v0,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,backend,exec_time
+onednn_verbose,v0,primitive,info,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
+onednn_verbose,v0,graph,info,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,backend,exec_time
 onednn_verbose,v0,primitive,create:dispatch,matmul,cpu,matmul,brg:avx512_core_amx_fp16,undef,src_u8:a:any:any::f0 wei_s8:a:any:any::f0 dst_f32:a:any:any::f0,,,256x256:256x256,unsupported isa,src/cpu/x64/matmul/brgemm_matmul.cpp:97
 onednn_verbose,v0,primitive,create:dispatch,matmul,cpu,matmul,brg:avx512_core_amx,undef,src_u8:a:any:any::f0 wei_s8:a:any:any::f0 dst_f32:a:any:any::f0,,,256x256:256x256,unsupported isa,src/cpu/x64/matmul/brgemm_matmul.cpp:97
 onednn_verbose,v0,primitive,create:dispatch,matmul,cpu,matmul,brg:avx512_core_fp16,undef,src_u8:a:any:any::f0 wei_s8:a:any:any::f0 dst_f32:a:any:any::f0,,,256x256:256x256,unsupported isa,src/cpu/x64/matmul/brgemm_matmul.cpp:97
@@ -167,8 +167,8 @@ onednn_verbose,v0,info,cpu,runtime:OpenMP,nthr:128
 onednn_verbose,v0,info,cpu,isa:Intel AVX-512 with Intel DL Boost
 onednn_verbose,v0,info,gpu,runtime:none
 onednn_verbose,v0,info,graph,backend,0:dnnl_backend
-onednn_verbose,v0,primitive,info,template:timestamp,operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
-onednn_verbose,v0,graph,info,template:timestamp,operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,backend,exec_time
+onednn_verbose,v0,primitive,info,timestamp,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
+onednn_verbose,v0,graph,info,timestamp,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,backend,exec_time
 onednn_verbose,v0,1693533460193.346924,primitive,create:cache_miss,cpu,convolution,jit:avx512_core,forward_training,src_f32:a:blocked:aBcd16b::f0 wei_f32:a:blocked:ABcd16b16a::f0 bia_f32:a:blocked:a::f0 dst_f32:a:blocked:aBcd16b::f0,,alg:convolution_direct,mb2_ic16oc16_ih7oh7kh5sh1dh0ph2_iw7ow7kw5sw1dw0pw2,0.709961
 onednn_verbose,v0,1693533460194.199951,primitive,create:cache_hit,cpu,convolution,jit:avx512_core,forward_training,src_f32:a:blocked:aBcd16b::f0 wei_f32:a:blocked:ABcd16b16a::f0 bia_f32:a:blocked:a::f0 dst_f32:a:blocked:aBcd16b::f0,,alg:convolution_direct,mb2_ic16oc16_ih7oh7kh5sh1dh0ph2_iw7ow7kw5sw1dw0pw2,0.0161133
 onednn_verbose,v0,1693533460228.559082,primitive,create:cache_miss,cpu,reorder,jit:uni,undef,src_f32::blocked:abcd::f0 dst_f32::blocked:ABcd16b16a::f0,,,16x16x5x5,0.724854
@@ -187,10 +187,10 @@ onednn_verbose,v0,1693533460314.072021,primitive,exec,cpu,reorder,jit:blk,undef,
 
 The first lines of verbose information, which are denoted with `info`, contain
 the build version and git hash, if available, as well as CPU and GPU runtimes.
-It also includes graph API backends, the supported instruction set architecture,
-and the verbose output format template since the amount of fields may vary
-depending on the set of enabled environment variables. This verbose header is
-printed when information is first logged.
+It also includes graph API backends, the supported instruction set architecture
+and the verbose graph and primitive format templates (as CSV headers) because
+the fields may vary depending on the set of enabled environment variables. This
+verbose header is printed when information is first logged.
 
 Each subsequent line of primitive verbose information is formatted as a
 comma-separated list and contains the following, in order of appearance in the

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023, 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -149,14 +149,14 @@ void print_header() noexcept {
         verbose_printf("info,experimental SYCL kernel compiler is enabled\n");
 #endif
         verbose_printf(
-                "primitive,info,template:%soperation,engine,primitive,"
+                "primitive,info,%sengine,primitive,"
                 "implementation,prop_kind,memory_descriptors,attributes,"
                 "auxiliary,problem_desc,exec_time\n",
                 get_verbose_timestamp() ? "timestamp," : "");
 
 #ifdef ONEDNN_BUILD_GRAPH
         verbose_printf(
-                "graph,info,template:%soperation,engine,partition_id,"
+                "graph,info,%sengine,partition_id,"
                 "partition_kind,op_names,data_formats,logical_tensors,fpmath_"
                 "mode,implementation,backend,exec_time\n",
                 get_verbose_timestamp() ? "timestamp," : "");


### PR DESCRIPTION
# Description


Fix verbose CSV headers for primitive and graph output by removing an extra header-only column.

The verbose header printed `template:operation` / `template:timestamp,operation`, but the corresponding data rows never had a column which corresponded to `operation`. This made the header wider than the data and broke CSV tools such as `xsv table`. This change updates the primitive and graph headers to match the emitted data rows, and refreshes the verbose documentation examples.

## Details 

```sh
ONEDNN_VERBOSE=1 ./tests/benchdnn/benchdnn --mode=r --matmul 1x1:1x1 \
    | grep 'onednn_verbose,v1,primitive' \
    | xsv table
```

Before the fix, this failed because the verbose header had one more CSV field than the emitted primitive rows, e.g.

```text
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,primitive,exec,cpu,matmul,gemm:jit:f32,undef,src:f32:a:blocked:ab::f0 wei:f32:a:blocked:ab::f0 dst:f32:a:blocked:ab::f0,,,1x1:1x1,0.0170898
```

After the fix, the header is:
```text
onednn_verbose,v1,primitive,info,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
```
and the `xsv table` command above succeeds.


The same issue existed in the graph verbose header and can be checked with:
```sh
ONEDNN_VERBOSE=1 ./tests/benchdnn/benchdnn --mode=P --graph --case=op/f32/abs.json \
    | grep 'onednn_verbose,v1,graph' \
    | xsv table
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?


### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests? I don't think there's a simple way to add a C++ `ctest` here, especially without adding dependencies, but ideas are welcome!

