### PR TITLE
x64: matmul: Add 3D scales and zero points support

### DIFF
--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -168,6 +168,12 @@ The following masks are supported by the primitive:
 - 2, which applies a scale / zero point values per column along the
   `n`-dimension for #DNNL_ARG_WEIGHTS.
 
+For batched matmul (3D and higher), scales and zero points can additionally
+be grouped over the batch dimension. When batch grouping is specified (via
+a third group element), the corresponding batch dimension bit is added to
+the mask. This allows different quantization parameters per batch group,
+enabling per-batch-group weight decompression.
+
 When scales and/or zero-points masks are specified, the user must
 provide the corresponding scales and/or zero-points as additional
 input memory objects with argument `DNNL_ARG_ATTR_SCALES |

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -212,10 +212,13 @@ struct matmul_pd_t : public primitive_desc_t {
             if (arg == DNNL_ARG_WEIGHTS) {
                 const auto &g0 = scales.get_group(arg, 0);
                 const auto &g1 = scales.get_group(arg, 1);
+                const auto &g2 = scales.get_group(arg, 2);
                 const bool wei_k_group_ok = IMPLICATION(g0 > 1, K() % g0 == 0);
                 const bool wei_n_group_ok = IMPLICATION(g1 > 1, N() % g1 == 0);
+                const bool wei_b_group_ok
+                        = IMPLICATION(g2 > 1, batched() && batch() % g2 == 0);
 
-                ok = ok && wei_k_group_ok && wei_n_group_ok;
+                ok = ok && wei_k_group_ok && wei_n_group_ok && wei_b_group_ok;
 
                 // Mask over K dim is allowed for fp types or weights decompression only.
                 if (types::is_integral_dt(weights_md(0)->data_type)) {

--- a/src/common/primitive_attr_quant.cpp
+++ b/src/common/primitive_attr_quant.cpp
@@ -68,6 +68,8 @@ std::string quant_entry_t::get_verbose() const {
                 .append(std::to_string(group_dims_[0]))
                 .append("x")
                 .append(std::to_string(group_dims_[1]));
+        if (group_ndims_ > 2)
+            s.append("x").append(std::to_string(group_dims_[2]));
     }
     if (is_host_scalar_) { s.append(":host_scalar"); }
     if (qmode_ != quantization_mode::static_sazp) {

--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -130,8 +130,14 @@ struct quant_entry_t : public c_compatible {
         utils::copy_dims_with_mask(quant_dims, in_dims, ndims, mask_,
                 /* fill_with_ones = */ true);
         if (!has_default_groups()) {
-            quant_dims[ndims - 2] /= get_group(0);
-            quant_dims[ndims - 1] /= get_group(1);
+            // Note: nstl::max guards are needed because get_group()
+            // returns 0 for out-of-bound access and MSVC raises C4723
+            // warning (potential divide by 0) treated as error.
+            quant_dims[ndims - 2] /= nstl::max(get_group(0), (dim_t)1);
+            quant_dims[ndims - 1] /= nstl::max(get_group(1), (dim_t)1);
+            if (group_ndims_ > 2 && ndims >= 3) {
+                quant_dims[ndims - 3] /= nstl::max(get_group(2), (dim_t)1);
+            }
         }
 
         CHECK(memory_desc_init_by_tag(

--- a/src/cpu/matmul/matmul_utils.hpp
+++ b/src/cpu/matmul/matmul_utils.hpp
@@ -153,7 +153,7 @@ struct matmul_helper_t {
 
     static dim_t get_quant_off(const dims_t &input_idx, const int ndims,
             const int quant_mask, const dim_t g0, const dim_t g1,
-            const memory_desc_t &quant_md) {
+            const memory_desc_t &quant_md, const dim_t g2 = 1) {
         if (types::is_zero_md(&quant_md)) return 0;
 
         dims_t quant_idx {};
@@ -167,6 +167,7 @@ struct matmul_helper_t {
             quant_idx[ndims - 1] /= g1;
             quant_idx[ndims - 2] /= g0;
         }
+        if (ndims >= 3 && g2 > 1) { quant_idx[ndims - 3] /= g2; }
 
         const memory_desc_wrapper q_mdw(quant_md);
         return q_mdw.off_v(quant_idx);

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -115,6 +115,7 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
     const auto &wei_zp_dt = attr_zps.get_data_type(DNNL_ARG_WEIGHTS);
     const auto wei_zp_group_k = attr_zps.get_group(DNNL_ARG_WEIGHTS, -2);
     const auto wei_zp_group_n = attr_zps.get_group(DNNL_ARG_WEIGHTS, -1);
+    const auto wei_zp_group_b = attr_zps.get_group(DNNL_ARG_WEIGHTS, 2);
     // Initialize a memory desc for quant entries for easier offset calculation.
     memory_desc_t wei_zp_md {};
     CHECK(attr_zps.get(DNNL_ARG_WEIGHTS).get_md(wei_zp_md, *weights_d.md_));
@@ -146,6 +147,7 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
     const auto wei_scale_group_k = attr_scales.get_group(DNNL_ARG_WEIGHTS, -2);
     const auto wei_scale_ngroups_k = K / wei_scale_group_k;
     const auto wei_scale_group_n = attr_scales.get_group(DNNL_ARG_WEIGHTS, -1);
+    const auto wei_scale_group_b = attr_scales.get_group(DNNL_ARG_WEIGHTS, 2);
     // Initialize a memory desc for quant entries for easier offset calculation.
     memory_desc_t wei_scale_md {};
     CHECK(attr_scales.get(DNNL_ARG_WEIGHTS)
@@ -196,7 +198,7 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                                 = matmul_helper_t::get_quant_off(
                                         weights_dims_idx, ndims, wei_zp_mask,
                                         wei_zp_group_k, wei_zp_group_n,
-                                        wei_zp_md);
+                                        wei_zp_md, wei_zp_group_b);
                         const auto wei_zp = io::load_float_value(
                                 wei_zp_dt, wei_zero_points, wei_zp_offset);
                         w -= wei_zp;
@@ -206,7 +208,7 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                                 = matmul_helper_t::get_quant_off(
                                         weights_dims_idx, ndims, wei_scale_mask,
                                         wei_scale_group_k, wei_scale_group_n,
-                                        wei_scale_md);
+                                        wei_scale_md, wei_scale_group_b);
                         const float wei_scale = io::load_float_value(
                                 wei_scale_dt, wei_scales, wei_scale_offset);
                         w *= wei_scale;
@@ -226,7 +228,8 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
             if (with_wei_scales && !with_wei_decompression) {
                 const dim_t wei_scale_offset = matmul_helper_t::get_quant_off(
                         weights_dims_idx, ndims, wei_scale_mask,
-                        wei_scale_group_k, wei_scale_group_n, wei_scale_md);
+                        wei_scale_group_k, wei_scale_group_n, wei_scale_md,
+                        wei_scale_group_b);
                 const float wei_scale = io::load_float_value(
                         wei_scale_dt, wei_scales, wei_scale_offset);
                 acc *= wei_scale;

--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -144,6 +144,10 @@ struct ref_matmul_t : public primitive_t {
                     // Only one non-unit group is supported.
                     ok = utils::one_of(1, gK, gN);
                     if (!ok) return false;
+
+                    const auto gB = zp.get_group(DNNL_ARG_WEIGHTS, 2);
+                    ok = IMPLICATION(gB > 1, batched() && batch() % gB == 0);
+                    if (!ok) return false;
                 }
             }
             if (!zp.has_default_values(DNNL_ARG_DST)) { return false; }

--- a/src/cpu/matmul/ref_matmul_int8.cpp
+++ b/src/cpu/matmul/ref_matmul_int8.cpp
@@ -97,6 +97,7 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
     const auto &wei_zp_dt = attr_zps.get_data_type(DNNL_ARG_WEIGHTS);
     const auto wei_zp_group_k = attr_zps.get_group(DNNL_ARG_WEIGHTS, 0);
     const auto wei_zp_group_n = attr_zps.get_group(DNNL_ARG_WEIGHTS, 1);
+    const auto wei_zp_group_b = attr_zps.get_group(DNNL_ARG_WEIGHTS, 2);
     const auto wei_zp_ngroups_k = wei_zp_group_k > 1 ? K / wei_zp_group_k : 1;
     // Initialize a memory desc for quant entries for easier offset calculation.
     memory_desc_t wei_zp_md {};
@@ -121,6 +122,7 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
     const auto wei_scale_dt = attr_scales.get_data_type(DNNL_ARG_WEIGHTS);
     const auto wei_scale_group_k = attr_scales.get_group(DNNL_ARG_WEIGHTS, 0);
     const auto wei_scale_group_n = attr_scales.get_group(DNNL_ARG_WEIGHTS, 1);
+    const auto wei_scale_group_b = attr_scales.get_group(DNNL_ARG_WEIGHTS, 2);
     const auto wei_scale_ngroups_k
             = wei_scale_group_k > 1 ? K / wei_scale_group_k : 1;
     // Initialize a memory desc for quant entries for easier offset calculation.
@@ -198,9 +200,10 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
                     s -= src_zp;
                 }
                 if (with_wei_zero_points && !with_src_pr) {
-                    const dim_t wei_zp_offset = matmul_helper_t::get_quant_off(
-                            weights_dims_idx, ndims, wei_zp_mask,
-                            wei_zp_group_k, wei_zp_group_n, wei_zp_md);
+                    const dim_t wei_zp_offset
+                            = matmul_helper_t::get_quant_off(weights_dims_idx,
+                                    ndims, wei_zp_mask, wei_zp_group_k,
+                                    wei_zp_group_n, wei_zp_md, wei_zp_group_b);
                     const auto wei_zp = io::load_int_value(
                             wei_zp_dt, wei_zero_points, wei_zp_offset);
                     w -= wei_zp;
@@ -218,7 +221,7 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
 
                 const dim_t wei_zp_offset = matmul_helper_t::get_quant_off(
                         weights_dims_idx, ndims, wei_zp_mask, wei_zp_group_k,
-                        wei_zp_group_n, wei_zp_md);
+                        wei_zp_group_n, wei_zp_md, wei_zp_group_b);
                 const auto wei_zp = io::load_int_value(
                         wei_zp_dt, wei_zero_points, wei_zp_offset);
                 acc -= src_pr * wei_zp;
@@ -237,7 +240,8 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
             if (with_wei_scales) {
                 const dim_t wei_scale_offset = matmul_helper_t::get_quant_off(
                         weights_dims_idx, ndims, wei_scale_mask,
-                        wei_scale_group_k, wei_scale_group_n, wei_scale_md);
+                        wei_scale_group_k, wei_scale_group_n, wei_scale_md,
+                        wei_scale_group_b);
                 const float wei_scale = io::load_float_value(
                         wei_scale_dt, wei_scales, wei_scale_offset);
                 acc_f *= wei_scale;

--- a/src/cpu/matmul/ref_matmul_int8.hpp
+++ b/src/cpu/matmul/ref_matmul_int8.hpp
@@ -118,6 +118,10 @@ struct ref_matmul_int8_t : public primitive_t {
                     // Only one non-unit group is supported.
                     ok = utils::one_of(1, gK, gN);
                     if (!ok) return false;
+
+                    const auto gB = zp.get_group(DNNL_ARG_WEIGHTS, 2);
+                    ok = IMPLICATION(gB > 1, batched() && batch() % gB == 0);
+                    if (!ok) return false;
                 }
             }
             if (!zp.has_default_values(DNNL_ARG_DST)) {

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -1344,8 +1344,8 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         ctx.current_K_iters = k_iters;
         ctx.current_K_pad = brgmm_ctx.get_current_K_pad(k_iters);
         ctx.src_scales_ptr = brgmm_ctx.get_src_scales_ptr();
-        ctx.wei_scales_ptr = brgmm_ctx.get_wei_scales_ptr(n, k);
-        ctx.zp_b_value_ptr = brgmm_ctx.get_wei_zp_ptr(n, k);
+        ctx.wei_scales_ptr = brgmm_ctx.get_wei_scales_ptr(n, b_idx, k);
+        ctx.zp_b_value_ptr = brgmm_ctx.get_wei_zp_ptr(n, b_idx, k);
         if (bgmmc.blocked_B && !bgmmc.is_f16_with_int_wei
                 && isa == avx512_core_fp16) {
             cvt_float16_to_float((float *)ctx.tr_src, (float16_t *)ctx.src,
@@ -2136,13 +2136,18 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Returns a pointer to the weights scales for the correspondent block based
     // on @p n and @p k.
-    const void *get_wei_scales_ptr(dim_t n, dim_t k = 0) const {
+    const void *get_wei_scales_ptr(dim_t n, dim_t b = 0, dim_t k = 0) const {
         if (bgmmc_.is_wei_scale_common) return wei_scales_;
         auto offset = n;
         if (bgmmc_.is_wei_scale_per_k) {
             const auto &k_group_sz = bgmmc_.wei_scales_k_gsize;
             const auto k_idx = k / k_group_sz;
             offset += k_idx * bgmmc_.N;
+        }
+
+        if (bgmmc_.wei_scales_batch_gsize > 0) {
+            const auto b_idx = b / bgmmc_.wei_scales_batch_gsize;
+            offset += b_idx * bgmmc_.wei_scales_batch_offset;
         }
 
         offset = offset * bgmmc_.wei_scales_dt_sz;
@@ -2174,17 +2179,22 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return -cpu::io::load_int_value(bgmmc_.wei_zp_dt, wei_zp_ptr_, 0);
     }
 
-    const void *get_wei_zp_ptr(dim_t n, dim_t k = 0) const {
+    const void *get_wei_zp_ptr(dim_t n, dim_t b = 0, dim_t k = 0) const {
         if (!bgmmc_.has_zero_point_b) return nullptr;
         if (bgmmc_.is_wei_zp_common)
             return wei_zp_ptr_; // single zero point value
-        // Locate the group based on (n,k)
+        // Locate the group based on (n, b, k)
         auto offset = n;
 
         if (bgmmc_.is_wei_zp_per_k) {
             const auto &k_group_sz = bgmmc_.wei_zp_k_gsize;
             const auto k_idx = k / k_group_sz;
             offset += k_idx * bgmmc_.N;
+        }
+
+        if (bgmmc_.wei_zp_batch_gsize > 0) {
+            const auto b_idx = b / bgmmc_.wei_zp_batch_gsize;
+            offset += b_idx * bgmmc_.wei_zp_batch_offset;
         }
 
         const auto dt_sz = types::data_type_size(bgmmc_.wei_zp_dt);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1461,6 +1461,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.wei_scales_dt = wei_scales.get_data_type();
         bgmmc.wei_scales_dt_sz = types::data_type_size(bgmmc.wei_scales_dt);
         bgmmc.wei_scales_k_gsize = wei_scales.get_group(0);
+        bgmmc.wei_scales_batch_gsize = wei_scales.get_group(2);
 
         // only common and per-oc-channel scales are supported
         // only per-ic-channel scales is supprted with weight decompression
@@ -1496,6 +1497,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.is_wei_zp_per_n = wei_zp_mask & (1 << (bgmmc.ndims - 1));
         bgmmc.wei_zp_dt = wei_zp.get_data_type();
         bgmmc.wei_zp_k_gsize = wei_zp.get_group(0);
+        bgmmc.wei_zp_batch_gsize = wei_zp.get_group(2);
 
         VCONDCHECK_BG(wei_zp_mask == 0 || bgmmc.is_wei_zp_per_k
                         || bgmmc.is_wei_zp_per_n,
@@ -1537,6 +1539,18 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.is_runtime_M = is_runtime_value(bgmmc.M);
     bgmmc.is_runtime_N = is_runtime_value(bgmmc.N);
     bgmmc.is_runtime_K = is_runtime_value(bgmmc.K);
+
+    // Set quantization batch offset if it's required
+    if (bgmmc.wei_scales_batch_gsize > 0) {
+        const auto scales_k_dim = bgmmc.K / bgmmc.wei_scales_k_gsize;
+        const auto scales_n_dim = bgmmc.N / wei_scales.get_group(1);
+        bgmmc.wei_scales_batch_offset = scales_k_dim * scales_n_dim;
+    }
+    if (bgmmc.wei_zp_batch_gsize > 0) {
+        const auto zp_k_dim = bgmmc.K / bgmmc.wei_zp_k_gsize;
+        const auto zp_n_dim = bgmmc.N / wei_zp.get_group(1);
+        bgmmc.wei_zp_batch_offset = zp_k_dim * zp_n_dim;
+    }
 
     bgmmc.is_gemv = is_gemv_applicable(
             bgmmc, bm_conf_utils, src_md, weights_md, attr);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -231,6 +231,8 @@ struct brgemm_matmul_conf_t {
     bool is_wei_scale_common = false;
     dim_t wei_scales_k_gsize = 0;
     data_type_t wei_scales_dt = data_type::undef;
+    dim_t wei_scales_batch_offset = 0;
+    dim_t wei_scales_batch_gsize = 0;
 
     // Zero points
     bool has_zero_point_a;
@@ -247,6 +249,8 @@ struct brgemm_matmul_conf_t {
     bool is_wei_zp_per_n = false;
     bool is_wei_zp_common = false;
     data_type_t wei_zp_dt = data_type::undef;
+    dim_t wei_zp_batch_offset = 0;
+    dim_t wei_zp_batch_gsize = 0;
 
     dim_t zp_a_comp_shift_n;
     dim_t zp_a_comp_elems_per_thr;

--- a/src/gpu/gpu_matmul_pd.hpp
+++ b/src/gpu/gpu_matmul_pd.hpp
@@ -29,6 +29,14 @@ namespace gpu {
 struct gpu_matmul_pd_t : public matmul_pd_t {
     using matmul_pd_t::matmul_pd_t;
 
+    bool attr_scales_ok(const std::vector<int> &supported_args
+            = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+            const std::vector<int> &supported_qmodes
+            = {quantization_mode::static_sazp}) const override {
+        if (!batch_groups_ok()) return false;
+        return matmul_pd_t::attr_scales_ok(supported_args, supported_qmodes);
+    }
+
     bool has_blocks() {
         for (auto md : {&src_md_, &weights_md_, &bias_md_, &dst_md_}) {
             memory_desc_wrapper mdw(md);
@@ -37,6 +45,23 @@ struct gpu_matmul_pd_t : public matmul_pd_t {
             }
         }
         return false;
+    }
+
+protected:
+    // 3D (batch) groups for scales and zero points are not supported on GPU.
+    bool batch_groups_ok() const {
+        const auto &scales = attr()->scales_;
+        for (int arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
+            if (!scales.has_default_values(arg)
+                    && scales.get(arg).get_group(2) > 1)
+                return false;
+        }
+        const auto &zps = attr()->zero_points_;
+        for (int arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
+            if (!zps.has_default_values(arg) && zps.get(arg).get_group(2) > 1)
+                return false;
+        }
+        return true;
     }
 };
 

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -45,6 +45,9 @@ struct gemm_t : public primitive_t {
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
 
+            // 3D (batch) groups for scales/zero points not supported on GPU.
+            if (!batch_groups_ok()) return status::unimplemented;
+
             primitive_attr_t gemm_attr;
             gemm_attr.fpmath_ = attr()->fpmath_;
             gemm_attr.acc_mode_ = attr()->acc_mode_;

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -346,9 +346,10 @@ int attr_t::arg_scales_t::entry_t::from_str(const std::string &s) {
     parser::parse_vector_str(this->groups, dims_t(),
             parser::parser_utils::stoll_safe, g_str, 'x');
 
-    if (!this->groups.empty() && this->groups.size() != 2) {
-        BENCHDNN_PRINT(
-                0, "%s\n", "Error: the number of groups is expected to be 2.");
+    if (!this->groups.empty() && this->groups.size() != 2
+            && this->groups.size() != 3) {
+        BENCHDNN_PRINT(0, "%s\n",
+                "Error: the number of groups is expected to be 2 or 3.");
         SAFE_V(FAIL);
     }
     HANDLE_DANGLING_SYMBOL_AND_END_OF_STRING();
@@ -408,9 +409,10 @@ int attr_t::zero_points_t::entry_t::from_str(const std::string &s) {
     const auto g_str = parser::get_substr(s, start_pos, ':');
     parser::parse_vector_str(this->groups, dims_t(),
             parser::parser_utils::stoll_safe, g_str, 'x');
-    if (!this->groups.empty() && this->groups.size() != 2) {
-        BENCHDNN_PRINT(
-                0, "%s\n", "Error: the number of groups is expected to be 2.");
+    if (!this->groups.empty() && this->groups.size() != 2
+            && this->groups.size() != 3) {
+        BENCHDNN_PRINT(0, "%s\n",
+                "Error: the number of groups is expected to be 2 or 3.");
         SAFE_V(FAIL);
     }
     HANDLE_DANGLING_SYMBOL_AND_END_OF_STRING();
@@ -456,9 +458,10 @@ int attr_t::precomputed_reductions_t::entry_t::from_str(const std::string &s) {
     const auto g_str = parser::get_substr(s, start_pos, ':');
     parser::parse_vector_str(this->groups, dims_t(),
             parser::parser_utils::stoll_safe, g_str, 'x');
-    if (!this->groups.empty() && this->groups.size() != 2) {
-        BENCHDNN_PRINT(
-                0, "%s\n", "Error: the number of groups is expected to be 2.");
+    if (!this->groups.empty() && this->groups.size() != 2
+            && this->groups.size() != 3) {
+        BENCHDNN_PRINT(0, "%s\n",
+                "Error: the number of groups is expected to be 2 or 3.");
         SAFE_V(FAIL);
     }
     HANDLE_DANGLING_SYMBOL_AND_END_OF_STRING();

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1890,13 +1890,19 @@ dims_t md2dims(const_dnnl_memory_desc_t md, int mask, bool extend_by_ones,
     for (int d = 0; d < ndims; ++d) {
         if (mask & (1 << d)) {
             dims.push_back(query_md_dims(md)[d]);
-            // Note: groups are done for matmul's last two dimensions.
+            // Note: groups are done for matmul's last two dimensions
+            // and optionally the batch dimension (ndims-3).
             const auto group_dim = d - (ndims - 2);
-            if (!groups.empty() && group_dim >= 0) {
+            if (!groups.empty() && group_dim >= 0
+                    && group_dim < (int)groups.size()) {
                 // If groups are passed, divide dims on the correspondent group
                 // size. It's needed to pass proper memory objects.
                 assert(dims.back() % groups[group_dim] == 0);
                 dims.back() /= groups[group_dim];
+            }
+            if (groups.size() > 2 && d == ndims - 3) {
+                assert(dims.back() % groups[2] == 0);
+                dims.back() /= groups[2];
             }
         } else if (extend_by_ones) {
             dims.push_back(1);

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -1028,9 +1028,13 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
             dims_t dims = {};
             int64_t ndims = 1;
             const auto &arg_md = query_md(const_pd, exec_arg);
-            const auto mask = sc.get_mask(exec_arg, prim_kind,
-                    query_md_ndims(arg_md), has_channel_groups);
+            const int arg_ndims = query_md_ndims(arg_md);
+            auto mask = sc.get_mask(
+                    exec_arg, prim_kind, arg_ndims, has_channel_groups);
             const auto &groups = sc.get(exec_arg).groups;
+
+            if (groups.size() > 2 && arg_ndims >= 3)
+                mask |= (1 << (arg_ndims - 3));
 
             if (mask > 0) {
                 const auto &md = query_md(const_pd, exec_arg);
@@ -1086,9 +1090,12 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
             int64_t ndims = 1;
             dims_t dims = {};
             const auto &arg_md = query_md(const_pd, exec_arg);
-            const auto mask
-                    = zp.get_mask(exec_arg, prim_kind, query_md_ndims(arg_md));
+            const int arg_ndims = query_md_ndims(arg_md);
+            auto mask = zp.get_mask(exec_arg, prim_kind, arg_ndims);
             const auto &groups = e.groups;
+
+            if (groups.size() > 2 && arg_ndims >= 3)
+                mask |= (1 << (arg_ndims - 3));
 
             if (mask > 0) {
                 const auto &md = query_md(const_pd, exec_arg);

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -438,12 +438,13 @@ int64_t dnn_mem_t::get_idx(int64_t logical_idx, int dims_mask, const int ndims,
     int64_t stride = 1;
     int64_t offset = 0;
 
-    assert(groups.empty() || groups.size() == 2);
+    assert(groups.empty() || groups.size() == 2 || groups.size() == 3);
     assert(groups.size() <= static_cast<size_t>(ndims));
     dims_t groups_ext(ndims, 1);
     if (!groups.empty()) {
         groups_ext[ndims - 2] = groups[0];
         groups_ext[ndims - 1] = groups[1];
+        if (groups.size() > 2 && ndims >= 3) groups_ext[ndims - 3] = groups[2];
     }
 
     for (int i = 0; i < ndims; ++i) {

--- a/tests/benchdnn/doc/knobs_attr.md
+++ b/tests/benchdnn/doc/knobs_attr.md
@@ -151,7 +151,10 @@ value for any other policies will trigger an error.
 `f32` (the default), `f16`, `bf16`, `e8m0`, `f8_e5m2`, `f8_e4m3`.
 
 `GROUPS` specifies how scales are grouped along dimensions where multiple scale
-factors are used.
+factors are used. Groups are specified as `KxN` for 2D grouping or `KxNxB` for
+3D grouping with a batch dimension. For the 3D case, the third element specifies
+the group size along the batch dimension (e.g., `32x1x3` means K-group=32,
+N-group=1, batch-group=3).
 
 To specify more than one memory argument for this attribute, `+` delimiter is
 used.
@@ -180,7 +183,8 @@ a value for any other policies will trigger an error.
 `s32` (the default), `s8`, `u8`, `s4`, `u4`.
 
 `GROUPS` specifies how zero points are grouped along dimensions where multiple
-zero points are used.
+zero points are used. Groups are specified as `KxN` for 2D grouping or `KxNxB`
+for 3D grouping with a batch dimension (same format as for scales).
 
 To specify more than one memory argument for this attribute, `+` delimiter is
 used.
@@ -392,6 +396,14 @@ Run a matmul problem with weight-only quantization where weights `bf16` scales a
   ./benchdnn --matmul --dt=f32:s8:f32 --attr-fpmath=bf16:true \
              --attr-scales=wei:per_ocic:bf16:2x1 \
              --attr-zero-points=wei:per_ocic:s8:2x1 6x4:4x5
+```
+
+Run a batched matmul problem with weight-only quantization where scales and
+zero points are grouped over both `ic` and batch dimensions:
+``` sh
+  ./benchdnn --matmul --dt=bf16:s8:bf16 --attr-fpmath=bf16:true \
+             --attr-scales=wei:per_ocic:bf16:32x1x3 \
+             --attr-zero-points=wei:per_ocic:u8:32x1x3 6x5x128:6x128x64
 ```
 
 Run a matmul problem with MXFP4 semantics:

