### PR TITLE
Fixup for misspellings in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ oneDNN uses gtests for lightweight functional testing and benchdnn for
 performance and functional testing.
 
 Verify the modified code is covered by existing tests. If not, update the
-coverage to validate the change and sumbit it as a part of the PR.
+coverage to validate the change and submit it as a part of the PR.
 
 Use the following command to run tests selected by a build configuration:
 ``` sh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,7 @@
 This document defines roles available in oneDNN project and includes the current
 list of Code Owners and Maintainers for the project.
 
-# Roles and responsibilties
+# Roles and responsibilities
 
 oneDNN project defines three main roles:
  * [Contributor](#contributor)
@@ -81,7 +81,7 @@ Responsibilities:
   * Follow and enforce the project [contributing guidelines](CONTRIBUTING.md)
   * Co-own with other component Maintainers on the technical direction of a specific component.
   * Co-own with other Maintainers on the project as a whole, including determining strategy and policy for the project.
-  * Suppport and guide Contributors and Code Owners.
+  * Support and guide Contributors and Code Owners.
 
 Requirements:
   * Experience as a Code Owner for at least 12 months.
@@ -89,7 +89,7 @@ Requirements:
   * Track record of major project contributions to a specific project component.
   * Demonstrated deep knowledge of a specific project component.
   * Demonstrated broad knowledge of the project across multiple areas.
-  * Commits to using priviledges responsibly for the good of the project.
+  * Commits to using privileges responsibly for the good of the project.
   * Is able to exercise judgment for the good of the project, independent of
     their employer, friends, or team.
 

--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -165,7 +165,7 @@ can be found in @ref dev_guide_attributes_rounding_mode.
 ## Hardware Limitations
 
 While all the platforms oneDNN supports have hardware acceleration for
-fp32 arithmetics, that is not the case for other data types. Support
+fp32 arithmetic, that is not the case for other data types. Support
 for low precision data types may not be available for older
 platforms. The next sections explain limitations that exist for low
 precision data types for Intel 64/AMD64 based processors and Intel Graphpics.


### PR DESCRIPTION
Run codespell on docs and .md files in the root. Fixed up findings 