### PR TITLE
benchdnn: inputs: graph: add cases for gated mlp with gelu activation

### DIFF
--- a/doc/graph/rst/graph_fusion_patterns.rst
+++ b/doc/graph/rst/graph_fusion_patterns.rst
@@ -44,12 +44,12 @@ details about the programming model.
     `Exp <dev_guide_op_exp.html>`_, `GELU <dev_guide_op_gelu.html>`_,
     `HardSigmoid <dev_guide_op_hardsigmoid.html>`_, `HardSwish <dev_guide_op_hardswish.html>`_,
     `LeakyReLU <dev_guide_op_leakyrelu.html>`_, `Log <dev_guide_op_log.html>`_,
-    `Mish <dev_guide_op_mish.html>`_, `Sigmoid <dev_guide_op_sigmoid.html>`_,
-    `SoftPlus <dev_guide_op_softplus.html>`_, `ReLU <dev_guide_op_relu.html>`_,
-    `Round <dev_guide_op_round.html>`_, `Sqrt <dev_guide_op_sqrt.html>`_,
+    `Mish <dev_guide_op_mish.html>`_, `ReLU <dev_guide_op_relu.html>`_,
+    `Round <dev_guide_op_round.html>`_, `Sigmoid <dev_guide_op_sigmoid.html>`_,
+    `SoftPlus <dev_guide_op_softplus.html>`_, `Sqrt <dev_guide_op_sqrt.html>`_,
     `Square <dev_guide_op_square.html>`_, `Tanh <dev_guide_op_tanh.html>`_.
 
-.. list-table:: 
+.. list-table::
    :widths: 30 70
    :header-rows: 1
 

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -404,6 +404,11 @@ logical_tensor::dims deserialized_op_t::get_NCX_shape(
     return src_dims;
 }
 
