### PR TITLE
cpu: aarch64: fix tmp reg clash in brgemm

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -1642,7 +1642,7 @@ void jit_brgemm_kernel_t::gemm_microkernel(int bd_block2, bool is_bdb_tail,
         // We need to bump the ptr forward if we will not be starting at 0 (vpad)
         if (bd_b != 0) {
             reg_A_ptr = strided_addr(reg_A_ptr, reg_A_ptr, reg_stride_bytes_A,
-                    A_stride_bytes, bd_b, X_TMP_4);
+                    A_stride_bytes, bd_b, X_TMP_3);
         }
         auto x_addr = reg_aux_B;
         unsigned long b_base_offset = 0;

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -433,3 +433,7 @@ mb64_ic3oc192_ih224oh14kh16sh16dh0ph0_iw224ow14kw16sw16dw0pw0n"rpad0_int8_accura
 --reset
 --dt=bf16:bf16:f32 --dir=FWD_I
 mb64_ic3oc192_ih224oh14kh16sh16dh0ph0_iw224ow14kw16sw16dw0pw0n"rpad0_bf16_accuracy"
+
+# Case with vpad != 0 in brgconv:sve_128 which triggered tmp register reuse issue
+--reset
+--dt=f32 --dir=FWD_B --impl=brgconv mb1ic342iw7oc10000ow7kw7pw3


### PR DESCRIPTION
# Description
Fix brgconv crashes due to `X_TMP_4` trying to be used twice in `add_imm`.
```
> OMP_NUM_THREADS=3 ./tests/benchdnn/benchdnn --conv --mode=c --skip-impl=simple,ref ic512iw121oc512ow122kw6pw3n"conv1d:21"
benchdnn: oneDNN/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_meta_mnemonic.h:39: void Xbyak_aarch64::CodeGenerator::add_imm(const Xbyak_aarch64::XReg&, const Xbyak_aarch64::XReg&, T, const Xbyak_aarch64::XReg&) [with T = int; typename std::enable_if<std::is_signed<_Tp>::value, std::nullptr_t>::type <anonymous> = nullptr]: Assertion `src.getIdx() != tmp.getIdx()' failed.
Aborted (core dumped)
```

Credit to Siddhartha Menon for finding bug

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests? (already in the test set, although not with that number of threads. Adding tests for different number of threads is probably out of the scope of this test)
