### PR TITLE
ci, build, docs: aarch64: bump ComputeLibrary version to 52.7.0

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "acl": "v52.4.0",
+        "acl": "v52.7.0",
         "gcc": "13",
         "clang": "17",
         "onednn-base": "v3.11"

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ On a CPU based on Arm AArch64 architecture, oneDNN CPU engine can be built with
 machine learning applications and provides AArch64 optimized implementations
 of core functions. This functionality currently requires that ACL is downloaded
 and built separately. See [Build from Source] section of the Developer Guide for
-details. The minimum supported version of ACL is 52.4.0.
+details. The minimum supported version of ACL is 52.7.0.
 
 [Arm Compute Library (ACL)]: https://github.com/arm-software/ComputeLibrary
 

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -1,5 +1,5 @@
 # ******************************************************************************
-# Copyright 2020-2025 Arm Limited and affiliates.
+# Copyright 2020-2026 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ find_package(ACL REQUIRED)
 
 # Required. The minimum compatible major-version as per Semantic Versioning.
 set(ACL_MIN_MAJOR_VERSION "52")
-set(ACL_MIN_MINOR_VERSION "4")
+set(ACL_MIN_MINOR_VERSION "7")
 set(ACL_MIN_VERSION "${ACL_MIN_MAJOR_VERSION}.${ACL_MIN_MINOR_VERSION}")
 
 # Optional. Maximum known compatible version if any.


### PR DESCRIPTION
# Description
This version is [needed to improve SME feature detection](https://github.com/ARM-software/ComputeLibrary/pull/1204). Motivated by [interest in adding SME kernels](https://github.com/uxlfoundation/oneDNN/pull/4691) to the project.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
