### PR TITLE
xe: conv: improve access locality for small L3 cache

### DIFF
--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -1484,6 +1484,41 @@ walk_order_t maybe_fixup_group_with_small_channels(
     return fixed;
 }
 
+// Adjusts walk order when weights do not fit L3 cache for non-1x1 forward
+// convolution. For such cases move `oh` to the innermost grid position to
+// increase kh-related data reuse in activations.
+walk_order_t maybe_fixup_large_weights(
+        const config_t &cfg, const walk_order_t &walk_order) {
+    // Apply the heuristic only for smaller L3 cache sizes.
+    const size_t l3_size = cfg.hw().l3_cache_size();
+    if (l3_size > (1 << 22)) return walk_order;
+
+    auto &prb = cfg.prb();
+    // No reuse for when kh is one.
+    if (prb.kh == 1 || !prb.is_fwd) return walk_order;
+    // Blocked walk order implies that it's already cache-aware.
+    for (int id = 0; id < 3; id++) {
+        if (walk_order.is_blocked(id)) return walk_order;
+    }
+
+    auto full_tile = cfg.shape(/*pad=*/false);
+    size_t wei_bytes = get_memory_footprint(
+            prb.ab_swap_transpose ? tensor_kind_t::a : tensor_kind_t::b, cfg,
+            full_tile);
+    if (wei_bytes < l3_size) return walk_order;
+
+    auto grid_tile = get_grid_tile(cfg);
+    // Apply the heuristic - move `oh` to be fast-changing in the grid.
+    walk_order_t fixed;
+    fixed.add(pvars::oh, grid_tile.get(pvars::oh), 0);
+    for (auto &b : walk_order.blocks()) {
+        if (b.dim == pvars::oh) continue;
+        fixed.add(b.dim, b.size, b.grid_id);
+    }
+    fixed.finalize(grid_tile);
+    return fixed;
+}
+
 walk_order_t get_default_walk_order(
         const config_t &cfg, const tile_t &grid_tile) {
     using vec_t = std::vector<pvar_t>;
@@ -1513,6 +1548,7 @@ walk_order_t get_default_walk_order(
     }
     walk_order.finalize(grid_tile);
     walk_order = maybe_fixup_group_with_small_channels(cfg, walk_order);
+    walk_order = maybe_fixup_large_weights(cfg, walk_order);
     return walk_order;
 }
 


### PR DESCRIPTION
Jira: [MFDNN-14746](https://jira.devtools.intel.com/browse/MFDNN-14746)

For SKUs with smaller caches, it seems to help to prioritize `oh` vs `oc` in the grid walk order to increase filter-related activations reuse. Needs additional testing to confirm no regressions.