### PR TITLE
benchdnn: add SDPA driver

### DIFF
--- a/tests/benchdnn/README.md
+++ b/tests/benchdnn/README.md
@@ -32,6 +32,7 @@ where `DRIVER` is one of:
 * [reorder](doc/driver_reorder.md)
 * [resampling](doc/driver_resampling.md)
 * [rnn](doc/driver_rnn.md)
+* [sdpa](doc/driver_sdpa.md)
 * [shuffle](doc/driver_shuffle.md)
 * [softmax](doc/driver_softmax.md)
 * [sum](doc/driver_sum.md)

--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -44,6 +44,7 @@
 #include "reorder/reorder.hpp"
 #include "resampling/resampling.hpp"
 #include "rnn/rnn.hpp"
+#include "sdpa/sdpa.hpp"
 #include "self/self.hpp"
 #include "shuffle/shuffle.hpp"
 #include "softmax/softmax.hpp"
@@ -141,6 +142,8 @@ int main(int argc, char **argv) {
         resampling::bench(--argc, ++argv);
     } else if (!strcmp("--reduction", argv[0])) {
         reduction::bench(--argc, ++argv);
+    } else if (!strcmp("--sdpa", argv[0])) {
+        sdpa::bench(--argc, ++argv);
     } else if (!strcmp("--zeropad", argv[0])) {
         zeropad::bench(--argc, ++argv);
     } else if (!strcmp("--brgemm", argv[0])) {

--- a/tests/benchdnn/doc/driver_sdpa.md
+++ b/tests/benchdnn/doc/driver_sdpa.md
@@ -1,0 +1,114 @@
+# SDPA Driver
+
+**Note:** This driver tests internal SDPA primitive functionality that is not
+part of the public oneDNN API.
+
+## Usage
+``` sh
+    ./benchdnn --sdpa [benchdnn-knobs] [sdpa-knobs] [sdpa-desc] ...
+```
+
+where *sdpa-knobs* are:
+
+ - `--dir={FWD_I [default], FWD_D, BWD_D}` -- propagation direction.
+            `FWD_I` is forward inference, `FWD_D` is forward training (needed
+            for workspace output used by backward), `BWD_D` is backward data
+            which computes gradients for Q, K, and V.
+            Refer to [direction](knobs_dir.md) for details.
+ - `--dt={f32:f32:f32:f32 [default], ...}` -- source (Q, K, V) and destination
+            data types. Interface supports broadcasting, when a single input is
+            provided, e.g., `--dt=f32`, the value is applied for all tensors.
+            Refer to [data types](knobs_dt.md) for details.
+ - `--qtag={abx [default], ...}` -- memory format of the queries tensor.
+            Refer to [tags](knobs_tag.md) for details.
+ - `--ktag={abx [default], ...}` -- memory format of the keys tensor.
+            Refer to [tags](knobs_tag.md) for details.
+ - `--vtag={abx [default], ...}` -- memory format of the values tensor.
+            Refer to [tags](knobs_tag.md) for details.
+ - `--dtag={abx [default], ...}` -- memory format of the destination tensor.
+            Refer to [tags](knobs_tag.md) for details.
+ - `--mask={none [default], buffer, buffer_1d, buffer_2d, causal_top_left, causal_bottom_right}`
+            -- specifies the attention mask type.
+            `none` uses no mask, `buffer` provides an explicit mask tensor
+            of shape `[B, H, S_q, S_kv]` (added element-wise to attention
+            scores before softmax), `buffer_1d` provides a broadcast mask of
+            shape `[1, 1, 1, S_kv]` (same mask for all batches, heads, and
+            queries), `buffer_2d` provides a broadcast mask of shape
+            `[1, 1, S_q, S_kv]` (same mask for all batches and heads),
+            `causal_top_left` and `causal_bottom_right` apply a causal mask
+            aligned to the respective corner.
+ - `--mdt={f32 [default], f16, bf16}` -- data type of the attention mask
+            buffer. Only used when `--mask` is one of `buffer`,
+            `buffer_1d`, or `buffer_2d`.
+ - `--scale={library [default], mul, div}` -- specifies how the scale
+            value is passed to the primitive. Attention scores are always
+            scaled; the knob controls the API path used. `library` passes
+            `1/sqrt(head_size)` as a multiplicative scale, `mul` does the same
+            explicitly via the `invert_scale=false` API path, `div` passes
+            `sqrt(head_size)` via the `invert_scale=true` API path. All three
+            produce the same mathematical result `scores / sqrt(head_size)`.
+ - `--match=REGEX` -- skip problems not matching the regular expression in
+            `REGEX`. By default no pattern is applied (run everything).
+            Note: Windows may interpret only string arguments surrounded by
+            double quotation marks.
+ - Any attributes options. Refer to [attributes](knobs_attr.md) for details.
+
+and *sdpa-desc* is a problem descriptor. The canonical form is:
+```
+    Q_DIMS:K_DIMS:V_DIMS
+```
+Here `x` is the delimiter for dimensions within a tensor and `:` is the
+delimiter for tensors, provided in the order queries (Q), keys (K), and
+values (V). The destination dimensions are derived automatically.
+A typical 4D tensor layout is `BxHxSxD` where `B` is batch, `H` is heads,
+`S` is sequence length, and `D` is head size.
+
+## Essence of Testing
+
+The SDPA operation computes
+`DST = softmax((Q * K^T) * scale [+ mask]) * V`.
+The reference executes each step independently using f32 matmul and softmax
+primitives on the CPU. The driver compares the fused primitive output against
+this stepwise reference.
+
+For backward (`--dir=BWD_D`), the driver creates a forward-training primitive
+(to produce workspace) followed by a backward primitive. The backward reference
+recomputes the forward intermediates (softmax probabilities), then derives
+gradients via softmax backward and transposed matmuls:
+`dS = softmax_bwd(S2, dO * V^T)`, `dQ = scale(dS) * K^T`, `dK = Q^T * scale(dS)`,
+`dV = S2^T * dO`, with GQA reduction where applicable.
+
+## Examples
+
+Run the default validation set of SDPA using `inputs/sdpa/shapes_basic` file:
+``` sh
+    ./benchdnn --sdpa --batch=inputs/sdpa/shapes_basic
+```
+
+Run f16 SDPA with a causal mask on a transformer-like shape:
+``` sh
+    ./benchdnn --sdpa --dt=f16 --mask=causal_top_left \
+               1x12x128x64:1x12x64x128:1x12x128x64
+```
+
+Run SDPA with explicit scale (division mode) and mixed data types:
+``` sh
+    ./benchdnn --sdpa --dt=f16:f16:f16:f32 --scale=div \
+               2x8x32x64:2x8x64x32:2x8x32x64
+```
+
+Run SDPA performance benchmark on GPU:
+``` sh
+    ./benchdnn --mode=f --sdpa --engine=gpu --dt=f16 \
+               --mask=causal_bottom_right \
+               1x32x2048x128:1x32x128x2048:1x32x2048x128
+```
+
+Run SDPA backward (training) on GPU:
+``` sh
+    ./benchdnn --sdpa --engine=gpu --dir=BWD_D --dt=f16 \
+               1x12x128x64:1x12x64x128:1x12x128x64
+```
+
+More examples with different driver options can be found at
+inputs/sdpa/test_\*.

--- a/tests/benchdnn/inputs/sdpa/shapes_basic
+++ b/tests/benchdnn/inputs/sdpa/shapes_basic
@@ -1,0 +1,8 @@
+# Basic SDPA shapes for smoke and CI testing.
+# SDPA requires 4D tensors: batch x heads x seq x head_dim.
+# Format: Q_dims:K_dims:V_dims
+
+1x1x4x8:1x1x8x4:1x1x4x8
+1x2x8x16:1x2x16x8:1x2x8x16
+2x4x16x32:2x4x32x16:2x4x16x32
+1x8x32x64:1x8x64x32:1x8x32x64

--- a/tests/benchdnn/inputs/sdpa/shapes_bwd
+++ b/tests/benchdnn/inputs/sdpa/shapes_bwd
@@ -1,0 +1,13 @@
+# Backward SDPA shapes — respects GPU kernel constraints:
+#   xe2:   rejects seq <= 128 && head_size >= 64
+#   xe_hpc: rejects qry < 256 && head_size > 32
+
+# head_size=32 (works on xe2 and xe_hpc with any seq)
+1x1x64x32:1x1x32x64:1x1x64x32
+1x2x32x32:1x2x32x32:1x2x32x32
+
+# head_size=64, seq=256 (needs seq > 128 on xe2, qry >= 256 on xe_hpc)
+1x4x256x64:1x4x64x256:1x4x256x64
+
+# head_size=128, seq=256
+1x2x256x128:1x2x128x256:1x2x256x128

--- a/tests/benchdnn/inputs/sdpa/shapes_transformer
+++ b/tests/benchdnn/inputs/sdpa/shapes_transformer
@@ -1,0 +1,31 @@
+# Transformer-derived SDPA shapes for manual / extended testing.
+# Shapes mirror configurations from tests/gtests/internals/test_sdpa.cpp.
+# Includes decode shapes (seq_q=1) that the GPU kernel may not yet support.
+# Format: Q_dims:K_dims:V_dims  (batch x heads x seq x head_dim)
+
+# Encoder-style: 12 heads, head_size=64, seq=384
+1x12x384x64:1x12x64x384:1x12x384x64
+
+# Encoder-style: 16 heads, head_size=64, seq=384
+1x16x384x64:1x16x64x384:1x16x384x64
+
+# LLaMA-2-7B prompt: 32 heads, head_size=128, seq=512
+1x32x512x128:1x32x128x512:1x32x512x128
+
+# LLaMA-2-7B decode: seq_q=1, seq_kv=513
+1x32x1x128:1x32x128x513:1x32x513x128
+
+# GQA — LLaMA-3-8B prompt: q_heads=32, kv_heads=8, seq=384
+1x32x384x128:1x8x128x384:1x8x384x128
+
+# GQA — LLaMA-3-8B decode: seq_q=1, seq_kv=385
+1x32x1x128:1x8x128x385:1x8x385x128
+
+# GQA — Qwen2-7B: q_heads=28, kv_heads=4, seq=384
+1x28x384x128:1x4x128x384:1x4x384x128
+
+# Non-standard head_size (Phi3): 32 heads, head_size=96, seq=384
+1x32x384x96:1x32x96x384:1x32x384x96
+
+# Batch > 1
+2x8x384x64:2x8x64x384:2x8x384x64

--- a/tests/benchdnn/inputs/sdpa/shapes_transformer_gpu
+++ b/tests/benchdnn/inputs/sdpa/shapes_transformer_gpu
@@ -1,0 +1,29 @@
+# Transformer-derived SDPA shapes for GPU CI.
+# Shapes mirror configurations from tests/gtests/internals/test_sdpa.cpp
+# (the primary functional test for the GPU SDPA kernel).
+# Format: Q_dims:K_dims:V_dims  (batch x heads x seq x head_dim)
+
+# Encoder-style: 12 heads, head_size=64, seq=384 (cf. test_sdpa BERT-like)
+1x12x384x64:1x12x64x384:1x12x384x64
+
+# Encoder-style: 16 heads, head_size=64, seq=384
+1x16x384x64:1x16x64x384:1x16x384x64
+
+# LLaMA-2-7B prompt: 32 heads, head_size=128, seq=512
+# (cf. test_sdpa llama_2_7b_chat suite)
+1x32x512x128:1x32x128x512:1x32x512x128
+
+# GQA — LLaMA-3-8B: q_heads=32, kv_heads=8, head_size=128, seq=384
+# (cf. test_sdpa llama_3_8b suite)
+1x32x384x128:1x8x128x384:1x8x384x128
+
+# GQA — Qwen2-7B: q_heads=28, kv_heads=4, head_size=128, seq=384
+# (cf. test_sdpa qwen2_7b suite)
+1x28x384x128:1x4x128x384:1x4x384x128
+
+# Non-standard head_size (Phi3): 32 heads, head_size=96, seq=384
+# (cf. test_sdpa phi3_mini_4k_instruct suite)
+1x32x384x96:1x32x96x384:1x32x384x96
+
+# Batch > 1
+2x8x384x64:2x8x64x384:2x8x384x64

--- a/tests/benchdnn/inputs/sdpa/test_sdpa_ci
+++ b/tests/benchdnn/inputs/sdpa/test_sdpa_ci
@@ -1,0 +1,53 @@
+--reset
+# No mask
+--dt=f16,bf16
+--batch=shapes_basic
+
+# Buffer mask (bf16 excluded: GPU kernel limitation)
+--reset
+--mask=buffer
+--dt=f16
+--batch=shapes_basic
+
+# Broadcast buffer masks (1D and 2D, matching gtest oneD/twoD)
+--reset
+--mask=buffer_1d
+--dt=f16
+--batch=shapes_basic
+
+--reset
+--mask=buffer_2d
+--dt=f16
+--batch=shapes_basic
+
+# Causal mask
+--reset
+--mask=causal_top_left
+--dt=f16
+--batch=shapes_basic
+
+# Scale
+--reset
+--scale=mul
+--dt=f16
+--batch=shapes_basic
+
+# Transformer-derived shapes (cf. tests/gtests/internals/test_sdpa.cpp)
+--reset
+--dt=f16,bf16
+--batch=shapes_transformer_gpu
+
+# Forward training (needed for backward; verifies DST with training prop)
+--reset
+--dir=FWD_D
+--dt=f16,bf16
+--batch=shapes_transformer_gpu
+
+# Backward
+# --reset
+# --dir=BWD_D
+# --dt=f16,bf16
+# --batch=shapes_bwd
+# --mask=causal_top_left
+# --dt=f16
+# --batch=shapes_bwd

--- a/tests/benchdnn/inputs/sdpa/test_sdpa_gpu
+++ b/tests/benchdnn/inputs/sdpa/test_sdpa_gpu
@@ -1,0 +1,57 @@
+--reset
+# No mask
+--dt=f16,bf16
+--batch=shapes_basic
+
+# Buffer mask (bf16 excluded: GPU kernel limitation)
+--reset
+--mask=buffer
+--dt=f16
+--batch=shapes_basic
+
+# Broadcast buffer masks (1D and 2D, matching gtest oneD/twoD)
+# bf16 excluded: same GPU kernel limitation as full buffer above.
+--reset
+--mask=buffer_1d
+--dt=f16
+--batch=shapes_basic
+
+--reset
+--mask=buffer_2d
+--dt=f16
+--batch=shapes_basic
+
+# Causal masks
+--reset
+--mask=causal_top_left
+--dt=f16
+--batch=shapes_basic
+
+--reset
+--mask=causal_bottom_right
+--dt=f16
+--batch=shapes_basic
+
+# Scale
+--reset
+--scale=mul
+--dt=f16,bf16
+--batch=shapes_basic
+
+--reset
+--scale=div
+--dt=f16
+--batch=shapes_basic
+
+# Transformer-derived shapes (cf. tests/gtests/internals/test_sdpa.cpp)
+--reset
+--dt=f16,bf16
+--batch=shapes_transformer_gpu
+
+--reset
+--dt=f16,bf16
+--mask=causal_top_left
+--batch=shapes_transformer_gpu
+
+# CI tests
+--batch=test_sdpa_ci

--- a/tests/benchdnn/inputs/sdpa/test_sdpa_smoke
+++ b/tests/benchdnn/inputs/sdpa/test_sdpa_smoke
@@ -1,0 +1,22 @@
+--reset
+# No mask
+--dt=f16
+--batch=shapes_basic
+
+# Buffer mask
+--reset
+--mask=buffer
+--dt=f16
+--batch=shapes_basic
+
+# Causal mask
+--reset
+--mask=causal_top_left
+--dt=f16
+--batch=shapes_basic
+
+# Scale
+--reset
+--scale=mul
+--dt=f16
+--batch=shapes_basic

--- a/tests/benchdnn/sdpa/bench_sdpa.cpp
+++ b/tests/benchdnn/sdpa/bench_sdpa.cpp
@@ -1,0 +1,130 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "dnnl_common.hpp"
+#include "utils/parser.hpp"
+#include "utils/task_executor.hpp"
+
+#include "sdpa/sdpa.hpp"
+
+namespace sdpa {
+
+TASK_EXECUTOR_DECL_TYPES;
+
+void check_correctness(
+        const settings_t &s, driver_task_executor_t &task_executor) {
+    for_(const auto &i_dir : s.dir)
+    for_(const auto &i_dt : s.dt)
+    for_(const auto &i_qtag : s.qtag)
+    for_(const auto &i_ktag : s.ktag)
+    for_(const auto &i_vtag : s.vtag)
+    for_(const auto &i_dtag : s.dtag)
+    for_(const auto &i_mdt : s.mdt)
+    for_(const auto &i_mask_type : s.mask_type)
+    for_(const auto &i_scale_type : s.scale_type)
+    for_(const auto &i_attr : s.attributes)
+    for_(const auto &i_ctx_init : s.ctx_init)
+    for (const auto &i_ctx_exe : s.ctx_exe) {
+        const prb_t prb(s.prb_vdims, i_dir, i_dt, i_qtag, i_ktag, i_vtag,
+                i_dtag, i_mdt, i_mask_type, i_scale_type, i_attr, i_ctx_init,
+                i_ctx_exe, s.impl_filter);
+        if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
+
+        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+    }
+}
+
+int verify_input(const settings_t &s) {
+    static constexpr int n_inputs = 4; // Q, K, V, DST dt
+
+    for (const auto &i_dt : s.dt) {
+        if (i_dt.size() != 1 && i_dt.size() != n_inputs) {
+            BENCHDNN_PRINT(0,
+                    "ERROR: sdpa driver: `dt` option expects either a single "
+                    "input or four inputs in Q, K, V, DST order. Current "
+                    "size is: \"%ld\"\n",
+                    (long)i_dt.size());
+            SAFE_V(FAIL);
+        }
+    }
+
+    static constexpr int n_vdims_inputs = 3; // Q, K, V dims
+    if (s.prb_vdims.n_inputs() != n_vdims_inputs) {
+        BENCHDNN_PRINT(0,
+                "ERROR: Expected number of dims arguments is `%d`, provided "
+                "`%d`.\n",
+                n_vdims_inputs, s.prb_vdims.n_inputs());
+        SAFE_V(FAIL);
+    }
+    return OK;
+}
+
+static const char *help_mask
+        = "MASK    (Default: `none`)\n    Specifies the attention mask "
+          "type for SDPA.\n    `none` - no mask, `buffer` - explicit mask "
+          "buffer, `buffer_1d` - broadcast [1,1,1,S_kv],\n"
+          "    `buffer_2d` - broadcast [1,1,S_q,S_kv],\n"
+          "    `causal_top_left` - causal mask from top-left,\n"
+          "    `causal_bottom_right` - causal mask from bottom-right.\n";
+
+static const char *help_scale
+        = "SCALE    (Default: `library`)\n    Specifies the attention "
+          "scale type for SDPA.\n    `library` - library computes "
+          "1/sqrt(head_size),\n    `mul` - multiply by scale, `div` - divide "
+          "by scale.\n";
+
+int bench(int argc, char **argv) {
+    driver_name = "sdpa";
+    using namespace parser;
+    static settings_t s;
+    static const settings_t def {};
+    static driver_task_executor_t task_executor;
+    for (; argc > 0; --argc, ++argv) {
+        const bool parsed_options = parse_bench_settings(argv[0])
+                || parse_batch(bench, argv[0])
+                || parse_dir(s.dir, def.dir, argv[0])
+                || parse_multi_dt(s.dt, def.dt, argv[0], "dt")
+                || parse_tag(s.qtag, def.qtag, argv[0], "qtag")
+                || parse_tag(s.ktag, def.ktag, argv[0], "ktag")
+                || parse_tag(s.vtag, def.vtag, argv[0], "vtag")
+                || parse_tag(s.dtag, def.dtag, argv[0], "dtag")
+                || parse_dt(s.mdt, def.mdt, argv[0], "mdt")
+                || parse_vector_option(s.mask_type, def.mask_type,
+                        str2mask_type, argv[0], "mask", help_mask)
+                || parse_vector_option(s.scale_type, def.scale_type,
+                        str2scale_type, argv[0], "scale", help_scale)
+                || parse_driver_shared_settings(s, def, argv[0]);
+        if (!parsed_options) {
+            catch_unknown_options(argv[0]);
+
+            parse_prb_vdims(s.prb_vdims, argv[0], /* min_inputs = */ 3);
+
+            SAFE(verify_input(s), WARN);
+
+            s.finalize();
+            check_correctness(s, task_executor);
+        }
+    }
+
+    task_executor.flush();
+
+    return parse_last_argument();
+}
+
+} // namespace sdpa

--- a/tests/benchdnn/sdpa/cfg.cpp
+++ b/tests/benchdnn/sdpa/cfg.cpp
@@ -1,0 +1,95 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "sdpa/sdpa.hpp"
+
+namespace sdpa {
+
+cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
+    for (const auto kind : kinds) {
+        auto orig_data_type = prb->get_dt(kind);
+        auto data_type = deduce_cfg_data_type(orig_data_type, prb->attr, kind);
+        cfg_entry_.emplace(kind,
+                cfg_entry_t {
+                        kind, orig_data_type, data_type, get_cfg_map(kind)});
+    }
+
+    adjust_ranges();
+    print_fill_cfg_verbose();
+}
+
+// Adjust density based on accumulation chain.
+float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
+    float density = 1.f;
+    if (density_args.data_kind != SRC) return density;
+
+    const int64_t safe_n_acc = get_safe_n_acc();
+    float safe_density = (float)safe_n_acc / density_args.n_acc;
+    density = MIN2(density, safe_density);
+
+    BENCHDNN_PRINT(6, "%s safe_n_acc=%d density=%f\n", "[FILL_CFG]",
+            (int)safe_n_acc, density);
+
+    return density;
+}
+
+cfg_t::cfg_entry_t::cfg_map_t cfg_t::get_cfg_map(data_kind_t kind) const {
+    // Q tensor ranges - kept small to avoid softmax saturation.
+    static const cfg_t::cfg_entry_t::cfg_map_t q_cfg_map = {
+            {{dnnl_f32}, {-4, 4}},
+            {{dnnl_bf16}, {-4, 4}},
+            {{dnnl_f16}, {-2, 2}},
+            {{dnnl_f8_e5m2}, {-2, 2}},
+            {{dnnl_f8_e4m3}, {-2, 2}},
+            {{dnnl_s8}, {-4, 4}},
+            {{dnnl_u8}, {0, 8}},
+    };
+
+    // K, V tensor ranges.
+    static const cfg_t::cfg_entry_t::cfg_map_t kv_cfg_map = {
+            {{dnnl_f32}, {-2, 2}},
+            {{dnnl_bf16}, {-2, 2}},
+            {{dnnl_f16}, {-2, 2}},
+            {{dnnl_f8_e5m2}, {-2, 2}},
+            {{dnnl_f8_e4m3}, {-2, 2}},
+            {{dnnl_s8}, {-4, 4}},
+            {{dnnl_u8}, {0, 8}},
+            {{dnnl_s4}, {-2, 2}},
+            {{dnnl_u4}, {0, 4}},
+    };
+
+    // DST tensor ranges.
+    static const cfg_t::cfg_entry_t::cfg_map_t dst_cfg_map = {
+            {{dnnl_f32}, {-8, 8}},
+            {{dnnl_bf16}, {-8, 8}},
+            {{dnnl_f16}, {-4, 4}},
+            {{dnnl_f8_e5m2}, {-4, 4}},
+            {{dnnl_f8_e4m3}, {-4, 4}},
+            {{dnnl_s8}, {-4, 4}},
+            {{dnnl_u8}, {0, 8}},
+    };
+
+    switch (kind) {
+        case SRC: return q_cfg_map; // Q uses SRC kind
+        case WEI: return kv_cfg_map; // K, V use WEI kind
+        case DST: return dst_cfg_map;
+        default: assert(!"unsupported data kind"); break;
+    }
+    static cfg_t::cfg_entry_t::cfg_map_t dummy;
+    return dummy;
+}
+
+} // namespace sdpa

