### PR TITLE
[GPU] fixup matmul ref implementation

### DIFF
--- a/src/gpu/intel/dynamic_scale.cl
+++ b/src/gpu/intel/dynamic_scale.cl
@@ -102,16 +102,7 @@ __kernel void dynamic_scale_dst(__global float *restrict src,
             c_stride_n / groupSize, c_stride_d0, c_stride_d1, c_stride_d2,
             c_stride_d3);
 #else
-#if NDIMS == 5
-    scale_off = DST_SCALE_OFF(
-            d2 % DST_D0, d1 % DST_D1, d0 % DST_D2, m, n, groupSize, 1);
-#elif NDIMS == 4
-    scale_off = DST_SCALE_OFF(d1 % DST_D0, d0 % DST_D1, 0, m, n, groupSize, 1);
-#elif NDIMS == 3
-    scale_off = DST_SCALE_OFF(d0 % DST_D0, m, 0, 0, n, groupSize, 1);
-#else
-    scale_off = DST_SCALE_OFF(m, n, 0, 0, 0, groupSize, 1);
-#endif
+    scale_off = DST_SCALE_OFF(n, m, d0, d1, d2, groupSize);
 #endif
     dst_scales[scale_off] = REF_TO_DST_SCALES(scale_val);
 }

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -438,6 +438,15 @@ bool pd_t::scales_ok() {
                             || x_scales.get_group(1) != 32
                             || arch_ < compute::gpu_arch_t::xe_hpc))
                 return false;
+
+            // Inner layout must be plain MxN for Dynamic Dst Quant
+            if (s == DNNL_ARG_C && with_mx_scale()) {
+                auto md = &desc()->c_desc;
+                auto strides = md->format_desc.blocking.strides;
+                if (strides[md->ndims - 1] != 1
+                        || strides[md->ndims - 2] != md->dims[md->ndims - 1])
+                    return false;
+            }
         }
     }
 

--- a/src/gpu/intel/gemm/ref.hpp
+++ b/src/gpu/intel/gemm/ref.hpp
@@ -134,6 +134,12 @@ struct ref_t : public primitive_t {
                     VERBOSE_INCONSISTENT_NDIMS_WITH_VALS, "desc()->a_desc",
                     "desc()->b_desc", static_cast<int>(desc()->a_desc.dims[0]),
                     static_cast<int>(desc()->b_desc.dims[0]));
+            // Bug in runtime dims support; defer to ref_matmul
+            VDISPATCH_GEMM(
+                    !utils::one_of(DNNL_RUNTIME_DIM_VAL, desc()->m(),
+                            desc()->n(), desc()->k(), desc()->lda(),
+                            desc()->ldb(), desc()->ldc(), desc()->batch()),
+                    VERBOSE_RUNTIMEDIM_UNSUPPORTED);
             VDISPATCH_GEMM(IMPLICATION(acc_dt != s32 && !wei_decompress,
                                    attr()->zero_points_.has_default_values()),
                     VERBOSE_UNSUPPORTED_ZP_CFG);

--- a/src/gpu/intel/include/types_specific.h
+++ b/src/gpu/intel/include/types_specific.h
@@ -913,10 +913,8 @@
     (((x0) % DST_B0) * DST_SB0 + ((x0) / DST_B0) * DST_S0 \
             + ((x1) % DST_B1) * DST_SB1 + ((x1) / DST_B1) * DST_S1)
 
-#define DST_SCALE_OFF(x0, x1, d, h, w, g0, g1) \
-    (((x0) % DST_B0) * DST_SB0 + ((x0) / DST_B0) * (DST_S0 / (g0)) \
-            + ((x1) % DST_B1) * DST_SB1 + ((x1) / DST_B1) * (DST_S1 / (g1)))
-
+#define DST_SCALE_OFF(n, m, d0, d1, d2, groupSize) \
+    (((m * DST_D1) / groupSize) + (n) * (1))
 #elif NDIMS == 3
 #define SRC_OFF(x0, x1, d, h, x2) \
     (((x0) % SRC_B0) * SRC_SB0 + ((x0) / SRC_B0) * SRC_S0 \
@@ -941,13 +939,9 @@
             + ((x1) % DST_B1) * DST_SB1 + ((x1) / DST_B1) * DST_S1 \
             + ((x2) % DST_B2) * DST_SB2 + ((x2) / DST_B2) * DST_S2)
 
