### PR TITLE
xe: gemm: jit: restrict bf16 quant stride override

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
@@ -338,8 +338,11 @@ void Generator<hw>::gemmDequantizeOperation(bool doA, Type T, Type Tq, BinaryOp 
     int xqGroupMN = doA ? problem.aqGroupM : problem.bqGroupN;
 
     bool common = (qlayout.rows() * qlayout.cols()) == 1;
+    bool colMajor = layout.colMajor();
+    int xqGroupX = colMajor == doA ? xqGroupMN : xqGroupK;
+    int xqGroupY = colMajor == doA ? xqGroupK : xqGroupMN;
 
-    bool bfSpecialPath = (T == Type::bf16) && (Tq == Type::f32) && (xqGroupMN > 1) && layout.hasFullCrosspack(2);
+    bool bfSpecialPath = (T == Type::bf16) && (Tq == Type::f32) && (xqGroupMN > 1) && layout.hasFullCrosspack(2) && (xqGroupY == 1);
     GRFMultirange qPairs;
     int npairs = 0;
 
@@ -353,12 +356,8 @@ void Generator<hw>::gemmDequantizeOperation(bool doA, Type T, Type Tq, BinaryOp 
 
     for (auto &block: layout) {
         auto crosspack = block.crosspack;
-        bool colMajor = block.colMajor;
         int nx = colMajor ? block.nr : block.nc;
         int ny = colMajor ? block.nc : block.nr;
-
-        int xqGroupX = colMajor == doA ? xqGroupMN : xqGroupK;
-        int xqGroupY = colMajor == doA ? xqGroupK : xqGroupMN;
 
         // If crosspack spans multiple groups, use a stride to restrict to one group
         bool qbroadcastY = (xqGroupY % crosspack == 0) || common || bfSpecialPath;


### PR DESCRIPTION
# Description

Restrict quantization stride override in cases of bf16 matrix multiplication. Resolves failures in bf16 GEMM quantization while preserving workaround for required cases in SDPA [CI_RUN](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f12dfdb3-be39-f188-9cf0-a4bf010d0e2d) (failures on XE3 are a pre-existing issue). 

Fixes # [MFDNN-14740](https://jira.devtools.intel.com/browse/MFDNN-14740)
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
