### PR TITLE
cpu: x64: xbyak: fix vcvthf82ph EVEX disp8N encoding

### DIFF
--- a/third_party/xbyak/xbyak.h
+++ b/third_party/xbyak/xbyak.h
@@ -2016,6 +2016,7 @@ private:
 	static const uint64_t T_SENTRY = (1ull << 38)-1; // attribute(>=T_SENTRY) is for error check
 	static const uint64_t T_ALLOW_DIFF_SIZE = 1ull << 38; // allow difference reg size
 	static const uint64_t T_ALLOW_ABCDH = 1ull << 39; // allow [abcd]h reg
+	static const uint64_t T_FP8 = 1ull << 40; // amx bf8 and hf8
 	// T_66 = 1, T_F3 = 2, T_F2 = 3
 	static inline uint32_t getPP(uint64_t type) { return (type & T_66) ? 1 : (type & T_F3) ? 2 : (type & T_F2) ? 3 : 0; }
 	// @@@end of avx_type_def.h

--- a/third_party/xbyak/xbyak_mnemonic.h
+++ b/third_party/xbyak/xbyak_mnemonic.h
@@ -2272,7 +2272,7 @@ void vcvtbiasph2bf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x
 void vcvtbiasph2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
 void vcvtbiasph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
 void vcvtdq2ph(const Xmm& x, const Operand& op) { checkCvt4(x, op); opCvt(x, op, T_N16|T_N_VL|T_MAP5|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x5B); }
-void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_MUST_EVEX | T_F2 | T_MAP5 | T_W0 | T_YMM | T_N1, 0x1E); }
+void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_N8|T_N_VL|T_F2|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x1E); }
 void vcvtne2ps2bf16(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_F2|T_0F38|T_W0|T_YMM|T_SAE_Z|T_MUST_EVEX|T_B32, 0x72); }
 void vcvtpd2ph(const Xmm& x, const Operand& op) { opCvt5(x, op, T_N16|T_N_VL|T_66|T_MAP5|T_EW1|T_ER_Z|T_MUST_EVEX|T_B64, 0x5A); }
 void vcvtpd2qq(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x7B); }


### PR DESCRIPTION
Fix for [MFDNN-14831](https://jira.devtools.intel.com/browse/MFDNN-14831)
### Problem

The xbyak upgrade from v7.28 to v7.35.3 changed the `vcvthf82ph`
mnemonic encoding in `xbyak_mnemonic.h` from `T_N8|T_N_VL` to `T_N1`.
This silently produced incorrect EVEX compressed displacements (`disp8N`)
in JIT-generated code whenever `vcvthf82ph` was called with a memory
operand.

At runtime this caused wrong memory addresses to be computed, manifesting
as SDE `"Could not read memory"` errors and SIGSEGV crashes in the
following primitives under `DNNL_MAX_CPU_ISA=AVX10_2_512_AMX_2`:

- `f8_e4m3` depthwise convolution
- `f8_e5m2`/`f8_e4m3` matmul
- `f8_e4m3`/`f8_e5m2` brgemm with uker

### Root Cause

In EVEX encoding, `disp8N` is the granularity by which a one-byte
compressed displacement is scaled. Xbyak's `T_N*` flags encode this
scaling factor:

| Flag | disp8N |
|------|--------|
| `T_N1` | 1 byte (fixed, no VL scaling) |
| `T_N8\|T_N_VL` | 8 × VL_multiplier: 8 / 16 / 32 bytes for XMM / YMM / ZMM output |

Per the
[Intel AVX10.2 Architecture Specification §9.3](https://www.intel.com/content/www/us/en/content-details/836199/intel-advanced-vector-extensions-10-2-intel-avx10-2-architecture-specification.html)
(document 361050-001US, Rev 1.0), `VCVTHF82PH` uses tuple type **HALF**:
the memory source is always half the destination vector width:

| Destination | Memory source | Correct disp8N |
|-------------|---------------|----------------|
| `xmm1` (128-bit) | `m64` | **8** |
| `ymm1` (256-bit) | `m128` | **16** |
| `zmm1` (512-bit) | `m256` | **32** |

`T_N8|T_N_VL` correctly encodes this VL-scaled disp8N. `T_N1` (always 1)
is architecturally incorrect for this instruction and is a bug
in upstream xbyak v7.35.3.

### Fix

Restore the pre-upgrade encoding with the correct tuple type flags and
re-add the `checkCvt1` operand size guard (which validates that the
destination register is always double the width of the source register,
consistent with the HALF tuple contract).