-#define DST_SCALE_OFF(x0, x1, d, h, x2, g0, g1) \
-    (((x0) % DST_B0) * (DST_SB0 / (g0 * g1)) \
-            + ((x0) / DST_B0) * (DST_S0 / (g0)) \
-            + ((x1) % DST_B1) * (DST_SB1 / (g0 * g1)) \
-            + ((x1) / DST_B1) * (DST_S1 / (g0 * g1)) \
-            + ((x2) % DST_B2) * (DST_SB2 / (g0 * g1)) \
-            + ((x2) / DST_B2) * (DST_S2 / (g0 * g1)))
+#define DST_SCALE_OFF(n, m, d0, d1, d2, groupSize) \
+    ((d0 % DST_D0) * ((DST_D1 * DST_D2) / groupSize) \
+            + ((m * DST_D2) / groupSize) + (n) * (1))
 #elif NDIMS == 4
 #define SRC_OFF(x0, x1, d, x2, x3) \
     (((x0) % SRC_B0) * SRC_SB0 + ((x0) / SRC_B0) * SRC_S0 \
@@ -976,15 +970,10 @@
             + ((x2) % DST_B2) * DST_SB2 + ((x2) / DST_B2) * DST_S2 \
             + ((x3) % DST_B3) * DST_SB3 + ((x3) / DST_B3) * DST_S3)
 
-#define DST_SCALE_OFF(x0, x1, d, x2, x3, g0, g1) \
-    (((x0) % DST_B0) * (DST_SB0 / (g0 * g1)) \
-            + ((x0) / DST_B0) * (DST_S0 / (g0)) \
-            + ((x1) % DST_B1) * (DST_SB1 / (g0 * g1)) \
-            + ((x1) / DST_B1) * (DST_S1 / (g0 * g1)) \
-            + ((x2) % DST_B2) * (DST_SB2 / (g0 * g1)) \
-            + ((x2) / DST_B2) * (DST_S2 / (g0 * g1)) \
-            + ((x3) % DST_B3) * (DST_SB3 / (g0 * g1)) \
-            + ((x3) / DST_B3) * (DST_S3 / (g0 * g1)))
+#define DST_SCALE_OFF(n, m, d0, d1, d2, groupSize) \
+    ((d1 % DST_D0) * ((DST_D1 * DST_D2 * DST_D3) / groupSize) \
+            + (d0 % DST_D1) * ((DST_D2 * DST_D3) / groupSize) \
+            + ((m * DST_D3) / groupSize) + (n) * (1))
 #elif NDIMS == 5
 #define SRC_OFF(x0, x1, x2, x3, x4) \
     (((x0) % SRC_B0) * SRC_SB0 + ((x0) / SRC_B0) * SRC_S0 \
@@ -1017,12 +1006,11 @@
             + ((x3) % DST_B3) * DST_SB3 + ((x3) / DST_B3) * DST_S3 \
             + ((x4) % DST_B4) * DST_SB4 + ((x4) / DST_B4) * DST_S4)
 
-#define DST_SCALE_OFF(x0, x1, x2, x3, x4, g0, g1) \
-    (((x0) % DST_B0) * DST_SB0 + ((x0) / DST_B0) * (DST_S0 / (g0)) \
-            + ((x1) % DST_B1) * DST_SB1 + ((x1) / DST_B1) * (DST_S1 / (g1)) \
-            + ((x2) % DST_B2) * DST_SB2 + ((x2) / DST_B2) * DST_S2 \
-            + ((x3) % DST_B3) * DST_SB3 + ((x3) / DST_B3) * DST_S3 \
-            + ((x4) % DST_B4) * DST_SB4 + ((x4) / DST_B4) * DST_S4)
+#define DST_SCALE_OFF(n, m, d0, d1, d2, groupSize) \
+    ((d2 % DST_D0) * ((DST_D1 * DST_D2 * DST_D3 * DST_D4) / groupSize) \
+            + (d1 % DST_D1) * ((DST_D2 * DST_D3 * DST_D4) / groupSize) \
+            + (d0 % DST_D2) * ((DST_D3 * DST_D4) / groupSize) \
+            + ((m * DST_D4) / groupSize) + (n) * (1))
 #endif
 
 #if SRC_DT_U8 == 1