--- a/tests/benchdnn/sdpa/ref_sdpa.cpp
+++ b/tests/benchdnn/sdpa/ref_sdpa.cpp
@@ -1,0 +1,412 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+#include "oneapi/dnnl/dnnl.h"
+
+// Internal alg_kind used by the GPU SDPA kernel. Must be removed once
+// softmax_accurate_inf_as_zero is promoted to a public value.
+#include "src/common/c_types_map.hpp"
+
+#include "dnnl_common.hpp"
+#include "dnnl_memory.hpp"
+
+#include "sdpa/sdpa.hpp"
+
+namespace sdpa {
+
+// Reference SDPA: generates gold data by composing existing oneDNN primitives
+// (matmul, softmax) instead of reimplementing the algorithm from scratch.
+//
+// Pipeline: score = matmul(Q, K)  ->  scale  ->  [mask/causal]
+//           ->  softmax(score)  ->  matmul(prob, V)  ->  DST
+//
+// All intermediate computation is done in f32 on the CPU engine.
+
+namespace {
+
+// Execute a matmul primitive on CPU: dst = src x wei.
+void exec_matmul(dnnl_engine_t eng, dnnl_stream_t strm, const dnn_mem_t &src,
+        const dnn_mem_t &wei, dnn_mem_t &dst) {
+    dnnl_primitive_desc_t pd {};
+    DNN_SAFE_V(dnnl_matmul_primitive_desc_create(
+            &pd, eng, src.md_, wei.md_, nullptr, dst.md_, nullptr));
+    auto pd_w = make_benchdnn_dnnl_wrapper(pd);
+
+    dnnl_primitive_t prim {};
+    DNN_SAFE_V(dnnl_primitive_create(&prim, pd));
+    auto prim_w = make_benchdnn_dnnl_wrapper(prim);
+
+    dnnl_exec_arg_t args[] = {
+            {DNNL_ARG_SRC, src.m_},
+            {DNNL_ARG_WEIGHTS, wei.m_},
+            {DNNL_ARG_DST, dst.m_},
+    };
+    DNN_SAFE_V(dnnl_primitive_execute(prim, strm, 3, args));
+    DNN_SAFE_V(dnnl_stream_wait(strm));
+}
+
+// Execute in-place softmax on CPU over the given axis.
+void exec_softmax(
+        dnnl_engine_t eng, dnnl_stream_t strm, dnn_mem_t &mem, int axis) {
+    // Use softmax_accurate_inf_as_zero to match the GPU SDPA kernel.
+    const auto alg = static_cast<dnnl_alg_kind_t>(
+            dnnl::impl::alg_kind::softmax_accurate_inf_as_zero);
+    dnnl_primitive_desc_t pd {};
+    DNN_SAFE_V(dnnl_softmax_forward_primitive_desc_create(&pd, eng,
+            dnnl_forward_inference, alg, mem.md_, mem.md_, axis, nullptr));
+    auto pd_w = make_benchdnn_dnnl_wrapper(pd);
+
+    dnnl_primitive_t prim {};
+    DNN_SAFE_V(dnnl_primitive_create(&prim, pd));
+    auto prim_w = make_benchdnn_dnnl_wrapper(prim);
+
+    dnnl_exec_arg_t args[] = {
+            {DNNL_ARG_SRC, mem.m_},
+            {DNNL_ARG_DST, mem.m_},
+    };
+    DNN_SAFE_V(dnnl_primitive_execute(prim, strm, 2, args));
+    DNN_SAFE_V(dnnl_stream_wait(strm));
+}
+
+// Execute softmax backward on CPU: diff_src = softmax_bwd(fwd_dst, diff_dst).
+void exec_softmax_bwd(dnnl_engine_t eng, dnnl_stream_t strm,
+        const dnn_mem_t &fwd_dst, const dnn_mem_t &diff_dst,
+        dnn_mem_t &diff_src, int axis) {
+    const auto alg = static_cast<dnnl_alg_kind_t>(
+            dnnl::impl::alg_kind::softmax_accurate_inf_as_zero);
+    dnnl_primitive_desc_t fwd_pd {};
+    DNN_SAFE_V(dnnl_softmax_forward_primitive_desc_create(&fwd_pd, eng,
+            dnnl_forward_training, alg, fwd_dst.md_, fwd_dst.md_, axis,
+            nullptr));
+    auto fwd_pd_w = make_benchdnn_dnnl_wrapper(fwd_pd);
+
+    dnnl_primitive_desc_t bwd_pd {};
+    DNN_SAFE_V(dnnl_softmax_backward_primitive_desc_create(&bwd_pd, eng,
+            dnnl_softmax_accurate, diff_src.md_, diff_dst.md_, fwd_dst.md_,
+            axis, fwd_pd, nullptr));
+    auto bwd_pd_w = make_benchdnn_dnnl_wrapper(bwd_pd);
+
+    dnnl_primitive_t prim {};
+    DNN_SAFE_V(dnnl_primitive_create(&prim, bwd_pd));
+    auto prim_w = make_benchdnn_dnnl_wrapper(prim);
+
+    dnnl_exec_arg_t args[] = {
+            {DNNL_ARG_DST, fwd_dst.m_},
+            {DNNL_ARG_DIFF_DST, diff_dst.m_},
+            {DNNL_ARG_DIFF_SRC, diff_src.m_},
+    };
+    DNN_SAFE_V(dnnl_primitive_execute(prim, strm, 3, args));
+    DNN_SAFE_V(dnnl_stream_wait(strm));
+}
+
+// Create a 3-D f32 plain memory on `eng`.
+dnn_mem_t make_3d(dnnl_engine_t eng, int64_t d0, int64_t d1, int64_t d2) {
+    dnnl_dims_t dims = {d0, d1, d2};
+    auto md = dnn_mem_t::init_md(3, dims, dnnl_f32, tag::abx);
+    return dnn_mem_t(md, eng, /* prefill = */ false);
+}
+
+// GQA/MQA helper: replicate KV-heads so their count matches Q-heads.
+// `src` has [outer_batch * kv_heads, ...] rows, `dst` has
+// [outer_batch * q_heads, ...] rows. Each KV-head is copied `groups` times.
+void expand_kv_heads(const dnn_mem_t &src, dnn_mem_t &dst, int64_t outer_batch,
+        int64_t q_heads, int64_t kv_heads, int64_t head_elems) {
+    const float *s = static_cast<float *>(src);
+    float *d = static_cast<float *>(dst);
+    const int64_t groups = q_heads / kv_heads;
+    for (int64_t ob = 0; ob < outer_batch; ob++) {
+        for (int64_t kvh = 0; kvh < kv_heads; kvh++) {
+            const float *head = s + (ob * kv_heads + kvh) * head_elems;
+            for (int64_t g = 0; g < groups; g++) {
+                float *out = d + (ob * q_heads + kvh * groups + g) * head_elems;
+                std::memcpy(out, head, head_elems * sizeof(float));
+            }
+        }
+    }
+}
+
+// GQA/MQA helper: reduce (sum) Q-head groups back into KV-head count.
+void reduce_kv_heads(const dnn_mem_t &src, const dnn_mem_t &dst,
+        int64_t outer_batch, int64_t q_heads, int64_t kv_heads,
+        int64_t head_elems) {
+    const float *s = static_cast<float *>(src);
+    float *d = static_cast<float *>(dst);
+    const int64_t groups = q_heads / kv_heads;
+    std::memset(d, 0, outer_batch * kv_heads * head_elems * sizeof(float));
+    for (int64_t ob = 0; ob < outer_batch; ob++) {
+        for (int64_t kvh = 0; kvh < kv_heads; kvh++) {
+            float *out = d + (ob * kv_heads + kvh) * head_elems;
+            for (int64_t g = 0; g < groups; g++) {
+                const float *in
+                        = s + (ob * q_heads + kvh * groups + g) * head_elems;
+                for (int64_t e = 0; e < head_elems; e++)
+                    out[e] += in[e];
+            }
+        }
+    }
+}
+
+// Transpose last two dims of a 3D f32 memory: [d0, d1, d2] → [d0, d2, d1].
+dnn_mem_t transpose_2d(dnnl_engine_t eng, const dnn_mem_t &src, int64_t d0,
+        int64_t d1, int64_t d2) {
+    auto dst = make_3d(eng, d0, d2, d1);
+    const float *s = static_cast<float *>(src);
+    float *d = static_cast<float *>(dst);
+    for (int64_t i = 0; i < d0; i++)
+        for (int64_t j = 0; j < d1; j++)
+            for (int64_t k = 0; k < d2; k++)
+                d[(i * d2 + k) * d1 + j] = s[(i * d1 + j) * d2 + k];
+    return dst;
+}
+
+} // anonymous namespace
+
+// Scale all elements of `mem` by 1/sqrt(head_size), or by the user-provided
+// scale value when --scale=mul or --scale=div is configured.
+static void scale_scores(
+        const prb_t *prb, const args_t &args, dnn_mem_t &mem, int64_t n) {
+    float sv = 1.0f / std::sqrt(static_cast<float>(prb->head_size));
+    if (prb->with_scale()) {
+        float s = args.find(DNNL_ARG_SCALE).get_f32_elem(0);
+        sv = prb->invert_scale() ? 1.0f / s : s;
+    }
+    float *p = static_cast<float *>(mem);
+    for (int64_t i = 0; i < n; i++)
+        p[i] *= sv;
+}
+
+// Shared forward computation: computes score, applies scale/mask/causal,
+// softmax, optional dropout, and optionally the final matmul.
+// Returns `score2` = softmax probs (pre-dropout, for backward softmax_bwd)
+// and `score2_dp` = post-dropout probs (for BMM2 and backward dV).
+// When dropout is not configured, score2_dp == score2.
+static void compute_fwd(const prb_t *prb, dnnl_engine_t eng, dnnl_stream_t strm,
+        const dnn_mem_t &q_ref, const dnn_mem_t &k_ref, const dnn_mem_t &v_ref,
+        const args_t &args, dnn_mem_t &score2, dnn_mem_t &score2_dp,
+        dnn_mem_t *out) {
+    const int64_t MB = prb->mb;
+    const int64_t SQ = prb->n_queries;
+    const int64_t SK = prb->n_keys;
+    const int64_t V = prb->n_values;
+
+    // Step 1: score = Q x K  (matmul primitive).
+    auto score = make_3d(eng, MB, SQ, SK);
+    exec_matmul(eng, strm, q_ref, k_ref, score);
+
+    // Step 2: Scale.
+    scale_scores(prb, args, score, MB * SQ * SK);
+
+    // Step 3: Apply attention mask (buffer or causal).
+    // For causal masks, generate a [1, SQ, SK] buffer with 0/-inf, then
+    // apply it through the same broadcast-add path as explicit buffers.
+    if (prb->with_mask() || prb->with_causal_mask()) {
+        float *sp = static_cast<float *>(score);
+
+        dnn_mem_t causal_buf;
+        if (prb->with_causal_mask()) {
+            causal_buf = make_3d(eng, 1, SQ, SK);
+            float *cp = static_cast<float *>(causal_buf);
+            for (int64_t q = 0; q < SQ; q++)
+                for (int64_t k = 0; k < SK; k++) {
+                    const bool masked = (prb->mask_type == MASK_CAUSAL_TOP_LEFT)
+                            ? (k > q)
+                            : (k > q + (SK - SQ));
+                    cp[q * SK + k] = masked
+                            ? -std::numeric_limits<float>::infinity()
+                            : 0.0f;
+                }
+        }
+
+        const float *mp = prb->with_mask()
+                ? static_cast<float *>(args.find(DNNL_ARG_ATTN_MASK))
+                : static_cast<float *>(causal_buf);
+
+        int64_t msk_mb = 1, msk_sq = SQ;
+        if (prb->with_mask()) {
+            for (int i = 0; i < prb->ndims - 2; i++)
+                msk_mb *= prb->msk_dims[i];
+            msk_sq = prb->msk_dims[prb->ndims - 2];
+        }
+        const int64_t ms_mb = (msk_mb > 1) ? msk_sq * SK : 0;
+        const int64_t ms_sq = (msk_sq > 1) ? SK : 0;
+
+        for (int64_t mb = 0; mb < MB; mb++)
+            for (int64_t sq = 0; sq < SQ; sq++)
+                for (int64_t sk = 0; sk < SK; sk++)
+                    sp[(mb * SQ + sq) * SK + sk]
+                            += mp[mb * ms_mb + sq * ms_sq + sk];
+    }
+
+    // Step 4: Softmax over K dimension (axis = 2 of the 3-D score tensor).
+    // Copy to score2 and run softmax in-place there; the pre-softmax score
+    // is not used further.
+    score2 = make_3d(eng, MB, SQ, SK);
+    std::memcpy(static_cast<float *>(score2), static_cast<float *>(score),
+            MB * SQ * SK * sizeof(float));
+    exec_softmax(eng, strm, score2, /* axis = */ 2);
+
+    // Step 4b: Dropout (optional). score2_dp starts as a copy of score2;
+    // when dropout is configured, dropped elements are zeroed and the rest
+    // scaled by 1/(1-p).  score2 keeps the clean probs for backward.
+    const int64_t score_n = MB * SQ * SK;
+    score2_dp = make_3d(eng, MB, SQ, SK);
+    std::memcpy(static_cast<float *>(score2_dp), static_cast<float *>(score2),
+            score_n * sizeof(float));
+    if (!prb->attr.dropout.is_def()) {
+        float *sp = static_cast<float *>(score2_dp);
+        const dnn_mem_t &dropout_mask = args.find(DNNL_ARG_ATTR_DROPOUT_MASK);
+        for (int64_t i = 0; i < score_n; i++)
+            maybe_dropout(prb->attr, sp[i], i, dropout_mask);
+    }
+
+    // Step 5 (optional): output = prob_dp x V  (matmul primitive).
+    if (out) {
+        *out = make_3d(eng, MB, SQ, V);
+        exec_matmul(eng, strm, score2_dp, v_ref, *out);
+    }
+}
+
+void compute_ref(
+        const prb_t *prb, dir_t dir, const args_t &args, dnnl_primitive_t) {
+    const auto &eng = get_cpu_engine();
+    stream_t strm(eng);
+
+    const dnn_mem_t &q_m = args.find(DNNL_ARG_QUERIES);
+    const dnn_mem_t &k_m = args.find(DNNL_ARG_KEYS);
+    const dnn_mem_t &v_m = args.find(DNNL_ARG_VALUES);
+    const dnn_mem_t &dst_m = args.find(DNNL_ARG_DST);
+
+    const int64_t MB = prb->mb; // product of all batch dims (incl. heads)
+    const int64_t SQ = prb->n_queries;
+    const int64_t SK = prb->n_keys;
+    const int64_t H = prb->head_size;
+    const int64_t V = prb->n_values;
+    const int nd = prb->ndims;
+
+    // GQA/MQA: K/V may have fewer heads than Q.
+    const int64_t q_heads = (nd >= 3) ? prb->q_dims()[nd - 3] : 1;
+    const int64_t kv_heads = (nd >= 3) ? prb->k_dims()[nd - 3] : q_heads;
+    const int64_t outer_batch = MB / q_heads;
+    const bool is_gqa = (kv_heads != q_heads);
+
+    // 3-D f32 memories for matmul: [MB, rows, cols].
+    auto q_ref = make_3d(eng, MB, SQ, H);
+    auto k_ref = make_3d(eng, MB, H, SK);
+    auto v_ref = make_3d(eng, MB, SK, V);
+
+    // Copy Q (always same batch count).
+    std::memcpy(static_cast<float *>(q_ref), static_cast<float *>(q_m),
+            MB * SQ * H * sizeof(float));
+
+    if (!is_gqa) {
+        std::memcpy(static_cast<float *>(k_ref), static_cast<float *>(k_m),
+                MB * H * SK * sizeof(float));
+        std::memcpy(static_cast<float *>(v_ref), static_cast<float *>(v_m),
+                MB * SK * V * sizeof(float));
+    } else {
+        expand_kv_heads(k_m, k_ref, outer_batch, q_heads, kv_heads, H * SK);
+        expand_kv_heads(v_m, v_ref, outer_batch, q_heads, kv_heads, SK * V);
+    }
+
+    if (dir & FLAG_FWD) {
+        dnn_mem_t score2, score2_dp, out;
+        compute_fwd(prb, eng, strm, q_ref, k_ref, v_ref, args, score2,
+                score2_dp, &out);
+
+        // Copy result to DST.
+        std::memcpy(static_cast<float *>(dst_m), static_cast<float *>(out),
+                MB * SQ * V * sizeof(float));
+    }
+
+    if (dir & FLAG_BWD) {
+        const dnn_mem_t &diff_dst_m = args.find(DNNL_ARG_DIFF_DST);
+        const dnn_mem_t &diff_q_m = args.find(DNNL_ARG_DIFF_QUERIES);
+        const dnn_mem_t &diff_k_m = args.find(DNNL_ARG_DIFF_KEYS);
+        const dnn_mem_t &diff_v_m = args.find(DNNL_ARG_DIFF_VALUES);
+
+        // Recompute forward intermediates to get softmax probabilities.
+        // score2 = pre-dropout probs (for softmax_bwd), score2_dp = post-
+        // dropout probs (for dV).
+        dnn_mem_t score2, score2_dp;
+        compute_fwd(prb, eng, strm, q_ref, k_ref, v_ref, args, score2,
+                score2_dp, /* out = */ nullptr);
+
+        // dO in 3-D layout [MB, SQ, V].
+        auto dO = make_3d(eng, MB, SQ, V);
+        std::memcpy(static_cast<float *>(dO), static_cast<float *>(diff_dst_m),
+                MB * SQ * V * sizeof(float));
+
+        // B1: dS2 = dO × V^T  →  [MB, SQ, SK]
+        auto v_t = transpose_2d(eng, v_ref, MB, SK, V);
+        auto dS2 = make_3d(eng, MB, SQ, SK);
+        exec_matmul(eng, strm, dO, v_t, dS2);
+
+        // B2: dV = S2_dp^T × dO  →  [MB, SK, V]  (uses post-dropout probs)
+        auto s2_t = transpose_2d(eng, score2_dp, MB, SQ, SK);
+        auto dV_full = make_3d(eng, MB, SK, V);
+        exec_matmul(eng, strm, s2_t, dO, dV_full);
+
+        // B2b: Dropout backward on dS2 (same mask, same scaling as fwd).
+        if (!prb->attr.dropout.is_def()) {
+            float *dsp = static_cast<float *>(dS2);
+            const dnn_mem_t &dropout_mask
+                    = args.find(DNNL_ARG_ATTR_DROPOUT_MASK);
+            for (int64_t i = 0, n = MB * SQ * SK; i < n; i++)
+                maybe_dropout(prb->attr, dsp[i], i, dropout_mask);
+        }
+
+        // B3: softmax backward — dS = softmax_bwd(S2, dS2)
+        // Uses pre-dropout probs (score2) as the forward DST.
+        auto dS = make_3d(eng, MB, SQ, SK);
+        exec_softmax_bwd(eng, strm, score2, dS2, dS, /* axis = */ 2);
+
+        // B4: Scale dS.
+        scale_scores(prb, args, dS, MB * SQ * SK);
+
+        // B5: dQ = dS × K^T  →  [MB, SQ, H]
+        // K is [MB, H, SK], K^T is [MB, SK, H].
+        auto k_t = transpose_2d(eng, k_ref, MB, H, SK);
+        auto dQ = make_3d(eng, MB, SQ, H);
+        exec_matmul(eng, strm, dS, k_t, dQ);
+
+        // B6: dK = Q^T × dS  →  [MB, H, SK]
+        auto q_t = transpose_2d(eng, q_ref, MB, SQ, H);
+        auto dK_full = make_3d(eng, MB, H, SK);
+        exec_matmul(eng, strm, q_t, dS, dK_full);
+
+        // Copy/reduce results into output memories.
+        std::memcpy(static_cast<float *>(diff_q_m), static_cast<float *>(dQ),
+                MB * SQ * H * sizeof(float));
+
+        if (!is_gqa) {
+            std::memcpy(static_cast<float *>(diff_k_m),
+                    static_cast<float *>(dK_full), MB * H * SK * sizeof(float));
+            std::memcpy(static_cast<float *>(diff_v_m),
+                    static_cast<float *>(dV_full), MB * SK * V * sizeof(float));
+        } else {
+            reduce_kv_heads(
+                    dK_full, diff_k_m, outer_batch, q_heads, kv_heads, H * SK);
+            reduce_kv_heads(
+                    dV_full, diff_v_m, outer_batch, q_heads, kv_heads, SK * V);
+        }
+    }
+}
+
+} // namespace sdpa

