### PR TITLE
cpu: x64: update prefetchw in brgemm kernel

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -74,6 +74,12 @@ typedef enum {
 } brgemm_kernel_prefetching_t;
 
 typedef enum {
+    brgemm_prfw_default = 0,
+    brgemm_prfw_store,
+    brgemm_prfw_loop_store,
+} brgemm_kernel_prefetchw_t;
+
+typedef enum {
     brgemm_innermost_undef = 0,
     brgemm_bd_loop_innermost,
     brgemm_ld_loop_innermost,
@@ -170,6 +176,8 @@ struct DNNL_API brgemm_attr_t {
     brgemm_kernel_loop_order_t hint_loop_order;
     brgemm_kernel_prefetching_t hint_prefetching
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
+    brgemm_kernel_prefetchw_t hint_prefetchw
+            = brgemm_kernel_prefetchw_t::brgemm_prfw_default;
     brgemm_prf_t hint_prfA, hint_prfB, hint_prfC;
 
     // This parameter determines how we will read the tail by K dimension from
@@ -220,7 +228,6 @@ struct DNNL_API brgemm_attr_t {
     int hint_bd_block2 {0};
     int hint_ld_block2 {0};
     bool hint_ununroll_bd_loop {false};
-    bool hint_loop_store_prefetch {false};
 
     brgemm_kernel_hint_mem_advice_t mem_advice {brgemm_hint_mem_advice_undef};
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -1526,7 +1526,10 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
 
     if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
 
-    if (is_superset(brg.isa_impl, avx10_2_512)) prefetchrst2(ptr[reg_aux_D]);
+    if (is_superset(brg.isa_impl, avx10_2_512))
+        prefetchrst2(ptr[reg_aux_D]);
+    else if (brg.brgattr.hint_prefetchw == brgemm_prfw_store)
+        prefetchw(ptr[reg_aux_D]);
 
     for_(dim_t bd = 0; bd < bd_block; bd++)
     for (dim_t ld = 0; ld < ld_block2; ld++) {
@@ -1534,7 +1537,9 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         auto vmm = accm(ld_block2, bd, ld);
         auto vmm_lower = Vmm_lower_t(vmm.getIdx());
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-        prefetchw(addr);
+        if (brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
+                && !is_superset(brg.isa_impl, avx10_2_512))
+            prefetchw(addr);
         if (is_superset(brg.isa_impl, avx512_core)) {
             const Vmm r_vmm = vmm_mask(vmm, is_tail, true, k_mask);
             const Vmm_lower_t r_ymm
@@ -1705,14 +1710,18 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
     reg64_savable_guard_t reg_aux_C_guard(
             {&reg_aux_C}, brg.is_runtime_ldc && bd_block > 1);
 
-    if (is_superset(brg.isa_impl, avx10_2_512)) prefetchrst2(ptr[reg_aux_C]);
-    if (!brg.brgattr.hint_loop_store_prefetch) prefetchw(ptr[reg_aux_C]);
+    if (is_superset(brg.isa_impl, avx10_2_512))
+        prefetchrst2(ptr[reg_aux_C]);
+    else if (brg.brgattr.hint_prefetchw == brgemm_prfw_store)
+        prefetchw(ptr[reg_aux_C]);
 
     if (brg.is_gemv) {
         for_(dim_t bd = 0; bd < bd_block; bd++)
         for (dim_t ld = 0; ld < ld_block2; ld++) {
             const auto addr_c = ptr[reg_aux_C + C_offset(bd, ld)];
-            if (brg.brgattr.hint_loop_store_prefetch) prefetchw(addr_c);
+            if (brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
+                    && !is_superset(brg.isa_impl, avx10_2_512))
+                prefetchw(addr_c);
             auto vmm = accm(ld_block2, bd, ld);
             uni_vmovss(addr_c, Xmm(vmm.getIdx()));
         }
@@ -1722,7 +1731,9 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
             auto vmm = accm(ld_block2, bd, ld);
             const auto addr_c = ptr[reg_aux_C + C_offset(bd, ld)];
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-            if (brg.brgattr.hint_loop_store_prefetch) prefetchw(addr_c);
+            if (brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
+                    && !is_superset(brg.isa_impl, avx10_2_512))
+                prefetchw(addr_c);
             if (!is_tail)
                 uni_vmovups(addr_c, vmm);
             else if (isa_has_masks(brg.isa_impl)) { // is_tail

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -411,7 +411,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                 = bgmmc_.post_ops_applicable && bgmmc_.nthr_k > 1;
         brgattr.mem_advice = bgmmc_.mem_advice;
         brgattr.max_bs = bs;
-        brgattr.hint_loop_store_prefetch = bgmmc_.need_loop_store_prefetch;
+        brgattr.hint_prefetchw = bgmmc_.hint_prefetchw;
         if (is_superset(kernel_isa, avx512_core_amx)) {
             brgattr.use_uker = true;
             brgattr.use_interleave_stores = true;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1860,10 +1860,16 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     // Sets things related to chunks and others
     init_aux_values(bgmmc, src_d, weights_d, dst_d);
 
+    const bool need_store_prfw = bgmmc.N <= 14528
+            && ((bgmmc.M <= 768 && bgmmc.K <= 128)
+                    || bgmmc.K * bgmmc.M <= 49152);
     if (!bgmmc.is_gemv && bm_conf_utils.is_f32() && bgmmc.nthr == 1
-            && is_superset(bgmmc.isa, avx512_core)) {
-        bgmmc.need_loop_store_prefetch = bgmmc.K < 16 && bgmmc.M <= 768
-                && bgmmc.N <= 14528 && bgmmc.N >= 4064;
+            && is_superset(bgmmc.isa, avx512_core) && need_store_prfw) {
+        const bool need_loop_store_prfw
+                = bgmmc.K < 16 && bgmmc.M <= 768 && bgmmc.N >= 4064;
+        bgmmc.hint_prefetchw = need_loop_store_prfw
+                ? brgemm_kernel_prefetchw_t::brgemm_prfw_loop_store
+                : brgemm_kernel_prefetchw_t::brgemm_prfw_store;
     }
 
     bgmmc.use_buffer_reduce

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -220,7 +220,8 @@ struct brgemm_matmul_conf_t {
     bool is_src_batch_layout_trivial = false;
     bool is_wei_batch_layout_trivial = false;
     bool is_dst_batch_layout_trivial = false;
-    bool need_loop_store_prefetch = false;
+    brgemm_kernel_prefetchw_t hint_prefetchw
+            = brgemm_kernel_prefetchw_t::brgemm_prfw_default;
 
     // Attributes related to quantization
     // Scales


### PR DESCRIPTION
Fixes MFDNN-14714

Disable `prefetchw` for convolution to fix the perf regression.

Before commit:
```
OMP_NUM_THREADS=32 ./tests/benchdnn/benchdnn --conv --dir=FWD_I --mode=p mb128_ic3oc32_ih224oh112kh3sh2dh0ph1_iw224ow112kw3sw2dw0pw1
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,brg_conv_fwd:avx512_core,,--mode=P --conv --dir=FWD_I mb128ic3ih224oc32oh112kh3sh2ph1,2.75804,2.18604,2.01001,1372.15,2.33591,1180.71
```
After commit:
```
OMP_NUM_THREADS=32 ./tests/benchdnn/benchdnn --conv --dir=FWD_I --mode=p mb128_ic3oc32_ih224oh112kh3sh2dh0ph1_iw224ow112kw3sw2dw0pw1
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,brg_conv_fwd:avx512_core,,--mode=P --conv --dir=FWD_I mb128ic3ih224oc32oh112kh3sh2ph1,2.75804,1.88159,1.84253,1496.88,2.42566,1137.03
```
