### PR TITLE
MFDNN-14690: Replace XE3P_35_10/11/UNKNOWN Core enum values with Xe3p

### DIFF
--- a/src/gpu/intel/bnorm/model.cpp
+++ b/src/gpu/intel/bnorm/model.cpp
@@ -95,7 +95,8 @@ void init_hw_params(hw_params_t &hw_params, impl::engine_t *engine) {
             = intel_engine->device_info()->max_wg_size(large_grf_mode);
     hw_params.eus_per_ss = intel_engine->device_info()->max_eus_per_wg();
     hw_params.max_ss = div_up(hw_params.eu_count, hw_params.eus_per_ss);
-    hw_params.max_slm_size = compute::device_info_t::max_slm_size(gpu_arch);
+    hw_params.max_slm_size = compute::device_info_t::max_slm_size(
+            intel_engine->device_info()->gpu_product());
     hw_params.engine = engine;
 
     // Experimentally selected, based on microbenchmarks results

--- a/src/gpu/intel/bnorm/nhwc.cpp
+++ b/src/gpu/intel/bnorm/nhwc.cpp
@@ -55,8 +55,8 @@ static void adjust_lws_calc_kernel(int ic_block, nhwc_params_t &conf,
     auto max_lws = intel_engine->device_info()->max_wg_size(large_grf_mode);
     auto eus_per_ss = intel_engine->device_info()->max_eus_per_wg();
     const int max_ss = div_up(eu_count, eus_per_ss);
-    auto gpu_arch = intel_engine->device_info()->gpu_arch();
-    const int max_slm_size = compute::device_info_t::max_slm_size(gpu_arch);
+    const int max_slm_size = compute::device_info_t::max_slm_size(
+            intel_engine->device_info()->gpu_product());
 
     auto generated_nd = dispatch.nd_range();
     const compute::range_t &base_gws = generated_nd.global_range();

--- a/src/gpu/intel/bnorm/xe.cpp
+++ b/src/gpu/intel/bnorm/xe.cpp
@@ -66,8 +66,8 @@ static void adjust_lws_calc_kernel(lookup_table::params_t &conf,
     auto eus_per_ss = intel_engine->device_info()->max_eus_per_wg();
     const int max_ss = div_up(eu_count, eus_per_ss);
 
-    auto gpu_arch = intel_engine->device_info()->gpu_arch();
-    const int max_slm_size = compute::device_info_t::max_slm_size(gpu_arch);
+    const int max_slm_size = compute::device_info_t::max_slm_size(
+            intel_engine->device_info()->gpu_product());
     auto generated_nd = dispatch.nd_range();
     const compute::range_t &base_gws = generated_nd.global_range();
     const compute::range_t &base_lws = generated_nd.local_range();

--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -45,9 +45,7 @@ uint64_t get_future_extensions(
         case gpu_arch_t::xe2:
         case gpu_arch_t::xe_hpc:
         case gpu_arch_t::xe3:
-        case gpu_arch_t::xe3p_35_10:
-        case gpu_arch_t::xe3p_35_11:
-        case gpu_arch_t::xe3p_35_unknown:
+        case gpu_arch_t::xe3p:
             extensions |= (uint64_t)device_ext_t::intel_global_float_atomics;
             extensions
                     |= (uint64_t)device_ext_t::intel_variable_eu_thread_count;
@@ -88,6 +86,12 @@ status_t device_info_t::init(
     }
 
     return status::success;
+}
+
+const ngen::Product &device_info_t::ngen_product(gpu_product_t &product) {
+    static_assert(sizeof(ngen::Product) == sizeof(compute::gpu_product_t),
+            "Can't cast gpu_product_t to ngen::Product");
+    return reinterpret_cast<const ngen::Product &>(product);
 }
 
 ngen::HW device_info_t::ngen_hw() const {
@@ -138,9 +142,7 @@ bool device_info_t::mayiuse_sub_group(int size) const {
         case gpu_arch_t::xe_hpc:
         case gpu_arch_t::xe2:
         case gpu_arch_t::xe3:
-        case gpu_arch_t::xe3p_35_10:
-        case gpu_arch_t::xe3p_35_11:
-        case gpu_arch_t::xe3p_35_unknown: return utils::one_of(size, 16, 32);
+        case gpu_arch_t::xe3p: return utils::one_of(size, 16, 32);
         default: return utils::one_of(size, 32);
     }
 }
@@ -177,9 +179,7 @@ int device_info_t::max_eus_per_wg(gpu_arch_t gpu_arch) {
     switch (gpu_arch) {
         case gpu::intel::compute::gpu_arch_t::xe_hpc:
         case gpu::intel::compute::gpu_arch_t::xe2:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_10:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_11:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_unknown:
+        case gpu::intel::compute::gpu_arch_t::xe3p:
         case gpu::intel::compute::gpu_arch_t::xe3: return 8;
         case gpu::intel::compute::gpu_arch_t::xe_lp:
         case gpu::intel::compute::gpu_arch_t::xe_hp:
@@ -193,9 +193,7 @@ int device_info_t::max_subgroup_size(gpu_arch_t gpu_arch) {
     switch (gpu_arch) {
         case gpu::intel::compute::gpu_arch_t::xe_hpc:
         case gpu::intel::compute::gpu_arch_t::xe2:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_10:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_11:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_unknown:
+        case gpu::intel::compute::gpu_arch_t::xe3p:
         case gpu::intel::compute::gpu_arch_t::xe3: return 32;
         case gpu::intel::compute::gpu_arch_t::xe_lp:
         case gpu::intel::compute::gpu_arch_t::xe_hp:
@@ -217,9 +215,7 @@ int device_info_t::min_subgroup_size() const {
         case gpu_arch_t::xe_hpg: return 8;
         case gpu_arch_t::xe_hpc:
         case gpu_arch_t::xe2:
-        case gpu_arch_t::xe3p_35_10:
-        case gpu_arch_t::xe3p_35_11:
-        case gpu_arch_t::xe3p_35_unknown:
+        case gpu_arch_t::xe3p:
         case gpu_arch_t::xe3: return 16;
         default: return 0;
     }
@@ -229,9 +225,7 @@ int device_info_t::max_exec_size(gpu_arch_t gpu_arch) {
     switch (gpu_arch) {
         case gpu::intel::compute::gpu_arch_t::xe_hpc:
         case gpu::intel::compute::gpu_arch_t::xe2:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_10:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_11:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_unknown:
+        case gpu::intel::compute::gpu_arch_t::xe3p:
         case gpu::intel::compute::gpu_arch_t::xe3: return 128;
         default: return 64;
     }
@@ -265,9 +259,7 @@ int device_info_t::threads_per_eu(gpu_arch_t gpu_arch, bool large_grf_mode) {
         case gpu::intel::compute::gpu_arch_t::xe_hpg:
         case gpu::intel::compute::gpu_arch_t::xe_hpc:
         case gpu::intel::compute::gpu_arch_t::xe2:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_10:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_11:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_unknown:
+        case gpu::intel::compute::gpu_arch_t::xe3p:
         case gpu::intel::compute::gpu_arch_t::xe3:
             return large_grf_mode ? 4 : 8;
         case gpu::intel::compute::gpu_arch_t::unknown: return 7;
@@ -275,7 +267,9 @@ int device_info_t::threads_per_eu(gpu_arch_t gpu_arch, bool large_grf_mode) {
     return 7;
 }
 
-int device_info_t::max_slm_size(gpu_arch_t gpu_arch) {
+int device_info_t::max_slm_size(gpu_product_t product) {
+    auto family = ngen_product(product).family;
+    auto gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(family));
     int slm_size = 0; // SLM size per SS or DSS.
     switch (gpu_arch) {
         case gpu::intel::compute::gpu_arch_t::xe_lp:
@@ -286,33 +280,34 @@ int device_info_t::max_slm_size(gpu_arch_t gpu_arch) {
         case gpu::intel::compute::gpu_arch_t::xe_hpc:
         case gpu::intel::compute::gpu_arch_t::xe2:
         case gpu::intel::compute::gpu_arch_t::xe3: slm_size = (1 << 17); break;
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_10:
-            slm_size = 196608;
-            break;
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_11:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_unknown:
-            slm_size = 3 * (1 << 17);
+        case gpu::intel::compute::gpu_arch_t::xe3p:
+            slm_size
+                    = (family == ngen::ProductFamily::NVLP) ? 3 << 16 : 3 << 17;
             break;
         case gpu::intel::compute::gpu_arch_t::unknown: assert(!"not expected");
     }
     return slm_size;
 }
 
-int device_info_t::max_slm_size_per_tg(gpu_arch_t gpu_arch) {
+int device_info_t::max_slm_size_per_tg(gpu_product_t product) {
+    auto gpu_arch = jit::convert_ngen_arch_to_dnnl(
+            ngen::getCore(ngen_product(product).family));
     switch (gpu_arch) {
         case gpu::intel::compute::gpu_arch_t::xe_hp:
         case gpu::intel::compute::gpu_arch_t::xe_hpg: return (1 << 16);
-        default: return max_slm_size(gpu_arch);
+        default: return max_slm_size(product);
     }
 }
 
 int device_info_t::max_slm_size_per_tg(
-        gpu_arch_t gpu_arch, int tg_size, bool large_grf_mode) {
+        int tg_size, bool large_grf_mode, gpu_product_t product) {
+    auto gpu_arch = jit::convert_ngen_arch_to_dnnl(
+            ngen::getCore(ngen_product(product).family));
     int eus_per_ss = max_eus_per_wg(gpu_arch);
     int tgs_per_ss
             = eus_per_ss * threads_per_eu(gpu_arch, large_grf_mode) / tg_size;
-    int slm_per_tg = max_slm_size(gpu_arch) / tgs_per_ss;
-    return std::min(max_slm_size_per_tg(gpu_arch), slm_per_tg);
+    int slm_per_tg = max_slm_size(product) / tgs_per_ss;
+    return std::min(max_slm_size_per_tg(product), slm_per_tg);
 }
 
 size_t device_info_t::icache_size() const {
@@ -323,9 +318,7 @@ size_t device_info_t::icache_size() const {
         case gpu::intel::compute::gpu_arch_t::xe_hpc: return 80 * 1024;
         case gpu::intel::compute::gpu_arch_t::xe2: return 96 * 1024;
         case gpu::intel::compute::gpu_arch_t::xe3: return 96 * 1024;
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_10:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_11:
-        case gpu::intel::compute::gpu_arch_t::xe3p_35_unknown: return 80 * 1024;
+        case gpu::intel::compute::gpu_arch_t::xe3p: return 80 * 1024;
         case gpu::intel::compute::gpu_arch_t::unknown: assert(!"not expected");
     }
     return 0;

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -30,10 +30,13 @@
 
 #include "oneapi/dnnl/dnnl_config.h"
 
+// NOLINTBEGIN(readability-identifier-naming)
 namespace ngen {
 enum class Core;
 using HW = Core;
+struct Product;
 } // namespace ngen
+// NOLINTEND(readability-identifier-naming)
 
 namespace dnnl {
 namespace impl {
@@ -49,9 +52,7 @@ enum class gpu_arch_t {
     xe_hpc,
     xe2,
     xe3,
-    xe3p_35_10,
-    xe3p_35_11,
-    xe3p_35_unknown,
+    xe3p,
 };
 
 // Memory for storing ngen::Product to avoid directly including nGEN because of
@@ -69,9 +70,7 @@ static inline const char *to_string(gpu_arch_t arch) {
     CASE(xe_hpc);
     CASE(xe2);
     CASE(xe3);
-    CASE(xe3p_35_10);
-    CASE(xe3p_35_11);
-    CASE(xe3p_35_unknown);
+    CASE(xe3p);
     return "unknown";
 #undef CASE
 }
@@ -85,9 +84,7 @@ static inline gpu_arch_t str2gpu_arch(const char *str) {
     CASE(xe_hpc);
     CASE(xe2);
     CASE(xe3);
-    CASE(xe3p_35_10);
-    CASE(xe3p_35_11);
-    CASE(xe3p_35_unknown);
+    CASE(xe3p);
     return gpu_arch_t::unknown;
 #undef CASE
 }
@@ -193,6 +190,7 @@ public:
     }
     gpu_arch_t gpu_arch() const { return gpu_arch_; }
     const gpu_product_t &gpu_product() const { return gpu_product_; }
+    static const ngen::Product &ngen_product(gpu_product_t &product);
     ngen::HW ngen_hw() const;
     int stepping_id() const;
     uint64_t native_extensions() const { return native_extensions_; }
@@ -216,10 +214,10 @@ public:
         return hw_threads_[large_grf_mode ? 1 : 0];
     }
     static int threads_per_eu(gpu_arch_t gpu_arch, bool large_grf_mode = false);
-    static int max_slm_size(gpu_arch_t gpu_arch);
-    static int max_slm_size_per_tg(gpu_arch_t gpu_arch);
+    static int max_slm_size(gpu_product_t product);
+    static int max_slm_size_per_tg(gpu_product_t product);
     static int max_slm_size_per_tg(
-            gpu_arch_t gpu_arch, int tg_size, bool large_grf_mode = false);
+            int tg_size, bool large_grf_mode, gpu_product_t product);
     size_t memory_size() const { return memory_size_; }
     size_t l3_cache_size() const { return l3_cache_size_; }
     size_t icache_size() const;

--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -1093,7 +1093,8 @@ status_t init_vec_size(config_t &cfg) {
 
 int default_regs(const config_t &cfg) {
     if (!cfg.hw().large_grf_support()) return 128;
-    if (cfg.hw() == ngen::HW::XE3P_35_11 && cfg.is_dpas_or_dpasw_fma())
+    if (cfg.hw().family() == ngen::ProductFamily::CRI
+            && cfg.is_dpas_or_dpasw_fma())
         return 512;
     if (cfg.is_dpas_or_dpasw_fma()) return 256;
     return 128;

--- a/src/gpu/intel/conv/jit/ir_builder.cpp
+++ b/src/gpu/intel/conv/jit/ir_builder.cpp
@@ -252,7 +252,7 @@ public:
         }
 
         // Assign {Fwd} for dpas when applicable.
-        if (cfg_.hw() > ngen::HW::XE3P_35_10)
+        if (cfg_.hw().family() > ngen::ProductFamily::NVLP)
             x2r_mul_stmt_ = inject_dpas_fwd(x2r_mul_stmt_);
         // Assign {Atomic} for dpas(w) when applicable.
         x2r_mul_stmt_ = inject_dpas_atomic(x2r_mul_stmt_);

--- a/src/gpu/intel/conv/jit/model_bridge.cpp
+++ b/src/gpu/intel/conv/jit/model_bridge.cpp
@@ -59,9 +59,7 @@ hw_t to_hw(ngen::HW hw) {
         case ngen::HW::XeHPC: return hw_t::xehpc;
         case ngen::HW::Xe2: return hw_t::xehpc;
         case ngen::HW::Xe3: return hw_t::xehpc;
-        case ngen::HW::XE3P_35_10:
-        case ngen::HW::XE3P_35_11:
-        case ngen::HW::XE3P_UNKNOWN: return hw_t::xehpc;
+        case ngen::HW::Xe3p: return hw_t::xehpc;
         default: gpu_error_not_expected() << "Unknown HW: " << to_string(hw);
     }
     return hw_t::undef;

--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -1355,8 +1355,9 @@ struct fma_context_t {
         bool is_dpas = is_dp_fma(fma);
         bool is_a = (abc == abc_kind_t::a);
         auto type = (is_a ? a_type : b_type);
-        bool cvt_f16 = ((hw < ngen::HW::XE3P_35_10 && layout.type().is_fp8())
-                || (hw < ngen::HW::XE3P_35_11 && layout.type().is_fp4()));
+        bool cvt_f16 = ((hw < ngen::HW::Xe3p && layout.type().is_fp8())
+                || (hw.family() < ngen::ProductFamily::CRI
+                        && layout.type().is_fp4()));
         int type_size = (cvt_f16 ? 2 : type.size());
         if (is_dpas) {
             int sdepth = 8;
@@ -2046,8 +2047,8 @@ private:
                 plan_.fma.fma_kind, fma_kind_t::dpas, fma_kind_t::dpasw);
         auto k_blk_dpas_aligned
                 = plan_.fma.m_blk == 1 || plan_.fma.k_blk == k_tile;
-        if (cfg_.hw() >= ngen::HW::XE3P_35_10 && is_dpas
-                && plan_.fma.m_blk % 2 != 0 && !k_blk_dpas_aligned)
+        if (cfg_.hw() >= ngen::HW::Xe3p && is_dpas && plan_.fma.m_blk % 2 != 0
+                && !k_blk_dpas_aligned)
             return plan_status_t::invalid_fma_layout;
         set_plan();
         return plan_status_t::success;
@@ -2276,7 +2277,7 @@ private:
         if (!use_prefetch(abc)) return plan_status_t::success;
         auto &tg = cfg_.thread_group_grid();
         auto thr_view = tg_view.split(tg, &grid);
-        if (cfg_.hw() == ngen::HW::XE3P_35_11) {
+        if (cfg_.hw().family() == ngen::ProductFamily::CRI) {
             maybe_extend_prefetch_thread_view_to_256_bytes(thr_view);
         }
         auto params = get_send_params(cfg_.options(), send_op_t::prefetch,

--- a/src/gpu/intel/conv/jit/tiler.cpp
+++ b/src/gpu/intel/conv/jit/tiler.cpp
@@ -765,8 +765,8 @@ private:
         auto &options = cfg_.options();
         dim_t tg_size = ctx.b_tg * ctx.m_tg * ctx.n_tg * ctx.k_tg;
         int max_slm_size = compute::device_info_t::max_slm_size_per_tg(
-                convert_ngen_arch_to_dnnl(cfg_.hw()), into<int>(tg_size),
-                options.regs() > 128);
+                into<int>(tg_size), options.regs() > 128,
+                to_gpu_product(cfg_.hw().product()));
         if (slm_size > max_slm_size) return false;
 
         return true;

--- a/src/gpu/intel/conv/jit/v2/plan.cpp
+++ b/src/gpu/intel/conv/jit/v2/plan.cpp
@@ -840,8 +840,8 @@ private:
                 << "Plan:\n"
                 << plan.str() << "\ncheck_plan: out of registers";
         int slm_bound = compute::device_info_t::max_slm_size_per_tg(
-                convert_ngen_arch_to_dnnl(hw_),
-                into<int>(desc_.thread_group_tile.elems()), desc_.regs > 128);
+                into<int>(desc_.thread_group_tile.elems()), desc_.regs > 128,
+                to_gpu_product(hw_.product()));
         int slm_bytes = plan.slm_usage_bytes();
         gpu_check(slm_bytes <= slm_bound)
                 << "Plan:\n"

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -195,7 +195,7 @@ struct gen_t : public primitive_t {
             // Check GPU architecture.
             bool arch_ok = utils::one_of(arch_, arch_t::xe_lp, arch_t::xe_hp,
                     arch_t::xe_hpg, arch_t::xe_hpc, arch_t::xe2, arch_t::xe3);
-            arch_ok |= (arch_ >= arch_t::xe3p_35_10);
+            arch_ok |= (arch_ >= arch_t::xe3p);
 
             VDISPATCH_GEMM(arch_ok, VERBOSE_UNSUPPORTED_ARCH, "gpu");
             VDISPATCH_GEMM(IMPLICATION(with_binary, arch_ >= arch_t::xe_hp),
@@ -261,7 +261,7 @@ struct gen_t : public primitive_t {
                                    !with_eltwise && !with_binary),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
-            if (arch_ >= arch_t::xe3p_35_10)
+            if (arch_ >= arch_t::xe3p)
                 kernel_desc_.set_efficient_64b(dev_info_->is_efficient_64bit());
 
             bool print_verbose = get_verbose(verbose_t::debuginfo) >= 5;

--- a/src/gpu/intel/gemm/jit/CMakeLists.txt
+++ b/src/gpu/intel/gemm/jit/CMakeLists.txt
@@ -73,22 +73,11 @@ if(DPCPP_HOST_COMPILER_KIND STREQUAL "DEFAULT")
     endif()
 
     foreach(isa ${DNNL_GPU_ISA_LIST})
-        if(${isa} STREQUAL "XE3P")
-            foreach(subvariant 35_10 35_11 UNKNOWN)
-                set(GENERATOR_LIB generatorXE3P_${subvariant})
-                add_library(${GENERATOR_LIB} OBJECT ${GENERATOR_SOURCES})
-                target_compile_definitions(${GENERATOR_LIB} PRIVATE DNNL_GPU_ISA_XE3P)
-                target_compile_definitions(${GENERATOR_LIB} PRIVATE DNNL_GPU_ISA_XE3P_${subvariant})
-                set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
-                                $<TARGET_OBJECTS:${GENERATOR_LIB}>)
-            endforeach()
-        else()
             set(GENERATOR_LIB generator${isa})
             add_library(${GENERATOR_LIB} OBJECT ${GENERATOR_SOURCES})
             target_compile_definitions(${GENERATOR_LIB} PRIVATE DNNL_GPU_ISA_${isa})
             set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
                             $<TARGET_OBJECTS:${GENERATOR_LIB}>)
-        endif()
     endforeach()
 endif()
 

--- a/src/gpu/intel/gemm/jit/dsl/hw.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/hw.cpp
@@ -63,9 +63,7 @@ int hw_t::eus_per_core() const {
         case ngen::HW::XeHPC:
         case ngen::HW::Xe2:
         case ngen::HW::Xe3:
-        case ngen::HW::XE3P_35_10:
-        case ngen::HW::XE3P_35_11:
-        case ngen::HW::XE3P_UNKNOWN: return 8;
+        case ngen::HW::Xe3p: return 8;
         default: gpu_error_not_expected(); return 8;
     }
 }
@@ -78,9 +76,7 @@ int hw_t::threads_per_eu(int regs) const {
         case ngen::HW::XeHPC:
         case ngen::HW::Xe2:
         case ngen::HW::Xe3:
-        case ngen::HW::XE3P_35_10:
-        case ngen::HW::XE3P_35_11:
-        case ngen::HW::XE3P_UNKNOWN: return is_large_grf ? 4 : 8;
+        case ngen::HW::Xe3p: return is_large_grf ? 4 : 8;
         default: gpu_error_not_expected(); return 8;
     }
 }
@@ -93,9 +89,7 @@ int hw_t::cache_line_size() const {
         case ngen::HW::XeHPC:
         case ngen::HW::Xe2:
         case ngen::HW::Xe3:
-        case ngen::HW::XE3P_35_10:
-        case ngen::HW::XE3P_35_11:
-        case ngen::HW::XE3P_UNKNOWN: return 64;
+        case ngen::HW::Xe3p: return 64;
         default: gpu_error_not_expected();
     }
     return 0;

--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/bank_conflict_allocation.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/bank_conflict_allocation.cpp
@@ -82,9 +82,7 @@ struct hw_context_t {
             case ngen::HW::XeHPC:
             case ngen::HW::Xe2:
             case ngen::HW::Xe3:
-            case ngen::HW::XE3P_35_10:
-            case ngen::HW::XE3P_35_11:
-            case ngen::HW::XE3P_UNKNOWN: return 16;
+            case ngen::HW::Xe3p: return 16;
             default: gpu_error_not_expected();
         }
         return -1;

--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/codegen.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/codegen.cpp
@@ -825,9 +825,7 @@ private:
 
 bool is_src1_ok(ngen::HW hw, const ngen_operand_t &dst,
         const ngen_operand_t &src0, const ngen_operand_t &src1) {
-    if (one_of(hw,
-                {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                        ngen::HW::XE3P_UNKNOWN})) {
+    if (hw == ngen::HW::Xe3p) {
         if (!src1.is_reg_data()) return true;
         auto src1_rd = src1.reg_data();
         if (src1_rd.isScalar()) return true;
@@ -871,8 +869,7 @@ public:
                             bind.reg_data(), 0);
                 } else {
                     const auto grf_size = ngen::GRF::bytes(hw());
-                    if (hw() >= ngen::HW::XE3P_35_10
-                            && bind.is_reg_buf_data()) {
+                    if (hw() >= ngen::HW::Xe3p && bind.is_reg_buf_data()) {
                         auto mod = dst_operand.mod();
                         auto dst = dst_operand.reg_data();
                         auto src = bind.reg_data();
@@ -1612,10 +1609,7 @@ private:
         auto t = tmp.format(0, obj.elems(), 1, w_type);
         reg_buf_data_t t_strided;
         bool align_with_dst = false;
-        if (one_of(hw(),
-                    {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                            ngen::HW::XE3P_UNKNOWN}))
-            align_with_dst = true;
+        if (hw() == ngen::HW::Xe3p) align_with_dst = true;
         if (align_with_dst) {
             int w_stride = dst_stride * (ngen::getBytes(dst.type()) / w_size);
             int tmp_strided_regs
@@ -1714,10 +1708,7 @@ ngen::NEOInterfaceHandler generate_ngen_interface(
     if (setup_flags.has_dpas || options.require_dpas()) interface.requireDPAS();
     if (setup_flags.has_send_atomics) interface.requireGlobalAtomics();
 
-    if (one_of(options.hw(),
-                {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                        ngen::HW::XE3P_UNKNOWN})
-            && !options.hw().efficient_64_bit())
+    if (options.hw() == ngen::HW::Xe3p && !options.hw().efficient_64_bit())
         interface.setEfficient64Bit(false);
 
     for (size_t i = 0; i < kernel_iface.nargs(); i++) {
@@ -1795,9 +1786,7 @@ ngen::NEOInterfaceHandler generate_ngen_interface(
         GEMMSTONE_XEHPC_ISA(GPU_HW_CASE_(XeHPC)); \
         GEMMSTONE_XE2_ISA(GPU_HW_CASE_(Xe2)); \
         GEMMSTONE_XE3_ISA(GPU_HW_CASE_(Xe3)); \
-        GEMMSTONE_XE3P_ISA(GPU_HW_CASE_(XE3P_35_10)); \
-        GEMMSTONE_XE3P_ISA(GPU_HW_CASE_(XE3P_35_11)); \
-        GEMMSTONE_XE3P_ISA(GPU_HW_CASE_(XE3P_UNKNOWN)); \
+        GEMMSTONE_XE3P_ISA(GPU_HW_CASE_(Xe3p)); \
         default: dsl_assert(false) << "Unexpected GPU architecture"; \
     }
 
@@ -1871,18 +1860,9 @@ GEMMSTONE_XE3_ISA(
                 const stmt_t &body, sycl_gen_t<ngen::HW::Xe3> &host,
                 const walk_order_t *kernel_grid_walk_order));
 GEMMSTONE_XE3P_ISA(
-        template void ir::convert_ir_to_ngen<sycl_gen_t<ngen::HW::XE3P_35_10>>(
-                const stmt_t &body, sycl_gen_t<ngen::HW::XE3P_35_10> &host,
+        template void ir::convert_ir_to_ngen<sycl_gen_t<ngen::HW::Xe3p>>(
+                const stmt_t &body, sycl_gen_t<ngen::HW::Xe3p> &host,
                 const walk_order_t *kernel_grid_walk_order));
-GEMMSTONE_XE3P_ISA(
-        template void ir::convert_ir_to_ngen<sycl_gen_t<ngen::HW::XE3P_35_11>>(
-                const stmt_t &body, sycl_gen_t<ngen::HW::XE3P_35_11> &host,
-                const walk_order_t *kernel_grid_walk_order));
-GEMMSTONE_XE3P_ISA(template void
-                ir::convert_ir_to_ngen<sycl_gen_t<ngen::HW::XE3P_UNKNOWN>>(
-                        const stmt_t &body,
-                        sycl_gen_t<ngen::HW::XE3P_UNKNOWN> &host,
-                        const walk_order_t *kernel_grid_walk_order));
 
 ::sycl::kernel make_kernel(
         const kernel_t &ir_kernel, ::sycl::context ctx, ::sycl::device dev) {
@@ -1935,16 +1915,8 @@ GEMMSTONE_XE3_ISA(
                 const stmt_t &body, ocl_gen_t<ngen::HW::Xe3> &host,
                 const walk_order_t *kernel_grid_walk_order));
 GEMMSTONE_XE3P_ISA(
-        template void ir::convert_ir_to_ngen<ocl_gen_t<ngen::HW::XE3P_35_10>>(
-                const stmt_t &body, ocl_gen_t<ngen::HW::XE3P_35_10> &host,
-                const walk_order_t *kernel_grid_walk_order));
-GEMMSTONE_XE3P_ISA(
-        template void ir::convert_ir_to_ngen<ocl_gen_t<ngen::HW::XE3P_35_11>>(
-                const stmt_t &body, ocl_gen_t<ngen::HW::XE3P_35_11> &host,
-                const walk_order_t *kernel_grid_walk_order));
-GEMMSTONE_XE3P_ISA(
-        template void ir::convert_ir_to_ngen<ocl_gen_t<ngen::HW::XE3P_UNKNOWN>>(
-                const stmt_t &body, ocl_gen_t<ngen::HW::XE3P_UNKNOWN> &host,
+        template void ir::convert_ir_to_ngen<ocl_gen_t<ngen::HW::Xe3p>>(
+                const stmt_t &body, ocl_gen_t<ngen::HW::Xe3p> &host,
                 const walk_order_t *kernel_grid_walk_order));
 
 cl_kernel make_kernel(

--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/kernel.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/kernel.hpp
@@ -900,10 +900,7 @@ public:
 
         // qot = (x * m) >> p
         bool use_mach = true;
-        if (one_of(hw_info(),
-                    {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                            ngen::HW::XE3P_UNKNOWN}))
-            use_mach = false;
+        if (hw_info() == ngen::HW::Xe3p) use_mach = false;
         if (use_mach) {
             auto acc = acc0.retype(div_type);
             mul(1, acc[0], _x, m & 0xFFFF);

--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/reorder.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/reorder.hpp
@@ -140,7 +140,7 @@ void align_src_dst_offset(GeneratorT *host, ngen_register_scope_t &scope,
     auto new_src_type = src.type();
     bool needs_stride_alignment = false;
     bool align_bf = is_bf_to_f && src.hs();
-    if (scope.hw() >= ngen::HW::XE3P_35_10 && (align_stride || align_bf)) {
+    if (scope.hw() >= ngen::HW::Xe3p && (align_stride || align_bf)) {
         auto src_stride_bytes = src.hs() * src_type_size;
         auto dst_stride_bytes = dst.hs() * dst_type_size;
         needs_stride_alignment = (src_stride_bytes != dst_stride_bytes);

--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/send.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/send.hpp
@@ -47,9 +47,7 @@ inline ngen::CacheSettingsLSC get_cache_settings(
                         ret = ngen::CacheSettingsLSC::L1C_L3C;
                     }
                     break;
-                case ngen::HW::XE3P_35_10:
-                case ngen::HW::XE3P_35_11:
-                case ngen::HW::XE3P_UNKNOWN:
+                case ngen::HW::Xe3p:
                     if (is_store) {
                         ret = ngen::CacheSettingsLSC::L1UC_L2UC_L3WB;
                     } else if (is_load || is_prefetch) {
@@ -227,7 +225,7 @@ private:
         } else if (send_.is_a64()) {
             *lsc_spec |= get_cache_settings(send_, host->hw_info());
             if (send_.is_load() || send_.is_prefetch()) {
-                if (host->hw_info() >= ngen::HW::XE3P_35_10)
+                if (host->hw_info() >= ngen::HW::Xe3p)
                     *lsc_spec |= ngen::DataSpecLSC::createOverfetch();
                 host->load.ugm(mod, data, *lsc_spec, host->A64, header);
             } else if (send_.is_store()) {

--- a/src/gpu/intel/gemm/jit/dsl/utils/utils.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/utils/utils.hpp
@@ -158,9 +158,7 @@ inline const name_map_t<ngen::HW> &get_name_map() {
             {ngen::HW::XeHPC, "XeHPC"},
             {ngen::HW::Xe2, "Xe2"},
             {ngen::HW::Xe3, "Xe3"},
-            {ngen::HW::XE3P_35_10, "XE3P_35_10"},
-            {ngen::HW::XE3P_35_11, "XE3P_35_11"},
-            {ngen::HW::XE3P_UNKNOWN, "XE3P_UNKNOWN"},
+            {ngen::HW::Xe3p, "Xe3p"},
     };
     return names;
 }
@@ -181,6 +179,9 @@ inline const name_map_t<ngen::ProductFamily> &get_name_map() {
             {ngen::ProductFamily::PVC, "PVC"},
             {ngen::ProductFamily::GenericXe2, "Xe2"},
             {ngen::ProductFamily::GenericXe3, "Xe3"},
+            {ngen::ProductFamily::GenericXe3p, "Xe3p"},
+            {ngen::ProductFamily::NVLP, "NVLP"},
+            {ngen::ProductFamily::CRI, "CRI"},
     };
     return names;
 }

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -222,8 +222,7 @@ status_t gen_desc_t::finalize(const char *tags) {
             problem_.B.setAlignment(nstl::max<int>(problem_.B.alignment, 16));
     }
 
-    if (utils::one_of(hw_, ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                ngen::HW::XE3P_UNKNOWN)) {
+    if (hw_ == ngen::HW::Xe3p) {
         // Use XeHPC banking if reusing XeHPC strategies (legacy mode)
         if (!efficient_64b_) strategy_.raHW = ngen::HW::XeHPC;
 
@@ -304,7 +303,7 @@ status_t gen_desc_t::finalize(const char *tags) {
     strategy_.relaxedAccumulation |= relaxed_acc_;
     strategy_.systolicAvailable &= !disable_systolic_;
     if (problem_.needsAGroupSums() || problem_.needsBGroupSums())
-        problem_.autoTypeConversions(hw_, strategy_.systolicAvailable);
+        problem_.autoTypeConversions(strategy_.systolicAvailable);
     adjustStrategy(hw_, problem_, strategy_, tags);
     try {
         strategy_.preflight(hw_, problem_);
@@ -318,36 +317,34 @@ status_t gen_desc_t::finalize(const char *tags) {
         if (problem_.bqGroupK % strategy_.bqGroupKGranularity())
             return status::unimplemented;
     if (problem_.aScale2D()
-            && problem_.aqGroupK
-                            % minOuterProductCount(hw_, problem_, strategy_)
+            && problem_.aqGroupK % minOuterProductCount(problem_, strategy_)
                     != 0) {
         if (!problem_.Ta.isF4() || !problem_.Tb.isF4())
             return status::unimplemented;
     }
     if (problem_.bScale2D()
-            && problem_.bqGroupK
-                            % minOuterProductCount(hw_, problem_, strategy_)
+            && problem_.bqGroupK % minOuterProductCount(problem_, strategy_)
                     != 0) {
         if (!problem_.Ta.isF4() || !problem_.Tb.isF4())
             return status::unimplemented;
     }
 
     // TODO: Fix kChain handling with BDPAS.
-    if (problem_.preferBDPAS(hw_)) { strategy_.kChain = 1; }
+    if (problem_.preferBDPAS()) { strategy_.kChain = 1; }
 
     // If the M/N group size is equal to M or N, align up to a multiple of unroll size
     // XXX: Increase group size to a large value before aligning to increase reusability
     // TODO: Refactor M/N groups/thread setting to preserve MN group count.
     constexpr int perMNGroupSize = 1 << 24;
     if (problem_.aqGroupM == m_
-            && ((!problem_.forceGroupSumsA && !problem_.preferBDPAS(hw_))
+            && ((!problem_.forceGroupSumsA && !problem_.preferBDPAS())
                     || m_ > 1)) {
         problem_.aqGroupM = std::max(problem_.aqGroupM, perMNGroupSize);
         problem_.aqGroupM
                 = utils::rnd_up(problem_.aqGroupM, strategy_.unroll[LoopM]);
     }
     if (problem_.bqGroupN == n_
-            && ((!problem_.forceGroupSumsB && !problem_.preferBDPAS(hw_))
+            && ((!problem_.forceGroupSumsB && !problem_.preferBDPAS())
                     || n_ > 1)) {
         problem_.bqGroupN = std::max(problem_.bqGroupN, perMNGroupSize);
         problem_.bqGroupN
@@ -378,9 +375,7 @@ void gen_desc_t::update_driver_info() {
         REG_XEHPC_ISA(ARCH_DISPATCH(XeHPC))
         REG_XE2_ISA(ARCH_DISPATCH(Xe2))
         REG_XE3_ISA(ARCH_DISPATCH(Xe3))
-        REG_XE3P_ISA(ARCH_DISPATCH(XE3P_35_10))
-        REG_XE3P_ISA(ARCH_DISPATCH(XE3P_35_11))
-        REG_XE3P_ISA(ARCH_DISPATCH(XE3P_UNKNOWN))
+        REG_XE3P_ISA(ARCH_DISPATCH(Xe3p))
         default:
             assert(!"Unsupported architecture");
             driver_info_ = entry_->driverInfo;
@@ -411,9 +406,7 @@ gen_nocopy_desc_t::select_kernel(compute::gpu_arch_t arch, int stepping,
     std::vector<MatchParams> match_params;
     MatchParams base(hw_, has_systolic, is_integrated, problem);
     /* Reuse PVC strategies for legacy mode on Xe3p */
-    if (utils::one_of(hw_, ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                ngen::HW::XE3P_UNKNOWN)
-            && !efficient_64b_)
+    if (hw_ == ngen::HW::Xe3p && !efficient_64b_)
         base.selector.hw = kcatalog::HWTagXeHPC;
 
     // By default gemmstone assumes that the accumulation type must be at least
@@ -606,26 +599,29 @@ status_t gen_nocopy_desc_t::finalize() {
     return gen_desc_t::finalize(tags_.c_str());
 }
 
-status_t gen_xe_systolic_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
-        int stepping, int eu_count, bool is_integrated, int batch_dims,
-        bool packed_c, bool trans_co, bool a_offset, bool b_offset,
-        bool c_offset, bool bias, float alpha, float beta, data_type_t a_type,
-        data_type_t b_type, data_type_t c_type, data_type_t ao_type,
-        data_type_t bo_type, data_type_t co_type, data_type_t acc_type, dim_t m,
-        dim_t n, dim_t k, dim_t batch, int unroll_m, int unroll_n, bool alt,
-        gpu_post_ops_t &&post_ops) {
+status_t gen_xe_systolic_kernel_desc_t::select_kernel(
+        compute::gpu_product_t product, int stepping, int eu_count,
+        bool is_integrated, int batch_dims, bool packed_c, bool trans_co,
+        bool a_offset, bool b_offset, bool c_offset, bool bias, float alpha,
+        float beta, data_type_t a_type, data_type_t b_type, data_type_t c_type,
+        data_type_t ao_type, data_type_t bo_type, data_type_t co_type,
+        data_type_t acc_type, dim_t m, dim_t n, dim_t k, dim_t batch,
+        int unroll_m, int unroll_n, bool alt, gpu_post_ops_t &&post_ops) {
     using namespace ngen;
     using namespace kcatalog;
 
-    arch_ = arch;
-    hw_ = convert_dnnl_arch_to_ngen(arch);
+    auto ngen_product = compute::device_info_t::ngen_product(product);
+    hw_ = getCore(ngen_product.family);
+    arch_ = convert_ngen_arch_to_dnnl(hw_);
     stepping_ = stepping;
+    problem_.product = ngen_product;
     m_ = m;
     n_ = n;
     k_ = k;
     eu_count_ = eu_count;
 
-    if (!utils::one_of(hw_, HW::XeHP, HW::XeHPG, HW::XeHPC, HW::Xe2, HW::Xe3))
+    if (!utils::one_of(hw_, HW::XeHP, HW::XeHPG, HW::XeHPC, HW::Xe2, HW::Xe3,
+                HW::Xe3p))
         return status::unimplemented;
 
     bool xehpc = (hw_ >= HW::XeHPC);
@@ -754,9 +750,7 @@ void gen_xe_systolic_kernel_desc_t::choose_unrolls(compute::gpu_arch_t arch,
         case compute::gpu_arch_t::xe_hpc:
         case compute::gpu_arch_t::xe2:
         case compute::gpu_arch_t::xe3:
-        case compute::gpu_arch_t::xe3p_35_10:
-        case compute::gpu_arch_t::xe3p_35_11:
-        case compute::gpu_arch_t::xe3p_35_unknown:
+        case compute::gpu_arch_t::xe3p:
             if (utils::one_of(a_type, f16, bf16)) {
                 if (unroll_m != 0)
                     unroll_n = (unroll_m > 16) ? 32 : 16;
@@ -1021,9 +1015,7 @@ status_t gen_kernel_t::get_kernel(
             REG_XEHPC_ISA(ARCH_DISPATCH(XeHPC))
             REG_XE2_ISA(ARCH_DISPATCH(Xe2))
             REG_XE3_ISA(ARCH_DISPATCH(Xe3))
-            REG_XE3P_ISA(ARCH_DISPATCH(XE3P_35_10))
-            REG_XE3P_ISA(ARCH_DISPATCH(XE3P_35_11))
-            REG_XE3P_ISA(ARCH_DISPATCH(XE3P_UNKNOWN))
+            REG_XE3P_ISA(ARCH_DISPATCH(Xe3p))
             default: assert(!"Unsupported architecture"); break;
         }
     } catch (const ngen::out_of_registers_exception &err) {

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -155,14 +155,14 @@ private:
 };
 
 struct gen_xe_systolic_kernel_desc_t : public gen_desc_t {
-    status_t select_kernel(compute::gpu_arch_t arch, int stepping, int eu_count,
-            bool is_integrated, int batch_dims, bool packed_c, bool trans_co,
-            bool a_offset, bool b_offset, bool c_offset, bool bias, float alpha,
-            float beta, data_type_t a_type, data_type_t b_type,
-            data_type_t c_type, data_type_t ao_type, data_type_t bo_type,
-            data_type_t co_type, data_type_t acc_type, dim_t m, dim_t n,
-            dim_t k, dim_t batch, int unroll_m, int unroll_n, bool alt,
-            gpu_post_ops_t &&post_ops);
+    status_t select_kernel(compute::gpu_product_t product, int stepping,
+            int eu_count, bool is_integrated, int batch_dims, bool packed_c,
+            bool trans_co, bool a_offset, bool b_offset, bool c_offset,
+            bool bias, float alpha, float beta, data_type_t a_type,
+            data_type_t b_type, data_type_t c_type, data_type_t ao_type,
+            data_type_t bo_type, data_type_t co_type, data_type_t acc_type,
+            dim_t m, dim_t n, dim_t k, dim_t batch, int unroll_m, int unroll_n,
+            bool alt, gpu_post_ops_t &&post_ops);
 
     static void choose_unrolls(compute::gpu_arch_t arch, int eu_count,
             data_type_t a_type, data_type_t b_type, data_type_t c_type, dim_t m,

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -202,7 +202,7 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
     auto stepping = hwInfo.gmdid & 0xFF;
 
     bool isIntegrated = getPlatformType(product.family) == PlatformType::Integrated;
-
+    problem.product = product;
     /* Strip internal upconversions */
     auto problemMatch = problem;
     if (problemMatch.Ta_ext.bits() < problemMatch.Ta.bits()) problemMatch.Ta = problemMatch.Ta_ext;
@@ -380,9 +380,7 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
                 REG_XEHPC_ISA(ARCH_DISPATCH(XeHPC))
                 REG_XE2_ISA(ARCH_DISPATCH(Xe2))
                 REG_XE3_ISA(ARCH_DISPATCH(Xe3))
-                REG_XE3P_ISA(ARCH_DISPATCH(XE3P_35_10))
-                REG_XE3P_ISA(ARCH_DISPATCH(XE3P_35_11))
-                REG_XE3P_ISA(ARCH_DISPATCH(XE3P_UNKNOWN))
+                REG_XE3P_ISA(ARCH_DISPATCH(Xe3p))
                 default: throw std::runtime_error("Unsupported architecture");
             }
             #undef ARCH_DISPATCH

--- a/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
@@ -229,7 +229,7 @@ void Generator<hw>::setupAddr(Type T, const GRFRange &addr, const BO &ptr, const
                         eadd(simd2, addr[2].uq(), addr[udStride].ud(0)(udStride), ptrShifted, strategy, state);
                     eadd(simd1, addr[0].uq(), addr[0].ud(0)(udStride), ptrShifted, strategy, state);
                 } else if (ptrShifted != 0) {
-                    if (consecutive > 1 || tblock > 1 || hw >= HW::XE3P_35_10)
+                    if (consecutive > 1 || tblock > 1 || hw >= HW::Xe3p)
                     {
                         mulConstant<uint32_t>(simdSize, addr, iv, stride);
                         add<uint32_t>(simdSize, addr, addr, ptrShifted);

--- a/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
@@ -1686,7 +1686,7 @@ void Generator<hw>::doAlternateCRemainder(COperation op, const GEMMProblem &prob
     bool nonuniformSubs = false;
 
     if (!uniform) {
-        int maxGRFs = (hw == HW::XE3P_35_11 ? 512 : 256);
+        int maxGRFs = GRF::maxRegs(hw);
         std::vector<uint8_t> baseIndices(maxGRFs, 0);
         std::vector<uint16_t> offIndices(maxGRFs, 0);
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/compute_utils.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/compute_utils.hpp
@@ -39,26 +39,26 @@ struct SystolicParams {
     int osys;           // Output vector length
 };
 
-static inline SystolicParams systolicParams(ngen::HW hw, GEMMProblem problem)
+static inline SystolicParams systolicParams(GEMMProblem problem)
 {
-    problem.autoTypeConversions(hw, true);
+    problem.autoTypeConversions(true);
 
     SystolicParams params;
     params.opsPerChan = std::max(1, std::min(4 / problem.Ta.real(), 4 / problem.Tb.real()));
     params.sdepth = 8;
     params.ksys = params.sdepth * params.opsPerChan;
-    params.osys = ngen::GRF::bytes(hw) / std::max(problem.Tc_compute().real().size(), 4);
+    params.osys = ngen::GRF::bytes(ngen::getCore(problem.product.family)) / std::max(problem.Tc_compute().real().size(), 4);
     params.rcountMax = 8;
-    params.rcountMin = problem.preferBDPAS(hw) ? 8 : 0;
+    params.rcountMin = problem.preferBDPAS() ? 8 : 0;
 
     return params;
 }
 
 // Return # of outer products performed at once.
-static inline int minOuterProductCount(ngen::HW hw, const GEMMProblem &problem, const GEMMStrategy &strategy)
+static inline int minOuterProductCount(const GEMMProblem &problem, const GEMMStrategy &strategy)
 {
     if (strategy.systolic) {
-        auto params = systolicParams(hw, problem);
+        auto params = systolicParams(problem);
         return params.ksys;
     }
     int kfma = std::max(strategy.dotVL, 1);
@@ -68,15 +68,15 @@ static inline int minOuterProductCount(ngen::HW hw, const GEMMProblem &problem, 
 }
 
 // Return # of outer products performed at once.
-static inline int outerProductCount(ngen::HW hw, const GEMMProblem &problem, const GEMMStrategy &strategy)
+static inline int outerProductCount(const GEMMProblem &problem, const GEMMStrategy &strategy)
 {
-    return minOuterProductCount(hw, problem, strategy) * strategy.kChain;
+    return minOuterProductCount(problem, strategy) * strategy.kChain;
 }
 
 // Get the A and B crosspacks needed by the kernel. 0 indicates any crosspack is OK.
 static inline std::tuple<int,int> targetKernelCrosspack(ngen::HW hw, const GEMMProblem &problem, const GEMMStrategy &strategy)
 {
-    int opBatch = minOuterProductCount(hw, problem, strategy);
+    int opBatch = minOuterProductCount(problem, strategy);
     bool aColMajor = isRegisterColMajor(problem.Ta, problem.A, strategy.A);
     bool bColMajor = isRegisterColMajor(problem.Tb, problem.B, strategy.B);
     bool cColMajor = isRegisterColMajor(problem.Tc, problem.C, strategy.C);
@@ -99,9 +99,9 @@ static inline std::tuple<int,int> targetKernelCrosspack(ngen::HW hw, const GEMMP
 }
 
 // Get the A and B crosspacks to use for SLM data.
-static inline std::tuple<int,int> targetSLMCrosspack(ngen::HW hw, const GEMMProblem &problem, const GEMMStrategy &strategy)
+static inline std::tuple<int,int> targetSLMCrosspack(const GEMMProblem &problem, const GEMMStrategy &strategy)
 {
-    int opBatch = minOuterProductCount(hw, problem, strategy);
+    int opBatch = minOuterProductCount(problem, strategy);
 
     if (strategy.systolic) {
         bool cColMajor = isRegisterColMajor(problem.Tc, problem.C, strategy.C);
@@ -119,7 +119,7 @@ static inline std::tuple<int,int> targetSLMCrosspack(ngen::HW hw, const GEMMProb
 static inline std::tuple<int,int,int,int> targetKernelTiling(ngen::HW hw, const GEMMProblem &problem, const GEMMStrategy &strategy)
 {
     if (strategy.systolic) {
-        auto params = systolicParams(hw, problem);
+        auto params = systolicParams(problem);
         bool cColMajor = isRegisterColMajor(problem.Tc, problem.C, strategy.C);
         auto tileO_V = params.osys;
         auto tileI_N = params.ksys;

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -733,8 +733,7 @@ void CopyPlan::split2DRegions()
                 continue;
             if (i.flag) stub("Unsupported predication");
             int w = i.src0.width, vs = i.src0.vs, hs = i.src0.stride;
-            bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
-            bool splitH = (w * w >= i.simd || (is_xe3p && i.dst.stride * w >= 8));
+            bool splitH = (w * w >= i.simd || (hw == ngen::HW::Xe3p && i.dst.stride * w >= 8));
             int nsplit = splitH ? (i.simd / w) : w;
             i.simd /= nsplit;
             i.src0.stride = splitH ? hs : vs;
@@ -792,8 +791,7 @@ void CopyPlan::planTypeConversions()
         if (st == dt)
             i.moveToIntegerPipe();
 
-        bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
-        if (is_xe3p && is4(st) && one_of(getBits(dt), {8, 16}))
+        if (hw == ngen::HW::Xe3p && is4(st) && one_of(getBits(dt), {8, 16}))
             if (planShflUpconvertXe3p(i))
                 continue;
 
@@ -1249,8 +1247,7 @@ void CopyPlan::planInt8ToBF(CopyInstruction &i)
         copyThrough(i, DataType::f);
         return;
     }
-    bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
-    if (is_xe3p){
+    if (hw == ngen::HW::Xe3p){
             copyThrough(i, DataType::f);
             return;
     }
@@ -1428,7 +1425,7 @@ void CopyPlan::planInt4Upconversion(CopyInstruction &i)
     if (i.src0.neg || i.hasCMod()) stub("Unsupported modifier");
     i.sat = false;
 
-    if (hw >= HW::XE3P_35_10 && one_of(getBits(i.dst.type), {8, 16}))
+    if (hw >= HW::Xe3p && one_of(getBits(i.dst.type), {8, 16}))
         if (planShflUpconvertXe3p(i))
             return;
 
@@ -1512,9 +1509,8 @@ void CopyPlan::planInt4Upconversion(CopyInstruction &i)
             }
         } else {
             // High nybble
-            bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
             auto tmp = newTemp(i.dst.type, i.simd, i.dst.stride, 1, 0);
-            if(is_xe3p && (i.src0.offset * getBytes(i.src0.type) != i.dst.offset * getBytes(i.dst.type))){
+            if(hw == ngen::HW::Xe3p && (i.src0.offset * getBytes(i.src0.type) != i.dst.offset * getBytes(i.dst.type))){
                 auto ie = splitMultiple<2>(i);
 
                 // High nybble
@@ -2242,7 +2238,7 @@ void CopyPlan::planEmulatedHFToF4(CopyInstruction &i)
         return;
     }
 
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         auto t0 = newTemp(DataType::hf, i.simd/2, 1);
         auto t1 = newTemp(DataType::hf, i.simd/2, 1);
         auto ie = splitMultiple<5>(i);
@@ -2509,8 +2505,7 @@ void CopyPlan::legalizeSIMD(bool initial)
         // Fracture instruction into legal SIMD lengths.
         int simd0 = std::min<int>(rounddown_pow2(i.simd), simdMax);
 
-        bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
-        if (is_xe3p && simd0 == 2) simd0 = 1;
+        if (hw == ngen::HW::Xe3p && simd0 == 2) simd0 = 1;
 
         if (!initial && forceSIMD1(i))
             simd0 = 1;
@@ -2743,7 +2738,7 @@ void CopyPlan::legalizeRegions()
             if (isFP(dt))
                 canSwizzle = false;
         }
-        if (hw >= HW::XE3P_35_10) {
+        if (hw >= HW::Xe3p) {
             auto isFlat = [&] (const CopyOperand &op) {
                 if (!op) return true;
                 if (isBroadcast(op)) return true;
@@ -2947,7 +2942,6 @@ void CopyPlan::legalizeNegation()
 // Pass to legalize immediate types.
 void CopyPlan::legalizeImmediateTypes()
 {
-    bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
     for (auto &i: insns) {
         for (auto *op: {&i.src0, &i.src1, &i.src2}) {
             if (op->kind != CopyOperand::Immediate)
@@ -2956,7 +2950,7 @@ void CopyPlan::legalizeImmediateTypes()
                 op->type = DataType::uw;
             else if (one_of(op->type, {DataType::b, DataType::s4}))
                 op->type = DataType::w;
-	    else if (is_xe3p && i.op != Opcode::mov && op->type == DataType::f && i.dst.type == DataType::bf)
+	    else if (hw == ngen::HW::Xe3p && i.op != Opcode::mov && op->type == DataType::f && i.dst.type == DataType::bf)
 	      legalizeBfImmediate(i);
         }
     }
@@ -3016,11 +3010,10 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
 
             if (i1.op != i2.op || i1.phase != i2.phase || i1.dst.grf != i2.dst.grf || i1.flag) break;
             if (i1.simd != i2.simd) continue;
-            bool xe3pPlus = (hw >= ngen::HW::XE3P_35_10);
 
             auto zippable = [&](const CopyOperand &o1, const CopyOperand &o2, bool zip2D = false, bool zipImm = false) {
                 if (o1.kind != o2.kind) return false;
-                if (o1.kind == CopyOperand::Immediate) return (o1.value == o2.value || (zipImm && !xe3pPlus));
+                if (o1.kind == CopyOperand::Immediate) return (o1.value == o2.value || (zipImm && !(hw >= ngen::HW::Xe3p)));
                 if (o1.kind != CopyOperand::GRF) return true;
                 if (o1.type != o2.type || o1.stride != o2.stride || o1.grf != o2.grf) return false;
                 if (o1.temp != o2.temp) return false;

--- a/src/gpu/intel/gemm/jit/generator/pieces/driver_info.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/driver_info.cxx
@@ -29,7 +29,7 @@ CommonDriverInfo Generator<hw>::driverInfo(GEMMProblem problem, const GEMMStrate
 {
     CommonDriverInfo info;
 
-    problem.autoTypeConversions(hw, strategy.systolic);
+    problem.autoTypeConversions(strategy.systolic);
 
     info.subgroupSize = strategy.subgroupSize;
     info.fusedLoop = strategy.fused ? strategy.fusedLoop : LoopNone;

--- a/src/gpu/intel/gemm/jit/generator/pieces/emulation.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/emulation.cxx
@@ -117,7 +117,7 @@ template <HW hw>
 template <typename DT>
 void Generator<hw>::emul(const ngen::InstructionModifier &mod, const ngen::RegData &dst, const ngen::RegData &src0, const ngen::RegData &src1, const CommonStrategy &strategy,  CommonState &state,  ngen::SourceLocation loc)
 {
-    bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
+    bool is_xe3p = (hw == ngen::HW::Xe3p);
     bool dstBf = dst.getType() == DataType::bf;
     bool src1F = src1.getType() == DataType::f;
     // Xe3p has specific restrictions for mixed bf16/f32 mul.

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
@@ -56,7 +56,7 @@ void Generator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState
     setDefaultAutoSWSB();
 
     // Set up.
-    problem.autoTypeConversions(hw, strategy.systolic);
+    problem.autoTypeConversions(strategy.systolic);
     gemmInitState(problem, strategy, state);
 
     // Transfer surface indices to strategy AddressBases.

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -30,7 +30,7 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
 
     interface = interface_;
 
-    problem.autoTypeConversions(hw, strategy.systolic);
+    problem.autoTypeConversions(strategy.systolic);
     gemmInitState(problem, strategy, state);
     for (int q = 0; q < 2; q++)
         state.ra.safeRelease(state.emulate.temp[q]);
@@ -202,7 +202,7 @@ microkernel::Package Generator<hw>::gemmMicrokernelPackage(const GEMMProblem &pr
     Package package;
 
     auto problem = problem_;
-    problem.autoTypeConversions(hw, strategy.systolic);
+    problem.autoTypeConversions(strategy.systolic);
 
     gemmMicrokernel(problem, strategy, interface_);
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -1219,9 +1219,9 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
     if (strategy.slmBuffers > 0) {
         int A_slmCP, B_slmCP;
         int A_tileR, A_tileC, B_tileR, B_tileC;
-        std::tie(A_slmCP, B_slmCP) = targetSLMCrosspack(hw, problem, strategy);
+        std::tie(A_slmCP, B_slmCP) = targetSLMCrosspack(problem, strategy);
         std::tie(A_tileR, A_tileC, B_tileR, B_tileC) = targetKernelTiling(hw, problem, strategy);
-        auto opCount = outerProductCount(hw, problem, strategy);
+        auto opCount = outerProductCount(problem, strategy);
 
         if (slmA) {
             coopSplit(true, state.ma_slm, state.ka_slm, unrollM, unrollKSLM, strategy.wgTile(LoopM), state.effCoopA, problem.A, strategy);
@@ -1635,7 +1635,7 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
     state.repackA |= problem.earlyDequantizeA() && !slmA;
     state.repackB |= problem.earlyDequantizeB() && !slmB;
 
-    bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
+    bool is_xe3p = (hw == ngen::HW::Xe3p);
     state.upConvertATo8Bit =  is_xe3p && Ta.bits() == 4 && Tb.bits() == 8 && strategy.systolic;
     state.upConvertBTo8Bit =  is_xe3p && Tb.bits() == 4 && Ta.bits() == 8 && strategy.systolic;
 
@@ -1657,7 +1657,7 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
         int repackN = state.ka_repack;
         if (problem.aqGroupK % state.ka_repack != 0 && state.ka_repack % problem.aqGroupK != 0){
                 state.ka_repack = gcd(problem.aqGroupK, state.ka_repack);
-                repackN = std::max(state.ka_repack, outerProductCount(hw, problem, strategy));
+                repackN = std::max(state.ka_repack, outerProductCount(problem, strategy));
         }
 	    auto Ta_repack = Ta;
 	    if (state.upConvertATo8Bit)
@@ -1672,7 +1672,7 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
 	    state.Br_layout = RegisterLayout(hw, Tb_repack, strategy.kb_load, unrollN, state.B_layout.colMajor(), state.upConvertBTo8Bit ? crosspackB/2 : crosspackB, tileK_B, tileN_B, true, splitB);
     }
     // Prepare to repack C if needed, and choose repack tile size.
-    if (Tc != Tc_compute || problem.forceLateQuant(hw, minOuterProductCount(hw, problem, strategy))) {
+    if (Tc != Tc_compute || problem.forceLateQuant(minOuterProductCount(problem, strategy))) {
         auto &period = state.cRepackPeriod;
         int panel = strategy.cRepackPanel;
         if (panel == 0)
@@ -1694,7 +1694,7 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
         } else {
             // Repack partial tiles, interleaved with computation.
             Cr_unrollX = panel;
-            period = outerProductCount(hw, problem, strategy);
+            period = outerProductCount(problem, strategy);
         }
 
         if (strategy.kInterleave)
@@ -2578,7 +2578,7 @@ void Generator<hw>::gemmInitInterface(GEMMProblem &problem, GEMMStrategy &strate
         interface.requireBarrier();
     }
 
-    size_t slm = maxSLMPerWG(hw, strategy.GRFs);
+    size_t slm = maxSLMPerWG(problem.product, strategy.GRFs);
     if (slmSize > slm || slmPerK * strategy.wg[LoopK] > slm)
         stub("Strategy requests more SLM than available");
 
@@ -3185,7 +3185,7 @@ void Generator<hw>::gemmInitState(GEMMProblem &problem, GEMMStrategy &strategy, 
         state.tempCStrategy.padded = true;
     }
 
-    state.useBDPAS = problem.preferBDPAS(hw) && strategy.systolic;
+    state.useBDPAS = problem.preferBDPAS() && strategy.systolic;
 }
 
 GEMMSTONE_NAMESPACE_END

--- a/src/gpu/intel/gemm/jit/generator/pieces/hw_template_instantiations.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/hw_template_instantiations.cxx
@@ -32,13 +32,7 @@ REG_XE2_ISA(template class Generator<HW::Xe2>);
 #elif defined(DNNL_GPU_ISA_XE3)
 REG_XE3_ISA(template class Generator<HW::Xe3>);
 #elif defined(DNNL_GPU_ISA_XE3P)
-#if defined(DNNL_GPU_ISA_XE3P_35_10)
-REG_XE3P_ISA(template class Generator<HW::XE3P_35_10>);
-#elif defined(DNNL_GPU_ISA_XE3P_35_11)
-REG_XE3P_ISA(template class Generator<HW::XE3P_35_11>);
-#else
-REG_XE3P_ISA(template class Generator<HW::XE3P_UNKNOWN>);
-#endif
+REG_XE3P_ISA(template class Generator<HW::Xe3p>);
 #else
 // Default to instantiating all classes
 REG_XELP_ISA(template class Generator<HW::Gen12LP>);
@@ -47,7 +41,5 @@ REG_XEHPG_ISA(template class Generator<HW::XeHPG>);
 REG_XEHPC_ISA(template class Generator<HW::XeHPC>);
 REG_XE2_ISA(template class Generator<HW::Xe2>);
 REG_XE3_ISA(template class Generator<HW::Xe3>);
-REG_XE3P_ISA(template class Generator<HW::XE3P_35_10>);
-REG_XE3P_ISA(template class Generator<HW::XE3P_35_11>);
-REG_XE3P_ISA(template class Generator<HW::XE3P_UNKNOWN>);
+REG_XE3P_ISA(template class Generator<HW::Xe3p>);
 #endif

--- a/src/gpu/intel/gemm/jit/generator/pieces/hw_utils.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/hw_utils.hpp
@@ -46,7 +46,7 @@ static inline bool canSwizzle(ngen::HW hw, ngen::DataType dt)
     using namespace ngen;
 
     if (hw < HW::XeHP) return true;
-    if (hw >= HW::XE3P_35_10) return false;
+    if (hw >= HW::Xe3p) return false;
 
     switch (dt) {
         case DataType::b:
@@ -73,7 +73,7 @@ static inline bool hasNativeAtomicAdd(ngen::HW hw, Type T, const MatrixAddressin
     bool floatAtomics = (astrategy.base.getModel() == ModelA64);
     if (astrategy.newDP)
         floatAtomics |= (astrategy.base.getModel() != ModelSLM);
-    if (hw >= HW::XE3P_35_10) floatAtomics = true;
+    if (hw >= HW::Xe3p) floatAtomics = true;
 
     if (T.isInt4())
         return false;
@@ -82,16 +82,17 @@ static inline bool hasNativeAtomicAdd(ngen::HW hw, Type T, const MatrixAddressin
     else if (T == Type::f32)
         return floatAtomics && (hw >= HW::XeHP);
     else if (T == Type::f16 || T == Type::bf16)
-        return (hw >= HW::XE3P_35_10);
+        return (hw >= HW::Xe3p);
     else if (T == Type::f64)
         return floatAtomics && (hw >= HW::XeHPC);
     else
         return false;
 }
 
-static inline size_t slmCapacity(ngen::HW hw)
+static inline size_t slmCapacity(ngen::Product p)
 {
     using namespace ngen;
+    auto hw = ngen::getCore(p.family);
     switch (hw) {
         case HW::Gen12LP:
         case HW::XeHP:
@@ -99,17 +100,16 @@ static inline size_t slmCapacity(ngen::HW hw)
         case HW::XeHPC:      return 131072;
         case HW::Xe2:        return 131072;
         case HW::Xe3:        return 131072;
-        case HW::XE3P_35_10: return 196608;
-        case HW::XE3P_35_11:
-        case HW::XE3P_UNKNOWN: return 393216;
+        case HW::Xe3p:       return (p.family >= ProductFamily::CRI) ? 393216 : 196608;
         default:
             return 0;
     }
 }
 
-static inline size_t maxSLMPerWG(ngen::HW hw, int grfCount)
+static inline size_t maxSLMPerWG(ngen::Product p, int grfCount)
 {
-    auto slmMax = slmCapacity(hw);
+    auto slmMax = slmCapacity(p);
+    auto hw = ngen::getCore(p.family);
     if (hw <= ngen::HW::XeHPG)
         slmMax = std::min<size_t>(slmMax, 65536);
     return slmMax;
@@ -129,9 +129,7 @@ static inline int eusPerSubslice(ngen::HW hw)
     switch (hw) {
         case HW::XeHPC:
         case HW::Xe2:
-        case HW::XE3P_35_10:
-        case HW::XE3P_35_11:
-        case HW::XE3P_UNKNOWN:
+        case HW::Xe3p:
         case HW::Xe3:
             return 8;
         case HW::Gen12LP:
@@ -166,7 +164,7 @@ static inline int block2DMinAlignment(ngen::HW hw, const MatrixAddressing &atype
     if (!isBlock2D(astrategy.accessType) && !asIfBlock2D) return 0;
     if (hw == HW::Xe2) return 16;
     if (hw == HW::Xe3) return 16;
-    if (hw >= HW::XE3P_35_10) return 4;
+    if (hw >= HW::Xe3p) return 4;
     return (isTransposing(astrategy.accessType) || astrategy.prefetch) ? 4 : 8;
 }
 
@@ -174,7 +172,7 @@ static inline int block2DMinAlignment(ngen::HW hw, const MatrixAddressing &atype
 static inline int block2DBaseAlignment(ngen::HW hw, int stepping)
 {
     using namespace ngen;
-    if (hw >= HW::XE3P_35_10) return 4;
+    if (hw >= HW::Xe3p) return 4;
     if (hw == HW::XeHPC && stepping < SteppingPVCXTB4)
         return 128;
     return 64;

--- a/src/gpu/intel/gemm/jit/generator/pieces/k_loop.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/k_loop.cxx
@@ -52,8 +52,8 @@ void Generator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMMStrategy &
     auto Ta_load = state.Ta_load, Tb_load = state.Tb_load;
 
     bool cLoadAhead = strategy.cLoadAhead;
-    auto opCountMain = outerProductCount(hw, problem, strategy);
-    auto minOPCount = minOuterProductCount(hw, problem, strategy);
+    auto opCountMain = outerProductCount(problem, strategy);
+    auto minOPCount = minOuterProductCount(problem, strategy);
     auto opCountRem = minOPCount;
 
     auto A_copies = strategy.A_copies;
@@ -1759,7 +1759,7 @@ void Generator<hw>::gemmAiBiRemLoadInc(int h, bool incremental, bool incremental
     auto kSLMPMod = kSLMCountUp ? ge : gt;
 
     bool prezero = !willRemask && ((doA ? state.slmASums : state.slmBSums)
-                                       || (minOuterProductCount(hw, problem, strategy) > 1));
+                                       || (minOuterProductCount(problem, strategy) > 1));
 
     if (!incremental) {
         if (prezero) zeroMatrix(Xi_regs, strategy);
@@ -2061,7 +2061,7 @@ void Generator<hw>::kLoopActivateSLMRemainder(bool active, bool preactivate, con
     auto &effKMasksBi = shareKMasksAiBi ? state.kMasksAi : state.kMasksBi;
     auto &initSLMKOffset = state.initSLMKOffset;
 
-    auto minOPCount = minOuterProductCount(hw, problem, strategy);
+    auto minOPCount = minOuterProductCount(problem, strategy);
 
     // Calculate or recalculate SLM k remainders as needed.
     if (active && !preactivate && kSLMStorage.isInvalid()) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/k_loop_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/k_loop_setup.cxx
@@ -41,7 +41,7 @@ bool Generator<hw>::kLoopSetup(const GEMMProblem &problem, const GEMMStrategy &s
     auto Ta_ext = problem.Ta_ext, Tb_ext = problem.Tb_ext;
     auto Ta_load = state.Ta_load, Tb_load = state.Tb_load;
 
-    auto minOPCount = minOuterProductCount(hw, problem, strategy);
+    auto minOPCount = minOuterProductCount(problem, strategy);
     auto unrollM = strategy.unroll[LoopM];
     auto unrollN = strategy.unroll[LoopN];
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/kernel_queries.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/kernel_queries.cpp
@@ -58,7 +58,7 @@ size_t gemmPerKSLMSize(HW hw, const GEMMProblem &problem, const GEMMStrategy &st
         int mnThreads = strategy.wg[LoopM] * strategy.wg[LoopN];
         if (mnThreads <= 0) stub();
         int concurrentK = std::max(1, threadsPerEU(hw, strategy) * eusPerSubslice(hw) / mnThreads);
-        slmSize = rounddown_pow2(maxSLMPerWG(hw, strategy.GRFs) / concurrentK);
+        slmSize = rounddown_pow2(maxSLMPerWG(problem.product, strategy.GRFs) / concurrentK);
         if (!problem.sumA && !problem.sumB) {
             auto singleTile = strategy.wg[LoopM] * strategy.wg[LoopN]
                             * align_up(strategy.unroll[LoopM] * strategy.unroll[LoopN] * problem.Tc, GRF::bytes(hw));

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
@@ -104,7 +104,7 @@ void Generator<hw>::loadMatrixBlock(const Register &dest, const RegisterBlock &b
         case AccessType::Scattered:
         case AccessType::ChannelScattered: {
             auto spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Read);
-            if(hw >= HW::XE3P_35_10) spec |= Overfetch;
+            if(hw >= HW::Xe3p) spec |= Overfetch;
             if (astrategy.atomic && hw >= HW::Xe2) {
                 spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Atomic);
                 atomic(AtomicOp::load, mod, dest, spec, astrategy.base, getAddress(addr, block, astrategy));
@@ -125,7 +125,7 @@ void Generator<hw>::loadMatrixBlock(const Register &dest, const RegisterBlock &b
             auto spec = block_2d(getDataSizeLSC(block.ebytes, false), w, h, count) | astrategy.cachingR;
             if (astrategy.accessType == AccessType::Block2DTranspose) spec |= transpose;
             if (astrategy.accessType == AccessType::Block2DVNNI)      spec |= vnni;
-            if(hw >= HW::XE3P_35_10) spec |= Overfetch;
+            if(hw >= HW::Xe3p) spec |= Overfetch;
             load(mod, dest, spec, astrategy.base, getAddress(addr, block, astrategy));
             break;
         }
@@ -313,7 +313,7 @@ void Generator<hw>::atomicAddMatrixBlock(Type T, const GRF &src, const RegisterB
                     auto mod = simd | maskMod | ExecutionOffset(eoff);
                     if (block.ebytes * block.count != T.real().size()) stub();
                     if (astrategy.newDP) {
-                        auto op = T.isFP() ? (hw >= HW::XE3P_35_10 && T == Type::bf16) ? AtomicOp::bfadd : AtomicOp::fadd
+                        auto op = T.isFP() ? (hw >= HW::Xe3p && T == Type::bf16) ? AtomicOp::bfadd : AtomicOp::fadd
                                            : AtomicOp::add;
                         atomic(op, mod, specLSC, astrategy.base, getAddress(addr[hoff], block, astrategy), curSrc);
                     } else switch (T.real()) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -59,7 +59,7 @@ void Generator<hw>::outerProductFMA(int h, int ha, int hb, int opCount, bool rem
     bool atomicFMA = strategy.atomicFMA;
     bool noAccSBSet = strategy.extendedAtomicFMA && (hw >= HW::XeHPC);
 
-    int minOPCount = minOuterProductCount(hw, problem, strategy);
+    int minOPCount = minOuterProductCount(problem, strategy);
     int kChain = opCount / minOPCount;
     int aCP, bCP;
     std::tie(aCP, bCP) = targetKernelCrosspack(hw, problem, strategy);
@@ -380,7 +380,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
     if (state.upConvertATo8Bit) Ta = Ta == Type::s4 ? Type::s8 : Type::u8;
     if (state.upConvertBTo8Bit) Tb = Tb == Type::s4 ? Type::s8 : Type::u8;
     bool globalCM = state.C_layout.colMajor();
-    auto params = systolicParams(hw, problem);
+    auto params = systolicParams(problem);
     auto ksys = params.ksys;
     auto osys = params.osys;
     auto sdepth = params.sdepth;
@@ -635,7 +635,7 @@ void Generator<hw>::outerProductRepackC(int x0, int xr0, int nx, int h, bool rem
     bool doBO2DLate = problem.needsAGroupSums();
     if (doAO2DLate || doBO2DLate) {
         auto period = gcd(problem.aqGroupK, problem.bqGroupK);
-        bool offsetTime = rem ? ((h % period) < minOuterProductCount(hw, problem, strategy))
+        bool offsetTime = rem ? ((h % period) < minOuterProductCount(problem, strategy))
                               : (period - (h % period) <= state.cRepackPeriod);
         if (offsetTime) {
             if (doAO2DLate) applyLateABOffset(true,  h, problem, strategy, state, x0, xr0, nx);

--- a/src/gpu/intel/gemm/jit/generator/pieces/monolithic_k_loop_dpasw.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/monolithic_k_loop_dpasw.cxx
@@ -66,7 +66,7 @@ template <HW hw>
 bool Generator<hw>::sysgemmAccumulateC(GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
     using namespace sysgemm;
-    auto params = systolicParams(hw, problem);
+    auto params = systolicParams(problem);
     auto unrollM = strategy.unroll[LoopM];
     auto unrollN = strategy.unroll[LoopN];
     auto wgM = strategy.wg[LoopM];
@@ -1410,7 +1410,7 @@ template <HW hw>
 bool Generator<hw>::sysgemm2AccumulateC(GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
     using namespace sysgemm2;
-    auto params = systolicParams(hw, problem);
+    auto params = systolicParams(problem);
     auto unrollM = strategy.unroll[LoopM];
     auto unrollN = strategy.unroll[LoopN];
     auto localIDM = state.lidM;

--- a/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
@@ -82,7 +82,7 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
     if (Txo_int.isInt8()) Txo_int = Type::s16, cpoDiv = 2;
     // Use lateScale for cases of applying scale to inputs that will be natively dpas'd
     // but do not support add/mul.
-    if (xs2D && ((Txs.paddedSize() > Tx.paddedSize() && Tx.isInteger()) || problem.forceLateQuant(hw, minOuterProductCount(hw, problem, strategy)) || state.useBDPAS)) {
+    if (xs2D && ((Txs.paddedSize() > Tx.paddedSize() && Tx.isInteger()) || problem.forceLateQuant(minOuterProductCount(problem, strategy)) || state.useBDPAS)) {
         lateScale = true;
         Txs_int = problem.Tc;
     }
@@ -239,7 +239,7 @@ void Generator<hw>::gemmRepack2DQuantizationData(Type Ts, Type Td, const Registe
     int r = layoutDst.rows();
     int c = layoutDst.cols();
     // FP4 bdpas with group > 32 requires duplicating scales into upper half of registers.
-    if(state.useBDPAS && r * c < minOuterProductCount(hw, problem, strategy)){
+    if(state.useBDPAS && r * c < minOuterProductCount(problem, strategy)){
         int halfRegElems = elementsPerGRF(hw, Td) / 2;
         if(r * c > halfRegElems) stub();
         RegisterLayout offsetLayout(layoutDst);

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
@@ -205,7 +205,7 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
 
     C_chunk = alignup_pow2(C_chunk, Bundle(0, 0).group_size(raHW) * 2);
     if (strategy.systolic) {
-        auto params = systolicParams(hw, problem);
+        auto params = systolicParams(problem);
         C_chunk = std::max(C_chunk, (params.osys * params.rcountMax * Tc.real()) / GRF::bytes(hw));
         Vr_chunk = std::max(Vr_chunk, (params.osys * params.ksys * Tv.real()) / GRF::bytes(hw));
         Nr_chunk = std::max(Nr_chunk, (params.rcountMax * params.ksys * Tn.real()) / GRF::bytes(hw));
@@ -439,7 +439,7 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
             if (repackC)
                 mnStride = globalCM ? state.Cr_layout.rows() : state.Cr_layout.cols();
 
-            int minOPCount = minOuterProductCount(hw, problem, strategy);
+            int minOPCount = minOuterProductCount(problem, strategy);
             int lastMN0 = -1;
             int sliceRegs = 0;
             BundleGroup V_bundles(raHW);

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -43,7 +43,7 @@ void CommonStrategy::preflight(HW hw, const CommonProblem &problem)
     bool emulateNeedsAcc = emulate.emulate64 || emulate.emulateDWxDW || emulate.emulate64_mul;
     if (moveR0 == MoveR0::Acc && emulateNeedsAcc)
         moveR0 = MoveR0::None;
-    if (hw >= HW::XE3P_35_10) moveR0 = MoveR0::None;
+    if (hw >= HW::Xe3p) moveR0 = MoveR0::None;
 
     spf &= !fused;
 }
@@ -238,8 +238,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     if (AccumulatorRegister::count(hw, GRFs, problem.Tc.real().ngen()) == 0)
         kChain = 1;
     // Using acc and mad not working on xe3p
-    bool is_xe3p = one_of(hw, {ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN});
-    if (!systolic && !dotVL && is_xe3p)
+    if (!systolic && !dotVL && hw == HW::Xe3p)
         kChain = 1;
     cAccumulators &= (kChain == 1);
 
@@ -257,8 +256,8 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     checkAdd32 &= (A.base.isStateless() || B.base.isStateless() || problem.quantized2DA() || problem.quantized2DB());
     checkAdd32 &= !(A.address2D && B.address2D && (!prefetchA || A_prefetch.address2D) && (!prefetchB || B_prefetch.address2D));
 
-    int opCount = outerProductCount(hw, problem, *this);
-    int minOPCount = minOuterProductCount(hw, problem, *this);
+    int opCount = outerProductCount(problem, *this);
+    int minOPCount = minOuterProductCount(problem, *this);
     int ukAlign = opCount;
 
     if (kParallelLocal)
@@ -291,7 +290,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
 
     // Systolic handling.
     if (systolic) {
-        auto params = systolicParams(hw, problem);
+        auto params = systolicParams(problem);
 
         ukAlign = lcm(ukAlign, params.ksys);
         auto tileX = params.osys;
@@ -331,7 +330,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     }
 
     if (dpasw) {
-        auto params = systolicParams(hw, problem);
+        auto params = systolicParams(problem);
         if (globalCM) {
             if (!fusedM()) stub();
             B.dpasw = true;
@@ -494,7 +493,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
 bool GEMMStrategy::minimize(HW hw, const GEMMProblem &problem)
 {
     bool better = false;
-    auto minOPCount = minOuterProductCount(hw, problem, *this);
+    auto minOPCount = minOuterProductCount(problem, *this);
     auto ka_load_best_min = std::max<int>({1, 4 / problem.Ta, minOPCount});
     auto kb_load_best_min = std::max<int>({1, 4 / problem.Tb, minOPCount});
 
@@ -630,7 +629,7 @@ void downgradeBPFAccess(const GEMMProblem &problem, GEMMStrategy &strategy)
 
 void GEMMStrategy::trimKChain(HW hw, int k, const GEMMProblem &problem)
 {
-    int minOPCount = minOuterProductCount(hw, problem, *this);
+    int minOPCount = minOuterProductCount(problem, *this);
     kChain = gcd(kChain, k / minOPCount);
 }
 

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -120,7 +120,7 @@ CacheSettingsLSC getCaching(char l1, char l2, char l3) {
 
 CacheSettingsLSC getCachingEntry(std::stringstream &s, HW hw)
 {
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         char l1, l2, l3;
         s >> l1 >> l2 >> l3;
         return getCaching(l1, l2, l3);
@@ -142,7 +142,7 @@ void getCaching(std::stringstream &s, HW hw, MatrixAddressingStrategy &astrategy
         cachingW = CacheSettingsLSC::L1WB_L3WB;
         if (hw >= HW::XeHPC)
             cachingW = CacheSettingsLSC::L1UC_L3WB;
-        if (hw >= HW::XE3P_35_10)
+        if (hw >= HW::Xe3p)
             cachingR = CacheSettingsLSC::L1C_L2C_L3C;
     }
 
@@ -265,7 +265,7 @@ void parseStrategy(const std::string &str, HW hw, const GEMMProblem &problem, GE
     strategy.A.cachingW = CacheSettingsLSC::Default;
     strategy.B.cachingW = CacheSettingsLSC::Default;
     strategy.CO.cachingR = CacheSettingsLSC::L1C_L3C;
-    if (hw >= HW::XE3P_35_10) strategy.CO.cachingR = CacheSettingsLSC::L1C_L2C_L3C;
+    if (hw >= HW::Xe3p) strategy.CO.cachingR = CacheSettingsLSC::L1C_L2C_L3C;
     strategy.A_prefetch.prefetch = true;
     strategy.B_prefetch.prefetch = true;
     strategy.C_prefetch.prefetch = true;
@@ -286,7 +286,7 @@ void parseStrategy(const std::string &str, HW hw, const GEMMProblem &problem, GE
     strategy.AB_prefetchL3.base = getAddressBase(strategy.l3PrefetchA ? asA : asB);
     if (strategy.AB_prefetchL3.cachingR == CacheSettingsLSC::Default) {
         strategy.AB_prefetchL3.cachingR = CacheSettingsLSC::L1UC_L3C;
-        if (hw >= HW::XE3P_35_10)
+        if (hw >= HW::Xe3p)
             strategy.AB_prefetchL3.cachingR = CacheSettingsLSC::L1UC_L2C_L3C;
     }
 
@@ -1083,7 +1083,7 @@ void unparseCaching(HW hw, std::ostream &s, const MatrixAddressingStrategy &astr
 
     s << '{';
 
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         switch (cachingR) {
             case CacheSettingsLSC::Default:             s << "ddd"; break;
             case CacheSettingsLSC::L1UC_L2UC_L3UC:      s << "uuu"; break;

--- a/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
@@ -195,6 +195,7 @@ struct GEMMProblem : public CommonProblem {
     bool cMXScale = false;
     MatrixAddressing sroundSeed;
     PostOpsProblem postOps;                         // Fused post operations to apply
+    ngen::Product product = {};
 
     // The following data is derived from the postOps and does not need
     //   to be considered for equality/hashing purposes.
@@ -268,24 +269,23 @@ struct GEMMProblem : public CommonProblem {
     bool needsASums() const { return sumA || (bOffset == ABOffset::Calc && !earlyDequantizeB() && !quantized2DB()); }
     bool needsBSums() const { return sumB || (aOffset == ABOffset::Calc && !earlyDequantizeA() && !quantized2DA()); }
 
-
-    bool nativeBDPAS(ngen::HW hw) const {
+    bool nativeBDPAS() const {
         return ((Ta.isF4() || Ta.isF8() || Ta == Type::f16 || Ta == Type::bf16) &&
                 (Tb.isF4() || Tb.isF8() || Tb == Type::f16 || Tb == Type::bf16) && 
-        hw >= ngen::Core::XE3P_35_10);
+        ngen::getCore(product.family) >= ngen::HW::Xe3p);
     }
-    bool forceLateQuant(ngen::HW hw, int minOPCount) const {
-        bool fp4_fp8_dpas = ((Ta.isF8() && Tb.isF8()) || (Ta.isF4() && Tb.isF4())) && nativeBDPAS(hw);
-        return fp4_fp8_dpas && ((aScale2D() && !preferBDPAS(hw) && aqGroupK % minOPCount == 0)
-            || (bScale2D() && !preferBDPAS(hw) && bqGroupK % minOPCount == 0));
+    bool forceLateQuant(int minOPCount) const {
+        bool fp4_fp8_dpas = ((Ta.isF8() && Tb.isF8()) || (Ta.isF4() && Tb.isF4())) && nativeBDPAS();
+        return fp4_fp8_dpas && ((aScale2D() && !preferBDPAS() && aqGroupK % minOPCount == 0)
+            || (bScale2D() && !preferBDPAS() && bqGroupK % minOPCount == 0));
     }
-    bool forceUpconvertQuant(ngen::HW hw) const {
+    bool forceUpconvertQuant() const {
         // Cover cases where scale group < ksys by upconverting, using normal dpas and scale routines.
-        return nativeBDPAS(hw) && Ta.isF4() && Tb.isF4() && ((aScale2D() && !preferBDPAS(hw) && aqGroupK % 64 != 0)
-            || (bScale2D() && !preferBDPAS(hw) && bqGroupK % 64 != 0));
+        return nativeBDPAS() && Ta.isF4() && Tb.isF4() && ((aScale2D() && !preferBDPAS() && aqGroupK % 64 != 0)
+            || (bScale2D() && !preferBDPAS() && bqGroupK % 64 != 0));
     }
-    bool preferBDPAS(ngen::HW hw) const {
-        bool useBDPAS = (bdpasEnabled && nativeBDPAS(hw) && (aScale2D() || bScale2D()));
+    bool preferBDPAS() const {
+        bool useBDPAS = (bdpasEnabled && nativeBDPAS() && (aScale2D() || bScale2D()));
         if (aScale2D()) useBDPAS &= (Ta_scale == Type::f8_e8m0) && (aqGroupK % 32 == 0);
         if (bScale2D()) useBDPAS &= (Tb_scale == Type::f8_e8m0) && (bqGroupK % 32 == 0);
         return useBDPAS;
@@ -313,7 +313,7 @@ struct GEMMProblem : public CommonProblem {
     bool isLegalAAlignment(int align, int unrollM) const { return (A.layout != MatrixLayout::N) || ((unrollM * Ta) % align == 0); }
     bool isLegalBAlignment(int align, int unrollN) const { return (B.layout != MatrixLayout::T) || ((unrollN * Tb) % align == 0); }
 
-    inline void autoTypeConversions(ngen::HW hw, bool systolicAvailable);
+    inline void autoTypeConversions(bool systolicAvailable);
     void transpose();
 
     std::string toString() const;
@@ -349,15 +349,16 @@ struct GEMMProblem : public CommonProblem {
         s.append(sumA, sumB);
         s.append(sroundSeed);
         s.append(postOps);
+        s.append(product);
     }
 };
 
 
 // Apply automatic internal type conversions to a problem.
-void GEMMProblem::autoTypeConversions(ngen::HW hw, bool systolicAvailable)
+void GEMMProblem::autoTypeConversions(bool systolicAvailable)
 {
     using namespace ngen;
-
+    auto hw = getCore(product.family);
     // Weights decompression
     if ((Ta.isInt8() || Ta.isInt4()) && Tb.isFP() && Tc.isFP()) Ta = Tb;
     if ((Tb.isInt8() || Tb.isInt4()) && Ta.isFP() && Tc.isFP()) Tb = Ta;
@@ -369,14 +370,14 @@ void GEMMProblem::autoTypeConversions(ngen::HW hw, bool systolicAvailable)
 
     if (Ta == Ta_ext.asSigned()) Ta = Ta_ext;
     if (Tb == Tb_ext.asSigned()) Tb = Tb_ext;
-    if (hw < HW::XE3P_35_10 || !systolicAvailable)
+    if (hw < HW::Xe3p || !systolicAvailable)
     {
         if (Ta.isF8()) Ta = Type::f16;
         if (Tb.isF8()) Tb = Type::f16;
     }
-    if (hw < HW::XE3P_35_11 || !systolicAvailable || forceUpconvertQuant(hw))
+    if (hw < HW::Xe3p ||  product.family < ProductFamily::CRI || !systolicAvailable || forceUpconvertQuant())
     {
-        if (hw == HW::XE3P_35_10 && (!forceUpconvertQuant(hw) || validLateScaleGroups())){
+        if (product.family == ProductFamily::NVLP && (!forceUpconvertQuant() || validLateScaleGroups())){
             if (Ta.isF4()) Ta = Type::bf8;
             if (Tb.isF4()) Tb = Type::bf8;
         } else {

--- a/src/gpu/intel/gemm/jit/include/internal/generator_inline.hxx
+++ b/src/gpu/intel/gemm/jit/include/internal/generator_inline.hxx
@@ -19,7 +19,7 @@
 
 static inline int r0DWords(ngen::HW hw)
 {
-    if (hw >= ngen::HW::XE3P_35_10) return 16;
+    if (hw >= ngen::HW::Xe3p) return 16;
     return 8;
 }
 

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -522,7 +522,7 @@ status_t pd_t::init_GEMMProblem(
     using namespace gemmstone;
     problem = {};
 
-    auto hw = convert_dnnl_arch_to_ngen(engine->device_info()->gpu_arch());
+    problem.product = get_ngen_product(*engine->device_info());
     bool has_systolic
             = engine->mayiuse(compute::device_ext_t::
                               intel_subgroup_matrix_multiply_accumulate)
@@ -730,7 +730,7 @@ status_t pd_t::init_GEMMProblem(
     problem.postOps.cStochasticRound = dst_sround;
 
     if (problem.needsAGroupSums() || problem.needsBGroupSums())
-        problem.autoTypeConversions(hw, has_systolic);
+        problem.autoTypeConversions(has_systolic);
 
     if (problem.needsAGroupSums()) {
         data_type_t gs_dt = a_quant.gs_type == data_type::undef
@@ -752,7 +752,7 @@ status_t pd_t::init_GEMMProblem(
     }
     // Disable bdpas with unsupported k dim.
     // TODO: Enable 2D block, masking scale loads.
-    if (problem.nativeBDPAS(hw)) {
+    if (problem.nativeBDPAS()) {
         if (((!problem.Ta.isF4() || !problem.Tb.isF4()) || k % 64 == 0))
             problem.bdpasEnabled = true;
     }

--- a/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
@@ -341,7 +341,7 @@ MatchParamsBase::MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isInt
         unrollReq[LoopN] = 2;
     }
 
-    ReqBDPASDims = problem.preferBDPAS(hw);
+    ReqBDPASDims = problem.preferBDPAS();
 
     if (ReqBDPASDims) {
         unrollReq[LoopM] = 8;
@@ -360,9 +360,7 @@ MatchParamsBase::MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isInt
         case ngen::HW::XeHPC:   selector.hw = kcatalog::HWTagXeHPC;   break;
         case ngen::HW::Xe2:     selector.hw = kcatalog::HWTagXe2;     break;
         case ngen::HW::Xe3:     selector.hw = kcatalog::HWTagXe3;   break;
-        case ngen::HW::XE3P_35_10:
-        case ngen::HW::XE3P_35_11:
-        case ngen::HW::XE3P_UNKNOWN:     selector.hw = kcatalog::HWTagXe3p;   break;
+        case ngen::HW::Xe3p:    selector.hw = kcatalog::HWTagXe3p;   break;
     }
 
     auto &C = problem.C;
@@ -436,11 +434,11 @@ MatchParamsBase::MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isInt
     if (problem.aoPtrDims > 0 || problem.boPtrDims > 0)
         *tagPtr++ = ReqOffsetMultiDim;
 
-    problem.autoTypeConversions(hw, systolicAvailable);
+    problem.autoTypeConversions(systolicAvailable);
     if (problem.needsASums() && !problem.sumA) *tagPtr++ = ReqSumA;
     if (problem.needsBSums() && !problem.sumB) *tagPtr++ = ReqSumB;
 
-    if (one_of(hw, {ngen::HW::Xe2, ngen::HW::Xe3, ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11, ngen::HW::XE3P_UNKNOWN})) *tagPtr++ = ReqXe2Block2D;
+    if (one_of(hw, {ngen::HW::Xe2, ngen::HW::Xe3, ngen::HW::Xe3p})) *tagPtr++ = ReqXe2Block2D;
 
 
     sizes.batch = sizes.m = sizes.n = sizes.k = 0;

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -101,7 +101,7 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
     if (dt_int_ok) attr_skip_mask |= smask_t::zero_points;
 
     bool arch_ok = utils::one_of(arch, arch_t::xe_hp, arch_t::xe_hpg,
-            arch_t::xe_hpc, arch_t::xe2, arch_t::xe3);
+            arch_t::xe_hpc, arch_t::xe2, arch_t::xe3, arch_t::xe3p);
 
     VDISPATCH_GEMM(limits_ok, VERBOSE_RUNTIMEDIM_UNSUPPORTED);
     VDISPATCH_GEMM((dt_float_ok || dt_int_ok), VERBOSE_UNSUPPORTED_DT_CFG);
@@ -580,8 +580,9 @@ status_t xe_hp_systolic_t::init_compute(impl::engine_t *engine) {
     kd_t kd_full;
 
     bool is_integrated = intel_engine->device_info()->is_integrated();
+    auto product = intel_engine->device_info()->gpu_product();
 
-    auto status = kd_full.select_kernel(arch_, stepping, eu_count_,
+    auto status = kd_full.select_kernel(product, stepping, eu_count_,
             is_integrated, pd()->with_batch(), pd()->packed_c(), trans_co,
             pd()->with_a_zero_points(), pd()->with_b_zero_points(),
             pd()->with_c_zero_points(), pd()->with_bias(), pd()->alpha(),
@@ -619,7 +620,7 @@ status_t xe_hp_systolic_t::init_compute(impl::engine_t *engine) {
 
                 kd_t kd;
 
-                auto status = kd.select_kernel(arch_, stepping, eu_count_,
+                auto status = kd.select_kernel(product, stepping, eu_count_,
                         is_integrated, pd()->with_batch(), pd()->packed_c(),
                         trans_co, pd()->with_a_zero_points(),
                         pd()->with_b_zero_points(), this_c_offset,

--- a/src/gpu/intel/jit/binary_format.cpp
+++ b/src/gpu/intel/jit/binary_format.cpp
@@ -81,8 +81,7 @@ public:
         requireSIMD((GRF::bytes(hw) == 64) ? 16 : 8);
         requireLocalID(3); // r1-r3
         requireLocalSize(); // r7.0-2:ud
-        if (utils::one_of(hw, ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                    ngen::HW::XE3P_UNKNOWN))
+        if (hw == ngen::HW::Xe3p)
             setEfficient64Bit(engine->device_info()->is_efficient_64bit());
         finalizeInterface();
 
@@ -206,17 +205,9 @@ public:
                     kernel = binary_format_kernel_t<HW::Xe3>::make_kernel(
                             engine, skip_check);
                     break;
-                case compute::gpu_arch_t::xe3p_35_10:
-                    kernel = binary_format_kernel_t<
-                            HW::XE3P_35_10>::make_kernel(engine, skip_check);
-                    break;
-                case compute::gpu_arch_t::xe3p_35_11:
-                    kernel = binary_format_kernel_t<
-                            HW::XE3P_35_11>::make_kernel(engine, skip_check);
-                    break;
-                case compute::gpu_arch_t::xe3p_35_unknown:
-                    kernel = binary_format_kernel_t<
-                            HW::XE3P_UNKNOWN>::make_kernel(engine, skip_check);
+                case compute::gpu_arch_t::xe3p:
+                    kernel = binary_format_kernel_t<HW::Xe3p>::make_kernel(
+                            engine, skip_check);
                     break;
 
                 case compute::gpu_arch_t::unknown:

--- a/src/gpu/intel/jit/codegen/kernel_ext.cpp
+++ b/src/gpu/intel/jit/codegen/kernel_ext.cpp
@@ -50,6 +50,9 @@ REG_XE2_ISA(extern template void convert_ir_to_ngen<gen_t<ngen::HW::Xe2>>(
 REG_XE3_ISA(extern template void convert_ir_to_ngen<gen_t<ngen::HW::Xe3>>(
         const stmt_t &body, gen_t<ngen::HW::Xe3> &host,
         const walk_order_t *kernel_grid_walk_order));
+REG_XE3P_ISA(extern template void convert_ir_to_ngen<gen_t<ngen::HW::Xe3p>>(
+        const stmt_t &body, gen_t<ngen::HW::Xe3p> &host,
+        const walk_order_t *kernel_grid_walk_order));
 
 } // namespace ir
 } // namespace dsl
@@ -103,8 +106,8 @@ void ir_kernel_t::generate_from_ir(
 
     if (local_range_) {
         size_t max_slm_size = compute::device_info_t::max_slm_size_per_tg(
-                convert_ngen_arch_to_dnnl(options_.hw()), thread_group_size(),
-                options_.regs() > 128);
+                thread_group_size(), options_.regs() > 128,
+                to_gpu_product(options_.hw().product()));
         if (interface.getSLMSize() > max_slm_size) {
             gpu_trace() << "SLM size limit exceeded: " << interface.getSLMSize()
                         << " > " << max_slm_size;

--- a/src/gpu/intel/jit/eltwise_injector.cpp
+++ b/src/gpu/intel/jit/eltwise_injector.cpp
@@ -52,8 +52,7 @@ int eltwise_injector_f32_t<ngen_generator_t>::min_scratch_regs() {
             case eltwise_square: return 0;
             case eltwise_swish: return 1;
             case eltwise_tanh:
-            case eltwise_tanh_use_dst_for_bwd:
-                return (hw() < gpu_xe3p_35_10) ? 2 : 1;
+            case eltwise_tanh_use_dst_for_bwd: return (hw() < gpu_xe3p) ? 2 : 1;
             case eltwise_round: return 0;
             case eltwise_linear: return 0;
             case eltwise_clip:
@@ -73,7 +72,7 @@ int eltwise_injector_f32_t<ngen_generator_t>::min_scratch_regs() {
             case eltwise_square: return 0;
             case eltwise_linear: return 0;
             case eltwise_clip: return 1;
-            case eltwise_gelu_tanh: return (hw() < gpu_xe3p_35_10) ? 2 : 1;
+            case eltwise_gelu_tanh: return (hw() < gpu_xe3p) ? 2 : 1;
             default: assert(!"unsupported eltwise algorithm");
         }
     }
@@ -163,10 +162,9 @@ int eltwise_injector_f32_t<ngen_generator_t>::phase_count(alg_kind_t alg) {
             case eltwise_relu:
             case eltwise_relu_use_dst_for_bwd: return (alpha_ == 0) ? 1 : 2;
             case eltwise_soft_relu: return 10;
-            case eltwise_swish: return (hw() < gpu_xe3p_35_10) ? 5 : 3;
+            case eltwise_swish: return (hw() < gpu_xe3p) ? 5 : 3;
             case eltwise_tanh:
-            case eltwise_tanh_use_dst_for_bwd:
-                return (hw() < gpu_xe3p_35_10) ? 6 : 1;
+            case eltwise_tanh_use_dst_for_bwd: return (hw() < gpu_xe3p) ? 6 : 1;
             case eltwise_linear: return (beta_ == 0) ? 1 : 2;
             case eltwise_clip:
             case eltwise_clip_v2:
@@ -174,14 +172,14 @@ int eltwise_injector_f32_t<ngen_generator_t>::phase_count(alg_kind_t alg) {
             case eltwise_gelu_tanh: return 8;
             case eltwise_logistic:
             case eltwise_logistic_use_dst_for_bwd:
-                return (hw() < gpu_xe3p_35_10) ? 4 : 1;
+                return (hw() < gpu_xe3p) ? 4 : 1;
             default: break;
         }
     } else {
         switch (alg) {
             case eltwise_abs: return 2;
             case eltwise_clip: return 4;
-            case eltwise_gelu_tanh: return (hw() < gpu_xe3p_35_10) ? 14 : 8;
+            case eltwise_gelu_tanh: return (hw() < gpu_xe3p) ? 14 : 8;
             default: break;
         }
     }
@@ -262,7 +260,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::square_compute_fwd(
 template <typename ngen_generator_t>
 void eltwise_injector_f32_t<ngen_generator_t>::tanh_compute_fwd(
         int simd, const ngen::GRF &r, int phase, int off, int batch) {
-    if (hw() < gpu_xe3p_35_10) {
+    if (hw() < gpu_xe3p) {
         const float log2e = 1.44269502162933349609375f; // log_2(e)
         auto one_half = scratch_[0].f(7);
         auto a = scratch_[off + batch].f();
@@ -457,7 +455,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::philox_4x32(
         h->mov(4, key.ud(1)(4, 4, 2), uint32_t(0xBB67AE85u));
     }
 
-    if (hw() < gpu_xe3p_35_10) {
+    if (hw() < gpu_xe3p) {
         h->template mov<uint16_t>(4, offs.uw(16)(1), Immediate::uv(0x00009988));
         h->template mul<uint32_t>(
                 4, offs.ud(8)(1), key.ud(0)(4, 4, 1), offs.uw(16)(4, 4, 1));
@@ -524,7 +522,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::philox_4x32(
         const auto grf_size = ngen::GRF::bytes(hw());
         const int esize = grf_size / 8; // 8 = 2 * dword bytes
         const int steps = utils::div_up(8, esize);
-        if (hw() < gpu_xe3p_35_10) {
+        if (hw() < gpu_xe3p) {
             auto acc = h->acc0.retype(DataType::ud);
             for (int i = 0, off = 0; i < steps; ++i, off += 2 * esize)
                 h->mul(esize, acc[i](2), ctr.ud(off)(8, 4, 2),
@@ -566,7 +564,7 @@ template <typename ngen_generator_t>
 void eltwise_injector_f32_t<ngen_generator_t>::swish_compute_fwd(
         int simd, const ngen::GRF &r, int phase, int off) {
     auto temp = scratch_[off].f();
-    if (hw() < gpu_xe3p_35_10) {
+    if (hw() < gpu_xe3p) {
         const float log2e = 1.442695f; // log_2(e)
         switch (phase) {
             case 0: h->mul(simd, temp, r, -1.f * log2e * alpha_); break;
@@ -635,7 +633,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::gelu_tanh_compute_fwd(
 template <typename ngen_generator_t>
 void eltwise_injector_f32_t<ngen_generator_t>::logistic_compute_fwd(
         int simd, const ngen::GRF &r, int phase) {
-    if (hw() < gpu_xe3p_35_10) {
+    if (hw() < gpu_xe3p) {
         const float log2e = 1.442695f; // log_2(e)
         switch (phase) {
             case 0: h->mul(simd, r, r, -1.f * log2e); break;
@@ -689,7 +687,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::clip_prepare_bwd() {
 
 template <typename ngen_generator_t>
 void eltwise_injector_f32_t<ngen_generator_t>::tanh_prepare_fwd() {
-    if (hw() < gpu_xe3p_35_10) {
+    if (hw() < gpu_xe3p) {
         auto one_half = scratch_[0].f(7);
         h->mov(1, one_half, 0.5f);
     }
@@ -762,7 +760,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::gelu_tanh_compute_bwd(
     if (hw() == gpu_xe_hp) msimd = 16;
 
     auto a = scratch_[off].f();
-    if (hw() < gpu_xe3p_35_10) {
+    if (hw() < gpu_xe3p) {
         auto b = scratch_[off + batch].f();
         switch (phase) {
             case 0: h->mul(simd, a, r, r); break;
@@ -1140,10 +1138,7 @@ REG_XEHPG_ISA(template struct eltwise_injector_f32_t<code_gen<gpu_xe_hpg>>);
 REG_XEHPC_ISA(template struct eltwise_injector_f32_t<code_gen<gpu_xe_hpc>>);
 REG_XE2_ISA(template struct eltwise_injector_f32_t<code_gen<gpu_xe2>>);
 REG_XE3_ISA(template struct eltwise_injector_f32_t<code_gen<gpu_xe3>>);
-REG_XE3P_ISA(template struct eltwise_injector_f32_t<code_gen<gpu_xe3p_35_10>>);
-REG_XE3P_ISA(template struct eltwise_injector_f32_t<code_gen<gpu_xe3p_35_11>>);
-REG_XE3P_ISA(
-        template struct eltwise_injector_f32_t<code_gen<gpu_xe3p_35_unknown>>);
+REG_XE3P_ISA(template struct eltwise_injector_f32_t<code_gen<gpu_xe3p>>);
 
 #ifdef NGEN_ASM
 template struct eltwise_injector_f32_t<ngen::AsmCodeGenerator>;

--- a/src/gpu/intel/jit/emulated_generator.cpp
+++ b/src/gpu/intel/jit/emulated_generator.cpp
@@ -449,9 +449,7 @@ REG_XEHPG_ISA(template class emulated_generator_t<gpu_xe_hpg>);
 REG_XEHPC_ISA(template class emulated_generator_t<gpu_xe_hpc>);
 REG_XE2_ISA(template class emulated_generator_t<gpu_xe2>);
 REG_XE3_ISA(template class emulated_generator_t<gpu_xe3>);
-REG_XE3P_ISA(template class emulated_generator_t<gpu_xe3p_35_10>);
-REG_XE3P_ISA(template class emulated_generator_t<gpu_xe3p_35_11>);
-REG_XE3P_ISA(template class emulated_generator_t<gpu_xe3p_35_unknown>);
+REG_XE3P_ISA(template class emulated_generator_t<gpu_xe3p>);
 
 } // namespace jit
 } // namespace intel

--- a/src/gpu/intel/jit/generator.hpp
+++ b/src/gpu/intel/jit/generator.hpp
@@ -62,9 +62,7 @@ constexpr gpu_gen_t gpu_xe_hpg = ngen::HW::XeHPG;
 constexpr gpu_gen_t gpu_xe_hpc = ngen::HW::XeHPC;
 constexpr gpu_gen_t gpu_xe2 = ngen::HW::Xe2;
 constexpr gpu_gen_t gpu_xe3 = ngen::HW::Xe3;
-constexpr gpu_gen_t gpu_xe3p_35_10 = ngen::HW::XE3P_35_10;
-constexpr gpu_gen_t gpu_xe3p_35_11 = ngen::HW::XE3P_35_11;
-constexpr gpu_gen_t gpu_xe3p_35_unknown = ngen::HW::XE3P_UNKNOWN;
+constexpr gpu_gen_t gpu_xe3p = ngen::HW::Xe3p;
 
 #if (!defined(NDEBUG) || defined(DNNL_DEV_MODE))
 #define GENERATOR_NAME __FILE__

--- a/src/gpu/intel/jit/ir/block_2d_utils.hpp
+++ b/src/gpu/intel/jit/ir/block_2d_utils.hpp
@@ -41,9 +41,7 @@ inline int block_2d_base_alignment(ngen::HW hw) {
         case ngen::HW::XeHPC: return 64;
         case ngen::HW::Xe2:
         case ngen::HW::Xe3: return 64;
-        case ngen::HW::XE3P_35_10:
-        case ngen::HW::XE3P_35_11:
-        case ngen::HW::XE3P_UNKNOWN: return 4;
+        case ngen::HW::Xe3p: return 4;
         default: gpu_error_not_expected();
     }
     return 0;
@@ -75,9 +73,7 @@ inline int block_2d_pitch_alignment(ngen::HW hw) {
         case ngen::HW::XeHPC: return 8;
         case ngen::HW::Xe2: return 16;
         case ngen::HW::Xe3: return 16;
-        case ngen::HW::XE3P_35_10:
-        case ngen::HW::XE3P_35_11:
-        case ngen::HW::XE3P_UNKNOWN: return 4;
+        case ngen::HW::Xe3p: return 4;
         default: gpu_error_not_expected();
     }
     return 0;
@@ -98,9 +94,7 @@ inline bool block_2d_pitch_ok(
 inline int block_2d_max_count(ngen::HW hw, bool is_prefetch, bool is_store,
         bool is_transpose, int block_width, int type_size) {
     if (is_store || is_transpose) return 1;
-    if (utils::one_of(hw, ngen::HW::XE3P_35_10, ngen::HW::XE3P_35_11,
-                ngen::HW::XE3P_UNKNOWN)
-            && is_prefetch) {
+    if (hw == ngen::HW::Xe3p && is_prefetch) {
         return 256 / (block_width * type_size);
     }
     return 64 / (block_width * type_size);

--- a/src/gpu/intel/jit/post_op_injector.cpp
+++ b/src/gpu/intel/jit/post_op_injector.cpp
@@ -69,9 +69,7 @@ REG_XEHPG_ISA(template struct post_op_injector_t<code_gen<gpu_xe_hpg>>);
 REG_XEHPC_ISA(template struct post_op_injector_t<code_gen<gpu_xe_hpc>>);
 REG_XE2_ISA(template struct post_op_injector_t<code_gen<gpu_xe2>>);
 REG_XE3_ISA(template struct post_op_injector_t<code_gen<gpu_xe3>>);
-REG_XE3P_ISA(template struct post_op_injector_t<code_gen<gpu_xe3p_35_10>>);
-REG_XE3P_ISA(template struct post_op_injector_t<code_gen<gpu_xe3p_35_11>>);
-REG_XE3P_ISA(template struct post_op_injector_t<code_gen<gpu_xe3p_35_unknown>>);
+REG_XE3P_ISA(template struct post_op_injector_t<code_gen<gpu_xe3p>>);
 
 #ifdef NGEN_ASM
 template struct post_op_injector_t<ngen::AsmCodeGenerator>;

--- a/src/gpu/intel/jit/reduction_injector.cpp
+++ b/src/gpu/intel/jit/reduction_injector.cpp
@@ -276,12 +276,7 @@ REG_XEHPG_ISA(template struct reduction_injector_f32_t<code_gen<gpu_xe_hpg>>);
 REG_XEHPC_ISA(template struct reduction_injector_f32_t<code_gen<gpu_xe_hpc>>);
 REG_XE2_ISA(template struct reduction_injector_f32_t<code_gen<gpu_xe2>>);
 REG_XE3_ISA(template struct reduction_injector_f32_t<code_gen<gpu_xe3>>);
-REG_XE3P_ISA(
-        template struct reduction_injector_f32_t<code_gen<gpu_xe3p_35_10>>);
-REG_XE3P_ISA(
-        template struct reduction_injector_f32_t<code_gen<gpu_xe3p_35_11>>);
-REG_XE3P_ISA(template struct reduction_injector_f32_t<
-        code_gen<gpu_xe3p_35_unknown>>);
+REG_XE3P_ISA(template struct reduction_injector_f32_t<code_gen<gpu_xe3p>>);
 
 #ifdef NGEN_ASM
 template struct reduction_injector_f32_t<ngen::AsmCodeGenerator>;

--- a/src/gpu/intel/jit/utils/type_bridge.hpp
+++ b/src/gpu/intel/jit/utils/type_bridge.hpp
@@ -82,10 +82,7 @@ inline ngen::HW convert_dnnl_arch_to_ngen(compute::gpu_arch_t gpu_arch) {
         case compute::gpu_arch_t::xe_hpc: return ngen::HW::XeHPC;
         case compute::gpu_arch_t::xe2: return ngen::HW::Xe2;
         case compute::gpu_arch_t::xe3: return ngen::HW::Xe3;
-        case compute::gpu_arch_t::xe3p_35_10: return ngen::HW::XE3P_35_10;
-        case compute::gpu_arch_t::xe3p_35_11: return ngen::HW::XE3P_35_11;
-        case compute::gpu_arch_t::xe3p_35_unknown:
-            return ngen::HW::XE3P_UNKNOWN;
+        case compute::gpu_arch_t::xe3p: return ngen::HW::Xe3p;
         case compute::gpu_arch_t::unknown: return ngen::HW::Unknown;
     }
     return ngen::HW::Unknown;
@@ -99,10 +96,7 @@ inline compute::gpu_arch_t convert_ngen_arch_to_dnnl(ngen::HW gpu_arch) {
         case ngen::HW::XeHPC: return compute::gpu_arch_t::xe_hpc;
         case ngen::HW::Xe2: return compute::gpu_arch_t::xe2;
         case ngen::HW::Xe3: return compute::gpu_arch_t::xe3;
-        case ngen::HW::XE3P_35_10: return compute::gpu_arch_t::xe3p_35_10;
-        case ngen::HW::XE3P_35_11: return compute::gpu_arch_t::xe3p_35_11;
-        case ngen::HW::XE3P_UNKNOWN:
-            return compute::gpu_arch_t::xe3p_35_unknown;
+        case ngen::HW::Xe3p: return compute::gpu_arch_t::xe3p;
         case ngen::HW::Gen9:
         case ngen::HW::Gen10:
         case ngen::HW::Gen11:
@@ -157,6 +151,13 @@ inline gemmstone::dsl::type_t to_ir(const data_type_t &dt) {
         default: gpu_error_not_expected();
     }
     return {};
+}
+
+inline compute::gpu_product_t to_gpu_product(const ngen::Product &p) {
+    compute::gpu_product_t result;
+    static_assert(sizeof(ngen::Product) == sizeof(compute::gpu_product_t), "");
+    std::memcpy(&result, &p, sizeof(result));
+    return result;
 }
 
 } // namespace jit

--- a/src/gpu/intel/jit/utils/utils.hpp
+++ b/src/gpu/intel/jit/utils/utils.hpp
@@ -708,9 +708,7 @@ static auto hw_names = nstl::to_array({
         make_enum_name(ngen::Core::XeHPC, "xehpc"),
         make_enum_name(ngen::Core::Xe2, "xe2"),
         make_enum_name(ngen::Core::Xe3, "xe3"),
-        make_enum_name(ngen::Core::XE3P_35_10, "xe3p_35_10"),
-        make_enum_name(ngen::Core::XE3P_35_11, "xe3p_35_11"),
-        make_enum_name(ngen::Core::XE3P_UNKNOWN, "xe3p_35_unknown"),
+        make_enum_name(ngen::Core::Xe3p, "xe3p"),
 });
 GPU_DEFINE_PARSE_ENUM(ngen::HW, hw_names)
 
@@ -729,9 +727,9 @@ static auto product_family_names = nstl::to_array({
         make_enum_name(ngen::ProductFamily::PVC, "pvc"),
         make_enum_name(ngen::ProductFamily::GenericXe2, "xe2"),
         make_enum_name(ngen::ProductFamily::GenericXe3, "xe3"),
-        make_enum_name(ngen::ProductFamily::XE3P_35_10, "xe3p_35_10"),
-        make_enum_name(ngen::ProductFamily::XE3P_35_11, "xe3p_35_11"),
-        make_enum_name(ngen::ProductFamily::XE3P_UNKNOWN, "xe3p_35_unknown"),
+        make_enum_name(ngen::ProductFamily::NVLP, "nvlp"),
+        make_enum_name(ngen::ProductFamily::CRI, "cri"),
+        make_enum_name(ngen::ProductFamily::GenericXe3p, "xe3p"),
 });
 GPU_DEFINE_PARSE_ENUM(ngen::ProductFamily, product_family_names)
 
@@ -1241,9 +1239,7 @@ void deserialize_from_hex(T &t, const std::string &s_hex) {
         REG_XEHPC_ISA(GPU_HW_CASE_(XeHPC)); \
         REG_XE2_ISA(GPU_HW_CASE_(Xe2)); \
         REG_XE3_ISA(GPU_HW_CASE_(Xe3)); \
-        REG_XE3P_ISA(GPU_HW_CASE_(XE3P_35_10)); \
-        REG_XE3P_ISA(GPU_HW_CASE_(XE3P_35_11)); \
-        REG_XE3P_ISA(GPU_HW_CASE_(XE3P_UNKNOWN)); \
+        REG_XE3P_ISA(GPU_HW_CASE_(Xe3p)); \
         default: gpu_assert(false) << "Unexpected GPU architecture"; \
     }
 

--- a/src/gpu/intel/lnorm/vectorized.cpp
+++ b/src/gpu/intel/lnorm/vectorized.cpp
@@ -46,7 +46,8 @@ bool is_fused_kernel_applicable(conf_t &conf, const pd_t *pd,
     const int max_ss = utils::div_up(eu_count, max_eus_per_wg);
     const size_t max_wg_size
             = intel_engine->device_info()->max_wg_size(large_grf_mode);
-    const size_t max_slm_size = device_info_t::max_slm_size(gpu_arch);
+    const size_t max_slm_size = device_info_t::max_slm_size(
+            intel_engine->device_info()->gpu_product());
 
     // Plain layout only
     const bool is_plain = src_mdw.matches_one_of_tag(ab, abc)

--- a/src/gpu/intel/pool/xe.cpp
+++ b/src/gpu/intel/pool/xe.cpp
@@ -81,7 +81,7 @@ static status_t init_conf_common(
         auto is_xe3p = utils::downcast<intel::engine_t *>(engine)
                                ->device_info()
                                ->gpu_arch()
-                >= compute::gpu_arch_t::xe3p_35_10;
+                >= compute::gpu_arch_t::xe3p;
         VDISPATCH_POOLING_IC(!(is_xe3p && src_mdw.data_type() == data_type::u8),
                 "%s," VERBOSE_IMPL_HEURISTIC_FAIL, pd->info(engine),
                 "workaround xe3p compiler bug: u8 with mb_c_block");

--- a/third_party/ngen/ngen.hpp
+++ b/third_party/ngen/ngen.hpp
@@ -62,9 +62,7 @@ template <HW hw> struct Instruction12Dispatch       { using type = Instruction12
 template <> struct Instruction12Dispatch<HW::XeHPC> { using type = InstructionXeHPC; };
 template <> struct Instruction12Dispatch<HW::Xe2>   { using type = InstructionXeHPC; };
 template <> struct Instruction12Dispatch<HW::Xe3>   { using type = InstructionXeHPC; };
-template <> struct Instruction12Dispatch<HW::XE3P_35_10>  { using type = InstructionXe3p;  };
-template <> struct Instruction12Dispatch<HW::XE3P_35_11>  { using type = InstructionXe3p;  };
-template <> struct Instruction12Dispatch<HW::XE3P_UNKNOWN>  { using type = InstructionXe3p;  };
+template <> struct Instruction12Dispatch<HW::Xe3p>  { using type = InstructionXe3p;  };
 
 // MSVC v140 workaround for enum comparison in template arguments.
 static constexpr bool hwLT(HW hw1, HW hw2) { return hw1 < hw2; }
@@ -207,7 +205,7 @@ protected:
 
 private:
     InstructionModifier defaultModifier;
-    bool useEfficient64Bit = (hw >= HW::XE3P_35_10);
+    bool useEfficient64Bit = (hw >= HW::Xe3p);
 
     LabelManager labelManager;
     InstructionStream rootStream;
@@ -763,35 +761,35 @@ public:
     template <typename DT = void>
     void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
 #endif
         opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
     void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
 #endif
         opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
     void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
 #endif
         opX(Opcode::mach, getDataType<DT>(), (hw >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1, loc);
     }
     template <typename DT = void>
     void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
 #endif
         opX(Opcode::mach, getDataType<DT>(), (hw >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1, loc);
     }
     template <typename DT = void>
     void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         if (hw < HW::Gen10) unsupported();
 #endif
         opX((hw >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1, loc);
@@ -799,7 +797,7 @@ public:
     template <typename DT = void>
     void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         if (hw < HW::Gen10) unsupported();
 #endif
         opX((hw >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1, loc);
@@ -2137,7 +2135,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 
     i.binary.cmod = static_cast<int>(mod.getCMod());
 
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         if (op == Opcode::math)
             i.binaryXe3pImm.src0Reg8 = 0;
         i.binaryXe3p.dstReg8 = getHighBit(dst);
@@ -2221,7 +2219,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
         i.imm64.high = val >> 32;
     }
 
-    if (hw >= HW::XE3P_35_10)
+    if (hw >= HW::Xe3p)
         i.unaryXe3pImm.dstReg8 = getHighBit(dst);
 
     db(i, loc);
@@ -2304,7 +2302,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 
     i.binary.cmod = static_cast<int>(mod.getCMod());
 
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         i.binaryXe3pImm.src0Reg8 = 0;
         i.binaryXe3p.dstReg8 = getHighBit(dst);
         i.binaryXe3p.src0Reg8 = getHighBit(src0);
@@ -2388,7 +2386,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
     i.binary.src1Imm = true;
     i.imm32.value = uint32_t(static_cast<uint64_t>(src1));
 
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         i.binaryXe3pImm.dstReg8 = getHighBit(dst);
         i.binaryXe3pImm.src0Reg8 = getHighBit(src0);
     }
@@ -2609,7 +2607,7 @@ template <HW hw>
 void BinaryCodeGenerator<hw>::opBdpas(Opcode op, DataType defaultType, const InstructionModifier &mod, int sdepth, int rcount,
                                       RegData dst, RegData src0, RegData src1, RegData src2, RegData src3, RegData src4, SourceLocation loc)
 {
-    if (hw < HW::XE3P_35_10) unsupported();
+    if (hw < HW::Xe3p) unsupported();
     if (sdepth != 8 || rcount != 8) unsupported();
 
     Instruction12 i{};
@@ -2963,7 +2961,7 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
     i.branches.jip = jip;
     i.branches.uip = uip;
 
-    if (hw >= HW::XE3P_35_10)
+    if (hw >= HW::Xe3p)
         i.branchXe3p.dstReg8 = getHighBit(dst);
 
     db(i, loc);
@@ -3011,7 +3009,7 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
     i.binary.src0Imm = true;
     i.branches.jip = jip;
 
-    if (hw >= HW::XE3P_35_10)
+    if (hw >= HW::Xe3p)
         i.branchXe3p.dstReg8 = getHighBit(dst);
 
     db(i, loc);
@@ -3061,7 +3059,7 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
         i.binary.src0 &= 0xFFFF;
 
 
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         i.branchXe3p.dstReg8 = getHighBit(dst);
         i.branchXe3p.src0Reg8 = getHighBit(src0);
     }

--- a/third_party/ngen/ngen_asm.hpp
+++ b/third_party/ngen/ngen_asm.hpp
@@ -488,7 +488,7 @@ public:
         isGen12 = (hardware >= HW::Gen12LP);
         _workaround_();
         streamStack.push_back(new InstructionStream());
-        useEfficient64Bit = (hardware >= HW::XE3P_35_10);
+        useEfficient64Bit = (hardware >= HW::Xe3p);
     }
 
     explicit AsmCodeGenerator(HW hardware_, int stepping_ = 0) : AsmCodeGenerator({genericProductFamily(hardware_), 0, PlatformType::Unknown}) {}
@@ -1074,33 +1074,33 @@ public:
     }
     template <typename DT = void>
     void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1);
     }
     template <typename DT = void>
     void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1);
     }
     template <typename DT = void>
     void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         opX(Opcode::mach, getDataType<DT>(), (hardware >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1);
     }
     template <typename DT = void>
     void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         opX(Opcode::mach, getDataType<DT>(), (hardware >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1);
     }
     template <typename DT = void>
     void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         if (hardware < HW::Gen10) unsupported();
         opX((hardware >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1);
     }
     template <typename DT = void>
     void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
-        if (hardware >= HW::XE3P_35_10) unsupported();
+        if (hardware >= HW::Xe3p) unsupported();
         if (hardware < HW::Gen10) unsupported();
         opX((hardware >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1);
     }

--- a/third_party/ngen/ngen_auto_swsb.hpp
+++ b/third_party/ngen/ngen_auto_swsb.hpp
@@ -387,7 +387,7 @@ inline GeneralizedPipe getPipe(HW hw, const Instruction &insn, bool checkOOO = t
     unsigned lmask = (hw >= HW::XeHPC) ? 0b1011 : 0b0011;
     if ((dt & lmask) == lmask)
         mask = PipeMaskL;
-    else if ((hw >= HW::XE3P_35_10) && (op == Opcode::mov_gen12 || op == Opcode::srnd) && (dt != insn.src0Typecode()))
+    else if ((hw >= HW::Xe3p) && (op == Opcode::mov_gen12 || op == Opcode::srnd) && (dt != insn.src0Typecode()))
         mask = PipeMaskI;
     else if (dt & 8)
         mask = PipeMaskF;
@@ -1298,7 +1298,7 @@ inline Directive getDirective(const Instruction &insn)
 template <typename Instruction>
 inline bool canDefaultPipe(HW hw, const Instruction &insn)
 {
-    if (hw >= HW::XE3P_35_10 && insn.opcode() == Opcode::mov_gen12)
+    if (hw >= HW::Xe3p && insn.opcode() == Opcode::mov_gen12)
         return false;
     if (hw >= HW::XeHP && insn.opcode() == Opcode::mov_gen12 && (insn.dstTypecode() ^ insn.src0Typecode()) & 0x8)
         return false;

--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -257,9 +257,7 @@ enum class Core {
     Gen12p8 = XeHPC,    /* Deprecated -- will be removed in the future */
     Xe2,
     Xe3,
-    XE3P_35_10,
-    XE3P_35_11,
-    XE3P_UNKNOWN,
+    Xe3p,
 };
 
 typedef Core HW;
@@ -287,9 +285,8 @@ enum class ProductFamily : int {
     LNL,
     GenericXe3,
     GenericXe3p,
-    XE3P_35_10,
-    XE3P_35_11,
-    XE3P_UNKNOWN,
+    NVLP,
+    CRI,
 };
 
 enum class PlatformType {Unknown, Integrated, Discrete};
@@ -316,7 +313,7 @@ static inline constexpr14 PlatformType getPlatformType(ProductFamily family) {
         case ProductFamily::MTL:
         case ProductFamily::ARL:
         case ProductFamily::LNL:
-        case ProductFamily::XE3P_35_10:
+        case ProductFamily::NVLP:
             return PlatformType::Integrated;
         // Could be integrated or discrete
         case ProductFamily::GenericXeLP:
@@ -324,7 +321,6 @@ static inline constexpr14 PlatformType getPlatformType(ProductFamily family) {
         case ProductFamily::GenericXe2:
         case ProductFamily::GenericXe3:
         case ProductFamily::GenericXe3p:
-        case ProductFamily::XE3P_UNKNOWN:
             return PlatformType::Unknown;
         // Guaranteed discrete
         case ProductFamily::GenericXeHP:
@@ -333,7 +329,7 @@ static inline constexpr14 PlatformType getPlatformType(ProductFamily family) {
         case ProductFamily::PVC:
         case ProductFamily::PVCVG:
         case ProductFamily::BMG:
-        case ProductFamily::XE3P_35_11:
+        case ProductFamily::CRI:
             return PlatformType::Discrete;
         case ProductFamily::Unknown:
             return PlatformType::Unknown;
@@ -353,19 +349,14 @@ static inline constexpr14 ProductFamily genericProductFamily(HW hw)
         case HW::XeHPC: return ProductFamily::GenericXeHPC;
         case HW::Xe2:   return ProductFamily::GenericXe2;
         case HW::Xe3:   return ProductFamily::GenericXe3;
-        case HW::XE3P_35_10:
-        case HW::XE3P_35_11:
-        case HW::XE3P_UNKNOWN: return ProductFamily::GenericXe3p;
+        case HW::Xe3p:  return ProductFamily::GenericXe3p;
         default:        return ProductFamily::Unknown;
     }
 }
 
 static inline constexpr14 Core getCore(ProductFamily family)
 {
-    if (family >= ProductFamily::XE3P_UNKNOWN)  return Core::XE3P_UNKNOWN;
-    if (family >= ProductFamily::XE3P_35_11)  return Core::XE3P_35_11;
-    if (family >= ProductFamily::XE3P_35_10)  return Core::XE3P_35_10;
-    if (family >= ProductFamily::GenericXe3p) return Core::XE3P_35_10;
+    if (family >= ProductFamily::GenericXe3p) return Core::Xe3p;
     if (family >= ProductFamily::GenericXe3)   return Core::Xe3;
     if (family >= ProductFamily::GenericXe2)   return Core::Xe2;
     if (family >= ProductFamily::GenericXeHPC) return Core::XeHPC;
@@ -527,7 +518,7 @@ enum class MathFunction : uint8_t {
 
 static inline int mathArgCount(HW hw, MathFunction func)
 {
-    if (hw >= HW::XE3P_35_10) {
+    if (hw >= HW::Xe3p) {
         static const char argCounts[16] = {0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 2, 2, 2, 2, 1};
         return argCounts[static_cast<uint8_t>(func) & 0xF];
     }
@@ -1300,7 +1291,7 @@ public:
     static constexpr int maxRegs()                         { return 512; }
     static constexpr int maxRegs(HW hw) {
         return (hw < HW::XeHP) ? 128
-            : (hw == HW::XE3P_35_11) ? 512
+            : (hw >= HW::Xe3p) ? 512
             : 256;
     }
 };
@@ -2013,7 +2004,7 @@ static inline bool trackedByToken(HW hw, Opcode op, unsigned dstTypecode)
         case Opcode::dpasw:
             return true;
         case Opcode::bdpas:
-            return (hw >= HW::XE3P_35_10);
+            return (hw >= HW::Xe3p);
         default:
             if (isSend(op)) return true;
             if (hw == HW::XeHPG && dstTypecode == 0b1011 /* :df */) return true;

--- a/third_party/ngen/ngen_decoder.hpp
+++ b/third_party/ngen/ngen_decoder.hpp
@@ -80,7 +80,7 @@ bool Decoder::getOperandRegion(autoswsb::DependencyRegion &region, int opNum) co
 {
     checkCompaction();
     region.hw = hw;
-    if (hw >= HW::XE3P_35_10)
+    if (hw >= HW::Xe3p)
         return get<InstructionXe3p>().getOperandRegion(region, opNum);
     if (hw >= HW::XeHPC)
         return get<InstructionXeHPC>().getOperandRegion(region, opNum);

--- a/third_party/ngen/ngen_emulation.hpp
+++ b/third_party/ngen/ngen_emulation.hpp
@@ -53,7 +53,7 @@ struct EmulationStrategy {
             else
                 emulate64_mul = emulate64_logic = true;
         }
-        if (hw_ >= HW::XE3P_35_10)
+        if (hw_ >= HW::Xe3p)
             emulateDWxDW = emulate64_mul = false;
         emulate64_mul |= emulate64;
     }

--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -35,9 +35,7 @@ template <> struct EncodingTag12Dispatch<HW::Xe2>   { using tag = EncodingTagXeH
 template <> struct EncodingTag12Dispatch<HW::Xe3>   { using tag = EncodingTagXeHPC; };
 struct EncodingTagXe3p : public EncodingTagXeHPC {};
 
-template <> struct EncodingTag12Dispatch<HW::XE3P_35_10>  { using tag = EncodingTagXe3p; };
-template <> struct EncodingTag12Dispatch<HW::XE3P_35_11>  { using tag = EncodingTagXe3p; };
-template <> struct EncodingTag12Dispatch<HW::XE3P_UNKNOWN>  { using tag = EncodingTagXe3p; };
+template <> struct EncodingTag12Dispatch<HW::Xe3p>  { using tag = EncodingTagXe3p; };
 
 class SWSBInfo12
 {

--- a/third_party/ngen/ngen_interface.hpp
+++ b/third_party/ngen/ngen_interface.hpp
@@ -84,7 +84,7 @@ class InterfaceHandler
 
 public:
     InterfaceHandler(HW hw_) : hw(hw_), simd(GRF::bytes(hw_) >> 2)
-                             , useEfficient64Bit(hw_ >= HW::XE3P_35_10)
+                             , useEfficient64Bit(hw_ >= HW::Xe3p)
                              , requestedInlineBytes(defaultInlineBytes(hw))
     {}
 
@@ -641,7 +641,7 @@ void InterfaceHandler::setPrologueLabels(InterfaceLabels &labels, LabelManager &
     };
 
     int immOffset = 0xC;
-    if (hw >= HW::XE3P_35_10) immOffset = 0x8;
+    if (hw >= HW::Xe3p) immOffset = 0x8;
 
     setOffset(labels.localIDsLoaded, offsetSkipPerThread);
     setOffset(labels.argsLoaded, offsetSkipCrossThread);

--- a/third_party/ngen/ngen_level_zero.hpp
+++ b/third_party/ngen/ngen_level_zero.hpp
@@ -239,7 +239,7 @@ template <HW hw>
 bool LevelZeroCodeGenerator<hw>::detectEfficient64Bit(ze_context_handle_t context, ze_device_handle_t device, HW inHW)
 {
     if (inHW == HW::Unknown) inHW = hw;
-    if (inHW < HW::XE3P_35_10) return false;
+    if (inHW < HW::Xe3p) return false;
 
     auto binary = detail::getDummyModuleBinary(context, device);
     return npack::isBinaryEfficient64Bit(binary, inHW);

--- a/third_party/ngen/ngen_opencl.hpp
+++ b/third_party/ngen/ngen_opencl.hpp
@@ -365,7 +365,7 @@ bool OpenCLCodeGenerator<hw>::detectEfficient64Bit(cl_context context, cl_device
     const char *dummyCL = "kernel void _ngen_eff64b_detect(){}";
 
     if (inHW == HW::Unknown) inHW = hw;
-    if (inHW < HW::XE3P_35_10) return false;
+    if (inHW < HW::Xe3p) return false;
 
     auto binary = detail::getOpenCLCProgramBinary(context, device, dummyCL, "");
     return npack::isBinaryEfficient64Bit(binary, inHW);

--- a/third_party/ngen/ngen_register_allocator.hpp
+++ b/third_party/ngen/ngen_register_allocator.hpp
@@ -253,9 +253,7 @@ int Bundle::firstReg(HW hw) const
         case HW::XeHPC:
         case HW::Xe2:
         case HW::Xe3:
-        case HW::XE3P_35_10:
-        case HW::XE3P_35_11:
-        case HW::XE3P_UNKNOWN:
+        case HW::Xe3p:
             return (bundle0 << 1) | bank0;
         case HW::XeHP:
         case HW::XeHPG:
@@ -292,9 +290,7 @@ int Bundle::stride(HW hw) const
         case HW::Gen12LP:
         case HW::Xe2:
         case HW::Xe3:
-        case HW::XE3P_35_10:
-        case HW::XE3P_35_11:
-        case HW::XE3P_UNKNOWN:
+        case HW::Xe3p:
             return 16;
         case HW::XeHP:
         case HW::XeHPG:
@@ -325,9 +321,7 @@ uint64_t Bundle::regMask(HW hw, int offset) const
         case HW::Gen12LP:
         case HW::Xe2:
         case HW::Xe3:
-        case HW::XE3P_35_10:
-        case HW::XE3P_35_11:
-        case HW::XE3P_UNKNOWN:
+        case HW::Xe3p:
             if (bundle_id != any)                           base_mask  = 0x0003000300030003;
             if (bank_id != any)                             base_mask &= 0x5555555555555555;
             return base_mask << (bank0 + (bundle0 << 1));
@@ -358,9 +352,7 @@ Bundle Bundle::locate(HW hw, RegData reg)
         case HW::Gen12LP:
         case HW::Xe2:
         case HW::Xe3:
-        case HW::XE3P_35_10:
-        case HW::XE3P_35_11:
-        case HW::XE3P_UNKNOWN:
+        case HW::Xe3p:
             return Bundle(base & 1, (base >> 1) & 7);
         case HW::XeHP:
         case HW::XeHPG:

--- a/third_party/ngen/ngen_register_decl.hpp
+++ b/third_party/ngen/ngen_register_decl.hpp
@@ -803,9 +803,7 @@ template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::XeHPG>;
 template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::XeHPC>;
 template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::Xe2>;
 template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::Xe3>;
-template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::XE3P_35_10>;
-template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::XE3P_35_11>;
-template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::XE3P_UNKNOWN>;
+template class NGEN_NAMESPACE::BinaryCodeGenerator<NGEN_NAMESPACE::HW::Xe3p>;
 
 
 #endif /* (defined(NGEN_CPP11) || defined(NGEN_CPP14)) && !defined(NGEN_GLOBAL_REGS) */

--- a/third_party/ngen/npack/neo_packager.hpp
+++ b/third_party/ngen/npack/neo_packager.hpp
@@ -194,15 +194,8 @@ inline HW decodeGfxCoreFamily(GfxCoreFamily family)
         case GfxCoreFamily::XeHPC:        return HW::XeHPC;
         case GfxCoreFamily::Xe2:          return HW::Xe2;
         case GfxCoreFamily::Xe3:          return HW::Xe3;
-	    // XE3P_35_10 and XE3P_35_11 use duplicate GfxCore.
-	    // Detection via GfxCore is therefore unsupported.
-	    case GfxCoreFamily::XE3P_35_10:   return HW::Unknown;
-        case GfxCoreFamily::XE3P_UNKNOWN: return HW::XE3P_UNKNOWN;
-        default:                          if (family > GfxCoreFamily::XE3P_35_10) {
-                                              return HW::XE3P_UNKNOWN;
-                                          } else {
-                                              return HW::Unknown;
-                                          }
+        case GfxCoreFamily::Xe3p:         return HW::Xe3p;
+        default:                          return HW::Unknown;
     }
 }
 
@@ -218,14 +211,8 @@ inline GfxCoreFamily encodeGfxCoreFamily(HW hw)
         case HW::XeHPC:        return GfxCoreFamily::XeHPC;
         case HW::Xe2:          return GfxCoreFamily::Xe2;
         case HW::Xe3:          return GfxCoreFamily::Xe3;
-        case HW::XE3P_35_10:   return GfxCoreFamily::XE3P_35_10;
-        case HW::XE3P_35_11:   return GfxCoreFamily::XE3P_35_11;
-        case HW::XE3P_UNKNOWN: return GfxCoreFamily::XE3P_UNKNOWN;
-        default:               if (hw > HW::XE3P_35_10) {
-                                   return GfxCoreFamily::XE3P_UNKNOWN;
-                               } else {
-                                   return GfxCoreFamily::Unknown;
-                               }
+        case HW::Xe3p:         return GfxCoreFamily::Xe3p;
+        default:               return GfxCoreFamily::Unknown;
     }
 }
 
@@ -243,9 +230,9 @@ inline NGEN_NAMESPACE::ProductFamily decodeProductFamily(ProductFamily family)
     if (family == ProductFamily::BMG) return NGEN_NAMESPACE::ProductFamily::BMG;
     if (family >= ProductFamily::LNL && family <= ProductFamily::LNL_M) return NGEN_NAMESPACE::ProductFamily::LNL;
     if (family == ProductFamily::PTL) return NGEN_NAMESPACE::ProductFamily::GenericXe3;
-    if (family == ProductFamily::XE3P_35_10) return NGEN_NAMESPACE::ProductFamily::XE3P_35_10;
-    if (family == ProductFamily::XE3P_35_11) return NGEN_NAMESPACE::ProductFamily::XE3P_35_11;
-    if (family >= ProductFamily::XE3P_35_11) return NGEN_NAMESPACE::ProductFamily::XE3P_UNKNOWN;
+    if (family == ProductFamily::NVLP) return NGEN_NAMESPACE::ProductFamily::NVLP;
+    if (family == ProductFamily::CRI) return NGEN_NAMESPACE::ProductFamily::CRI;
+    if (family >= ProductFamily::CRI) return NGEN_NAMESPACE::ProductFamily::GenericXe3p;
     return NGEN_NAMESPACE::ProductFamily::Unknown;
 }
 
@@ -334,11 +321,11 @@ inline NGEN_NAMESPACE::Product decodeHWIPVersion(uint32_t rawVersion)
         case 30: outProduct.family = NGEN_NAMESPACE::ProductFamily::GenericXe3; break;
         case 35:
             if (version.release == 10)
-                outProduct.family = NGEN_NAMESPACE::ProductFamily::XE3P_35_10;
+                outProduct.family = NGEN_NAMESPACE::ProductFamily::NVLP;
             else if (version.release == 11)
-                outProduct.family = NGEN_NAMESPACE::ProductFamily::XE3P_35_11;
-            else if (version.release >= 11)
-                outProduct.family = NGEN_NAMESPACE::ProductFamily::XE3P_UNKNOWN;
+                outProduct.family = NGEN_NAMESPACE::ProductFamily::CRI;
+            else
+                outProduct.family = NGEN_NAMESPACE::ProductFamily::GenericXe3p;
             break;
         default: outProduct.family = NGEN_NAMESPACE::ProductFamily::Unknown; break;
     }
@@ -353,7 +340,7 @@ inline NGEN_NAMESPACE::Product decodeHWIPVersion(uint32_t rawVersion)
 
 inline bool isBinaryEfficient64Bit(const std::vector<uint8_t> &binary, HW hw)
 {
-    return (hw >= HW::XE3P_35_10) && !hasGatewayEOTSend(binary);
+    return (hw >= HW::Xe3p) && !hasGatewayEOTSend(binary);
 }
 
 } /* namespace npack */

--- a/third_party/ngen/npack/neo_structs.hpp
+++ b/third_party/ngen/npack/neo_structs.hpp
@@ -45,9 +45,7 @@ enum class GfxCoreFamily : uint32_t {
     XeHPC = 0xC08,
     Xe2 = 0xC09,
     Xe3 = 0x1E00,
-    XE3P_35_10 = 0x2300,
-    XE3P_35_11 = XE3P_35_10,
-    XE3P_UNKNOWN = 0xFFFF,
+    Xe3p = 0x2300,
 };
 
 enum class ProductFamily : uint32_t {
@@ -66,9 +64,8 @@ enum class ProductFamily : uint32_t {
     LNL = 1275,
     LNL_M = 1276,
     PTL = 1300,
-    XE3P_35_10 = 1360,
-    XE3P_35_11 = 1380,
-    XE3P_UNKNOWN = 9999,
+    NVLP = 1360,
+    CRI = 1380,
 };
 
 struct SProgramBinaryHeader


### PR DESCRIPTION
Collapse ngen::Core::XE3P_35_10, XE3P_35_11, and XE3P_UNKNOWN into a single ngen::Core::Xe3p value. Use ngen::ProductFamily to distinguish hardware-specific features where needed (512 GRFs, F4 DPAS support, SLM capacity).

addresses MFDNN-14960