### PR TITLE
[rls-v3.11] revert: graph: backend: dnnl: fix use-of-uninitialized-value

### DIFF
--- a/src/graph/backend/dnnl/thread_local_cache.hpp
+++ b/src/graph/backend/dnnl/thread_local_cache.hpp
@@ -185,8 +185,8 @@ private:
                 static auto global_cache = std::shared_ptr<global_cache_type_t>(
                         new global_cache_type_t {},
                         [](global_cache_type_t *ptr) {
-                            return ptr->release();
-                        });
+                    return ptr->release();
+                });
                 return global_cache.get();
             } catch (...) { return nullptr; }
         }


### PR DESCRIPTION
This reverts commit 2cbf9a0d1ca89fd358112d1832dd1bdc0a0e5c8c.

`std::call_once` should not be called in header file.

I tried but moving the `get_global_cache()` function into a new cpp file is a bit complicated, involving templated class explicit instantiation in cpp file. Hence, I decided to just revert the previous change.

Fixes [MFDNN-14824](https://jira.devtools.intel.com/browse/MFDNN-14824)