### PR TITLE
graph: backend: dnnl: fix a symbol leak issue caused by std::call_once

### DIFF
--- a/src/graph/backend/dnnl/thread_local_cache.hpp
+++ b/src/graph/backend/dnnl/thread_local_cache.hpp
@@ -185,8 +185,8 @@ private:
                 static auto global_cache = std::shared_ptr<global_cache_type_t>(
                         new global_cache_type_t {},
                         [](global_cache_type_t *ptr) {
-                            return ptr->release();
-                        });
+                    return ptr->release();
+                });
                 return global_cache.get();
             } catch (...) { return nullptr; }
         }


### PR DESCRIPTION
- Forward port PR: #4901 
- Fix MFDNN-14824