--- a/tests/benchdnn/inputs/matmul/harness_matmul_decompression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_decompression
@@ -357,3 +357,13 @@
 --attr-zero-points=,wei:common:2,wei:per_oc:s4,wei:per_ocic:s4:192x1
 --attr-fpmath=strict:true
 12x4x576:12x576x192
+
+## Grouping over batch dimension (3D scales/ZP groups)
+--reset
+--dt=bf16:s8:bf16
+--wtag=any,abc
+--attr-scales=wei:per_ocic:bf16:128x1x1,wei:per_ocic:bf16:128x1x3
+--attr-zero-points=,wei:per_ocic:s8:128x1x1,wei:per_ocic:s8:128x1x3
+--attr-fpmath=bf16:true
+6x5x256:6x256x64
+9x8x384:9x384x64

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -207,28 +207,37 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
     attr_args_t attr_args;
     attr_args.prepare_post_ops_mds(prb->attr, prb->ndims, prb->dst_dims.data());
 
-    const auto overload_quant_mask = [&](policy_t policy, int arg) {
+    const auto overload_quant_mask
+            = [&](policy_t policy, int arg, const dims_t &groups = {}) {
         // Overload PER_OC/PER_OCIC mask definition for batched cases.
         if (policy == policy_t::PER_OC || policy == policy_t::PER_OCIC) {
             int mask = 1 << (prb->ndims - 1);
             if (policy == policy_t::PER_OCIC) mask += 1 << (prb->ndims - 2);
+            if (groups.size() > 2 && prb->ndims >= 3)
+                mask += 1 << (prb->ndims - 3);
             attr_args.prepare_quant(prb->attr, arg, mask);
         }
     };
 
     overload_quant_mask(prb->attr.scales.get(DNNL_ARG_SRC).policy,
-            DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
+            DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC,
+            prb->attr.scales.get(DNNL_ARG_SRC).groups);
     overload_quant_mask(prb->attr.scales.get(DNNL_ARG_WEIGHTS).policy,
-            DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS);
+            DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,
+            prb->attr.scales.get(DNNL_ARG_WEIGHTS).groups);
     overload_quant_mask(prb->attr.scales.get(DNNL_ARG_DST).policy,
-            DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+            DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
+            prb->attr.scales.get(DNNL_ARG_DST).groups);
     overload_quant_mask(prb->attr.zero_points.get(DNNL_ARG_SRC).policy,
-            DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC);
+            DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC,
+            prb->attr.zero_points.get(DNNL_ARG_SRC).groups);
     overload_quant_mask(prb->attr.zero_points.get(DNNL_ARG_WEIGHTS).policy,
-            DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS);
+            DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
+            prb->attr.zero_points.get(DNNL_ARG_WEIGHTS).groups);
     overload_quant_mask(
             prb->attr.precomputed_reductions.get(DNNL_ARG_SRC).policy,
-            DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS | DNNL_ARG_SRC);
+            DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS | DNNL_ARG_SRC,
+            prb->attr.precomputed_reductions.get(DNNL_ARG_SRC).groups);
 
     auto dnnl_attr = make_benchdnn_dnnl_wrapper(
             create_dnnl_attr(prb->attr, attr_args, prb->ndims));