--- a/src/gpu/intel/matmul/ref.cl
+++ b/src/gpu/intel/matmul/ref.cl
@@ -29,14 +29,16 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
 #else
         __global SRC_ZP_DATA_T *a0,
 #endif
-        long src_zp_stride_k, long src_zp_stride_m, long src_zp_group_k,
+        long src_zp_stride_k, long src_zp_stride_m, long src_zp_stride_d0,
+        long src_zp_stride_d1, long src_zp_stride_d2, long src_zp_group_k,
 #if WITH_HOST_WEI_ZP
         WEI_ZP_DATA_T b0_value,
 #else
         __global WEI_ZP_DATA_T *b0,
 #endif
         long wei_zp_stride_n, long wei_zp_stride_k, long wei_zp_stride_d0,
-        long wei_zp_stride_d1, long wei_zp_group_n, long wei_zp_group_k,
+        long wei_zp_stride_d1, long wei_zp_stride_d2, long wei_zp_group_n,
+        long wei_zp_group_k,
 #if WITH_HOST_DST_ZP
         int c0_value,
 #else
@@ -49,7 +51,8 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
 #endif
         long src_scale_stride_k, long src_scale_stride_m,
         long src_scale_stride_d0, long src_scale_stride_d1,
-        long src_scale_group_m, long src_scale_group_k,
+        long src_scale_stride_d2, long src_scale_group_m,
+        long src_scale_group_k,
 #if WITH_HOST_WEI_SCALE
         WEI_SCALES_DATA_T wei_scale_value,
 #else
@@ -57,22 +60,23 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
 #endif
         long wei_scale_stride_n, long wei_scale_stride_k,
         long wei_scale_stride_d0, long wei_scale_stride_d1,
-        long wei_scale_group_n, long wei_scale_group_k,
+        long wei_scale_stride_d2, long wei_scale_group_n,
+        long wei_scale_group_k,
 #if WITH_HOST_DST_SCALE
         DST_SCALES_DATA_T dst_scale_value,
 #else
         __global DST_SCALES_DATA_T *dst_scales,
 #endif
         __global SRC_GS_DATA_T *ag, long src_gs_stride_k, long src_gs_stride_m,
-        long src_gs_stride_d0, long src_gs_stride_d1, long src_gs_group_k,
-        long group_K, long K, long N, long M, long D0, long D1, long D2,
-        long bia_stride_d3, long bia_stride_d2, long bia_stride_d1,
-        long bia_stride_d0, long bia_stride_m, long bia_stride_n,
-        long a_stride_d3, long a_stride_d2, long a_stride_d1, long a_stride_d0,
-        long a_stride_m, long a_stride_k, long b_stride_d3, long b_stride_d2,
-        long b_stride_d1, long b_stride_d0, long b_stride_k, long b_stride_n,
-        long c_stride_d3, long c_stride_d2, long c_stride_d1, long c_stride_d0,
-        long c_stride_m, long c_stride_n
+        long src_gs_stride_d0, long src_gs_stride_d1, long src_gs_stride_d2,
+        long src_gs_group_k, long group_K, long K, long N, long M, long D0,
+        long D1, long D2, long bia_stride_d3, long bia_stride_d2,
+        long bia_stride_d1, long bia_stride_d0, long bia_stride_m,
+        long bia_stride_n, long a_stride_d3, long a_stride_d2, long a_stride_d1,
+        long a_stride_d0, long a_stride_m, long a_stride_k, long b_stride_d3,
+        long b_stride_d2, long b_stride_d1, long b_stride_d0, long b_stride_k,
+        long b_stride_n, long c_stride_d3, long c_stride_d2, long c_stride_d1,
+        long c_stride_d0, long c_stride_m, long c_stride_n
 #if WITH_DROPOUT
         ,
         __global uchar *dropout_mask_buf,
@@ -178,13 +182,15 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
 #if WITH_WEI_ZPOINTS && !WITH_SRC_GROUP_SUMS
             long wei_zp_off = wei_zp_stride_n * (n / wei_zp_group_n)
                     + wei_zp_stride_k * (k / wei_zp_group_k)
