### PR TITLE
cpu: x64: xbyak: enable XBYAK_STRICT_CHECK_MEM_REG_SIZE Xbyak v7.25 feature

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -46,13 +46,8 @@
 #define XBYAK_NO_EXCEPTION
 #endif
 
-// Several JIT kernels intentionally or unintentionally use size-mismatched memory operands
-// (e.g. zword[]-annotated addresses with 64-bit GPR instructions, or dword[] fields loaded into
-// Reg64 registers). These are architecturally correct on x86-64 but trigger this check. Until all
-// call sites are updated to use properly-sized operands or stripped annotations, set this to 0 to
-// suppress the false-positive errors.
 #if !defined(XBYAK_STRICT_CHECK_MEM_REG_SIZE)
-#define XBYAK_STRICT_CHECK_MEM_REG_SIZE 0
+#define XBYAK_STRICT_CHECK_MEM_REG_SIZE 1
 #endif
 
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
@@ -201,16 +201,16 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
     sal(bm0, SHIFT_UNROLL_K + SHIFT_A);
     sal(bm1, SHIFT_UNROLL_K + SHIFT_A);
 
-    mov(TILEW(0x10), bm0);
-    mov(TILEW(0x12), bm1);
+    mov(TILEW(0x10), bm0w);
+    mov(TILEW(0x12), bm1w);
 
     sar(bm0, SHIFT_UNROLL_K + SHIFT_A - SHIFT_C);
     sar(bm1, SHIFT_UNROLL_K + SHIFT_A - SHIFT_C);
 
-    mov(TILEW(0x18), bm0);
-    mov(TILEW(0x1a), bm0);
-    mov(TILEW(0x1c), bm1);
-    mov(TILEW(0x1e), bm1);
+    mov(TILEW(0x18), bm0w);
+    mov(TILEW(0x1a), bm0w);
+    mov(TILEW(0x1c), bm1w);
+    mov(TILEW(0x1e), bm1w);
 
     sal(bm, SHIFT_UNROLL_KK + SHIFT_A);
 
@@ -239,13 +239,13 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
     mov(TILEW(0x14), UNROLL_KK * SIZE_B);
     mov(TILEW(0x16), UNROLL_KK * SIZE_B);
 
-    mov(TILEB(0x32), T0);
-    mov(TILEB(0x33), T1);
+    mov(TILEB(0x32), T0b);
+    mov(TILEB(0x33), T1b);
 