@@ -912,15 +921,35 @@ void skip_invalid_prb(const prb_t *prb, res_t *res) {
                 res->state = SKIPPED;
                 res->reason = skip_reason::invalid_case;
                 return;
-            } else if (groups.size() > 2) {
+            } else if (groups.size() > 3) {
                 BENCHDNN_PRINT(2,
                         "[INVALID][%s:%d]: Weight-only quantization scales "
                         "groups "
-                        "support only two dimensions\n",
+                        "support up to three dimensions\n",
                         __FILE__, __LINE__);
                 res->state = SKIPPED;
                 res->reason = skip_reason::invalid_case;
                 return;
+            } else if (groups.size() == 3 && prb->ndims < 3) {
+                BENCHDNN_PRINT(2,
+                        "[INVALID][%s:%d]: Weight-only quantization scales "
+                        "3D groups require at least 3 dimensions\n",
+                        __FILE__, __LINE__);
+                res->state = SKIPPED;
+                res->reason = skip_reason::invalid_case;
+                return;
+            } else if (groups.size() == 3 && prb->ndims >= 3) {
+                const auto batch_dim = prb->weights_dims()[prb->ndims - 3];
+                if (batch_dim % groups[2]) {
+                    BENCHDNN_PRINT(2,
+                            "[INVALID][%s:%d]: Weight-only quantization "
+                            "scales require batch dim ('%d') to be "
+                            "divisible by batch group ('%d')\n",
+                            __FILE__, __LINE__, (int)batch_dim, (int)groups[2]);
+                    res->state = SKIPPED;
+                    res->reason = skip_reason::invalid_case;
+                    return;
+                }
             }
         }
     }