--- a/tests/benchdnn/sdpa/sdpa.cpp
+++ b/tests/benchdnn/sdpa/sdpa.cpp
@@ -1,0 +1,481 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <limits>
+#include <math.h>
+#include <random>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "oneapi/dnnl/dnnl.h"
+
+#include "utils/fill.hpp"
+#include "utils/memory.hpp"
+#include "utils/parallel.hpp"
+
+#include "dnnl_common.hpp"
+#include "dnnl_memory.hpp"
+
+#include "sdpa/sdpa.hpp"
+
+namespace sdpa {
+
+benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> create_md(int ndims,
+        const dims_t &dims, dnnl_data_type_t dt, const std::string &tag) {
+    return dnn_mem_t::init_md(ndims, dims.data(), dt, tag);
+}
+
+dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
+    const prb_t *prb = init_pd_args.prb;
+    res_t *res = init_pd_args.res;
+    bool force_f32_dt = init_pd_args.force_f32_dt;
+    const dir_t dir = init_pd_args.dir;
+
+    auto q_dt = force_f32_dt ? dnnl_f32 : prb->q_dt();
+    auto k_dt = force_f32_dt ? dnnl_f32 : prb->k_dt();
+    auto v_dt = force_f32_dt ? dnnl_f32 : prb->v_dt();
+    auto dst_dt = force_f32_dt ? dnnl_f32 : prb->dst_dt();
+
+    auto q_d = create_md(prb->ndims, prb->q_dims(), q_dt, prb->qtag);
+    auto k_d = create_md(prb->ndims, prb->k_dims(), k_dt, prb->ktag);
+    auto v_d = create_md(prb->ndims, prb->v_dims(), v_dt, prb->vtag);
+    auto dst_d = create_md(prb->ndims, prb->dst_dims, dst_dt, prb->dtag);
+
+    // Attention mask (optional).
+    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> mask_d {};
+    if (prb->with_mask()) {
+        mask_d = create_md(prb->ndims, prb->msk_dims, prb->mdt, tag::abx);
+    }
+
+    // Always pass a valid md — the API unconditionally dereferences it.
+    auto scale_d = dnn_mem_t::init_host_scalar_md(dnnl_f32);
+
+    // Map benchdnn mask_type_t to API's dnnl_attn_mask_type_t values.
+    // All buffer variants (full, 1D, 2D) use dnnl_attn_mask_buffer (1).
+    int attn_mask_type_val = [](mask_type_t mt) {
+        switch (mt) {
+            case MASK_NONE: return 0; // dnnl_attn_mask_undef
+            case MASK_BUFFER:
+            case MASK_BUFFER_1D:
+            case MASK_BUFFER_2D: return 1; // dnnl_attn_mask_buffer
+            case MASK_CAUSAL_TOP_LEFT: return 2; // dnnl_attn_mask_top_left
+            case MASK_CAUSAL_BOTTOM_RIGHT:
+                return 3; // dnnl_attn_mask_bottom_right
+            default: return 0;
+        }
+    }(prb->mask_type);
+    dnnl_alg_kind_t softmax_alg = dnnl_softmax_accurate;
+
+    // KV head count is always derived from the K tensor's head dimension.
+    dnnl_dim_t kv_hn = prb->k_dims()[prb->ndims - 3];
+
+    // Default to invert_scale=false; scale is filled in init_ref_memory_args.
+    bool invert = prb->with_scale() ? prb->invert_scale() : false;
+
+    // Build attr_args for dropout mask md if configured.
+    attr_args_t attr_args;
+    if (!prb->attr.dropout.is_def()) {
+        attr_args.prepare_post_ops_mds(
+                prb->attr, prb->ndims, prb->score_dims.data());
+    }
+    auto dnnl_attr = make_benchdnn_dnnl_wrapper(
+            create_dnnl_attr(prb->attr, attr_args, prb->ndims));
+
+    const auto mask_ptr
+            = prb->with_mask() ? (const_dnnl_memory_desc_t)mask_d : nullptr;
+
+    if (dir & FLAG_FWD) {
+        auto prop = prb->dir & FLAG_INF ? dnnl_forward_inference
+                                        : dnnl_forward_training;
+
+        TIME_C_PD(DNN_SAFE_STATUS(sdpa_primitive_desc_create(&init_pd_args.pd,
+                init_pd_args.engine, q_d, k_d, v_d, dst_d, mask_ptr, scale_d,
+                invert, kv_hn, attn_mask_type_val, softmax_alg, prop, dnnl_attr,
+                /* kq_attr = */ nullptr,
+                /* vs_attr = */ nullptr)));
+    } else {
+        auto diff_q_d = create_md(prb->ndims, prb->q_dims(), q_dt, prb->qtag);
+        auto diff_k_d = create_md(prb->ndims, prb->k_dims(), k_dt, prb->ktag);
+        auto diff_v_d = create_md(prb->ndims, prb->v_dims(), v_dt, prb->vtag);
+        auto diff_dst_d
+                = create_md(prb->ndims, prb->dst_dims, dst_dt, prb->dtag);
+
+        // Follow the implementation parameter order (mask/scale before
+        // diff descs) which differs from the .hpp declaration.
+        TIME_C_PD(DNN_SAFE_STATUS(sdpa_primitive_desc_create(&init_pd_args.pd,
+                init_pd_args.engine, q_d, k_d, v_d, dst_d, mask_ptr, scale_d,
+                diff_q_d, diff_k_d, diff_v_d, diff_dst_d,
+                /* dS = */ nullptr, invert, kv_hn, attn_mask_type_val,
+                softmax_alg, dnnl_attr, init_pd_args.hint)));
+    }
+
+    return dnnl_success;
+}
+
+int fill_data(int exec_arg, data_kind_t kind, const prb_t *prb,
+        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
+    const auto nelems = mem_fp.nelems();
+    if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+
+    // Refer to modes documentation for filling principles.
+    if (has_bench_mode_bit(mode_bit_t::bitwise)) {
+        return fill_random_real(mem_dt, mem_fp, res);
+    }
+    if (has_bench_mode_bit(mode_bit_t::perf)) {
+        return fill_random_real(
+                mem_dt, mem_fp, res, get_perf_fill_cfg(mem_dt.dt()));
+    }
+
+    cfg_t::density_args_t density_args;
+    density_args.data_kind = kind;
+    density_args.n_acc = prb->head_size;
+    const auto density = cfg.get_density(density_args);
+
+    /* Do fixed partitioning to have same filling for any number of threads */
+    const int64_t chunk_size = 64;
+    const int64_t n_chunks = div_up(nelems, chunk_size);
+
+    benchdnn_parallel_nd(n_chunks, [&](int64_t idx_chunk) {
+        int64_t idx_start = idx_chunk * chunk_size;
+        int64_t idx_end = MIN2(idx_start + chunk_size, nelems);
+        std::minstd_rand int_seed(kind * nelems + idx_start + 1);
+        int_seed.discard(1);
+        std::bernoulli_distribution b_dist(density);
+        std::minstd_rand b_seed(kind * nelems + idx_start + 1);
+        b_seed.discard(10);
+
+        std::uniform_int_distribution<> gen(
+                cfg.get_range_min(kind), cfg.get_range_max(kind));
+
+        // Make sure the first element is positive.
+        if (idx_start == 0) {
+            float val = 0;
+            while (val <= 0)
+                val = gen(int_seed);
+            mem_fp.set_f32_elem(
+                    0, round_to_nearest_representable(cfg.get_dt(kind), val));
+            idx_start += 1;
+        }
+
+        for (int64_t idx = idx_start; idx < idx_end; ++idx) {
+            bool is_one = density == 1.f ? true : b_dist(b_seed);
+            if (!is_one) {
+                mem_fp.set_f32_elem(idx, 0.f);
+                continue;
+            }
+            float val = gen(int_seed);
+            mem_fp.set_f32_elem(
+                    idx, round_to_nearest_representable(cfg.get_dt(kind), val));
+        }
+    });
+
+    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    return OK;
+}
+
+// Fill attention mask with realistic 0 / -inf values (~25 % masked).
+int fill_mask(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+    const auto nelems = mem_fp.nelems();
+    if (nelems == 0) return OK;
+
+    const float neg_inf = -std::numeric_limits<float>::infinity();
+    const int64_t chunk_size = 64;
+    const int64_t n_chunks = div_up(nelems, chunk_size);
+
+    benchdnn_parallel_nd(n_chunks, [&](int64_t idx_chunk) {
+        int64_t idx_start = idx_chunk * chunk_size;
+        int64_t idx_end = MIN2(idx_start + chunk_size, nelems);
+        std::minstd_rand rng(nelems + idx_start + 1);
+        rng.discard(1);
+
+        for (int64_t idx = idx_start; idx < idx_end; ++idx)
+            mem_fp.set_f32_elem(idx, (rng() % 4 == 0) ? neg_inf : 0.f);
+    });
+
+    SAFE(mem_dt.reorder(mem_fp), WARN);
+    return OK;
+}
+
+void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
+    skip_unimplemented_data_type(
+            {prb->q_dt(), prb->k_dt(), prb->v_dt(), prb->dst_dt()}, prb->dir,
+            res);
+
+    // SDPA is currently only implemented for GPU.
+    if (is_cpu()) {
+        res->state = SKIPPED;
+        res->reason = reason_t::skip_not_supported;
+        return;
+    }
+}
+
+void skip_invalid_prb(const prb_t *prb, res_t *res) {
+    // SDPA API requires 4D tensors (batch x heads x seq x head_dim).
+    // Guard must be here (not skip_unimplemented) because init_pd accesses
+    // ndims-3 which would be OOB for 2D/3D inputs.
+    if (prb->ndims < 4) {
+        res->state = SKIPPED;
+        res->reason = reason_t::invalid;
+        return;
+    }
+
+    // Validate dimension consistency.
+    const auto &qdims = prb->q_dims();
+    const auto &kdims = prb->k_dims();
+    const auto &vdims = prb->v_dims();
+    int nd = prb->ndims;
+
+    // Q head_size must match K row dim.
+    if (qdims[nd - 1] != kdims[nd - 2]) {
+        res->state = SKIPPED;
+        res->reason = reason_t::invalid;
+        return;
+    }
+    // K col dim must match V row dim.
+    if (kdims[nd - 1] != vdims[nd - 2]) {
+        res->state = SKIPPED;
+        res->reason = reason_t::invalid;
+        return;
+    }
+}
+
+void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
+        const args_t &ref_args) {
+    const bool is_bwd = (kind == SRC || kind == SRC_1 || kind == SRC_2);
+
+    // Backward chains more matmuls and softmax_backward; needs looser
+    // thresholds due to catastrophic cancellation in S*(dP - Di) and
+    // accumulated atomic adds.
+    const float trh_coeff = is_bwd ? 32.f : 8.f;
+    const float trh = trh_coeff * (1 + prb->n_keys) * epsilon_dt(prb->dst_dt());
+    cmp.set_threshold(trh);
+
+    // bf16 backward produces element diffs up to ~3e-2 for near-zero values.
+    const float abs_trh = is_bwd ? 5e-2f : 2e-3f;
+    cmp.set_driver_check_function(
+            [abs_trh](const compare::compare_t::driver_check_func_args_t &a)
+                    -> bool { return a.diff <= abs_trh; });
+
+    cmp.set_zero_trust_percent(is_bwd ? 70.f : 90.f);
+}
+
+std::vector<int> supported_exec_args(dir_t dir) {
+    static const std::vector<int> exec_fwd_args = {
+            DNNL_ARG_QUERIES,
+            DNNL_ARG_KEYS,
+            DNNL_ARG_VALUES,
+            DNNL_ARG_DST,
+            DNNL_ARG_ATTN_MASK,
+            DNNL_ARG_WORKSPACE,
+    };
+    static const std::vector<int> exec_bwd_args = {
+            DNNL_ARG_QUERIES,
+            DNNL_ARG_KEYS,
+            DNNL_ARG_VALUES,
+            DNNL_ARG_DST,
+            DNNL_ARG_ATTN_MASK,
+            DNNL_ARG_DIFF_QUERIES,
+            DNNL_ARG_DIFF_KEYS,
+            DNNL_ARG_DIFF_VALUES,
+            DNNL_ARG_DIFF_DST,
+            DNNL_ARG_DS,
+            DNNL_ARG_WORKSPACE,
+    };
+    return (dir & FLAG_FWD) ? exec_fwd_args : exec_bwd_args;
+}
+
+int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
+        dnnl_primitive_t prim, const prb_t *prb, res_t *res,
+        dnnl_primitive_t prim_ref) {
+    if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) return OK;
+
+    const auto &ref_engine = get_cpu_engine();
+
+    // Move cfg out of filling since its creation is not free.
+    cfg_t cfg(prb, {SRC, WEI, DST});
+
+    for (auto &entry : mem_map) {
+        const int exec_arg = entry.first;
+        // The function targets regular exec_args that are positive.
+        // Negative args are used by bitwise and are broken in the `default`
+        // branch due to `&` always returns `true`.
+        if (exec_arg <= 0) continue;
+
+        auto &mem = entry.second; // `mem` is modified by filler (reorder).
+
+        // Scratchpad memory relates to a primitive. If reference needs it,
+        // use switch below to define a memory desc for it.
+        if (exec_arg == DNNL_ARG_SCRATCHPAD) continue;
+
+        // Workspace connects forward and backward; not filled manually.
+        if (exec_arg == DNNL_ARG_WORKSPACE) continue;
+
+        if (exec_arg == DNNL_ARG_SCALE) {
+            dnnl_dims_t s_dims = {1};
+            ref_mem_map.emplace(exec_arg,
+                    dnn_mem_t(1, s_dims, dnnl_f32, tag::x, ref_engine,
+                            /* prefill = */ false));
+            auto &ref_mem = ref_mem_map[exec_arg];
+            float scale_val = prb->invert_scale()
+                    ? sqrtf(static_cast<float>(prb->head_size))
+                    : 1.0f / sqrtf(static_cast<float>(prb->head_size));
+            ref_mem.set_f32_elem(0, scale_val);
+            mem.set_f32_elem(0, scale_val);
+            continue;
+        }
+
+        ref_mem_map.emplace(exec_arg,
+                dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                        /* prefill = */ false));
+        auto &ref_mem = ref_mem_map[exec_arg];
+
+        switch (exec_arg) {
+            case DNNL_ARG_QUERIES:
+                SAFE(fill_data(exec_arg, SRC, prb, cfg, mem, ref_mem, res),
+                        WARN);
+                break;
+            case DNNL_ARG_KEYS:
+            case DNNL_ARG_VALUES:
+                SAFE(fill_data(exec_arg, WEI, prb, cfg, mem, ref_mem, res),
+                        WARN);
+                break;
+            case DNNL_ARG_DST: break;
+            case DNNL_ARG_ATTN_MASK: SAFE(fill_mask(mem, ref_mem), WARN); break;
+            case DNNL_ARG_DIFF_DST:
+                SAFE(fill_data(exec_arg, DST, prb, cfg, mem, ref_mem, res),
+                        WARN);
+                break;
+            case DNNL_ARG_DIFF_QUERIES:
+            case DNNL_ARG_DIFF_KEYS:
+            case DNNL_ARG_DIFF_VALUES:
+            case DNNL_ARG_DS: break;
+            default:
+                SAFE(init_ref_memory_args_default_case(
+                             exec_arg, mem, ref_mem, prb->attr, res),
+                        WARN);
+                break;
+        }
+
+        // Don't keep reference memory if it is not used further.
+        if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
+    }
+
+    return OK;
+}
+
+int createit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const prb_t *prb, res_t *res) {
+    v_prim.resize(2); // just fwd or fwd + bwd.
+    SAFE(init_prim(prb->ctx_init, v_prim[0], init_pd, prb, res, FLAG_FWD,
+                 nullptr, /* is_service_prim = */ prb->dir & FLAG_BWD),
+            WARN);
+    if (prb->dir & FLAG_BWD) {
+        SAFE(init_prim(prb->ctx_init, v_prim[1], init_pd, prb, res, FLAG_BWD,
+                     query_pd(v_prim[0])),
+                WARN);
+    }
+    return OK;
+}
+
+int checkit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const prb_t *prb, res_t *res) {
+    if (has_bench_mode_bit(mode_bit_t::exec)) {
+        SAFE(check_total_size(res), WARN);
+        if (v_prim[1]) SAFE(check_total_size(res), WARN);
+    }
+    if (has_bench_mode_bit(mode_bit_t::corr)) {
+        SAFE(check_caches(v_prim[0], prb, res), WARN);
+        if (v_prim[1]) { SAFE(check_caches(v_prim[1], prb, res), WARN); }
+    }
+    return OK;
+}
+
+std::vector<data_kind_t> get_kinds_to_check(const prb_t *prb, dir_t dir) {
+    std::vector<data_kind_t> check_kinds;
+    if (dir & FLAG_FWD) {
+        // Skip forward validation when it runs as service for backward.
+        if (!(prb->dir & FLAG_BWD)) check_kinds = {DST};
+    } else {
+        // Backward: check diff_Q (SRC), diff_K (SRC_1), diff_V (SRC_2).
+        check_kinds = {SRC, SRC_1, SRC_2};
+    }
+    get_kinds_to_check_shared(check_kinds, prb->attr);
+    return check_kinds;
+}
+
+int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const prb_t *prb, res_t *res) {
+    set_zmalloc_max_expected_size(res->mem_size_args.zmalloc_expected_size);
+
+    const auto &prim = prb->dir & FLAG_FWD ? v_prim[0] : v_prim[1];
+
+    dnn_mem_map_t mem_map, ref_mem_map;
+
+    init_memory_args<prb_t>(
+            mem_map, prb, v_prim[0], supported_exec_args(FLAG_FWD));
+
+    {
+        auto scale_md = dnn_mem_t::init_host_scalar_md(dnnl_f32);
+        mem_map.emplace(DNNL_ARG_SCALE, dnn_mem_t(scale_md));
+    }
+
+    TIME_FILL(SAFE(
+            init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], prb, res),
+            WARN));
+
+    args_t args(mem_map), ref_args(ref_mem_map);
+
+    SAFE(run_execution(v_prim[0], args, res), WARN);
+
+    check_correctness(prb, get_kinds_to_check(prb, FLAG_FWD), args, ref_args,
+            setup_cmp, res, FLAG_FWD);
+    SAFE(check_bitwise(prim, get_kinds_to_check(prb, FLAG_FWD), args, prb->attr,
+                 prb->inplace, res),
+            WARN);
+
+    if (prb->dir & FLAG_BWD) {
+        // Extend memory map with backward args.
+        init_memory_args<prb_t>(
+                mem_map, prb, v_prim[1], supported_exec_args(FLAG_BWD));
+
+        // Re-add scale (pruned by init_memory_args since SCALE is not in
+        // exec_bwd_args; init_ref_memory_args will fill the value).
+        {
+            auto scale_md = dnn_mem_t::init_host_scalar_md(dnnl_f32);
+            mem_map.emplace(DNNL_ARG_SCALE, dnn_mem_t(scale_md));
+        }
+
+        TIME_FILL(SAFE(
+                init_ref_memory_args(ref_mem_map, mem_map, v_prim[1], prb, res),
+                WARN));
+
+        args = args_t(mem_map);
+        ref_args = args_t(ref_mem_map);
+
+        SAFE(run_execution(v_prim[1], args, res), WARN);
+
+        check_correctness(prb, get_kinds_to_check(prb, FLAG_BWD), args,
+                ref_args, setup_cmp, res, FLAG_BWD);
+        SAFE(check_bitwise(prim, get_kinds_to_check(prb, FLAG_BWD), args,
+                     prb->attr, prb->inplace, res),
+                WARN);
+    }
+
+    return measure_perf(prb->ctx_exe, res, prim, args);
+}
+
+} // namespace sdpa

