### PR TITLE
cpu: rv64: brgemm: improve brgemm kernel by pre computing

### DIFF
--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -50,6 +50,12 @@ void jit_brgemm_kernel_t::generate() {
     const dim_t N_stride_B = 4 * LDB_bytes; // B advance per 4-col group
     const dim_t N_stride_C = 4 * LDC_bytes; // C advance per 4-col group
 
+    // If all B column offsets (0, LDB, 2*LDB, 3*LDB in bytes) fit in the
+    // 12-bit signed immediate of flw, use a single B pointer with immediate
+    // offsets instead of 4 separate column pointers.  This saves 3 addi per
+    // K step and 3 add at N-loop setup.
+    const bool use_single_b = (3 * LDB_bytes <= 2047);
+
     const Reg reg_param = a0;
     const Reg reg_tmp0 = a0; // reused after param loads
 
@@ -109,6 +115,13 @@ void jit_brgemm_kernel_t::generate() {
     li(reg_ldb, LDB_bytes);
     li(reg_ldc, LDC_bytes);
 
+    if (use_single_b) {
+        // Pre-compute N-stride into callee-saved registers (s2, s3).
+        // These replace reg_B2/reg_B3 which are unused in single-B mode.
+        li(s2, N_stride_B);
+        li(s3, N_stride_C);
+    }
+
     // ---- Compute K_main = (K / 4) * 4 for 4× unrolled loop ----
     srli(reg_K_main, reg_K_val, 2);
     slli(reg_K_main, reg_K_main, 2);
@@ -127,11 +140,13 @@ void jit_brgemm_kernel_t::generate() {
 
     mv(reg_A, reg_A_base);
 
-    // ---- Setup 4 B column pointers for current N group ----
+    // ---- Setup B pointer(s) for current N group ----
     mv(reg_B0, reg_B_base);
-    add(reg_B1, reg_B_base, reg_ldb);
-    add(reg_B2, reg_B1, reg_ldb); // B_base + 2*LDB
-    add(reg_B3, reg_B2, reg_ldb); // B_base + 3*LDB
+    if (!use_single_b) {
+        add(reg_B1, reg_B_base, reg_ldb);
+        add(reg_B2, reg_B1, reg_ldb); // B_base + 2*LDB
+        add(reg_B3, reg_B2, reg_ldb); // B_base + 3*LDB
+    }
 
     vmv_v_i(v_c0, 0);
     vmv_v_i(v_c1, 0);
@@ -142,20 +157,28 @@ void jit_brgemm_kernel_t::generate() {
     mv(reg_k, x0);
     Label lbl_k_main_end, lbl_k_tail, lbl_k_tail_end;
 
-    // Helper: load 4 B scalars (all independent, no address chains).
+    // Helper: load 4 B scalars.
     auto emit_b_load = [&]() {
         flw(freg_b0, reg_B0, 0);
-        flw(freg_b1, reg_B1, 0);
-        flw(freg_b2, reg_B2, 0);
-        flw(freg_b3, reg_B3, 0);
+        if (use_single_b) {
+            flw(freg_b1, reg_B0, LDB_bytes);
+            flw(freg_b2, reg_B0, 2 * LDB_bytes);
+            flw(freg_b3, reg_B0, 3 * LDB_bytes);
+        } else {
+            flw(freg_b1, reg_B1, 0);
+            flw(freg_b2, reg_B2, 0);
+            flw(freg_b3, reg_B3, 0);
+        }
     };
 
-    // Helper: advance all 4 B pointers to the next k row.
+    // Helper: advance B pointer(s) to the next k row.
     auto emit_b_advance = [&]() {
         addi(reg_B0, reg_B0, 4);
-        addi(reg_B1, reg_B1, 4);
-        addi(reg_B2, reg_B2, 4);
-        addi(reg_B3, reg_B3, 4);
+        if (!use_single_b) {
+            addi(reg_B1, reg_B1, 4);
+            addi(reg_B2, reg_B2, 4);
+            addi(reg_B3, reg_B3, 4);
+        }
     };
 
     // Pipelined K step: prefetch next A into v_next while computing
@@ -191,6 +214,7 @@ void jit_brgemm_kernel_t::generate() {
     vle32_v(v_a0, reg_A);
     add(reg_A, reg_A, reg_lda);
 
+    align(16);
     {
         Label lbl_pipe, lbl_pipe_end;
         L(lbl_pipe);
@@ -274,11 +298,15 @@ void jit_brgemm_kernel_t::generate() {
     }
 
     // ---- Advance B_base and C for next 4-column group ----
-    li(reg_tmp1, N_stride_B);
-    add(reg_B_base, reg_B_base, reg_tmp1);
-
-    li(reg_tmp1, N_stride_C);
-    add(reg_C, reg_C, reg_tmp1);
+    if (use_single_b) {
+        add(reg_B_base, reg_B_base, s2); // N_stride_B (precomputed)
+        add(reg_C, reg_C, s3); // N_stride_C (precomputed)
+    } else {
+        li(reg_tmp1, N_stride_B);
+        add(reg_B_base, reg_B_base, reg_tmp1);
+        li(reg_tmp1, N_stride_C);
+        add(reg_C, reg_C, reg_tmp1);
+    }
 
     addi(reg_n, reg_n, 4);
     j_(lbl_n_loop);


### PR DESCRIPTION
# Description

This PR introduces three JIT-level micro-optimizations to the RVV BRGEMM kernel (`brgemm:rvv`), reducing instruction count in the hot K-loop and improving instruction fetch alignment.

This version provides:

1. **Single B-pointer with immediate offsets**: when `3 * LDB_bytes <= 2047`, all four B-column scalar loads use 12-bit signed immediates from a single base pointer instead of four independent pointers, saving 3 `addi` per K step and 3 `add` at N-loop setup.
2. **Pre-computed N-stride constants**: the callee-saved registers freed by the single-pointer optimization (`s2`, `s3`) are reused to hold `N_stride_B` and `N_stride_C`, eliminating 2 `li` instructions per N iteration.
3. **Loop alignment**: `align(16)` before the pipelined K main loop to reduce instruction fetch bubbles.

## Implementation Details

The optimisation is a JIT-time code-generation decision: the flag `use_single_b` is evaluated once at kernel construction time from the `brgemm_desc_t` layout parameters and emits one of two code paths. There is no runtime branch overhead — the kernel binary simply contains the shorter instruction sequence when the constraint is satisfied.

The constraint `3 * LDB_bytes <= 2047` corresponds to `OC <= 170` for `f32` data, which covers the majority of convolution shapes in common networks (GoogLeNet-v3, ResNet-50, VGG-11).

Register allocation is unchanged for the fallback path. When `use_single_b` is true, `reg_B1` (`a7`) is freed and `reg_B2`/`reg_B3` (`s2`/`s3`) are repurposed from column pointers to stride constants, with no additional callee-saved register saves beyond the original four (`s0`–`s3`).

# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on a SpacemiT K1/X60 platform with VLEN=128 using RISC-V GNU toolchain 14.2. We draw comparisons among:

1. **baseline**: upstream `main` branch (`brgemm:rvv` before this PR) 
2. **this PR**: `improve-rvv-brgemm` branch with the three optimisations

### Single-Core Performance

Results are collected with `benchdnn --mode=f --conv --batch=<shapes>` on a single core (`taskset -c 32`). The `0time` column (average runtime in ms) is used for comparison.

#### GoogLeNet-v3

| Layer | Baseline (ms) | This PR (ms) | Speedup |
|-------|---------------|--------------|---------|
| conv_1_1_conv2d | 477.28 | 447.93 | **+6.5%** |
| conv_2_2_conv2d | 990.91 | 931.43 | **+6.4%** |
| conv_4_4_conv2d | 1775.81 | 1530.40 | **+16.0%** |
| mixed_tower_conv_1_conv2d×3 | 191.76 | 181.21 | **+5.8%** |
| mixed_tower_1_conv_1_conv2d×4 | 155.94 | 146.00 | **+6.8%** |
| mixed_tower_1_conv_2_conv2d×3 | 222.88 | 210.09 | **+6.1%** |

#### ResNet-50

| Layer | Baseline (ms) | This PR (ms) | Speedup |
|-------|---------------|--------------|---------|
| res2a_branch2b×3 | 582.30 | 546.32 | **+6.5%** |
| res3a_branch1 | 1167.27 | 1170.13 | -0.2% |
| res3a_branch2a | 296.89 | 297.88 | -0.3% |
| res3a_branch2b×4 | 650.02 | 626.17 | **+4.4%** |

#### VGG-11

| Layer | Baseline (ms) | This PR (ms) | Speedup |
|-------|---------------|--------------|---------|
| conv1_2 | 1325.97 | 1252.82 | **+5.8%** |
| conv2_1 | 642.30 | 567.21 | **+13.2%** |
| conv2_2 | 1515.52 | 1301.80 | **+16.4%** |
| conv3_1 | 477.95 | 424.30 | **+12.6%** |
| conv3_2 | 715.09 | 716.52 | -0.2% |

### Overall Performance

| Dataset | Baseline (ms) | This PR (ms) | Improvement |
|---------|---------------|--------------|-------------|
| GoogLeNet-v3 | 3814.58 | 3447.07 | **+9.6%** |
| ResNet-50 | 2696.49 | 2640.50 | **+2.1%** |
| VGG-11 | 4676.83 | 4062.65 | **+13.1%** |
| **Total** | **11187.88** | **10350.19** | **+7.5%** |

**Dispatch Coverage:**
- All 15 shapes use `brgemm:rvv` implementation
- 12/15 shapes (80%) benefit from the single-B-pointer fast path (`OC ≤ 170`)
- 3/15 shapes (20%) fall back to the 4-pointer path (`conv_4_4`, `res3a_branch1`, `conv3_2`)

**Key Observations:**
- Shapes using the single-B-pointer path show consistent **+5–7%** improvement from reduced instruction count in the hot K-loop
- `conv_4_4` shows a larger improvement despite being a fallback shape, likely benefiting from the `align(16)` optimisation and reduced code footprint improving instruction cache behaviour
- `res3a_branch1` (OC=512) and `conv3_2` (OC=192) show performance parity, consistent with the fallback path being unchanged for these shapes
- VGG-11 shapes show **+13–16%** improvement for medium-sized convolutions where the BRGEMM kernel is the dominant bottleneck

