### PR TITLE
tests: benchdnn: print csv friendly perf header

### DIFF
--- a/tests/benchdnn/binary/binary.hpp
+++ b/tests/benchdnn/binary/binary.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -131,9 +132,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_vdims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const std::vector<dnnl_data_type_t> *sdt() const override {
         return &p_->sdt;
     }

--- a/tests/benchdnn/bnorm/bnorm.hpp
+++ b/tests/benchdnn/bnorm/bnorm.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -227,11 +228,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->mb << ',' << p_->ic << ',' << p_->id << ',' << p_->ih << ','
-          << p_->iw << ',' << p_->eps;
     }
 
     void dump_flags(std::ostream &s) const override {

--- a/tests/benchdnn/brgemm/brgemm.hpp
+++ b/tests/benchdnn/brgemm/brgemm.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -223,9 +224,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_vdims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     double ops() const override { return p_->ops; }
     const std::vector<dnnl_data_type_t> *sdt() const override {
         return &p_->dt;

--- a/tests/benchdnn/concat/concat.hpp
+++ b/tests/benchdnn/concat/concat.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -132,9 +133,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_vdims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -212,22 +213,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->g << ',' << p_->mb << ','
-
-          << p_->ic << ',' << p_->id << ',' << p_->ih << ',' << p_->iw << ','
-
-          << p_->oc << ',' << p_->od << ',' << p_->oh << ',' << p_->ow << ','
-
-          << p_->kd << ',' << p_->kh << ',' << p_->kw << ','
-
-          << p_->sd << ',' << p_->sh << ',' << p_->sw << ','
-
-          << p_->pd << ',' << p_->ph << ',' << p_->pw << ','
-
-          << p_->dd << ',' << p_->dh << ',' << p_->dw;
     }
 
     double ops() const override { return p_->ops; }

--- a/tests/benchdnn/deconv/deconv.hpp
+++ b/tests/benchdnn/deconv/deconv.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -210,22 +211,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->g << ',' << p_->mb << ','
-
-          << p_->ic << ',' << p_->id << ',' << p_->ih << ',' << p_->iw << ','
-
-          << p_->oc << ',' << p_->od << ',' << p_->oh << ',' << p_->ow << ','
-
-          << p_->kd << ',' << p_->kh << ',' << p_->kw << ','
-
-          << p_->sd << ',' << p_->sh << ',' << p_->sw << ','
-
-          << p_->pd << ',' << p_->ph << ',' << p_->pw << ','
-
-          << p_->dd << ',' << p_->dh << ',' << p_->dw;
     }
 
     double ops() const override { return p_->ops; }

--- a/tests/benchdnn/doc/knobs_perf_report.md
+++ b/tests/benchdnn/doc/knobs_perf_report.md
@@ -136,7 +136,7 @@ CSV-style:
                --batch=inputs/ip/test_ip_all
 ```
 ```
-Output template: perf,%engine%,%name%,%dir%,%cfg%,%attr%,%DESC%,%Gops%,%Gfreq%,%-time%,%-Gflops%,%0time%,%0Gflops%
+Output template: perf,%engine%,%name%,%dir%,%cfg%,%attr%,%desc%,%Gops%,%Gfreq%,%-time%,%-Gflops%,%0time%,%0Gflops%
 perf,cpu,"resnet:ip1",FWD_B,f32,,112,1000,2048,1,1,0.458752,0,0.520264,881.768,0.564043,813.328
 ```
 

--- a/tests/benchdnn/doc/knobs_perf_report.md
+++ b/tests/benchdnn/doc/knobs_perf_report.md
@@ -124,8 +124,10 @@ dumping results with a standard performance template:
                --batch=inputs/ip/test_ip_all
 ```
 ```
-Output template: perf,%engine%,%name%,%prb%,%Gops%,%Gfreq%,%-time%,%-Gflops%,%0time%,%0Gflops%
-perf,cpu,"resnet:ip1",mb112oc1000ic2048n"resnet:ip1",0.458752,0,0.521729,879.293,0.576451,795.822
+Template entries: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
+perf,engine,impl,name,prb,Gops,max_ctime,min_time,min_Gflops,avg_time,avg_Gflops
+perf,cpu,brg_matmul:avx512_core,"resnet:ip1",--mode=P --max-ms-per-prb=6000 --ip ic2048oc1000n"resnet:ip1",0.008192,0.935547,0.0234375,349.525,0.0269902,303.518
+...
 ```
 
 Runs a set of inner products measuring performance and dumping results in
@@ -135,8 +137,10 @@ CSV-style:
                --batch=inputs/ip/test_ip_all
 ```
 ```