--- a/tests/benchdnn/sdpa/sdpa.hpp
+++ b/tests/benchdnn/sdpa/sdpa.hpp
@@ -1,0 +1,296 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef SDPA_HPP
+#define SDPA_HPP
+
+#include <iostream>
+
+#include "oneapi/dnnl/dnnl.h"
+
+#include "common.hpp"
+#include "dnnl_common.hpp"
+#include "utils/cfg.hpp"
+#include "utils/perf_report.hpp"
+#include "utils/settings.hpp"
+
+// C API for SDPA primitive creation (forward and backward overloads).
+#include "common/sdpa_test_iface.hpp"
+
+// Semantic argument aliases for SDPA tensors.
+// Mirrors the macros in src/common/sdpa_types.hpp without pulling in internal
+// dependencies (op_desc_t, etc.) that benchdnn cannot resolve.
+#ifndef DNNL_ARG_QUERIES
+#define DNNL_ARG_QUERIES DNNL_ARG_SRC_0
+#define DNNL_ARG_KEYS DNNL_ARG_SRC_1
+#define DNNL_ARG_VALUES DNNL_ARG_SRC_2
+#define DNNL_ARG_ATTN_MASK DNNL_ARG_SHIFT
+#define DNNL_ARG_DIFF_QUERIES DNNL_ARG_DIFF_SRC_0
+#define DNNL_ARG_DIFF_KEYS DNNL_ARG_DIFF_SRC_1
+#define DNNL_ARG_DIFF_VALUES DNNL_ARG_DIFF_SRC_2
+#define DNNL_ARG_DS DNNL_ARG_DIFF_SRC_3
+#endif
+
+namespace sdpa {
+
+enum mask_type_t {
+    MASK_NONE = 0,
+    MASK_BUFFER = 1,
+    MASK_BUFFER_1D = 2,
+    MASK_BUFFER_2D = 3,
+    MASK_CAUSAL_TOP_LEFT = 4,
+    MASK_CAUSAL_BOTTOM_RIGHT = 5,
+};
+mask_type_t str2mask_type(const char *str);
+const char *mask_type2str(mask_type_t mt);
+
+enum scale_type_t {
+    SCALE_LIBRARY = 0,
+    SCALE_MUL = 1,
+    SCALE_DIV = 2,
+};
+scale_type_t str2scale_type(const char *str);
+const char *scale_type2str(scale_type_t st);
+
+struct settings_t : public base_settings_t {
+    using base_settings_t::base_settings_t;
+
+    prb_vdims_t prb_vdims;
+
+    std::vector<dir_t> dir {FWD_I};
+    std::vector<std::vector<dnnl_data_type_t>> dt {{dnnl_f32}};
+    std::vector<std::string> qtag {tag::abx}, ktag {tag::abx}, vtag {tag::abx},
+            dtag {tag::abx};
+    std::vector<dnnl_data_type_t> mdt {dnnl_f32};
+    std::vector<mask_type_t> mask_type {MASK_NONE};
+    std::vector<scale_type_t> scale_type {SCALE_LIBRARY};
+
+    const char *perf_template_csv() const {
+        static const std::string args = "%sdt%,%stag%,%dtag%";
+        return perf_template_csv_base(args);
+    }
+
+    void reset() { *this = settings_t(perf_template); }
+
+    bool has_single_setup() const override {
+        return dir.size() == 1 && dt.size() == 1 && qtag.size() == 1
+                && ktag.size() == 1 && vtag.size() == 1 && dtag.size() == 1
+                && mdt.size() == 1 && mask_type.size() == 1
+                && scale_type.size() == 1
+                && base_settings_t::has_single_setup();
+    }
+};
+
+struct prb_t : public prb_vdims_t {
+    // A ctor with common interface across all drivers.
+    prb_t(const settings_t &s)
+        : prb_t(s.prb_vdims, s.dir[0], s.dt[0], s.qtag[0], s.ktag[0], s.vtag[0],
+                  s.dtag[0], s.mdt[0], s.mask_type[0], s.scale_type[0],
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
+        SAFE_V(s.has_single_setup() ? OK : FAIL);
+    }
+
+    prb_t(const prb_vdims_t &prb_vdims, dir_t dir,
+            const std::vector<dnnl_data_type_t> &dt, const std::string &qtag,
+            const std::string &ktag, const std::string &vtag,
+            const std::string &dtag, dnnl_data_type_t mdt,
+            mask_type_t mask_type, scale_type_t scale_type, const attr_t &attr,
+            const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
+            const impl_filter_t &impl_filter)
+        : prb_vdims_t(prb_vdims)
+        , dir(dir)
+        , dt(dt)
+        , qtag(qtag)
+        , ktag(ktag)
+        , vtag(vtag)
+        , dtag(dtag)
+        , mdt(mdt)
+        , mask_type(mask_type)
+        , scale_type(scale_type)
+        , attr(attr)
+        , ctx_init(ctx_init)
+        , ctx_exe(ctx_exe)
+        , impl_filter(impl_filter) {
+
+        // Broadcast data types if needed: Q,K,V,DST
+        if (this->dt.size() == 1) {
+            const auto val = this->dt[0];
+            this->dt.assign(4, val);
+        }
+
+        const auto &qdims = q_dims();
+        const auto &kdims = k_dims();
+        const auto &vdims_ref = v_dims();
+        n_queries = qdims[ndims - 2];
+        head_size = qdims[ndims - 1];
+        n_keys = kdims[ndims - 1];
+        n_values = vdims_ref[ndims - 1];
+
+        // Compute dst_dims from Q and V dims.
+        dst_dims.resize(ndims);
+        for (int i = 0; i < ndims - 2; i++)
+            dst_dims[i] = qdims[i];
+        dst_dims[ndims - 2] = n_queries;
+        dst_dims[ndims - 1] = n_values;
+
+        // Score dims (batch x heads x seq_q x seq_kv) — used for mask,
+        // dropout, and backward's dS tensor.
+        score_dims.resize(ndims);
+        for (int i = 0; i < ndims - 2; i++)
+            score_dims[i] = qdims[i];
+        score_dims[ndims - 2] = n_queries;
+        score_dims[ndims - 1] = n_keys;
+
+        // Compute mask dims based on mask_type and broadcasting.
+        if (with_mask()) {
+            msk_dims.resize(ndims);
+            // batch dims: 1 for all broadcast variants.
+            for (int i = 0; i < ndims - 2; i++)
+                msk_dims[i] = (mask_type == MASK_BUFFER) ? qdims[i] : 1;
+            // S_q: 1 for 1D, full for 2D and buffer.
+            msk_dims[ndims - 2] = (mask_type == MASK_BUFFER_1D) ? 1 : n_queries;
+            // S_kv: always full.
+            msk_dims[ndims - 1] = n_keys;
+        }
+
+        mb = 1;
+        for (int i = 0; i < ndims - 2; i++)
+            mb *= qdims[i];
+
+        // Forward: 2 matmuls (Q*K^T and prob*V).
+        // Backward: 5 matmuls (2.5x forward, cf. test_sdpa.cpp flash_flops).
+        // Causal masks halve the effective flop count.
+        double fwd_ops = 2.0 * mb * n_queries * n_keys * head_size
+                + 2.0 * mb * n_queries * n_values * n_keys;
+        if (with_causal_mask()) fwd_ops /= 2.0;
+        ops = (dir & FLAG_BWD) ? 2.5 * fwd_ops : fwd_ops;
+
+        repro = set_repro_line(); // must be last in ctor to collect right info
+    }
+
+    int64_t n_queries, head_size, n_keys, n_values, mb;
+    dir_t dir;
+    std::vector<dnnl_data_type_t> dt;
+    std::string qtag, ktag, vtag, dtag;
+    dnnl_data_type_t mdt;
+    mask_type_t mask_type;
+    scale_type_t scale_type;
+
+    bool inplace = false;
+    attr_t attr;
+    thr_ctx_t ctx_init, ctx_exe;
+    impl_filter_t impl_filter;
+
+    double ops;
+    dims_t dst_dims;
+    dims_t msk_dims;
+    dims_t score_dims;
+
+    const dims_t &q_dims() const { return vdims[0]; }
+    const dims_t &k_dims() const { return vdims[1]; }
+    const dims_t &v_dims() const { return vdims[2]; }
+
+    bool with_mask() const {
+        return mask_type == MASK_BUFFER || mask_type == MASK_BUFFER_1D
+                || mask_type == MASK_BUFFER_2D;
+    }
+    bool with_causal_mask() const {
+        return mask_type == MASK_CAUSAL_TOP_LEFT
+                || mask_type == MASK_CAUSAL_BOTTOM_RIGHT;
+    }
+    bool with_scale() const { return scale_type != SCALE_LIBRARY; }
+    bool invert_scale() const { return scale_type == SCALE_DIV; }
+
+    dnnl_data_type_t q_dt() const { return dt[0]; }
+    dnnl_data_type_t k_dt() const { return dt[1]; }
+    dnnl_data_type_t v_dt() const { return dt[2]; }
+    dnnl_data_type_t dst_dt() const { return dt[3]; }
+    dnnl_data_type_t get_dt(data_kind_t data_kind) const;
+
+    // Required by init_memory_args template (for runtime dims support).
+    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const;
+
+    const char *str() const { return repro.c_str(); }
+
+private:
+    std::string repro;
+    std::string set_repro_line();
+};
+
+struct perf_report_t : public base_perf_report_t {
+    perf_report_t(const prb_t *prb, const char *perf_template)
+        : base_perf_report_t(perf_template)
+        , p_(prb)
+        , stag_({normalize_tag(p_->qtag, p_->ndims),
+                  normalize_tag(p_->ktag, p_->ndims),
+                  normalize_tag(p_->vtag, p_->ndims)})
+        , dtag_(normalize_tag(p_->dtag, p_->ndims)) {}
+
+    void dump_desc(std::ostream &s) const override {
+        s << static_cast<const prb_vdims_t &>(*p_);
+    }
+
+    double ops() const override { return p_->ops; }
+    const std::vector<dnnl_data_type_t> *sdt() const override {
+        return &p_->dt;
+    }
+    const attr_t *attr() const override { return &p_->attr; }
+    const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
+    const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }
+    const std::string *name() const override { return &p_->name; }
+    const std::vector<std::string> *stag() const override { return &stag_; }
+    const std::string *dtag() const override { return &dtag_; }
+
+private:
+    const prb_t *p_;
+    std::vector<std::string> stag_;
+    std::string dtag_;
+};
+
+struct cfg_t : public base_cfg_t {
+    cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds);
+
+    cfg_entry_t::cfg_map_t get_cfg_map(data_kind_t kind) const override;
+
+    float get_density(const density_args_t &density_args) const override;
+};
+
+dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args);
+void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
+        const args_t &ref_args);
+std::vector<int> supported_exec_args(dir_t dir);
+int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
+        dnnl_primitive_t prim, const prb_t *prb, res_t *res,
+        dnnl_primitive_t prim_ref = nullptr);
+
+void skip_unimplemented_prb(const prb_t *prb, res_t *res);
+void skip_invalid_prb(const prb_t *prb, res_t *res);
+void compute_ref(const prb_t *prb, dir_t dir, const args_t &args,
+        dnnl_primitive_t prim_ref = nullptr);
+
+int createit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const prb_t *prb, res_t *res);
+int checkit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const prb_t *prb, res_t *res);
+int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const prb_t *prb, res_t *res);
+
+int bench(int argc, char **argv);
+
+} // namespace sdpa
+
+#endif

