### PR TITLE
[rls-v3.10] third_party: ngen: add workaround for GCC13

### DIFF
--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -767,7 +767,7 @@ static inline void encodeTernarySrc2(Instruction12 &i, S2 src2, Tag tag)
 template <typename Tag>
 static inline void encodeTernarySrc2(Instruction12 &i, const Immediate &src2, Tag tag)
 {
-    i.ternary.src2Imm = true;
+    i.qword[0] |= 0x800000000000; /* same as (i.ternary.src2Imm = true), update directly to avoid gcc13 bug */
     i.ternary.src2 = static_cast<uint64_t>(src2);
 }
 


### PR DESCRIPTION
Backport of #4635 to rls-v3.10. See: [MFDNN-14743](https://jira.devtools.intel.com/browse/MFDNN-14743).