### PR TITLE
xe: ggemm: Relax the src quantization mask. Fix bia conversion bug.

### DIFF
--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -452,7 +452,10 @@ The following are supported:
     are supported.
   - Scale data type includes: `f32`, `bf16`, `f16`, `e8m0` for MXFP8 and MXFP4,
     `f8_e4m3` for NVFP4 block scales.
-- Zero points attribute for weights tensors with the same masks as scales.
+- Zero points attribute for source and weights tensors:
+  - The masks must match the scales mask
+  - Source zero points data types include `u8`, `s8`
+  - Weights zero points data types include `u8`, `s8`, `u4`, `s4‘
 - Post-ops: binary post-ops are supported (e.g., binary `mul` with a scalar
   `f32` tensor can be used to apply a global scale factor, as needed for NVFP4
   two-level scaling).

--- a/src/cpu/matmul/ref_grouped_gemm.cpp
+++ b/src/cpu/matmul/ref_grouped_gemm.cpp
@@ -144,147 +144,139 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
         const dim_t wei_stride_n
                 = wei_d.blocking_desc().strides[wei_d.ndims() - 1];
 
-        for (dim_t m = 0; m < M; ++m) {
-            for (dim_t n = 0; n < N; ++n) {
-                float result = 0.0f;
+        for_(dim_t m = 0; m < M; ++m)
+        for (dim_t n = 0; n < N; ++n) {
+            float result = 0.0f;
 
-                // int wei path (either int src + int wei or fp src + int wei WOQ)
-                // int src follows ref_matmul_int8_t
-                // fp  src (WOQ) follows dequantize then multiply
-                if (use_int_arithmetic || use_woq) {
-                    for (dim_t i_group = 0; i_group < n_k_groups; i_group++) {
-                        float wei_scale = 1.0f;
-                        int wei_zp_val = 0;
+            // int wei path (either int src + int wei or fp src + int wei WOQ)
+            // int src follows ref_matmul_int8_t
+            // fp  src (WOQ) follows dequantize then multiply
+            if (use_int_arithmetic || use_woq) {
+                for (dim_t i_group = 0; i_group < n_k_groups; i_group++) {
+                    float wei_scale = 1.0f;
+                    int wei_zp_val = 0;
 
-                        if (with_wei_scales) {
-                            const dim_t wei_k_group = i_group
-                                    * wei_scale_ngroups_k / n_k_groups;
-                            const dim_t idx = group_id * wei_scale_ngroups_k * N
-                                    + wei_k_group * N + n;
-                            wei_scale = io::load_float_value(
-                                    wei_scale_dt, wei_scales, idx);
-                        }
-                        if (with_wei_zps) {
-                            const dim_t wei_k_group
-                                    = i_group * wei_zp_ngroups_k / n_k_groups;
-                            const dim_t idx = group_id * wei_zp_ngroups_k * N
-                                    + wei_k_group * N + n;
-                            wei_zp_val = io::load_int_value(
-                                    wei_zp_dt, wei_zps, idx);
-                        }
-
-                        float acc = 0.0f;
-                        if (use_int_arithmetic) {
-                            int acc_int = 0;
-                            for (dim_t k = 0; k < k_group_size; ++k) {
-                                const dim_t k_abs = k + i_group * k_group_size;
-                                const dim_t src_idx
-                                        = src_base_idx + m * K + k_abs;
-                                const dim_t wei_idx = wei_group_base
-                                        + k_abs * wei_stride_k
-                                        + n * wei_stride_n;
-                                const int s = io::load_int_value(
-                                        src_dt, src_data, src_idx);
-                                const int w = io::load_int_value(
-                                        wei_dt, wei_data, wei_idx);
-                                acc_int += s * (w - wei_zp_val);
-                            }
-                            acc = static_cast<float>(acc_int);
-                        } else {
-                            for (dim_t k = 0; k < k_group_size; ++k) {
-                                const dim_t k_abs = k + i_group * k_group_size;
-                                const dim_t src_idx
-                                        = src_base_idx + m * K + k_abs;
-                                const dim_t wei_idx = wei_group_base
-                                        + k_abs * wei_stride_k
-                                        + n * wei_stride_n;
-                                const float s = io::load_float_value(
-                                        src_dt, src_data, src_idx);
-                                const int w_int = io::load_int_value(
-                                        wei_dt, wei_data, wei_idx);
-                                acc += s
-                                        * static_cast<float>(
-                                                w_int - wei_zp_val);
-                            }
-                        }
-
-                        if (with_src_scales) {
-                            const dim_t src_k_group = i_group
-                                    * src_scale_ngroups_k / n_k_groups;
-                            const dim_t idx = (src_offset_start + m)
-                                            * src_scale_ngroups_k
-                                    + src_k_group;
-                            const float src_scale = io::load_float_value(
-                                    src_scale_dt, src_scales, idx);
-                            acc *= src_scale;
-                        }
-
-                        result += acc * wei_scale;
+                    if (with_wei_scales) {
+                        const dim_t wei_k_group
+                                = i_group * wei_scale_ngroups_k / n_k_groups;
+                        const dim_t idx = group_id * wei_scale_ngroups_k * N
+                                + wei_k_group * N + n;
+                        wei_scale = io::load_float_value(
+                                wei_scale_dt, wei_scales, idx);
                     }
-                } else {
-                    // fp arithmetic
-                    for (dim_t i_group = 0; i_group < n_k_groups; i_group++) {
-                        float acc = 0.0f;
+                    if (with_wei_zps) {
+                        const dim_t wei_k_group
+                                = i_group * wei_zp_ngroups_k / n_k_groups;
+                        const dim_t idx = group_id * wei_zp_ngroups_k * N
+                                + wei_k_group * N + n;
+                        wei_zp_val
+                                = io::load_int_value(wei_zp_dt, wei_zps, idx);
+                    }
 
+                    float acc = 0.0f;
+                    if (use_int_arithmetic) {
+                        int acc_int = 0;
                         for (dim_t k = 0; k < k_group_size; ++k) {
                             const dim_t k_abs = k + i_group * k_group_size;
                             const dim_t src_idx = src_base_idx + m * K + k_abs;
                             const dim_t wei_idx = wei_group_base
                                     + k_abs * wei_stride_k + n * wei_stride_n;
-
+                            const int s = io::load_int_value(
+                                    src_dt, src_data, src_idx);
+                            const int w = io::load_int_value(
+                                    wei_dt, wei_data, wei_idx);
+                            acc_int += s * (w - wei_zp_val);
+                        }
+                        acc = static_cast<float>(acc_int);
+                    } else {
+                        for (dim_t k = 0; k < k_group_size; ++k) {
+                            const dim_t k_abs = k + i_group * k_group_size;
+                            const dim_t src_idx = src_base_idx + m * K + k_abs;
+                            const dim_t wei_idx = wei_group_base
+                                    + k_abs * wei_stride_k + n * wei_stride_n;
                             const float s = io::load_float_value(
                                     src_dt, src_data, src_idx);
-                            const float w = io::load_float_value(
+                            const int w_int = io::load_int_value(
                                     wei_dt, wei_data, wei_idx);
-                            acc += s * w;
+                            acc += s * static_cast<float>(w_int - wei_zp_val);
                         }
-
-                        if (with_src_scales) {
-                            const dim_t src_k_group = i_group
-                                    * src_scale_ngroups_k / n_k_groups;
-                            const dim_t idx = (src_offset_start + m)
-                                            * src_scale_ngroups_k
-                                    + src_k_group;
-                            const float src_scale = io::load_float_value(
-                                    src_scale_dt, src_scales, idx);
-                            acc *= src_scale;
-                        }
-
-                        if (with_wei_scales) {
-                            const dim_t wei_k_group = i_group
-                                    * wei_scale_ngroups_k / n_k_groups;
-                            const dim_t idx = group_id * wei_scale_ngroups_k * N
-                                    + wei_k_group * N + n;
-                            const float wei_scale = io::load_float_value(
-                                    wei_scale_dt, wei_scales, idx);
-                            acc *= wei_scale;
-                        }
-
-                        result += acc;
                     }
+
+                    if (with_src_scales) {
+                        const dim_t src_k_group
+                                = i_group * src_scale_ngroups_k / n_k_groups;
+                        const dim_t idx
+                                = (src_offset_start + m) * src_scale_ngroups_k
+                                + src_k_group;
+                        const float src_scale = io::load_float_value(
+                                src_scale_dt, src_scales, idx);
+                        acc *= src_scale;
+                    }
+
+                    result += acc * wei_scale;
                 }
+            } else {
+                // fp arithmetic
+                for (dim_t i_group = 0; i_group < n_k_groups; i_group++) {
+                    float acc = 0.0f;
 
-                // Add bias
-                if (with_bias) {
-                    const dim_t bias_idx = group_id * N + n;
-                    result += io::load_float_value(bia_dt, bias_data, bias_idx);
+                    for (dim_t k = 0; k < k_group_size; ++k) {
+                        const dim_t k_abs = k + i_group * k_group_size;
+                        const dim_t src_idx = src_base_idx + m * K + k_abs;
+                        const dim_t wei_idx = wei_group_base
+                                + k_abs * wei_stride_k + n * wei_stride_n;
+
+                        const float s = io::load_float_value(
+                                src_dt, src_data, src_idx);
+                        const float w = io::load_float_value(
+                                wei_dt, wei_data, wei_idx);
+                        acc += s * w;
+                    }
+
+                    if (with_src_scales) {
+                        const dim_t src_k_group
+                                = i_group * src_scale_ngroups_k / n_k_groups;
+                        const dim_t idx
+                                = (src_offset_start + m) * src_scale_ngroups_k
+                                + src_k_group;
+                        const float src_scale = io::load_float_value(
+                                src_scale_dt, src_scales, idx);
+                        acc *= src_scale;
+                    }
+
+                    if (with_wei_scales) {
+                        const dim_t wei_k_group
+                                = i_group * wei_scale_ngroups_k / n_k_groups;
+                        const dim_t idx = group_id * wei_scale_ngroups_k * N
+                                + wei_k_group * N + n;
+                        const float wei_scale = io::load_float_value(
+                                wei_scale_dt, wei_scales, idx);
+                        acc *= wei_scale;
+                    }
+
+                    result += acc;
                 }
-
-                const dim_t dst_idx = dst_base_idx + m * N + n;
-
-                // Apply post-ops (binary mul for NVFP4 global scale)
-                if (with_post_ops) {
-                    ref_post_ops_t::args_t args;
-                    args.dst_val
-                            = io::load_float_value(dst_dt, dst_data, dst_idx);
-                    args.ctx = &ctx;
-                    args.l_offset = dst_idx;
-                    args.dst_md = pd()->dst_md();
-                    ref_post_ops->execute(result, args);
-                }
-
-                io::store_float_value(dst_dt, result, dst_data, dst_idx);
             }
+
+            // Add bias
+            if (with_bias) {
+                const dim_t bias_idx = group_id * N + n;
+                result += io::load_float_value(bia_dt, bias_data, bias_idx);
+            }
+
+            const dim_t dst_idx = dst_base_idx + m * N + n;
+
+            // Apply post-ops (binary mul for NVFP4 global scale)
+            if (with_post_ops) {
+                ref_post_ops_t::args_t args;
+                args.dst_val = io::load_float_value(dst_dt, dst_data, dst_idx);
+                args.ctx = &ctx;
+                args.l_offset = dst_idx;
+                args.dst_md = pd()->dst_md();
+                ref_post_ops->execute(result, args);
+            }
+
+            io::store_float_value(dst_dt, result, dst_data, dst_idx);
         }
     });
 

--- a/src/cpu/matmul/ref_grouped_gemm.cpp
+++ b/src/cpu/matmul/ref_grouped_gemm.cpp
@@ -83,8 +83,16 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
     const void *wei_scales
             = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS);
 
-    // wei zero_points: column-wise or blocked (K grouping)
+    // src zero_points: row-wise or blocked (K grouping)
     const auto &attr_zps = pd()->attr()->zero_points_;
+    const bool with_src_zps = !attr_zps.has_default_values(DNNL_ARG_SRC);
+    const auto src_zp_dt = attr_zps.get_data_type(DNNL_ARG_SRC);
+    const auto src_zp_group_k = attr_zps.get_group(DNNL_ARG_SRC, -1);
+    const dim_t src_zp_ngroups_k = src_zp_group_k > 1 ? K / src_zp_group_k : 1;
+    const void *src_zps = CTX_IN_MEM(
+            const void *, DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC);
+
+    // wei zero_points: column-wise or blocked (K grouping)
     const bool with_wei_zps = !attr_zps.has_default_values(DNNL_ARG_WEIGHTS);
     const auto wei_zp_dt = attr_zps.get_data_type(DNNL_ARG_WEIGHTS);
     const auto wei_zp_group_k = attr_zps.get_group(DNNL_ARG_WEIGHTS, -2);
@@ -93,8 +101,8 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
             const void *, DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS);
 
     // Use the finest K-group granularity across src/wei scales and wei ZPs
-    const dim_t n_k_groups = std::max(
-            {src_scale_ngroups_k, wei_scale_ngroups_k, wei_zp_ngroups_k});
+    const dim_t n_k_groups = std::max({src_scale_ngroups_k, wei_scale_ngroups_k,
+            src_scale_ngroups_k, wei_zp_ngroups_k});
     const dim_t k_group_size = K / n_k_groups;
 
     // Check if int arithmetic (int4/int8 src and wei)
@@ -153,8 +161,19 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
             // fp  src (WOQ) follows dequantize then multiply
             if (use_int_arithmetic || use_woq) {
                 for (dim_t i_group = 0; i_group < n_k_groups; i_group++) {
+                    int src_zp_val = 0;
                     float wei_scale = 1.0f;
                     int wei_zp_val = 0;
+
+                    if (with_src_zps) {
+                        const dim_t src_k_group
+                                = i_group * src_zp_ngroups_k / n_k_groups;
+                        const dim_t idx
+                                = (src_offset_start + m) * src_zp_ngroups_k
+                                + src_k_group;
+                        src_zp_val
+                                = io::load_int_value(src_zp_dt, src_zps, idx);
+                    }
 
                     if (with_wei_scales) {
                         const dim_t wei_k_group
@@ -185,10 +204,11 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
                                     src_dt, src_data, src_idx);
                             const int w = io::load_int_value(
                                     wei_dt, wei_data, wei_idx);
-                            acc_int += s * (w - wei_zp_val);
+                            acc_int += (s - src_zp_val) * (w - wei_zp_val);
                         }
                         acc = static_cast<float>(acc_int);
                     } else {
+                        assert(src_zp_val == 0);
                         for (dim_t k = 0; k < k_group_size; ++k) {
                             const dim_t k_abs = k + i_group * k_group_size;
                             const dim_t src_idx = src_base_idx + m * K + k_abs;

--- a/src/cpu/matmul/ref_grouped_gemm.hpp
+++ b/src/cpu/matmul/ref_grouped_gemm.hpp
@@ -142,12 +142,33 @@ struct ref_grouped_t : public primitive_t {
             VDISPATCH_MATMUL(attr_scales.has_default_values(DNNL_ARG_DST),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-            // Zero-points are supported for wei: for WOQ (fp src) and for int arithmetic (int src)
+            // Zero-points are supported for src and wei: for WOQ (fp src) and
+            // for int arithmetic (int src)
             const auto &attr_zps = attr()->zero_points_;
-            VDISPATCH_MATMUL(attr_zps.has_default_values(DNNL_ARG_SRC),
-                    VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_MATMUL(attr_zps.has_default_values(DNNL_ARG_DST),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
+
+            // Allow row-wise or blocked (K grouping) zps for src
+            if (!attr_zps.has_default_values(DNNL_ARG_SRC)) {
+                VDISPATCH_MATMUL(is_int_src, VERBOSE_UNSUPPORTED_ZP_CFG);
+                VDISPATCH_MATMUL(
+                        utils::one_of(attr_zps.get_data_type(DNNL_ARG_SRC), u8,
+                                s8, s32),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                const int zp_mask = attr_zps.get_mask(DNNL_ARG_SRC);
+                const int rowwise_mask = src_qmask_M();
+                const int blocked_mask = src_qmask_M() | src_qmask_K();
+                VDISPATCH_MATMUL(
+                        zp_mask == rowwise_mask || zp_mask == blocked_mask,
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                if (!attr_zps.get(DNNL_ARG_SRC).has_default_groups()) {
+                    const auto gM = attr_zps.get_group(DNNL_ARG_SRC, -2);
+                    VDISPATCH_MATMUL(gM == 1, VERBOSE_UNSUPPORTED_ZP_CFG);
+                    const auto gK = attr_zps.get_group(DNNL_ARG_SRC, -1);
+                    VDISPATCH_MATMUL(gK > 1, VERBOSE_UNSUPPORTED_ZP_CFG);
+                    VDISPATCH_MATMUL(K() % gK == 0, VERBOSE_UNSUPPORTED_ZP_CFG);
+                }
+            }
 
             // Allow column-wise or blocked (K grouping) zps for weights
             if (!attr_zps.has_default_values(DNNL_ARG_WEIGHTS)) {

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -48,7 +48,7 @@ void load_bias(
 #else
     bias_in_tile_type bias_in_tile;
     tile_load(&bias_in_tile, ptr, n, 1, 0, sg_i0, 0);
-    tile_convert(bias_in_tile, (*tile), CONVERT_FLOAT_T);
+    tile_convert(bias_in_tile, (*tile), BIA_TO_REF);
 #endif
 }
 #endif

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -195,7 +195,7 @@ grouped_micro_gemm(const global SRC_DATA_T *src, long ldsrc,
     src_attr_scales += src_offset.x * ldsrcq;
 #endif
 #if WITH_SRC_ZP
-    src_attr_zp += src_offset.x / SRC_ZP_ELEMS_PER_BYTE;
+    src_attr_zp += src_offset.x * ldsrcq / SRC_ZP_ELEMS_PER_BYTE;
 #endif
 #if WITH_WEI_SCALES
     wei_attr_scales += batch * n * (k / WEI_GROUP_SIZE);

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -172,6 +172,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     auto strat_override = [&](gemmstone::GEMMStrategy &strat) {
         std::string newStrat;
         using namespace gemmstone;
+        strat.dpasw |= strat.fused;
         newStrat = gpu_utils::dev_getenv("GRPGEMM_USTRATEGY", newStrat);
         if (!newStrat.empty()) {
             // Example: 16 16 1 0 aT32 aM32 aB wg 2x4 sys

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -149,7 +149,10 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     // can avoid using group sums by converting one of the inputs to
     // f16/bf16.
     if (problem.Ta.isInteger() && problem.Tb.isInteger()
-            && (problem.needsAGroupSums() || problem.needsBGroupSums())) {
+            && ((problem.needsAGroupSums() || problem.needsBGroupSums())
+                    || ((opts.scaleA || opts.scaleB)
+                            && dev_info->gpu_arch()
+                                    < compute::gpu_arch_t::xe_hpc))) {
         Type ctype = Type::f16;
         if (utils::one_of(Type::bf16, problem.Ta_scale, problem.Tb_scale,
                     convert_dnnl_to_kernel_type(dst_mdw.data_type())))

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -353,7 +353,7 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
     if (src_quant_.with_scale()) {
         VDISPATCH_MATMUL(utils::one_of(src_quant_.scale_dt(), f32, f16, bf16,
                                  f8_e5m2, f8_e4m3, e8m0, f4_e2m1, f4_e3m0),
-                VERBOSE_UNSUPPORTED_SCALES_CFG ": %s(%s)", "src scales",
+                VERBOSE_UNSUPPORTED_SCALES_CFG ": src scales dt(%s)",
                 dnnl_dt2str(src_quant_.scale_dt()));
     }
 
@@ -362,9 +362,10 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
         // Only per-row or per-column zero points supported for src
         VDISPATCH_MATMUL(utils::one_of(src_zp_mask, src_qmask_M(),
                                  src_qmask_M() | src_qmask_K(), 0),
-                VERBOSE_UNSUPPORTED_ZP_CFG ": %s", "src zero points");
+                VERBOSE_UNSUPPORTED_ZP_CFG ": src zero points mask(%d)",
+                src_zp_mask);
         VDISPATCH_MATMUL(utils::one_of(src_quant_.zp_dt(), u8, s8),
-                VERBOSE_UNSUPPORTED_ZP_CFG ": %s(%s)", "src zero points",
+                VERBOSE_UNSUPPORTED_ZP_CFG ": src zero points dt(%s)",
                 dnnl_dt2str(src_quant_.zp_dt()));
     }
 
@@ -383,7 +384,7 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
                 utils::one_of(wei_mask, 7, 5), VERBOSE_UNSUPPORTED_SCALES_CFG);
         VDISPATCH_MATMUL(utils::one_of(wei_quant_.scale_dt(), f32, f16, bf16,
                                  f8_e5m2, f8_e4m3, e8m0, f4_e2m1, f4_e3m0),
-                VERBOSE_UNSUPPORTED_SCALES_CFG ": %s(%s)", "wei scales",
+                VERBOSE_UNSUPPORTED_SCALES_CFG ": wei scales dt(%s)",
                 dnnl_dt2str(wei_quant_.scale_dt()));
     }
 
@@ -391,9 +392,10 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
         const int wei_zp_mask = wei_quant_.zp_mask();
         // Only per-column zero points supported for weights
         VDISPATCH_MATMUL(utils::one_of(wei_zp_mask, 7, 5),
-                VERBOSE_UNSUPPORTED_ZP_CFG ": %s", "wei zero points");
+                VERBOSE_UNSUPPORTED_ZP_CFG ": wei zero points mask(%d)",
+                wei_zp_mask);
         VDISPATCH_MATMUL(utils::one_of(wei_quant_.zp_dt(), u8, s8, u4, s4),
-                VERBOSE_UNSUPPORTED_ZP_CFG ": %s(%s)", "wei zero points",
+                VERBOSE_UNSUPPORTED_ZP_CFG ": wei zero points dt(%s)",
                 dnnl_dt2str(wei_quant_.zp_dt()));
     }
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -359,13 +359,22 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
 
     if (src_quant_.with_zp()) {
         const int src_zp_mask = src_quant_.zp_mask();
-        const int src_qmask = src_qmask_M() | src_qmask_K();
         // Only per-row or per-column zero points supported for src
-        VDISPATCH_MATMUL(utils::one_of(src_zp_mask, src_qmask, 0),
+        VDISPATCH_MATMUL(utils::one_of(src_zp_mask, src_qmask_M(),
+                                 src_qmask_M() | src_qmask_K(), 0),
                 VERBOSE_UNSUPPORTED_ZP_CFG ": %s", "src zero points");
-        VDISPATCH_MATMUL(utils::one_of(src_quant_.zp_dt(), u8, s8, u4, s4),
+        VDISPATCH_MATMUL(utils::one_of(src_quant_.zp_dt(), u8, s8),
                 VERBOSE_UNSUPPORTED_ZP_CFG ": %s(%s)", "src zero points",
                 dnnl_dt2str(src_quant_.zp_dt()));
+    }
+
+    if (src_quant_.with_scale() && src_quant_.with_zp()) {
+        const int src_scale_mask = src_quant_.scale_mask();
+        const int src_zp_mask = src_quant_.zp_mask();
+        VDISPATCH_MATMUL(src_scale_mask == src_zp_mask,
+                VERBOSE_UNSUPPORTED_SCALES_CFG
+                ": src scale(%d) and zp(%d) mask must match",
+                src_scale_mask, src_zp_mask);
     }
 
     if (wei_quant_.with_scale()) {
@@ -386,6 +395,15 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
         VDISPATCH_MATMUL(utils::one_of(wei_quant_.zp_dt(), u8, s8, u4, s4),
                 VERBOSE_UNSUPPORTED_ZP_CFG ": %s(%s)", "wei zero points",
                 dnnl_dt2str(wei_quant_.zp_dt()));
+    }
+
+    if (wei_quant_.with_scale() && wei_quant_.with_zp()) {
+        const int wei_scale_mask = wei_quant_.scale_mask();
+        const int wei_zp_mask = wei_quant_.zp_mask();
+        VDISPATCH_MATMUL(wei_scale_mask == wei_zp_mask,
+                VERBOSE_UNSUPPORTED_SCALES_CFG
+                ": wei scale(%d) and zp(%d) mask must match",
+                wei_scale_mask, wei_zp_mask);
     }
 
     VDISPATCH_MATMUL(attr_scales.has_default_values(DNNL_ARG_DST),

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -138,13 +138,15 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
                 = static_cast<int>(utils::rnd_up_pow2(src_group_sizes_[1]));
     }
 
-    // internal conversions do not work well when both A and B are integers
-    if (problem.Ta.isInteger() && problem.Tb.isInteger()) {
+    // When both A and B are integers and group sums are needed, we
+    // can avoid using group sums by converting one of the inputs to
+    // f16/bf16.
+    if (problem.Ta.isInteger() && problem.Tb.isInteger()
+            && (problem.needsAGroupSums() || problem.needsBGroupSums())) {
         Type ctype = Type::f16;
         if (utils::one_of(Type::bf16, problem.Ta_scale, problem.Tb_scale,
                     convert_dnnl_to_kernel_type(dst_mdw.data_type())))
             ctype = Type::bf16;
-
         if (problem.Ta_ext.bits() < problem.Tb_ext.bits()) {
             problem.Ta = ctype;
         } else {

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -115,7 +115,10 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
         problem.B_scale.setAlignment(
                 static_cast<int>(types::data_type_size(src_scale_dt)));
         problem.B_scale.layout = MatrixLayout::N;
-        problem.bsPtrDims = 2;
+        problem.bsPtrDims
+                = (src_quant_.scale_mask() == (src_qmask_M() | src_qmask_K()))
+                ? 2
+                : 1;
     }
     if (opts.offsetB) {
         data_type_t src_zp_dt = src_quant_.zp_dt();
@@ -123,7 +126,9 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
         problem.BO.setAlignment(
                 static_cast<int>(types::data_type_size(src_zp_dt)));
         problem.BO.layout = MatrixLayout::N;
-        problem.boPtrDims = 2;
+        problem.boPtrDims
+                = (src_quant_.zp_mask() == (src_qmask_M() | src_qmask_K())) ? 2
+                                                                            : 1;
         problem.bOffset = ABOffset::Calc;
     }
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -114,22 +114,24 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
         problem.Tb_scale = convert_dnnl_to_kernel_type(src_scale_dt);
         problem.B_scale.setAlignment(
                 static_cast<int>(types::data_type_size(src_scale_dt)));
-        problem.B_scale.layout = MatrixLayout::N;
         problem.bsPtrDims
                 = (src_quant_.scale_mask() == (src_qmask_M() | src_qmask_K()))
                 ? 2
                 : 1;
+        problem.B_scale.layout
+                = problem.bsPtrDims > 1 ? MatrixLayout::N : MatrixLayout::T;
     }
     if (opts.offsetB) {
         data_type_t src_zp_dt = src_quant_.zp_dt();
         problem.Tbo = convert_dnnl_to_kernel_type(src_zp_dt);
         problem.BO.setAlignment(
                 static_cast<int>(types::data_type_size(src_zp_dt)));
-        problem.BO.layout = MatrixLayout::N;
         problem.boPtrDims
                 = (src_quant_.zp_mask() == (src_qmask_M() | src_qmask_K())) ? 2
                                                                             : 1;
         problem.bOffset = ABOffset::Calc;
+        problem.BO.layout
+                = problem.boPtrDims > 1 ? MatrixLayout::N : MatrixLayout::T;
     }
 
     if (opts.scaleA || opts.offsetA) {

--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
@@ -86,11 +86,24 @@
 --attr-scales=src:1+wei:7:bf16:128x1,src:1+wei:7:bf16:32x1
 32x512:4x512x256
 
+# Combine row-wise src scales and zp u8/s8
 --reset
---dt=s8:s4:f32
+--dt=s8:s4:f32,s8:s4:bf16,u8:s4:bf16
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8
+--bia-dt=undef,bf16 --bia_mask=2
 --attr-scales=src:1+wei:7:f32:128x1
+--attr-zero-points=,src:1:u8,src:1:s8
+32x512:4x512x256
+
+# Combine blocked src scales and zp u8/s8
+--reset
+--dt=s8:s4:bf16,u8:s4:bf16
+--wtag=abc,acb
+--grouped=0:4:8+8+8+8
+--bia-dt=undef,bf16 --bia_mask=2
+--attr-scales=src:3:f32:1x128
+--attr-zero-points=,src:3:u8:1x128,src:3:s8:1x128
 32x512:4x512x256
 
 # int src + int wei with column-wise scales and ZPs


### PR DESCRIPTION
# Description

This PR allows src scales attributes for grouped gemm. This functionallity was implemented but was blocked behind a dipatch check for specific masks. The mask condition was too restrictive. Currently only s8 and u8 types are supported.

This PR also addresses a conversion bug in the bias parameter passed into the kernel.

This PR also refined the problem definition so that all integer times integer calculations are not first converted to floating point by the microkernel. We now only need to do that for grouped scales and weight cases. Row/column quantization can be directly passed in as integers.