-Output template: perf,%engine%,%name%,%dir%,%cfg%,%attr%,%desc%,%Gops%,%Gfreq%,%-time%,%-Gflops%,%0time%,%0Gflops%
-perf,cpu,"resnet:ip1",FWD_B,f32,,112,1000,2048,1,1,0.458752,0,0.520264,881.768,0.564043,813.328
+Template entries: perf,%engine%,%impl%,%name%,%dir%,%sdt%,%stag%,%wtag%,%dtag%,%attr%,%desc%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
+perf,engine,impl,name,dir,sdt,stag,wtag,dtag,attr,desc,Gops,max_ctime,min_time,min_Gflops,avg_time,avg_Gflops
+perf,cpu,brg_matmul:avx512_core,"resnet:ip1",FWD_B,f32:f32:f32,any,any,any,,ic2048oc1000n"resnet:ip1",0.008192,0.9375,0.0234375,349.525,0.027302,300.051
+...
 ```
 
 Runs a set of inner products measuring performance and dumping custom template -
@@ -147,6 +151,8 @@ not a special symbol here; any other delimiter can be used:
                --batch=inputs/ip/test_ip_all
 ```
 ```
-Output template: %prb%,%-time%,%-Gflops%
-mb112oc1000ic2048n"resnet:ip1",0.521973,878.881
+Template entries: %prb%,%-time%,%-Gflops%
+prb,min_time,min_Gflops
+--mode=P --ip ic2048oc1000n"resnet:ip1",0.0234375,349.525
+...
 ```

--- a/tests/benchdnn/doc/knobs_perf_report.md
+++ b/tests/benchdnn/doc/knobs_perf_report.md
@@ -54,7 +54,6 @@ Other problem specific options supported:
 | %attr%       | All                                                                   | Primitive attributes
 | %axis%       | Concat, Shuffle, Softmax                                              | Primitive axis
 | %desc%       | All                                                                   | String style problem descriptor
-| %DESC%       | All                                                                   | CSV-style problem descriptor values only
 | %dir%        | All, except Concat, RNN, Reorder, Sum                                 | Primitive prop kind
 | %direction%  | RNN                                                                   | RNN direction execution
 | %driver%     | All                                                                   | Name of the current driver (e.g. conv, reorder)