-                    + wei_zp_stride_d0 * d0 + wei_zp_stride_d1 * d1;
+                    + wei_zp_stride_d0 * d0 + wei_zp_stride_d1 * d1
+                    + wei_zp_stride_d2 * d2;
             wei_zp = WEI_ZP_TO_REF(b0, wei_zp_off);
 #endif
             int src_zp = 0;
 #if WITH_SRC_ZPOINTS && !WITH_SRC_GROUP_SUMS
             long src_zp_off = src_zp_stride_k * (k / src_zp_group_k)
-                    + src_zp_stride_m * m;
+                    + src_zp_stride_m * m + src_zp_stride_d0 * d0
+                    + src_zp_stride_d1 * d1 + src_zp_stride_d2 * d2;
             src_zp = SRC_ZP_TO_REF(a0, src_zp_off);
 #endif
 #if SRC_DT_F4_E2M1 || SRC_DT_F4_E3M0
@@ -207,13 +213,15 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
 #if WITH_SRC_SCALES
         long src_scale_off = src_scale_stride_m * (m / src_scale_group_m)
                 + src_scale_stride_k * (g * group_K / src_scale_group_k)
-                + src_scale_stride_d0 * d0 + src_scale_stride_d1 * d1;
+                + src_scale_stride_d0 * d0 + src_scale_stride_d1 * d1
+                + src_scale_stride_d2 * d2;
         src_scale = SRC_SCALES_TO_REF(src_scales[src_scale_off]);
 #endif
 #if WITH_WEI_SCALES
         long wei_scale_off = wei_scale_stride_n * (n / wei_scale_group_n)
                 + wei_scale_stride_k * (g * group_K / wei_scale_group_k)
-                + wei_scale_stride_d0 * d0 + wei_scale_stride_d1 * d1;
+                + wei_scale_stride_d0 * d0 + wei_scale_stride_d1 * d1
+                + wei_scale_stride_d2 * d2;
         wei_scale = WEI_SCALES_TO_REF(wei_scales[wei_scale_off]);
 #endif
         FLT_ACC_DATA_T acc_g_to_f = ACC_TO_REF(acc_g) * src_scale * wei_scale;
@@ -227,22 +235,24 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
         long src_scale_g = g * src_gs_group_k / src_scale_group_k;
         long src_scale_off = src_scale_stride_m * (m / wei_scale_group_n)
                 + src_scale_stride_k * src_scale_g + src_scale_stride_d0 * d0
-                + src_scale_stride_d1 * d1;
+                + src_scale_stride_d1 * d1 + src_scale_stride_d2 * d2;
         src_scale = SRC_SCALES_TO_REF(src_scales[src_scale_off]);
 #endif
 #if WITH_WEI_SCALES
         long wei_scale_g = g * src_gs_group_k / wei_scale_group_k;
         long wei_scale_off = wei_scale_stride_n * (n / wei_scale_group_n)
                 + wei_scale_stride_k * wei_scale_g + wei_scale_stride_d0 * d0
-                + wei_scale_stride_d1 * d1;
+                + wei_scale_stride_d1 * d1 + wei_scale_stride_d2 * d2;
         wei_scale = WEI_SCALES_TO_REF(wei_scales[wei_scale_off]);
 #endif
         long src_gs_off = src_gs_stride_m * m + src_gs_stride_k * g
-                + src_gs_stride_d0 * d0 + src_gs_stride_d1 * d1;
+                + src_gs_stride_d0 * d0 + src_gs_stride_d1 * d1
+                + src_gs_stride_d2 * d2;
         int src_gs = SRC_ZP_TO_REF(ag, src_gs_off);
         long wei_zp_off = wei_zp_stride_n * (n / wei_zp_group_n)
                 + wei_zp_stride_k * (g * src_gs_group_k / wei_zp_group_k)
-                + wei_zp_stride_d0 * d0 + wei_zp_stride_d1 * d1;
+                + wei_zp_stride_d0 * d0 + wei_zp_stride_d1 * d1
+                + wei_zp_stride_d2 * d2;
         int wei_zp = WEI_ZP_TO_REF(b0, wei_zp_off);
         acc -= src_scale * wei_scale * TO_ACC(src_gs) * TO_ACC(wei_zp);
     }

--- a/src/gpu/intel/matmul/ref.cpp
+++ b/src/gpu/intel/matmul/ref.cpp
@@ -125,6 +125,8 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
             = b_d.ndims() > 2 ? wei_scale_strides[b_d.ndims() - 3] : 0;
     const dim_t wei_scale_stride_b1
             = b_d.ndims() > 3 ? wei_scale_strides[b_d.ndims() - 4] : 0;
