### PR TITLE
[GPU] Widen GPU offsets (part2)

### DIFF
--- a/src/gpu/intel/binary/simple.cl
+++ b/src/gpu/intel/binary/simple.cl
@@ -64,7 +64,7 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
         __global float *src1_scale) {
 
     // since gws = no. of total elems in A, id will be the logical offset
-    int dims0[6] = {0};
+    off_t dims0[6] = {0};
     dims0[0] = GWS_GET_D0();
     dims0[1] = GWS_GET_D1();
     dims0[2] = GWS_GET_D2();
@@ -72,9 +72,9 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
     dims0[4] = GWS_GET_D4();
     dims0[5] = GWS_GET_D5();
     int d1_block = GWS_GET_D1_BLOCK();
-    int dims0_po[6]
+    off_t dims0_po[6]
             = {dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]};
-    int d1_init = GWS_GET_D1();
+    off_t d1_init = GWS_GET_D1();
 
     off_t dst_off = DST_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);

--- a/src/gpu/intel/bnorm/xe_nhwc_bwd.cl
+++ b/src/gpu/intel/bnorm/xe_nhwc_bwd.cl
@@ -65,8 +65,8 @@ __kernel void xe_calculate_stats_nhwc(__global DATA_T *src,
         if (sp_block_idx * STAT_SP_BLOCK + sp >= SP) break;
 #else // issue
 #if HAS_STAT_SP_BLOCK_TAIL
-    for (int sp = 0; sp < min(STAT_SP_BLOCK, SP - sp_block_idx * STAT_SP_BLOCK);
-            ++sp) {
+    int sp_remaining = (int)(SP - sp_block_idx * STAT_SP_BLOCK);
+    for (int sp = 0; sp < min(STAT_SP_BLOCK, sp_remaining); ++sp) {
 #else
     for (int sp = 0; sp < STAT_SP_BLOCK; ++sp) {
 #endif

--- a/src/gpu/intel/bnorm/xe_nhwc_fwd.cl
+++ b/src/gpu/intel/bnorm/xe_nhwc_fwd.cl
@@ -54,8 +54,8 @@ __kernel void xe_calc_mean_var_nhwc(__global DATA_T *src,
     SUM_DATA_T sum_sq[IC_BLOCK_SGROUPS] = {0.0f};
 
 #if HAS_STAT_SP_BLOCK_TAIL
-    for (int sp = 0; sp < min(STAT_SP_BLOCK, SP - sp_block_idx * STAT_SP_BLOCK);
-            ++sp) {
+    int sp_remaining = (int)(SP - sp_block_idx * STAT_SP_BLOCK);
+    for (int sp = 0; sp < min(STAT_SP_BLOCK, sp_remaining); ++sp) {
 #else
     for (int sp = 0; sp < STAT_SP_BLOCK; ++sp) {
 #endif
@@ -123,8 +123,8 @@ __kernel void xe_calc_mean_nhwc(__global DATA_T *src,
     float v_mean[IC_BLOCK_SGROUPS] = {0.0f};
 
 #if HAS_STAT_SP_BLOCK_TAIL
-    for (int sp = 0; sp < min(STAT_SP_BLOCK, SP - sp_block_idx * STAT_SP_BLOCK);
-            ++sp) {
+    int sp_remaining = (int)(SP - sp_block_idx * STAT_SP_BLOCK);
+    for (int sp = 0; sp < min(STAT_SP_BLOCK, sp_remaining); ++sp) {
 #else
     for (int sp = 0; sp < STAT_SP_BLOCK; ++sp) {
 #endif
@@ -190,8 +190,8 @@ __kernel void xe_calc_variance_nhwc(__global DATA_T *src, __global float *mean,
     float v0[IC_BLOCK_SGROUPS] = {0.0f};
 
 #if HAS_STAT_SP_BLOCK_TAIL
-    for (int sp = 0; sp < min(STAT_SP_BLOCK, SP - sp_block_idx * STAT_SP_BLOCK);
-            ++sp) {
+    int sp_remaining = (int)(SP - sp_block_idx * STAT_SP_BLOCK);
+    for (int sp = 0; sp < min((off_t)STAT_SP_BLOCK, sp_remaining); ++sp) {
 #else
     for (int sp = 0; sp < STAT_SP_BLOCK; ++sp) {
 #endif

--- a/src/gpu/intel/conv/deconv_backward_bias.cl
+++ b/src/gpu/intel/conv/deconv_backward_bias.cl
@@ -18,14 +18,15 @@
 
 __kernel void deconv_backward_bias(
         __global DST_DATA_T *diff_dst, __global BIA_DATA_T *diff_bias) {
-    const int g = get_global_id(0) / OC;
-    const int oc = get_global_id(0) % OC;
+    const off_t g = get_global_id(0) / OC;
+    const off_t oc = get_global_id(0) % OC;
     ACC_DATA_T db = 0;
-    for (int mb = 0; mb < MB; ++mb)
-        for (int od = 0; od < OD; ++od)
-            for (int oh = 0; oh < OH; ++oh)
-                for (int ow = 0; ow < OW; ++ow) {
-                    uint diff_dst_off = DST_OFF(mb, g * OC + oc, od, oh, ow);
+    for (off_t mb = 0; mb < MB; ++mb)
+        for (off_t od = 0; od < OD; ++od)
+            for (off_t oh = 0; oh < OH; ++oh)
+                for (off_t ow = 0; ow < OW; ++ow) {
+                    const off_t diff_dst_off
+                            = DST_OFF(mb, g * OC + oc, od, oh, ow);
                     db += DST_TO_REF(diff_dst[diff_dst_off]);
                 }
 

--- a/src/gpu/intel/conv/deconvolution.hpp
+++ b/src/gpu/intel/conv/deconvolution.hpp
@@ -187,6 +187,8 @@ struct conv_bwd_weights_t : public primitive_t {
         memory_desc_wrapper diff_dst_mdw(pd()->diff_dst_md());
         kernel_ctx.set_data_type(pd()->diff_dst_md()->data_type);
         kernel_ctx.require_stateless_addressing(pd()->has_large_buffers());
+        kernel_ctx.register_buffer_size(diff_dst_mdw);
+        kernel_ctx.register_buffer_size(*pd()->diff_weights_md(1));
         offsets_t off;
         set_offsets(diff_dst_mdw, off.dst_off);
         def_offsets(off.dst_off, kernel_ctx, "DST",

--- a/src/gpu/intel/include/math_utils.h
+++ b/src/gpu/intel/include/math_utils.h
@@ -44,11 +44,12 @@ int __attribute__((overloadable)) rnd_up(int a, unsigned int b) {
     return div_up(a, b) * b;
 }
 
-int __attribute__((overloadable)) rnd_up(unsigned int a, unsigned int b) {
+unsigned int __attribute__((overloadable)) rnd_up(
+        unsigned int a, unsigned int b) {
     return div_up(a, b) * b;
 }
 
-int __attribute__((overloadable)) rnd_up(long a, unsigned int b) {
+long __attribute__((overloadable)) rnd_up(long a, unsigned int b) {
     return div_up(a, b) * b;
 }
 
@@ -56,11 +57,12 @@ int __attribute__((overloadable)) rnd_down(int a, unsigned int b) {
     return (a / b) * b;
 }
 
-int __attribute__((overloadable)) rnd_down(unsigned int a, unsigned int b) {
+unsigned int __attribute__((overloadable)) rnd_down(
+        unsigned int a, unsigned int b) {
     return (a / b) * b;
 }
 
-int __attribute__((overloadable)) rnd_down(long a, unsigned int b) {
+long __attribute__((overloadable)) rnd_down(long a, unsigned int b) {
     return (a / b) * b;
 }
 

--- a/src/gpu/intel/rnn/common.h
+++ b/src/gpu/intel/rnn/common.h
@@ -56,15 +56,17 @@
 #define TO_WS_STATE(x) TO_SRC(x)
 
 #define OFF6(i0, D0, i1, D1, i2, D2, i3, D3, i4, D4, i5, D5) \
-    ((((((i0) * (D1) + (i1)) * (D2) + (i2)) * (D3) + (i3)) * (D4) + (i4)) \
-                    * (D5) \
+    (((((((off_t)(i0)) * (D1) + (i1)) * (D2) + (i2)) * (D3) + (i3)) * (D4) \
+             + (i4)) * (D5) \
             + (i5))
 #define OFF5(i0, D0, i1, D1, i2, D2, i3, D3, i4, D4) \
-    (((((i0) * (D1) + (i1)) * (D2) + (i2)) * (D3) + (i3)) * (D4) + (i4))
+    ((((((off_t)(i0)) * (D1) + (i1)) * (D2) + (i2)) * (D3) + (i3)) * (D4) \
+            + (i4))
 #define OFF4(i0, D0, i1, D1, i2, D2, i3, D3) \
-    ((((i0) * (D1) + (i1)) * (D2) + (i2)) * (D3) + (i3))
-#define OFF3(i0, D0, i1, D1, i2, D2) (((i0) * (D1) + (i1)) * (D2) + (i2))
-#define OFF2(i0, D0, i1, D1) ((i0) * (D1) + (i1))
+    (((((off_t)(i0)) * (D1) + (i1)) * (D2) + (i2)) * (D3) + (i3))
+#define OFF3(i0, D0, i1, D1, i2, D2) \
+    ((((off_t)(i0)) * (D1) + (i1)) * (D2) + (i2))
+#define OFF2(i0, D0, i1, D1) (((off_t)(i0)) * (D1) + (i1))
 
 const int vanilla_rnn_n_gates = 1;
 const int vanilla_rnn_n_bias = 1;
@@ -86,11 +88,11 @@ const int n_bias = 3;
 #error "Unimplemented cell kind"
 #endif
 
-int comp_off(int n_dir, int dhc, int i0, int i1, int i2, int i3) {
+off_t comp_off(int n_dir, int dhc, int i0, int i1, int i2, int i3) {
     return (((i0 * n_dir + i1) * n_bias + i2) * dhc + i3);
 }
 
-int off_ws_state(int n_layer, int n_dir, int n_iter, int batch,
+off_t off_ws_state(int n_layer, int n_dir, int n_iter, int batch,
         int states_ws_ld, int i0_, int i1, int i2_, int i3, int i4) {
     int i0 = COPY_SRC_LAYER ? i0_ + 1 : i0_;
     int i0_size = COPY_SRC_LAYER ? n_layer + 1 : n_layer;
@@ -98,7 +100,7 @@ int off_ws_state(int n_layer, int n_dir, int n_iter, int batch,
     return OFF5(i0, i0_size, i1, n_dir, i2, n_iter + 1, i3, batch, i4,
             states_ws_ld);
 }
-int off_ws_c_state(int n_layer, int n_dir, int n_iter, int batch,
+off_t off_ws_c_state(int n_layer, int n_dir, int n_iter, int batch,
         int states_ws_ld, int i0_, int i1, int i2_, int i3, int i4) {
     int i0 = i0_;
     int i0_size = n_layer;
@@ -107,26 +109,26 @@ int off_ws_c_state(int n_layer, int n_dir, int n_iter, int batch,
             states_ws_ld);
 }
 // cannot be presented by OFF6 due to leading dimension across two dims
-int off_ws_gates(int n_dir, int n_iter, int batch, int gates_ws_ld, int dhc,
+off_t off_ws_gates(int n_dir, int n_iter, int batch, int gates_ws_ld, int dhc,
         int i0, int i1, int i2, int i3, int i4, int i5) {
-    return i0 * n_dir * n_iter * batch * gates_ws_ld
+    return ((off_t)i0) * n_dir * n_iter * batch * gates_ws_ld
             + i1 * n_iter * batch * gates_ws_ld + i2 * batch * gates_ws_ld
             + i3 * gates_ws_ld + i4 * dhc + i5;
 }
-int off_ws_bias(
+off_t off_ws_bias(
         int n_layer, int n_dir, int dhc, int i0, int i1, int i2, int i3) {
     return OFF4(i0, n_layer, i1, n_dir, i2, n_bias, i3, dhc);
 }
 // grid offset for lbr GRU, LD = DHC
-int off_ws_grid_offset(int n_layer, int n_dir, int n_iter, int batch, int dhc,
+off_t off_ws_grid_offset(int n_layer, int n_dir, int n_iter, int batch, int dhc,
         int i0, int i1, int i2, int i3, int i4) {
     return OFF5(i0, n_layer, i1, n_dir, i2, n_iter, i3, batch, i4, dhc);
 }
 
-int off_ker_bias(int dhc, int i0, int i1) {
+off_t off_ker_bias(int dhc, int i0, int i1) {
     return OFF2(i0, n_gates, i1, dhc);
 }
-int off_scratch_diff_states(int n_layer, int n_dir, int n_states, int n_iter,
+off_t off_scratch_diff_states(int n_layer, int n_dir, int n_states, int n_iter,
         int batch, int scratch_diff_states_ld, int i0, int i1, int i2, int i3,
         int i4, int i5) {
     bool have_result_layer = COPY_DIFF_SRC_LAYER || n_layer > 1;
@@ -149,165 +151,158 @@ int off_scratch_diff_states(int n_layer, int n_dir, int n_states, int n_iter,
     return OFF6(i0, i0_size, i1, n_dir, i2, i2_size, i3, i3_size, i4, batch, i5,
             scratch_diff_states_ld);
 }
-int off_scratch_dhg1(int batch, int scratch_diff_states_ld, int i0, int i1) {
+off_t off_scratch_dhg1(int batch, int scratch_diff_states_ld, int i0, int i1) {
     return OFF2(i0, batch, i1, scratch_diff_states_ld);
 }
-int off_scratch_cell(int batch, int states_ws_ld, int i0, int i1) {
+off_t off_scratch_cell(int batch, int states_ws_ld, int i0, int i1) {
     return OFF2(i0, batch, i1, states_ws_ld);
 }
 
 // for cell - shorter forms
 
-int cell_ws_state(int states_ws_ld, int i, int j) {
+off_t cell_ws_state(int states_ws_ld, int i, int j) {
     // OFF_WS_STATE(0, 0, 0, i4, i5)
     return i * states_ws_ld + j;
 }
-int cell_ws_gates(int gates_ws_ld, int dhc, int i, int n, int j) {
+off_t cell_ws_gates(int gates_ws_ld, int dhc, int i, int n, int j) {
     // OFF_WS_GATES(0, 0, 0, i3, i4, i5)
     return i * gates_ws_ld + n * dhc + j;
 }
-int cell_ws_grid_comp(int dhc, int i3, int i4) {
+off_t cell_ws_grid_comp(int dhc, int i3, int i4) {
     // OFF_WS_GRID_OFFSET(0, 0, 0, i3, i4)
     return i3 * dhc + i4;
 }
-int cell_scratch_mem(int scratch_gates_ld, int dhc, int i, int n, int j) {
+off_t cell_scratch_mem(int scratch_gates_ld, int dhc, int i, int n, int j) {
     // OFF_SCRATCH_MEM(0, i1, i2, i3)
     return i * scratch_gates_ld + n * dhc + j;
 }
-int cell_scratch_diff_states(
+off_t cell_scratch_diff_states(
         int batch, int scratch_diff_states_ld, int i4, int i5) {
     // OFF_SCRATCH_DIFF_STATES(0, 0, i2, 0, i4, i5)
     return (i4 * scratch_diff_states_ld + i5);
 }
 
-int bias_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t bias_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
-    return ((x0 % BIAS_B0) * BIAS_SB0 + (x0 / BIAS_B0) * (int)s[0]
-            + (x1 % BIAS_B1) * BIAS_SB1 + (x1 / BIAS_B1) * (int)s[1]
-            + (x2 % BIAS_B2) * BIAS_SB2 + (x2 / BIAS_B2) * (int)s[2]
-            + (x3 % BIAS_B3) * BIAS_SB3 + (x3 / BIAS_B3) * (int)s[3]);
+    return ((x0 % BIAS_B0) * BIAS_SB0 + (x0 / BIAS_B0) * s[0]
+            + (x1 % BIAS_B1) * BIAS_SB1 + (x1 / BIAS_B1) * s[1]
+            + (x2 % BIAS_B2) * BIAS_SB2 + (x2 / BIAS_B2) * s[2]
+            + (x3 % BIAS_B3) * BIAS_SB3 + (x3 / BIAS_B3) * s[3]);
 }
-int src_l_off(int64x3_t strides, int iter, int batch, int slc) {
+off_t src_l_off(int64x3_t strides, int iter, int batch, int slc) {
     int64_t *s = strides.array;
-    return ((iter % SRC_L_B0) * SRC_L_SB0 + (iter / SRC_L_B0) * (int)s[0]
-            + (batch % SRC_L_B1) * SRC_L_SB1 + (batch / SRC_L_B1) * (int)s[1]
-            + (slc % SRC_L_B2) * SRC_L_SB2 + (slc / SRC_L_B2) * (int)s[2]);
+    return ((iter % SRC_L_B0) * SRC_L_SB0 + (iter / SRC_L_B0) * s[0]
+            + (batch % SRC_L_B1) * SRC_L_SB1 + (batch / SRC_L_B1) * s[1]
+            + (slc % SRC_L_B2) * SRC_L_SB2 + (slc / SRC_L_B2) * s[2]);
 }
-int src_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t src_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
-    return ((x0 % SRC_I_B0) * SRC_I_SB0 + (x0 / SRC_I_B0) * (int)s[0]
-            + (x1 % SRC_I_B1) * SRC_I_SB1 + (x1 / SRC_I_B1) * (int)s[1]
-            + (x2 % SRC_I_B2) * SRC_I_SB2 + (x2 / SRC_I_B2) * (int)s[2]
-            + (x3 % SRC_I_B3) * SRC_I_SB3 + (x3 / SRC_I_B3) * (int)s[3]);
+    return ((x0 % SRC_I_B0) * SRC_I_SB0 + (x0 / SRC_I_B0) * s[0]
+            + (x1 % SRC_I_B1) * SRC_I_SB1 + (x1 / SRC_I_B1) * s[1]
+            + (x2 % SRC_I_B2) * SRC_I_SB2 + (x2 / SRC_I_B2) * s[2]
+            + (x3 % SRC_I_B3) * SRC_I_SB3 + (x3 / SRC_I_B3) * s[3]);
 }
 #if WITH_SRC_ITER_C
-int src_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t src_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
-    return ((x0 % SRC_I_C_B0) * SRC_I_C_SB0 + (x0 / SRC_I_C_B0) * (int)s[0]
-            + (x1 % SRC_I_C_B1) * SRC_I_C_SB1 + (x1 / SRC_I_C_B1) * (int)s[1]
-            + (x2 % SRC_I_C_B2) * SRC_I_C_SB2 + (x2 / SRC_I_C_B2) * (int)s[2]
-            + (x3 % SRC_I_C_B3) * SRC_I_C_SB3 + (x3 / SRC_I_C_B3) * (int)s[3]);
+    return ((x0 % SRC_I_C_B0) * SRC_I_C_SB0 + (x0 / SRC_I_C_B0) * s[0]
+            + (x1 % SRC_I_C_B1) * SRC_I_C_SB1 + (x1 / SRC_I_C_B1) * s[1]
+            + (x2 % SRC_I_C_B2) * SRC_I_C_SB2 + (x2 / SRC_I_C_B2) * s[2]
+            + (x3 % SRC_I_C_B3) * SRC_I_C_SB3 + (x3 / SRC_I_C_B3) * s[3]);
 }
 #endif
-int dst_l_off(int64x3_t strides, int x0, int x1, int x2) {
+off_t dst_l_off(int64x3_t strides, int x0, int x1, int x2) {
     int64_t *s = strides.array;
-    return ((x0 % DST_L_B0) * DST_L_SB0 + (x0 / DST_L_B0) * (int)s[0]
-            + (x1 % DST_L_B1) * DST_L_SB1 + (x1 / DST_L_B1) * (int)s[1]
-            + (x2 % DST_L_B2) * DST_L_SB2 + (x2 / DST_L_B2) * (int)s[2]);
+    return ((x0 % DST_L_B0) * DST_L_SB0 + (x0 / DST_L_B0) * s[0]
+            + (x1 % DST_L_B1) * DST_L_SB1 + (x1 / DST_L_B1) * s[1]
+            + (x2 % DST_L_B2) * DST_L_SB2 + (x2 / DST_L_B2) * s[2]);
 }
-int dst_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t dst_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
-    return ((x0 % DST_I_B0) * DST_I_SB0 + (x0 / DST_I_B0) * (int)s[0]
-            + (x1 % DST_I_B1) * DST_I_SB1 + (x1 / DST_I_B1) * (int)s[1]
-            + (x2 % DST_I_B2) * DST_I_SB2 + (x2 / DST_I_B2) * (int)s[2]
-            + (x3 % DST_I_B3) * DST_I_SB3 + (x3 / DST_I_B3) * (int)s[3]);
+    return ((x0 % DST_I_B0) * DST_I_SB0 + (x0 / DST_I_B0) * s[0]
+            + (x1 % DST_I_B1) * DST_I_SB1 + (x1 / DST_I_B1) * s[1]
+            + (x2 % DST_I_B2) * DST_I_SB2 + (x2 / DST_I_B2) * s[2]
+            + (x3 % DST_I_B3) * DST_I_SB3 + (x3 / DST_I_B3) * s[3]);
 }
 #if WITH_DST_ITER_C
-int dst_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t dst_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
-    return ((x0 % DST_I_C_B0) * DST_I_C_SB0 + (x0 / DST_I_C_B0) * (int)s[0]
-            + (x1 % DST_I_C_B1) * DST_I_C_SB1 + (x1 / DST_I_C_B1) * (int)s[1]
-            + (x2 % DST_I_C_B2) * DST_I_C_SB2 + (x2 / DST_I_C_B2) * (int)s[2]
-            + (x3 % DST_I_C_B3) * DST_I_C_SB3 + (x3 / DST_I_C_B3) * (int)s[3]);
+    return ((x0 % DST_I_C_B0) * DST_I_C_SB0 + (x0 / DST_I_C_B0) * s[0]
+            + (x1 % DST_I_C_B1) * DST_I_C_SB1 + (x1 / DST_I_C_B1) * s[1]
+            + (x2 % DST_I_C_B2) * DST_I_C_SB2 + (x2 / DST_I_C_B2) * s[2]
+            + (x3 % DST_I_C_B3) * DST_I_C_SB3 + (x3 / DST_I_C_B3) * s[3]);
 }
 #endif
 #if !IS_FWD
-int diff_src_l_off(int64x3_t strides, int x0, int x1, int x2) {
+off_t diff_src_l_off(int64x3_t strides, int x0, int x1, int x2) {
     int64_t *s = strides.array;
-    return ((x0 % DIFF_SRC_L_B0) * DIFF_SRC_L_SB0
-            + (x0 / DIFF_SRC_L_B0) * (int)s[0]
+    return ((x0 % DIFF_SRC_L_B0) * DIFF_SRC_L_SB0 + (x0 / DIFF_SRC_L_B0) * s[0]
             + (x1 % DIFF_SRC_L_B1) * DIFF_SRC_L_SB1
-            + (x1 / DIFF_SRC_L_B1) * (int)s[1]
+            + (x1 / DIFF_SRC_L_B1) * s[1]
             + (x2 % DIFF_SRC_L_B2) * DIFF_SRC_L_SB2
-            + (x2 / DIFF_SRC_L_B2) * (int)s[2]);
+            + (x2 / DIFF_SRC_L_B2) * s[2]);
 }
-int diff_dst_l_off(int64x3_t strides, int iter, int batch, int dhc) {
+off_t diff_dst_l_off(int64x3_t strides, int iter, int batch, int dhc) {
     int64_t *s = strides.array;
     return ((iter % DIFF_DST_L_B0) * DIFF_DST_L_SB0
-            + (iter / DIFF_DST_L_B0) * (int)s[0]
+            + (iter / DIFF_DST_L_B0) * s[0]
             + (batch % DIFF_DST_L_B1) * DIFF_DST_L_SB1
-            + (batch / DIFF_DST_L_B1) * (int)s[1]
+            + (batch / DIFF_DST_L_B1) * s[1]
             + (dhc % DIFF_DST_L_B2) * DIFF_DST_L_SB2
-            + (dhc / DIFF_DST_L_B2) * (int)s[2]);
+            + (dhc / DIFF_DST_L_B2) * s[2]);
 }
-int diff_src_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t diff_src_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
-    return ((x0 % DIFF_SRC_I_B0) * DIFF_SRC_I_SB0
-            + (x0 / DIFF_SRC_I_B0) * (int)s[0]
+    return ((x0 % DIFF_SRC_I_B0) * DIFF_SRC_I_SB0 + (x0 / DIFF_SRC_I_B0) * s[0]
             + (x1 % DIFF_SRC_I_B1) * DIFF_SRC_I_SB1
-            + (x1 / DIFF_SRC_I_B1) * (int)s[1]
+            + (x1 / DIFF_SRC_I_B1) * s[1]
             + (x2 % DIFF_SRC_I_B2) * DIFF_SRC_I_SB2
-            + (x2 / DIFF_SRC_I_B2) * (int)s[2]
+            + (x2 / DIFF_SRC_I_B2) * s[2]
             + (x3 % DIFF_SRC_I_B3) * DIFF_SRC_I_SB3
-            + (x3 / DIFF_SRC_I_B3) * (int)s[3]);
+            + (x3 / DIFF_SRC_I_B3) * s[3]);
 }
-int diff_dst_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t diff_dst_i_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
-    return ((x0 % DIFF_DST_I_B0) * DIFF_DST_I_SB0
-            + (x0 / DIFF_DST_I_B0) * (int)s[0]
+    return ((x0 % DIFF_DST_I_B0) * DIFF_DST_I_SB0 + (x0 / DIFF_DST_I_B0) * s[0]
             + (x1 % DIFF_DST_I_B1) * DIFF_DST_I_SB1
-            + (x1 / DIFF_DST_I_B1) * (int)s[1]
+            + (x1 / DIFF_DST_I_B1) * s[1]
             + (x2 % DIFF_DST_I_B2) * DIFF_DST_I_SB2
-            + (x2 / DIFF_DST_I_B2) * (int)s[2]
+            + (x2 / DIFF_DST_I_B2) * s[2]
             + (x3 % DIFF_DST_I_B3) * DIFF_DST_I_SB3
-            + (x3 / DIFF_DST_I_B3) * (int)s[3]);
+            + (x3 / DIFF_DST_I_B3) * s[3]);
 }
 #if WITH_SRC_ITER_C
-int diff_src_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t diff_src_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
     return ((x0 % DIFF_SRC_I_C_B0) * DIFF_SRC_I_C_SB0
-            + (x0 / DIFF_SRC_I_C_B0) * (int)s[0]
+            + (x0 / DIFF_SRC_I_C_B0) * s[0]
             + (x1 % DIFF_SRC_I_C_B1) * DIFF_SRC_I_C_SB1
-            + (x1 / DIFF_SRC_I_C_B1) * (int)s[1]
+            + (x1 / DIFF_SRC_I_C_B1) * s[1]
             + (x2 % DIFF_SRC_I_C_B2) * DIFF_SRC_I_C_SB2
-            + (x2 / DIFF_SRC_I_C_B2) * (int)s[2]
+            + (x2 / DIFF_SRC_I_C_B2) * s[2]
             + (x3 % DIFF_SRC_I_C_B3) * DIFF_SRC_I_C_SB3
-            + (x3 / DIFF_SRC_I_C_B3) * (int)s[3]);
+            + (x3 / DIFF_SRC_I_C_B3) * s[3]);
 }
 #endif
 #if WITH_DST_ITER_C
-int diff_dst_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
+off_t diff_dst_i_c_off(int64x4_t strides, int x0, int x1, int x2, int x3) {
     int64_t *s = strides.array;
     return ((x0 % DIFF_DST_I_C_B0) * DIFF_DST_I_C_SB0
-            + (x0 / DIFF_DST_I_C_B0) * (int)s[0]
+            + (x0 / DIFF_DST_I_C_B0) * s[0]
             + (x1 % DIFF_DST_I_C_B1) * DIFF_DST_I_C_SB1
-            + (x1 / DIFF_DST_I_C_B1) * (int)s[1]
+            + (x1 / DIFF_DST_I_C_B1) * s[1]
             + (x2 % DIFF_DST_I_C_B2) * DIFF_DST_I_C_SB2
-            + (x2 / DIFF_DST_I_C_B2) * (int)s[2]
+            + (x2 / DIFF_DST_I_C_B2) * s[2]
             + (x3 % DIFF_DST_I_C_B3) * DIFF_DST_I_C_SB3
-            + (x3 / DIFF_DST_I_C_B3) * (int)s[3]);
+            + (x3 / DIFF_DST_I_C_B3) * s[3]);
 }
 #endif
-int diff_bias_off(int64x4_t diff_bias, int x0, int x1, int x2, int x3) {
+off_t diff_bias_off(int64x4_t diff_bias, int x0, int x1, int x2, int x3) {
     int64_t *s = diff_bias.array;
-    return ((x0 % DIFF_BIAS_B0) * DIFF_BIAS_SB0
-            + (x0 / DIFF_BIAS_B0) * (int)s[0]
-            + (x1 % DIFF_BIAS_B1) * DIFF_BIAS_SB1
-            + (x1 / DIFF_BIAS_B1) * (int)s[1]
-            + (x2 % DIFF_BIAS_B2) * DIFF_BIAS_SB2
-            + (x2 / DIFF_BIAS_B2) * (int)s[2]
-            + (x3 % DIFF_BIAS_B3) * DIFF_BIAS_SB3
-            + (x3 / DIFF_BIAS_B3) * (int)s[3]);
+    return ((x0 % DIFF_BIAS_B0) * DIFF_BIAS_SB0 + (x0 / DIFF_BIAS_B0) * s[0]
+            + (x1 % DIFF_BIAS_B1) * DIFF_BIAS_SB1 + (x1 / DIFF_BIAS_B1) * s[1]
+            + (x2 % DIFF_BIAS_B2) * DIFF_BIAS_SB2 + (x2 / DIFF_BIAS_B2) * s[2]
+            + (x3 % DIFF_BIAS_B3) * DIFF_BIAS_SB3 + (x3 / DIFF_BIAS_B3) * s[3]);
 }
 #endif // !IS_FWD
 #endif

--- a/src/gpu/intel/rnn/config.hpp
+++ b/src/gpu/intel/rnn/config.hpp
@@ -181,8 +181,9 @@ struct ocl_conf_t {
     bool copy_diff_dst_layer = false;
     bool copy_diff_src_layer;
     bool deterministic = false;
+    bool use_int32_offset = true;
     bool require_stateless_addressing = true;
-    uint8_t pad2[7] = {};
+    uint8_t pad2[6] = {};
     struct comp_conf_t {
         bool is_enabled = false;
         bool compute_gemm_layer = false;

--- a/src/gpu/intel/rnn/grid.cl
+++ b/src/gpu/intel/rnn/grid.cl
@@ -124,10 +124,10 @@ __kernel void simple_rnn_copy_init_iter(__global WS_STATE_DATA_T *dst_base,
 #if IS_FWD
     __global INPUT_DATA_T *src = (__global INPUT_DATA_T *)(src_base);
     __global WS_STATE_DATA_T *dst = dst_base;
-    int ws_state_offset = off_ws_state(
+    off_t ws_state_offset = off_ws_state(
             n_layer, n_dir, n_iter, batch, states_ws_ld, lay, dir, -1, b, s);
     if (s < sic) {
-        int src_i_offset = src_i_off(src_iter_strides, lay, dir, b, s);
+        off_t src_i_offset = src_i_off(src_iter_strides, lay, dir, b, s);
         dst[ws_state_offset] = src_base
                 ? (quantize ? TO_WS_STATE(src[src_i_offset] * scale + shift)
                             : src[src_i_offset])
@@ -137,7 +137,7 @@ __kernel void simple_rnn_copy_init_iter(__global WS_STATE_DATA_T *dst_base,
     __global SRC_C_DATA_T *src_c = (__global SRC_C_DATA_T *)(src_c_base);
     __global AUX_DATA_T *dst_c = dst_c_base;
     if (s < dhc) {
-        int ws_c_state_offset = off_ws_c_state(n_layer, n_dir, n_iter, batch,
+        off_t ws_c_state_offset = off_ws_c_state(n_layer, n_dir, n_iter, batch,
                 states_ws_ld, lay, dir, -1, b, s);
         dst_c[ws_c_state_offset] = src_c_base
                 ? TO_AUX(src_c[src_i_c_off(src_iter_c_strides, lay, dir, b, s)])
@@ -351,7 +351,7 @@ __kernel void rnn_bias_prepare(__global float *ws_bias, __global float *scales,
     __global float *wei_layer_comp
             = (__global float *)(((unsigned long)temp + (sizeof(float) - 1))
                     & -sizeof(float));
-    const int off = comp_off(n_dir, dhc, layer_, dir_, nbias_, dhc_);
+    const off_t off = comp_off(n_dir, dhc, layer_, dir_, nbias_, dhc_);
     const float comp = wei_layer_comp[off] + wei_iter_comp[off];
     ws_bias[off_ws_bias(n_layer, n_dir, dhc, layer_, dir_, nbias_, dhc_)]
             = bias[bias_off(bias_strides, layer_, dir_, nbias_, dhc_)]
@@ -814,10 +814,12 @@ __kernel void simple_rnn_elemwise_bwd() {}
 #if CELL_COMP_ENABLED
 
 void gemm_sum_inner(float(C)[M_THR_BLOCK][N_THR_BLOCK],
-        const __global WS_STATE_DATA_T *restrict A, const int a_stride,
-        const __global WEI_LAYER_DATA_T *restrict B, const int b_stride,
-        const int m_thr_stride, const int n_thr_stride, int m_l_end,
-        int k_l_end, int n_l_end, bool mn_valid) {
+        const __global WS_STATE_DATA_T *restrict A,
+        const cell_offset_t a_stride,
+        const __global WEI_LAYER_DATA_T *restrict B,
+        const cell_offset_t b_stride, const int m_thr_stride,
+        const int n_thr_stride, int m_l_end, int k_l_end, int n_l_end,
+        bool mn_valid) {
 
     // Load A - Invariant across the subgroup, can do cooperative load
     float A_l[M_THR_BLOCK] = {};
@@ -851,11 +853,12 @@ void gemm_sum_inner(float(C)[M_THR_BLOCK][N_THR_BLOCK],
 
 // Perform C += A * B where all matrices are in row major layout
 void gemm_sum(float(C)[N_OUTER_BLOCK][M_THR_BLOCK][N_THR_BLOCK],
-        const __global WS_STATE_DATA_T *restrict A, const int a_stride,
-        const __global WEI_LAYER_DATA_T *restrict B, const int b_stride,
-        gemm_dims_t size, int m_sg, int m_thr_stride, int n_sg,
-        int n_thr_stride, bool enable_m_tail, bool enable_k_tail,
-        bool enable_n_tail) {
+        const __global WS_STATE_DATA_T *restrict A,
+        const cell_offset_t a_stride,
+        const __global WEI_LAYER_DATA_T *restrict B,
+        const cell_offset_t b_stride, gemm_dims_t size, int m_sg,
+        int m_thr_stride, int n_sg, int n_thr_stride, bool enable_m_tail,
+        bool enable_k_tail, bool enable_n_tail) {
 
     // Optimization opportunity: Loads across the m and n dimension can overflow
     // so long as they do not cross the end of the buffer.
@@ -864,16 +867,18 @@ void gemm_sum(float(C)[N_OUTER_BLOCK][M_THR_BLOCK][N_THR_BLOCK],
             && (!enable_n_tail
                     || n_sg + n_thr_stride * N_THR_BLOCK <= size.n_inner);
     if (valid_mn) {
-        int k_outer = 0;
+        cell_dim_t k_outer = 0;
         while (valid_mn && k_outer < size.k - gemm_k_block + 1) {
             int k_l_end = gemm_k_block;
             const int m_l_end = m_thr_stride * M_THR_BLOCK;
             const int n_l_end = n_thr_stride * N_THR_BLOCK;
 
-            const int a_off_base = m_sg * a_stride + k_outer;
+            const cell_offset_t a_off_base
+                    = (cell_offset_t)m_sg * a_stride + k_outer;
             for (int n_outer = 0; n_outer < N_OUTER_BLOCK; n_outer++) {
-                const int b_off_base
-                        = n_outer * size.n_inner + k_outer * b_stride + n_sg;
+                const cell_offset_t b_off_base
+                        = (cell_offset_t)n_outer * size.n_inner
+                        + (cell_offset_t)k_outer * b_stride + n_sg;
                 gemm_sum_inner(C[n_outer], A + a_off_base, a_stride,
                         B + b_off_base, b_stride, m_thr_stride, n_thr_stride,
                         m_l_end, k_l_end, n_l_end, true);
@@ -885,10 +890,12 @@ void gemm_sum(float(C)[N_OUTER_BLOCK][M_THR_BLOCK][N_THR_BLOCK],
             const int m_l_end = size.m - m_sg;
             const int n_l_end = size.n_inner - n_sg;
 
-            const int a_off_base = m_sg * a_stride + k_outer;
+            const cell_offset_t a_off_base
+                    = (cell_offset_t)m_sg * a_stride + k_outer;
             for (int n_outer = 0; n_outer < N_OUTER_BLOCK; n_outer++) {
-                const int b_off_base
-                        = n_outer * size.n_inner + k_outer * b_stride + n_sg;
+                const cell_offset_t b_off_base
+                        = (cell_offset_t)n_outer * size.n_inner
+                        + (cell_offset_t)k_outer * b_stride + n_sg;
                 gemm_sum_inner(C[n_outer], A + a_off_base, a_stride,
                         B + b_off_base, b_stride, m_thr_stride, n_thr_stride,
                         m_l_end, k_l_end, n_l_end, true);
@@ -896,16 +903,18 @@ void gemm_sum(float(C)[N_OUTER_BLOCK][M_THR_BLOCK][N_THR_BLOCK],
             k_outer += gemm_k_block;
         }
     } else {
-        int k_outer = 0;
+        cell_dim_t k_outer = 0;
         while (k_outer < size.k) {
             int k_l_end = enable_k_tail ? size.k - k_outer : gemm_k_block;
             const int m_l_end = size.m - m_sg;
             const int n_l_end = size.n_inner - n_sg;
 
-            const int a_off_base = m_sg * a_stride + k_outer;
+            const cell_offset_t a_off_base
+                    = (cell_offset_t)m_sg * a_stride + k_outer;
             for (int n_outer = 0; n_outer < N_OUTER_BLOCK; n_outer++) {
-                const int b_off_base
-                        = n_outer * size.n_inner + k_outer * b_stride + n_sg;
+                const cell_offset_t b_off_base
+                        = (cell_offset_t)n_outer * size.n_inner
+                        + (cell_offset_t)k_outer * b_stride + n_sg;
                 gemm_sum_inner(C[n_outer], A + a_off_base, a_stride,
                         B + b_off_base, b_stride, m_thr_stride, n_thr_stride,
                         m_l_end, k_l_end, n_l_end, false);

--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -159,6 +159,17 @@ static status_t init_ocl_conf(ocl_conf_t &ocl_conf, const pd_t *pd,
     const memory_desc_wrapper &dst_iter_c_d = pd->dst_md(2);
 
     ocl_conf.require_stateless_addressing = pd->has_large_buffers();
+    ocl_conf.use_int32_offset = true;
+    auto update_use_int32_offset = [&](const memory_desc_t *md) {
+        if (!md || md->format_kind == format_kind::undef) return;
+        if (memory_desc_wrapper(md).nelems(true) > INT32_MAX)
+            ocl_conf.use_int32_offset = false;
+    };
+    for (int i = 0; i < pd->n_inputs(); ++i)
+        update_use_int32_offset(pd->invariant_src_md(i));
+    update_use_int32_offset(pd->invariant_wei_md());
+    for (int i = 0; i < pd->n_outputs(); ++i)
+        update_use_int32_offset(pd->invariant_dst_md(i));
     ocl_conf.src_dt = conf.src_data_type;
     ocl_conf.src_c_dt = src_iter_c_d.data_type();
     ocl_conf.wei_dt = weights_layer_d.data_type();
@@ -338,6 +349,7 @@ status_t ocl_conf_t::init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const {
     ocl_attr.deterministic_ = deterministic;
     kernel_ctx = compute::kernel_ctx_t(&ocl_attr);
 
+    kernel_ctx.use_int32_offset(use_int32_offset);
     kernel_ctx.require_stateless_addressing(require_stateless_addressing);
 
     kernel_ctx.add_option("-cl-std=CL2.0");

--- a/src/gpu/intel/rnn/reorder.cl
+++ b/src/gpu/intel/rnn/reorder.cl
@@ -94,8 +94,8 @@ __kernel void wei_reorder(__global DT_IN *input, __global DT_IN *scales,
 
     int reduction = 0;
     for (int d2 = 0; d2 < SRC_D2; ++d2) {
-        const int in_off = IN_OFF(d0, d1, d2, d3, d4, 0);
-        const int out_off = OUT_OFF(d0, d1, d2, d3, d4, 0);
+        const off_t in_off = IN_OFF(d0, d1, d2, d3, d4, 0);
+        const off_t out_off = OUT_OFF(d0, d1, d2, d3, d4, 0);
 
         REORDER(output[out_off], input[in_off], s);
 

--- a/src/gpu/intel/rnn/reorders.cpp
+++ b/src/gpu/intel/rnn/reorders.cpp
@@ -70,6 +70,9 @@ status_t weights_reorder_t::pd_t::init_kernel_ctx(
     const memory_desc_wrapper src_mdw(src_md());
     const memory_desc_wrapper dst_mdw(dst_md());
 
+    kernel_ctx.register_buffer_size(src_mdw);
+    kernel_ctx.register_buffer_size(dst_mdw);
+
     auto input_type = src_mdw.data_type();
     auto output_type = dst_mdw.data_type();
 

--- a/src/gpu/intel/shuffle/ref.cl
+++ b/src/gpu/intel/shuffle/ref.cl
@@ -27,7 +27,7 @@
 #define DST_OFF(x0, x1, x2, x3, x4, x5) \
     OFF_MD(DST, (x0), (x1), (x2), (x3), (x4), (x5))
 
-int rev_transposed(int a) {
+off_t rev_transposed(off_t a) {
     return ((a % TRANSPOSE_COL) * TRANSPOSE_ROW + a / TRANSPOSE_COL);
 }
 
@@ -36,7 +36,7 @@ __kernel void ref_shuffle(__global DATA_T *src, __global DATA_T *dst) {
     src += SRC_OFFSET0;
     dst += DST_OFFSET0;
 
-    int d[6];
+    off_t d[6];
     d[0] = GWS_GET_D0();
     d[1] = GWS_GET_D1();
     d[2] = GWS_GET_D2();
@@ -44,10 +44,10 @@ __kernel void ref_shuffle(__global DATA_T *src, __global DATA_T *dst) {
     d[4] = GWS_GET_D4();
     d[5] = GWS_GET_D5();
 
-    const ulong src_off = SRC_OFF(d[0], d[1], d[2], d[3], d[4], d[5]);
+    const off_t src_off = SRC_OFF(d[0], d[1], d[2], d[3], d[4], d[5]);
 
     d[AXIS] = rev_transposed(d[AXIS]);
-    const ulong dst_off = DST_OFF(d[0], d[1], d[2], d[3], d[4], d[5]);
+    const off_t dst_off = DST_OFF(d[0], d[1], d[2], d[3], d[4], d[5]);
 
     dst[dst_off] = src[src_off];
 }

--- a/src/gpu/intel/sum/many_inputs.cl
+++ b/src/gpu/intel/sum/many_inputs.cl
@@ -21,21 +21,21 @@
 #define INIT_MAX_N_INPUTS(i) \
     if (i < MAX_N_INPUTS) inputs[i] = input##i;
 
-float get_value(__global SRC_DATA_T *src, ptrdiff_t offset) {
-    if (offset >= N_ELEMS) return 0;
+float get_value(__global SRC_DATA_T *src, ptrdiff_t offset, dim_t nelems) {
+    if (offset >= nelems) return 0;
     return CONVERT_FLOAT_T(src[offset]);
 }
 #define many_inputs_sum_impl(inputs, output, scales, num_inputs, local_val) \
-    const uint group_id = get_group_id(0); \
-    const uint group_size = get_local_size(0); \
-    const uint gid = get_global_id(0); \
+    const dim_t group_id = get_group_id(0); \
+    const dim_t group_size = get_local_size(0); \
+    const dim_t gid = get_global_id(0); \
     ptrdiff_t offset = gid / num_inputs; \
     const int tensor_idx = gid % num_inputs; \
     const int local_id = get_local_id(0); \
-    local_val[local_id] \
-            = get_value(inputs[tensor_idx], offset) * scales[tensor_idx]; \
+    local_val[local_id] = get_value(inputs[tensor_idx], offset, nelems) \
+            * scales[tensor_idx]; \
     barrier(CLK_LOCAL_MEM_FENCE); \
-    if (tensor_idx == 0 && offset < N_ELEMS) { \
+    if (tensor_idx == 0 && offset < nelems) { \
         float final_val = 0; \
         for (int i = 0; i < num_inputs; i++) { \
             final_val += local_val[local_id + i]; \
@@ -52,7 +52,7 @@ __kernel void many_inputs_sum(__global SRC_DATA_T *input0,
         __global SRC_DATA_T *input11, __global SRC_DATA_T *input12,
         __global SRC_DATA_T *input13, __global SRC_DATA_T *input14,
         __global SRC_DATA_T *input15, __global DST_DATA_T *output,
-        __global float *scales) {
+        __global float *scales, dim_t nelems) {
 
     __local float local_val[256];
     __global SRC_DATA_T *inputs[16];
@@ -85,7 +85,7 @@ __kernel void many_inputs_sum_batched(__global SRC_DATA_T *input0,
         __global SRC_DATA_T *input11, __global SRC_DATA_T *input12,
         __global SRC_DATA_T *input13, __global SRC_DATA_T *input14,
         __global SRC_DATA_T *input15, __global DST_DATA_T *output,
-        __global float *scales) {
+        __global float *scales, dim_t nelems) {
 
     __local float local_val[256];
     __global SRC_DATA_T *inputs[16];

--- a/src/gpu/intel/sum/many_inputs.cpp
+++ b/src/gpu/intel/sum/many_inputs.cpp
@@ -14,6 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <limits>
+
 #include "gpu/intel/sum/many_inputs.hpp"
 
 namespace dnnl {
@@ -27,7 +29,7 @@ status_t many_inputs_t::execute(const exec_ctx_t &ctx) const {
     const int num_arrs = pd()->n_inputs()
             - 1; // input0 is copied over to output. Accumulate the rest.
     const memory_desc_wrapper o_d(pd()->dst_md());
-    const size_t nelems = o_d.nelems(true);
+    const dim_t nelems = o_d.nelems(true);
     compute::kernel_arg_list_t arg_list;
 
     int num_batches = utils::div_up(num_arrs, max_num_arrs);
@@ -57,9 +59,22 @@ status_t many_inputs_t::execute(const exec_ctx_t &ctx) const {
         arg_list.set(many_inputs_t::max_num_arrs, output);
         arg_list.set(
                 many_inputs_t::max_num_arrs + 1, CTX_GPU_RES_STORAGE(SCALES_));
+        arg_list.set(many_inputs_t::max_num_arrs + 2, nelems);
 
-        const size_t total_width = nelems * kernel_num_arrs;
+        const size_t nelems_sz = into<size_t>(nelems);
+        const size_t kernel_num_arrs_sz = into<size_t>(kernel_num_arrs);
+        if (kernel_num_arrs_sz != 0
+                && nelems_sz > (std::numeric_limits<size_t>::max()
+                           / kernel_num_arrs_sz)) {
+            return status::invalid_arguments;
+        }
+        const size_t total_width = nelems_sz * kernel_num_arrs_sz;
         const size_t lws = utils::rnd_dn(256, kernel_num_arrs);
+        const size_t max_gws0 = std::numeric_limits<uint32_t>::max();
+        if (total_width > max_gws0
+                || utils::rnd_up(total_width, lws) > max_gws0) {
+            return status::invalid_arguments;
+        }
 
         compute::nd_range_t nd_range({utils::rnd_up(total_width, lws)}, {lws});
         if (batch_iter == num_batches - 1) {

--- a/src/gpu/intel/sum/many_inputs.hpp
+++ b/src/gpu/intel/sum/many_inputs.hpp
@@ -64,8 +64,6 @@ struct many_inputs_t : public primitive_t {
         kernel_ctx.set_data_type(data_s.data_type());
         kernel_ctx.require_stateless_addressing(pd()->has_large_buffers());
 
-        kernel_ctx.define_int("N_ELEMS", data_d.nelems(true));
-
         const int num_arrs = pd()->n_inputs() - 1;
         int N_INPUTS = (num_arrs) % max_num_arrs;
         if (N_INPUTS == 0) { N_INPUTS = max_num_arrs; };

--- a/src/gpu/intel/sum/simple.cl
+++ b/src/gpu/intel/sum/simple.cl
@@ -17,7 +17,7 @@
 __kernel void simple_sum(
         __global float *input, __global float *output, float scale, int a) {
 
-    const int c = get_global_id(0);
+    const off_t c = get_global_id(0);
     if (a == 0)
         output[c] = (scale * input[c]);
     else

--- a/src/gpu/intel/sum/simple.hpp
+++ b/src/gpu/intel/sum/simple.hpp
@@ -60,6 +60,8 @@ struct simple_t : public primitive_t {
     status_t init(impl::engine_t *engine) override {
         compute::kernel_ctx_t kernel_ctx;
         kernel_ctx.require_stateless_addressing(pd()->has_large_buffers());
+        kernel_ctx.register_buffer_size(*pd()->src_md());
+        kernel_ctx.register_buffer_size(*pd()->dst_md());
         CHECK(create_kernel(engine, &kernel_, "simple_sum", kernel_ctx));
         if (!kernel_) return status::runtime_error;
         return status::success;

--- a/src/gpu/intel/sum/xe.cl
+++ b/src/gpu/intel/sum/xe.cl
@@ -71,17 +71,17 @@
 
 #include "gpu/intel/include/types.h"
 
-float8 get_values(__global SRC_DATA_T *src, ptrdiff_t offset) {
+float8 get_values(__global SRC_DATA_T *src, ptrdiff_t offset, dim_t nelems) {
     float8 val;
     const uint max_sub_group_size = get_max_sub_group_size();
     __global BLOCK_DATA_T *read_pos = (__global BLOCK_DATA_T *)src + offset;
 
-    if (offset + VECT_DT_N * max_sub_group_size < N_ELEMS) {
+    if (offset + VECT_DT_N * max_sub_group_size < nelems) {
         val = CONVERT_FLOAT8_T(AS_DATA8_T(BLOCK_READ8(read_pos)));
     } else {
-        const uint sub_group_local_id = get_sub_group_local_id();
-        uint pos = offset + sub_group_local_id;
-        for (uint i = 0; pos < N_ELEMS && i < VECT_DT_N; i++) {
+        const ptrdiff_t sub_group_local_id = get_sub_group_local_id();
+        ptrdiff_t pos = offset + sub_group_local_id;
+        for (uint i = 0; pos < nelems && i < VECT_DT_N; i++) {
             val[i] = CONVERT_FLOAT_T(src[pos]);
             pos += max_sub_group_size;
         }
@@ -97,7 +97,7 @@ __kernel void xe_sum(__global SRC_DATA_T *input0, __global SRC_DATA_T *input1,
         __global SRC_DATA_T *input10, __global SRC_DATA_T *input11,
         __global SRC_DATA_T *input12, __global SRC_DATA_T *input13,
         __global SRC_DATA_T *input14, __global SRC_DATA_T *input15,
-        __global DST_DATA_T *output, __global float *scales) {
+        __global DST_DATA_T *output, __global float *scales, dim_t nelems) {
 
     const uint group_id = get_group_id(0);
     const uint group_size = get_local_size(0);
@@ -113,28 +113,34 @@ __kernel void xe_sum(__global SRC_DATA_T *input0, __global SRC_DATA_T *input1,
 
     int id = 0;
     float8 sum = 0;
-    if (id < N_INPUTS) sum += get_values(input0, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input1, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input2, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input3, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input4, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input5, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input6, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input7, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input8, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input9, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input10, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input11, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input12, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input13, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input14, offset) * scales[id++];
-    if (id < N_INPUTS) sum += get_values(input15, offset) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input0, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input1, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input2, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input3, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input4, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input5, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input6, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input7, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input8, offset, nelems) * scales[id++];
+    if (id < N_INPUTS) sum += get_values(input9, offset, nelems) * scales[id++];
+    if (id < N_INPUTS)
+        sum += get_values(input10, offset, nelems) * scales[id++];
+    if (id < N_INPUTS)
+        sum += get_values(input11, offset, nelems) * scales[id++];
+    if (id < N_INPUTS)
+        sum += get_values(input12, offset, nelems) * scales[id++];
+    if (id < N_INPUTS)
+        sum += get_values(input13, offset, nelems) * scales[id++];
+    if (id < N_INPUTS)
+        sum += get_values(input14, offset, nelems) * scales[id++];
+    if (id < N_INPUTS)
+        sum += get_values(input15, offset, nelems) * scales[id++];
 
-    if (offset + VECT_DT_N * max_sub_group_size < N_ELEMS) {
+    if (offset + VECT_DT_N * max_sub_group_size < nelems) {
         DST_BLOCK_WRITE8(write_pos, TO_DST8(sum));
     } else {
-        uint pos = offset + sub_group_local_id;
-        for (uint i = 0; pos < N_ELEMS && i < VECT_DT_N; i++) {
+        ptrdiff_t pos = offset + sub_group_local_id;
+        for (uint i = 0; pos < nelems && i < VECT_DT_N; i++) {
             output[pos] = TO_DST(sum[i]);
             pos += max_sub_group_size;
         }

--- a/src/gpu/intel/sum/xe.cpp
+++ b/src/gpu/intel/sum/xe.cpp
@@ -29,7 +29,7 @@ status_t xe_t::execute(const exec_ctx_t &ctx) const {
     auto &output = CTX_OUT_STORAGE(DNNL_ARG_DST);
     const int num_arrs = pd()->n_inputs();
     const memory_desc_wrapper o_d(pd()->dst_md());
-    const size_t nelems = o_d.nelems(true);
+    const dim_t nelems = o_d.nelems(true);
     compute::kernel_arg_list_t arg_list;
 
     for (int a = 0; a < max_num_arrs; ++a) {
@@ -41,8 +41,9 @@ status_t xe_t::execute(const exec_ctx_t &ctx) const {
     }
     arg_list.set(16, output);
     arg_list.set(17, CTX_GPU_RES_STORAGE(SCALES_));
+    arg_list.set(18, nelems);
 
-    const size_t total_width = utils::div_up(nelems, vector_size);
+    const size_t total_width = utils::div_up(into<size_t>(nelems), vector_size);
     const size_t lws = 256;
 
     compute::nd_range_t nd_range({utils::rnd_up(total_width, lws)}, {lws});

--- a/src/gpu/intel/sum/xe.hpp
+++ b/src/gpu/intel/sum/xe.hpp
@@ -77,7 +77,6 @@ struct xe_t : public primitive_t {
         if (io_bytes < 10 * 1024 * 1024) { vector_size /= 2; }
         kernel_ctx.define_int("VECT_DT_N", vector_size);
         kernel_ctx.define_int("N_INPUTS", pd()->n_inputs());
-        kernel_ctx.define_int("N_ELEMS", data_d.nelems(true));
 
         def_memory_desc_info(
                 kernel_ctx, memory_desc_info_t::create(data_d), "SRC");

--- a/tests/benchdnn/inputs/bnorm/shapes_regressions
+++ b/tests/benchdnn/inputs/bnorm/shapes_regressions
@@ -11,6 +11,3 @@ mb88ic900ih16 # 56-core system w/ 1.5MB LLC slices
 # Spatial threading bugs for bfloat16
 mb12ic4ih8
 mb1ic24ih14iw14
-
-# Large-axis index stress
-mb1ic512ih65536

--- a/tests/benchdnn/inputs/bnorm/test_bnorm_gpu
+++ b/tests/benchdnn/inputs/bnorm/test_bnorm_gpu
@@ -112,5 +112,5 @@
 
 # Large-axis index stress (off_t overflow coverage)
 --reset
---batch=shapes_regressions
+mb1ic512ih65536
 

--- a/tests/benchdnn/inputs/conv/test_conv_gpu
+++ b/tests/benchdnn/inputs/conv/test_conv_gpu
@@ -169,8 +169,6 @@ mb128ic3ih230oc64oh112kh7sh2ph0
 --attr-post-ops=add:f32:per_oc+linear:42.5+clip:0:255
 --batch=shapes_mobilenet_dw
 
---batch=harness_conv_arbitrary_dst
-
 # Test CI in Nightly
 --reset
 --batch=test_conv_gpu_ci

--- a/tests/benchdnn/inputs/deconv/test_deconv_gpu
+++ b/tests/benchdnn/inputs/deconv/test_deconv_gpu
@@ -62,6 +62,19 @@
 --attr-post-ops=sum:0.5+add:f32+add:u8:per_dim_01+linear:0.5:1.5:2.0+mul:f32:per_dim_0+add:s8:per_oc+add:f32:per_dim_01+relu:0.5
 g1ic16iw5oc16ow5kw1pw0
 
+# Large-axis stress tests for offset widening
+--reset
+--impl=conv:any
+--dt=f32,bf16
+--mb=1
+--dir=FWD_D,BWD_W
+--alg=DIRECT
+--bia-dt=f32
+
+# Large spatial dimensions (stress output buffer offsets)
+g1mb1ic64ih1024iw1024oc64oh1024ow1024kh1kw1sh1sw1ph0pw0
+g1mb1ic128ih512iw2048oc128oh512ow2048kh1kw1sh1sw1ph0pw0
+
 # Test CI in Nightly
 --reset
 --batch=test_deconv_ci

--- a/tests/benchdnn/inputs/rnn/test_rnn_gpu
+++ b/tests/benchdnn/inputs/rnn/test_rnn_gpu
@@ -80,6 +80,16 @@
 
 --alg=VANILLA_RNN --activation=RELU --batch=shapes_large
 
+# Large-offset regression for cell GEMM indexing
+--reset
+--cfg=f32
+--alg=VANILLA_RNN
+--activation=RELU
+--direction=left2right
+--prop=FWD_I
+--trivial-strides=true,false
+l1t1mb1sic4096slc4096dhc4096dic4096
+
 # Test CI in Nightly
 --reset
 --batch=test_augru_ci

--- a/tests/benchdnn/inputs/shuffle/test_shuffle_gpu
+++ b/tests/benchdnn/inputs/shuffle/test_shuffle_gpu
@@ -24,6 +24,19 @@
 --axis=0,1
 48x48
 
+# Large-axis stress tests for offset widening
+--reset
+--impl=ocl:ref
+--group=4
+--dir=FWD_D,BWD_D
+--dt=f32,bf16
+--tag=abx
+--axis=1 1x2097152x1 1x1048576x2
+--axis=3 1x1x1x2097152 1x1x1x1048576
+
+--tag=aBx16b
+--axis=1 1x256x16384 1x512x8192
+
 # Test CI in Nightly
 --reset
 --batch=test_shuffle_ci

--- a/tests/benchdnn/inputs/sum/test_sum_gpu
+++ b/tests/benchdnn/inputs/sum/test_sum_gpu
@@ -53,6 +53,24 @@
 --dtag=AB48a16b
 512x1024
 
+# Large-axis stress tests for offset widening
+--reset
+--impl=ocl:xe
+--ddt=f32
+--sdt=f32:f32
+--stag=abx:abx
+--inplace=false
+# Large single-axis tensors (test nelems > 2^31)
+1x2097152x1 1x1x2097152 2097152x1x1
+
+--reset
+--ddt=bf16
+--sdt=bf16:bf16
+--stag=abx:abx
+--inplace=false
+# Large axis with bf16
+1x1048576x2 1x2x1048576
+
 # Test CI in Nightly
 --reset
 --batch=test_sum_ci


### PR DESCRIPTION
# Description

This is part 2 of widening offsets for openCL kernels that were left from part 1, find [here](https://github.com/uxlfoundation/oneDNN/pull/4822).
Primitives touched in this part:
> sum
> shuffle
> ref_deconv
> RNN

This also patches a fix to (https://jira.devtools.intel.com/browse/MFDNN-14896) restraining the regression testing to GPU only. 

This PR also fixes the implicit conversion loss in math_utils.h (found in src/gpu/intel/include) thanks to check introduced by @rjoursler comments in part 1.

Fixes # (MFDNN-14771, MFDNN-14896)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?