--- a/tests/benchdnn/eltwise/eltwise.hpp
+++ b/tests/benchdnn/eltwise/eltwise.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -131,9 +132,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_dims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/gnorm/gnorm.hpp
+++ b/tests/benchdnn/gnorm/gnorm.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -218,11 +219,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->g << ',' << p_->mb << ',' << p_->ic << ',' << p_->id << ','
-          << p_->ih << ',' << p_->iw << ',' << p_->eps;
     }
 
     void dump_flags(std::ostream &s) const override {

--- a/tests/benchdnn/graph/graph.hpp
+++ b/tests/benchdnn/graph/graph.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,7 +56,7 @@ struct settings_t : public base_settings_t {
     std::vector<std::map<size_t, std::string>> op_kind_map {
             {{SIZE_MAX, "default"}}};
 
-    const char *perf_template_csv = "perf,%engine%,%DESC%,%-time%,%0time%";
+    const char *perf_template_csv = "perf,%engine%,%desc%,%-time%,%0time%";
     static constexpr const char *perf_template_def
             = "perf,%engine%,%prb%,%-time%,%0time%";
 

--- a/tests/benchdnn/graph/graph.hpp
+++ b/tests/benchdnn/graph/graph.hpp
@@ -91,7 +91,6 @@ struct perf_report_t : public base_perf_report_t {
     perf_report_t(const std::string &case_str, const char *perf_template)
         : base_perf_report_t(perf_template), case_str_(case_str) {}
     void dump_desc(std::ostream &s) const override { s << case_str_; }
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
 
 private:
     const std::string case_str_;

--- a/tests/benchdnn/ip/ip.hpp
+++ b/tests/benchdnn/ip/ip.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -157,11 +158,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->mb << ',' << p_->oc << ',' << p_->ic << ',' << p_->id << ','
-          << p_->ih << ',' << p_->iw;
     }
 
     double ops() const override { return p_->ops; }

--- a/tests/benchdnn/lnorm/lnorm.hpp
+++ b/tests/benchdnn/lnorm/lnorm.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -226,9 +227,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_dims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     void dump_flags(std::ostream &s) const override {
         s << flags2str(p_->flags);
     }

--- a/tests/benchdnn/lrn/lrn.hpp
+++ b/tests/benchdnn/lrn/lrn.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -132,12 +133,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->mb << ',' << p_->ic << ',' << p_->id << ',' << p_->ih << ','
-          << p_->iw << ',' << p_->ls << ',' << p_->alpha << ',' << p_->beta
-          << ',' << p_->k;
     }
 
     const int64_t *user_mb() const override { return &p_->user_mb; }

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -231,9 +232,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_vdims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     double ops() const override { return p_->ops; }
     const std::vector<dnnl_data_type_t> *sdt() const override {
         return &p_->dt;

--- a/tests/benchdnn/pool/pool.hpp
+++ b/tests/benchdnn/pool/pool.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -189,22 +190,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->mb << ','
-
-          << p_->ic << ',' << p_->id << ',' << p_->ih << ',' << p_->iw << ','
-
-          << p_->od << ',' << p_->oh << ',' << p_->ow << ','
-
-          << p_->kd << ',' << p_->kh << ',' << p_->kw << ','
-
-          << p_->sd << ',' << p_->sh << ',' << p_->sw << ','
-
-          << p_->pd << ',' << p_->ph << ',' << p_->pw << ','
-
-          << p_->dd << ',' << p_->dh << ',' << p_->dw;
     }
 
     const int64_t *user_mb() const override { return &p_->user_mb; }

--- a/tests/benchdnn/prelu/prelu.hpp
+++ b/tests/benchdnn/prelu/prelu.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -113,9 +114,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_vdims_t &>(*prb_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const attr_t *attr() const override { return &prb_->attr; }
     const thr_ctx_t *ctx_init() const override { return &prb_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &prb_->ctx_exe; }

--- a/tests/benchdnn/reduction/reduction.hpp
+++ b/tests/benchdnn/reduction/reduction.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -145,9 +146,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_vdims_t &>(*prb_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const attr_t *attr() const override { return &prb_->attr; }
     const thr_ctx_t *ctx_init() const override { return &prb_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &prb_->ctx_exe; }

--- a/tests/benchdnn/reorder/reorder.hpp
+++ b/tests/benchdnn/reorder/reorder.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -155,9 +156,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_dims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     void dump_engine(std::ostream &s) const override {
         if (p_->cross_engine == CPU2GPU)
             s << "cpu2gpu";

--- a/tests/benchdnn/resampling/resampling.hpp
+++ b/tests/benchdnn/resampling/resampling.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -145,14 +146,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->mb << ','
-
-          << p_->ic << ',' << p_->id << ',' << p_->ih << ',' << p_->iw << ','
-
-          << p_->od << ',' << p_->oh << ',' << p_->ow;
     }
 
     const int64_t *user_mb() const override { return &p_->user_mb; }

--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -571,11 +572,6 @@ struct perf_report_t : public base_perf_report_t {
 
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const desc_t &>(*p_);
-    }
-
-    void dump_desc_csv(std::ostream &s) const override {
-        s << p_->n_layer << "," << p_->n_iter << "," << p_->mb << "," << p_->sic
-          << "," << p_->slc << "," << p_->dhc << "," << p_->dic;
     }
 
     void dump_rnn_activation(std::ostream &s) const override {

--- a/tests/benchdnn/shuffle/shuffle.hpp
+++ b/tests/benchdnn/shuffle/shuffle.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -117,9 +118,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_dims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/softmax/softmax.hpp
+++ b/tests/benchdnn/softmax/softmax.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -146,9 +147,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_dims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/sum/sum.hpp
+++ b/tests/benchdnn/sum/sum.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -132,9 +133,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_dims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/utils/perf_report.cpp
+++ b/tests/benchdnn/utils/perf_report.cpp
@@ -21,7 +21,7 @@
 #include "utils/perf_report.hpp"
 
 void base_perf_report_t::report(res_t *res, const char *prb_str) const {
-    dump_perf_footer();
+    dump_perf_header();
 
     dnnl::impl::stringstream_t ss;
 
@@ -155,4 +155,40 @@ void base_perf_report_t::handle_option(std::ostream &s, const char *&option,
     BENCHDNN_PRINT(0, "Error: perf report option \"%s\" is not supported\n",
             opt_name.c_str());
     SAFE_V(FAIL);
+}
+
+void base_perf_report_t::dump_perf_header() const {
+
+    static bool header_printed = false;
+    if (header_printed) return;
+
+    BENCHDNN_PRINT(0, "Template entries: %s\n", pt_);
+
+    // Process template into a CSV friendly header, which can be easily processed as a
+    // dataframe (i.e. no symbols other than _ and not starting with a number)
+    const char *pt = pt_;
+    char c;
+    dnnl::impl::stringstream_t ss;
+    while ((c = *pt++) != '\0') {
+        // Print anything that isn't %
+        if (c != '%') {
+            ss << c;
+            continue;
+        }
+        // Replace -/0/+ modifiers immediately after % with min/avg/max in header
+        char c_next = *pt;
+        if (c_next != '\0'
+                && (c_next == '-' || c_next == '0' || c_next == '+')) {
+            switch (c_next) {
+                case '-': ss << "min_"; break;
+                case '0': ss << "avg_"; break;
+                case '+': ss << "max_"; break;
+                default: break;
+            }
+            pt++;
+        }
+    }
+
+    BENCHDNN_PRINT(0, "%s\n", ss.str().c_str());
+    header_printed = true;
 }

--- a/tests/benchdnn/utils/perf_report.cpp
+++ b/tests/benchdnn/utils/perf_report.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -105,7 +106,6 @@ void base_perf_report_t::handle_option(std::ostream &s, const char *&option,
     HANDLE("alg", dump_alg(s));
     HANDLE("cfg", dump_cfg(s));
     HANDLE("desc", dump_desc(s));
-    HANDLE("DESC", dump_desc_csv(s));
     HANDLE("engine", dump_engine(s));
     HANDLE("flags", dump_flags(s));
     HANDLE("activation", dump_rnn_activation(s));

--- a/tests/benchdnn/utils/perf_report.hpp
+++ b/tests/benchdnn/utils/perf_report.hpp
@@ -75,13 +75,7 @@ private:
     void handle_option(std::ostream &s, const char *&option, res_t *res,
             const char *prb_str) const;
 
-    void dump_perf_footer() const {
-        static bool footer_printed = false;
-        if (!footer_printed) {
-            BENCHDNN_PRINT(0, "Output template: %s\n", pt_);
-            footer_printed = true;
-        }
-    }
+    void dump_perf_header() const;
 
     static timer::timer_t::mode_t modifier2mode(char c) {
         if (c == '-') return timer::timer_t::min;

--- a/tests/benchdnn/utils/perf_report.hpp
+++ b/tests/benchdnn/utils/perf_report.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,7 +65,6 @@ struct base_perf_report_t {
     virtual void dump_alg(std::ostream &) const { SAFE_V(FAIL); }
     virtual void dump_cfg(std::ostream &) const { SAFE_V(FAIL); }
     virtual void dump_desc(std::ostream &) const { SAFE_V(FAIL); }
-    virtual void dump_desc_csv(std::ostream &) const { SAFE_V(FAIL); }
     virtual void dump_flags(std::ostream &) const { SAFE_V(FAIL); }
     virtual void dump_rnn_activation(std::ostream &) const { SAFE_V(FAIL); }
     virtual void dump_rnn_direction(std::ostream &) const { SAFE_V(FAIL); }

--- a/tests/benchdnn/utils/settings.hpp
+++ b/tests/benchdnn/utils/settings.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -110,7 +111,7 @@ struct base_settings_t {
         static const std::string csv_pre
                 = std::string("perf,%engine%,%impl%,%name%,");
         static const std::string csv_post = std::string(
-                ",%attr%,%DESC%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%"
+                ",%attr%,%desc%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%"
                 "0Gflops%");
         static const std::string csv = csv_pre + driver_args + csv_post;
         return csv.c_str();

--- a/tests/benchdnn/zeropad/zeropad.hpp
+++ b/tests/benchdnn/zeropad/zeropad.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,9 +88,6 @@ struct perf_report_t : public base_perf_report_t {
     void dump_desc(std::ostream &s) const override {
         s << static_cast<const prb_dims_t &>(*p_);
     }
-
-    void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }
-
     const std::string *name() const override { return &p_->name; }
     const dnnl_data_type_t *dt() const override { return &p_->dt; }
     const std::string *tag() const override { return &tag_; }


### PR DESCRIPTION
# Description

Most of the `benchdnn` `perf-template`s already emit CSV-shaped data, but there are no headers, and the template doesn't match the columns. Specifically, `%DESC%` can expand to multiple columns for some drivers, which makes the output hard to parse. This change adds a CSV header row that matches each driver's concrete `%DESC%` expansion while preserving the existing `Output template: ...` banner. This makes the CSV output easy to consume with standard tools (e.g. `xsv`).

E.g. after this change,

```sh
./tests/benchdnn/benchdnn --conv --mode=P --perf-template=csv  mb1_ic1oc1_id1ih5iw5_od1oh3ow3_kd1kh3kw3_sd1sh1sw1_pd0ph0pw0_dd0dh0dw0 \
    | grep '^perf,' \
    | xsv table

perf  engine  impl         name  dir    sdt          stag  wtag  dtag  alg     attr  g   mb  ic  id  ih  iw  oc  od  oh  ow  kd  kh  kw  sd  sh  sw  pd  ph  pw  dd  dh  dw  Gops      max_ctime  min_time  min_Gflops  avg_time  avg_Gflops
perf  cpu     jit:sve_128        FWD_B  f32:f32:f32  any   any   any   direct        1   1   1   1   5   5   1   1   3   3   1   3   3   1   1   1   0   0   0   0   0   0   1.62e-07  0.994385   0.137695  0.00117651  0.32537   0.000497895
```

Not sure how to test this using ctest, I'm open to ideas...

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
