### PR TITLE
cpu: x64: fix vcvt_f8_to_f16 for is_fp8_native path

### DIFF
--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -260,7 +260,15 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f16(
             true, op_in.isXMM(), op_in.isYMM(), op_in.isZMM(), op_in.isMEM()));
 
     if (is_fp8_native()) {
-        host_->vcvthf82ph(xmm_out, op_in);
+        if (!op_in.isMEM()) {
+            // src register must be at least half the size of dst register (xbyak checkCvt1)
+            if (xmm_out.isZMM())
+                host_->vcvthf82ph(xmm_out, Xbyak::Ymm(op_in.getIdx()));
+            else
+                host_->vcvthf82ph(xmm_out, Xbyak::Xmm(op_in.getIdx()));
+        } else {
+            host_->vcvthf82ph(xmm_out, op_in);
+        }
         return;
     }
 
@@ -355,11 +363,7 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f32(
     const Xbyak::Zmm zmm_out(xmm_out.getIdx());
 
     // f16 <- f8_e4m3
-    if (is_fp8_native())
-        host_->vcvthf82ph(ymm_mask(xmm_out), op_in);
-    else
-        vcvt_f8_to_f16(ymm_mask(xmm_out), op_in);
-
+    vcvt_f8_to_f16(ymm_mask(xmm_out), op_in);
     // f32 <- f16
     host_->vcvtph2psx(zmm_out, ymm_out);
 }


### PR DESCRIPTION
[MFDNN-14831](https://jira.devtools.intel.com/browse/MFDNN-14831)

### Problem

After updating Xbyak from v7.28 to v7.35.3, the `f8_e4m3` pooling test fails with a `runtime_error` during `create_primitive` when running under SDE with `DNNL_MAX_CPU_ISA=AVX10_2_512_AMX_2`: `--pool --dt=f8_e4m3:f8_e4m3 ic64iw32ow16kw3sw2pw0`

Xbyak v7.35.3 introduced `checkCvt1`, a new operand-size validation for conversion instructions. `vcvthf82ph` requires the source register to be half the width of the destination (e.g. `(xmm/ymm dst, xmm src)` or `(zmm dst, ymm src)`).

| dst | src | valid |
|----|-----|------|
| XMM/YMM | XMM | yes |
| ZMM | YMM | yes |
| XMM/YMM | YMM | no |
| ZMM | ZMM | no |
| any | MEM | yes |

 Callers of `fp8_conversionion_e4m3::vcvt_f8_to_f16` and `vcv_f8_to_f32` were passing same-width registers (e.g. YMM src to YMM dst),  which was silently accepted before v7.35.3 but now throws `ERR_BAD_COMBINATION`, propagating as a `runtime_error`.

### Fix

Updated `fp8_conversion_e4m3::vcvt_f8_to_f16` to adjust register sizes to conform with the `checkCvt1` requirements. `cvct_f8_to_f16` will have the same behavior as it had before the Xbyak library update. It will silently accept registers of the same width and different width. 

`vcvt_f8_to_f32` is simplified to delegate to `vcvt_f8_to_f16`, removing a previously duplicated native-path inline that was the original source of the bug.

Note: `f8_e5m2` conversions use `vpmovzxbw` internally, which does not have the `checkCvt1` size constraint and required no changes.

### Testing

```bash
DNNL_MAX_CPU_ISA=AVX10_2_512_AMX_2 \
  sde -chip_check_exe_only -dmr -- \
  benchdnn --pool --dt=f8_e4m3:f8_e4m3 ic64iw32ow16kw3sw2pw0 #from nightly build

DNNL_MAX_CPU_ISA=AVX10_2_512_AMX_2 \
  sde -chip_check_exe_only -dmr -- \
  benchdnn --reorder --sdt=f8_e4m3 --ddt=f32,bf16,f16,f8_e5m2 8x8 64x64 128x128 #based on code changed
```
**PASSES**

