### PR TITLE
cpu: aarch64: make post-op injectors vector length agnostic

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2024-2026 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -295,11 +295,11 @@ void jit_brdgmm_kernel_base_t::apply_post_ops(
         const bool p_sum_scale_reg_set = *p_sum_scale != 1.f;
         const bool p_sum_zp_reg_set = *p_sum_zp != 0;
 
-        const injector_utils::conditional_register_preserve_guard_t<sve_512>
+        const injector_utils::conditional_register_preserve_guard_t<sve>
                 register_guard_sum_scale(
                         (with_binary_non_scalar_bcast_) && p_sum_scale_reg_set,
                         this, {reg_ptr_sum_scale});
-        const injector_utils::conditional_register_preserve_guard_t<sve_512>
+        const injector_utils::conditional_register_preserve_guard_t<sve>
                 register_guard_sum_zp(p_sum_zp_reg_set, this, {reg_ptr_sum_zp});
 
         auto vmm_sum_zp = vmm_tmp(0);

--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ struct jit_brdgmm_kernel_base_t : public jit_generator_t {
     }
 
 private:
-    using po_injector_t = injector::jit_uni_postops_injector_t<sve_512>;
+    using po_injector_t = injector::jit_uni_postops_injector_t<sve>;
     std::unique_ptr<po_injector_t> postops_injector_;
 
     Xbyak_aarch64::Label permute_index_table;

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -116,7 +116,7 @@ struct jit_brgemm_kernel_t : public jit_generator_t {
     brgemm_desc_t brg;
 
 private:
-    using po_injector_t = injector::jit_uni_postops_injector_t<sve_512>;
+    using po_injector_t = injector::jit_uni_postops_injector_t<sve>;
     std::unique_ptr<po_injector_t> postops_injector_;
 
     // Register decomposition
@@ -805,7 +805,7 @@ void jit_brgemm_kernel_t::apply_post_ops(
         int bd_block, int ld_block2, int ldb_and_bdb_offset, bool is_ld_tail) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
 
-    const injector_utils::conditional_register_preserve_guard_t<sve_512>
+    const injector_utils::conditional_register_preserve_guard_t<sve>
             register_guard(brg.with_binary, this, {param1});
     const auto guard_space = register_guard.stack_space_occupied();
     if (brg.with_binary) {
@@ -832,11 +832,11 @@ void jit_brgemm_kernel_t::apply_post_ops(
         const bool p_sum_zp_reg_set = *p_sum_zp != 0;
 
         {
-            const injector_utils::conditional_register_preserve_guard_t<sve_512>
+            const injector_utils::conditional_register_preserve_guard_t<sve>
                     register_guard_sum_scale((with_binary_non_scalar_bcast_)
                                     && p_sum_scale_reg_set,
                             this, {reg_ptr_sum_scale});
-            const injector_utils::conditional_register_preserve_guard_t<sve_512>
+            const injector_utils::conditional_register_preserve_guard_t<sve>
                     register_guard_sum_zp(
                             p_sum_zp_reg_set, this, {reg_ptr_sum_zp});
 

--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 * limitations under the License.
 *******************************************************************************/
 #include <numeric>
-#include "common/broadcast_strategy.hpp"
+#include <vector>
 #include "cpu/aarch64/injectors/injector_utils.hpp"
 
 namespace dnnl {
@@ -30,26 +30,38 @@ register_preserve_guard_t<isa>::register_preserve_guard_t(jit_generator_t *host,
         std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
         std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
     : host_(host)
-    , reg64_stack_(reg64_to_preserve)
-    , vmm_stack_(vmm_to_preserve)
+    , gpr_regs_(reg64_to_preserve)
+    , vec_regs_(vmm_to_preserve)
     , vmm_to_preserve_size_bytes_(
               calc_vmm_to_preserve_size_bytes(vmm_to_preserve)) {
 
-    for (const auto &reg : reg64_to_preserve)
-        host_->str(reg, pre_ptr(host_->X_SP, -8));
+    if (reg64_to_preserve.size() != 0) {
+        const auto store_pairs = reg64_to_preserve.size() / 2;
+        const bool has_lone_store = reg64_to_preserve.size() % 2;
+        uint32_t i = 0;
+        for (; i < store_pairs; ++i)
+            host_->stp(gpr_regs_[2 * i], gpr_regs_[2 * i + 1],
+                    pre_ptr(host_->X_SP, -16));
 
-    if (!vmm_stack_.empty()) {
+        if (has_lone_store) {
+            // The hardware requires the stack pointer to be quad-word aligned
+            // https://github.com/ARM-software/abi-aa/blob/e2534ac15f02fa2e03b7f336f069f7cf392257d9/aapcs64/aapcs64.rst?#645the-stack
+            host_->str(gpr_regs_[2 * i], pre_ptr(host_->X_SP, -16));
+        }
+    }
+
+    if (!vec_regs_.empty()) {
         host_->sub(host_->X_SP, host_->X_SP, vmm_to_preserve_size_bytes_);
 
         uint32_t stack_offset = vmm_to_preserve_size_bytes_;
         for (const auto &vmm : vmm_to_preserve) {
-            const uint32_t bytes = cpu_isa_traits<isa>::vlen;
-            stack_offset -= bytes;
+            const uint32_t vlen_bytes = simd_bytes(isa);
+            stack_offset -= vlen_bytes;
             const auto idx = vmm.getIdx();
-            if (is_superset(isa, sve_256)) {
-                if (stack_offset % cpu_sveLen_ == 0) {
+            if (vlen_bytes > 16) {
+                if (stack_offset % vlen_bytes == 0) {
                     host_->st1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
-                            ptr(host_->X_SP, stack_offset / bytes,
+                            ptr(host_->X_SP, stack_offset / vlen_bytes,
                                     Xbyak_aarch64::MUL_VL));
                 } else {
                     host_->add_imm(host_->X_DEFAULT_ADDR, host_->X_SP,
@@ -70,14 +82,14 @@ register_preserve_guard_t<isa>::~register_preserve_guard_t() {
 
     uint32_t tmp_stack_offset = 0;
 
-    while (!vmm_stack_.empty()) {
-        const Xbyak_aarch64::VReg &vmm = vmm_stack_.top();
-        const uint32_t bytes = cpu_isa_traits<isa>::vlen;
+    while (!vec_regs_.empty()) {
+        const Xbyak_aarch64::VReg &vmm = vec_regs_.back();
+        const uint32_t vlen_bytes = simd_bytes(isa);
         const auto idx = vmm.getIdx();
-        if (is_superset(isa, sve_256)) {
-            if (tmp_stack_offset % cpu_sveLen_ == 0) {
+        if (vlen_bytes > 16) {
+            if (tmp_stack_offset % vlen_bytes == 0) {
                 host_->ld1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
-                        ptr(host_->X_SP, tmp_stack_offset / bytes,
+                        ptr(host_->X_SP, tmp_stack_offset / vlen_bytes,
                                 Xbyak_aarch64::MUL_VL));
             } else {
                 host_->add_imm(host_->X_DEFAULT_ADDR, host_->X_SP,
@@ -90,17 +102,26 @@ register_preserve_guard_t<isa>::~register_preserve_guard_t() {
                     ptr(host_->X_SP, tmp_stack_offset));
         }
 
-        tmp_stack_offset += bytes;
-        vmm_stack_.pop();
+        tmp_stack_offset += vlen_bytes;
+        vec_regs_.pop_back();
     }
 
     if (vmm_to_preserve_size_bytes_)
         host_->add_imm(host_->X_SP, host_->X_SP, vmm_to_preserve_size_bytes_,
                 host_->X_TMP_0);
 
-    while (!reg64_stack_.empty()) {
-        host_->ldr(reg64_stack_.top(), post_ptr(host_->X_SP, 8));
-        reg64_stack_.pop();
+    if (!gpr_regs_.empty()) {
+        const bool has_lone_store = gpr_regs_.size() % 2;
+
+        if (has_lone_store) {
+            host_->ldr(gpr_regs_.back(), post_ptr(host_->X_SP, 16));
+            gpr_regs_.pop_back();
+        }
+
+        for (int i = gpr_regs_.size() - 1; i > 0; --i) {
+            host_->ldp(
+                    gpr_regs_[i - 1], gpr_regs_[i], post_ptr(host_->X_SP, 16));
+        }
     }
 }
 
@@ -112,7 +133,7 @@ size_t register_preserve_guard_t<isa>::calc_vmm_to_preserve_size_bytes(
     return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
             std::size_t(0u),
             [](std::size_t accum, const Xbyak_aarch64::VReg &vmm) {
-        return accum + cpu_isa_traits<isa>::vlen;
+        return accum + simd_bytes(isa);
     });
 }
 
@@ -120,7 +141,7 @@ template <cpu_isa_t isa>
 size_t register_preserve_guard_t<isa>::stack_space_occupied() const {
     constexpr static size_t reg64_size = 8;
     const size_t stack_space_occupied
-            = vmm_to_preserve_size_bytes_ + reg64_stack_.size() * reg64_size;
+            = vmm_to_preserve_size_bytes_ + gpr_regs_.size() * reg64_size;
 
     return stack_space_occupied;
 }
@@ -136,12 +157,8 @@ conditional_register_preserve_guard_t<
                                 vmm_to_preserve}
                       : register_preserve_guard_t<isa> {nullptr, {}, {}}} {};
 
-template class register_preserve_guard_t<sve_512>;
-template class register_preserve_guard_t<sve_256>;
-template class register_preserve_guard_t<sve_128>;
-template class conditional_register_preserve_guard_t<sve_512>;
-template class conditional_register_preserve_guard_t<sve_256>;
-template class conditional_register_preserve_guard_t<sve_128>;
+template class register_preserve_guard_t<sve>;
+template class conditional_register_preserve_guard_t<sve>;
 
 } // namespace injector_utils
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/injector_utils.hpp
+++ b/src/cpu/aarch64/injectors/injector_utils.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,10 +18,9 @@
 #ifndef CPU_AARCH64_INJECTORS_INJECTOR_UTILS_HPP
 #define CPU_AARCH64_INJECTORS_INJECTOR_UTILS_HPP
 
-#include <array>
 #include <cstddef>
 #include <set>
-#include <stack>
+#include <vector>
 
 #include "cpu/aarch64/jit_generator.hpp"
 
@@ -33,24 +32,6 @@ namespace injector_utils {
 
 using vmm_index_set_t = typename std::set<size_t>;
 using vmm_index_set_iterator_t = typename std::set<size_t>::iterator;
-template <cpu_isa_t isa>
-struct vmm_size_t;
-
-template <>
-struct vmm_size_t<sve_512> {
-    static constexpr std::size_t bytes = 64u;
-};
-
-template <>
-struct vmm_size_t<sve_256> {
-    static constexpr std::size_t bytes = 32u;
-};
-
-/*
-template <>
-struct vmm_size_t<sve_128> {
-    static constexpr std::size_t bytes = 16u;
-    };*/
 
 enum class layout_t { ncsp, c_blocked, nspc, cspn, unsupported };
 
@@ -88,15 +69,14 @@ public:
 
 private:
     jit_generator_t *host_;
-    std::stack<Xbyak_aarch64::XReg> reg64_stack_;
-    std::stack<Xbyak_aarch64::VReg> vmm_stack_;
-    const uint64_t cpu_sveLen_ = get_sve_length();
+    std::vector<Xbyak_aarch64::XReg> gpr_regs_;
+    std::vector<Xbyak_aarch64::VReg> vec_regs_;
     size_t vmm_to_preserve_size_bytes_;
 };
 
 template <cpu_isa_t isa>
 class conditional_register_preserve_guard_t
-    : public register_preserve_guard_t<isa> {
+    : public register_preserve_guard_t<to_vla_sve(isa)> {
 public:
     conditional_register_preserve_guard_t(bool condition_to_be_met,
             jit_generator_t *host,

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -495,18 +495,26 @@ void jit_uni_binary_injector_t<isa>::compute_vector_range(
             || rhs_arg_data_type != data_type::f32 || should_preserve_vmm_tail;
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
 
+    const std::initializer_list<Xbyak_aarch64::XReg> gpr_maybe_preserve_list {
+            rhs_arg_static_params_.rhs_addr_reg,
+            rhs_arg_static_params_.rhs_helper_reg};
+
+    const std::initializer_list<Xbyak_aarch64::VReg> vmm_maybe_preserve_list {
+            Xbyak_aarch64::VReg(vmm_hint)};
+
     // Phase 2 Protect temporary registers content.
-    const injector_utils::register_preserve_guard_t<isa> register_guard {host_,
-            (rhs_arg_static_params_.preserve_gpr_helpers
-                            ? std::initializer_list<Xbyak_aarch64::XReg>(
-                                      {rhs_arg_static_params_.rhs_addr_reg,
-                                              rhs_arg_static_params_
-                                                      .rhs_helper_reg})
-                            : std::initializer_list<Xbyak_aarch64::XReg>()),
-            (rhs_arg_static_params_.preserve_vmm_helper && dt_helper_vmm_needed
-                            ? std::initializer_list<Xbyak_aarch64::VReg>(
-                                      {Xbyak_aarch64::VReg(vmm_hint)})
-                            : std::initializer_list<Xbyak_aarch64::VReg>())};
+    const injector_utils::register_preserve_guard_t<to_vla_sve(isa)>
+            register_guard {host_,
+                    (rhs_arg_static_params_.preserve_gpr_helpers
+                                    ? gpr_maybe_preserve_list
+                                    : std::initializer_list<
+                                              Xbyak_aarch64::XReg>()),
+
+                    (rhs_arg_static_params_.preserve_vmm_helper
+                                            && dt_helper_vmm_needed
+                                    ? vmm_maybe_preserve_list
+                                    : std::initializer_list<
+                                              Xbyak_aarch64::VReg>())};
 
     bool vmm0_was_preserved = false;
     static const Vmm zero_vmm(0);
@@ -862,8 +870,7 @@ void jit_uni_binary_injector_t<isa>::calculate_oc_blocked(
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     // output = X_TMP_0
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int simd_w = cpu_isa_traits<isa>::vlen
-            / types::data_type_size(dst_d.data_type());
+    const int simd_w = simd_elems(dst_d.data_type(), isa);
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
     const auto X_TMP_0 = host_->X_TMP_0;
     const auto X_TMP_1 = host_->X_TMP_1;
@@ -1013,8 +1020,7 @@ void jit_uni_binary_injector_t<isa>::calculate_mb_sp_blocked(
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
     // output = X_TMP_0
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int simd_w = cpu_isa_traits<isa>::vlen
-            / types::data_type_size(dst_d.data_type());
+    const int simd_w = simd_elems(dst_d.data_type(), isa);
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
 
     const auto X_TMP_0 = host_->X_TMP_0;
@@ -1395,7 +1401,7 @@ void jit_uni_binary_injector_t<isa>::inject_binary(
         Xbyak_aarch64::PReg mask = host_->P_ALL_ONE;
         if (with_tail_fusable_to_binary_op) {
             assert(rhs_arg_static_params_.is_opmask_set()
-                    && "Opmask is not set for tail loading sve512");
+                    && "Opmask is not set for tail loading on SVE");
             const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
             mask = tail_opmask;
             host_->mov(dst.s, mask / Xbyak_aarch64::T_z, dst.s);
@@ -1494,7 +1500,7 @@ void jit_uni_binary_injector_t<isa>::execute_broadcast_tail_with_opmask(
         const rhs_address_t &rhs_addr) const {
 
     assert(rhs_arg_static_params_.is_opmask_set()
-            && "Opmask is not set for tail loading sve_512");
+            && "Opmask is not set for tail loading on SVE");
 
     const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
     Xbyak_aarch64::PReg mask = tail_opmask;
@@ -1565,7 +1571,7 @@ void jit_uni_binary_injector_t<isa>::load_rhs_tail_dynamically_with_opmask(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const rhs_address_t &rhs_addr) const {
     assert(rhs_arg_static_params_.is_opmask_set()
-            && "Opmask is not set for tail loading sve_512");
+            && "Opmask is not set for tail loading on SVE");
 
     const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
     Xbyak_aarch64::PReg mask = tail_opmask;
@@ -1607,7 +1613,7 @@ static void load_bytes(jit_generator_t *host, const Xbyak_aarch64::ZReg &vmm,
     assert(load_size >= 0 && load_size <= 32);
 
     // Ensure that vector register is compatible with the ISA in hand
-    assert(mayiuse(sve_128));
+    assert(mayiuse(sve));
 
     if (load_size == 0) {
         return;
@@ -1902,9 +1908,7 @@ void jit_uni_binary_injector_t<isa>::compute_vector(size_t idx,
     compute_vector_range({idx}, rhs_arg_idx, post_op, rhs_arg_params);
 }
 
-template class jit_uni_binary_injector_t<sve_512>;
-template class jit_uni_binary_injector_t<sve_256>;
-template class jit_uni_binary_injector_t<sve_128>;
+template class jit_uni_binary_injector_t<sve>;
 
 } // namespace binary_injector
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
@@ -95,7 +95,7 @@ bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
  * @param dst_orig_offset - offset 0 to destination tensor
  * @param dst_d - descriptor of destination tensor (result after applying all post-ops
  * operations).
- * @param tail_opmask - register with loaded by user mask, used in sve512 for load with
+ * @param tail_opmask - register with loaded by user mask, used in sve for load with
  * tail handling.
  * @param tail_size - size of processed tail in elements.
  * @param use_exact_tail_scalar_bcast - in case of scalar broadcast user can disable
@@ -381,7 +381,7 @@ bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
 
 /*
  * Main mechanism responsible for injecting binary postops supporting various
- * isa: sve_512
+ * isa: sve
  * types: f32, s32, u8, s8.
  */
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -257,9 +257,7 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
     return true;
 }
 
-template class jit_uni_postops_injector_t<sve_512>;
-template class jit_uni_postops_injector_t<sve_256>;
-template class jit_uni_postops_injector_t<sve_128>;
+template class jit_uni_postops_injector_t<sve>;
 
 } // namespace injector
 } // namespace aarch64

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -88,7 +88,7 @@ struct jit_brgemm_kernel_post_ops_t : public jit_generator_t {
                     save_state, reserved_eltwise_gpr, reserved_eltwise_maskr};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<isa>>(
+                    injector::jit_uni_postops_injector_t<to_vla_sve(isa)>>(
                     this, attr.post_ops_, bsp, esp);
         }
 
@@ -121,7 +121,7 @@ private:
     data_type_t inp_dt_;
     data_type_t out_dt_;
     data_type_t bia_dt_;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<to_vla_sve(isa)>>
             postops_injector_;
 
     const bool with_binary_non_scalar_bcast_;

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -20,6 +20,7 @@
 #define CPU_AARCH64_JIT_GENERATOR_HPP
 
 #include <limits.h>
+#include <vector>
 
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
@@ -816,13 +817,10 @@ public:
     void runtime_tail_process(const Xbyak_aarch64::XReg &reg_tail,
             const Xbyak_aarch64::XReg &reg_tmp,
             const std::function<void(int)> &tail_process) {
-        constexpr int simd_w_ymm = 8;
-        constexpr int f32_bits = sizeof(float) * 8;
-        const auto simd_w = cpu_isa_traits<isa>::vlen * 8 / f32_bits;
-        assert(simd_w != cpu_isa_traits<isa>::vlen * 8 / f32_bits);
+        const size_t simd_w = simd_elems(data_type_t::dnnl_f32, isa);
 
         Xbyak_aarch64::Label label_tbl, label_tbl_end;
-        Xbyak_aarch64::Label l_case[simd_w_ymm];
+        std::vector<Xbyak_aarch64::Label> l_case(simd_w);
 
         adr(reg_tmp, label_tbl);
         mov_imm(X_TMP_0, sizeof(void *));

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
-* Copyright 2024-2025 Arm Ltd. and affiliates
+* Copyright 2024-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -47,8 +47,8 @@ using namespace dnnl::impl::format_tag;
 using namespace dnnl::impl::prop_kind;
 using namespace dnnl::impl::utils;
 
-template <cpu_isa_t isa_>
-jit_sve_1x1_conv_kernel_t<isa_>::jit_sve_1x1_conv_kernel_t(
+template <cpu_isa_t isa>
+jit_sve_1x1_conv_kernel_t<isa>::jit_sve_1x1_conv_kernel_t(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
     : jcp(ajcp), attr_(attr) {
@@ -69,13 +69,13 @@ jit_sve_1x1_conv_kernel_t<isa_>::jit_sve_1x1_conv_kernel_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<isa_>>(
+                injector::jit_uni_postops_injector_t<to_vla_sve(isa)>>(
                 this, jcp.post_ops, static_params);
     }
 }
 
-template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel_t<isa_>::bcast_loop(int load_loop_blk) {
+template <cpu_isa_t isa>
+void jit_sve_1x1_conv_kernel_t<isa>::bcast_loop(int load_loop_blk) {
 
     mov(aux1_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_bcast_data, reg_bcast_data);
@@ -156,8 +156,8 @@ static void iterate(const int load_loop_blk, const int ur, const F &fun) {
     iterate(load_loop_blk, ur, false, fun);
 }
 
-template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel_t<isa_>::apply_postops(
+template <cpu_isa_t isa>
+void jit_sve_1x1_conv_kernel_t<isa>::apply_postops(
         const bool is_out_layout_nxc, const int load_loop_blk, const int ur) {
     injector_utils::vmm_index_set_t vmm_idxs;
     if (jcp.with_binary) {
@@ -187,8 +187,8 @@ void jit_sve_1x1_conv_kernel_t<isa_>::apply_postops(
     }
 }
 
-template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel_t<isa_>::reduce_loop(
+template <cpu_isa_t isa>
+void jit_sve_1x1_conv_kernel_t<isa>::reduce_loop(
         int load_loop_blk, int ur, int substep, bool wraparound) {
 
     const bool out_layout_nxc = is_out_layout_nxc(jcp);
@@ -365,7 +365,7 @@ void jit_sve_1x1_conv_kernel_t<isa_>::reduce_loop(
         };
 
         Label unaligned_store, end_store;
-        tst(aux_reg_output_data, cpu_isa_traits<isa_>::vlen - 1);
+        tst(aux_reg_output_data, cpu_isa_traits<isa>::vlen - 1);
         b(NE, unaligned_store);
         store_output(true);
         b(end_store);
@@ -463,8 +463,8 @@ void jit_sve_1x1_conv_kernel_t<isa_>::reduce_loop(
     store();
 }
 
-template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel_t<isa_>::generate() {
+template <cpu_isa_t isa>
+void jit_sve_1x1_conv_kernel_t<isa>::generate() {
     preamble();
 
     sub_imm(X_SP, X_SP, stack_space_needed, X_TMP_0);
@@ -565,7 +565,7 @@ void jit_sve_1x1_conv_kernel_t<isa_>::generate() {
         }
     };
 
-    const int simd_w = cpu_isa_traits<isa_>::vlen / sizeof(float);
+    const int simd_w = cpu_isa_traits<isa>::vlen / sizeof(float);
 
     Label load_loop_blk[7];
 
@@ -626,15 +626,15 @@ void jit_sve_1x1_conv_kernel_t<isa_>::generate() {
     if (jcp.with_eltwise) postops_injector_->prepare_table();
 }
 
-template <cpu_isa_t isa_>
-status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
+template <cpu_isa_t isa>
+status_t jit_sve_1x1_conv_kernel_t<isa>::init_conf(jit_1x1_conv_conf_t &jcp,
         const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
         const memory_desc_wrapper &weights_d, const memory_desc_wrapper &dst_d,
         const primitive_attr_t &attr, int nthreads, bool reduce_src) {
 
     /* arch check */
-    if (!mayiuse(isa_)) { return status::unimplemented; }
-    jcp.isa = isa_;
+    if (!mayiuse(isa)) { return status::unimplemented; }
+    jcp.isa = isa;
 
     if (!everyone_is(data_type::f32, src_d.data_type(), weights_d.data_type(),
                 dst_d.data_type())) {
@@ -644,7 +644,7 @@ status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nthr = nthreads;
 
     const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
-    const int simd_w = cpu_isa_traits<isa_>::vlen / sizeof(float);
+    const int simd_w = cpu_isa_traits<isa>::vlen / sizeof(float);
     const int ndims = src_d.ndims();
     /* Forward_[training, inference], backward_[data, weight] */
     jcp.prop_kind = cd.prop_kind;
@@ -724,7 +724,7 @@ status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
     bool is_data_layout_nxc;
     format_tag_t required_dat_tag;
 
-    switch (isa_) {
+    switch (isa) {
         case sve_512: {
             const auto dat_tag_nCx16c
                     = pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
@@ -789,7 +789,7 @@ status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
     /* Channel blocking size is simd_w */
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    switch (isa_) {
+    switch (isa) {
         case sve_512: {
             jcp.ver = ver_sve_512;
             break;
@@ -811,7 +811,7 @@ status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
 
         /* Set weight data layout tag */
         format_tag_t wei_tag;
-        switch (isa_) {
+        switch (isa) {
             case sve_512: {
                 wei_tag = with_groups
                         ? pick(2 * ndims - 6 + is_bwd_d, gOIw16i16o, gIOw16o16i,
@@ -1327,8 +1327,8 @@ status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
     return status::success;
 }
-template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel_t<isa_>::init_scratchpad(
+template <cpu_isa_t isa>
+void jit_sve_1x1_conv_kernel_t<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad,
         const jit_1x1_conv_conf_t &jcp) {
 
@@ -1356,8 +1356,8 @@ void jit_sve_1x1_conv_kernel_t<isa_>::init_scratchpad(
 }
 
 /* BWD W*/
-template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel_t<isa_>::balance(jit_1x1_conv_conf_t &jcp) {
+template <cpu_isa_t isa>
+void jit_sve_1x1_conv_kernel_t<isa>::balance(jit_1x1_conv_conf_t &jcp) {
     int nthreads = jcp.nthr;
     // initialize jcp reduction threading properties
     jcp.nthr = jcp.nthr_mb = jcp.nthr_g = jcp.nthr_oc_b = jcp.nthr_ic_b = 1;

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,9 +35,9 @@ namespace cpu {
 namespace aarch64 {
 
 /* Get vector offsets, ofs / VL(eg VL: 512bits = 64Bytes ) */
-#define VL64_OFS(ofs) ((ofs) >> cpu_isa_traits<isa_>::vlen_shift)
+#define VL64_OFS(ofs) ((ofs) >> cpu_isa_traits<isa>::vlen_shift)
 
-template <cpu_isa_t isa_ = isa_undef>
+template <cpu_isa_t isa = isa_undef>
 struct jit_sve_1x1_conv_kernel_t : public jit_generator_t {
     jit_sve_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
@@ -93,11 +93,11 @@ private:
 
     reg64_t reg_load_dim_tail_mask = aux_reg_load_data;
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa_>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<to_vla_sve(isa)>>
             postops_injector_;
 
     constexpr static int isa_simd_width_
-            = cpu_isa_traits<isa_>::vlen / sizeof(float);
+            = cpu_isa_traits<isa>::vlen / sizeof(float);
 
     ZReg vreg_bcast = ZReg(31);
     PReg k_load_dim_mask = p2;

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ void jit_uni_binary_kernel_t<isa>::init_post_ops_injector() {
             get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 
     postops_injector_ = utils::make_unique<
-            injector::jit_uni_postops_injector_t<inject_isa>>(
+            injector::jit_uni_postops_injector_t<to_vla_sve(inject_isa)>>(
             this, po, bsp, esp);
 }
 
@@ -165,8 +165,8 @@ void jit_uni_binary_kernel_t<isa>::apply_postops(int unroll, bool tail) {
         binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
         const XReg &reg_offt_dst = conf_.is_i8 ? reg_offt_dst_ : reg_offt_src0_;
 
-        const injector_utils::register_preserve_guard_t<isa> register_guard {
-                this, {reg_tmp1_}};
+        const injector_utils::register_preserve_guard_t<to_vla_sve(isa)>
+                register_guard {this, {reg_tmp1_}};
 
         mov(reg_tmp1_, reg_dst_);
         add(reg_tmp1_, reg_tmp1_, reg_offt_dst);

--- a/src/cpu/aarch64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -117,7 +117,8 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
 
     static constexpr cpu_isa_t inject_isa = isa;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<inject_isa>>
+    std::unique_ptr<
+            injector::jit_uni_postops_injector_t<to_vla_sve(inject_isa)>>
             postops_injector_;
     const PReg elt_inj_opmask_ = p1;
     const PReg elt_inj_p_tmp0_ = p2;

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -2,7 +2,7 @@
 * Copyright 2017 Intel Corporation
 * Copyright 2018 YANDEX LLC
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,9 +66,9 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
         const binary_injector::static_params_t bsp {
                 reg_param, get_supported_bcast_strategies(), rhs_sp};
 
-        postops_injector_
-                = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
-                        this, jpp.post_ops, bsp);
+        postops_injector_ = utils::make_unique<
+                injector::jit_uni_postops_injector_t<to_vla_sve(isa)>>(
+                this, jpp.post_ops, bsp);
     }
 }
 

--- a/src/cpu/aarch64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.hpp
@@ -2,7 +2,7 @@
 * Copyright 2017 Intel Corporation
 * Copyright 2018 YANDEX LLC
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ private:
     static bool post_ops_ok(jit_pool_conf_t &jpp, const primitive_attr_t &attr,
             const memory_desc_wrapper &dst_d);
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<to_vla_sve(isa)>>
             postops_injector_;
 };
 


### PR DESCRIPTION
# Description

Makes the post-op injectors, and related utilities, vector-length agnostic.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

cc: @jondea 