### PR TITLE
ze api: add support for persistent cache

### DIFF
--- a/include/oneapi/dnnl/dnnl_ze.h
+++ b/include/oneapi/dnnl/dnnl_ze.h
@@ -36,6 +36,67 @@ extern "C" {
 /// @addtogroup dnnl_api_ze_interop
 /// @{
 
+/// Retrieves a cache blob ID for the Level Zero device.
+///
+/// @warning
+///     This API is intended to be used with
+///     #dnnl_ze_interop_engine_get_cache_blob() and
+///     #dnnl_ze_interop_engine_create_from_cache_blob(). The returned cache
+///     blob ID can only be used as an ID of the cache blob returned by
+///     #dnnl_ze_interop_engine_get_cache_blob().
+///
+/// @note The cache blob ID can be empty (@p size will be 0 and
+///     @p cache_blob_id will be nullptr) if oneDNN doesn't have anything to
+///     put in the cache blob. (#dnnl_ze_interop_engine_get_cache_blob will
+///     return an empty cache blob).
+///
+/// @param driver A Level Zero driver.
+/// @param device A Level Zero device.
+/// @param size Size of the cache blob ID in bytes.
+/// @param cache_blob_id Cache blob id of size @p size. If
+///     the @p cache_blob_id is nullptr then the size of the cache blob ID is
+///     returned in @p size.
+///
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_ze_interop_engine_get_cache_blob_id(
+        ze_driver_handle_t driver, ze_device_handle_t device, size_t *size,
+        uint8_t *cache_blob_id);
+
+/// Retrieves a cache blob associated with the given engine.
+///
+/// @note The cache blob can be empty (@p size will be 0 and @p cache_blob
+///     will be nullptr) if oneDNN doesn't have anything to put in the cache
+///     blob. It's the user's responsibility to check whether it's empty
+///     prior to passing it to
+///     #dnnl_ze_interop_engine_create_from_cache_blob().
+///
+/// @param engine Engine to query for the cache blob.
+/// @param size Size of the cache blob in bytes.
+/// @param cache_blob Cache blob of size @p size. If the @p cache_blob is
+///     nullptr then the size of the cache blob is returned in @p size.
+///
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_ze_interop_engine_get_cache_blob(
+        dnnl_engine_t engine, size_t *size, uint8_t *cache_blob);
+
+/// Creates an engine from the given cache blob.
+///
+/// @param engine Output engine.
+/// @param driver The Level Zero driver that this engine will encapsulate.
+/// @param device The Level Zero device that this engine will encapsulate.
+/// @param context The Level Zero context (containing the device) that this
+///     engine will use for all operations.
+/// @param size Size of the cache blob in bytes.
+/// @param cache_blob Cache blob of size @p size.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_ze_interop_engine_create_from_cache_blob(
+        dnnl_engine_t *engine, ze_driver_handle_t driver,
+        ze_device_handle_t device, ze_context_handle_t context, size_t size,
+        const uint8_t *cache_blob);
+
 /// Creates an engine associated with a Level Zero device and a Level Zero
 /// context.
 ///