+    const dim_t wei_scale_stride_b2
+            = b_d.ndims() > 4 ? wei_scale_strides[b_d.ndims() - 5] : 0;
 
     const int src_scale_mask = attr_scales.get_mask(DNNL_ARG_SRC);
     const bool src_scale_per_k = src_scale_mask & pd()->src_qmask_K();
@@ -160,6 +162,8 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
             = a_d.ndims() > 2 ? src_scale_strides[a_d.ndims() - 3] : 0;
     const dim_t src_scale_stride_b1
             = a_d.ndims() > 3 ? src_scale_strides[a_d.ndims() - 4] : 0;
+    const dim_t src_scale_stride_b2
+            = a_d.ndims() > 4 ? src_scale_strides[a_d.ndims() - 5] : 0;
 
     const auto &attr_zps = pd()->attr()->zero_points_;
     int wei_zp_mask = attr_zps.get_mask(DNNL_ARG_WEIGHTS);
@@ -190,6 +194,8 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
             = b_d.ndims() > 2 ? wei_zp_strides[b_d.ndims() - 3] : 0;
     const dim_t wei_zp_stride_b1
             = b_d.ndims() > 3 ? wei_zp_strides[b_d.ndims() - 4] : 0;
+    const dim_t wei_zp_stride_b2
+            = b_d.ndims() > 4 ? wei_zp_strides[b_d.ndims() - 5] : 0;
 
     int src_zp_mask = attr_zps.get_mask(DNNL_ARG_SRC);
     const auto src_zp_group_k = attr_zps.get_group(DNNL_ARG_SRC, 1);
@@ -213,6 +219,12 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
     }
     const dim_t src_zp_stride_k = src_zp_strides[a_d.ndims() - 1];
     const dim_t src_zp_stride_m = src_zp_strides[a_d.ndims() - 2];
+    const dim_t src_zp_stride_b0
+            = a_d.ndims() > 2 ? src_zp_strides[a_d.ndims() - 3] : 0;
+    const dim_t src_zp_stride_b1
+            = a_d.ndims() > 3 ? src_zp_strides[a_d.ndims() - 4] : 0;
+    const dim_t src_zp_stride_b2
+            = a_d.ndims() > 4 ? src_zp_strides[a_d.ndims() - 5] : 0;
 
     const auto &attr_pr = pd()->attr()->precomputed_reductions_;
     const int src_pr_mask = attr_pr.get_mask(DNNL_ARG_SRC);
@@ -240,6 +252,8 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
             = a_d.ndims() > 2 ? src_pr_strides[a_d.ndims() - 3] : 0;
     const dim_t src_pr_stride_b1
             = a_d.ndims() > 3 ? src_pr_strides[a_d.ndims() - 4] : 0;
+    const dim_t src_pr_stride_b2
+            = a_d.ndims() > 4 ? src_pr_strides[a_d.ndims() - 5] : 0;
 
     // For compute kernel, the minimal group is picked.
     const auto scale_ngroups_k
@@ -267,12 +281,16 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
     arg_list.set(arg_idx++, a0);
     arg_list.set(arg_idx++, src_zp_stride_k);
     arg_list.set(arg_idx++, src_zp_stride_m);
+    arg_list.set(arg_idx++, src_zp_stride_b0);
+    arg_list.set(arg_idx++, src_zp_stride_b1);
+    arg_list.set(arg_idx++, src_zp_stride_b2);
     arg_list.set(arg_idx++, src_zp_group_k);
     arg_list.set(arg_idx++, b0);
     arg_list.set(arg_idx++, wei_zp_stride_n);
     arg_list.set(arg_idx++, wei_zp_stride_k);
     arg_list.set(arg_idx++, wei_zp_stride_b0);
     arg_list.set(arg_idx++, wei_zp_stride_b1);
+    arg_list.set(arg_idx++, wei_zp_stride_b2);
     arg_list.set(arg_idx++, wei_zp_group_n);
     arg_list.set(arg_idx++, wei_zp_group_k);
     arg_list.set(arg_idx++, c0);
@@ -281,6 +299,7 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
     arg_list.set(arg_idx++, src_scale_stride_m);
     arg_list.set(arg_idx++, src_scale_stride_b0);
     arg_list.set(arg_idx++, src_scale_stride_b1);