@@ -937,15 +966,36 @@ void skip_invalid_prb(const prb_t *prb, res_t *res) {
                 res->state = SKIPPED;
                 res->reason = skip_reason::invalid_case;
                 return;
-            } else if (groups.size() > 2) {
+            } else if (groups.size() > 3) {
                 BENCHDNN_PRINT(2,
                         "[INVALID][%s:%d]: Weight-only quantization "
                         "zero-points "
-                        "groups support only two dimensions\n",
+                        "groups support up to three dimensions\n",
                         __FILE__, __LINE__);
                 res->state = SKIPPED;
                 res->reason = skip_reason::invalid_case;
                 return;
+            } else if (groups.size() == 3 && prb->ndims < 3) {
+                BENCHDNN_PRINT(2,
+                        "[INVALID][%s:%d]: Weight-only quantization "
+                        "zero-points 3D groups require at least 3 "
+                        "dimensions\n",
+                        __FILE__, __LINE__);
+                res->state = SKIPPED;
+                res->reason = skip_reason::invalid_case;
+                return;
+            } else if (groups.size() == 3 && prb->ndims >= 3) {
+                const auto batch_dim = prb->weights_dims()[prb->ndims - 3];
+                if (batch_dim % groups[2]) {
+                    BENCHDNN_PRINT(2,
+                            "[INVALID][%s:%d]: Weight-only quantization "
+                            "zero-points require batch dim ('%d') to be "
+                            "divisible by batch group ('%d')\n",
+                            __FILE__, __LINE__, (int)batch_dim, (int)groups[2]);
+                    res->state = SKIPPED;
+                    res->reason = skip_reason::invalid_case;
+                    return;
+                }
             }
         }
     }

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -105,6 +105,9 @@ static chunk_params_t make_chunk_params(const prb_t *prb, const args_t &args) {
             DNNL_ARG_SRC, dnnl_matmul, p.src_m->ndims());
     p.wei_scale_mask = prb->attr.scales.get_mask(
             DNNL_ARG_WEIGHTS, dnnl_matmul, p.wei_m->ndims());