+const deserialized_op_t &deserialized_op_t::dummy() {
+    static const deserialized_op_t op {};
+    return op;
+}
+
 void deserialized_graph_t::load(const std::string &pass_config_json) {
     std::ifstream fs(pass_config_json.c_str());
     utils::json::json_reader_t read(&fs);
@@ -661,8 +666,7 @@ const deserialized_op_t &deserialized_graph_t::get_op(size_t id) const {
         if (op.id_ == id) return op;
     }
     assert(!"Given id was not found in the deserialized graph.");
-    static deserialized_op_t dummy;
-    return dummy;
+    return deserialized_op_t::dummy();
 }
 
 const deserialized_op_t &deserialized_graph_t::get_op_by_out_lt(
@@ -672,8 +676,7 @@ const deserialized_op_t &deserialized_graph_t::get_op_by_out_lt(
         if (out_lt.id_ == out_lt_id) return op;
     }
 
-    static deserialized_op_t dummy;
-    return dummy;
+    return deserialized_op_t::dummy();
 }
 
 const deserialized_op_t &deserialized_graph_t::get_op_by_in_lt(
@@ -683,8 +686,7 @@ const deserialized_op_t &deserialized_graph_t::get_op_by_in_lt(
         if (in_lt.id_ == in_lt_id) return op;
     }
 
-    static deserialized_op_t dummy;
-    return dummy;
+    return deserialized_op_t::dummy();
 }
 
 void deserialized_graph_t::detect_recognized_patterns() {
@@ -887,8 +889,8 @@ const std::vector<deserialized_op_t> &deserialized_graph_t::get_child_ops(
     }
 
     const auto out_id = op.out_lts_[0].id_;
-    static deserialized_op_t dummy;
-    static std::vector<deserialized_op_t> dummy_vec {dummy};
+    static std::vector<deserialized_op_t> dummy_vec {
+            deserialized_op_t::dummy()};
 
     if (in_lt_2_ops_.find(out_id) == in_lt_2_ops_.end()) return dummy_vec;
     return in_lt_2_ops_.at(out_id);
@@ -908,8 +910,8 @@ const deserialized_op_t &deserialized_graph_t::find_next_until(
         cur_op_ptr = &child_ops[0];
     }
 
-    static deserialized_op_t dummy;
-    return (cur_op_ptr->kind_ == target_kind) ? *cur_op_ptr : dummy;
+    return (cur_op_ptr->kind_ == target_kind) ? *cur_op_ptr
+                                              : deserialized_op_t::dummy();
 }
 
 bool deserialized_graph_t::check_tensor_with_mb(size_t tensor_id,

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -703,6 +703,11 @@ void deserialized_graph_t::detect_recognized_patterns() {
         BENCHDNN_PRINT(3, "%s\n", "[INFO]:sdpa_bwd pattern is recognized");
         return;
     }
+    if (ops_.size() >= 5 && detect_gmlp_impl()) {
+        recognized_pattern_ = graph_recognized_pattern_t::gmlp;
+        BENCHDNN_PRINT(3, "%s\n", "[INFO]:gmlp pattern is recognized");
+        return;
+    }
 }
 
 bool deserialized_graph_t::detect_sdpa_fwd_impl() const {
@@ -873,6 +878,85 @@ bool deserialized_graph_t::detect_sdpa_bwd_impl() const {
         //                      ->Multiply->MatMul->[dQ / dK]
         // Mul->ReduceSum->Sub            ->End (optional)
         // It will be considered as a SDPA bwd implementation.
+        return true;
+    }
+
+    return false;
+}
+
+bool deserialized_graph_t::detect_gmlp_impl() const {
+    static const std::unordered_set<std::string> mm_gate_pre_op_kind
+            = {"Dequantize", "TypeCast", "DynamicDequantize"};
+    static const std::unordered_set<std::string> mm_down_pre_op_kind
+            = {"TypeCast"};
+    const auto is_root_op = [&](const deserialized_op_t &op) {
+        return std::none_of(op.in_lts_.begin(), op.in_lts_.end(),
+                [&](const deserialized_lt_t &lt) {
+            return !get_op_by_out_lt(lt.id_).empty();
+        });
+    };
+
+    std::vector<std::reference_wrapper<const deserialized_op_t>> starter_ops;
+    for (const auto &aop : ops_) {
+        if (is_root_op(aop)) starter_ops.emplace_back(aop);
+    }
+
+    for (const auto &starter : starter_ops) {
+        // find MatMul Gate
+        auto cur_op_ref
+                = find_next_until(starter.get(), "MatMul", mm_gate_pre_op_kind);
+        if (cur_op_ref.empty()) {
+            BENCHDNN_PRINT(8, "%s\n",
+                    "[DETECT_GMLP]: failed due to no MatMul for Gate");
+            continue;
+        }
+
+        // find any Unary
+        auto cur_op_refs = get_child_ops(cur_op_ref);
+        cur_op_ref = deserialized_op_t::dummy();
+        for (const auto &mm_child : cur_op_refs) {
+            if (!is_unary(mm_child.kind_)) continue;
+
+            cur_op_ref = mm_child;
+            break;
+        }
+
+        if (cur_op_ref.empty()) {
+            BENCHDNN_PRINT(8, "%s\n",
+                    "[DETECT_GMLP]: failed due to no Unary MatMul post-op");
+            continue;
+        }
+
+        // find Multiply after Unary
+        cur_op_ref = get_child_ops(cur_op_ref)[0];
+        if (cur_op_ref.kind_ != "Multiply") {
+            BENCHDNN_PRINT(8, "%s\n",
+                    "[DETECT_GMLP]: failed due to no Multiply after Unary");
+            continue;
+        }
+
+        // In theory, to have a precise pattern, MatMul Up should be identified.
+        // However, it seems, just following the Gate-Down side is enough so
+        // far...
+
+        cur_op_ref = get_child_ops(cur_op_ref)[0];
+        if (cur_op_ref.kind_ == "Multiply") {
+            // If one more Multiply is detected, it likely means Swiglu, thus,
+            // step over this Multiply.
+            cur_op_ref = get_child_ops(cur_op_ref)[0];
+        }
+
+        // find MatMul Down.
+        cur_op_ref = find_next_until(cur_op_ref, "MatMul", mm_down_pre_op_kind);
+        if (cur_op_ref.empty()) {
+            BENCHDNN_PRINT(
+                    8, "%s\n", "[DETECT_GMLP]: failed due to no MatMul Down");
+            continue;
+        }
+
+        // If a path that contains MatMul->Unary->Multiply->MatMul was found,
+        //                                 Matmul-^
+        // the graph will be considered as a GMLP implementation.
         return true;
     }
 

--- a/tests/benchdnn/graph/deserialize.hpp
+++ b/tests/benchdnn/graph/deserialize.hpp
@@ -207,6 +207,8 @@ private:
     bool detect_sdpa_fwd_impl() const;
     // check whether the graph is a sdpa backpropagation implementation.
     bool detect_sdpa_bwd_impl() const;
+    // check whether the graph is gated mlp implementation.
+    bool detect_gmlp_impl() const;
 };
 std::ostream &operator<<(std::ostream &s, const deserialized_graph_t &dg);
 

