### PR TITLE
xe: fix kernel cache key validation

### DIFF
--- a/src/common/serialization.hpp
+++ b/src/common/serialization.hpp
@@ -273,10 +273,10 @@ private:
     const serialization_stream_t &sstream_;
 };
 
-template <typename T>
-struct trivially_serializable_t {
-    static constexpr bool is_trivially_validatable = true;
+struct trivially_serializable_base_t {};
 
+template <typename T>
+struct trivially_serializable_t : public trivially_serializable_base_t {
     serialization_stream_t serialize() const {
         DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(T);
         return serialization_stream_t(*static_cast<const T *>(this));

--- a/src/gpu/intel/conv/jit/v2/kernel_desc.hpp
+++ b/src/gpu/intel/conv/jit/v2/kernel_desc.hpp
@@ -494,7 +494,7 @@ public:
 } // namespace conv
 #if __cplusplus >= 202002L
 template <>
-struct trivial_key_validator_t<conv::jit::v2::kernel_desc_t> {
+struct key_validator_t<conv::jit::v2::kernel_desc_t> {
     static bool is_valid(const conv::jit::v2::kernel_desc_t &t) {
         auto tmp = conv::jit::v2::kernel_desc_t::deserialize(t.serialize());
         return (t.prop == tmp.prop) && (t.is_dw == tmp.is_dw)

--- a/src/gpu/intel/conv/jit/zero_out.hpp
+++ b/src/gpu/intel/conv/jit/zero_out.hpp
@@ -51,7 +51,9 @@ public:
             const intel::engine_t &engine, compute::kernel_t &kernel) const;
     serialization_stream_t serialize() const override;
     static zero_out_kernel_desc_t deserialize(const serialization_stream_t &s);
-
+#if __cplusplus >= 202002L
+    bool operator==(const zero_out_kernel_desc_t &) const = default;
+#endif
     static compute::nd_range_t nd_range(int simd, size_t size);
 
 private:

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -194,24 +194,22 @@ protected:
 } // namespace gemm
 
 template <>
-struct trivial_key_validator_t<gemm::jit::gen_desc_t> {
+struct key_validator_t<gemm::jit::gen_desc_t> {
     static bool is_valid(const gemm::jit::gen_desc_t &) { return true; }
 };
 
 template <>
-struct trivial_key_validator_t<gemm::jit::gen_nocopy_desc_t> {
+struct key_validator_t<gemm::jit::gen_nocopy_desc_t> {
     static bool is_valid(const gemm::jit::gen_nocopy_desc_t &derived) {
-        return trivial_key_validator_t<gemm::jit::gen_desc_t>::is_valid(
-                derived);
+        return key_validator_t<gemm::jit::gen_desc_t>::is_valid(derived);
     }
 };
 
 template <>
-struct trivial_key_validator_t<gemm::jit::gen_xe_systolic_kernel_desc_t> {
+struct key_validator_t<gemm::jit::gen_xe_systolic_kernel_desc_t> {
     static bool is_valid(
             const gemm::jit::gen_xe_systolic_kernel_desc_t &derived) {
-        return trivial_key_validator_t<gemm::jit::gen_desc_t>::is_valid(
-                derived);
+        return key_validator_t<gemm::jit::gen_desc_t>::is_valid(derived);
     }
 };
 

--- a/src/gpu/intel/jit/ir/kernel_desc.hpp
+++ b/src/gpu/intel/jit/ir/kernel_desc.hpp
@@ -56,6 +56,9 @@ public:
             primitive_t *primitive, impl::engine_t *engine) const
             = 0;
     virtual serialization_stream_t serialize() const = 0;
+#if __cplusplus >= 202002L
+    bool operator==(const kernel_desc_base_t &) const = default;
+#endif
 };
 
 class kernel_params_base_t {

--- a/src/gpu/intel/kernel_cache.hpp
+++ b/src/gpu/intel/kernel_cache.hpp
@@ -33,24 +33,18 @@ namespace gpu {
 namespace intel {
 
 template <typename T>
-struct trivial_key_validator_t {
+struct key_validator_t {
 
     template <typename V>
-    struct is_trivially_validatable_t {
-        using yes_t = uint8_t;
-        using no_t = uint16_t;
+    using is_trivial_t = std::is_base_of<trivially_serializable_base_t, V>;
 
-        template <typename U>
-        static yes_t test(bool value = V::is_trivially_validatable);
-        template <typename U>
-        static no_t test(...);
-
-        static const bool value = sizeof(test<V>(false)) == sizeof(yes_t);
-    };
+    static_assert(!is_trivial_t<std::vector<int>>::value,
+            "is_trivial_t has unexpected behavior");
+    static_assert(is_trivial_t<trivially_serializable_t<int>>::value,
+            "is_trivial_t has unexpected behavior");
 
     template <typename U,
-            utils::enable_if_t<is_trivially_validatable_t<U>::value, bool>
-            = true>
+            utils::enable_if_t<is_trivial_t<U>::value, bool> = true>
     static bool is_valid(const U &t) {
         static_assert(std::is_same<T, U>::value,
                 "key validation is not intended for comparing different types");
@@ -58,8 +52,7 @@ struct trivial_key_validator_t {
     }
 
     template <typename U,
-            utils::enable_if_t<!is_trivially_validatable_t<U>::value, bool>
-            = true>
+            utils::enable_if_t<!is_trivial_t<U>::value, bool> = true>
     static bool is_valid(const U &t) {
         // Runtime validation only occurs in C++20 as default comparisons
         // significantly improves the reliability of this check.
@@ -111,7 +104,7 @@ struct trivial_key_t : public T {
 
     bool is_valid() const {
         const T *base = this;
-        return trivial_key_validator_t<T>::is_valid(*base);
+        return key_validator_t<T>::is_valid(*base);
     }
 
 private:


### PR DESCRIPTION
@echeresh Noticed that kernel cache key debug validation was not behaving as expected. This patch resolves this issue and addresses some missing functionality needed for the validation.