--- a/include/oneapi/dnnl/dnnl_ze.hpp
+++ b/include/oneapi/dnnl/dnnl_ze.hpp
@@ -36,12 +36,84 @@ namespace dnnl {
 
 /// @addtogroup dnnl_api_ze_interop Level Zero interoperability API
 /// API extensions to interact with the underlying Level Zero run-time.
-///
-/// @sa @ref dev_guide_level_zero_interoperability in developer guide
 /// @{
 
 /// Level Zero interoperability namespace
 namespace ze_interop {
+
+/// Returns the cache blob ID of the Level Zero device.
+///
+/// @warning
+///     This API is intended to be used with
+///     #dnnl::ze_interop::get_engine_cache_blob(const engine &) and
+///     #dnnl::ze_interop::make_engine(ze_driver_handle_t, ze_device_handle_t, ze_context_handle_t, const std::vector<uint8_t> &).
+///     The returned cache blob ID can only be used as an ID of the cache blob
+///     returned by #dnnl::ze_interop::get_engine_cache_blob(const engine &).
+///
+/// @note The cache blob ID can be empty (@p size will be 0 and
+///     @p cache_blob_id will be nullptr) if oneDNN doesn't have anything to
+///     put in the cache blob. (#dnnl_ze_interop_engine_get_cache_blob will
+///     return an empty cache blob).
+///
+/// @param driver A Level Zero driver.
+/// @param device A Level Zero device.
+///
+/// @returns A vector containing the cache blob ID.
+inline std::vector<uint8_t> get_engine_cache_blob_id(
+        ze_driver_handle_t driver, ze_device_handle_t device) {
+    size_t size = 0;
+    error::wrap_c_api(dnnl_ze_interop_engine_get_cache_blob_id(
+                              driver, device, &size, nullptr),
+            "could not get an engine cache blob id size");
+
+    std::vector<uint8_t> cache_blob_id(size);
+    error::wrap_c_api(dnnl_ze_interop_engine_get_cache_blob_id(
+                              driver, device, &size, cache_blob_id.data()),
+            "could not get an engine cache blob id");
+    return cache_blob_id;
+}
+
+/// Returns a cache blob for the engine.
+///
+/// @note The cache blob vector can be empty if oneDNN doesn't have anything
+///     to put in the cache blob. It's the user's responsibility to check
+///     whether it's empty prior to passing it to
+///     #dnnl::ze_interop::make_engine(ze_driver_handle_t, ze_device_handle_t, ze_context_handle_t, const std::vector<uint8_t> &)
+///
+/// @param aengine Engine to query for the cache blob.
+///
+/// @returns Vector containing the cache blob.
+inline std::vector<uint8_t> get_engine_cache_blob(const engine &aengine) {
+    size_t size = 0;
+    error::wrap_c_api(dnnl_ze_interop_engine_get_cache_blob(
+                              aengine.get(), &size, nullptr),
+            "could not get an engine cache blob size");
+
+    std::vector<uint8_t> cache_blob(size);
+    error::wrap_c_api(dnnl_ze_interop_engine_get_cache_blob(
+                              aengine.get(), &size, cache_blob.data()),
+            "could not get an engine cache blob");
+    return cache_blob;
+}
+
+/// Constructs an engine from the given cache blob.
+///
+/// @param driver The Level Zero driver that this engine will encapsulate.
+/// @param device The Level Zero device that this engine will encapsulate.
+/// @param context The Level Zero context (containing the device) that this
+///     engine will use for all operations.
+/// @param cache_blob Cache blob.
+///
+/// @returns An engine.
+inline engine make_engine(ze_driver_handle_t driver, ze_device_handle_t device,
+        ze_context_handle_t context, const std::vector<uint8_t> &cache_blob) {
+    dnnl_engine_t c_engine;
+    error::wrap_c_api(
+            dnnl_ze_interop_engine_create_from_cache_blob(&c_engine, driver,
+                    device, context, cache_blob.size(), cache_blob.data()),
+            "could not create an engine from cache blob");
+    return engine(c_engine);
+}
 
 /// Constructs an engine from Level Zero device and context objects.
 ///

--- a/src/common/cache_blob_id.cpp
+++ b/src/common/cache_blob_id.cpp
@@ -50,9 +50,6 @@ const std::vector<uint8_t> &cache_blob_id_t::get(
         }
 
         sstream_.append(engine_kind);
-        // TODO: blob object can probably be re-used for different runtimes
-        // if the engine kind is the same. Check this assumption when extending
-        // this API to DPCPP runtime.
         sstream_.append(runtime_kind);
 
         engine->serialize_device(sstream_);

--- a/src/common/cache_blob_id.cpp
+++ b/src/common/cache_blob_id.cpp
@@ -32,16 +32,9 @@ const std::vector<uint8_t> &cache_blob_id_t::get(
     auto engine_kind = engine->kind();
     auto runtime_kind = engine->runtime_kind();
 
-    if (engine_kind != engine_kind::gpu
-            || (engine_kind == engine_kind::gpu
-                    && runtime_kind != runtime_kind::ocl)) {
-        return sstream_.get_data();
-    }
+    if (!engine->is_cache_blob_supported()) { return sstream_.get_data(); }
 
     if (pd->kind() == primitive_kind::zero_pad) { return sstream_.get_data(); }
-
-    assert(engine->kind() == engine_kind::gpu
-            && engine->runtime_kind() == runtime_kind::ocl);
 
     const auto init_id = [&]() {
         serialize_desc(sstream_, pd->op_desc());

--- a/src/common/engine.hpp
+++ b/src/common/engine.hpp
@@ -154,8 +154,9 @@ struct dnnl_engine : public dnnl::impl::c_compatible {
 
     bool is_cache_blob_supported() const {
         if (kind() != dnnl::impl::engine_kind::gpu) return false;
-        if (!dnnl::impl::utils::one_of(
-                    runtime_kind(), dnnl::impl::runtime_kind::ocl))
+        if (!dnnl::impl::utils::one_of(runtime_kind(),
+                    dnnl::impl::runtime_kind::ocl,
+                    dnnl::impl::runtime_kind::ze))
             return false;
         return true;
     }

--- a/src/common/engine.hpp
+++ b/src/common/engine.hpp
@@ -152,6 +152,14 @@ struct dnnl_engine : public dnnl::impl::c_compatible {
         return dnnl::impl::status::runtime_error;
     }
 
+    bool is_cache_blob_supported() const {
+        if (kind() != dnnl::impl::engine_kind::gpu) return false;
+        if (!dnnl::impl::utils::one_of(
+                    runtime_kind(), dnnl::impl::runtime_kind::ocl))
+            return false;
+        return true;
+    }
+
     virtual bool mayiuse_system_memory_allocators() const { return false; }
     virtual bool mayiuse_f16_accumulator_with_f16() const { return false; }
 

--- a/src/common/primitive_cache.cpp
+++ b/src/common/primitive_cache.cpp
@@ -19,6 +19,7 @@
 #include "cache_utils.hpp"
 #include "kernel_cache.hpp"
 #include "primitive.hpp"
+#include "primitive_cache_test_api.hpp"
 #include "primitive_desc_iface.hpp"
 #include "primitive_iface.hpp"
 #include "z_magic.hpp"
@@ -59,7 +60,7 @@ private:
         key.attr_ = pd->attr();
     }
     // Used for testing.
-    friend size_t DNNL_API set_primitive_cache_capacity_without_clearing(
+    friend size_t set_primitive_cache_capacity_without_clearing(
             size_t capacity);
     void set_capacity_without_clearing(int capacity) {
         cache_.set_capacity_without_clearing(capacity);
@@ -81,27 +82,6 @@ primitive_cache_t &global_primitive_cache() {
 
 primitive_cache_iface_t primitive_cache() {
     return global_primitive_cache();
-}
-
-// Undocumented API, for testing only
-status_t get_primitive_cache_size(int *size) {
-    if (size == nullptr) return dnnl::impl::status::invalid_arguments;
-    *size = 0;
-#ifndef DNNL_DISABLE_PRIMITIVE_CACHE
-    *size = global_primitive_cache().get_size();
-#endif
-    return dnnl::impl::status::success;
-}
-
-bool is_pd_in_cache(const primitive_desc_iface_t *pd_iface) {
-    const auto *pd = pd_iface->impl().get();
-    const auto *engine = pd_iface->engine();
-    primitive_hashing::key_t key(pd, engine);
-    return bool(global_primitive_cache().get_pd(key));
-}
-
-bool is_primitive_in_cache(const primitive_iface_t *p_iface) {
-    return is_pd_in_cache(p_iface->pd());
 }
 
 size_t set_primitive_cache_capacity_without_clearing(size_t capacity) {
@@ -164,4 +144,36 @@ dnnl::impl::status_t dnnl_get_primitive_cache_capacity(int *capacity) {
 
 dnnl::impl::status_t dnnl_set_primitive_cache_capacity(int capacity) {
     return dnnl::impl::set_primitive_cache_capacity(capacity, capacity);
+}
+
+// Undocumented API declared in primitive_cache_test_api.hpp
+using namespace dnnl;
+using namespace dnnl::impl;
+
+status_t dnnl_test_get_primitive_cache_size(int *size) {
+    if (size == nullptr) return impl::status::invalid_arguments;
+    *size = 0;
+#ifndef DNNL_DISABLE_PRIMITIVE_CACHE
+    *size = global_primitive_cache().get_size();
+#endif
+    return impl::status::success;
+}
+
+int dnnl_test_is_pd_in_cache(const primitive_desc_iface_t *pd_iface) {
+    const auto *pd = pd_iface->impl().get();
+    const auto *engine = pd_iface->engine();
+    primitive_hashing::key_t key(pd, engine);
+    return int(bool(global_primitive_cache().get_pd(key)));
+}
+
+int dnnl_test_is_primitive_in_cache(const primitive_iface_t *p_iface) {
+    return dnnl_test_is_pd_in_cache(p_iface->pd());
+}
+
+size_t dnnl_test_set_primitive_cache_capacity_without_clearing(
+        size_t capacity) {
+#ifndef DNNL_DISABLE_PRIMITIVE_CACHE
+    return set_primitive_cache_capacity_without_clearing(capacity);
+#endif
+    return size_t(0);
 }

--- a/src/common/primitive_cache.hpp
+++ b/src/common/primitive_cache.hpp
@@ -62,12 +62,6 @@ primitive_cache_iface_t primitive_cache();
 status_t set_primitive_cache_capacity(
         int primitive_capacity, int kernel_capacity);
 
-// Undocumented API for testing.
-status_t DNNL_API get_primitive_cache_size(int *size);
-bool DNNL_API is_primitive_in_cache(const primitive_iface_t *p_iface);
-bool DNNL_API is_pd_in_cache(const primitive_desc_iface_t *pd_iface);
-size_t DNNL_API set_primitive_cache_capacity_without_clearing(size_t capacity);
-
 } // namespace impl
 } // namespace dnnl
 #endif

--- a/src/common/primitive_cache_test_api.hpp
+++ b/src/common/primitive_cache_test_api.hpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef COMMON_PRIMITIVE_CACHE_TEST_API_HPP
+#define COMMON_PRIMITIVE_CACHE_TEST_API_HPP
+
+#include "oneapi/dnnl/dnnl.h"
+
+// Undocumented API for testing.
+dnnl_status_t DNNL_API dnnl_test_get_primitive_cache_size(int *size);
+int DNNL_API dnnl_test_is_primitive_in_cache(const_dnnl_primitive_t p_iface);
+int DNNL_API dnnl_test_is_pd_in_cache(const_dnnl_primitive_desc_t pd_iface);
+size_t DNNL_API dnnl_test_set_primitive_cache_capacity_without_clearing(
+        size_t capacity);
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -227,11 +227,7 @@ status_t dnnl_primitive_create_from_cache_blob(
             || size == 0) {
         return invalid_arguments;
     }
-    const auto ekind = primitive_desc_iface->engine()->kind();
-    const auto runtime_kind = primitive_desc_iface->engine()->runtime_kind();
-    if (ekind != engine_kind::gpu
-            || (ekind == engine_kind::gpu
-                    && runtime_kind != runtime_kind::ocl)) {
+    if (!primitive_desc_iface->engine()->is_cache_blob_supported()) {
         return status::unimplemented;
     }
 
@@ -286,11 +282,7 @@ status_t dnnl_primitive_get_cache_blob(const primitive_iface_t *primitive_iface,
         return status::invalid_arguments;
     }
 
-    const auto ekind = primitive_iface->engine()->kind();
-    const auto runtime_kind = primitive_iface->engine()->runtime_kind();
-    if (ekind != engine_kind::gpu
-            || (ekind == engine_kind::gpu
-                    && runtime_kind != runtime_kind::ocl)) {
+    if (!primitive_iface->engine()->is_cache_blob_supported()) {
         return status::unimplemented;
     }
 

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -572,8 +572,9 @@ template <typename... Args>
 std::string format_impl(const char *fmt, Args... args) {
     // volatile here is a workaround for GCC 8 format-truncation warning e.g.:
     // ‘%d’ directive output truncated writing 1 byte into a region of size 0
-    // triggered by overaggressive optmization in '-O3'; fixed in GCC 9+
-#if defined(__GNUC__) && __GNUC__ == 8 && !defined(__clang__)
+    // triggered by overaggressive optmization in '-O3'; fixed in random GCC
+    // versions.
+#if defined(__GNUC__) && __GNUC__ >= 8 && !defined(__clang__)
     volatile size_t sz = snprintf(nullptr, 0, fmt, args...);
 #else
     size_t sz = snprintf(nullptr, 0, fmt, args...);

--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -67,6 +67,29 @@ uint64_t get_future_extensions(
     return extensions;
 }
 
+status_t device_info_t::init(
+        impl::engine_t *engine, const std::vector<uint8_t> &cache_blob) {
+    if (!cache_blob.empty()) {
+        CHECK(init_from_cache_blob(cache_blob));
+        return init_serialized_device_info(cache_blob);
+    }
+
+    CHECK(init_device_name(engine));
+    CHECK(init_arch(engine));
+    CHECK(init_runtime_version(engine));
+    CHECK(init_extensions(engine));
+    CHECK(init_attributes(engine));
+    fixup_l3_cache_size();
+
+    CHECK(init_attributes_common(engine));
+
+    if (dnnl_version()->gpu_runtime == DNNL_RUNTIME_OCL) {
+        CHECK(init_serialized_device_info());
+    }
+
+    return status::success;
+}
+
 ngen::HW device_info_t::ngen_hw() const {
     ngen::Product p = jit::get_ngen_product(*this);
     return ngen::getCore(p.family);

--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -83,7 +83,7 @@ status_t device_info_t::init(
 
     CHECK(init_attributes_common(engine));
 
-    if (dnnl_version()->gpu_runtime == DNNL_RUNTIME_OCL) {
+    if (engine->is_cache_blob_supported()) {
         CHECK(init_serialized_device_info());
     }
 

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -183,27 +183,7 @@ public:
     virtual ~device_info_t() = default;
 
     status_t init(impl::engine_t *engine,
-            const std::vector<uint8_t> &cache_blob = {}) {
-        if (!cache_blob.empty()) {
-            CHECK(init_from_cache_blob(cache_blob));
-            return init_serialized_device_info(cache_blob);
-        }
-
-        CHECK(init_device_name(engine));
-        CHECK(init_arch(engine));
-        CHECK(init_runtime_version(engine));
-        CHECK(init_extensions(engine));
-        CHECK(init_attributes(engine));
-        fixup_l3_cache_size();
-
-        CHECK(init_attributes_common(engine));
-
-        if (dnnl_version()->gpu_runtime == DNNL_RUNTIME_OCL) {
-            CHECK(init_serialized_device_info());
-        }
-
-        return status::success;
-    }
+            const std::vector<uint8_t> &cache_blob = {});
 
     std::string get_cl_ext_options() const;
 

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -161,18 +161,17 @@ static inline const char *ext2cl_str(device_ext_t ext) {
 }
 
 enum class native_ext_t : uint64_t {
-    // clang-format off
     // OpenCL data types
-    fp32_atomic_add = 1ull << 0,                   
-    fp32_atomic_min_max = 1ull << 1, 
-    fp32_atomic_load_store = 1ull << 2,  
-    fp16_atomic_add = 1ull << 3,                   
-    fp16_atomic_min_max = 1ull << 4,              
-    fp16_atomic_load_store = 1ull << 5,  
+    fp32_atomic_add = 1ull << 0,
+    fp32_atomic_min_max = 1ull << 1,
+    fp32_atomic_load_store = 1ull << 2,
+    fp16_atomic_add = 1ull << 3,
+    fp16_atomic_min_max = 1ull << 4,
+    fp16_atomic_load_store = 1ull << 5,
     fp64_atomic_add = 1ull << 6,
     fp64_atomic_min_max = 1ull << 7,
-    fp64_atomic_load_store = 1ull << 8,  
-    last
+    fp64_atomic_load_store = 1ull << 8,
+    last,
 };
 
 // Needed workaround for future HW extensions
@@ -183,8 +182,8 @@ struct device_info_t {
 public:
     virtual ~device_info_t() = default;
 
-    status_t init(
-            impl::engine_t *engine, const std::vector<uint8_t> &cache_blob = {}) {
+    status_t init(impl::engine_t *engine,
+            const std::vector<uint8_t> &cache_blob = {}) {
         if (!cache_blob.empty()) {
             CHECK(init_from_cache_blob(cache_blob));
             return init_serialized_device_info(cache_blob);
@@ -209,9 +208,11 @@ public:
     std::string get_cl_ext_options() const;
 
     bool has(device_ext_t ext) const { return extensions_ & (uint64_t)ext; }
-    bool has_native(native_ext_t ext) const { return native_extensions_ & (uint64_t)ext; }
+    bool has_native(native_ext_t ext) const {
+        return native_extensions_ & (uint64_t)ext;
+    }
     gpu_arch_t gpu_arch() const { return gpu_arch_; }
-    const gpu_product_t &gpu_product() const {return gpu_product_;}
+    const gpu_product_t &gpu_product() const { return gpu_product_; }
     ngen::HW ngen_hw() const;
     int stepping_id() const;
     uint64_t native_extensions() const { return native_extensions_; }
@@ -226,7 +227,7 @@ public:
     int max_subgroup_size(data_type_t type = data_type::undef) const;
     static int max_subgroup_size(gpu_arch_t gpu_arch);
     static int grf_size(gpu_arch_t gpu_arch);
-    int grf_size() const { return grf_size(gpu_arch_); };
+    int grf_size() const { return grf_size(gpu_arch_); }
     int min_subgroup_size() const;
     size_t max_wg_size(bool large_grf_mode, size_t subgroup_size = 0) const;
     int eu_count() const { return eu_count_; }

--- a/src/gpu/intel/gemm/jit/dsl/runtime.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/runtime.cpp
@@ -255,7 +255,8 @@ dsl::hw_t get_hardware(ze_device_handle_t device, ze_context_handle_t context) {
                 context, device, hw))
         attr |= dsl::hw::attr_t::efficient_64bit;
 
-    return dsl::hw_t(product, eu_count, max_wg_size, l3_cache_size, attr);
+    return dsl::hw_t(product, static_cast<int>(eu_count),
+            static_cast<int>(max_wg_size), l3_cache_size, attr);
 }
 
 LevelZeroKernelAndModule make_kernel(const GEMMKernelDesc &desc,

--- a/src/gpu/intel/ze/engine.cpp
+++ b/src/gpu/intel/ze/engine.cpp
@@ -35,13 +35,13 @@ namespace ze {
 
 status_t engine_create(impl::engine_t **engine, engine_kind_t engine_kind,
         ze_driver_handle_t dri, ze_device_handle_t dev, ze_context_handle_t ctx,
-        size_t index) {
+        size_t index, const std::vector<uint8_t> &cache_blob) {
     gpu_assert(engine_kind == engine_kind::gpu);
     std::unique_ptr<ze::engine_t, engine_deleter_t> e(
             (new ze::engine_t(dri, dev, ctx, index)));
     if (!e) return status::out_of_memory;
 
-    CHECK(e->init());
+    CHECK(e->init(cache_blob));
     *engine = e.release();
 
     return status::success;
@@ -53,8 +53,12 @@ engine_t::engine_t(ze_driver_handle_t driver, ze_device_handle_t device,
               engine_kind::gpu, driver, device, context, index)) {}
 
 status_t engine_t::init() {
+    return init({});
+}
+
+status_t engine_t::init(const std::vector<uint8_t> &cache_blob) {
     CHECK(init_impl());
-    CHECK(intel::engine_t::init());
+    CHECK(intel::engine_t::init(cache_blob));
 
     return status::success;
 }
@@ -191,8 +195,8 @@ status_t engine_t::create_kernels_from_cache_blob(
         CHECK(cache_blob.get_binary(&binary_data, &binary_size));
 
         xpu::binary_t binary(binary_data, binary_data + binary_size);
-        CHECK(create_kernel_from_binary(
-                kernels[i], binary, kernel_names[i], compute::program_src_t()));
+        CHECK(create_kernel_from_binary(kernels[i], binary, kernel_name.c_str(),
+                compute::program_src_t()));
     }
 
     return status::success;
@@ -201,6 +205,24 @@ status_t engine_t::create_kernels_from_cache_blob(
 gpu_utils::device_id_t engine_t::device_id() const {
     return std::tuple_cat(
             std::make_tuple(1), xpu::ze::get_device_uuid(device()));
+}
+
+status_t engine_t::serialize_device(serialization_stream_t &sstream) const {
+    sstream.append_array(
+            device_info()->name().size(), device_info()->name().data());
+    sstream.append(device_info()->runtime_version().major);
+    sstream.append(device_info()->runtime_version().minor);
+    sstream.append(device_info()->runtime_version().build);
+
+    return status::success;
+}
+
+status_t engine_t::get_cache_blob_size(size_t *size) const {
+    return device_info_->get_cache_blob_size(size);
+}
+
+status_t engine_t::get_cache_blob(size_t size, uint8_t *cache_blob) const {
+    return device_info_->get_cache_blob(size, cache_blob);
 }
 
 ze_driver_handle_t engine_t::driver() const {
@@ -224,16 +246,14 @@ cl_context engine_t::ocl_context() const {
 }
 
 status_t engine_t::init_device_info() {
-    device_info_ = std::make_shared<ze::device_info_t>();
-    CHECK(device_info_->init(this));
-
-    return status::success;
+    return init_device_info({});
 }
 
 status_t engine_t::init_device_info(const std::vector<uint8_t> &cache_blob) {
-    gpu_assert(false) << "unimplemented function init_device_info() called";
+    device_info_ = std::make_shared<ze::device_info_t>();
+    CHECK(device_info_->init(this, cache_blob));
 
-    return status::runtime_error;
+    return status::success;
 }
 
 } // namespace ze

--- a/src/gpu/intel/ze/engine.hpp
+++ b/src/gpu/intel/ze/engine.hpp
@@ -29,7 +29,7 @@ namespace ze {
 
 status_t engine_create(impl::engine_t **engine, engine_kind_t engine_kind,
         ze_driver_handle_t dri, ze_device_handle_t dev, ze_context_handle_t ctx,
-        size_t index);
+        size_t index, const std::vector<uint8_t> &cache_blob);
 
 class engine_t : public intel::engine_t {
 public:
@@ -40,6 +40,7 @@ public:
     ~engine_t() override = default;
 
     status_t init() override;
+    status_t init(const std::vector<uint8_t> &cache_blob);
 
     status_t create_stream(
             impl::stream_t **stream, impl::stream_impl_t *stream_impl) override;
@@ -59,6 +60,11 @@ public:
             const std::vector<const char *> &kernel_names) const override;
 
     gpu_utils::device_id_t device_id() const override;
+
+    status_t serialize_device(serialization_stream_t &sstream) const override;
+
+    status_t get_cache_blob_size(size_t *size) const override;
+    status_t get_cache_blob(size_t size, uint8_t *cache_blob) const override;
 
     ze_driver_handle_t driver() const;
     ze_device_handle_t device() const;

--- a/src/gpu/intel/ze/kernel.cpp
+++ b/src/gpu/intel/ze/kernel.cpp
@@ -189,8 +189,18 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
     return status::success;
 }
 
+status_t kernel_t::get_binary(
+        const impl::engine_t *engine, xpu::binary_t &binary) const {
+    return ze::get_module_binary(*module_, binary);
+}
+
 status_t kernel_t::get_kernel_binary(xpu::binary_t &binary) const {
     return ze::get_kernel_binary(kernel_, binary);
+}
+
+status_t kernel_t::get_binary_size(
+        const impl::engine_t *engine, size_t *binary_size) const {
+    return ze::get_binary_size(*module_, binary_size);
 }
 
 status_t kernel_t::dump() const {

--- a/src/gpu/intel/ze/kernel.hpp
+++ b/src/gpu/intel/ze/kernel.hpp
@@ -46,7 +46,11 @@ public:
             const compute::kernel_arg_list_t &arg_list,
             const xpu::event_t &deps, xpu::event_t &out_dep) override;
 
+    status_t get_binary(
+            const impl::engine_t *engine, xpu::binary_t &binary) const override;
     status_t get_kernel_binary(xpu::binary_t &binary) const override;
+    status_t get_binary_size(
+            const impl::engine_t *engine, size_t *binary_size) const override;
 
     std::string name() const override { return kernel_name_; }
 

--- a/src/gpu/intel/ze/utils.cpp
+++ b/src/gpu/intel/ze/utils.cpp
@@ -204,11 +204,17 @@ status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
     return status::success;
 }
 
+status_t get_binary_size(
+        ze_module_handle_t module_handle, size_t *binary_size) {
+    CHECK(xpu::ze::zeModuleGetNativeBinary(
+            module_handle, binary_size, nullptr));
+    return status::success;
+}
+
 status_t get_module_binary(
         ze_module_handle_t module_handle, xpu::binary_t &binary) {
     size_t module_binary_size;
-    CHECK(xpu::ze::zeModuleGetNativeBinary(
-            module_handle, &module_binary_size, nullptr));
+    CHECK(get_binary_size(module_handle, &module_binary_size));
 
     binary.resize(module_binary_size);
     CHECK(xpu::ze::zeModuleGetNativeBinary(
@@ -259,9 +265,26 @@ status_t create_kernels(ze_device_handle_t device, ze_context_handle_t context,
     for (size_t i = 0; i < kernel_names.size(); i++) {
         if (kernel_names[i] == nullptr) continue;
 
+        std::string kernel_name(kernel_names[i]);
+        if (kernel_name.empty()) {
+            // (copied from OCL backend).
+            // Handle the ngen cases when kernel name is not available.
+            // Query the kernel name from the program. It's expected that
+            // an ngen based program contains only 1 kernel.
+            if (kernel_names.size() != 1 || kernels.size() != 1)
+                return status::invalid_arguments;
+
+            uint32_t count = 1;
+            const char *name = nullptr;
+            CHECK(xpu::ze::zeModuleGetKernelNames(*module_ptr, &count, &name));
+
+            kernel_name = std::string(name);
+            assert(!kernel_name.empty());
+            if (kernel_name.empty()) return status::runtime_error;
+        }
         ze_kernel_desc_t kernel_desc {};
         kernel_desc.stype = ZE_STRUCTURE_TYPE_KERNEL_DESC;
-        kernel_desc.pKernelName = kernel_names[i];
+        kernel_desc.pKernelName = kernel_name.c_str();
 
         ze_kernel_handle_t kernel;
         CHECK(xpu::ze::zeKernelCreate(*module_ptr, &kernel_desc, &kernel));

--- a/src/gpu/intel/ze/utils.hpp
+++ b/src/gpu/intel/ze/utils.hpp
@@ -33,6 +33,8 @@ status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
         uint64_t &native_extensions, bool &mayiuse_systolic,
         bool &mayiuse_ngen_kernels, bool &is_efficient_64bit);
 
+status_t get_binary_size(ze_module_handle_t module_handle, size_t *binary_size);
+
 status_t get_module_binary(
         ze_module_handle_t module_handle, xpu::binary_t &binary);
 

--- a/src/xpu/ocl/capi/engine.cpp
+++ b/src/xpu/ocl/capi/engine.cpp
@@ -135,6 +135,9 @@ status_t dnnl_ocl_interop_engine_get_cache_blob_id(
     OCL_CHECK(err);
 
     if (!cache_blob) {
+        // The last component corresponds to the number of
+        // `sstream.append_array` calls which adds the size itself besides
+        // the content of the array.
         id_size = platform_name_size + device_name_size + driver_version_size
                 + sizeof(version->major) + sizeof(version->minor)
                 + sizeof(version->patch) + std::strlen(version->hash)

--- a/src/xpu/ze/capi/engine.cpp
+++ b/src/xpu/ze/capi/engine.cpp
@@ -27,8 +27,10 @@ using namespace dnnl::impl;
 status_t dnnl_ze_interop_engine_create(engine_t **engine,
         ze_driver_handle_t driver, ze_device_handle_t device,
         ze_context_handle_t context) {
-    bool args_ok = !utils::any_null(engine, driver, device, context);
-    if (!args_ok) return status::invalid_arguments;
+    VERROR_ENGINE(engine, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(driver, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(device, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(context, status::invalid_arguments, VERBOSE_NULL_ARG);
 
     xpu::ze::engine_factory_t f(engine_kind::gpu);
 
@@ -73,6 +75,107 @@ status_t dnnl_ze_interop_engine_get_driver(
     auto *ze_engine_impl
             = utils::downcast<const xpu::ze::engine_impl_t *>(engine->impl());
     *driver = ze_engine_impl->driver();
+
+    return status::success;
+}
+
+status_t dnnl_ze_interop_engine_create_from_cache_blob(engine_t **engine,
+        ze_driver_handle_t driver, ze_device_handle_t device,
+        ze_context_handle_t context, size_t size, const uint8_t *cache_blob) {
+    VERROR_ENGINE(engine, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(driver, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(device, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(context, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(cache_blob, status::invalid_arguments, VERBOSE_NULL_ARG);
+    VERROR_ENGINE(size > 0, status::invalid_arguments, VERBOSE_NULL_ARG);
+
+    xpu::ze::engine_factory_t f(engine_kind::gpu);
+
+    size_t index;
+    CHECK(xpu::ze::get_device_index(&index, device));
+
+    const std::vector<uint8_t> cb(cache_blob, cache_blob + size);
+    return f.engine_create(engine, driver, device, context, index, cb);
+}
+
+status_t dnnl_ze_interop_engine_get_cache_blob(
+        engine_t *engine, size_t *size, uint8_t *cache_blob) {
+    VERROR_ENGINE(engine->kind() == engine_kind::gpu, status::invalid_arguments,
+            VERBOSE_BAD_ENGINE_KIND);
+    VERROR_ENGINE(size, status::invalid_arguments, VERBOSE_NULL_ARG);
+
+    if (!cache_blob) {
+        size_t sz = 0;
+        CHECK(engine->get_cache_blob_size(&sz));
+        (*size) = sz;
+        return status::success;
+    }
+
+    CHECK(engine->get_cache_blob(*size, cache_blob));
+    return status::success;
+}
+
+status_t dnnl_ze_interop_engine_get_cache_blob_id(ze_driver_handle_t driver,
+        ze_device_handle_t device, size_t *size, uint8_t *cache_blob) {
+    VERROR_ENGINE(size, status::invalid_arguments, VERBOSE_NULL_ARG);
+    size_t &id_size = *size;
+
+    // Get oneDNN version.
+    auto version = dnnl_version();
+
+    // Get device name.
+    ze_device_properties_t device_properties = {};
+    device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+    CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
+    auto device_name = std::string(device_properties.name);
+
+    // Get driver version size.
+    // Note: copied from engine_impl. See a comment there.
+    ze_result_t (*pfnGetDriverVersionFn)(ze_driver_handle_t, char *, size_t *);
+    CHECK(xpu::ze::zeDriverGetExtensionFunctionAddress(driver,
+            "zeIntelGetDriverVersionString", (void **)&pfnGetDriverVersionFn));
+
+    size_t driver_version_len = 0;
+    ZE_CHECK(pfnGetDriverVersionFn(driver, nullptr, &driver_version_len));
+    driver_version_len++; // driver_version_len does not account for '\0'.
+
+    if (!cache_blob) {
+        // The last component corresponds to the number of
+        // `sstream.append_array` calls which adds the size itself besides
+        // the content of the array.
+        id_size = device_name.size() + driver_version_len
+                + sizeof(version->major) + sizeof(version->minor)
+                + sizeof(version->patch) + std::strlen(version->hash)
+                + 3 * sizeof(size_t);
+        return status::success;
+    }
+
+    // Get driver version.
+    std::string driver_version(driver_version_len, '\0');
+    ZE_CHECK(pfnGetDriverVersionFn(driver,
+            const_cast<char *>(driver_version.data()), &driver_version_len));
+
+    serialization_stream_t sstream;
+
+    // Serialize device name.
+    sstream.append_array(device_name.size(), device_name.data());
+
+    // Serialize driver version.
+    sstream.append_array(driver_version.size(), driver_version.data());
+
+    // Serialize oneDNN version.
+    sstream.append(version->major);
+    sstream.append(version->minor);
+    sstream.append(version->patch);
+
+    // Serialize oneDNN hash.
+    sstream.append_array(std::strlen(version->hash), version->hash);
+
+    VERROR_ENGINE(id_size == sstream.get_data().size(),
+            status::invalid_arguments,
+            "not enough buffer space for copying cache blob");
+
+    std::memcpy(cache_blob, sstream.get_data().data(), id_size);
 
     return status::success;
 }

--- a/src/xpu/ze/engine_factory.cpp
+++ b/src/xpu/ze/engine_factory.cpp
@@ -85,9 +85,10 @@ status_t engine_factory_t::engine_create(
 
 status_t engine_factory_t::engine_create(impl::engine_t **engine,
         ze_driver_handle_t driver, ze_device_handle_t device,
-        ze_context_handle_t context, size_t index) const {
-    return gpu::intel::ze::engine_create(
-            engine, engine_kind::gpu, driver, device, context, index);
+        ze_context_handle_t context, size_t index,
+        const std::vector<uint8_t> &cache_blob) const {
+    return gpu::intel::ze::engine_create(engine, engine_kind::gpu, driver,
+            device, context, index, cache_blob);
 }
 
 } // namespace ze

--- a/src/xpu/ze/engine_factory.cpp
+++ b/src/xpu/ze/engine_factory.cpp
@@ -52,7 +52,6 @@ status_t engine_factory_t::engine_create(
         impl::engine_t **engine, size_t index) const {
     ze_driver_handle_t driver = nullptr;
     ze_device_handle_t device = nullptr;
-    ze_context_handle_t context = nullptr;
 
     uint32_t driver_count = 0;
     CHECK(ze::zeDriverGet(&driver_count, nullptr));
@@ -73,14 +72,7 @@ status_t engine_factory_t::engine_create(
     CHECK(ze::zeDeviceGet(driver, &device_count, devices.data()));
     device = devices[index];
 
-    ze_context_desc_t context_desc = {};
-    context_desc.stype = ZE_STRUCTURE_TYPE_CONTEXT_DESC;
-    context_desc.pNext = nullptr;
-    context_desc.flags = 0;
-
-    CHECK(ze::zeContextCreate(driver, &context_desc, &context));
-
-    return engine_create(engine, driver, device, context, index);
+    return engine_create(engine, driver, device, nullptr, index);
 }
 
 status_t engine_factory_t::engine_create(impl::engine_t **engine,

--- a/src/xpu/ze/engine_factory.hpp
+++ b/src/xpu/ze/engine_factory.hpp
@@ -38,7 +38,7 @@ public:
             impl::engine_t **engine, size_t index) const override;
     status_t engine_create(impl::engine_t **engine, ze_driver_handle_t adriver,
             ze_device_handle_t adevice, ze_context_handle_t acontext,
-            size_t index) const;
+            size_t index, const std::vector<uint8_t> &cache_blob = {}) const;
 
 private:
     engine_factory_t() = delete;

--- a/src/xpu/ze/engine_impl.cpp
+++ b/src/xpu/ze/engine_impl.cpp
@@ -31,6 +31,16 @@ engine_impl_t::engine_impl_t(engine_kind_t kind, ze_driver_handle_t driver,
     , context_(context, /* owner = */ !context) {}
 
 status_t engine_impl_t::init() {
+    // Initialize the context if it wasn't provided by the user.
+    if (!context_) {
+        ze_context_desc_t context_desc = {};
+        context_desc.stype = ZE_STRUCTURE_TYPE_CONTEXT_DESC;
+        context_desc.pNext = nullptr;
+        context_desc.flags = 0;
+
+        CHECK(ze::zeContextCreate(driver_, &context_desc, &context_.unwrap()));
+    }
+
     cl_int err;
     std::vector<cl_device_id> ocl_devices;
     xpu::ocl::get_devices(&ocl_devices, CL_DEVICE_TYPE_GPU);

--- a/src/xpu/ze/utils.hpp
+++ b/src/xpu/ze/utils.hpp
@@ -87,7 +87,7 @@ static inline std::string to_string(ze_result_t r) {
     do { \
         ze_result_t res_ = (f); \
         if (res_ != ZE_RESULT_SUCCESS) { \
-            std::string err_str_ = to_string(res_); \
+            std::string err_str_ = xpu::ze::to_string(res_); \
             VERROR(common, level_zero, "errcode %s", err_str_.c_str()); \
             return status::runtime_error; \
         } \
@@ -149,6 +149,7 @@ INDIRECT_ZE_CALL(zeModuleCreate)
 INDIRECT_ZE_CALL(zeModuleDestroy)
 INDIRECT_ZE_CALL(zeModuleBuildLogGetString)
 INDIRECT_ZE_CALL(zeModuleBuildLogDestroy)
+INDIRECT_ZE_CALL(zeModuleGetKernelNames)
 INDIRECT_ZE_CALL(zeModuleGetNativeBinary)
 INDIRECT_ZE_CALL(zeKernelCreate)
 INDIRECT_ZE_CALL(zeKernelDestroy)

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -259,8 +259,10 @@ int test_persistent_cache_api(
         dnnl_memory_desc_create_with_blob(&new_md, md_blob.data());
         auto mew_mdw = make_benchdnn_dnnl_wrapper(new_md);
 
-        if (dnnl_memory_desc_equal(wei_md, new_md) == 0)
-            return res->state = FAILED, FAIL;
+        if (dnnl_memory_desc_equal(wei_md, new_md) == 0) {
+            res->state = FAILED;
+            SAFE(FAIL, WARN);
+        }
     }
 
     // Start testing persistent cache API.
@@ -275,7 +277,10 @@ int test_persistent_cache_api(
     // 2. Get cache blob ID to use it as a key for the `test_cache`.
     std::vector<uint8_t> cache_blob_id;
     auto st = get_cache_blob_id(cache_blob_id, pd);
-    if (st != OK) return res->state = FAILED, FAIL;
+    if (st != OK) {
+        res->state = FAILED;
+        SAFE(FAIL, WARN);
+    }
     // 3. Check if a cache blob for the obtained cache blob ID is present in the
     //    `test_cache`.
     //    a) If the cache blob is found the primitive is created from it.
@@ -290,11 +295,17 @@ int test_persistent_cache_api(
         const uint8_t *cache_blob = cache_value.data();
         auto dnnl_st = dnnl_primitive_create_from_cache_blob(
                 &p, pd, size, cache_blob);
-        if (dnnl_st != dnnl_success) return res->state = FAILED, FAIL;
+        if (dnnl_st != dnnl_success) {
+            res->state = FAILED;
+            DNN_SAFE(dnnl_st, WARN);
+        }
     } else {
         std::vector<uint8_t> cache_blob;
         st = get_cache_blob(cache_blob, prim);
-        if (st != OK) return res->state = FAILED, FAIL;
+        if (st != OK) {
+            res->state = FAILED;
+            SAFE(FAIL, WARN);
+        }
 
         // The cross-engine and direct copy reorders are special primitives that
         // may contain no kernels therefore the cache blob will always be empty,
@@ -316,12 +327,15 @@ int test_persistent_cache_api(
             BENCHDNN_PRINT(
                     0, "error: %s\n", "cache blob is not expected to be empty");
             res->state = FAILED;
-            return FAIL;
+            SAFE(FAIL, WARN);
         }
 
         auto dnnl_st = dnnl_primitive_create_from_cache_blob(
                 &p, pd, cache_blob.size(), cache_blob.data());
-        if (dnnl_st != dnnl_success) return res->state = FAILED, FAIL;
+        if (dnnl_st != dnnl_success) {
+            res->state = FAILED;
+            DNN_SAFE(dnnl_st, WARN);
+        }
         cache.add(cache_blob_id, cache_blob);
     }
     prim.reset(p);

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -40,9 +40,8 @@
 #include "oneapi/dnnl/dnnl_threadpool.h"
 #endif
 
-#ifndef DNNL_DISABLE_PRIMITIVE_CACHE
-#include "src/common/primitive_cache.hpp"
-#endif
+// Uses only publicly available types.
+#include "src/common/primitive_cache_test_api.hpp"
 
 #include "cpu/platform.hpp"
 
@@ -141,7 +140,7 @@ int check_pd_cache(const_dnnl_primitive_desc_t pd, res_t *res) {
         && DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
     int capacity = 0;
     DNN_SAFE(dnnl_get_primitive_cache_capacity(&capacity), FAIL);
-    if (capacity && !dnnl::impl::is_pd_in_cache(pd)) {
+    if (capacity && !dnnl_test_is_pd_in_cache(pd)) {
         res->state = FAILED;
         BENCHDNN_PRINT(0, "%s\n",
                 "Error: primitive descriptor is expected to be fetched from "
@@ -158,7 +157,7 @@ int check_primitive_cache(dnnl_primitive_t p, res_t *res) {
         && DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
     int capacity = 0;
     DNN_SAFE(dnnl_get_primitive_cache_capacity(&capacity), WARN);
-    if (capacity && !dnnl::impl::is_primitive_in_cache(p)) {
+    if (capacity && !dnnl_test_is_primitive_in_cache(p)) {
         res->state = FAILED;
         BENCHDNN_PRINT(0, "%s\n",
                 "Error: primitive is expected to be fetched from the primitive "
@@ -167,13 +166,6 @@ int check_primitive_cache(dnnl_primitive_t p, res_t *res) {
     }
 #endif
     return OK;
-}
-
-size_t set_primitive_cache_capacity_without_clearing(size_t capacity) {
-#ifndef DNNL_DISABLE_PRIMITIVE_CACHE
-    return dnnl::impl::set_primitive_cache_capacity_without_clearing(capacity);
-#endif
-    return size_t(0);
 }
 
 int get_cache_blob_id(
@@ -278,7 +270,8 @@ int test_persistent_cache_api(
 
     // 1. Disable primitive cache to make sure that the next primitive will
     // be created from the cache blob and not fetched from the primitive cache.
-    const auto old_capacity = set_primitive_cache_capacity_without_clearing(0);
+    const auto old_capacity
+            = dnnl_test_set_primitive_cache_capacity_without_clearing(0);
     // 2. Get cache blob ID to use it as a key for the `test_cache`.
     std::vector<uint8_t> cache_blob_id;
     auto st = get_cache_blob_id(cache_blob_id, pd);
@@ -307,7 +300,8 @@ int test_persistent_cache_api(
         // may contain no kernels therefore the cache blob will always be empty,
         // which is the correct behavior.
         if (cache_blob.empty()) {
-            set_primitive_cache_capacity_without_clearing(old_capacity);
+            dnnl_test_set_primitive_cache_capacity_without_clearing(
+                    old_capacity);
             if (query_prim_kind(pd) == dnnl_reorder
                     && (res->impl_name.find("cross_engine") != std::string::npos
                             || res->impl_name.find("direct_copy")
@@ -333,7 +327,7 @@ int test_persistent_cache_api(
     prim.reset(p);
 
     // 4. Restore the original primitive cache capacity to make it functional.
-    set_primitive_cache_capacity_without_clearing(old_capacity);
+    dnnl_test_set_primitive_cache_capacity_without_clearing(old_capacity);
 
     return OK;
 }

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -266,9 +266,7 @@ int test_persistent_cache_api(
     }
 
     // Start testing persistent cache API.
-    if (!is_gpu() || (is_gpu() && DNNL_GPU_RUNTIME != DNNL_RUNTIME_OCL)) {
-        return OK;
-    }
+    if (!is_gpu() || !(is_opencl_engine() || is_ze_engine())) { return OK; }
 
     // 1. Disable primitive cache to make sure that the next primitive will
     // be created from the cache blob and not fetched from the primitive cache.

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -62,7 +62,7 @@
 #include "src/common/float16.hpp"
 #include "src/common/memory_desc_wrapper.hpp"
 #include "src/common/nstl.hpp"
-#include "src/common/primitive_cache.hpp"
+#include "src/common/primitive_cache_test_api.hpp"
 #include "tests/gtests/test_malloc.hpp"
 #include "tests/test_thread.hpp"
 
@@ -1160,7 +1160,7 @@ inline dnnl::stream make_stream(const dnnl::engine &engine,
 
 inline int get_primitive_cache_size() {
     int result = 0;
-    auto status = dnnl::impl::get_primitive_cache_size(&result);
+    auto status = dnnl_test_get_primitive_cache_size(&result);
     if (status != dnnl::impl::status::success) return -1;
     return result;
 }

--- a/tests/gtests/test_concurrency.cpp
+++ b/tests/gtests/test_concurrency.cpp
@@ -287,6 +287,12 @@ protected:
         if (get_test_engine_kind() == engine::kind::gpu)
             set_primitive_cache_capacity(0);
 #endif
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
+        // Note: necessary abstractions to support concurrent kernel generation
+        // are not introduced for Level Zero backend.
+        SKIP_IF(true,
+                "Concurrent execution is not supported by Level Zero backend.");
+#endif
         // This test doesn't work properly under SDE.
         const int len = 1024;
         char value_str[len];

--- a/tests/gtests/test_iface_primitive_cache.cpp
+++ b/tests/gtests/test_iface_primitive_cache.cpp
@@ -32,11 +32,11 @@ void custom_unsetenv(const char *name) {
 
 namespace dnnl {
 
-void fill_primitive_cache(int n) {
+void fill_primitive_cache(
+        int n, const engine &eng = engine(get_test_engine_kind(), 0)) {
     using tag = memory::format_tag;
     using dt = memory::data_type;
 
-    engine eng(get_test_engine_kind(), 0);
     for (int i = 0; i < n; i++) {
         // fill primitive cache with n primitives
         auto md = memory::desc({i, 1, 1, 1}, dt::f32, tag::nchw);
@@ -104,8 +104,19 @@ TEST(primitive_cache_test, TestSizeGreaterCapacity) {
 TEST(primitive_cache_test, TestCacheHit) {
     set_primitive_cache_capacity(0);
     set_primitive_cache_capacity(2);
-    fill_primitive_cache(1);
-    fill_primitive_cache(1);
+
+    // This is designed to verify that different engines objects would trigger
+    // cache misses due to different engine_id values.
+    //
+    // It's important to keep engines in the outer scope as underlying interop
+    // objects, if re-created, might return the same address if the engine
+    // object creation is moved inside the `fill_primitive_cache` function.
+    // This behavior is observed for ZE backend, though not observed for OCL and
+    // SYCL backends.
+    engine eng0(get_test_engine_kind(), 0);
+    engine eng1(get_test_engine_kind(), 0);
+    fill_primitive_cache(1, eng0);
+    fill_primitive_cache(1, eng1);
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_SYCL
     if (get_test_engine_kind() == engine::kind::cpu) {

--- a/tests/gtests/test_persistent_cache_api.cpp
+++ b/tests/gtests/test_persistent_cache_api.cpp
@@ -47,7 +47,8 @@ HANDLE_EXCEPTIONS_FOR_TEST(
 
     if (get_test_engine_kind() != engine::kind::gpu
             || (get_test_engine_kind() == engine::kind::gpu
-                    && DNNL_GPU_RUNTIME != DNNL_RUNTIME_OCL)) {
+                    && (DNNL_GPU_RUNTIME != DNNL_RUNTIME_OCL
+                            && DNNL_GPU_RUNTIME != DNNL_RUNTIME_ZE))) {
         ASSERT_EQ(cache_blob_id.empty(), true);
         EXPECT_ANY_THROW(cache_blob = p.get_cache_blob());
         ASSERT_EQ(cache_blob.empty(), true);
@@ -91,6 +92,41 @@ HANDLE_EXCEPTIONS_FOR_TEST(
     ASSERT_EQ(get_engine_cache_blob(eng), cache_blob);
     ASSERT_EQ(get_engine_cache_blob_id(get_device(eng)), cache_blob_id);
 }
+#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
+HANDLE_EXCEPTIONS_FOR_TEST(
+        persistent_cache_api_test_t, TestPersistentCacheAPIEngine) {
+    using namespace dnnl::ze_interop;
+    engine test_engine = get_test_engine();
+
+    if (get_test_engine_kind() != engine::kind::gpu) {
+        ASSERT_ANY_THROW(get_engine_cache_blob(test_engine));
+        return;
+    }
+
+    std::vector<uint8_t> cache_blob;
+    std::vector<uint8_t> cache_blob_id;
+
+    ASSERT_NO_THROW(cache_blob = get_engine_cache_blob(test_engine));
+    ASSERT_NO_THROW(cache_blob_id = get_engine_cache_blob_id(
+                            get_driver(test_engine), get_device(test_engine)));
+
+    ASSERT_EQ(get_engine_cache_blob(test_engine), cache_blob);
+    ASSERT_EQ(get_engine_cache_blob_id(
+                      get_driver(test_engine), get_device(test_engine)),
+            cache_blob_id);
+
+    ASSERT_TRUE(!cache_blob.empty());
+    ASSERT_TRUE(!cache_blob_id.empty());
+
+    auto eng = make_engine(get_driver(test_engine), get_device(test_engine),
+            get_context(test_engine), cache_blob);
+
+    ASSERT_EQ(get_engine_cache_blob(eng), cache_blob);
+    ASSERT_EQ(
+            get_engine_cache_blob_id(get_driver(test_engine), get_device(eng)),
+            cache_blob_id);
+}
+
 #endif
 
 HANDLE_EXCEPTIONS_FOR_TEST(

--- a/third_party/ngen/ngen_level_zero.hpp
+++ b/third_party/ngen/ngen_level_zero.hpp
@@ -123,7 +123,7 @@ static inline void handleL0(ze_result_t result)
 }
 
 struct ze_module_deleter_t {
-    void operator()(ze_module_handle_t *h) const { handleL0(dynamic::zeModuleDestroy(*h)); }
+    void operator()(ze_module_handle_t *h) const { dynamic::zeModuleDestroy(*h); }
 };
 
 static inline std::vector<uint8_t> getDummyModuleBinary(ze_context_handle_t context, ze_device_handle_t device) {


### PR DESCRIPTION
Prepares sources for smoother support of the cache_blob extension for future runtimes and adds such support for ZE backend.

Additionally, unties benchdnn from internal types availability and improves error checking for persistent cache.

Note: there's still no available validation for L0, running it manually.