### PR TITLE
cpu: rv64: enable f16 graph coverage in benchdnn

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -169,6 +169,8 @@ bool has_training_support(data_type_t data_type) {
             return x64::mayiuse(x64::avx512_core_fp16);
 #elif defined(DNNL_AARCH64_USE_ACL)
             return arm_compute::CPUInfo::get().has_fp16();
+#elif DNNL_RV64
+            return rv64::mayiuse(rv64::zvfh);
 #else
             return false;
 #endif

--- a/src/graph/backend/dnnl/platform.cpp
+++ b/src/graph/backend/dnnl/platform.cpp
@@ -20,6 +20,8 @@
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
 #if DNNL_X64
 #include "cpu/x64/cpu_isa_traits.hpp"
+#elif DNNL_RV64
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #elif DNNL_AARCH64
 #if defined(DNNL_AARCH64_USE_ACL)
 // For checking if fp16 isa is supported on the platform
@@ -115,6 +117,9 @@ bool has_cpu_data_type_support(data_type_t data_type) {
         case data_type::f16:
 #if DNNL_X64
             return mayiuse(avx512_core_fp16) || mayiuse(avx2_vnni_2);
+#elif DNNL_RV64
+            using namespace dnnl::impl::cpu::rv64;
+            return mayiuse(zvfh);
 #elif defined(DNNL_AARCH64_USE_ACL)
             return arm_compute::CPUInfo::get().has_fp16();
 #else
@@ -153,6 +158,9 @@ bool has_cpu_training_support(data_type_t data_type) {
         case data_type::f16:
 #if DNNL_X64
             return mayiuse(avx512_core_fp16);
+#elif DNNL_RV64
+            using namespace dnnl::impl::cpu::rv64;
+            return mayiuse(zvfh);
 #elif defined(DNNL_AARCH64_USE_ACL)
             return arm_compute::CPUInfo::get().has_fp16();
 #else

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -561,19 +561,6 @@ int skip_unimplemented_partitions(const std::vector<partition> &partitions,
         skip_unimplemented_data_type(in_out_dt, dir, res);
         if (res->state == SKIPPED) return OK;
 
-            // TODO: Temporarily skip all f16 graph tests for the RV64 backend.
-            // This patch avoids UNIMPLEMENTED, FAIL errors, as f16 is not yet implemented
-            // for most RV64 primitives (conv, matmul, etc.).
-            // This block can be removed as f16 primitives are progressively implemented.
-#if defined(DNNL_RV64) && DNNL_RV64
-        for (auto dt : in_out_dt) {
-            if (dt == dnnl_f16) {
-                res->state = SKIPPED;
-                return OK;
-            }
-        }
-#endif
-
         BENCHDNN_PRINT(3, "[INFO]: partition #%zd is unsupported!\n", i);
         return res->state = UNIMPLEMENTED, FAIL;
     }


### PR DESCRIPTION
# Description

This PR removes a temporary RV64 `f16` graph skip in benchdnn and aligns RV64 `f16` capability checks across CPU platform and graph backend paths.

# Background

PR #4322 added runtime `Zvfh` detection and CPU platform support for RV64 `f16`. That change was needed so oneDNN could verify at runtime whether the machine actually supports `Zvfh`, instead of relying only on the compile-time `DNNL_RISCV_USE_ZVFH_INTRINSICS` switch.

However, after that change, benchdnn graph `f16` cases were no longer skipped at the platform level. Many of them then reached the graph backend, where unsupported partitions were reported as `UNIMPLEMENTED`, and benchdnn graph counted those cases as `FAILED` by design.

To avoid CI noise, a temporary workaround was added in the graph driver to skip all RV64 `f16` graph cases.

# What this PR changes

This PR fixes that inconsistency by:

1. removing the temporary RV64 `f16` graph skip from `tests/benchdnn/graph/graph.cpp`
2. treating RV64 `Zvfh` as `f16` training support in `src/cpu/platform.cpp`
3. aligning graph backend `f16` data type / training support checks in `src/graph/backend/dnnl/platform.cpp`

As a result, RV64 `f16` graph cases are no longer hidden behind a global skip and can follow the normal graph execution path.

# How to reproduce the old issue

On a branch where the old RV64 graph skip is removed but the support checks are not aligned yet, run:

```bash
./tests/benchdnn/benchdnn --mode=C --graph --batch=op/harness_f16_ci
./tests/benchdnn/benchdnn --mode=C --graph --batch=pattern/harness_f16_ci
````

or

```
ctest -R test_benchdnn_modeC_graph_ci_cpu
```

# Validation

Validated on `MUSE Pi Pro` with a full oneDNN build.

Commands:

```bash
mkdir -p build && cd build
export CC=clang CXX=clang++
cmake ..
make -j16

cd tests/benchdnn
./benchdnn --mode=C --graph --batch=op/harness_f16_ci
./benchdnn --mode=C --graph --batch=pattern/harness_f16_ci
```

Results on the fixed branch:

* `op/harness_f16_ci`: tests:28 passed:28 skipped:0
* `pattern/harness_f16_ci`: tests:1 passed:1 skipped:0

and

```
Test project /home/xiazz/codex/oneDNN/build
    Start 211: test_benchdnn_modeC_graph_ci_cpu
1/1 Test #211: test_benchdnn_modeC_graph_ci_cpu ...   Passed  524.42 sec

100% tests passed, 0 tests failed out of 1
```

This shows that this PR fixes the capability exposure path so those RV64 `f16` graph cases can run successfully.