+    arg_list.set(arg_idx++, src_scale_stride_b2);
     arg_list.set(arg_idx++, src_scale_group_m);
     arg_list.set(arg_idx++, src_scale_group_k);
     arg_list.set(arg_idx++, wei_scales);
@@ -288,6 +307,7 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
     arg_list.set(arg_idx++, wei_scale_stride_k);
     arg_list.set(arg_idx++, wei_scale_stride_b0);
     arg_list.set(arg_idx++, wei_scale_stride_b1);
+    arg_list.set(arg_idx++, wei_scale_stride_b2);
     arg_list.set(arg_idx++, wei_scale_group_n);
     arg_list.set(arg_idx++, wei_scale_group_k);
     arg_list.set(arg_idx++, dst_scales);
@@ -296,6 +316,7 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
     arg_list.set(arg_idx++, src_pr_stride_m);
     arg_list.set(arg_idx++, src_pr_stride_b0);
     arg_list.set(arg_idx++, src_pr_stride_b1);
+    arg_list.set(arg_idx++, src_pr_stride_b2);
     arg_list.set(arg_idx++, src_pr_group_k);
     arg_list.set(arg_idx++, group_K);
     arg_list.set(arg_idx++, K);

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -75,8 +75,12 @@ struct ref_t : public primitive_t {
             VDISPATCH_MATMUL(
                     precomputed_reductions_ok(), VERBOSE_UNSUPPORTED_PR_CFG);
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_MATMUL(IMPLICATION(has_blocks(), dst_md()->ndims < 6),
+            VDISPATCH_MATMUL(
+                    IMPLICATION(has_blocks() || !attr()->has_default_values(),
+                            dst_md()->ndims < 6),
                     VERBOSE_BAD_NDIMS, "dst", dst_md()->ndims);
+            VDISPATCH_MATMUL(dst_md()->ndims <= 6, VERBOSE_BAD_NDIMS, "dst",
+                    dst_md()->ndims);
 
             const bool is_f64
                     = utils::everyone_is(f64, src_dt_, wei_dt_, dst_dt_);

--- a/tests/benchdnn/inputs/matmul/harness_matmul_smoke_ref
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_smoke_ref
@@ -117,3 +117,34 @@
 --attr-dropout=0.5:12345678
 --stag=ab --dtag=ab
 --batch=shapes_2d_ci
+
+#Regression
+--reset
+--impl=ref
+--dt=f8_e4m3:f8_e4m3:f8_e4m3
+--stag=abc --wtag=cab --dtag=abc
+--attr-scales=src:per_tensor:e8m0:1x32+dst:mx:e8m0:1x32+wei:per_tensor:e8m0:32x1
+1x1x1024:1x1024x1024
+
+--reset
+--impl=ref
+--dt=s8:u8:f16 --stag=abx --wtag=xab --dtag=abx
+--attr-scales=src:per_tensor:f16:1x128+wei:per_oc:f16
+--attr-zero-points=wei:per_oc:u8
+--attr-precomputed-reductions=src:per_tensor:s32:1x128
+--attr-post-ops=swish:1+mul:f16:6:abx
+7x3x2x42x256:7x3x2x256x84
+
+--reset
+--impl=ref
+--dt=s8:s4:f16
+--attr-scales=src:per_ocic:f16:1x256+wei:per_tensor:f16:128x1
+--attr-zero-points=src:per_ocic:u4:1x256+wei:per_tensor:s4:128x1
+5x2x3x6x256:5x2x3x256x100
+
+--reset
+--impl=ref
+--dt=f8_e4m3:f8_e4m3:f32 --stag=abc --wtag=abc --dtag=abc
+--runtime_dims_masks=1:1
+--bia-dt=f32 --bia_mask=4
+1x30x30:1x30x20


### PR DESCRIPTION
closes [MFDNN-14852](https://jira.devtools.intel.com/browse/MFDNN-14852
)
[MFDNN-14853](https://jira.devtools.intel.com/browse/MFDNN-14853
)
1) Ref implementation incorrectly uses dst layout for dynamic scales layout; scales layout should always be plain.
2) Ref gemm does not properly support runtime dims; defer to ref matmul.
3) jit gemm expects plain layout for dst when applying dynamic scales