### PR TITLE
benchdnn: restrict mode to single-char only

### DIFF
--- a/tests/benchdnn/doc/benchdnn_general_info.md
+++ b/tests/benchdnn/doc/benchdnn_general_info.md
@@ -92,11 +92,10 @@ otherwise. The following modes (`--mode`) are supported:
   if the case is passing, it doesn't necessarily mean the problem is free of
   issues; it may happen that it was not triggered.
 * Performance (`P`): This flow executes all steps, skipping steps 6 and 7.
+  When running on a GPU engine, the `M` modifier (see below) is automatically
+  enabled to align data filling with the Fast Performance mode.
 * Fast Performance (`F`): This flow executes Performance mode with `P` and `M`
   modifiers (see below) enabled and updated maximum measuring time per case.
-* Correctness & performance (`CP`). This flow executes all steps, skipping the
-  bitwise step. It's not recommended for the usage due to filling data conflicts
-  between correctness and performance modes.
 
 ## Mode modifiers
 

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -150,10 +150,10 @@ runtimes. `KIND` values can be `usm` (default), `buffer`, `usm_device`
 `--mode=MODE` specifies **benchdnn** mode to be used for benchmarking.
 `MODE` values can be:
   - `C` or `c` for correctness testing (the default)
-  - `P` or `p` for performance testing
+  - `P` or `p` for performance testing. On a GPU engine, the `M` modifier is
+               automatically enabled to align data filling with `--mode=F`
   - `F` or `f` for fast performance testing, an alias for
                `--mode=P --mode-modifier=PM --max-ms-per-prb=10`
-  - `CP` or `cp` for both correctness and performance testing
   - `B` or `b` for bitwise (numerical determinism) testing
   - `R` or `r` for run mode, enables `--mode-modifier=M`
   - `I` or `i` for initialization mode