--- a/tests/benchdnn/graph/deserialize.hpp
+++ b/tests/benchdnn/graph/deserialize.hpp
@@ -105,6 +105,8 @@ struct deserialized_op_t {
 
     // Returns `true` if `deserialized_op_t` wasn't created.
     bool empty() const { return kind_.empty(); }
+
+    static const deserialized_op_t &dummy();
 };
 std::ostream &operator<<(std::ostream &s, const deserialized_op_t &dop);
 

--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -454,6 +454,44 @@ partition_data_displacer_t::partition_data_displacer_t(
                             aop, 1, *aop_in_lt, filling_type_t::softmax_stats});
             break;
         }
+
+        // Fill proper data for gated MLP shared activations.
+        while (aop.kind_ == "MatMul") {
+            if (dg.get_recognized_pattern() != graph_recognized_pattern_t::gmlp)
+                break;
+
+            // Bold assumption that first in_lts is shared.
+            // TODO: query the index from dg, maybe?
+            auto *aop_in_lt = &aop.in_lts_[0];
+
+            // Don't update Down MatMul.
+            auto *parent_op = &dg_->get_op_by_out_lt(aop_in_lt->id_);
+            if (!parent_op->empty()) break;
+
+            // Don't submit another displacer for same input.
+            if (displace_args_.find(aop_in_lt->id_) != displace_args_.end())
+                break;
+
+            // Fill activations very-very sparsely with small pow-2 values:
+            // (2^-12 ... 2^-14). The rationale is keep MatMul output values
+            // small in absolute value to avoid Multiply output values severely
+            // increase since it can be a square value of a MatMul output. This
+            // might happen because weights will be filled identically as they
+            // have identical shape, activations are shared between Gate and Up,
+            // unary activation (GeLU, etc.) may keep positive value as is.
+            static const std::vector<float> user_set {
+                    1.f / 4096.f, 1.f / 8192.f, 1.f / 16384.f};
+            // Use roughly 3 non-zero elements per K dim.
+            const auto &shape = aop_in_lt->shape_;
+            const auto K = shape[shape.size() - 1];
+            const float density = 3.f / K;
+            displace_args_.emplace(aop_in_lt->id_,
+                    displace_args_t {aop, 0, *aop_in_lt,
+                            filling_type_t::fixed_setting,
+                            {user_set, density,
+                                    "GMLP MatMul Activation displacer"}});
+            break;
+        }
     }
 }
 
@@ -798,8 +836,14 @@ int partition_data_displacer_t::gen_fixed_set_filling(dnn_mem_t &mem,
         int_seed.discard(1);
 
         std::uniform_int_distribution<> gen(0, n_vals - 1);
+        std::bernoulli_distribution b_dist(fill_cfg.density_);
 
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
+            bool is_one = fill_cfg.density_ == 1.f ? true : b_dist(int_seed);
+            if (!is_one) {
+                m.set_elem(idx, 0.f);
+                continue;
+            }
             const float val = vals[gen(int_seed)];
             m.set_elem(idx, val);
         }

