### PR TITLE
benchdnn: graph: test rmsnorm with different epsilon values

### DIFF
--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -1298,6 +1298,12 @@ bool get_lnorm_dt(const deserialized_op_t &base_op_ref, dnnl_data_type_t &dt) {
     return true;
 }
 
+bool get_lnorm_eps(const deserialized_op_t &base_op_ref, float &eps) {
+    auto ret = base_op_ref.get_attr_f32(eps, "epsilon");
+    if (!ret) { eps = 1e-5f; }
+    return true;
+}
+
 bool get_lnorm_flags(
         const deserialized_op_t &base_op_ref, ::lnorm::flags_t &flags) {
     bool use_affine = false;
@@ -1371,6 +1377,8 @@ bool get_lnorm_flags(
             lnorm::get_lnorm_flags(base_op_ref, op_setting.flags.front()), res);
     DNN_GRAPH_CHECK_SETTINGS(
             get_graph_attr(base_op_ref, op_setting.fpmath_mode.front()), res);
+    DNN_GRAPH_CHECK_SETTINGS(
+            lnorm::get_lnorm_eps(base_op_ref, op_setting.eps.front()), res);
 
     return op_setting;
 }

--- a/tests/benchdnn/inputs/graph/op/harness_f32_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f32_all
@@ -873,3 +873,4 @@
 --reset --in-shapes=1:1 --case=op/f32/greaterequal.json
 --reset --op-attrs=0:mode:gelu_erf,0:mode:gelu_tanh --case=op/f32/gelu.json
 --reset --case=op/f32/rmsnorm.json
+--reset --op-attrs=0:epsilon:0.00001 --case=op/f32/rmsnorm.json

--- a/tests/benchdnn/lnorm/bench_lnorm.cpp
+++ b/tests/benchdnn/lnorm/bench_lnorm.cpp
@@ -39,13 +39,14 @@ void check_correctness(
     for_(const auto &i_stat_tag : s.stat_tag)
     for_(const auto &i_ss_dt : s.ss_dt)
     for_(const auto &i_flags : s.flags)
+    for_(const auto &i_eps : s.eps)
     for_(const auto &i_attr : s.attributes)
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
         const prb_t prb(s.prb_dims, i_tag, i_stat_tag, i_ss_dt, i_dir, i_dt,
-                i_flags, s.check_alg, i_inplace, i_attr, i_ctx_init, i_ctx_exe,
-                s.impl_filter);
+                i_flags, s.check_alg, i_eps, i_inplace, i_attr, i_ctx_init,
+                i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
         task_executor.submit(prb, s.perf_template, createit, checkit, doit);

--- a/tests/benchdnn/lnorm/lnorm.hpp
+++ b/tests/benchdnn/lnorm/lnorm.hpp
@@ -58,8 +58,11 @@ struct settings_t : public base_settings_t {
     std::vector<flags_t> flags {NONE};
     check_alg_t check_alg = check_alg_t::ALG_AUTO;
 
+    std::vector<float> eps {1.f / 16};
+
     const char *perf_template_csv() const {
-        static const std::string args = "%dir%,%dt%,%tag%,%stat_tag%,%flags%";
+        static const std::string args
+                = "%dir%,%dt%,%tag%,%stat_tag%,%flags%,%eps%";
         return perf_template_csv_base(args);
     }
 
@@ -67,7 +70,7 @@ struct settings_t : public base_settings_t {
 
     bool has_single_setup() const override {
         return dir.size() == 1 && dt.size() == 1 && tag.size() == 1
-                && stat_tag.size() == 1 && flags.size() == 1
+                && stat_tag.size() == 1 && flags.size() == 1 && eps.size() == 1
                 && base_settings_t::has_single_setup();
     }
 };
@@ -76,7 +79,7 @@ struct prb_t : public prb_dims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.tag[0], s.stat_tag[0], s.ss_dt[0], s.dir[0],
-                  s.dt[0], s.flags[0], s.check_alg, s.inplace[0],
+                  s.dt[0], s.flags[0], s.check_alg, s.eps[0], s.inplace[0],
                   s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
                   s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
@@ -85,7 +88,7 @@ struct prb_t : public prb_dims_t {
     prb_t(const prb_dims_t &prb_dims, const std::vector<std::string> &tag,
             const std::string &stat_tag, dnnl_data_type_t ss_dt, dir_t dir,
             const std::vector<dnnl_data_type_t> &dt, flags_t flags,
-            check_alg_t check_alg, bool inplace, const attr_t &attr,
+            check_alg_t check_alg, float eps, bool inplace, const attr_t &attr,
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
@@ -103,7 +106,7 @@ struct prb_t : public prb_dims_t {
         , impl_filter(impl_filter)
         , n(1)
         , c(dims[ndims - 1])
-        , eps(1.f / 16) {
+        , eps(eps) {
         for (int d = 0; d < ndims - 1; d++)
             n *= dims[d];
 


### PR DESCRIPTION
Fixes MFDNN-14781

1. In Graph API, if epsilon is not specified, it's default to 1e-5 per the op definition. Epsilon can be specified through the JSON file or --op-attrs rewriting.
2. In lnorm driver, epsilon = 1.f/16 (0.0625f) is always used for lnorm primitive testing.
3. This change passes the epsilon value from RMS Norm test case to the lnorm driver in benchdnn for correctness validation.