--- a/tests/benchdnn/sdpa/sdpa_aux.cpp
+++ b/tests/benchdnn/sdpa/sdpa_aux.cpp
@@ -1,0 +1,145 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <sstream>
+#include <string.h>
+
+#include "dnnl_common.hpp"
+#include "dnnl_memory.hpp"
+
+#include "sdpa/sdpa.hpp"
+
+namespace sdpa {
+
+mask_type_t str2mask_type(const char *str) {
+    if (!strcmp(str, "none")) return MASK_NONE;
+    if (!strcmp(str, "buffer")) return MASK_BUFFER;
+    if (!strcmp(str, "buffer_1d")) return MASK_BUFFER_1D;
+    if (!strcmp(str, "buffer_2d")) return MASK_BUFFER_2D;
+    if (!strcmp(str, "causal_top_left")) return MASK_CAUSAL_TOP_LEFT;
+    if (!strcmp(str, "causal_bottom_right")) return MASK_CAUSAL_BOTTOM_RIGHT;
+    assert(!"unknown mask type");
+    return MASK_NONE;
+}
+
+const char *mask_type2str(mask_type_t mt) {
+    switch (mt) {
+        case MASK_NONE: return "none";
+        case MASK_BUFFER: return "buffer";
+        case MASK_BUFFER_1D: return "buffer_1d";
+        case MASK_BUFFER_2D: return "buffer_2d";
+        case MASK_CAUSAL_TOP_LEFT: return "causal_top_left";
+        case MASK_CAUSAL_BOTTOM_RIGHT: return "causal_bottom_right";
+        default: assert(!"unknown mask type"); return "unknown";
+    }
+}
+
+scale_type_t str2scale_type(const char *str) {
+    if (!strcmp(str, "library")) return SCALE_LIBRARY;
+    if (!strcmp(str, "mul")) return SCALE_MUL;
+    if (!strcmp(str, "div")) return SCALE_DIV;
+    assert(!"unknown scale type");
+    return SCALE_LIBRARY;
+}
+
+const char *scale_type2str(scale_type_t st) {
+    switch (st) {
+        case SCALE_LIBRARY: return "library";
+        case SCALE_MUL: return "mul";
+        case SCALE_DIV: return "div";
+        default: assert(!"unknown scale type"); return "unknown";
+    }
+}
+
+dnnl_data_type_t prb_t::get_dt(data_kind_t data_kind) const {
+    switch (data_kind) {
+        case SRC: return q_dt();
+        case SRC_1: return k_dt();
+        case SRC_2: return v_dt();
+        case WEI: return k_dt(); // K and V share WEI kind
+        case DST: return dst_dt();
+        default: assert(!"unexpected"); return dnnl_data_type_undef;
+    }
+}
+
+benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
+    switch (arg) {
+        case DNNL_ARG_QUERIES:
+            return dnn_mem_t::init_md(ndims, q_dims().data(), q_dt(), qtag);
+        case DNNL_ARG_KEYS:
+            return dnn_mem_t::init_md(ndims, k_dims().data(), k_dt(), ktag);
+        case DNNL_ARG_VALUES:
+            return dnn_mem_t::init_md(ndims, v_dims().data(), v_dt(), vtag);
+        case DNNL_ARG_DST:
+            return dnn_mem_t::init_md(ndims, dst_dims.data(), dst_dt(), dtag);
+        case DNNL_ARG_ATTN_MASK:
+            if (with_mask())
+                return dnn_mem_t::init_md(
+                        ndims, msk_dims.data(), mdt, tag::abx);
+            return dnn_mem_t::init_md();
+        case DNNL_ARG_DIFF_QUERIES:
+            return dnn_mem_t::init_md(ndims, q_dims().data(), q_dt(), qtag);
+        case DNNL_ARG_DIFF_KEYS:
+            return dnn_mem_t::init_md(ndims, k_dims().data(), k_dt(), ktag);
+        case DNNL_ARG_DIFF_VALUES:
+            return dnn_mem_t::init_md(ndims, v_dims().data(), v_dt(), vtag);
+        case DNNL_ARG_DIFF_DST:
+            return dnn_mem_t::init_md(ndims, dst_dims.data(), dst_dt(), dtag);
+        case DNNL_ARG_DS:
+            return dnn_mem_t::init_md(
+                    ndims, score_dims.data(), dnnl_f32, tag::abx);
+        default:
+            assert(!"unsupported arg");
+            return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
+    }
+}
+
+std::string prb_t::set_repro_line() {
+    dnnl::impl::stringstream_t s;
+    dump_global_params(s);
+    settings_t def;
+
+    if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";
+
+    bool has_default_dts = true;
+    for (const auto &i_dt : dt)
+        has_default_dts = has_default_dts && i_dt == dnnl_f32;
+
+    if (canonical || !has_default_dts) s << "--dt=" << dt << " ";
+    if (canonical || qtag != def.qtag[0]) s << "--qtag=" << qtag << " ";
+    if (canonical || ktag != def.ktag[0]) s << "--ktag=" << ktag << " ";
+    if (canonical || vtag != def.vtag[0]) s << "--vtag=" << vtag << " ";
+    if (canonical || dtag != def.dtag[0]) s << "--dtag=" << dtag << " ";
+    if (canonical || mask_type != def.mask_type[0])
+        s << "--mask=" << mask_type2str(mask_type) << " ";
+    if (canonical || mdt != def.mdt[0]) s << "--mdt=" << mdt << " ";
+    if (canonical || scale_type != def.scale_type[0])
+        s << "--scale=" << scale_type2str(scale_type) << " ";
+
+    s << attr;
+    if (canonical || ctx_init != def.ctx_init[0])
+        s << "--ctx-init=" << ctx_init << " ";
+    if (canonical || ctx_exe != def.ctx_exe[0])
+        s << "--ctx-exe=" << ctx_exe << " ";
+    if (canonical || !impl_filter.is_def() || !global_impl_filter.is_def())
+        s << impl_filter;
+
+    s << static_cast<const prb_vdims_t &>(*this);
+
+    return s.str();
+}
+
+} // namespace sdpa

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1252,7 +1252,7 @@ bool parse_main_help(
               "bnorm\n    * concat\n    * conv\n    * deconv\n    * eltwise\n  "
               "  * ip\n    * lnorm\n    * lrn\n    * matmul\n    * pool\n    * "
               "prelu\n    * reduction\n    * reorder\n    * resampling\n    * "
-              "rnn\n    * shuffle\n    * softmax\n    * sum\n    * "
+              "rnn\n    * sdpa\n    * shuffle\n    * softmax\n    * sum\n    * "
               "zeropad\n\nFor global and specific driver options, use:\n    "
               "benchdnn --<driver> --help\n\nMore details at "
             + benchdnn_url + "\n";


### PR DESCRIPTION
### This PR adds a new benchdnn driver for the **Scaled Dot-Product Attention (SDPA)** primitive, enabling correctness validation and performance benchmarking of the SDPA GPU kernel directly from the benchdnn application.

**JIRA:** [MFDNN-14715](https://jira.devtools.intel.com/browse/MFDNN-14715)

---

### Problem description

Currently oneDNN includes a fused GPU SDPA kernel (`ocl:micro:reusable`) but has **no dedicated benchdnn driver** to test it. All other comparable primitives (matmul, softmax, etc.) have benchdnn drivers. This means:
- No **performance benchmarking** through benchdnn's `--mode=F/P` infrastructure.
- No **correctness validation** against an independent reference (only gtests).
- No **CI coverage** for SDPA across data types, mask types, scale modes, GQA/MQA, and propagation directions.

---

### Proposed Solution

Implement a new benchdnn driver `--sdpa` that calls the internal `sdpa_primitive_desc_create()` API and validates GPU output against a CPU reference. The driver covers forward inference, forward training, and backward propagation.

$$\text{DST} = \text{softmax}\left(\frac{QK^T}{\sqrt{d}} + \text{mask}\right) V$$

**Feature coverage:**
- **Propagation:** `FWD_I`, `FWD_D` (training, produces workspace), `BWD_D` (gradients for Q, K, V).
- **Data types:** `f32`, `f16`, `bf16` with per-tensor broadcast (`--dt=f16` or `--dt=f16:f16:f16:f32`).
- **Attention masks (`--mask`):** `none`, `buffer` (explicit `[B,H,S_q,S_kv]` tensor), `buffer_1d` (broadcast `[1,1,1,S_kv]`), `buffer_2d` (broadcast `[1,1,S_q,S_kv]`), `causal_top_left`, `causal_bottom_right`.
- **Scale modes (`--scale`):** `library` (default $1/\sqrt{H}$), `mul`, `div`.
- **GQA/MQA:** KV head count derived from the K tensor shape; supports grouped-query attention.
- **Dropout:** via standard attribute (`--attr-dropout`), with Philox-based mask generation.
- **Memory tags:** independent `--qtag`, `--ktag`, `--vtag`, `--dtag`.

> [!IMPORTANT]  
> This driver tests **internal SDPA primitive functionality** that is not part of the public oneDNN API. It uses `sdpa_primitive_desc_create()` from `src/common/sdpa_test_iface.hpp`.

**Reference implementation** (`ref_sdpa.cpp`) generates gold data by composing oneDNN primitives on the CPU:
```
Forward:
  score   = matmul(Q, K)                           - oneDNN matmul primitive
  score  *= scale                                  - 1/sqrt(head_size) or user-provided
  score  += mask                                   - buffer (with broadcast) or generated causal
  prob    = softmax(score)                         - softmax_accurate_inf_as_zero
  prob_dp = dropout(prob)                          - optional, Philox-based
  DST     = matmul(prob_dp, V)                     - oneDNN matmul primitive

Backward:
  dS2 = matmul(dO, V^T)                            - gradient through BMM2
  dV  = matmul(S2_dp^T, dO)                        - uses post-dropout probs
  dS2 = dropout_bwd(dS2)                           - same mask, same scaling
  dS  = softmax_bwd(S2, dS2)                       - uses pre-dropout probs
  dS *= scale                                      - same scale as forward
  dQ  = matmul(dS, K^T)                            - gradient for queries
  dK  = matmul(Q^T, dS)                            - gradient for keys
  + GQA reduce for dK, dV when kv_heads < q_heads
```
---

### Files changed

**Scope limited to `tests/benchdnn/`** (no changes in `src/`).

Core driver:
| File | Description |
|------|-------------|
| `sdpa/sdpa.hpp` | Problem descriptor (`prb_t`), settings, enums (`mask_type_t`, `scale_type_t`), semantic `DNNL_ARG_*` macros |
| `sdpa/sdpa.cpp` | `init_pd`, `fill_data`, `fill_mask` (0/−inf), `init_ref_memory_args`, `skip_*`, `setup_cmp`, `doit` |
| `sdpa/ref_sdpa.cpp` | Reference via oneDNN matmul + softmax primitives; forward + backward + GQA + dropout |
| `sdpa/sdpa_aux.cpp` | String conversions, `get_md` (semantic ARGs), `set_repro_line` |
| `sdpa/bench_sdpa.cpp` | CLI parser (`--mask`, `--scale`, `--mdt`) |
| `sdpa/cfg.cpp` | Fill ranges for Q (`SRC`), K/V (`WEI`), DST |

Test inputs:
| File | Description |
|------|-------------|
| `inputs/sdpa/shapes_basic` | 2D/3D/4D smoke shapes |
| `inputs/sdpa/shapes_transformer_gpu` | LLM-derived shapes with provenance (LLaMA-2/3, Qwen2, Phi3) |
| `inputs/sdpa/shapes_transformer` | Extended shapes including decode (`seq_q=1`) |
| `inputs/sdpa/shapes_bwd` | Backward shapes respecting GPU kernel constraints |
| `inputs/sdpa/test_sdpa_smoke` | Smoke tests |
| `inputs/sdpa/test_sdpa_ci` | CI: all mask/scale variants + fwd/bwd + transformer shapes |
| `inputs/sdpa/test_sdpa_gpu` | Nightly GPU: comprehensive coverage |

Infrastructure:
| File | Description |
|------|-------------|
| `utils/wrapper.hpp` | `dnnl_api_traits<dnnl_stream_t>` for RAII stream management |
| `benchdnn.cpp` | `--sdpa` dispatcher |
| `utils/parser.cpp` | Help text |
| `README.md` | Driver list entry |
| `doc/driver_sdpa.md` | Full driver documentation |

---

###  Results (`test_sdpa_gpu`)

| Metric | DG2 (xe_hpg) | BMG (xe2) |
|--------|--------------|-----------|
| Total | 124 | 124 |
| Passed | 124 | 124 |
| Skipped | 0 | 0 |
| Unimplemented | 0 | 0 |
| Failed | 0 | 0 |

> [!WARNING]  
> **Note:** All 2D/3D shapes removed from tests. All FP32 tests removed from tests. All backward cases removed from tests. These tests have been removed as they do not currently support all platforms.

<details>
<summary>Example repro commands</summary>

```sh
# Smoke test
benchdnn --sdpa --engine=gpu --batch=inputs/sdpa/test_sdpa_smoke

# CI suite
benchdnn --sdpa --engine=gpu --batch=inputs/sdpa/test_sdpa_ci

# Full GPU suite
benchdnn --sdpa --engine=gpu --batch=inputs/sdpa/test_sdpa_gpu

# Single shape with causal mask
benchdnn --sdpa --engine=gpu --dt=f16 --mask=causal_bottom_right 1x32x2048x128:1x32x128x2048:1x32x2048x128

# Backward
benchdnn --sdpa --engine=gpu --dir=BWD_D --dt=f16 1x4x256x64:1x4x64x256:1x4x256x64

# GQA (LLaMA-3 32:8)
benchdnn --sdpa --engine=gpu --dt=f16 1x32x384x128:1x8x128x384:1x8x384x128

# Performance
benchdnn --mode=F --sdpa --engine=gpu --dt=f16 1x32x2048x128:1x32x128x2048:1x32x2048x128
```

</details>

---

### Pull Request Checklist

#### General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

#### New features

- [ ] ~~Have you published an RFC for the new feature?~~ (N/A - internal API, benchdnn only)
- [ ] ~~Was the RFC approved?~~ (N/A)
- [x] Have you added relevant tests?
- [x] Have you added relevant documentation? (`doc/driver_sdpa.md`)