### PR TITLE
tests: benchdnn: fix binary post-op strides printing

### DIFF
--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -963,7 +963,8 @@ std::ostream &operator<<(std::ostream &s, const attr_t::post_ops_t &post_ops) {
                 }
             }
             if (e.binary.tag != tag::any) s << src_delim << e.binary.tag;
-            if (!e.binary.strides.empty()) s << src_delim << e.binary.strides;
+            if (!e.binary.strides.empty())
+                s << src_delim << dims2str(e.binary.strides);
 
             if (e.is_binary_kind_with_ternary_op()) {
                 bool delim_added = false;


### PR DESCRIPTION
Fixed printing of binary post-op strides in benchdnn repro output: strides were being printed with `:` between dimensions, which caused `--attr-post-ops` to be parsed into multiple arguments. Now strides are serialized with `dims2str` (using `x` separators) so the entire post-op tensor shape stays a single argument.

Example: given the test
`--matmul --allow-enum-tags-only=0 --dt=s8:s8:f32 --stag=abcd --wtag=abdc --dtag=abcd --strides=:: --attr-post-ops=binary_add:f32:13:abcd:16512x16512x129x1 --attr-scratchpad=user 2x16x128x64:2x16x64x128`

the repro used to be:
`__REPRO: --matmul --allow-enum-tags-only=false --dt=s8:s8:f32 --stag=abcd --wtag=abdc --dtag=abcd --attr-post ops=add:f32:13:abcd:16512:16512:129:1 --attr-scratchpad=user 2x16x128x64:2x16x64x128`

and now is:
`REPRO: --matmul --allow-enum-tags-only=false --dt=s8:s8:f32 --stag=abcd --wtag=abdc --dtag=abcd --attr-post-ops=add:f32:13:abcd:16512x16512x129x1 --attr-scratchpad=user 2x16x128x64:2x16x64x128`