### PR TITLE
build: bumped version to v3.11.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.11.1")
+set(PROJECT_VERSION "3.11.2")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.11.1:
* Fixed an issue with unintentionally exposed internal symbols in Graph API (d369c5f1a6afbba3e61a2349146a5e40f08c69b1, 8fc3ec332a689e464e07e63582ce65b01397e08d)
* Fixed an integer overflow in memory descriptor size computation for humungous tensors (265704b46a8e24b486a299e8544141c50448402a, 98e2011d9fdc4323f053a45d2e51cb4eeb94e5b4)
* Fixed a potential heap corruption in `f32` GEMM kernels on x64 CPUs (6191181f2fce1d174a619ef1596a0b3a5c53d832)
* Added support for `bf16` and `f16` matmul with transposed source on x64 CPUs with Intel AVX2 instruction set support (5af82d4d0395bc866a5f0228a1af78c810a5eb0e, f0c6428e402723562c12b15e04e48baae1b207c9, eef1cf0f87413c2791b969887a837548ea5e6762)
* Updated benchdnn to use non-compressible random data in performance benchmarking mode on Intel GPUs (8051b378c99105bc7ee1d3a52f284bcc31038ed7)
