### PR TITLE
common: memory: follow-up on large tensor dimension checks 

### DIFF
--- a/src/common/memory_desc.cpp
+++ b/src/common/memory_desc.cpp
@@ -31,6 +31,54 @@ using namespace dnnl::impl::utils;
 namespace dnnl {
 namespace impl {
 
+inline status_t memory_desc_sanity_check(int ndims, const dims_t dims,
+        data_type_t data_type, format_kind_t format_kind) {
+    using namespace data_type;
+
+    if (ndims == 0) return status::success;
+
+    VCHECK_MEMORY(dims != nullptr, status::invalid_arguments, "%s (dims)",
+            VERBOSE_NULL_ARG);
+    VCHECK_MEMORY(0 < ndims && ndims <= DNNL_MAX_NDIMS,
+            status::invalid_arguments, VERBOSE_BAD_NDIMS, "tensor", ndims);
+    VCHECK_MEMORY(utils::one_of(data_type, f4_e2m1, e8m0, f8_e5m2, f8_e4m3, f16,
+                          bf16, f32, f64, s64, s32, s8, u8, s4, u4),
+            status::invalid_arguments, VERBOSE_UNSUPPORTED_DT);
+
+    // A bounds check on the dimensions ensures that the tensor size
+    // computation does not trigger a overflow during memory creation.
+    dim_t prod = 1;
+    for (int d = 0; d < ndims; ++d) {
+        if (!is_runtime_value(dims[d])) {
+            if (dims[d] < 0)
+                VCHECK_MEMORY(false, status::invalid_arguments, VERBOSE_BAD_DIM,
+                        "dims", d);
+            if (dims[d] > 0) {
+                if (prod > std::numeric_limits<dim_t>::max() / dims[d])
+                    VCHECK_MEMORY(false, status::invalid_arguments,
+                            VERBOSE_INTEGRAL_OVERFLOW_DIM, "dims", d);
+                prod *= dims[d];
+            }
+        }
+    }
+
+    bool has_runtime_dims = false;
+    for (int d = 0; d < ndims; ++d) {
+        if (is_runtime_value(dims[d])) has_runtime_dims = true;
+    }
+
+    VCHECK_MEMORY(
+            IMPLICATION(has_runtime_dims, format_kind != format_kind::any),
+            status::invalid_arguments, VERBOSE_UNSUPPORTED_FORMAT_KIND);
+
+    return status::success;
+}
+
+status_t memory_desc_sanity_check(const memory_desc_t &md) {
+    return memory_desc_sanity_check(
+            md.ndims, md.dims, md.data_type, md.format_kind);
+}
+
 status_t memory_desc_init_host_scalar(
         memory_desc_t &memory_desc, data_type_t data_type) {
     memory_desc.ndims = 1;

--- a/src/common/memory_desc.cpp
+++ b/src/common/memory_desc.cpp
@@ -38,9 +38,8 @@ status_t memory_desc_init_host_scalar(
     memory_desc.data_type = data_type;
     memory_desc.format_kind = format_kind::host_scalar;
 
-    bool args_ok = memory_desc_sanity_check(memory_desc.ndims, memory_desc.dims,
-            memory_desc.data_type, memory_desc.format_kind);
-    VCHECK_MEMORY(args_ok, invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(memory_desc.ndims, memory_desc.dims,
+            memory_desc.data_type, memory_desc.format_kind));
 
     return success;
 }
@@ -55,9 +54,7 @@ status_t memory_desc_init_by_tag(memory_desc_t &memory_desc, int ndims,
     format_kind_t format_kind = types::format_tag_to_kind(tag);
 
     /* memory_desc != 0 */
-    bool args_ok
-            = memory_desc_sanity_check(ndims, dims, data_type, format_kind);
-    VCHECK_MEMORY(args_ok, invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(ndims, dims, data_type, format_kind));
 
     auto md = memory_desc_t();
     md.ndims = ndims;
@@ -89,9 +86,7 @@ status_t memory_desc_init_by_strides(memory_desc_t &memory_desc, int ndims,
     }
 
     /* memory_desc != 0 */
-    bool args_ok = memory_desc_sanity_check(
-            ndims, dims, data_type, format_kind::undef);
-    VCHECK_MEMORY(args_ok, invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(ndims, dims, data_type, format_kind::undef));
 
     auto md = memory_desc_t();
     md.ndims = ndims;
@@ -112,8 +107,7 @@ status_t memory_desc_init_by_strides(memory_desc_t &memory_desc, int ndims,
         }
         strides = default_strides;
     }
-    VCHECK_MEMORY(memory_desc_strides_check(md, strides), invalid_arguments,
-            VERBOSE_UNSUPPORTED_MEM_STRIDE);
+    CHECK(memory_desc_strides_check(md, strides));
 
     array_copy(md.format_desc.blocking.strides, strides, md.ndims);
 
@@ -133,9 +127,7 @@ status_t memory_desc_init_by_csr_encoding(memory_desc_t &memory_desc, int ndims,
     // This is the only number of dims that is supported at this point.
     VCHECK_MEMORY(ndims <= 2, unimplemented, VERBOSE_BAD_NDIMS, "", ndims);
 
-    bool args_ok = memory_desc_sanity_check(
-            ndims, dims, data_type, format_kind::undef);
-    VCHECK_MEMORY(args_ok, invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(ndims, dims, data_type, format_kind::undef));
 
     auto md = memory_desc_t();
     md.ndims = ndims;
@@ -164,9 +156,7 @@ status_t memory_desc_init_by_coo_encoding(memory_desc_t &memory_desc, int ndims,
     // This is the only number of dims that is supported at this point.
     VCHECK_MEMORY(ndims <= 2, unimplemented, VERBOSE_BAD_NDIMS, "", ndims);
 
-    bool args_ok = memory_desc_sanity_check(
-            ndims, dims, data_type, format_kind::undef);
-    VCHECK_MEMORY(args_ok, invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(ndims, dims, data_type, format_kind::undef));
 
     auto md = memory_desc_t();
     md.ndims = ndims;
@@ -190,9 +180,7 @@ status_t memory_desc_init_by_packed_encoding(memory_desc_t &memory_desc,
         return success;
     }
 
-    bool args_ok = memory_desc_sanity_check(
-            ndims, dims, data_type, format_kind::undef);
-    VCHECK_MEMORY(args_ok, invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(ndims, dims, data_type, format_kind::undef));
 
     auto md = memory_desc_t();
     md.ndims = ndims;
@@ -234,9 +222,7 @@ status_t memory_desc_init_with_grouped_encoding(memory_desc_t &memory_desc,
 
     VCHECK_MEMORY(ndims <= 2, unimplemented, VERBOSE_BAD_NDIMS, "", ndims);
 
-    bool args_ok = memory_desc_sanity_check(
-            ndims, dims, data_type, format_kind::undef);
-    VCHECK_MEMORY(args_ok, invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(ndims, dims, data_type, format_kind::undef));
 
     VCHECK_MEMORY(group_count > 0, invalid_arguments, VERBOSE_BAD_PARAM,
             "group_count");
@@ -288,8 +274,7 @@ status_t memory_desc_init_with_grouped_encoding(memory_desc_t &memory_desc,
 status_t memory_desc_init_submemory(memory_desc_t &memory_desc,
         const memory_desc_t &parent_memory_desc, const dims_t dims,
         const dims_t offsets) {
-    VCHECK_MEMORY(memory_desc_sanity_check(parent_memory_desc),
-            invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(parent_memory_desc));
 
     const memory_desc_wrapper src_d(parent_memory_desc);
     VCHECK_MEMORY((!src_d.has_runtime_dims_or_strides()), unimplemented,
@@ -350,11 +335,9 @@ status_t memory_desc_reshape(memory_desc_t &out_memory_desc,
         return prod;
     };
 
-    VCHECK_MEMORY(memory_desc_sanity_check(in_memory_desc), invalid_arguments,
-            VERBOSE_MEM_DESC_CHECK_FAIL);
-    VCHECK_MEMORY(memory_desc_sanity_check(ndims, dims,
-                          in_memory_desc.data_type, in_memory_desc.format_kind),
-            invalid_arguments, VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(in_memory_desc));
+    CHECK(memory_desc_sanity_check(
+            ndims, dims, in_memory_desc.data_type, in_memory_desc.format_kind));
     VCHECK_MEMORY(one_of(in_memory_desc.format_kind, format_kind::any,
                           format_kind::blocked),
             invalid_arguments, VERBOSE_UNSUPPORTED_TAG);
@@ -550,8 +533,7 @@ status_t memory_desc_reshape(memory_desc_t &out_memory_desc,
 
 status_t memory_desc_permute_axes(memory_desc_t &out_memory_desc,
         const memory_desc_t &in_memory_desc, const int *perm) {
-    VCHECK_MEMORY(memory_desc_sanity_check(in_memory_desc), invalid_arguments,
-            VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(in_memory_desc));
     VCHECK_MEMORY(one_of(in_memory_desc.format_kind, format_kind::any,
                           format_kind::blocked),
             invalid_arguments, VERBOSE_UNSUPPORTED_TAG);

--- a/src/common/memory_desc.hpp
+++ b/src/common/memory_desc.hpp
@@ -272,6 +272,11 @@ struct memory_extra_desc_t {
     dim_t dst_size;
 };
 
+status_t memory_desc_sanity_check(int ndims, const dims_t dims,
+        data_type_t data_type, format_kind_t format_kind);
+
+status_t memory_desc_sanity_check(const memory_desc_t &md);
+
 status_t memory_desc_init_host_scalar(
         memory_desc_t &memory_desc, data_type_t data_type);
 

--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -22,12 +22,8 @@
 #include "c_types_map.hpp"
 #include "nstl.hpp"
 #include "utils.hpp"
-#include "verbose.hpp"
 
 #include "type_helpers.hpp"
-
-#define VCHECK_MEMORY(cond, stat, msg, ...) \
-    VCONDCHECK(common, create, check, memory, (cond), stat, msg, ##__VA_ARGS__)
 
 namespace dnnl {
 namespace impl {

--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -201,6 +201,9 @@ struct memory_desc_wrapper : public c_compatible {
 
     /** returns true if memory descriptor contains zero as one of its dim */
     bool has_zero_dim() const {
+        // to be consistent for when memory descriptor is zero with ndims = 0
+        if (is_zero()) return true;
+
         for (int d = 0; d < ndims(); ++d)
             if (dims()[d] == 0) return true;
         return false;

--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -25,6 +25,11 @@
 
 #include "type_helpers.hpp"
 
+#include "verbose.hpp"
+
+#define VCHECK_MEMORY(cond, stat, msg, ...) \
+    VCONDCHECK(common, create, check, memory, (cond), stat, msg, ##__VA_ARGS__)
+
 namespace dnnl {
 namespace impl {
 

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -237,8 +237,7 @@ status_t post_ops_t::validate_binary(alg_kind_t alg,
     bool is_ternary_op = (alg == binary_select);
 
     VCHECK_ATTR(alg_ok, VERBOSE_BAD_ALGORITHM);
-    VCHECK_ATTR(memory_desc_sanity_check(*user_src1_desc),
-            VERBOSE_MEM_DESC_CHECK_FAIL);
+    CHECK(memory_desc_sanity_check(*user_src1_desc));
 
     // Additional check to restrict run-time dimension usage until supported.
     for (int d = 0; d < user_src1_desc->ndims; ++d) {
@@ -248,8 +247,7 @@ status_t post_ops_t::validate_binary(alg_kind_t alg,
 
     // Additional checks if the algorithm involves ternary inputs
     if (is_ternary_op) {
-        VCHECK_ATTR(memory_desc_sanity_check(*user_src2_desc),
-                VERBOSE_MEM_DESC_CHECK_FAIL);
+        CHECK(memory_desc_sanity_check(*user_src2_desc));
         for (int d = 0; d < user_src2_desc->ndims; ++d) {
             VCHECK_ATTR(!is_runtime_value(user_src2_desc->dims[d]),
                     VERBOSE_RUNTIMEDIM_UNSUPPORTED);

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -1168,6 +1168,15 @@ inline status_t memory_desc_strides_check(
 
         // update min_stride for next iteration
         const auto padded_dim = md.padded_dims[d];
+
+        const dim_t blocks_ratio = padded_dim / blocks[d];
+        VCHECK_MEMORY(IMPLICATION(strides[d] > 0 && block_size > 0
+                                      && blocks_ratio > 0,
+                              strides[d] <= std::numeric_limits<dim_t>::max()
+                                              / (block_size * blocks_ratio)),
+                status::invalid_arguments, VERBOSE_INTEGRAL_OVERFLOW_DIM,
+                "strides", d);
+
         min_stride = block_size * strides[d] * (padded_dim / blocks[d]);
         if (max_stride <= strides[d]) {
             max_stride = strides[d];

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -1361,7 +1361,7 @@ inline bool memory_desc_sanity_check(int ndims, const dims_t dims,
     // computation does not trigger a overflow during memory creation.
     dim_t prod = 1;
     for (int d = 0; d < ndims; ++d) {
-        if (dims[d] != DNNL_RUNTIME_DIM_VAL) {
+        if (!is_runtime_value(dims[d])) {
             if (dims[d] < 0) return false;
             if (dims[d] > 0) {
                 if (prod > std::numeric_limits<dim_t>::max() / dims[d])

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -34,9 +34,6 @@
 #include "utils.hpp"
 #include "verbose.hpp"
 
-#define VCHECK_MEMORY(cond, stat, msg, ...) \
-    VCONDCHECK(common, create, check, memory, (cond), stat, msg, ##__VA_ARGS__)
-
 namespace dnnl {
 namespace impl {
 
@@ -1163,17 +1160,19 @@ inline status_t memory_desc_strides_check(
         if ((strides[d] == 0) || (md.padded_dims[d] == 1))
             continue;
         else if (strides[d] < min_stride)
-            VCHECK_MEMORY(false, status::invalid_arguments,
-                    VERBOSE_INTEGRAL_OVERFLOW_DIM, "strides", d);
+            VCONDCHECK(common, create, check, memory, false,
+                    status::invalid_arguments, VERBOSE_INTEGRAL_OVERFLOW_DIM,
+                    "strides", d);
 
         // update min_stride for next iteration
         const auto padded_dim = md.padded_dims[d];
 
         const dim_t blocks_ratio = padded_dim / blocks[d];
-        VCHECK_MEMORY(IMPLICATION(strides[d] > 0 && block_size > 0
-                                      && blocks_ratio > 0,
-                              strides[d] <= std::numeric_limits<dim_t>::max()
-                                              / (block_size * blocks_ratio)),
+        VCONDCHECK(common, create, check, memory,
+                IMPLICATION(
+                        strides[d] > 0 && block_size > 0 && blocks_ratio > 0,
+                        strides[d] <= std::numeric_limits<dim_t>::max()
+                                        / (block_size * blocks_ratio)),
                 status::invalid_arguments, VERBOSE_INTEGRAL_OVERFLOW_DIM,
                 "strides", d);
 
@@ -1191,10 +1190,10 @@ inline status_t memory_desc_strides_check(
         size_t dim_val = static_cast<size_t>(
                 md.padded_dims[max_stride_d] / blocks[max_stride_d]);
         dim_val = dim_val == (size_t)max_stride ? 1 : dim_val;
-        VCHECK_MEMORY((dim_val <= SIZE_MAX / max_stride),
-                status::invalid_arguments, VERBOSE_INTEGRAL_OVERFLOW_DIM,
-                "padded_dims", max_stride_d);
-        VCHECK_MEMORY(
+        VCONDCHECK(common, create, check, memory,
+                (dim_val <= SIZE_MAX / max_stride), status::invalid_arguments,
+                VERBOSE_INTEGRAL_OVERFLOW_DIM, "padded_dims", max_stride_d);
+        VCONDCHECK(common, create, check, memory,
                 (dt_size && ((dim_val * max_stride) <= SIZE_MAX / dt_size)),
                 status::invalid_arguments, VERBOSE_INTEGRAL_OVERFLOW_DIM,
                 "padded_dims", max_stride_d);
@@ -1362,55 +1361,6 @@ format_tag_t memory_desc_matches_one_of_tag(
     }
     return format_tag::undef;
 }
-
-inline status_t memory_desc_sanity_check(int ndims, const dims_t dims,
-        data_type_t data_type, format_kind_t format_kind) {
-    using namespace data_type;
-
-    if (ndims == 0) return status::success;
-
-    VCHECK_MEMORY(dims != nullptr, status::invalid_arguments, "%s (dims)",
-            VERBOSE_NULL_ARG);
-    VCHECK_MEMORY(0 < ndims && ndims <= DNNL_MAX_NDIMS,
-            status::invalid_arguments, VERBOSE_BAD_NDIMS, "tensor", ndims);
-    VCHECK_MEMORY(utils::one_of(data_type, f4_e2m1, e8m0, f8_e5m2, f8_e4m3, f16,
-                          bf16, f32, f64, s64, s32, s8, u8, s4, u4),
-            status::invalid_arguments, VERBOSE_UNSUPPORTED_DT);
-
-    // A bounds check on the dimensions ensures that the tensor size
-    // computation does not trigger a overflow during memory creation.
-    dim_t prod = 1;
-    for (int d = 0; d < ndims; ++d) {
-        if (!is_runtime_value(dims[d])) {
-            if (dims[d] < 0)
-                VCHECK_MEMORY(false, status::invalid_arguments, VERBOSE_BAD_DIM,
-                        "dims", d);
-            if (dims[d] > 0) {
-                if (prod > std::numeric_limits<dim_t>::max() / dims[d])
-                    VCHECK_MEMORY(false, status::invalid_arguments,
-                            VERBOSE_INTEGRAL_OVERFLOW_DIM, "dims", d);
-                prod *= dims[d];
-            }
-        }
-    }
-
-    bool has_runtime_dims = false;
-    for (int d = 0; d < ndims; ++d) {
-        if (is_runtime_value(dims[d])) has_runtime_dims = true;
-    }
-
-    VCHECK_MEMORY(
-            IMPLICATION(has_runtime_dims, format_kind != format_kind::any),
-            status::invalid_arguments, VERBOSE_UNSUPPORTED_FORMAT_KIND);
-
-    return status::success;
-}
-
-inline status_t memory_desc_sanity_check(const memory_desc_t &md) {
-    return memory_desc_sanity_check(
-            md.ndims, md.dims, md.data_type, format_kind::undef);
-}
-
 template <typename... Args>
 inline bool any_memory_desc_host_scalar(const memory_desc_t *md, Args... mds) {
     if (md != nullptr && md->format_kind == format_kind::host_scalar)

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -32,6 +32,10 @@
 #include "opdesc.hpp"
 #include "sdpa_types.hpp"
 #include "utils.hpp"
+#include "verbose.hpp"
+
+#define VCHECK_MEMORY(cond, stat, msg, ...) \
+    VCONDCHECK(common, create, check, memory, (cond), stat, msg, ##__VA_ARGS__)
 
 namespace dnnl {
 namespace impl {
@@ -1102,22 +1106,22 @@ inline memory_desc_t cvt_sparse_packed2blocked(
 }
 
 /** returns true if strides are compatible with memory_desc_t */
-inline bool memory_desc_strides_check(
+inline status_t memory_desc_strides_check(
         const memory_desc_t &md, const dims_t strides) {
     if (strides == nullptr || md.ndims == 0
             || md.format_kind != format_kind::blocked)
-        return true;
+        return status::success;
 
     dims_t blocks = {0};
     int perm[DNNL_MAX_NDIMS] = {0};
     for (int d = 0; d < md.ndims; ++d) {
         // no strides check needed for empty tensor
-        if (md.padded_dims[d] == 0) return true;
+        if (md.padded_dims[d] == 0) return status::success;
 
         // no strides verification for runtime dims
         const bool has_runtime_dim
                 = any_runtime_value(strides[d], md.padded_dims[d]);
-        if (has_runtime_dim) return true;
+        if (has_runtime_dim) return status::success;
 
         perm[d] = d;
         blocks[d] = 1;
@@ -1159,7 +1163,8 @@ inline bool memory_desc_strides_check(
         if ((strides[d] == 0) || (md.padded_dims[d] == 1))
             continue;
         else if (strides[d] < min_stride)
-            return false;
+            VCHECK_MEMORY(false, status::invalid_arguments,
+                    VERBOSE_INTEGRAL_OVERFLOW_DIM, "strides", d);
 
         // update min_stride for next iteration
         const auto padded_dim = md.padded_dims[d];
@@ -1177,11 +1182,15 @@ inline bool memory_desc_strides_check(
         size_t dim_val = static_cast<size_t>(
                 md.padded_dims[max_stride_d] / blocks[max_stride_d]);
         dim_val = dim_val == (size_t)max_stride ? 1 : dim_val;
-        if (dim_val > SIZE_MAX / max_stride) return false;
-        if (dt_size && ((dim_val * max_stride) > SIZE_MAX / dt_size))
-            return false;
+        VCHECK_MEMORY((dim_val <= SIZE_MAX / max_stride),
+                status::invalid_arguments, VERBOSE_INTEGRAL_OVERFLOW_DIM,
+                "padded_dims", max_stride_d);
+        VCHECK_MEMORY(
+                (dt_size && ((dim_val * max_stride) <= SIZE_MAX / dt_size)),
+                status::invalid_arguments, VERBOSE_INTEGRAL_OVERFLOW_DIM,
+                "padded_dims", max_stride_d);
     }
-    return true;
+    return status::success;
 }
 
 inline status_t memory_desc_init_by_strides(
@@ -1199,8 +1208,7 @@ inline status_t memory_desc_init_by_tag(
     CHECK(memory_desc_init_by_tag(
             md_tmp, md.ndims, md.dims, md.data_type, tag));
 
-    if (strides != nullptr && !memory_desc_strides_check(md_tmp, strides))
-        return status::invalid_arguments;
+    CHECK(memory_desc_strides_check(md_tmp, strides));
 
     if (is_sparse) {
         if (md.format_desc.sparse_desc.encoding != sparse_encoding::packed
@@ -1346,26 +1354,32 @@ format_tag_t memory_desc_matches_one_of_tag(
     return format_tag::undef;
 }
 
-inline bool memory_desc_sanity_check(int ndims, const dims_t dims,
+inline status_t memory_desc_sanity_check(int ndims, const dims_t dims,
         data_type_t data_type, format_kind_t format_kind) {
     using namespace data_type;
 
-    if (ndims == 0) return true;
+    if (ndims == 0) return status::success;
 
-    bool ok = dims != nullptr && 0 < ndims && ndims <= DNNL_MAX_NDIMS
-            && utils::one_of(data_type, f4_e2m1, e8m0, f8_e5m2, f8_e4m3, f16,
-                    bf16, f32, f64, s64, s32, s8, u8, s4, u4);
-    if (!ok) return false;
+    VCHECK_MEMORY(dims != nullptr, status::invalid_arguments, "%s (dims)",
+            VERBOSE_NULL_ARG);
+    VCHECK_MEMORY(0 < ndims && ndims <= DNNL_MAX_NDIMS,
+            status::invalid_arguments, VERBOSE_BAD_NDIMS, "tensor", ndims);
+    VCHECK_MEMORY(utils::one_of(data_type, f4_e2m1, e8m0, f8_e5m2, f8_e4m3, f16,
+                          bf16, f32, f64, s64, s32, s8, u8, s4, u4),
+            status::invalid_arguments, VERBOSE_UNSUPPORTED_DT);
 
     // A bounds check on the dimensions ensures that the tensor size
     // computation does not trigger a overflow during memory creation.
     dim_t prod = 1;
     for (int d = 0; d < ndims; ++d) {
         if (!is_runtime_value(dims[d])) {
-            if (dims[d] < 0) return false;
+            if (dims[d] < 0)
+                VCHECK_MEMORY(false, status::invalid_arguments, VERBOSE_BAD_DIM,
+                        "dims", d);
             if (dims[d] > 0) {
                 if (prod > std::numeric_limits<dim_t>::max() / dims[d])
-                    return false;
+                    VCHECK_MEMORY(false, status::invalid_arguments,
+                            VERBOSE_INTEGRAL_OVERFLOW_DIM, "dims", d);
                 prod *= dims[d];
             }
         }
@@ -1376,15 +1390,14 @@ inline bool memory_desc_sanity_check(int ndims, const dims_t dims,
         if (is_runtime_value(dims[d])) has_runtime_dims = true;
     }
 
-    if (has_runtime_dims) {
-        // format `any` is currently not supported for run-time dims
-        if (format_kind == format_kind::any) return false;
-    }
+    VCHECK_MEMORY(
+            IMPLICATION(has_runtime_dims, format_kind != format_kind::any),
+            status::invalid_arguments, VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    return true;
+    return status::success;
 }
 
-inline bool memory_desc_sanity_check(const memory_desc_t &md) {
+inline status_t memory_desc_sanity_check(const memory_desc_t &md) {
     return memory_desc_sanity_check(
             md.ndims, md.dims, md.data_type, format_kind::undef);
 }

--- a/src/common/verbose_msg.hpp
+++ b/src/common/verbose_msg.hpp
@@ -75,6 +75,8 @@
 #define VERBOSE_BAD_NDIMS "%s has a bad number of dimensions %d"
 #define VERBOSE_BAD_DIM "bad dimension %s:%d"
 #define VERBOSE_OUT_OF_RANGE_DIMS "out-of-range dimensions for %s"
+#define VERBOSE_INTEGRAL_OVERFLOW_DIM \
+    "dimension %s:%d triggers integral overflow"
 
 #define VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME "unsupported threadpool runtime"
 #define VERBOSE_UNSUPPORTED_ISA "unsupported isa"

--- a/tests/gtests/api/test_memory_desc_ops.cpp
+++ b/tests/gtests/api/test_memory_desc_ops.cpp
@@ -124,6 +124,57 @@ TEST(memory_desc_properties_test, TestMemoryDescSizeSubByte) {
 #endif
 }
 
+TEST(memory_desc_properties_test, TestOOBTensorDimensions) {
+    using dt = memory::data_type;
+
+    const dnnl::impl::dim_t out_of_bounds_dim = dnnl::impl::dim_t {1} << 62;
+
+    // Overflow checks for memory descriptor creation with out-of-bound
+    // tensor dimensions
+
+    // Memory descriptor initialization with strides
+    catch_expected_failures([&]() {
+        auto md = memory::desc(
+                {2, out_of_bounds_dim}, dt::f32, {out_of_bounds_dim, 1});
+    }, true, dnnl_invalid_arguments);
+
+    // Memory descriptor initialization init by tag
+    catch_expected_failures([&]() {
+        auto md = memory::desc({out_of_bounds_dim, 4}, dt::f32, fmt::ab);
+    }, true, dnnl_invalid_arguments);
+
+    // Overflow checks for blocking descriptor
+    catch_expected_failures([&]() {
+        auto md = memory::desc(
+                {2, out_of_bounds_dim, 8, 8}, dt::f32, fmt::nChw8c);
+    }, true, dnnl_invalid_arguments);
+
+    // Negative dimensions
+    catch_expected_failures([&]() {
+        auto md = memory::desc({-1, 4}, dt::f32, fmt::ab);
+    }, true, dnnl_invalid_arguments);
+
+    // Dimension product overflow - multiple large dimensions
+    catch_expected_failures([&]() {
+        const dnnl::impl::dim_t large_dim = dnnl::impl::dim_t {1} << 31;
+        auto md = memory::desc(
+                {large_dim, large_dim, large_dim}, dt::f32, fmt::abc);
+    }, true, dnnl_invalid_arguments);
+
+    // Stride overflow - strides that would cause address overflow
+    catch_expected_failures([&]() {
+        auto md = memory::desc({2, 4}, dt::f32, {out_of_bounds_dim, 1});
+    }, true, dnnl_invalid_arguments);
+
+    // Blocked format with overflow in block dimensions
+    catch_expected_failures([&]() {
+        // Large outer dimension with blocking that causes overflow
+        const dnnl::impl::dim_t large_outer
+                = (dnnl::impl::dim_t {1} << 60) / 16;
+        auto md = memory::desc({2, large_outer, 8, 8}, dt::f32, fmt::nChw16c);
+    }, true, dnnl_invalid_arguments);
+}
+
 } // namespace properties
 
 namespace reshape {


### PR DESCRIPTION
# Description

The PR adds the following updates for large dimension checks for nd tensors:
- include gtest check to verify for the overflow from large dimensions
- update checks with new runtime dimension check method (followup from this [comment](https://github.com/uxlfoundation/oneDNN/pull/4852#discussion_r2969307660)).
- updates empty tensor checks with uninitialized memory descriptors to account for zero memory descriptors. 
- introduces verbose checks for md initialization.  

Addresses [MFDNN-14803](https://jira.devtools.intel.com/browse/MFDNN-14803).