+    if (prb->attr.scales.get(DNNL_ARG_WEIGHTS).groups.size() > 2
+            && p.wei_m->ndims() >= 3)
+        p.wei_scale_mask |= (1 << (p.wei_m->ndims() - 3));
     p.dst_scale_mask = prb->attr.scales.get_mask(
             DNNL_ARG_DST, dnnl_matmul, p.dst_m->ndims());
 
@@ -122,6 +125,9 @@ static chunk_params_t make_chunk_params(const prb_t *prb, const args_t &args) {
             ? prb->attr.zero_points.get_mask(
                       DNNL_ARG_WEIGHTS, dnnl_matmul, p.wei_m->ndims())
             : 0;
+    if (prb->attr.zero_points.get(DNNL_ARG_WEIGHTS).groups.size() > 2
+            && p.wei_m->ndims() >= 3)
+        p.wei_zp_mask |= (1 << (p.wei_m->ndims() - 3));
     p.dst_zp_mask = p.has_dst_zp ? prb->attr.zero_points.get_mask(DNNL_ARG_DST,
                                            dnnl_matmul, p.dst_m->ndims())
                                  : 0;


### PR DESCRIPTION
[MFDNN-14588](https://jira.devtools.intel.com/browse/MFDNN-14588)
This PR enables 3D-scales and zero points for matmul.

Library changes:
- `brgemm_matmul_utils.hpp`: Add `wei_scales_batch_gsize`, `wei_scales_batch_offset`, `wei_zp_batch_gsize`, `wei_zp_batch_offset` attributes to `brgemm_matmul_conf_t`.
- `brgemm_matmul_utils.cpp`: Read batch group size from `get_group(2)` and compute batch offsets for scales and zero points.
- `brgemm_matmul.cpp`: Pass batch index to `get_wei_scales_ptr()` and `get_wei_zp_ptr()`, add batch offset calculation in those functions.
- `primitive_attr_quant.hpp`: Update `get_md()` to divide the batch dimension by corresponding group element.

Benchdnn changes:
- `dnn_types.cpp`: Enable 3D scales and zero points.
- `dnnl_memory.cpp`: Add one more dimension `get_idx()` .
- `matmul/matmul.cpp`: Enable 3D in  `overload_quant_mask` .
- `harness_matmul_decompression`: Add test cases for batch dimension weight decompression.