--- a/tests/benchdnn/utils/bench_mode.hpp
+++ b/tests/benchdnn/utils/bench_mode.hpp
@@ -67,7 +67,6 @@ enum class bench_mode_t : unsigned {
     corr = exec | static_cast<unsigned>(mode_bit_t::corr),
     perf = exec | static_cast<unsigned>(mode_bit_t::perf),
     perf_fast = perf | static_cast<unsigned>(mode_bit_t::fast),
-    corr_perf = corr | perf,
     bitwise = exec | static_cast<unsigned>(mode_bit_t::bitwise),
 };
 

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1617,30 +1617,15 @@ static bool parse_mode(
               "    * `P` for performance testing.\n"
               "    * `F` for fast performance testing (GPU only).\n"
               "    * `B` for bitwise (numerical determinism) testing.\n"
-              "    * `CP` for both correctness and performance testing.\n"
               "    More details at "
             + doc_url + "benchdnn_general_info.md\n";
 
     const auto str2bench_mode = [](const std::string &_str) {
         bench_mode_t mode = default_bench_mode;
-        if (_str.size() > 2) {
+        if (_str.size() > 1) {
             BENCHDNN_PRINT(
                     0, "%s\n%s", "Error: mode value is invalid.", help.c_str());
             SAFE_V(FAIL);
-        } else if (_str.size() == 2) {
-            for (size_t i = 0; i < _str.size(); i++) {
-                switch (_str[i]) {
-                    case 'c':
-                    case 'C':
-                    case 'p':
-                    case 'P': break;
-                    default:
-                        BENCHDNN_PRINT(0, "%s\n%s",
-                                "Error: mode value is invalid.", help.c_str());
-                        SAFE_V(FAIL);
-                }
-            }
-            mode = bench_mode_t::corr_perf;
         } else if (_str.size() == 1) {
             switch (_str[0]) {
                 case 'l':
@@ -1656,7 +1641,11 @@ static bool parse_mode(
                 case 'c':
                 case 'C': mode = bench_mode_t::corr; break;
                 case 'p':
-                case 'P': mode = bench_mode_t::perf; break;
+                case 'P':
+                    mode = bench_mode_t::perf;
+                    if (is_gpu())
+                        bench_mode_modifier |= mode_modifier_t::no_ref_memory;
+                    break;
                 case 'f':
                 case 'F':
                     mode = bench_mode_t::perf_fast;


### PR DESCRIPTION
### This PR restricts `--mode` to single-character values and auto-enables `no_ref_memory` for `--mode=P` on GPUs to align performance data filling with `--mode=F`.

JIRA: [MFDNN-14789](https://jira.devtools.intel.com/browse/MFDNN-14789)

---

### Problem description

Two issues with benchdnn performance mode data filling on GPUs:

1. **Multi-character mode values (e.g. `--mode=CP`) are broken**: the combined correctness + performance mode is unused and currently broken on both CPU and GPU. Correctness validation requires specific low-range data filling (less randomness in mantissa to minimize round-off errors), which makes the data compressible by the GPU driver and produces unreliable performance numbers.

2. **`--mode=P` vs `--mode=F` data mismatch**: in `--mode=P`, `fill_random_real_dense()` overwrites GPU buffers with deterministic CPU-generated data via `reorder()`, replacing the incompressible Philox PRNG data written by `gpu_fill_random()` during `dnn_mem_t::initialize()`. This leads to different (and potentially compressible) data patterns compared to `--mode=F`.

---

### Proposed Solution

Two changes inline in `parse_mode()` (`parser.cpp`), following the existing pattern used by `--mode=R` and `--mode=F`:

1. **Restrict mode to single characters**: the `_str.size() > 1` check now rejects any multi-character mode value with a generic "mode value is invalid" error. This eliminates `--mode=CP` (and any other multi-char combinations) without needing a dedicated branch. Users should run `--mode=C` and `--mode=P` (or `--mode=F`) separately.

2. **Auto-enable `no_ref_memory` for `--mode=P` on GPUs**: in the `case 'P'` branch, when `is_gpu()` returns true, automatically set the `no_ref_memory` modifier. This skips CPU reference memory allocation and `fill_random_real_dense()` calls, so GPU buffers retain incompressible Philox PRNG data aligning `--mode=P` data filling with `--mode=F`.

   For CPU, `--mode=F` uses `0x3F` memset (different from `--mode=P` which uses `fill_random_real_dense`), so the existing behavior is intentionally preserved, no change for CPU.

Documentation updated in `knobs_common.md` and `benchdnn_general_info.md` to reflect the removal of the `CP` mode and the automatic `M` modifier behavior for `--mode=P` on GPU engines.

---

### Example

**Before:** `--mode=CP` silently runs but produces NaN in correctness output (broken) and unreliable perf numbers:
```
> benchdnn --mode=CP --matmul --engine=gpu --dt=f16 128x128:128x128

[   0][DST][0:0] exp_f32:     2438.02 exp:        2438 got:        -nan diff:     nan rdiff:     nan
[   1][DST][0:1] exp_f32:     115.184 exp:     115.188 got:        -nan diff:     nan rdiff:     nan
[   2][DST][0:2] exp_f32:     258.576 exp:       258.5 got:        -nan diff:     nan rdiff:     nan
...
perf,gpu,jit:gemm:any,,--mode=CP --matmul --engine=gpu --dt=f16:f16:f16 128x128:128x128,0.0041943,...
tests:1 passed:1 skipped:0 ... failed:0
```

**After:** `--mode=CP` is rejected as an invalid mode value:
```
> benchdnn --mode=CP --matmul --engine=gpu --dt=f16 128x128:128x128

Error: mode value is invalid.
MODE    (Default: `C`)
    Specifies a `MODE` for benchmarking.
    `MODE` values are:
    * `L` for listing mode.
    * `I` for initialization mode.
    * `R` for execution mode (no correctness validation).
    * `C` for correctness testing.
    * `P` for performance testing.
    * `F` for fast performance testing (GPU only).
    * `B` for bitwise (numerical determinism) testing.
    More details at https://github.com/uxlfoundation/oneDNN/blob/main/tests/benchdnn/doc/benchdnn_general_info.md
```

---