### PR TITLE
benchdnn: allow gpu_smoke files for TEST_SET=SMOKE

### DIFF
--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -160,6 +160,7 @@ foreach(driver ${all_drivers})
             inputs/${driver}/test_*_gpu_ci)
     file(GLOB test_files_gpu RELATIVE ${driver_dir} inputs/${driver}/test_*_gpu)
     file(GLOB test_files_ci RELATIVE ${driver_dir} inputs/${driver}/test_*_ci)
+    file(GLOB test_files_gpu_smoke RELATIVE ${driver_dir} inputs/${driver}/test_*_gpu_smoke)
     file(GLOB test_files_smoke RELATIVE ${driver_dir} inputs/${driver}/test_*_smoke)
     file(GLOB test_files_cpu RELATIVE ${driver_dir} inputs/${driver}/test_*)
     file(GLOB test_files_with_all RELATIVE ${driver_dir}
@@ -167,8 +168,18 @@ foreach(driver ${all_drivers})
         inputs/graph/test_graph_all inputs/rnn/test_lstm_all)
 
     if(DNNL_TEST_SET_COVERAGE EQUAL DNNL_TEST_SET_SMOKE)
+        # gpu_smoke files may happen if standard coverage is not applicable on gpu.
+        # Filter out gpu_smoke inputs from smoke
+        foreach(test_file ${test_files_gpu_smoke})
+            string(REPLACE "${test_file}" "" test_files_smoke "${test_files_smoke}")
+        endforeach()
+
         if(has_gpu)
-            register_all_tests(gpu "${driver}" "${test_files_smoke}")
+            if(test_files_gpu_smoke)
+                register_all_tests(gpu "${driver}" "${test_files_gpu_smoke}")
+            else()
+                register_all_tests(gpu "${driver}" "${test_files_smoke}")
+            endif()
         endif()
         if(has_cpu)
             register_all_tests(cpu "${driver}" "${test_files_smoke}")
@@ -177,7 +188,8 @@ foreach(driver ${all_drivers})
         if(NOT DNNL_EXPERIMENTAL_GROUPED_MEMORY)
             list(REMOVE_ITEM test_files_ci "test_matmul_grouped_ci")
         endif()
-        # gpu_ci files may happen if cpu coverage can not be used on gpu
+
+        # gpu_ci files may happen if standard coverage is not applicable on gpu.
         # Filter out gpu_ci inputs from ci
         foreach(test_file ${test_files_gpu_ci})
             string(REPLACE "${test_file}" "" test_files_ci "${test_files_ci}")
@@ -197,7 +209,8 @@ foreach(driver ${all_drivers})
     elseif(DNNL_TEST_SET_COVERAGE EQUAL DNNL_TEST_SET_NIGHTLY)
         ## Filter out gpu, large cpu and invalid inputs from cpu
         foreach(test_file ${test_files_large_cpu} ${test_files_gpu_ci}
-            ${test_files_gpu} ${test_files_ci} ${test_files_smoke})
+            ${test_files_gpu} ${test_files_ci} ${test_files_smoke}
+            ${test_files_gpu_smoke})
             string(REPLACE "${test_file}" "" test_files_cpu "${test_files_cpu}")
         endforeach()
         ## Then filter files with "all" suffix by exact name since there may

--- a/tests/benchdnn/doc/benchdnn_input_files_naming_convention.md
+++ b/tests/benchdnn/doc/benchdnn_input_files_naming_convention.md
@@ -49,10 +49,14 @@ file to avoid option collision.
   DNNL_TEST_SET=CI should be specified. If no additional `_ci` files are
   present, an input file will be shared between CPU and GPU backend.
     * **test_\<driver\>_gpu_ci**: These files are used in CI testing for GPU
-      when differentiation on input files are needed. `_ci` file in this case
-      will not be used for GPU backend.
+      when differentiation on input files is needed. Non-suffixed `_ci` file in
+      this case will not be used for GPU backend.
 
 * **test_\<driver\>_smoke**: These files are used in public validation. Smoke is
   the thinnest testing cycle validating base functionality. To deploy benchdnn
   testing targets with smoke inputs, DNNL_TEST_SET=SMOKE should be specified.