--- a/tests/benchdnn/graph/input_displacer.hpp
+++ b/tests/benchdnn/graph/input_displacer.hpp
@@ -50,9 +50,10 @@ public:
 
     deserialized_op_t main_op_;
     size_t main_op_offset_;
-    //the tensor as a displace starting point
+    // The tensor as a displace starting point
     deserialized_lt_t tensor_;
     filling_type_t filling_type_;
+    // Mandatory config for a `filling_type_t::fixed_setting`.
     fill_cfg_t fill_cfg_;
 };
 

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -278,27 +278,17 @@ void ref_partition_t::exec_ops(res_t *res) {
                 && (!has_child_op(op, &child_op)
                         || child_op->kind_ == "ReduceSum");
 
-        // For gated-MLP, it is complicated - the Swish op is decomposed into
-        // Sigmoid and Multiply which has inputs from MatMul0 and Sigmoid. Its
-        // output is passed to another Multiply which is the target for the
-        // reorder, both input and output (since its input is down-converted
-        // by MatMul0, and its output would be a down-converted output of
-        // MatMul1). The variable below carefully checks which Multiply it is
-        // there - Swish's one or not.
-        const bool is_child_multiply
+        // gMLP can have two Multiply ops - one as a part of SwigLU, the other
+        // is a Gate-Up connection, which is a target of reorder through a
+        // potential TypeCast after it.
+        const bool is_multiply_in_gmlp_pattern
                 = ref_prim->get_kind() == dnnl::graph::op::kind::Multiply
-                && has_parent_op(op, /* check_all_in_lts */ true);
-        bool is_multiply_in_gated_mlp_pattern = false;
-        if (is_child_multiply && op.in_lts_.size() == 2) {
-            const auto &parent0 = get_parent_op(op.in_lts_[0].id_)->kind_;
-            const auto &parent1 = get_parent_op(op.in_lts_[1].id_)->kind_;
-            is_multiply_in_gated_mlp_pattern
-                    = (parent0 == "MatMul" && parent1 == "Multiply")
-                    || (parent0 == "Multiply" && parent1 == "MatMul");
-        }
+                && dg_->get_recognized_pattern()
+                        == graph_recognized_pattern_t::gmlp
+                && has_child_op(op, &child_op) && child_op->kind_ == "MatMul";
 
         if (is_softmax_in_sdpa_pattern || is_matmul_in_sdpa_bwd_pattern
-                || is_multiply_in_gated_mlp_pattern) {
+                || is_multiply_in_gmlp_pattern) {
             for (size_t i = 0; i < op.in_lts_.size(); i++) {
                 const auto dt = ref_prim->get_lt_dt(op.in_lts_[i].id_);
                 // There's no need to reorder data for f32 tensors.
@@ -306,7 +296,7 @@ void ref_partition_t::exec_ops(res_t *res) {
 
                 // MLP pattern requires reorder only for an input coming from
                 // MatMul0 directly, not from Swish.
-                if (is_multiply_in_gated_mlp_pattern) {
+                if (is_multiply_in_gmlp_pattern) {
                     const auto parent_op = get_parent_op(op.in_lts_[i].id_);
                     if (!parent_op) continue;
                     if (parent_op->kind_ != "MatMul") continue;
@@ -330,7 +320,7 @@ void ref_partition_t::exec_ops(res_t *res) {
         // A data type to where transform the data will also be provided by the
         // same function since there are corner cases.
         if (is_softmax_in_sdpa_pattern || is_matmul_in_sdpa_bwd_pattern
-                || is_multiply_in_gated_mlp_pattern) {
+                || is_multiply_in_gmlp_pattern) {
             for (size_t i = 0; i < op.out_lts_.size(); i++) {
                 dnnl_data_type_t dt = dnnl_data_type_undef;
                 if (!need_unfusable_output_crop(op, i, dt)) continue;

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -364,6 +364,39 @@ dnnl::graph::op::kind opstr2kind(const std::string &kind) {
     return dnnl::graph::op::kind::LastSymbol;
 }
 
+// The list of operations considered Unary from documentation point of view.
+//
+// Note: this list is disconnected from the rest of driver internals.
+// TODO: come up with a single struct and provide different converters and
+// getters.
+bool is_unary(const std::string &kind) {
+    return is_unary(opstr2kind(kind));
+}
+bool is_unary(dnnl::graph::op::kind akind) {
+    using namespace dnnl::graph;
+    static const std::vector<op::kind> unary_ops {
+            op::kind::Abs,
+            op::kind::Clamp,
+            op::kind::Elu,
+            op::kind::Exp,
+            op::kind::GELU,
+            op::kind::HardSigmoid,
+            op::kind::HardSwish,
+            op::kind::LeakyReLU,
+            op::kind::Log,
+            op::kind::Mish,
+            op::kind::ReLU,
+            op::kind::Round,
+            op::kind::Sigmoid,
+            op::kind::SoftPlus,
+            op::kind::Sqrt,
+            op::kind::Square,
+            op::kind::Tanh,
+    };
+    return std::any_of(unary_ops.begin(), unary_ops.end(),
+            [akind](dnnl::graph::op::kind _kind) { return _kind == akind; });
+}
+
 dnnl::graph::op::attr attrstr2kind(const std::string &attr_name) {
     const std::unordered_map<std::string, dnnl::graph::op::attr> attr_map = {
             // float32 attributes. The value of these attributes can be any single

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -81,6 +81,7 @@ enum class graph_recognized_pattern_t {
     ordinary,
     sdpa_fwd,
     sdpa_bwd,
+    gmlp,
 };
 
 extern bdnn_state_t convert_state(const dnnl_status_t &s);

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -143,6 +143,8 @@ int measure_perf(timer::timer_t &t,
         res_t *res);
 
 dnnl::graph::op::kind opstr2kind(const std::string &kind);
+bool is_unary(const std::string &kind);
+bool is_unary(dnnl::graph::op::kind akind);
 dnnl::graph::op::attr attrstr2kind(const std::string &attr_name);
 const std::string &attrstr2type(const std::string &attr_name);
 

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mlp_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mlp_ci
@@ -1,9 +1,14 @@
 --reset --case=complex_fusion/mlp/gated-mlp-f16-f32.json
+--reset --op-attrs=8:mode:gelu_tanh,8:mode:gelu_erf --case=complex_fusion/mlp/gated-mlp-gelu-f16-f32.json
+
 --reset --dt=0:bf16+1:bf16+4:bf16+14:bf16+15:bf16+16:bf16 --case=complex_fusion/mlp/gated-mlp-f16-f32.json
+--reset --dt=0:bf16+1:bf16+4:bf16+12:bf16+13:bf16+14:bf16 --op-attrs=8:mode:gelu_tanh,8:mode:gelu_erf --case=complex_fusion/mlp/gated-mlp-gelu-f16-f32.json
+
 
 # WA1: use smaller problem to pass correctness check for f32 on pvc.
 # WA2: use subtract binary to avoid precision issue for f32 on xe-lpg.
 --reset --in-shapes=0:1x128+1:128x256+4:128x256+13:256x128 --op-kind=12:Subtract --case=complex_fusion/mlp/gated-mlp-f32.json
+--reset --op-attrs=8:mode:gelu_tanh,8:mode:gelu_erf --case=complex_fusion/mlp/gated-mlp-gelu-f32.json
 
 # f16-int4 case
 --reset --case=complex_fusion/mlp/gated-mlp-int4.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/mlp/gated-mlp-gelu-f16-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mlp/gated-mlp-gelu-f16-f32.json
@@ -1,0 +1,351 @@
+{
+  "version": "3.13.0",
+  "engine_kind": "cpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    1,
+    0,
+    4,
+    13
+  ],
+  "output_ports": [
+    14
+  ],
+  "graph": [
+    {
+      "id": 3,
+      "name": "fc_gate",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "f16",
+          "shape": [
+            1,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 1,
+          "dtype": "f16",
+          "shape": [
+            4096,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 2,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "name": "gelu_erf",
+      "kind": "GELU",
+      "attrs": {
+        "mode": {
+          "type": "string",
+          "value": "gelu_erf"
+        }
+      },
+      "inputs": [
+        {
+          "id": 2,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "fc_up",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "f16",
+          "shape": [
+            1,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 4,
+          "dtype": "f16",
+          "shape": [
+            4096,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "name": "mul",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "name": "typecast",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 12,
+          "dtype": "f16",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "name": "fc_down",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 12,
+          "dtype": "f16",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 13,
+          "dtype": "f16",
+          "shape": [
+            14336,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 14,
+          "dtype": "f16",
+          "shape": [
+            1,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/benchdnn/inputs/graph/complex_fusion/mlp/gated-mlp-gelu-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mlp/gated-mlp-gelu-f32.json
@@ -1,0 +1,313 @@
+{
+  "version": "3.13.0",
+  "engine_kind": "cpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    1,
+    0,
+    4,
+    12
+  ],
+  "output_ports": [
+    13
+  ],
+  "graph": [
+    {
+      "id": 3,
+      "name": "fc_gate",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "f32",
+          "shape": [
+            1,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 1,
+          "dtype": "f32",
+          "shape": [
+            4096,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 2,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "name": "gelu_erf",
+      "kind": "GELU",
+      "attrs": {
+        "mode": {
+          "type": "string",
+          "value": "gelu_erf"
+        }
+      },
+      "inputs": [
+        {
+          "id": 2,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "fc_up",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "f32",
+          "shape": [
+            1,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 4,
+          "dtype": "f32",
+          "shape": [
+            4096,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "name": "mul",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "name": "fc_down",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            1,
+            14336
+          ],
+          "stride": [
+            14336,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 12,
+          "dtype": "f32",
+          "shape": [
+            14336,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 13,
+          "dtype": "f32",
+          "shape": [
+            1,
+            4096
+          ],
+          "stride": [
+            4096,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -214,7 +214,10 @@ int compare_t::compare_norm(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
 
     const bool dump = need_dump || !ok;
     if (dump) {
-        dump_p2p_errors();
+        if (!need_dump) {
+            // Forced dump was printed in p2p.
+            dump_p2p_errors();
+        }
         dump_norm_values(diff_norm, get_kind_str());
     }
 
@@ -556,7 +559,7 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
         // If norm fallback is allowed, these dumps will be printed there.
         // This is done to avoid an output disturbance if p2p check fails but
         // norm passes.
-        if (!allow_norm_check_) dump_p2p_errors();
+        if (need_dump || !allow_norm_check_) dump_p2p_errors();
     }
 
     // Set state to FAILED in case of any errors.
@@ -611,8 +614,8 @@ int compare_t::compare(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
     BENCHDNN_PRINT(6, "[COMPARE]%s: zero_trust%%=%.2f%% extra=%s\n",
             get_kind_str().c_str(), zero_trust_percent_, add_args.c_str());
     auto st = compare_p2p(exp_mem, got_mem, attr, res);
-    if (st != OK) {
-        bool call_norm_check = allow_norm_check_;
+    if (st != OK && allow_norm_check_) {
+        bool call_norm_check = true;
         // Note: the following code specifies additional driver's individual
         // desires when to enable norm check. This one purely depends on the
         // result of p2p comparison. So far graph is the only driver needing
@@ -632,12 +635,16 @@ int compare_t::compare(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
                     norm_check_allowed ? "allowed" : "prohibited", res->errors,
                     res->total, allowed_error_points, res->total);
 
-            call_norm_check = call_norm_check && norm_check_allowed;
+            call_norm_check = norm_check_allowed;
         }
 
         if (call_norm_check) {
             res->reset_stats(EXECUTED);
             st = compare_norm(exp_mem, got_mem, attr, res);
+        } else {
+            // Can be triggered by graph only if output wasn't requested.
+            const bool need_dump = verbose >= 99;
+            if (!need_dump) dump_p2p_errors();
         }
     }
     return st;

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -31,6 +31,7 @@ fill_cfg_t::fill_cfg_t(dnnl_data_type_t dt, float range_min_val,
     : dt_(dt)
     , range_min_val_(MAX2(lowest_dt(dt_), range_min_val))
     , range_max_val_(MIN2(max_dt(dt_), range_max_val))
+    , density_(1.f)
     , only_integer_(is_integral_dt(dt_) || only_integer)
     , name_(name) {
     if (alg == attr_t::post_ops_t::kind_t::SUB) {
@@ -54,10 +55,15 @@ fill_cfg_t::fill_cfg_t(dnnl_data_type_t dt, float range_min_val,
 
 fill_cfg_t::fill_cfg_t(
         const std::vector<float> &user_set, const std::string &name)
+    : fill_cfg_t(user_set, 1.f, name) {}
+
+fill_cfg_t::fill_cfg_t(const std::vector<float> &user_set, float density,
+        const std::string &name)
     : dt_(dnnl_data_type_undef)
     , range_min_val_(-FLT_MAX)
     , range_max_val_(FLT_MAX)
     , predefined_set_(user_set)
+    , density_(density)
     , only_integer_(false)
     , name_(name) {
     assert(!predefined_set_.empty());
@@ -81,6 +87,8 @@ std::string fill_cfg_t::print_verbose() const {
         ss << " range:[" << range_min_val_ << ";" << range_max_val_ << "]";
         if (only_integer_) ss << " only_integer:true";
     }
+
+    if (density_ < 1.f) { ss << " density:" << density_; }
 
     return ss.str();
 }
@@ -223,6 +231,8 @@ int fill_random_real_dense(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
 
     // This function doesn't handle the predefined set yet.
     assert(fill_cfg.predefined_set_.empty());
+    // This function doesn't handle density yet.
+    assert(fill_cfg.density_ == 1.f);
 
     // The `nelems()` function returns a product of dims/pdims regardless of
     // whether the tensor is dense or sparse (this is by design). Because of

--- a/tests/benchdnn/utils/fill.hpp
+++ b/tests/benchdnn/utils/fill.hpp
@@ -33,7 +33,8 @@
 // potential floating-point issues. E.g., `sub` algorithm will inverse the range
 // borders to act like `add`, which allows to keep output data positive.
 //
-// Note: keep members public for better flexibility on modifying configs.
+// Note: members are exposed as public for higher flexibility on modifying
+// configs.
 //
 struct fill_cfg_t {
     fill_cfg_t()
@@ -41,12 +42,16 @@ struct fill_cfg_t {
         , range_min_val_(-16.f)
         , range_max_val_(16.f)
         , predefined_set_({})
+        , density_(1.f)
         , only_integer_(false) {}
 
     fill_cfg_t(dnnl_data_type_t dt, float range_min_val, float range_max_val,
             bool only_integer, attr_t::post_ops_t::kind_t alg,
             const std::string &name);
+
     fill_cfg_t(const std::vector<float> &user_set, const std::string &name);
+    fill_cfg_t(const std::vector<float> &user_set, float density,
+            const std::string &name);
 
     std::string print_verbose() const;
 
@@ -62,6 +67,11 @@ struct fill_cfg_t {
     //
     // Helpful to generate pow2 filling, by passing {2.f, 4.f, ...};
     std::vector<float> predefined_set_;
+    // Specify density as a value from [0.f; 1.f] range, where 0.f means
+    // completely sparse (all zeros), and 1.f means completely dense.
+    //
+    // Works in pair with `predefined_set_`.
+    float density_;
     // A flag to generate only integer values.
     bool only_integer_;
     // Config name for verbosity.


### PR DESCRIPTION
The original cases use swish activation which is decomposed into sigmoid + multiply in the graph and json files. We cannot simply use benchdnn rewrite options in command line to test gelu activation. Thus, this PR adds two additional json files. `--op-attrs` is used to test different gelu approximation modes.