-    mov(TILEB(0x34), T0);
-    mov(TILEB(0x35), T1);
-    mov(TILEB(0x36), T0);
-    mov(TILEB(0x37), T1);
+    mov(TILEB(0x34), T0b);
+    mov(TILEB(0x35), T1b);
+    mov(TILEB(0x36), T0b);
+    mov(TILEB(0x37), T1b);
 
     sal(bn, SHIFT_UNROLL_KK + SHIFT_B);
 

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
@@ -166,8 +166,8 @@ struct xbyak_gemm_smalln_tn_t : public jit_generator_t {
         mov(LDC, ARG_LDC);
         mov(LDB, ARG_LDB);
 
-        mov(ARG_ALPHA, dword[ARG_ALPHA]);
-        mov(ARG_BETA, dword[ARG_BETA]);
+        mov(ARG_ALPHA.cvt32(), dword[ARG_ALPHA]);
+        mov(ARG_BETA.cvt32(), dword[ARG_BETA]);
         mov(ALPHA, ARG_ALPHA);
         mov(BETA, ARG_BETA);
 

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -840,7 +840,11 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_base(
         Xbyak::Address addr, const Xbyak::Reg64 &out_reg) const {
-    host_->lea(out_reg, addr);
+    // addr may carry a zword[] (512-bit) size annotation because it was built
+    // for a Zmm vmm access. LEA only needs the address computation, not the
+    // size, so strip the annotation to avoid xbyak STRICT_CHECK_MEM_REG_SIZE
+    // flagging the Reg64 vs zword size mismatch.
+    host_->lea(out_reg, host_->ptr[addr.getRegExp()]);
     host_->sub(out_reg,
             host_->ptr[param1_ + rhs_arg_static_params_.dst_orig_offset]);
     host_->shr(out_reg,

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -322,10 +322,15 @@ public:
         auto re = RegExp() + base + offt;
         if (scale) re = re + reg_EVEX_max_8b_offt * scale;
 
+        // Returns ptr[re] (no size annotation) for the non-broadcast path so
+        // that xbyak STRICT_CHECK_MEM_REG_SIZE does not fire when the
+        // result is used with a GPR instruction.  For vector instructions,
+        // xbyak infers the memory operand size from the register (zmm/ymm/xmm)
+        // so the annotation is not needed for correctness.
         if (bcast)
             return zword_b[re];
         else
-            return zword[re];
+            return ptr[re];
     }
 
     template <typename T>

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -531,15 +531,15 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
         mov(reg_ptr_mean_, PARAM_PTR(mean));
         mov(reg_ptr_var_, PARAM_PTR(var));
 #undef PARAM_PTR
-        mov(reg_blk_has_tail_, dword[PARAM_ADDR(blk_has_tail)]);
-        mov(reg_do_normalise_, dword[PARAM_ADDR(do_normalise)]);
+        mov(reg_blk_has_tail_.cvt32(), dword[PARAM_ADDR(blk_has_tail)]);
+        mov(reg_do_normalise_.cvt32(), dword[PARAM_ADDR(do_normalise)]);
     }
 
     void zeroise() {
         Label label_zeroise;
         xor_(reg_off_c_, reg_off_c_);
         uni_vpxor(vzero_, vzero_, vzero_);
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_zeroise);
         {
             jit_tail_.uni_vmovups_maybe_tail(
@@ -648,14 +648,14 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
 
     void compute_blocked(bool compute_mean) {
         Label label_C, label_S;
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_C);
         {
             mov(reg_off_dat_, reg_off_dat_save_);
 
             load_stat(compute_mean);
 
-            mov(reg_S_, dword[PARAM_ADDR(S)]);
+            mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
             L(label_S);
             {
                 compute_stat(compute_mean);
@@ -677,7 +677,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
     }
 
     void compute_nspc(bool compute_mean) {
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
 
         // When a variance is computed, two values are unrolled: mean and variance,
         // so number_of_vmms_to_unrolling_variables_ is divided by 2.
@@ -698,7 +698,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
                 load_stat(compute_mean, c_blks_to_unroll);
 
                 Label label_S;
-                mov(reg_S_, dword[PARAM_ADDR(S)]);
+                mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
                 L(label_S);
                 {
                     is_avx2_ne_xf16_
@@ -727,7 +727,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
 
     void compute(bool compute_mean) {
         Label label_N;
-        mov(reg_N_, dword[PARAM_ADDR(N)]);
+        mov(reg_N_.cvt32(), dword[PARAM_ADDR(N)]);
         L(label_N);
         {
             xor_(reg_off_dat_save_, reg_off_dat_save_);
@@ -764,7 +764,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
         uni_vbroadcastss(vNS_, xtmp);
 
         xor_(reg_off_c_, reg_off_c_);
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_normalise);
         {
             jit_tail_.uni_vmovups_maybe_tail(
@@ -952,7 +952,7 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
         uni_vmovq(x, reg_tmp_);
         uni_vbroadcastss(vone_, x);
 
-        mov(reg_blk_has_tail_, dword[PARAM_ADDR(blk_has_tail)]);
+        mov(reg_blk_has_tail_.cvt32(), dword[PARAM_ADDR(blk_has_tail)]);
 
         mov(reg_tmp_, PARAM_PTR(shift));
         mov(ptr[rsp + stack_off_shift], reg_tmp_);
@@ -1064,7 +1064,7 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
 
     void compute_avx2_ne_xf16(bool stream_store_allowed) {
         Label label_C, label_S, label_C_tail, label_C_end, label_S_C_tail;
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_C);
         {
             cmp(reg_C_, 1);
@@ -1073,7 +1073,7 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
             mov(reg_off_dat_, reg_off_dat_save_);
             load_two_c_mean_sqrtvar();
 
-            mov(reg_S_, dword[PARAM_ADDR(S)]);
+            mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
             L(label_S);
             {
                 compute_bnorm_avx2_ne_xf16(false, stream_store_allowed);
@@ -1097,7 +1097,7 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
             mov(reg_off_dat_, reg_off_dat_save_);
             load_c_specifics(false);
 
-            mov(reg_S_, dword[PARAM_ADDR(S)]);
+            mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
             L(label_S_C_tail);
             {
                 compute_bnorm_avx2_ne_xf16(true, stream_store_allowed);
@@ -1112,14 +1112,14 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
 
     void compute_blocked(bool stream_store_allowed) {
         Label label_C, label_S;
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_C);
         {
             mov(reg_off_dat_, reg_off_dat_save_);
 
             load_c_specifics(false);
 
-            mov(reg_S_, dword[PARAM_ADDR(S)]);
+            mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
             L(label_S);
             {
                 compute_bnorm(
@@ -1311,7 +1311,7 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
         uni_vmovq(x, reg_tmp_);
         uni_vbroadcastss(vNS_, x);
 
-        mov(reg_blk_has_tail_, dword[PARAM_ADDR(blk_has_tail)]);
+        mov(reg_blk_has_tail_.cvt32(), dword[PARAM_ADDR(blk_has_tail)]);
     }
 
     void load_c_specifics() {
@@ -1375,14 +1375,14 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
 
     void compute_blocked(bool stream_store_allowed) {
         Label label_C, label_S;
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_C);
         {
             mov(reg_off_dat_, reg_off_dat_save_);
 
             load_c_specifics();
 
-            mov(reg_S_, dword[PARAM_ADDR(S)]);
+            mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
             L(label_S);
             {
                 compute_bnorm(stream_store_allowed);
@@ -1403,13 +1403,13 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
 
     void compute_nspc(bool stream_store_allowed) {
         Label label_C, label_S;
-        mov(reg_S_, dword[PARAM_ADDR(S)]);
+        mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
         L(label_S);
         {
             mov(reg_off_dat_, reg_off_dat_save_);
             xor_(reg_off_c_, reg_off_c_);
 
-            mov(reg_C_, dword[PARAM_ADDR(C)]);
+            mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
             L(label_C);
             {
                 load_c_specifics();
@@ -1432,7 +1432,7 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
 
     void compute(bool stream_store_allowed) {
         Label label_N;
-        mov(reg_N_, dword[PARAM_ADDR(N)]);
+        mov(reg_N_.cvt32(), dword[PARAM_ADDR(N)]);
         L(label_N);
         {
             xor_(reg_off_dat_save_, reg_off_dat_save_);
@@ -1602,14 +1602,14 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
         uni_vmovq(x, reg_tmp_);
         uni_vbroadcastss(vone_, x);
 
-        mov(reg_blk_has_tail_, dword[PARAM_ADDR(blk_has_tail)]);
+        mov(reg_blk_has_tail_.cvt32(), dword[PARAM_ADDR(blk_has_tail)]);
     }
 
     void zeroise() {
         Label label_zeroise;
         xor_(reg_off_c_, reg_off_c_);
         uni_vpxor(vzero_, vzero_, vzero_);
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_zeroise);
         {
             jit_tail_.uni_vmovups_maybe_tail(
@@ -1756,7 +1756,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
 
     void compute_blocked() {
         Label label_C, label_S;
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
         L(label_C);
         {
             mov(reg_off_dat_, reg_off_dat_save_);
@@ -1764,7 +1764,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
             load_mean();
             zeroise_diff_beta_and_diff_gamma();
 
-            mov(reg_S_, dword[PARAM_ADDR(S)]);
+            mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
             L(label_S);
             {
                 compute_diff_beta_and_diff_gamma();
@@ -1787,7 +1787,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
     }
 
     void compute_nspc() {
-        mov(reg_C_, dword[PARAM_ADDR(C)]);
+        mov(reg_C_.cvt32(), dword[PARAM_ADDR(C)]);
 
         constexpr int max_of_unrolled_c_blks
                 = number_of_vmms_to_unrolling_variables_
@@ -1807,7 +1807,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
                 zeroise_diff_beta_and_diff_gamma(c_blks_to_unroll);
 
                 Label label_S;
-                mov(reg_S_, dword[PARAM_ADDR(S)]);
+                mov(reg_S_.cvt32(), dword[PARAM_ADDR(S)]);
                 L(label_S);
                 {
                     compute_diff_beta_and_diff_gamma(c_blks_to_unroll);
@@ -1834,7 +1834,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
 
     void compute() {
         Label label_N;
-        mov(reg_N_, dword[PARAM_ADDR(N)]);
+        mov(reg_N_.cvt32(), dword[PARAM_ADDR(N)]);
         L(label_N);
         {
             xor_(reg_off_dat_save_, reg_off_dat_save_);


### PR DESCRIPTION
## Enable the `XBYAK_STRICT_CKECK_MEM_REG_SIZE` feature.

The `XBYAK_STRICT_CKECK_MEM_REG_SIZE` feature has been part of Xbyak since v7.25 but was not imported into OneDNN till the recent PR to update Xbyak to v7.35.3.

## What the `XBYAK_STRICT_CHECK_MEM_REG_SIZE` feature does

If a memory operand has an explicit size annotation (e.g. `dword[]` = 32, `zword[]` = 512) and that size does not match the register's bit-width, it will throw an error immediately during JIT kernel construction. The check is intentionally non-intrusive for unannotated `ptr[]` addresses.

# Why this check is valuable

## Catches subtle bugs at the point of emission, not at runtime

Without this check, a mismatch operand pair like `mov(Reg64, dword[...])` assembles silently into well-formed but wrong machine code (a 32-bit `mov`) that the programmer may have intended to be a 64-bit load. The bug would manifest as a subtle data corruption or wrong data result at inference time. Often with no crash, and no assertion. The check converts this class of bug from nondeterministic runtime anomaly into an immediate error when the JIT kernel is generated.

## Helps enforce x86 operand-size discipline in JIT code

Unlike C++ code the JIT code does not protect against unit32_t/uint64_t mismatches. This check helps fill that gap, acting like a type-system layer for the assembly-level operand size.

## Zero runtime overhead
The check runs only during JIT kernel construction, never during the execution of the generated code. In testing the extra check was negligible.

## Enabling the check Aligns oneDNN with the upsteam intent of the Xbyak maintainer.

The `XBYAK_STRICT_CHECK_MEM_REG_SIZE` check defaults to `1` in the upstream project. With a comment explicitly calling out that the macro "may be removed in future version". Indicating that this will eventually become the unconditional default.