-  Input files are shared between CPU and GPU backend.
+  If no additional `_smoke` files are present, an input file will be shared
+  between CPU and GPU backend.
+    * **test_\<driver\>_gpu_smoke**: These files are used in smoke testing for
+      GPU when differentiation on input files is needed. Non-suffixed `_smoke`
+      file in this case will not be used for GPU backend.

--- a/tests/benchdnn/inputs/matmul/test_matmul_gpu_smoke
+++ b/tests/benchdnn/inputs/matmul/test_matmul_gpu_smoke
@@ -1,0 +1,143 @@
+--reset
+--dt=f16,bf16,f32
+--stag=abx --wtag=abx --dtag=abx
+--attr-post-ops=,tanh,logistic,swish,mish
+--batch=shapes_2d
+--batch=shapes_3d
+
+# f8:f8:f16-32
+--reset
+--dt=f8_e5m2:f8_e4m3:f16,f8_e5m2:f8_e4m3:bf16,f8_e5m2:f8_e4m3:f32
+--stag=abx --wtag=abx --dtag=abx
+--batch=shapes_2d
+
+# f8
+--reset
+--dt=f8_e5m2:f8_e4m3:f8_e5m2,f8_e4m3:f8_e5m2:f8_e4m3,f8_e5m2,f8_e4m3
+--stag=abx --wtag=abx --dtag=abx
+--batch=shapes_2d
+--batch=shapes_3d
+
+# batch, mixed fp8
+--reset
+--dt=bf16:bf16:f8_e5m2
+8x8x8x1x8:8x8x1x8x8
+
+# wei_decomp
+## f16-32:i4:f16-32
+--reset --dt=bf16:u4:bf16,f16:s4:f16,f32:u4:f32 --attr-fpmath=bf16:true --stag=ab --wtag=ab --dtag=ab --batch=shapes_2d
+## f16-32:i4:f8
+--reset --dt=bf16:u4:f8_e5m2,f16:s4:f8_e4m3,f32:u4:f8_e4m3 --attr-fpmath=f16:true --stag=ab --wtag=ab --dtag=ab --batch=shapes_2d
+## f8:i4:f16-32
+--reset --dt=f8_e4m3:u4:bf16,f8_e5m2:s4:f32 --attr-fpmath=bf16:true --stag=ab --wtag=ab --dtag=ab --batch=shapes_2d
+--reset --dt=f8_e5m2:s4:f16,f8_e4m3:u4:f32 --attr-fpmath=f16:true --stag=ab --wtag=ab --dtag=ab --batch=shapes_2d
+## f8:i4:f8
+--reset --dt=f8_e4m3:u4:f8_e4m3,f8_e5m2:s4:f8_e5m2,f8_e4m3:u4:f8_e5m2 --attr-fpmath=strict:true --stag=ab --wtag=ab --dtag=ab --batch=shapes_2d
+
+# fp16/32:int4:fp16/32
+# 2D block wei scale, zp (fp16/32)
+
+--reset
+--dt=bf16:s4:bf16,bf16:u4:bf16
+--stag=abc
+--attr-scales=wei:per_ocic:bf16:32x1
+--attr-zero-points=wei:per_ocic:s4:32x1
+--attr-fpmath=bf16:true
+7x6x32:7x32x64
+7x6x32:1x32x64
+3x6x96:3x96x64
+3x6x96:1x96x64
+
+--reset
+--dt=f16:s4:f16,f16:u4:f16
+--stag=abc
+--attr-scales=wei:per_ocic:f16:32x1
+--attr-zero-points=wei:per_ocic:s4:32x1
+--attr-fpmath=f16:true
+7x6x32:7x32x64
+7x6x32:1x32x64
+3x6x96:3x96x64
+3x6x96:1x96x64
+
+# TODO: re-enable when f32 scales are fixed by backport from main
+#--reset
+#--dt=f32:s4:f32,f32:u4:f32
+#--stag=abc #,acb
+#--attr-scales=wei:per_ocic:f32:32x1
+#--attr-zero-points=wei:per_ocic:s4:32x1
+#--attr-fpmath=strict:true
+#7x6x32:7x32x64
+#7x6x32:1x32x64
+#3x6x96:3x96x64
+#3x6x96:1x96x64
+
+# fp8:fp8:fp8
+# common/per_oc src, wei, dst scale (bf16/f32)
+
+--reset
+--dt=f8_e5m2:f8_e4m3:f8_e5m2,f8_e4m3:f8_e5m2:f8_e4m3,f8_e5m2,f8_e4m3
+--attr-scales=wei:per_oc:bf16+src:per_ocic:bf16:1x256+dst:per_oc:bf16,\
+              wei:common:2:bf16+src:common:2:bf16+dst:common:2:bf16,\
+              wei:per_oc:f32+src:per_ocic:f32:1x256+dst:per_oc:f32,\
+              wei:common:2:f32+src:common:2:f32+dst:common:2:f32
+--stag=ab --wtag=ab --dtag=ab
+2x256:256x128n"DLRM:2*1"
+2x256:256x2n"DLRM:7*1"
+
+# fp8:fp8:fp16/32
+# common/per_oc src, wei scale (bf16/f32)
+
+--reset
+--dt=f8_e5m2:f8_e4m3:f32,f8_e4m3:f8_e5m2:f16,f8_e5m2:f8_e4m3:bf16
+--attr-scales=wei:per_oc:bf16+src:per_ocic:bf16:1x256,\
+              wei:common:2:bf16+src:common:2:bf16,\
+              wei:per_oc:f32+src:per_ocic:f32:1x256,\
+              wei:common:2:f32+src:common:2:f32
+--stag=ab --wtag=ab --dtag=ab
+2x256:256x128n"DLRM:2*1"
+2x256:256x2n"DLRM:7*1"
+
+# fp16/32:int4:fp8
+# 2D block wei scale (fp16/32)
+# common/per_oc dst scale (fp16/32)
+
+--reset
+--dt=bf16:s4:f8_e5m2,bf16:u4:f8_e4m3
+--stag=abc
+--attr-scales=wei:per_ocic:bf16:32x1+dst:per_oc:bf16,\
+              wei:per_ocic:bf16:32x1+dst:common:2:bf16
+--attr-zero-points=wei:per_ocic:s4:32x1
+--attr-fpmath=bf16:true
+7x6x32:7x32x64
+7x6x32:1x32x64
+3x6x96:3x96x64
+3x6x96:1x96x64
+
+# fp8:int4:fp16/32
+# 2D block wei scale (fp16/32)
+# common/per_oc src scale (fp16/32)
+
+--reset
+--dt=f8_e5m2:s4:bf16,f8_e4m3:u4:bf16
+--stag=abc
+--attr-scales=wei:per_ocic:bf16:32x1+src:per_oc:bf16:1x32,\
+              wei:per_ocic:bf16:32x1+src:common:2:bf16
+--attr-zero-points=wei:per_ocic:s4:32x1
+--attr-fpmath=bf16:true
+7x6x32:7x32x64
+7x6x32:1x32x64
+
+# fp8:int4:fp8
+# 2D block wei scale (fp16/32/fp8)
+# common/per_oc src, dst scale (f32)
+
+--reset
+--dt=f8_e5m2:s4:f8_e5m2,f8_e4m3:u4:f8_e4m3
+--stag=abc
+--attr-scales=wei:per_ocic:f8_e5m2:32x1+src:per_oc:f32:1x32,\
+              wei:per_ocic:f8_e4m3:32x1+src:common:2:f32,\
+              wei:per_ocic:f32:32x1+src:common:2:f32
+--attr-zero-points=wei:per_ocic:s4:32x1
+--attr-fpmath=bf16:true
+7x6x32:7x32x64
+7x6x32:1x32x64


### PR DESCRIPTION
A lightweight version of #4878

Any further updated coverage should be handled through ***_gpu_smoke files.