### PR TITLE
cpu: x64: int8: Enable quantized matmul with src grouped quantization

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -506,7 +506,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     const bool scales_ok = attr->scales_.has_default_values({DNNL_ARG_SRC,
                                    DNNL_ARG_WEIGHTS, DNNL_ARG_DST})
             && IMPLICATION(!src_scales.has_default_values(),
-                    src_scales.get_mask() == 0)
+                    src_scales.get_mask() == 0 || brg->is_ic_src_scales)
             && IMPLICATION(!dst_scales.has_default_values(),
                     dst_scales.get_mask() == 0);
     if (!scales_ok) return status::unimplemented;
@@ -830,6 +830,9 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(is_ic_wei_scales);
     CMP_BRGEMM_FIELD(wei_scale_k_group_size);
     CMP_BRGEMM_FIELD(with_src_scales);
+    CMP_BRGEMM_FIELD(is_ic_src_scales);
+    CMP_BRGEMM_FIELD(src_scale_k_group_size);
+    CMP_BRGEMM_FIELD(src_scale_m_stride);
     CMP_BRGEMM_FIELD(with_wei_scales);
     CMP_BRGEMM_FIELD(with_dst_scales);
     CMP_BRGEMM_FIELD(dt_wei_scales);

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -79,6 +79,14 @@ void brgemm_desc_t::cleanup_dst_md() {
     dst_md_ = nullptr;
 }
 
+void brgemm_kernel_execute_params(
+        const brgemm_kernel_t *brg, brgemm_kernel_params_t &params) {
+    assert(brg);
+    assert(&params);
+
+    (*brg)(&params);
+}
+
 void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
@@ -467,7 +475,12 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
             = !brg->skip_scales && !src_scales.has_default_values();
     brg->with_wei_scales
             = !brg->skip_scales && !wei_scales.has_default_values();
-    if (brg->with_wei_scales) {
+    // In order to parse the mask correctly the `ndims` value is required,
+    // if mask is set by the primitive using this kernel, no need to
+    // override it. Other cases will be parsed as 2D (`ndims` = 2).
+    bool wei_scales_are_set = brg->is_single_wei_scale || brg->is_oc_wei_scales
+            || brg->is_ic_wei_scales;
+    if (brg->with_wei_scales && !wei_scales_are_set) {
         // Note. the current version supports only two different wei scales
         // types:
         //     1) common (mask = 0)
@@ -479,7 +492,12 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         // So if wei_scales.get_mask() > 0 (not common) it's assumed here that
         // scale type is per_n_dim_scale and driver which calls brgemm kernel
         // checked that mask has correct value for this case
-        brg->is_oc_scale = wei_scales.get_mask() > 0;
+
+        const auto &wei_scales_mask = wei_scales.get_mask();
+        brg->is_single_wei_scale = wei_scales_mask == 0;
+        brg->is_oc_wei_scales = wei_scales_mask > 0;
+        brg->is_ic_wei_scales = false;
+        brg->wei_scale_k_group_size = wei_scales.get_group(0);
         brg->dt_wei_scales = wei_scales.get_data_type();
     }
 
@@ -807,7 +825,10 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(zp_type_c);
 
     CMP_BRGEMM_FIELD(skip_scales);
-    CMP_BRGEMM_FIELD(is_oc_scale);
+    CMP_BRGEMM_FIELD(is_single_wei_scale);
+    CMP_BRGEMM_FIELD(is_oc_wei_scales);
+    CMP_BRGEMM_FIELD(is_ic_wei_scales);
+    CMP_BRGEMM_FIELD(wei_scale_k_group_size);
     CMP_BRGEMM_FIELD(with_src_scales);
     CMP_BRGEMM_FIELD(with_wei_scales);
     CMP_BRGEMM_FIELD(with_dst_scales);

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -518,7 +518,8 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         zp_type = brgemm_broadcast_t::none;
 
         const bool skip_zero_point
-                = mem_arg == DNNL_ARG_WEIGHTS && brg->skip_zp_b_compensation;
+                = (mem_arg == DNNL_ARG_WEIGHTS && brg->skip_zp_b_compensation)
+                || (mem_arg == DNNL_ARG_SRC && brg->skip_zp_a_compensation);
         if (skip_zero_point) return status::success;
 
         if (!zp.has_default_values(mem_arg)) {

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -246,6 +246,13 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
         void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);
 
+/// Execute BRGEMM kernel with pre-set params
+/// @param brg_kernel BRGEMM kernel
+/// @param params Pre-set parameters for the BRGEMM kernel
+/// Useful for setting addtitional parameters, like IC scales or post-ops.
+void brgemm_kernel_execute_params(
+        const brgemm_kernel_t *brg_kernel, brgemm_kernel_params_t &params);
+
 /// Execute BRGEMM kernel (brgemm_addr version)
 ///
 /// @note

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -305,8 +305,12 @@ struct brgemm_desc_t {
 
     // `skip_scales` is controlled by the implementation and not by kernel API.
     bool skip_scales = false;
-    int is_oc_scale = 0;
+    int is_single_wei_scale = 0;
+    int is_oc_wei_scales = 0;
+    int is_ic_wei_scales = 0;
+    int wei_scale_k_group_size = 0;
     bool with_src_scales = false;
+    bool has_ic_scales() const { return is_ic_wei_scales; }
     bool with_wei_scales = false;
     // `dst_scales` passed as a bare pointer making kernel change multiplication
     // to division was proved to be significantly slower, both for pure divps
@@ -608,33 +612,35 @@ struct brgemm_dynamic_values_t {
 };
 
 struct brgemm_kernel_params_t {
-    const void *ptr_A;
-    const void *ptr_B;
-    const brgemm_batch_element_t *batch;
-    void *ptr_C;
+    const void *ptr_A = nullptr;
+    const void *ptr_B = nullptr;
+    const brgemm_batch_element_t *batch = nullptr;
+    void *ptr_C = nullptr;
 
-    const void *ptr_bias;
-    void *ptr_D;
+    const void *ptr_bias = nullptr;
+    void *ptr_D = nullptr;
 
     const void *ptr_src_scales = nullptr;
     const void *ptr_wei_scales = nullptr;
     const void *ptr_dst_scales = nullptr;
-    void *ptr_buf;
+    void *ptr_buf = nullptr;
 
-    size_t do_post_ops;
-    size_t do_apply_comp;
-    size_t BS;
+    size_t do_post_ops = 0;
+    size_t do_apply_comp = 0;
+    size_t BS = 0;
+    // Used for K-grouped scales application
+    dim_t k_start = 0;
 
     /*
      * ptr to table of void * elements that are pointers to post_op binary
      * src1 tensors
      */
-    const void *post_ops_binary_rhs_arg_vec;
-    size_t oc_logical_off;
-    size_t first_mb_matrix_addr_off;
-    size_t dst_row_logical_off;
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    size_t oc_logical_off = 0;
+    size_t first_mb_matrix_addr_off = 0;
+    size_t dst_row_logical_off = 0;
 
-    const char *data_C_ptr_;
+    const char *data_C_ptr_ = nullptr;
 
     const void *a_zp_compensations = nullptr;
     const void *b_zp_compensations = nullptr;

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -296,6 +296,7 @@ struct brgemm_desc_t {
     impl::data_type_t sum_dt = data_type::undef;
     bool with_eltwise = false;
     bool with_binary = false;
+    bool skip_zp_a_compensation = false;
     bool skip_zp_b_compensation = false;
     bool n_bcast_1_load = false;
 

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -310,7 +310,12 @@ struct brgemm_desc_t {
     int is_ic_wei_scales = 0;
     int wei_scale_k_group_size = 0;
     bool with_src_scales = false;
-    bool has_ic_scales() const { return is_ic_wei_scales; }
+    int is_ic_src_scales = 0;
+    int src_scale_k_group_size = 0;
+    // Row stride (in bytes) for src scales array: num_k_groups * dt_sz
+    dim_t src_scale_m_stride = 0;
+    data_type_t dt_src_scales = data_type::undef;
+    bool has_ic_scales() const { return is_ic_wei_scales || is_ic_src_scales; }
     bool with_wei_scales = false;
     // `dst_scales` passed as a bare pointer making kernel change multiplication
     // to division was proved to be significantly slower, both for pure divps

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -254,7 +254,16 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     // see vmm_zp_a_shift(), vmm_one_bytes() in brgemm kernel
     const int zp_a_comp_pads_regs = req_zp_a_comp_pads ? 2 : 0;
 
-    const int microkernel_regs = zp_a_comp_pads_regs + compensation_regs;
+    // IC weight scales in maybe_dot_product_with_ic_scales() uses:
+    //   vmm_tmp(1) for scales (reused for both wei and src scales),
+    //   vmm_tmp(2) for tmp_acc.
+    //   vmm_tmp(3) is only needed for s8s8 compensation (vmm_s8s8_comp).
+    // Wei and src scales are applied sequentially and share vmm_tmp(1).
+    const int ic_scales_regs
+            = brg->has_ic_scales() ? (brg->req_s8s8_compensation ? 3 : 2) : 0;
+
+    const int microkernel_regs
+            = zp_a_comp_pads_regs + compensation_regs + ic_scales_regs;
 
     const auto microkernel_max_reg_count
             = max_isa_regs - microkernel_regs - load_regs - max_bcst_regs;

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -398,7 +398,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     if (brg.with_wei_scales) {
         reg_aux_wei_scales.restore();
-        const bool is_single_scale = !brg.is_oc_scale;
+        const bool is_single_scale = brg.is_single_wei_scale;
         if (!is_single_scale) {
             assert(brg.dt_wei_scales == data_type::f32);
             lea(reg_aux_wei_scales,

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -399,7 +399,8 @@ private:
         return brg.typesize_bias * (n * n_block1() + v * simd_w_);
     }
     int wei_scales_offset(int n, int v) {
-        return sizeof(float) * brg.is_oc_scale * (n * n_block1() + v * simd_w_);
+        return sizeof(float) * brg.is_oc_wei_scales
+                * (n * n_block1() + v * simd_w_);
     }
     size_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -190,6 +190,7 @@ private:
     const reg64_savable_t reg_zp_a_values {regscratchpad_, rbx, r18};
     const reg64_savable_t reg_zp_comp_b {regscratchpad_, rbx, r19};
     const reg64_savable_t reg_zp_c_values {regscratchpad_, rbx, r20};
+    const reg64_savable_t reg_src_scales_ic {regscratchpad_, rbx, r21};
     const reg64_t reg_ptr_sum_zp = rbx;
     const reg64_t reg_converted_stride = rsi;
     const reg64_t reg_zp_comp_pad_a = rsi;
@@ -935,6 +936,11 @@ void jit_brgemm_amx_uker_base_t::read_params() {
         mov(reg_zp_c_values, ptr[param1 + GET_OFF(c_zp_values)]);
         reg_zp_c_values.save();
     }
+
+    if (brg.is_ic_src_scales) {
+        mov(reg_src_scales_ic, ptr[param1 + GET_OFF(ptr_src_scales)]);
+        reg_src_scales_ic.save();
+    }
 }
 
 void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
@@ -1185,7 +1191,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
     }
 
-    if (brg.with_src_scales) {
+    if (brg.with_src_scales && !brg.is_ic_src_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
@@ -1208,7 +1214,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
             const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
 
             if (is_single_scale) {
-                if (brg.with_src_scales) {
+                if (brg.with_src_scales && !brg.is_ic_src_scales) {
                     // Single value is not anticipated to be of any other type
                     // when both scales are defined.
                     assert(brg.dt_wei_scales == data_type::f32);
@@ -1253,7 +1259,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 default: assert(!"unsupported wei_scales data type");
             }
 
-            if (brg.with_src_scales) {
+            if (brg.with_src_scales && !brg.is_ic_src_scales) {
                 // Src scales are set, need to multiply by their value.
                 vmulps(zmm_scale_masked, zmm_scale, zmm_wei_scale);
             } else {
@@ -1502,10 +1508,33 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         if (brg.has_ic_scales() && !bi.skip_accumulation) {
             vcvtdq2ps(zmm, zmm);
 
+            const Xbyak::Zmm scaled_zmm = vmm_mask(zmm, true, false, k_mask);
+            // Apply IC wei_scales if present (pre-loaded per-ldb vector).
             if (brg.is_ic_wei_scales) {
-                const Xbyak::Zmm scaled_zmm
-                        = vmm_mask(zmm, true, false, k_mask);
                 vmulps(scaled_zmm, scaled_zmm, zmm_scales(ldb));
+            }
+            // Apply IC src_scales per-bd: each M-row has its own scalar.
+            if (brg.is_ic_src_scales) {
+                reg_src_scales_ic.restore();
+                const auto src_sc_offset = bd * brg.src_scale_m_stride;
+                const auto src_sc_ptr
+                        = EVEX_compress_addr(reg_src_scales_ic, src_sc_offset);
+                const auto zmm_src_sc = zmm_tmp_1();
+                switch (brg.dt_src_scales) {
+                    case data_type::f32:
+                        vbroadcastss(zmm_src_sc, src_sc_ptr);
+                        break;
+                    case data_type::bf16:
+                        vpbroadcastw(zmm_src_sc, src_sc_ptr);
+                        vpslld(zmm_src_sc, zmm_src_sc, 16);
+                        break;
+                    case data_type::f16:
+                        vpbroadcastw(zmm_src_sc, src_sc_ptr);
+                        vcvtph2ps(zmm_src_sc, Xbyak::Ymm(zmm_src_sc.getIdx()));
+                        break;
+                    default: assert(!"unsupported src_scales data type");
+                }
+                vmulps(scaled_zmm, scaled_zmm, zmm_src_sc);
             }
         }
 
@@ -1556,10 +1585,14 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         }
     }
 
-    // When IC scales (wei) are used, they were already applied
+    // When IC scales (wei and/or src) are used, they were already applied
     // per K-block above. Only apply the remaining scales (non-IC) in postops.
-    const bool apply_scales_in_postops = brg.with_src_scales
-            || (brg.with_wei_scales && !brg.is_ic_wei_scales);
+    const bool src_scales_in_postops
+            = brg.with_src_scales && !brg.is_ic_src_scales;
+    const bool wei_scales_in_postops
+            = brg.with_wei_scales && !brg.is_ic_wei_scales;
+    const bool apply_scales_in_postops
+            = src_scales_in_postops || wei_scales_in_postops;
     if (apply_scales_in_postops) {
         for (auto bd = bd_start; bd < bd_finish; bd++) {
             if (!is_out_bd(bi.bdi, bdb, bd)) continue;

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -577,7 +577,8 @@ private:
         const bool need_to_apply_post_ops
                 = are_post_ops_applicable_ && apply_post_ops;
         const auto store_by_vectors = need_to_apply_alpha_beta_
-                || need_to_apply_post_ops || brg.brgattr.bd_mask_level;
+                || need_to_apply_post_ops || brg.brgattr.bd_mask_level
+                || brg.has_ic_scales();
         return store_by_vectors;
     }
     bool actual_ils(bool apply_post_ops, bool skip_accumulation = false) const {
@@ -829,7 +830,7 @@ dim_t jit_brgemm_amx_uker_base_t::bias_offset(int ldb) const noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::scales_offset(int ldb) const noexcept {
-    return brg.is_oc_scale * ldb * ld_block_scales_size_;
+    return brg.is_oc_wei_scales * ldb * ld_block_scales_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(int ldb) const noexcept {
@@ -975,7 +976,11 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     const bool apply_beta = brg.beta != 0.f;
     if (!apply_alpha && !apply_beta) return;
 
-    const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
+    // When IC scales (wei or src) are applied, accumulator is already
+    // converted to float (dq2ps + scales before alpha_beta), C stores floats.
+    const bool is_integer_acc = brg.is_int8 && !brg.has_ic_scales();
+    const bool dq2ps_required
+            = is_integer_acc && (apply_alpha || brg.beta != 1.f);
     const bool use_vadd_for_beta = brg.beta == 1.f && !dq2ps_required;
 
     if (apply_beta && !use_vadd_for_beta) {
@@ -993,7 +998,7 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     if (apply_beta) {
         if (use_vadd_for_beta) {
             auto zmm_masked = zmm | k_mask | T_z;
-            if (brg.is_int8)
+            if (is_integer_acc)
                 vpaddd(zmm_masked, zmm, addr);
             else
                 vaddps(zmm_masked, zmm, addr);
@@ -1131,8 +1136,43 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         brgemm_iteration_t &bi) {
-    if (!bi.apply_postops) return;
+
     const auto ldi = bi.ldi;
+
+    // Load wei_scales for per K-block application (is_ic_wei_scales).
+    // This must happen for both apply_postops and non-apply_postops paths.
+    if (brg.with_wei_scales && brg.is_ic_wei_scales) {
+        mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+            auto scales_ptr = EVEX_compress_addr(
+                    reg_scales, scales_offset(ldi->pos(ldb)));
+            auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
+            if (brg.is_single_wei_scale) {
+                // Broadcast a single scale value — handle non-f32 types.
+                switch (brg.dt_wei_scales) {
+                    case data_type::f32:
+                        vbroadcastss(zmm_scales(ldb), scales_ptr);
+                        break;
+                    case data_type::bf16:
+                        vpbroadcastw(zmm_scales(ldb), scales_ptr);
+                        vpslld(zmm_scales(ldb), zmm_scales(ldb), 16);
+                        break;
+                    case data_type::f16:
+                        vpbroadcastw(zmm_scales(ldb), scales_ptr);
+                        vcvtph2ps(zmm_scales(ldb),
+                                Xbyak::Ymm(zmm_scales(ldb).getIdx()));
+                        break;
+                    default: vbroadcastss(zmm_scales(ldb), scales_ptr); break;
+                }
+            } else {
+                // Load a vector of scale values with proper type conversion.
+                cvt2ps(brg.dt_wei_scales, zmm_scales(ldb), scales_ptr, true,
+                        false, k_mask);
+            }
+        }
+    }
+
+    if (!bi.apply_postops) return;
 
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
@@ -1156,13 +1196,13 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
     }
 
-    if (brg.with_wei_scales) {
+    if (brg.with_wei_scales && !brg.is_ic_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
-            const bool is_single_scale = !brg.is_oc_scale;
+            const bool is_single_scale = brg.is_single_wei_scale;
 
             const auto zmm_scale = zmm_scales(ldb);
             const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
@@ -1457,6 +1497,18 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
             vmovups(vreg_acc, ptr[reg_buf + buf_offset + wsp_offset]);
         }
 
+        // For IC scales (wei and/or src), convert int32->float and apply
+        // the current K-group's scales BEFORE alpha_beta accumulation.
+        if (brg.has_ic_scales() && !bi.skip_accumulation) {
+            vcvtdq2ps(zmm, zmm);
+
+            if (brg.is_ic_wei_scales) {
+                const Xbyak::Zmm scaled_zmm
+                        = vmm_mask(zmm, true, false, k_mask);
+                vmulps(scaled_zmm, scaled_zmm, zmm_scales(ldb));
+            }
+        }
+
         if (need_to_apply_alpha_beta_ || bi.skip_accumulation) {
             const auto c_offset = C_offset(bi, bdb, bd, bi.ldi->pos(ldb));
             const auto ptr_C
@@ -1467,7 +1519,8 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
         if (!bi.apply_postops) continue;
 
-        if (dq2ps_required) vcvtdq2ps(zmm, zmm);
+        // When IC scales (wei or src) are used, dq2ps already applied above.
+        if (dq2ps_required && !brg.has_ic_scales()) vcvtdq2ps(zmm, zmm);
 
         if (brg.req_comp_pads_with_bcast)
             apply_comp_pad_to_vector(bi, bdb, bd, ldb, zmm.getIdx());
@@ -1503,7 +1556,11 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         }
     }
 
-    if (brg.with_src_scales || brg.with_wei_scales) {
+    // When IC scales (wei) are used, they were already applied
+    // per K-block above. Only apply the remaining scales (non-IC) in postops.
+    const bool apply_scales_in_postops = brg.with_src_scales
+            || (brg.with_wei_scales && !brg.is_ic_wei_scales);
+    if (apply_scales_in_postops) {
         for (auto bd = bd_start; bd < bd_finish; bd++) {
             if (!is_out_bd(bi.bdi, bdb, bd)) continue;
 
@@ -2944,7 +3001,7 @@ void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
                 = brg.alpha != 1.0f || brg.beta != 0.f;
         const bool beta_uses_vadd = brg.beta == 1.f
                 && IMPLICATION(brg.is_int8, brg.alpha == 1.0f);
-        dt_requires_saturation_ = brg.is_int8
+        dt_requires_saturation_ = brg.is_int8 && !brg.has_ic_scales()
                 && !IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd);
     }
     use_sat_cvt_ = dt_requires_saturation_

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -187,8 +187,11 @@ private:
     const reg64_t reg_A = r13;
     const reg64_t reg_B = r12;
 
-    const reg64_t reg_aux_A = r11;
-    const reg64_t reg_aux_B = r10;
+    // r10, r11 are used in dot product with scales application and should be properly
+    // saved and restored
+    const reg64_savable_t reg_aux_A {regscratchpad_, r11};
+    const reg64_savable_t reg_aux_B {regscratchpad_, r10};
+
     const reg64_t reg_aux_A_vpad = r11;
 
     const reg64_savable_t reg_bdb_loop {regscratchpad_, r9, r16};
@@ -200,11 +203,13 @@ private:
     const reg64_t reg_s8_input_shift = r9;
     const reg64_t reg_zp_a_input_shift = r9;
 
-    const reg64_t reg_BS_loop = rax;
-    const reg64_t reg_rdb_loop = rbx;
-    const reg64_t reg_BS = abi_not_param1;
+    // rax is used for div instruction in microkernel, so it should be savable
+    const reg64_savable_t reg_BS_loop {regscratchpad_, rax};
 
-    const reg64_t reg_a_offset = rdx;
+    const reg64_savable_t reg_rdb_loop {regscratchpad_, rbx};
+    const reg64_t reg_BS = abi_not_param1; // rcx (rdi for win os)
+
+    const reg64_savable_t reg_a_offset {regscratchpad_, rdx};
     const reg64_t reg_b_offset = rsi;
 
     const reg64_savable_t reg_aux1_A {regscratchpad_, rbx, rbp, may_use_rbp()};
@@ -228,7 +233,11 @@ private:
 
     const reg64_savable_t reg_aux_src_scales {regscratchpad_, r10};
     const reg64_savable_t reg_aux_wei_scales {regscratchpad_, r10};
+    const reg64_savable_t reg_global_k {regscratchpad_, r11};
+    const reg64_savable_t reg_ic_group_size {regscratchpad_, r9};
+    const reg64_savable_t reg_grouped_k {regscratchpad_, r10};
     const reg64_savable_t reg_aux_scale_adjust {regscratchpad_, r10};
+
     const reg64_savable_t reg_do_post_ops {regscratchpad_, rbx};
     const reg64_savable_t reg_do_comp {regscratchpad_, rbx};
     const reg64_savable_t reg_skip_accm {regscratchpad_, rbx};
@@ -424,6 +433,11 @@ private:
             matrix_kind_t mk);
     void maybe_tileloadd_nt(matrix_kind_t matrix_kind, dim_t idx, dim_t offset,
             bool is_rd_tail, bool is_tail, bool last_bdb);
+    bool maybe_dot_product_with_ic_scales(dim_t rd, dim_t bd, dim_t ld,
+            bool is_ld_tail, const Vmm &acc, const Vmm &vmm_B_wei,
+            const Vmm &vmm_A_bcst);
+    void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
+            const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
     void gemm_microkernel(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
             bool is_rd_tail, bool is_ld_tail, dim_t vpad,
@@ -611,7 +625,7 @@ template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
         dim_t ld, bool is_tail) const noexcept {
     const dim_t ld_offset = is_tail ? brg.ldb_tail : ld * brg.ld_block;
-    return ld_offset * brg.is_oc_scale
+    return ld_offset * brg.is_oc_wei_scales
             * types::data_type_size(brg.dt_wei_scales);
 }
 
@@ -917,6 +931,7 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
 
     mov(reg_C, ptr[param1 + GET_OFF(ptr_C)]);
     mov(reg_D, ptr[param1 + GET_OFF(ptr_D)]);
+    reg_D.save();
     mov(reg_BS, ptr[param1 + GET_OFF(BS)]);
 
     // ptr_buf is re-used for passing compensations for
@@ -938,6 +953,16 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
     if (brg.with_wei_scales) {
         mov(reg_wei_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
         reg_wei_scales.save();
+        if (brg.is_ic_wei_scales) {
+            mov(reg_ic_group_size, brg.wei_scale_k_group_size);
+            reg_ic_group_size.save();
+        }
+    }
+
+    if (brg.has_ic_scales()) {
+        mov(reg_global_k, ptr[param1 + GET_OFF(k_start)]);
+        reg_global_k.save();
+        reg_D.restore();
     }
 
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
@@ -1088,7 +1113,9 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
         dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
     const bool apply_alpha = brg.alpha != 1.f;
-    const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
+    const bool is_integer_acc = brg.is_int8 && !brg.has_ic_scales();
+    const bool dq2ps_required
+            = is_integer_acc && (apply_alpha || brg.beta != 1.f);
 
     auto vmm_alpha = vmm_tmp(0);
     if (apply_alpha) {
@@ -1129,13 +1156,13 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
             else if (IMPLICATION(
                              is_tail, is_superset(brg.isa_impl, avx512_core))) {
                 auto vmm_masked = vmm_mask(vmm, is_tail, false, k_mask);
-                if (brg.is_int8)
+                if (is_integer_acc)
                     uni_vpaddd(vmm_masked, vmm, ptr_C);
                 else
                     uni_vaddps(vmm_masked, vmm, ptr_C);
             } else {
                 vmaskmovps(vmm_prev_dst, vmm_tail_mask(), ptr_C);
-                if (brg.is_int8)
+                if (is_integer_acc)
                     uni_vpaddd(vmm, vmm, vmm_prev_dst);
                 else
                     uni_vaddps(vmm, vmm, vmm_prev_dst);
@@ -1285,6 +1312,61 @@ void jit_brgemm_kernel_t<Wmm>::reduce_gemv_accumulators(
     }
 }
 
+/** Loads scales to a given vmm, applying masking if needed.
+* Used in multiple places for loading scales for variety of supported data types.
+* @param type_in data type of the scales to be loaded.
+* @param vmm_scales vmm register to load the scales to.
+* @param op an operand to load the scales from, must point to memory.
+* @param is_ld_tail tail flag used for applying tail mask
+* @param is_single_scale single scale flag, broadcasting if it's true.
+*/
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::load_scales_to_vmm(const data_type_t type_in,
+        const Vmm &vmm_scales, const Xbyak::Operand &op, bool is_ld_tail,
+        bool is_single_scale) {
+    const auto k_mask = is_ld_tail ? ld_tail_mask : ld_full_mask;
+    if (is_single_scale) {
+        switch (type_in) {
+            case data_type::f32: vbroadcastss(vmm_scales, op); break;
+            case data_type::bf16:
+                vpbroadcastw(vmm_scales, op);
+                uni_vpslld(vmm_scales, vmm_scales, 16);
+                break;
+            case data_type::f16:
+                vpbroadcastw(vmm_scales, op);
+                vcvtph2ps(Xmm(vmm_scales.getIdx()), Xmm(vmm_scales.getIdx()));
+                vbroadcastss(vmm_scales, Xmm(vmm_scales.getIdx()));
+                break;
+            default: assert(!"unsupported scales data type");
+        }
+    } else {
+        if (IMPLICATION(is_ld_tail, isa_has_masks(brg.isa_impl))) {
+            const Vmm vmm_scales_masked
+                    = vmm_mask(vmm_scales, is_ld_tail, false, k_mask);
+            const auto addr = op.getAddress();
+            switch (type_in) {
+                case data_type::f32:
+                    if (brg.is_gemv) {
+                        if (!brg.treat_y_as_row)
+                            uni_vmovss(vmm_scales_masked, addr);
+                    } else {
+                        uni_vmovups(vmm_scales_masked, addr);
+                    }
+                    break;
+                case data_type::bf16:
+                    uni_vpmovzxwd(vmm_scales_masked, addr);
+                    uni_vpslld(vmm_scales, vmm_scales, 16);
+                    break;
+                case data_type::f16: vcvtph2ps(vmm_scales_masked, addr); break;
+                default: assert(!"unsupported scales data type");
+            }
+        } else {
+            assert(type_in == data_type::f32);
+            vmaskmovps(vmm_scales, vmm_tail_mask(), op.getAddress());
+        }
+    }
+}
+
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         dim_t ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail) {
@@ -1303,8 +1385,11 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     // done only once despite all scales and bias applications requiring it.
     // TODO: perform conversion in a dedicated loop if it is required as it is
     // done in brgemm_post_ops kernel?
-    bool dq2ps_cvt_done = false;
+    // In case of IC scales, the conversion is done during gemm_microkernel.
+    bool dq2ps_cvt_done = brg.has_ic_scales();
 
+    // When IC src scales are active, they are applied in the microkernel.
+    // Only apply broadcast src_scales here when NOT per-k.
     if (brg.with_src_scales) {
         reg_src_scales.restoreTo(reg_aux_src_scales);
         auto vmm_src_scales = vmm_tmp(0);
@@ -1325,59 +1410,16 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         dq2ps_cvt_done = true;
     }
 
-    if (brg.with_wei_scales) {
+    if (brg.with_wei_scales && !brg.is_ic_wei_scales) {
         reg_aux_wei_scales.restore();
         for (dim_t ld = 0; ld < ld_block2; ld++) {
             const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(ld)];
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-            const bool is_single_scale = !brg.is_oc_scale;
+            const bool is_single_scale = brg.is_single_wei_scale;
 
             const Vmm vmm_wei_scales = vmm_tmp(0);
-            const Vmm vmm_wei_scales_masked
-                    = vmm_mask(vmm_wei_scales, is_tail, false, k_mask);
-            if (is_single_scale) {
-                switch (brg.dt_wei_scales) {
-                    case data_type::f32:
-                        vbroadcastss(vmm_wei_scales, addr);
-                        break;
-                    case data_type::bf16:
-                        vpbroadcastw(vmm_wei_scales, addr);
-                        uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
-                        break;
-                    case data_type::f16:
-                        vpbroadcastw(vmm_wei_scales, addr);
-                        vcvtph2ps(Xmm(vmm_wei_scales.getIdx()),
-                                Xmm(vmm_wei_scales.getIdx()));
-                        vbroadcastss(
-                                vmm_wei_scales, Xmm(vmm_wei_scales.getIdx()));
-                        break;
-                    default: assert(!"unsupported wei_scales data type");
-                }
-            } else {
-                if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
-                    switch (brg.dt_wei_scales) {
-                        case data_type::f32:
-                            if (brg.is_gemv) {
-                                if (!brg.treat_y_as_row)
-                                    uni_vmovss(vmm_wei_scales_masked, addr);
-                            } else {
-                                uni_vmovups(vmm_wei_scales_masked, addr);
-                            }
-                            break;
-                        case data_type::bf16:
-                            uni_vpmovzxwd(vmm_wei_scales_masked, addr);
-                            uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
-                            break;
-                        case data_type::f16:
-                            vcvtph2ps(vmm_wei_scales_masked, addr);
-                            break;
-                        default: assert(!"unsupported wei_scales data type");
-                    }
-                } else {
-                    assert(brg.dt_wei_scales == data_type::f32);
-                    vmaskmovps(vmm_wei_scales, vmm_tail_mask(), addr);
-                }
-            }
+            load_scales_to_vmm(brg.dt_wei_scales, vmm_wei_scales, addr, is_tail,
+                    is_single_scale);
 
             for (dim_t bd = 0; bd < bd_block; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
@@ -1390,7 +1432,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                     } else {
                         auto addr = ptr[reg_aux_wei_scales
                                 + wei_scales_offset(bd)];
-                        uni_vmovss(Xmm(vmm_wei_scales_masked.getIdx()), addr);
+                        uni_vmovss(Xmm(vmm_wei_scales.getIdx()), addr);
                         uni_vmulss(Xmm(vmm.getIdx()), Xmm(vmm.getIdx()),
                                 vmm_wei_scales);
                     }
@@ -1521,6 +1563,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
 
     if (brg.is_bf16_emu) bf16_emu_->init_vcvtneps2bf16();
 
+    if (brg.has_ic_scales() && !brg.is_tmm) reg_aux_D.restore();
     reg64_savable_guard_t reg_aux_D_backup_guard(
             {&reg_aux_D_backup}, brg.is_runtime_ldd && bd_block > 1);
 
@@ -1654,7 +1697,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_compensation(
         }
     }
 
-    if (!brg.req_cal_comp_pads && brg.req_s8s8_compensation) {
+    // For the IC scales compensation is done in gemm microkernel.
+    if (!brg.req_cal_comp_pads && brg.req_s8s8_compensation
+            && !brg.has_ic_scales()) {
         reg_aux_compensation.restore();
         auto vmm_comp = vmm_tmp(0);
         for (dim_t ld = 0; ld < ld_block2; ld++) {
@@ -1688,7 +1733,10 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
     const bool beta_uses_vadd
             = brg.beta == 1.f && IMPLICATION(brg.is_int8, brg.alpha == 1.0f);
     const bool dt_requires_saturation = brg.is_int8
-            && !IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd);
+            && !IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd)
+            // Saturation causes correctness errors when IC scales are applied
+            // For IC scales intermediate results are in f32.
+            && !brg.has_ic_scales();
     const bool use_sat_cvt
             = dt_requires_saturation && isa_has_sat_cvt(brg.isa_impl, brg.dt_d);
 
@@ -1768,6 +1816,32 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
         else
             mov(reg_stride_ld_block, brg.LDC * brg.typesize_C);
 
+        /**
+         * Optionally applies IC weights/src scales for AMX.
+         * NOTE: Stores f32 values after applying in order not to loose precision.
+         * @param ldb the current ldb idx
+         * @param vmm_acc accumulator register to apply the scales to
+        */
+        auto maybe_apply_ic_scales_amx
+                = [&](const int ldb, const Vmm &vmm_acc) {
+            if (brg.has_ic_scales()) {
+                // Convert int32 accumulator to f32 once
+                uni_vcvtdq2ps(vmm_acc, vmm_acc);
+
+                if (brg.is_ic_wei_scales) {
+                    reg_aux_wei_scales.restore();
+                    const auto addr
+                            = ptr[reg_aux_wei_scales + wei_scales_offset(ldb)];
+                    const bool is_tail = is_ld_tail && ldb + 1 == ld_block2;
+                    const bool is_single_scale = brg.is_single_wei_scale;
+                    const Vmm vmm_wei_scales = vmm_tmp(0);
+                    load_scales_to_vmm(brg.dt_wei_scales, vmm_wei_scales, addr,
+                            is_tail, is_single_scale);
+                    uni_vmulps(vmm_acc, vmm_acc, vmm_wei_scales);
+                }
+            }
+        };
+
         auto store_accumulators_amx
                 = [&](const bool apply_post_ops,
                           const bool apply_zp_a_compensation = false) {
@@ -1820,6 +1894,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                                         : accm(1, bd, 0);
                                 uni_vmovups(
                                         vreg_acc, ptr[reg_buf + buf_offset]);
+                                maybe_apply_ic_scales_amx(ldb, vreg_acc);
                             }
                         }
 
@@ -2092,7 +2167,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
                                : brg.get_B_tensor(idx, is_tail);
     auto t1 = Tmm(tmm_idx);
 
-    auto reg_base = is_A ? reg_aux_A : reg_aux_B;
+    auto &reg_base = is_A ? reg_aux_A : reg_aux_B;
 
     auto reg_stride = is_A ? reg_stride_lda : reg_stride_ldb;
     bool try_load_nt = brg.innermost_loop
@@ -2294,6 +2369,74 @@ void jit_brgemm_kernel_t<Wmm>::dot_product(Vmm v1, Vmm v2, Vmm v3) {
     }
 }
 
+/**
+ * Applies dot product with input channel scales if enabled.
+ * Accumulation is performed in f32 for precision.
+ * Handles both IC wei scales and IC src scales (or both).
+ * @param rd current rd index within the rd_block
+ * @param ld current ld index within the ld_block
+ * @param is_ld_tail whether current ld is the tail block
+ * @param acc the accumulator register to be updated with dot product result
+ * @param vmm_B_wei the Vmm register containing B matrix values in weight
+ * @param vmm_A_bcst the Vmm register containing broadcasted A matrix value for current rd and ld
+ * @return true if dot product with scales was applied, false otherwise
+ */
+template <typename Wmm>
+bool jit_brgemm_kernel_t<Wmm>::maybe_dot_product_with_ic_scales(dim_t rd,
+        dim_t bd, dim_t ld, bool is_ld_tail, const Vmm &acc,
+        const Vmm &vmm_B_wei, const Vmm &vmm_A_bcst) {
+    if (!brg.has_ic_scales()) return false;
+
+    const auto vmm_scales = vmm_tmp(1);
+    const auto tmp_acc = vmm_tmp(2);
+
+    // 1. Compute per-rd dot product into tmp_acc.
+    uni_vpxor(tmp_acc, tmp_acc, tmp_acc);
+    dot_product(tmp_acc, vmm_B_wei, vmm_A_bcst);
+
+    if (brg.req_s8s8_compensation) {
+        const auto vmm_comp_mask = vmm_tmp(1);
+        const auto vmm_s8s8_comp = vmm_tmp(3);
+        mov(rax, 0x80808080);
+        uni_vpbroadcastd(vmm_comp_mask, rax.cvt32());
+        uni_vpxor(vmm_s8s8_comp, vmm_s8s8_comp, vmm_s8s8_comp);
+        dot_product(vmm_s8s8_comp, vmm_B_wei, vmm_comp_mask);
+        uni_vpsubd(tmp_acc, tmp_acc, vmm_s8s8_comp);
+    }
+
+    uni_vcvtdq2ps(tmp_acc, tmp_acc);
+
+    // 2. Apply wei IC scales: per-N vector from scales[k_group][ld].
+    if (brg.is_ic_wei_scales) {
+        reg_grouped_k.restore();
+        reg_ic_group_size.restore();
+
+        xor_(rdx, rdx);
+        mov(rax, reg_grouped_k);
+        add(rax, rd);
+        div(reg_ic_group_size);
+
+        xor_(rdx, rdx);
+        mov(reg_ic_group_size,
+                brg.load_dim * types::data_type_size(brg.dt_wei_scales));
+        mul(reg_ic_group_size);
+
+        reg_aux_wei_scales.restore();
+        add(reg_aux_wei_scales, rax);
+
+        const auto addr
+                = ptr[reg_aux_wei_scales + wei_scales_offset(ld, is_ld_tail)];
+        load_scales_to_vmm(brg.dt_wei_scales, vmm_scales, addr, is_ld_tail,
+                brg.is_single_wei_scale);
+        uni_vmulps(tmp_acc, tmp_acc, vmm_scales);
+    }
+
+    // 4. Accumulate scaled result.
+    uni_vaddps(acc, acc, tmp_acc);
+
+    return true;
+}
+
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
         dim_t bd_b, dim_t bd_e, dim_t bd_block, dim_t ld_block2,
@@ -2413,6 +2556,15 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         dim_t vpad, dim_t rows_for_rd_tail) {
 
     MAYBE_UNUSED(bd_block2);
+
+    // rax, r10, r11 are used in fill_scales_vector lambda
+    if (brg.has_ic_scales()) {
+        reg_aux_A.save();
+        reg_aux_B.save();
+        reg_rdb_loop.save();
+        reg_a_offset.save();
+    }
+
     dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
     const auto bd_b = nstl::max(dim_t(0), vpad);
     const auto bd_e = nstl::min(bd_block, bd_block + vpad);
@@ -2435,15 +2587,16 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         rd_loop = brg.rd_block;
 
     if (brg.req_s8s8_compensation) {
-        reg_bdb_loop.save();
+        if (!brg.has_ic_scales()) reg_bdb_loop.save();
         mov(reg_s8_input_shift, 128);
         uni_vpbroadcastb(vmm_inp_shift(), reg_s8_input_shift.cvt8());
-        reg_bdb_loop.restore();
+        if (!brg.has_ic_scales()) reg_bdb_loop.restore();
     }
 
     auto broadcast_A
             = [this, rd_tail_size, is_rd_tail, rd_loop, rows_for_rd_tail, bd_e](
                       Vmm vmm_bcast, dim_t bd, dim_t rd) {
+        if (brg.has_ic_scales()) { reg_aux_A.restore(); }
         const auto offset = A_offset(bd, rd);
         const auto dt = brg.dt_a;
         const bool maybe_load_bytes
@@ -2485,11 +2638,23 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             }
         }
 
-        if (brg.req_s8s8_compensation)
+        if (brg.req_s8s8_compensation) {
             uni_vpaddb(vmm_bcast, vmm_bcast, vmm_inp_shift());
+        }
+    };
+
+    // vmm_inp_shift() is corrupted in dot-product with IC scales
+    // and this lambda restores it when needed for compensation.
+    auto maybe_restore_vmm_inp_shift = [&]() {
+        if (brg.req_s8s8_compensation && brg.has_ic_scales()) {
+            mov(reg_s8_input_shift, 128);
+            uni_vpbroadcastb(vmm_inp_shift(), reg_s8_input_shift.cvt8());
+        }
     };
 
     auto load_B = [this, is_ld_tail](dim_t vmm_load_idx, dim_t rd, dim_t ld) {
+        if (brg.has_ic_scales()) reg_aux_B.restore();
+
         const bool mem_advice_B
                 = utils::one_of(brg.brgattr.mem_advice,
                           brgemm_hint_mem_advice_B, brgemm_hint_mem_advice_A_B)
@@ -2573,6 +2738,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     for (dim_t rd = 0; rd < rd_loop; rd += brg.rd_step) {
         if (brg.n_bcast_1_load) {
+            if (rd > 0) maybe_restore_vmm_inp_shift();
             for (dim_t bd = bd_b; bd < bd_e && !is_emdbd; bd++)
                 broadcast_A(bcst(bd), bd, rd);
             for (dim_t ld = 0; ld < ld_block2; ld++) {
@@ -2581,7 +2747,10 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     maybe_pre_process_data(brg.dt_b, load(), vmm_fp8_load());
                 for (dim_t bd = bd_b; bd < bd_e; bd++) {
                     auto vmm = accm(ld_block2, bd, ld);
-                    if (is_emdbd)
+                    if (maybe_dot_product_with_ic_scales(
+                                rd, bd, ld, is_ld_tail, vmm, load(), bcst(bd)))
+                        ;
+                    else if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
                     else {
@@ -2604,6 +2773,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             }
 
             for (dim_t bd = bd_b; bd < bd_e; bd++) {
+                if (rd > 0 || bd > bd_b) maybe_restore_vmm_inp_shift();
                 if (!is_emdbd) broadcast_A(bcst(), bd, rd);
                 if (brg.is_fp8_via_convert_non_amx())
                     maybe_pre_process_data(brg.dt_a, bcst(), vmm_fp8_bcst());
@@ -2628,7 +2798,10 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 }
                 for (dim_t ld = 0; ld < ld_block2; ld++) {
                     auto vmm = accm(ld_block2, bd, ld);
-                    if (is_emdbd)
+                    if (maybe_dot_product_with_ic_scales(
+                                rd, bd, ld, is_ld_tail, vmm, load(ld), bcst()))
+                        ;
+                    else if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(ld),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
                     else {
@@ -2649,6 +2822,13 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
     if (brg.is_fp8_via_convert()) reg64_fp8_aux.restore();
 
     if (max_prefetch_offset > INT_MAX) reg_aux_C.restore();
+    // maybe_dot_product_with_ic_scales uses rax, rbp, r10 and r11
+    if (brg.has_ic_scales()) {
+        reg_aux_A.restore();
+        reg_aux_B.restore();
+        reg_rdb_loop.restore();
+        reg_a_offset.restore();
+    }
 }
 
 template <typename Wmm>
@@ -2657,6 +2837,11 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
         dim_t rows_for_rd_tail, bool skip_accumulation) {
 
     auto bs_loop_body = [&](dim_t vpad, bool last_bdb) {
+        if (brg.has_ic_scales()) {
+            reg_global_k.restoreTo(reg_grouped_k);
+            reg_grouped_k.save();
+        }
+
         set_A_B_matrices();
 
         dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
@@ -2685,7 +2870,10 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
 
                     add(reg_aux_A, rdb_A_offset());
                     add(reg_aux_B, rdb_B_offset());
-
+                    if (brg.has_ic_scales()) {
+                        add(dword[reg_grouped_k.getStoragePtr().getRegExp()],
+                                brg.rd_block);
+                    }
                     dec(reg_rdb_loop);
                     cmp(reg_rdb_loop, 0);
                     jg(rdb_loop_label, T_NEAR);
@@ -2718,7 +2906,11 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
             mov(reg_stride_ldb, brg.rd_step * brg.typesize_B * brg.LDB);
         }
 
-        if (brg.brgattr.max_bs > 1) mov(reg_BS_loop, reg_BS);
+        if (brg.brgattr.max_bs > 1) {
+            mov(reg_BS_loop, reg_BS);
+            if (brg.has_ic_scales()) reg_BS_loop.save();
+        } else if (brg.has_ic_scales())
+            reg_aux_D.save();
         L_aligned(BS_loop_label, 64);
         {
             if (first_bdb || last_bdb) {
@@ -2781,9 +2973,12 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
                 bs_loop_body(0, last_bdb);
             }
             if (brg.brgattr.max_bs > 1) {
+                if (brg.has_ic_scales()) reg_BS_loop.restore();
                 dec(reg_BS_loop);
                 cmp(reg_BS_loop, 0);
                 jg(BS_loop_label, T_NEAR);
+            } else if (brg.has_ic_scales()) {
+                reg_aux_D.restore();
             }
         }
     }
@@ -2995,10 +3190,12 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                     Label bdb_loop_label;
                     L_aligned(bdb_loop_label, 64);
                     {
+                        if (brg.has_ic_scales()) reg_bdb_loop.save();
                         bdb_loop_body(1, false, false, false,
                                 bd_blocks_for_rd_tail <= 1 ? 0
                                                            : rows_for_rd_tail,
                                 skip_accumulation);
+                        if (brg.has_ic_scales()) reg_bdb_loop.restore();
                         dec(reg_bdb_loop);
                         cmp(reg_bdb_loop, rows_for_rd_tail ? 1 : 0);
                         jg(bdb_loop_label, T_NEAR);

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -1390,7 +1390,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
 
     // When IC src scales are active, they are applied in the microkernel.
     // Only apply broadcast src_scales here when NOT per-k.
-    if (brg.with_src_scales) {
+    if (brg.with_src_scales && !brg.is_ic_src_scales) {
         reg_src_scales.restoreTo(reg_aux_src_scales);
         auto vmm_src_scales = vmm_tmp(0);
         if (!has_ptr_b_support)
@@ -1838,6 +1838,15 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                     load_scales_to_vmm(brg.dt_wei_scales, vmm_wei_scales, addr,
                             is_tail, is_single_scale);
                     uni_vmulps(vmm_acc, vmm_acc, vmm_wei_scales);
+                }
+                if (brg.is_ic_src_scales) {
+                    reg_src_scales.restoreTo(reg_aux_src_scales);
+                    const Vmm vmm_src_sc = vmm_tmp(0);
+                    // Src IC scale is a single scalar for this K-block
+                    load_scales_to_vmm(brg.dt_src_scales, vmm_src_sc,
+                            ptr[reg_aux_src_scales], false /*is_ld_tail*/,
+                            true /*is_single_scale*/);
+                    uni_vmulps(vmm_acc, vmm_acc, vmm_src_sc);
                 }
             }
         };
@@ -2428,6 +2437,17 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_dot_product_with_ic_scales(dim_t rd,
                 = ptr[reg_aux_wei_scales + wei_scales_offset(ld, is_ld_tail)];
         load_scales_to_vmm(brg.dt_wei_scales, vmm_scales, addr, is_ld_tail,
                 brg.is_single_wei_scale);
+        uni_vmulps(tmp_acc, tmp_acc, vmm_scales);
+    }
+
+    // 3. Apply src IC scales: broadcast scalar from scales[bd][k_group].
+    if (brg.is_ic_src_scales) {
+        reg_src_scales.restoreTo(reg_aux_src_scales);
+        if (bd > 0) add(reg_aux_src_scales, bd * brg.src_scale_m_stride);
+
+        load_scales_to_vmm(brg.dt_src_scales, vmm_scales,
+                ptr[reg_aux_src_scales], false /*is_ld_tail*/,
+                true /*is_single_scale*/);
         uni_vmulps(tmp_acc, tmp_acc, vmm_scales);
     }
 
@@ -3089,6 +3109,14 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
             add(reg_D, bdb_D_offset(bd_block2));
         }
         add(reg_a_offset, bdb_A_offset(bd_block2));
+
+        if (brg.is_ic_src_scales) {
+            const auto adj_bd_block = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
+            reg_src_scales.restore();
+            add(reg_src_scales,
+                    adj_bd_block * bd_block2 * brg.src_scale_m_stride);
+            reg_src_scales.save();
+        }
 
         if (brg.is_gemv && brg.treat_y_as_row) {
             if (brg.with_bias) {

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -822,9 +822,10 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
             const auto addr = ptr[aux_reg_wei_scales
-                    + brg_.is_oc_scale * sizeof(float) * (n * brg_.ld_block)];
+                    + brg_.is_oc_wei_scales * sizeof(float)
+                            * (n * brg_.ld_block)];
             const bool is_tail = tail > 0;
-            const bool is_single_scale = !brg_.is_oc_scale;
+            const bool is_single_scale = brg_.is_single_wei_scale;
 
             const auto vmm = vector(m, n);
             const auto vmm_wei_scales = vmm_tmp(0);
@@ -1060,7 +1061,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * sizeof(float) * oc_l_offset);
+                        brg_.is_oc_wei_scales * sizeof(float) * oc_l_offset);
         }
     }
     if (nb2_tail > 0) {
@@ -1088,7 +1089,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * sizeof(float) * oc_l_offset);
+                        brg_.is_oc_wei_scales * sizeof(float) * oc_l_offset);
         }
     }
     if (nb_tail > 0) {
@@ -1114,7 +1115,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * bia_typesize_ * (nb_tail));
+                        brg_.is_oc_wei_scales * bia_typesize_ * (nb_tail));
         }
         add(aux_reg_out, out_typesize_ * (nb_tail));
     }

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -70,6 +70,10 @@ void matmul_amx_blocking_params_t::update_configuration(
             ic_group_sz = ic_group_sz == 0
                     ? bgmmc.wei_scales_k_gsize
                     : nstl::min(ic_group_sz, bgmmc.wei_scales_k_gsize);
+        if (bgmmc.is_src_scale_per_k && bgmmc.src_scales_k_gsize > 0)
+            ic_group_sz = ic_group_sz == 0
+                    ? bgmmc.src_scales_k_gsize
+                    : nstl::min(ic_group_sz, bgmmc.src_scales_k_gsize);
         if (ic_group_sz > 0) {
             bgmmc.K_blk = ic_group_sz;
             bgmmc.brgemm_batch_size = 1;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -60,6 +60,25 @@ void matmul_amx_blocking_params_t::update_configuration(
     bgmmc.is_macro_heuristics
             = dynamic_cast<const matmul_amx_blocking_params_macro_t *>(this)
             != nullptr;
+
+    // Force K_blk alignment to scales group size for AMX IC scales.
+    // Each brgemm call must cover exactly one scale group so that
+    // post-gemm-ops can apply a single scale row per call.
+    if (bgmmc.with_int8_dynamic_quantization) {
+        dim_t ic_group_sz = 0;
+        if (bgmmc.is_wei_scale_per_k && bgmmc.wei_scales_k_gsize > 0)
+            ic_group_sz = ic_group_sz == 0
+                    ? bgmmc.wei_scales_k_gsize
+                    : nstl::min(ic_group_sz, bgmmc.wei_scales_k_gsize);
+        if (ic_group_sz > 0) {
+            bgmmc.K_blk = ic_group_sz;
+            bgmmc.brgemm_batch_size = 1;
+            bgmmc.K_chunk_size = 1;
+            bgmmc.extendable_k = false;
+            bgmmc.use_fused_copy_a = false;
+            bgmmc.use_buffer_c = bgmmc.use_buffer_c || bgmmc.K > bgmmc.K_blk;
+        }
+    }
 }
 
 dim_t matmul_amx_blocking_params_t::get_actual_lda() const {

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -275,8 +275,11 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             if (allow_multiple_wei_zp) {
                 const auto kn_mask = wei_qmask_N() + wei_qmask_K();
                 const bool zp_over_batch = (mask & kn_mask) != mask;
-                const bool mask_ok = (mask & ~kn_mask) == 0;
-                return !(zp_over_batch && batch() > 1) && mask_ok;
+                const bool is_grouped
+                        = !zp.get(DNNL_ARG_WEIGHTS).has_default_groups();
+                const bool mask_ok = is_grouped || (mask & ~kn_mask) == 0;
+                return !(zp_over_batch && batch() > 1 && !is_grouped)
+                        && mask_ok;
             } else {
                 return mask == 0;
             }
@@ -326,8 +329,9 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_POSTOP);
 
     VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
-    VDISPATCH_MATMUL(check_attr_zero_points(is_bf16_with_int_wei
-                             || is_f16_with_int_wei || is_f32_with_int_wei),
+    VDISPATCH_MATMUL(
+            check_attr_zero_points(is_bf16_with_int_wei || is_f16_with_int_wei
+                    || is_f32_with_int_wei || with_int8_dynamic_quantization),
             VERBOSE_UNSUPPORTED_ZP_CFG);
     VDISPATCH_MATMUL(check_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
     VDISPATCH_MATMUL(check_reduce(), VERBOSE_UNSUPPORTED_FEATURE,
@@ -409,7 +413,9 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         }
 
         auto LDD = bgmmc_.LDD;
-        if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
+        if ((bgmmc_.with_wei_decompression
+                    || bgmmc_.with_int8_dynamic_quantization)
+                && bgmmc_.has_zero_point_b)
             brg.skip_zp_b_compensation = true;
         brg.skip_scales = bgmmc_.apply_scales_in_buffer_b;
         // Fill up the scales info in case it's computing in brgemm
@@ -1282,9 +1288,12 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     // Note: instead of passing an address to a stack variable, a kernel may be
     // changed to take just zp_b value and perform negation itself, but updating
     // kernels is not straightforward for all platforms.
-    int32_t neg_zp_b
-            = !bgmmc.with_wei_decompression ? brgmm_ctx.get_neg_zp_b() : 0;
-    int32_t neg_zp_ab_comp = !bgmmc.with_wei_decompression
+    int32_t neg_zp_b = !(bgmmc.with_wei_decompression
+                               || bgmmc.with_int8_dynamic_quantization)
+            ? brgmm_ctx.get_neg_zp_b()
+            : 0;
+    int32_t neg_zp_ab_comp = !(bgmmc.with_wei_decompression
+                                     || bgmmc.with_int8_dynamic_quantization)
             ? bgmmc.K * brgmm_ctx.get_neg_zp_a()
             : 0;
     ctx.zp_b_neg_val_ptr = &neg_zp_b;
@@ -1376,7 +1385,7 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         ctx.current_K_pad = brgmm_ctx.get_current_K_pad(k_iters);
         ctx.src_scales_ptr = brgmm_ctx.get_src_scales_ptr();
         ctx.wei_scales_ptr = brgmm_ctx.get_wei_scales_ptr(n, k, b_idx);
-        ctx.zp_b_value_ptr = brgmm_ctx.get_wei_zp_ptr(n, k);
+        ctx.zp_b_value_ptr = brgmm_ctx.get_wei_zp_ptr(n, k, b_idx);
         if (bgmmc.blocked_B && !bgmmc.is_f16_with_int_wei
                 && isa == avx512_core_fp16) {
             cvt_float16_to_float((float *)ctx.tr_src, (float16_t *)ctx.src,
@@ -1387,7 +1396,9 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
     };
 
     // grouped zero points &-or scales
-    if (bgmmc.is_wei_zp_per_k || bgmmc.is_wei_scale_per_k) {
+    const bool is_grouped = (bgmmc.is_wei_zp_per_k || bgmmc.is_wei_scale_per_k)
+            && !bgmmc.with_int8_dynamic_quantization;
+    if (is_grouped) {
         const auto &k_group = bgmmc.is_wei_zp_per_k ? bgmmc.wei_zp_k_gsize
                                                     : bgmmc.wei_scales_k_gsize;
         const auto brgemm_k_blk = nstl::min(bgmmc.K, bgmmc.K_blk);
@@ -1777,8 +1788,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         num_threads_used_ = nthr_k_ * nthr_bmn_;
 
-        const bool need_to_calculate_compensation_for_a
-                = bgmmc.has_zero_point_b && !bgmmc.with_wei_decompression;
+        const bool need_to_calculate_compensation_for_a = bgmmc.has_zero_point_b
+                && !bgmmc.with_wei_decompression
+                && !bgmmc.with_int8_dynamic_quantization;
         const bool need_to_calculate_compensation_for_b = !IMPLICATION(
                 (bgmmc.has_zero_point_a || bgmmc.s8s8_compensation_required),
                 bgmmc.blocked_B);
@@ -2209,7 +2221,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return -cpu::io::load_int_value(bgmmc_.wei_zp_dt, wei_zp_ptr_, 0);
     }
 
-    const void *get_wei_zp_ptr(dim_t n, dim_t k = 0) const {
+    const void *get_wei_zp_ptr(dim_t n, dim_t k = 0, int b_idx = 0) const {
         if (!bgmmc_.has_zero_point_b) return nullptr;
         if (bgmmc_.is_wei_zp_common)
             return wei_zp_ptr_; // single zero point value
@@ -2220,6 +2232,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             const auto &k_group_sz = bgmmc_.wei_zp_k_gsize;
             const auto k_idx = k / k_group_sz;
             offset += k_idx * bgmmc_.N;
+        }
+
+        if (bgmmc_.wei_zp_batch_stride > 0) {
+            const int b = get_bb_idx(b_idx, bgmmc_.bcast_B_desc);
+            offset += b * bgmmc_.wei_zp_batch_stride;
         }
 
         const auto dt_sz = types::data_type_size(bgmmc_.wei_zp_dt);

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -176,6 +176,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             = utils::one_of(wei_dt, data_type::f4_e2m1, data_type::f4_e3m0);
     const bool is_f32_with_int_wei
             = src_dt == f32 && one_of(wei_dt, s8, u8, s4, u4) && dst_dt == f32;
+    const bool with_int8_dynamic_quantization = one_of(src_dt, u8, s8)
+            && one_of(wei_dt, s4, u4, s8, u8) && one_of(dst_dt, f16, bf16, f32);
 
     auto check_bias = [&]() -> bool {
         const auto bia_dt = weights_md(1)->data_type;
@@ -220,8 +222,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             if (is_runtime_value(N())) ok = false;
         }
         // Impl suppports f32 scales only for non-weight decompression
-        if (!(is_bf16_with_int_wei || is_f16_with_int_wei
-                    || is_f32_with_int_wei)) {
+        if (!(is_bf16_with_int_wei || is_f16_with_int_wei || is_f32_with_int_wei
+                    || with_int8_dynamic_quantization)) {
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_SRC), undef, f32);
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_WEIGHTS), undef, f32);
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_DST), undef, f32);
@@ -277,7 +279,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     };
     const bool problem_dt_correct = one_of(true, is_f4, is_int8, is_f8, is_bf16,
             is_f32, is_f16, is_f32_f16, is_f32_bf16, is_bf16_with_int_wei,
-            is_f16_with_int_wei, is_f32_with_int_wei);
+            is_f16_with_int_wei, is_f32_with_int_wei,
+            with_int8_dynamic_quantization);
 
     auto src_d = memory_desc_wrapper(src_md_);
     auto weights_d = memory_desc_wrapper(weights_md_);

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -426,6 +426,15 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             brg.wei_scale_k_group_size = bgmmc_.wei_scales_k_gsize;
             brg.dt_wei_scales = bgmmc_.wei_scales_dt;
         }
+        // Fill up src scales info for IC-grouped application
+        if (bgmmc_.with_src_scales && bgmmc_.is_src_scale_per_k) {
+            brg.is_ic_src_scales = true;
+            brg.src_scale_k_group_size = bgmmc_.src_scales_k_gsize;
+            brg.dt_src_scales = bgmmc_.src_scales_dt;
+            const auto num_k_groups
+                    = utils::div_up(bgmmc_.K, bgmmc_.src_scales_k_gsize);
+            brg.src_scale_m_stride = num_k_groups * bgmmc_.src_scales_dt_sz;
+        }
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 
@@ -848,7 +857,10 @@ void brgemm_matmul_t<isa>::compute_kernel(
         params.zp_a_val = 1;
         params.do_post_ops = true;
         params.do_apply_comp = true;
-        params.ptr_src_scales = brgmm_ctx.get_src_scales_ptr();
+        // Could be set separately in `maybe_set_ic_scales`.
+        // In that case do not overwrite it.
+        if (!params.ptr_src_scales)
+            params.ptr_src_scales = brgmm_ctx.get_src_scales_ptr();
         // Could be set separately in `maybe_set_ic_scales`.
         // In that case do not overdrite it.
         if (!params.ptr_wei_scales)
@@ -861,6 +873,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
     // Setting IC scales related params for brgemm kernel
     auto maybe_set_ic_scales = [&](brgemm_kernel_params_t &params) {
         const auto k = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
+        const auto m = brgmm_ctx.get_M_idx(m_blk_idx, true);
         if (bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b) {
             const auto k_idx_in_group = bgmmc.wei_scales_k_gsize > 0
                     ? k % bgmmc.wei_scales_k_gsize
@@ -868,6 +881,15 @@ void brgemm_matmul_t<isa>::compute_kernel(
             // Set pointer and k offset within group
             params.ptr_wei_scales = brgmm_ctx.get_wei_scales_ptr(n, k, b_idx);
             params.k_start = k_idx_in_group;
+        }
+        if (bgmmc.is_src_scale_per_k) {
+            params.ptr_src_scales = brgmm_ctx.get_src_scales_ptr(m, k);
+            if (!bgmmc.is_wei_scale_per_k) {
+                const auto k_idx_in_group = bgmmc.src_scales_k_gsize > 0
+                        ? k % bgmmc.src_scales_k_gsize
+                        : 0;
+                params.k_start = k_idx_in_group;
+            }
         }
     };
 
@@ -2175,7 +2197,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 + n_blk_local * bgmmc_.s8s8_comp_n_str;
     }
 
-    const void *get_src_scales_ptr() const { return src_scales_; }
+    const void *get_src_scales_ptr(dim_t m = 0, dim_t k = 0) const {
+        if (!bgmmc_.is_src_scale_per_k) return src_scales_;
+
+        const auto &k_group_sz = bgmmc_.src_scales_k_gsize;
+        const auto k_idx = k / k_group_sz;
+        const auto num_k_groups = utils::div_up(bgmmc_.K, k_group_sz);
+        auto offset = (m * num_k_groups + k_idx) * bgmmc_.src_scales_dt_sz;
+        return ((const char *)src_scales_ + offset);
+    }
 
     // Returns a pointer to the weights scales for the correspondent block based
     // on @p n and @p k.

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -228,27 +228,33 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_WEIGHTS), undef, f32);
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_DST), undef, f32);
         }
-        // This impl doesn't support scales over any batch dimensions.
+        // This impl doesn't support scales over batch dimensions for
+        // non-grouped scales.
         if (!asc.has_default_values(DNNL_ARG_WEIGHTS)) {
             const auto mask = asc.get_mask(DNNL_ARG_WEIGHTS);
             const int kn_mask = wei_qmask_N() + wei_qmask_K();
             const bool scale_over_batch = (mask & kn_mask) != mask;
-            if (scale_over_batch && batch() > 1) ok = false;
+            // For grouped scales (per_tensor with groups), batch bits are
+            // acceptable: each batch element gets its own scale plane.
+            const bool is_grouped
+                    = !asc.get(DNNL_ARG_WEIGHTS).has_default_groups();
+            if (scale_over_batch && batch() > 1 && !is_grouped) ok = false;
         }
         // Implementation has limited support w.r.t. scales groups.
         if (!asc.has_default_values(DNNL_ARG_WEIGHTS)) {
             if (!asc.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
                 // Only grouping over K is supported.
                 ok = ok && asc.get_group(DNNL_ARG_WEIGHTS, 1) == 1;
-                // Only 'per_ocic' mask is supported, but not 'per_tensor' in
-                // benchdnn terms. In numbers, it's '12' is supported while for
-                // 4D '15' is required.
+                // Validate that the K and N bits are set in the mask.
+                // Additional batch bits (as in per_tensor for 4D) are
+                // allowed: they just index per-batch-element scale planes.
                 const int mask = asc.get_mask(DNNL_ARG_WEIGHTS);
                 const int ndims = weights_md_.ndims;
                 const int last_dim = (1 << (ndims - 1));
                 const int prelast_dim = (1 << (ndims - 2));
-                const bool mask_ok = (mask & ~(last_dim | prelast_dim)) == 0;
-                ok = ok && mask_ok;
+                const bool has_kn = (mask & (last_dim | prelast_dim))
+                        == (last_dim | prelast_dim);
+                ok = ok && has_kn;
             }
         }
         return ok;
@@ -405,7 +411,15 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         auto LDD = bgmmc_.LDD;
         if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
             brg.skip_zp_b_compensation = true;
-        if (bgmmc_.apply_scales_in_buffer_b) brg.skip_scales = true;
+        brg.skip_scales = bgmmc_.apply_scales_in_buffer_b;
+        // Fill up the scales info in case it's computing in brgemm
+        if (!brg.skip_scales && bgmmc_.with_wei_scales) {
+            brg.is_single_wei_scale = bgmmc_.is_wei_scale_common;
+            brg.is_oc_wei_scales = bgmmc_.is_wei_scale_per_n;
+            brg.is_ic_wei_scales = bgmmc_.is_wei_scale_per_k;
+            brg.wei_scale_k_group_size = bgmmc_.wei_scales_k_gsize;
+            brg.dt_wei_scales = bgmmc_.wei_scales_dt;
+        }
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 
@@ -776,51 +790,97 @@ void brgemm_matmul_t<isa>::compute_kernel(
     brgmm_ctx.maybe_backup_dst_values_to_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
 
+    auto is_brg_amx = [&](const int brg_idx) {
+        return is_superset(
+                pd()->get_brg_desc(brg_idx).isa_impl, avx512_core_amx);
+    };
+
+    // Setting the basic params for brgemm kernel
+    auto set_main_params = [&](brgemm_kernel_params_t &params,
+                                   const int brg_idx, const int bs) {
+        const auto buf = is_brg_amx(brg_idx) ? (void *)wsp_tile : nullptr;
+        params.BS = bs;
+        params.batch = addr_batch;
+        params.ptr_buf = buf;
+        params.ptr_C = (void *)ptr_C;
+        params.ptr_D = (void *)ptr_D;
+        // Leading dimensions
+        params.dynamic_LDA = leading_dimensions.dynamic_LDA;
+        params.dynamic_LDB = leading_dimensions.dynamic_LDB;
+        params.dynamic_LDC = leading_dimensions.dynamic_LDC;
+        params.dynamic_LDD = leading_dimensions.dynamic_LDD;
+    };
+
+    // Setting post-ops related params for brgemm kernel considering the flag `is_applicable`
+    auto maybe_set_post_ops = [&](brgemm_kernel_params_t &params,
+                                      const int brg_idx, bool is_applicable) {
+        if (!is_applicable) return;
+
+        void *scratch = is_brg_amx(brg_idx)
+                ? static_cast<void *>(wsp_tile)
+                : static_cast<void *>(
+                          brgmm_ctx.get_s8s8_comp_ptr(ithr, b_idx, n_blk_idx));
+
+        const size_t dst_row_logical_off = brgmm_ctx.get_M_idx(m_blk_idx, true);
+        const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
+                ? b_idx / bgmmc.batch_without_first_dim
+                : 0;
+        const size_t first_mb_matrix_addr_off
+                = batch_first_dim_idx * (M * N) + (dst_row_logical_off * N + n);
+
+        // Set post-ops params to brgemm_kernel_params_t
+        params.ptr_bias = static_cast<const void *>(ptr_bias);
+        params.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+        params.oc_logical_off = static_cast<size_t>(n);
+        params.dst_row_logical_off = dst_row_logical_off;
+        params.data_C_ptr_ = brgmm_ctx.get_data_C_ptr(0, 0, 0);
+        params.first_mb_matrix_addr_off = first_mb_matrix_addr_off;
+        params.a_zp_compensations = static_cast<const void *>(zp_comp_a);
+        params.b_zp_compensations = static_cast<const void *>(zp_comp_b);
+        params.c_zp_values = brgmm_ctx.get_zp_c_ptr();
+        params.skip_accm = false;
+        params.zp_a_val = 1;
+        params.do_post_ops = true;
+        params.do_apply_comp = true;
+        params.ptr_src_scales = brgmm_ctx.get_src_scales_ptr();
+        // Could be set separately in `maybe_set_ic_scales`.
+        // In that case do not overdrite it.
+        if (!params.ptr_wei_scales)
+            params.ptr_wei_scales = brgmm_ctx.get_wei_scales_ptr(n, 0, b_idx);
+        params.ptr_dst_scales = brgmm_ctx.get_dst_scales_inv_ptr(ithr);
+        // Overwrite values specific to post-ops
+        params.ptr_buf = scratch;
+    };
+
+    // Setting IC scales related params for brgemm kernel
+    auto maybe_set_ic_scales = [&](brgemm_kernel_params_t &params) {
+        const auto k = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
+        if (bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b) {
+            const auto k_idx_in_group = bgmmc.wei_scales_k_gsize > 0
+                    ? k % bgmmc.wei_scales_k_gsize
+                    : 0;
+            // Set pointer and k offset within group
+            params.ptr_wei_scales = brgmm_ctx.get_wei_scales_ptr(n, k, b_idx);
+            params.k_start = k_idx_in_group;
+        }
+    };
+
     if (gemm_batch > 0 && brg_ker_idx >= 0) {
-        const bool is_amx = is_superset(
-                pd()->get_brg_desc(brg_ker_idx).isa_impl, avx512_core_amx);
         const auto brg_kernel = brg_kernels_[brg_ker_idx].get();
         assert(brg_kernel != nullptr);
         brgemm_palettes_.maybe_tile_configure(
-                is_amx, prev_ker_idx, brg_ker_idx);
+                is_brg_amx(brg_ker_idx), prev_ker_idx, brg_ker_idx);
 
         brgmm_ctx.init_brgemm_batch_elements_values(ithr, 0, gemm_batch,
                 A_data_batch_ptr, B_data_batch_ptr, b_idx, m_blk_idx, k_blk_idx,
                 n_blk_idx);
-        if (post_ops_applicable && is_last_K_blk && !is_K_tail) {
-            void *scratch = is_amx
-                    ? static_cast<void *>(wsp_tile)
-                    : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                              ithr, b_idx, n_blk_idx));
-
-            const size_t dst_row_logical_off
-                    = brgmm_ctx.get_M_idx(m_blk_idx, true);
-            const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
-                    ? b_idx / bgmmc.batch_without_first_dim
-                    : 0;
-            const size_t first_mb_matrix_addr_off
-                    = batch_first_dim_idx * (M * N)
-                    + (dst_row_logical_off * N + n);
-            const char *dst_anchor_point = brgmm_ctx.get_data_C_ptr(0, 0, 0);
-            const brgemm_post_ops_data_t post_ops_data {
-                    static_cast<const void *>(ptr_bias),
-                    post_ops_binary_rhs_arg_vec.data(), static_cast<size_t>(n),
-                    dst_row_logical_off, dst_anchor_point,
-                    first_mb_matrix_addr_off,
-                    static_cast<const void *>(zp_comp_a),
-                    static_cast<const void *>(zp_comp_b),
-                    brgmm_ctx.get_zp_c_ptr(), false, 1, false, false,
-                    brgmm_ctx.get_src_scales_ptr(),
-                    brgmm_ctx.get_wei_scales_ptr(n),
-                    brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
-            brgemm_kernel_execute_postops(brg_kernel, gemm_batch, addr_batch,
-                    (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch,
-                    &leading_dimensions);
-        } else {
-            brgemm_kernel_execute(brg_kernel, gemm_batch, addr_batch,
-                    (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
-                    &leading_dimensions);
-        }
+        brgemm_kernel_params_t kernel_params;
+        set_main_params(kernel_params, brg_ker_idx, gemm_batch);
+        maybe_set_ic_scales(kernel_params);
+        const bool need_postops
+                = post_ops_applicable && is_last_K_blk && !is_K_tail;
+        maybe_set_post_ops(kernel_params, brg_ker_idx, need_postops);
+        brgemm_kernel_execute_params(brg_kernel, kernel_params);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail, /* do_K_tail */ false);
@@ -837,47 +897,15 @@ void brgemm_matmul_t<isa>::compute_kernel(
             assert(!"Requested brgemm kernel was not created.");
             return;
         }
-        const bool is_amx = is_superset(
-                pd()->get_brg_desc(brg_ker_idx).isa_impl, avx512_core_amx);
         brgemm_palettes_.maybe_tile_configure(
-                is_amx, prev_ker_idx, brg_ker_idx);
+                is_brg_amx(brg_ker_idx), prev_ker_idx, brg_ker_idx);
         const auto brg_kernel_k_tail = brg_kernels_[brg_ker_idx].get();
 
-        if (post_ops_applicable) {
-            void *scratch = is_amx
-                    ? static_cast<void *>(wsp_tile)
-                    : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                              ithr, b_idx, n_blk_idx));
-
-            const size_t dst_row_logical_off
-                    = brgmm_ctx.get_M_idx(m_blk_idx, true);
-            const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
-                    ? b_idx / bgmmc.batch_without_first_dim
-                    : 0;
-            const size_t first_mb_matrix_addr_off
-                    = batch_first_dim_idx * (M * N)
-                    + (dst_row_logical_off * N + n);
-            const char *dst_anchor_point = brgmm_ctx.get_data_C_ptr(0, 0, 0);
-            const brgemm_post_ops_data_t post_ops_data {
-                    static_cast<const void *>(ptr_bias),
-                    post_ops_binary_rhs_arg_vec.data(), static_cast<size_t>(n),
-                    dst_row_logical_off, dst_anchor_point,
-                    first_mb_matrix_addr_off,
-                    static_cast<const void *>(zp_comp_a),
-                    static_cast<const void *>(zp_comp_b),
-                    brgmm_ctx.get_zp_c_ptr(), false, 1, false, false,
-                    brgmm_ctx.get_src_scales_ptr(),
-                    brgmm_ctx.get_wei_scales_ptr(n),
-                    brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
-
-            brgemm_kernel_execute_postops(brg_kernel_k_tail, 1, addr_batch,
-                    (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch,
-                    &leading_dimensions);
-        } else {
-            brgemm_kernel_execute(brg_kernel_k_tail, 1, addr_batch,
-                    (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
-                    &leading_dimensions);
-        }
+        brgemm_kernel_params_t kernel_params;
+        set_main_params(kernel_params, brg_ker_idx, /*bs=*/1);
+        maybe_set_ic_scales(kernel_params);
+        maybe_set_post_ops(kernel_params, brg_ker_idx, post_ops_applicable);
+        brgemm_kernel_execute_params(brg_kernel_k_tail, kernel_params);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail,
@@ -1208,7 +1236,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                             static_cast<const void *>(zp_comp_b),
                             brgmm_ctx.get_zp_c_ptr(), skip_accumulation, 1,
                             false, false, brgmm_ctx.get_src_scales_ptr(),
-                            brgmm_ctx.get_wei_scales_ptr(n),
+                            brgmm_ctx.get_wei_scales_ptr(n, 0, b),
                             brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
 
                     brgemm_kernel_execute_postops(brg_kernel, 0, nullptr,
@@ -1347,7 +1375,7 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         ctx.current_K_iters = k_iters;
         ctx.current_K_pad = brgmm_ctx.get_current_K_pad(k_iters);
         ctx.src_scales_ptr = brgmm_ctx.get_src_scales_ptr();
-        ctx.wei_scales_ptr = brgmm_ctx.get_wei_scales_ptr(n, k);
+        ctx.wei_scales_ptr = brgmm_ctx.get_wei_scales_ptr(n, k, b_idx);
         ctx.zp_b_value_ptr = brgmm_ctx.get_wei_zp_ptr(n, k);
         if (bgmmc.blocked_B && !bgmmc.is_f16_with_int_wei
                 && isa == avx512_core_fp16) {
@@ -2139,13 +2167,17 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Returns a pointer to the weights scales for the correspondent block based
     // on @p n and @p k.
-    const void *get_wei_scales_ptr(dim_t n, dim_t k = 0) const {
+    const void *get_wei_scales_ptr(dim_t n, dim_t k = 0, int b_idx = 0) const {
         if (bgmmc_.is_wei_scale_common) return wei_scales_;
         auto offset = n;
         if (bgmmc_.is_wei_scale_per_k) {
             const auto &k_group_sz = bgmmc_.wei_scales_k_gsize;
             const auto k_idx = k / k_group_sz;
             offset += k_idx * bgmmc_.N;
+        }
+        if (bgmmc_.wei_scales_batch_stride > 0) {
+            const int b = get_bb_idx(b_idx, bgmmc_.bcast_B_desc);
+            offset += b * bgmmc_.wei_scales_batch_stride;
         }
 
         offset = offset * bgmmc_.wei_scales_dt_sz;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -262,13 +262,15 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
     auto check_attr_zero_points = [&](bool allow_multiple_wei_zp) -> bool {
         const auto &zp = attr()->zero_points_;
-        static const std::vector<int> supported_args {
-                DNNL_ARG_SRC, DNNL_ARG_DST};
-        for (int arg : supported_args) {
-            if (!zp.has_default_values(arg)) {
-                const int mask = zp.get_mask(arg);
-                if (mask > 0) return false;
-            }
+        // Check SRC zero points
+        if (!zp.has_default_values(DNNL_ARG_SRC)) {
+            const int mask = zp.get_mask(DNNL_ARG_SRC);
+            if (mask > 0 && !with_int8_dynamic_quantization) return false;
+        }
+        // Check DST zero points
+        if (!zp.has_default_values(DNNL_ARG_DST)) {
+            const int mask = zp.get_mask(DNNL_ARG_DST);
+            if (mask > 0) return false;
         }
         if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
             const auto mask = zp.get_mask(DNNL_ARG_WEIGHTS);
@@ -413,6 +415,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         }
 
         auto LDD = bgmmc_.LDD;
+        if (bgmmc_.is_src_zp_per_k) brg.skip_zp_a_compensation = true;
         if ((bgmmc_.with_wei_decompression
                     || bgmmc_.with_int8_dynamic_quantization)
                 && bgmmc_.has_zero_point_b)
@@ -1299,6 +1302,7 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
 
     ctx.current_M_blk = brgmm_ctx.get_M_kernel_size(m_blk_idx);
+    ctx.current_M_start = m;
     ctx.zp_b_compensation_buffer_ptr
             = (void *)brgmm_ctx.get_zp_b_compensation_buffer_ptr(
                     ithr, m_blk_idx);
@@ -1328,6 +1332,7 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
                 ithr, m_blk_idx, k_blk_idx, gb);
         ctx.current_K_blk = nstl::min(bgmmc.K_blk, bgmmc.K);
         ctx.current_K_start = k;
+        ctx.zp_a_value_ptr = brgmm_ctx.get_src_zp_ptr(m, k);
 
         (*copy_A_kernel_)(&ctx);
     }
@@ -1339,6 +1344,7 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
                 ithr, m_blk_idx, k_blk_idx, gemm_batch_iters);
         ctx.current_K_blk = K_tail;
         ctx.current_K_start = k;
+        ctx.zp_a_value_ptr = brgmm_ctx.get_src_zp_ptr(m, k);
 
         (*copy_A_kernel_)(&ctx);
     }
@@ -2240,6 +2246,22 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     int32_t get_neg_zp_a() const {
         if (!bgmmc_.has_zero_point_a) return 0;
         return -cpu::io::load_int_value(bgmmc_.src_zp_dt, src_zp_ptr_, 0);
+    }
+
+    // Returns a pointer to the src zero points for the given (m, k) position.
+    const void *get_src_zp_ptr(dim_t m = 0, dim_t k = 0) const {
+        if (!bgmmc_.is_src_zp_per_k) return src_zp_ptr_;
+        const auto &k_group_sz = bgmmc_.src_zp_k_gsize;
+        const auto num_k_groups = utils::div_up(bgmmc_.K, k_group_sz);
+        const auto dt_sz = types::data_type_size(bgmmc_.src_zp_dt);
+        const auto is_int4
+                = one_of(bgmmc_.src_zp_dt, data_type::s4, data_type::u4);
+
+        if (is_int4) { return src_zp_ptr_; }
+
+        const auto m_stride = num_k_groups * dt_sz;
+        auto offset = m * m_stride;
+        return ((const char *)src_zp_ptr_ + offset);
     }
 
     // Used to compute compensation. Can't initialize the value at construction

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -51,8 +51,9 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
                                          ? static_cast<dim_t>(conf_->wei_k_blk)
                                          : conf_->LDA)
                   * tr_typesize_)
-        , do_compute_compensation_(
-                  conf_->has_zero_point_b && !conf_->with_wei_decompression)
+        , do_compute_compensation_(conf_->has_zero_point_b
+                  && !conf_->with_wei_decompression
+                  && !conf_->with_int8_dynamic_quantization)
         , avx512_core_dot_product_(
                   do_compute_compensation_ && !isa_has_int8_vnni(conf->isa))
         // See the note in `create_brgemm_matmul_copy_b` why `orig_src_dt` used.
@@ -151,6 +152,7 @@ private:
             vpaddd(v1, v1, vmm_dot_product_temp);
         }
     }
+
     void generate() override;
 };
 
@@ -2435,7 +2437,6 @@ protected:
             // TODO: Unify register usage over kernels
             const auto mask_vmm = Vmm(conf_->transposed_B ? 13 : 0);
             const auto tmp_vmm = vmm_permd;
-            // const auto tmp_vmm2 = Vmm(conf_->transposed_B ? 13: 4);
             // f32 and transposed used the same register for regq_tmp
             const auto reg_tmp = r15;
             alignas(64) static constexpr const uint32_t odd_indices[8] = {

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -54,6 +54,7 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
         , do_compute_compensation_(conf_->has_zero_point_b
                   && !conf_->with_wei_decompression
                   && !conf_->with_int8_dynamic_quantization)
+        , do_apply_src_zp_(conf_->is_src_zp_per_k)
         , avx512_core_dot_product_(
                   do_compute_compensation_ && !isa_has_int8_vnni(conf->isa))
         // See the note in `create_brgemm_matmul_copy_b` why `orig_src_dt` used.
@@ -86,6 +87,7 @@ private:
     const dim_t src_stride_;
     const dim_t tr_src_stride_;
     const bool do_compute_compensation_;
+    const bool do_apply_src_zp_;
     const bool avx512_core_dot_product_;
     const bool use_fp16_instructions_;
 
@@ -113,12 +115,21 @@ private:
     reg64_t reg_zp_ab_comp_ptr = imm_addr64;
     reg64_t reg_zp_b_neg_val_ptr = reg_K_blk;
 
+    // Stack offsets for src zp per_ocic
+    constexpr static int reg_src_zp_ptr_offs_ = 0;
+    constexpr static int reg_src_zp_cur_k_offs_ = 8;
+    constexpr static int reg_src_save_offs_ = 16;
+    // For int4 src ZP: absolute M row index to compute flat element index.
+    constexpr static int reg_src_zp_m_row_offs_ = 24;
+    constexpr static int src_zp_stack_space_ = 32;
+
     // Required in every dot product for INT8 non-VNNI computation.
     Vmm vmm_ones_words = Vmm(28);
     Vmm vmm_dot_product_temp = Vmm(29);
 
     Vmm vmm_comp_mul = Vmm(is_ymm_ ? 14 : 30); // 1s
     Vmm vmm_comp_add = Vmm(is_ymm_ ? 15 : 31); // 128
+    Vmm vmm_src_zp = Vmm(is_ymm_ ? 14 : 30);
 
     // Allows to shift A data by 128 for s8s8 problem for AVX512 in copy
     // routine, not in compute kernel. It's disabled for now, as it
@@ -151,6 +162,94 @@ private:
                     vmm_dot_product_temp, vmm_dot_product_temp, vmm_ones_words);
             vpaddd(v1, v1, vmm_dot_product_temp);
         }
+    }
+
+    /**
+     * @brief Applies src zero point shift for per-K (per_ocic) granularity.
+     *
+     * Loads a scalar src zero point for the current (m, k_group), upconverts
+     * it to s8/u8 if int4, broadcasts it, and subtracts from the source data.
+     *
+     * @param vmm_data Source data vector to apply zp to
+     * @param k_idx The k index within the K-block (in k_step_ units)
+     */
+    inline void maybe_apply_src_zp(Vmm vmm_data, int k_idx) {
+        if (!do_apply_src_zp_) return;
+
+        const auto &gsize = conf_->src_zp_k_gsize;
+        const auto is_int4_zp
+                = one_of(conf_->src_zp_dt, data_type::s4, data_type::u4);
+        const auto dt_sz = types::data_type_size(conf_->src_zp_dt);
+
+        // Save reg_src (rax) since we use it for division
+        mov(ptr[rsp + reg_src_save_offs_], reg_src);
+
+        // Compute absolute K position = current_K_start + k_idx * k_step_
+        mov(rax, ptr[rsp + reg_src_zp_cur_k_offs_]);
+        add(rax, k_idx * k_step_);
+
+        // Compute K-group index: k_group_idx = abs_k / gsize
+        xor_(rdx, rdx);
+        mov(regq_tmp, gsize);
+        div(regq_tmp);
+        // rax = k_group_idx
+
+        if (is_int4_zp) {
+            // Compute absolute flat element index from base pointer:
+            //   abs_elem = m_row * num_k_groups + k_group_idx
+            //   byte_offs = abs_elem / 2, nibble = abs_elem % 2
+            const auto num_k_groups = utils::div_up(conf_->K, gsize);
+            mov(regq_tmp, rax); // save k_group_idx
+
+            // abs_elem = m_row * num_k_groups + k_group_idx
+            mov(rax, ptr[rsp + reg_src_zp_m_row_offs_]);
+            imul(rax, rax, num_k_groups);
+            add(rax, regq_tmp); // rax = abs_elem
+
+            mov(regq_tmp, rax); // save abs_elem for nibble selection
+            shr(rax, 1); // byte_offset = abs_elem / 2
+
+            // Load the byte containing two packed int4 zero points
+            mov(rdx, ptr[rsp + reg_src_zp_ptr_offs_]);
+            movzx(edx, byte[rdx + rax]);
+
+            // Extract the correct nibble (low = even index, high = odd index)
+            test(regq_tmp, 1);
+            Label even_nibble, upconvert;
+            jz(even_nibble, T_NEAR);
+            // Odd index: high nibble -> shift right by 4
+            shr(edx, 4);
+            jmp(upconvert, T_NEAR);
+            L(even_nibble);
+            // Even index: low nibble -> mask off high nibble
+            and_(edx, 0x0F);
+            L(upconvert);
+
+            // Upconvert int4 to int8: sign-extend s4 by filling upper nibble
+            // with 0xF0 if sign bit (bit 3) is set. This matches the
+            // signed_mask_int4 pattern used in cvt_int4_to_int8.
+            if (conf_->src_zp_dt == data_type::s4) {
+                test(edx, 0x08);
+                Label positive;
+                jz(positive, T_NEAR);
+                or_(edx, 0xF0); // sign extend: fill upper nibble
+                L(positive);
+            }
+        } else {
+            // 8-bit zp: simple byte load from per-row pointer
+            mov(rdx, ptr[rsp + reg_src_zp_ptr_offs_]);
+            if (conf_->src_zp_dt == data_type::s8)
+                movsx(edx, byte[rdx + rax * dt_sz]);
+            else
+                movzx(edx, byte[rdx + rax * dt_sz]);
+        }
+
+        // Broadcast the (upconverted) zp byte value and subtract from data
+        uni_vpbroadcastb(vmm_src_zp, Reg8(rdx.getIdx()));
+        uni_vpsubb(vmm_data, vmm_data, vmm_src_zp);
+
+        // Restore reg_src
+        mov(reg_src, ptr[rsp + reg_src_save_offs_]);
     }
 
     void generate() override;
@@ -295,6 +394,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
             const size_t offset
                     = static_cast<size_t>(k_idx) * k_step_ * typesize_;
             load_vmm(k, offset);
+            maybe_apply_src_zp(get_vmm_copy(k), k_idx);
             maybe_compute_compensation(k_idx, get_vmm_copy(k));
         }
         if (allow_input_shift_for_s8s8 && conf_->s8s8_compensation_required) {
@@ -336,6 +436,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
 
     if (k_tail > 0) {
         load_tail(k_tail, num_k_iters * k_step_);
+        maybe_apply_src_zp(get_vmm_copy(0), num_k_iters);
         maybe_compute_compensation(0, get_vmm_copy(0));
 
         if (allow_input_shift_for_s8s8 && conf_->s8s8_compensation_required)
@@ -445,6 +546,21 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_M_loop(
             add(reg_zp_comp_buf_ptr, sizeof(int32_t) * 16);
         if (is_last_K_iter) add(reg_zp_comp_res_ptr, sizeof(int32_t));
     }
+    if (do_apply_src_zp_) {
+        const auto is_int4_zp
+                = one_of(conf_->src_zp_dt, data_type::s4, data_type::u4);
+        if (is_int4_zp) {
+            inc(qword[rsp + reg_src_zp_m_row_offs_]);
+        } else {
+            // Advance src zp pointer to next M row.
+            // Layout is [M, num_k_groups], stride = num_k_groups * dt_sz.
+            const auto &gsize = conf_->src_zp_k_gsize;
+            const auto num_k_groups = utils::div_up(conf_->K, gsize);
+            const auto dt_sz = types::data_type_size(conf_->src_zp_dt);
+            const auto m_stride = num_k_groups * dt_sz;
+            add(qword[rsp + reg_src_zp_ptr_offs_], m_stride);
+        }
+    }
 
     dec(reg_M_blk);
     jnz(loop_M, T_NEAR);
@@ -453,6 +569,8 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_M_loop(
 template <typename Vmm>
 void jit_brgemm_matmul_copy_a_impl_t<Vmm>::generate() {
     preamble();
+
+    if (do_apply_src_zp_) sub(rsp, src_zp_stack_space_);
 
     if (avx512_core_dot_product_) {
         mov(regq_tmp.cvt16(), 1);
@@ -463,6 +581,18 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::generate() {
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
     mov(reg_K_blk, ptr[param1 + GET_OFF(current_K_blk)]);
     mov(reg_M_blk, ptr[param1 + GET_OFF(current_M_blk)]);
+
+    if (do_apply_src_zp_) {
+        mov(regq_tmp, ptr[param1 + GET_OFF(zp_a_value_ptr)]);
+        mov(ptr[rsp + reg_src_zp_ptr_offs_], regq_tmp);
+        mov(regq_tmp, ptr[param1 + GET_OFF(current_K_start)]);
+        mov(ptr[rsp + reg_src_zp_cur_k_offs_], regq_tmp);
+        // For int4 src ZP: initialize absolute M row counter from
+        // current_M_start. This is used in maybe_apply_src_zp to compute
+        // the flat element index for correct nibble addressing.
+        mov(regq_tmp, ptr[param1 + GET_OFF(current_M_start)]);
+        mov(ptr[rsp + reg_src_zp_m_row_offs_], regq_tmp);
+    }
 
     if (allow_input_shift_for_s8s8 && conf_->s8s8_compensation_required) {
         mov(imm_addr64, 128);
@@ -521,6 +651,8 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::generate() {
     }
     copy_body(false, false);
     L(done);
+
+    if (do_apply_src_zp_) add(rsp, src_zp_stack_space_);
 
     postamble();
 }

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -2818,13 +2818,12 @@ protected:
 };
 
 template <typename Vmm>
-struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
-                                         public jit_generator_t {
+struct jit_brgemm_matmul_copy_b_int8_t
+    : public jit_brgemm_matmul_copy_b_common_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_b_int8_t)
 
     jit_brgemm_matmul_copy_b_int8_t(const brgemm_matmul_conf_t *conf)
-        : jit_brgemm_matmul_copy_b_t(conf)
-        , jit_generator_t(jit_name())
+        : jit_brgemm_matmul_copy_b_common_t(conf)
         , src_stride_(conf->copy_B_wei_stride)
         , tr_src_stride_(conf->LDB * k_blk_step_ * sizeof(int8_t))
         , is_amx_(mayiuse(avx512_core_amx))
@@ -2834,9 +2833,14 @@ struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
                   do_compute_compensation_ && !isa_has_int8_vnni(conf->isa))
         , is_dynamic_stride_(is_runtime_value(src_stride_))
         , is_dynamic_N_(conf->is_runtime_N)
-        , comp_acc_idx_(is_ymm_                      ? 13
+        , is_src_int4_(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
+        , has_vpermb_(cpu().has(Xbyak::util::Cpu::tAVX512_VBMI))
+        , comp_acc_idx_(is_ymm_ && is_src_int4_      ? 11
+                          : is_src_int4_             ? 23
+                          : is_ymm_                  ? 13
                           : avx512_core_dot_product_ ? 23
-                                                     : 25) {}
+                                                     : 25)
+        , src_elems_per_byte_(is_src_int4_ ? 2 : 1) {}
 
     void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
     status_t create_kernel() override {
@@ -2860,15 +2864,15 @@ protected:
     const bool avx512_core_dot_product_;
     const bool is_dynamic_stride_;
     const bool is_dynamic_N_;
+    const bool is_src_int4_;
+    const bool has_vpermb_;
+    const int comp_acc_idx_;
+    const dim_t src_elems_per_byte_;
 
     constexpr static int reg_src_offs_ = 0;
     constexpr static int reg_tr_src_offs_ = 8;
     constexpr static int reg_current_K_pad_offs_ = 16;
     constexpr static int stack_space_needed_ = 24;
-
-    const int comp_acc_idx_;
-
-    const Xbyak::Opmask kTail = k7;
 
     reg64_t reg_src = rax;
     reg64_t reg_tr_src = rbx;
@@ -2893,6 +2897,7 @@ protected:
     Vmm vmm_dot_product_temp = Vmm(25);
 
     // ZMM stuff
+    Vmm int4_permute_table = Vmm(24);
     Vmm vreg_idx_lo_256 = Vmm(26);
     Vmm vreg_idx_hi_256 = Vmm(27);
     Vmm vreg_idx_lo_128 = Vmm(28);
@@ -2901,6 +2906,9 @@ protected:
     // Shared
     Vmm vmm_comp_mul = Vmm(is_ymm_ ? 14 : 30);
     Vmm vmm_zero = Vmm(is_ymm_ ? 15 : 31);
+    // Only used for decompressing int4 values
+    Vmm vmm_tmp = Vmm(is_ymm_ ? 13 : 25);
+    Vmm vmm_tmp1 = Vmm(12); // Only for Ymm
 
     Vmm get_comp_acc(int i) { return Vmm(comp_acc_idx_ - i); }
     Vmm get_vmm_zp_comp_res(int i) { return get_comp_acc(i); }
@@ -2937,6 +2945,179 @@ protected:
             vpaddd(v1, v1, vmm_dot_product_temp);
         }
     }
+
+    /**
+    * @brief Applies sign extension for 4-bit signed integers stored in 8-bit lanes using AVX-512.
+    * Due to lack of byte-wise right arithmetic shift(vpsrad) this method is used.
+    * This method checks the sign bit (bit 3) of each byte and fills the upper nibble with 0xF0
+    * if the sign bit is set, preserving the signed semantics after conversion from int4 to int8.
+    *
+    * Steps:
+    * 1. Broadcast LUT (0xF0) across Zmm register.
+    * 2. Isolate sign bit using left shift vpslld.
+    * 3. XOR and shuffle with LUT to generate the correct fill pattern.
+    * 4. OR the result back into the original vector.
+    *
+    * @param vmm_src Zmm register containing int8 values derived from int4.
+    */
+    inline void signed_mask_int4(const Zmm &vmm_src) {
+        if (conf_->orig_wei_dt != data_type::s4) return;
+
+        const auto &vmm_sign_extend = vmm_tmp;
+        const auto &vmm_lut = vmm_zero;
+
+        mov(reg_tmp, 0xF0);
+        uni_vpbroadcastb(vmm_lut, reg_tmp.cvt8());
+
+        uni_vmovups(vmm_sign_extend, vmm_src);
+        vpslld(vmm_sign_extend, vmm_sign_extend, 4);
+
+        uni_vpxor(vmm_sign_extend, vmm_sign_extend, vmm_lut);
+        vpshufb(vmm_sign_extend, vmm_lut, vmm_sign_extend);
+        vpord(vmm_src, vmm_src, vmm_sign_extend);
+    }
+
+    /**
+    * @brief Applies sign extension for 4-bit signed integers stored in 8-bit lanes using AVX2.
+    * Due to lack of byte-wise right arithmetic shift(vpsrad) this method is used.
+    * This method uses a lookup table (LUT) and vpshufb to map sign bit presence to the correct
+    * upper nibble fill (0xF0 for negative, 0x00 for positive).
+    *
+    * Steps:
+    * 1. Load LUT into Ymm register.
+    * 2. Isolate sign bit using left shift vpslld.
+    * 3. Shuffle using LUT to replicate sign into upper nibble.
+    * 4. OR the result back into the original vector.
+    *
+    * @param vmm_src Ymm register containing int8 values derived from int4.
+    */
+    inline void signed_mask_int4(const Ymm &vmm_src) {
+        if (conf_->orig_wei_dt != data_type::s4) return;
+
+        const auto &vmm_sign_extend = Ymm(vmm_tmp.getIdx());
+        const auto &vmm_lut = Ymm(vmm_tmp1.getIdx());
+        // No matter which index at lut, for signed (7bit==1)
+        // vpshufb will select the same mask
+        alignas(64) static const constexpr uint8_t lut[32] = {0xF0, 0xF0, 0xF0,
+                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0};
+
+        mov(reg_tmp, (size_t)lut);
+        vmovdqu(vmm_lut, ptr[reg_tmp]);
+
+        uni_vmovups(vmm_sign_extend, vmm_src);
+        vpslld(vmm_sign_extend, vmm_sign_extend, 4);
+
+        uni_vpxor(vmm_sign_extend, vmm_sign_extend, vmm_lut);
+        vpshufb(vmm_sign_extend, vmm_lut, vmm_sign_extend);
+        vpor(vmm_src, vmm_src, vmm_sign_extend);
+    }
+
+    /**
+    * @brief Converts packed u4/s4 integers to u8/s8 using AVX-512.
+    *
+    * This method splits the original packed int4 values into low and high nibbles,
+    * expands them into separate bytes, and then applies(if needed) sign extension.
+    *
+    * Steps:
+    * 1. Duplicate source into low and high vectors.
+    * 2. Mask and shift high nibble, mask low nibble.
+    * 3. Merge low and high into full bytes:
+    *    - With AVX512_VBMI: vpermb byte permute.
+    *    - Without VBMI: vpunpcklbw/vpunpckhbw + vpermt2d.
+    * 4. Apply sign extension via signed_mask_int4().
+    *
+    * @param vmm_src Zmm register containing packed int4 values.
+    */
+    inline void cvt_int4_to_int8(const Zmm &vmm_src) {
+        if (!is_src_int4_) return;
+
+        using Vmm_lower_t = typename vreg_traits_t<Vmm>::Vmm_lower_t;
+
+        const auto &vmm_low = vmm_src; // Aliases for readability
+        const auto &vmm_high = vmm_zero;
+        const auto &vmm_mask = vmm_tmp;
+
+        uni_vmovups(vmm_high, vmm_low);
+
+        mov(reg_tmp, 0xF0);
+        uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
+        uni_vpand(vmm_high, vmm_high, vmm_mask);
+        vpsrld(vmm_high, vmm_high, 4);
+
+        mov(reg_tmp, 0x0F);
+        uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
+        uni_vpand(vmm_low, vmm_low, vmm_mask);
+
+        if (has_vpermb_) {
+            copy_half_reg(vmm_low, Vmm_lower_t(vmm_high.getIdx()));
+            vpermb(vmm_src, int4_permute_table, vmm_src);
+        } else {
+            vpunpcklbw(vmm_mask, vmm_low, vmm_high);
+            vpunpckhbw(vmm_low, vmm_low, vmm_high);
+            vpermt2d(vmm_mask, int4_permute_table, vmm_low);
+            uni_vmovups(vmm_src, vmm_mask);
+        }
+        signed_mask_int4(vmm_src);
+        // Clean vmm_zero
+        uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
+    }
+
+    /**
+    * @brief Converts packed u4/s4 to u8/s8 integers using AVX2.
+    *
+    * This method extracts low and high nibbles from each byte, unpacks them into separate
+    * bytes, and then applies(if needed) sign extension.
+    *
+    * Steps:
+    * 1. Copy source into low and high vectors.
+    * 2. Mask and shift high nibble, mask low nibble.
+    * 3. Interleave low and high bytes using vpunpcklbw/vpunpckhbw.
+    * 4. Apply sign extension via signed_mask_int4().
+    *
+    * @param vmm_src Ymm register containing packed int4 values.
+    */
+    inline void cvt_int4_to_int8(const Ymm &vmm_src) {
+        if (!is_src_int4_) return;
+
+        const auto vmm_out = Ymm(vmm_src.getIdx());
+        const auto vmm_low = Ymm(vmm_tmp1.getIdx());
+        const auto vmm_high = Ymm(vmm_zero.getIdx());
+        const auto vmm_mask = Ymm(vmm_tmp.getIdx());
+
+        uni_vmovups(vmm_low, vmm_out);
+        uni_vmovups(vmm_high, vmm_out);
+
+        alignas(64) static const constexpr uint8_t even_vector[32]
+                = {0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                        0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                        0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                        0xF0, 0xF0, 0xF0, 0xF0};
+        mov(reg_tmp, (size_t)even_vector);
+        vmovdqu(vmm_mask, ptr[reg_tmp]);
+        vpand(vmm_high, vmm_high, vmm_mask);
+        vpsrld(vmm_high, vmm_high, 4);
+
+        alignas(64) static const constexpr uint8_t odd_vector[32] = {0x0F, 0x0F,
+                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F};
+        mov(reg_tmp, (size_t)odd_vector);
+        vmovdqu(vmm_mask, ptr[reg_tmp]);
+        vpand(vmm_low, vmm_low, vmm_mask);
+
+        vpunpcklbw(vmm_mask, vmm_low, vmm_high);
+        vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 0);
+        vpunpckhbw(vmm_mask, vmm_low, vmm_high);
+        vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 1);
+        signed_mask_int4(vmm_out);
+        // Clean tmp regs
+        uni_vpxor(vmm_low, vmm_low, vmm_low);
+        uni_vpxor(vmm_high, vmm_high, vmm_high);
+        uni_vpxor(vmm_mask, vmm_mask, vmm_mask);
+    }
+
     void generate() override;
 };
 
@@ -2945,8 +3126,16 @@ inline void jit_brgemm_matmul_copy_b_int8_t<Zmm>::load(
         int blk, int i, bool is_tail) {
     auto vmm_src = get_vmm(blk, i % k_blk_step_);
     auto src_load = is_tail ? vmm_src | kTail | T_z : vmm_src;
-    const auto offset = is_dynamic_stride_ ? 0 : i * src_stride_;
-    vmovdqu8(src_load, EVEX_compress_addr(reg_src, offset));
+    const auto offset
+            = is_dynamic_stride_ ? 0 : i * src_stride_ / src_elems_per_byte_;
+    const auto addr = maybe_EVEX_compress_addr(reg_src, offset);
+    if (is_src_int4_) {
+        const auto ymm_src_load = maybe_mask(Ymm(src_load.getIdx()), is_tail);
+        vmovdqu8(ymm_src_load, addr);
+        cvt_int4_to_int8(vmm_src);
+    } else {
+        vmovdqu8(src_load, addr);
+    }
     if (is_dynamic_stride_) add(reg_src, reg_src_stride);
 }
 
@@ -3005,6 +3194,23 @@ private:
         vmovdqa64(vreg_idx_hi_256, (const void *)idx_hi_16);
         vmovdqa64(vreg_idx_lo_128, (const void *)idx_lo_8);
         vmovdqa64(vreg_idx_hi_128, (const void *)idx_hi_8);
+
+        if (is_src_int4_) {
+            if (has_vpermb_) {
+                alignas(64) static constexpr const uint8_t int4_permute[64] = {
+                        0, 32, 1, 33, 2, 34, 3, 35, 4, 36, 5, 37, 6, 38, 7, 39,
+                        8, 40, 9, 41, 10, 42, 11, 43, 12, 44, 13, 45, 14, 46,
+                        15, 47, 16, 48, 17, 49, 18, 50, 19, 51, 20, 52, 21, 53,
+                        22, 54, 23, 55, 24, 56, 25, 57, 26, 58, 27, 59, 28, 60,
+                        29, 61, 30, 62, 31, 63};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute);
+            } else {
+                alignas(64) static constexpr const uint32_t int4_permute_dw[16]
+                        = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22,
+                                23};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute_dw);
+            }
+        }
     }
 
     void copy_block(
@@ -3034,8 +3240,9 @@ private:
             mov(ptr[rsp + reg_src_offs_], reg_src);
             add(reg_src, reg_copy_block_n_shift);
             copy_4x64(nrows, n_blk_step_, zeropad);
-            add(reg_copy_block_n_shift, n_blk_step_ * typesize);
-            add(reg_src, n_blk_step_ * typesize);
+            add(reg_copy_block_n_shift,
+                    n_blk_step_ * typesize / src_elems_per_byte_);
+            add(reg_src, n_blk_step_ * typesize / src_elems_per_byte_);
 
             if (do_N_loop_)
                 // (n_blk_step_ /conf_->LDB) --> # of LDBs handled by copy_4x64
@@ -3083,7 +3290,8 @@ private:
         };
 
         const bool is_tail = ncolumns < n_blk_step_;
-        const auto tail_mask = size_t(((size_t)1 << ncolumns) - 1);
+        const auto tail_size = div_up(ncolumns, src_elems_per_byte_);
+        const auto tail_mask = size_t(((size_t)1 << tail_size) - 1);
 
         if (is_tail) kmovq(kTail, tail_mask);
 
@@ -3210,12 +3418,30 @@ private:
         vmovdqa64(vreg_idx_hi_256, (const void *)idx_hi_256);
         vmovdqa64(vreg_idx_lo_128, (const void *)idx_lo_128);
         vmovdqa64(vreg_idx_hi_128, (const void *)idx_hi_128);
+
+        if (is_src_int4_) {
+            if (has_vpermb_) {
+                alignas(64) static constexpr const uint8_t int4_permute[64] = {
+                        0, 32, 1, 33, 2, 34, 3, 35, 4, 36, 5, 37, 6, 38, 7, 39,
+                        8, 40, 9, 41, 10, 42, 11, 43, 12, 44, 13, 45, 14, 46,
+                        15, 47, 16, 48, 17, 49, 18, 50, 19, 51, 20, 52, 21, 53,
+                        22, 54, 23, 55, 24, 56, 25, 57, 26, 58, 27, 59, 28, 60,
+                        29, 61, 30, 62, 31, 63};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute);
+            } else {
+                alignas(64) static constexpr const uint32_t int4_permute_dw[16]
+                        = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22,
+                                23};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute_dw);
+            }
+        }
     }
 
     void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
         const bool is_tail = ncolumns < n_blk_step_;
         if (is_tail) {
-            const auto tail_mask = size_t(((size_t)1 << ncolumns) - 1);
+            const auto tail_size = div_up(ncolumns, src_elems_per_byte_);
+            const auto tail_mask = size_t(((size_t)1 << tail_size) - 1);
             kmovq(kTail, tail_mask);
         }
 
@@ -3327,8 +3553,11 @@ private:
         Xbyak::Ymm vmm_src = Xbyak::Ymm(ymm_idx);
         if (is_tail) {
             load_bytes(vmm_src, reg_src, offset, tail_sz);
+        } else if (is_src_int4_) {
+            load_bytes(vmm_src, reg_src, offset, simd_w_ / src_elems_per_byte_);
         } else
             uni_vmovups(vmm_src, ptr[reg_src + offset]);
+        cvt_int4_to_int8(vmm_src);
     }
 
     void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
@@ -3350,11 +3579,13 @@ private:
                     if (do_load) {
                         const bool do_tail = is_tail
                                 && IMPLICATION(pass == 0, ncolumns < simd_w_);
-                        const auto offset
-                                = (is_dynamic_stride_ ? 0 : i * src_stride_)
+                        auto offset = (is_dynamic_stride_ ? 0 : i * src_stride_)
                                 + pass * simd_w_;
-                        load_ymm(i % 4, offset, do_tail,
-                                ncolumns - pass * simd_w_);
+                        offset /= src_elems_per_byte_;
+                        const auto tail_size
+                                = div_up((ncolumns - pass * simd_w_),
+                                        src_elems_per_byte_);
+                        load_ymm(i % 4, offset, do_tail, tail_size);
                         if (is_dynamic_stride_) add(reg_src, reg_src_stride);
                     } else {
                         const auto src_ymm_1 = get_ymm(i % 4);
@@ -3459,7 +3690,8 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         L(K_loop_unrolled);
         copy_block(k_unroll * k_blk_step_, ncolumns, is_N_tail, zeropad);
         if (!zeropad && !is_dynamic_stride_)
-            add(reg_src, k_unroll * k_blk_step_ * src_stride_);
+            add(reg_src,
+                    k_unroll * k_blk_step_ * src_stride_ / src_elems_per_byte_);
         add(reg_tr_src, k_unroll * tr_src_stride_);
 
         sub(reg_K, k_unroll * k_blk_step_);
@@ -3472,7 +3704,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
 
         copy_block(k_blk_step_, ncolumns, is_N_tail, zeropad);
         if (!zeropad && !is_dynamic_stride_)
-            add(reg_src, k_blk_step_ * src_stride_);
+            add(reg_src, k_blk_step_ * src_stride_ / src_elems_per_byte_);
         add(reg_tr_src, tr_src_stride_);
 
         sub(reg_K, k_blk_step_);

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -2835,6 +2835,7 @@ struct jit_brgemm_matmul_copy_b_int8_t
         , is_dynamic_stride_(is_runtime_value(src_stride_))
         , is_dynamic_N_(conf->is_runtime_N)
         , is_src_int4_(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
+        , is_zp_int4_(one_of(conf->wei_zp_dt, data_type::s4, data_type::u4))
         , has_vpermb_(cpu().has(Xbyak::util::Cpu::tAVX512_VBMI))
         , comp_acc_idx_(is_ymm_ && is_src_int4_      ? 11
                           : is_src_int4_             ? 23
@@ -2866,6 +2867,7 @@ protected:
     const bool is_dynamic_stride_;
     const bool is_dynamic_N_;
     const bool is_src_int4_;
+    const bool is_zp_int4_;
     const bool has_vpermb_;
     const int comp_acc_idx_;
     const dim_t src_elems_per_byte_;
@@ -2873,7 +2875,10 @@ protected:
     constexpr static int reg_src_offs_ = 0;
     constexpr static int reg_tr_src_offs_ = 8;
     constexpr static int reg_current_K_pad_offs_ = 16;
-    constexpr static int stack_space_needed_ = 24;
+    constexpr static int reg_cur_k_offs_ = 24;
+    constexpr static int reg_comp_ptr_offs_ = 32;
+    constexpr static int reg_zp_ptr_offs_ = 40;
+    constexpr static int stack_space_needed_ = 48;
 
     reg64_t reg_src = rax;
     reg64_t reg_tr_src = rbx;
@@ -2948,175 +2953,348 @@ protected:
     }
 
     /**
-    * @brief Applies sign extension for 4-bit signed integers stored in 8-bit lanes using AVX-512.
+    * @brief Applies sign extension for 4-bit signed integers stored in 8-bit lanes.
     * Due to lack of byte-wise right arithmetic shift(vpsrad) this method is used.
     * This method checks the sign bit (bit 3) of each byte and fills the upper nibble with 0xF0
     * if the sign bit is set, preserving the signed semantics after conversion from int4 to int8.
     *
     * Steps:
-    * 1. Broadcast LUT (0xF0) across Zmm register.
+    * 1. Broadcast LUT (0xF0) across register.
     * 2. Isolate sign bit using left shift vpslld.
     * 3. XOR and shuffle with LUT to generate the correct fill pattern.
     * 4. OR the result back into the original vector.
     *
-    * @param vmm_src Zmm register containing int8 values derived from int4.
+    * @param vmm_src Register containing int8 values derived from int4.
+    * @param vmm_scratch1 Scratch register for sign computation.
+    * @param vmm_scratch2 Scratch register for the LUT.
+    * @param dt The data type to check for signedness (s4 triggers extension).
     */
-    inline void signed_mask_int4(const Zmm &vmm_src) {
-        if (conf_->orig_wei_dt != data_type::s4) return;
+    inline void signed_mask_int4(const Vmm &vmm_src, const Vmm &vmm_scratch1,
+            const Vmm &vmm_scratch2, data_type_t dt) {
+        if (dt != data_type::s4) return;
 
-        const auto &vmm_sign_extend = vmm_tmp;
-        const auto &vmm_lut = vmm_zero;
+        if (!is_ymm_) {
+            mov(reg_tmp, 0xF0);
+            uni_vpbroadcastb(vmm_scratch2, reg_tmp.cvt8());
+        } else {
+            alignas(64) static const constexpr uint8_t lut[32] = {0xF0, 0xF0,
+                    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                    0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0};
+            mov(reg_tmp, (size_t)lut);
+            vmovdqu(Ymm(vmm_scratch2.getIdx()), ptr[reg_tmp]);
+        }
 
-        mov(reg_tmp, 0xF0);
-        uni_vpbroadcastb(vmm_lut, reg_tmp.cvt8());
+        uni_vmovups(vmm_scratch1, vmm_src);
+        vpslld(vmm_scratch1, vmm_scratch1, 4);
 
-        uni_vmovups(vmm_sign_extend, vmm_src);
-        vpslld(vmm_sign_extend, vmm_sign_extend, 4);
-
-        uni_vpxor(vmm_sign_extend, vmm_sign_extend, vmm_lut);
-        vpshufb(vmm_sign_extend, vmm_lut, vmm_sign_extend);
-        vpord(vmm_src, vmm_src, vmm_sign_extend);
+        uni_vpxor(vmm_scratch1, vmm_scratch1, vmm_scratch2);
+        vpshufb(vmm_scratch1, vmm_scratch2, vmm_scratch1);
+        if (!is_ymm_)
+            vpord(vmm_src, vmm_src, vmm_scratch1);
+        else
+            vpor(Ymm(vmm_src.getIdx()), Ymm(vmm_src.getIdx()),
+                    Ymm(vmm_scratch1.getIdx()));
     }
 
     /**
-    * @brief Applies sign extension for 4-bit signed integers stored in 8-bit lanes using AVX2.
-    * Due to lack of byte-wise right arithmetic shift(vpsrad) this method is used.
-    * This method uses a lookup table (LUT) and vpshufb to map sign bit presence to the correct
-    * upper nibble fill (0xF0 for negative, 0x00 for positive).
+    * @brief Converts packed u4/s4 integers to u8/s8.
     *
-    * Steps:
-    * 1. Load LUT into Ymm register.
-    * 2. Isolate sign bit using left shift vpslld.
-    * 3. Shuffle using LUT to replicate sign into upper nibble.
-    * 4. OR the result back into the original vector.
+    * Unified implementation for both weight and zero-point int4-to-int8
+    * conversion. Handles AVX-512 and AVX2 paths via is_ymm_ flag.
+    * Uses vmm_zero and vmm_tmp as scratch (and vmm_tmp1 for AVX2).
+    * Cleans up vmm_zero at the end.
     *
-    * @param vmm_src Ymm register containing int8 values derived from int4.
+    * @param vmm_data Register with packed int4 values (converted in-place).
+    * @param dt Data type (s4/u4) to determine sign extension.
     */
-    inline void signed_mask_int4(const Ymm &vmm_src) {
-        if (conf_->orig_wei_dt != data_type::s4) return;
-
-        const auto &vmm_sign_extend = Ymm(vmm_tmp.getIdx());
-        const auto &vmm_lut = Ymm(vmm_tmp1.getIdx());
-        // No matter which index at lut, for signed (7bit==1)
-        // vpshufb will select the same mask
-        alignas(64) static const constexpr uint8_t lut[32] = {0xF0, 0xF0, 0xF0,
-                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0};
-
-        mov(reg_tmp, (size_t)lut);
-        vmovdqu(vmm_lut, ptr[reg_tmp]);
-
-        uni_vmovups(vmm_sign_extend, vmm_src);
-        vpslld(vmm_sign_extend, vmm_sign_extend, 4);
-
-        uni_vpxor(vmm_sign_extend, vmm_sign_extend, vmm_lut);
-        vpshufb(vmm_sign_extend, vmm_lut, vmm_sign_extend);
-        vpor(vmm_src, vmm_src, vmm_sign_extend);
-    }
-
-    /**
-    * @brief Converts packed u4/s4 integers to u8/s8 using AVX-512.
-    *
-    * This method splits the original packed int4 values into low and high nibbles,
-    * expands them into separate bytes, and then applies(if needed) sign extension.
-    *
-    * Steps:
-    * 1. Duplicate source into low and high vectors.
-    * 2. Mask and shift high nibble, mask low nibble.
-    * 3. Merge low and high into full bytes:
-    *    - With AVX512_VBMI: vpermb byte permute.
-    *    - Without VBMI: vpunpcklbw/vpunpckhbw + vpermt2d.
-    * 4. Apply sign extension via signed_mask_int4().
-    *
-    * @param vmm_src Zmm register containing packed int4 values.
-    */
-    inline void cvt_int4_to_int8(const Zmm &vmm_src) {
-        if (!is_src_int4_) return;
-
+    inline void cvt_int4_to_int8(const Vmm &vmm_data, data_type_t dt) {
         using Vmm_lower_t = typename vreg_traits_t<Vmm>::Vmm_lower_t;
 
-        const auto &vmm_low = vmm_src; // Aliases for readability
-        const auto &vmm_high = vmm_zero;
-        const auto &vmm_mask = vmm_tmp;
-
-        uni_vmovups(vmm_high, vmm_low);
-
-        mov(reg_tmp, 0xF0);
-        uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
-        uni_vpand(vmm_high, vmm_high, vmm_mask);
-        vpsrld(vmm_high, vmm_high, 4);
-
-        mov(reg_tmp, 0x0F);
-        uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
-        uni_vpand(vmm_low, vmm_low, vmm_mask);
-
-        if (has_vpermb_) {
-            copy_half_reg(vmm_low, Vmm_lower_t(vmm_high.getIdx()));
-            vpermb(vmm_src, int4_permute_table, vmm_src);
-        } else {
-            vpunpcklbw(vmm_mask, vmm_low, vmm_high);
-            vpunpckhbw(vmm_low, vmm_low, vmm_high);
-            vpermt2d(vmm_mask, int4_permute_table, vmm_low);
-            uni_vmovups(vmm_src, vmm_mask);
+        // Pick scratch registers that don't conflict with vmm_data.
+        const bool data_is_tmp = vmm_data.getIdx() == vmm_tmp.getIdx();
+        // When vmm_data aliases vmm_tmp, use vmm_comp_mul as mask scratch
+        // (save/restore if compensation is active).
+        if (data_is_tmp && do_compute_compensation_) {
+            sub(rsp, simd_w_);
+            uni_vmovups(ptr[rsp], vmm_comp_mul);
         }
-        signed_mask_int4(vmm_src);
+
+        if (!is_ymm_) {
+            // AVX-512 path: in-place with 2 scratch regs.
+            const auto &vmm_high = vmm_zero;
+            const auto &vmm_mask = data_is_tmp ? vmm_comp_mul : vmm_tmp;
+            const auto &vmm_low = vmm_data;
+
+            uni_vmovups(vmm_high, vmm_low);
+
+            mov(reg_tmp, 0xF0);
+            uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
+            uni_vpand(vmm_high, vmm_high, vmm_mask);
+            vpsrld(vmm_high, vmm_high, 4);
+
+            mov(reg_tmp, 0x0F);
+            uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
+            uni_vpand(vmm_low, vmm_low, vmm_mask);
+
+            if (has_vpermb_) {
+                copy_half_reg(
+                        Zmm(vmm_low.getIdx()), Vmm_lower_t(vmm_high.getIdx()));
+                vpermb(Zmm(vmm_data.getIdx()), int4_permute_table,
+                        Zmm(vmm_data.getIdx()));
+            } else {
+                vpunpcklbw(Zmm(vmm_mask.getIdx()), Zmm(vmm_low.getIdx()),
+                        Zmm(vmm_high.getIdx()));
+                vpunpckhbw(Zmm(vmm_low.getIdx()), Zmm(vmm_low.getIdx()),
+                        Zmm(vmm_high.getIdx()));
+                vpermt2d(Zmm(vmm_mask.getIdx()), int4_permute_table,
+                        Zmm(vmm_low.getIdx()));
+                uni_vmovups(vmm_data, vmm_mask);
+            }
+            signed_mask_int4(vmm_data, vmm_high, vmm_mask, dt);
+        } else {
+            // AVX2 path: need 3 scratch regs (high, mask, low_copy).
+            // vmm_comp_mul used as fallback mask when vmm_data == vmm_tmp.
+            const auto vmm_out = Ymm(vmm_data.getIdx());
+            const auto vmm_high = Ymm(vmm_zero.getIdx());
+            const auto vmm_mask = data_is_tmp ? Ymm(vmm_comp_mul.getIdx())
+                                              : Ymm(vmm_tmp.getIdx());
+            const auto vmm_low = Ymm(vmm_tmp1.getIdx());
+
+            uni_vmovups(vmm_low, vmm_out);
+            uni_vmovups(vmm_high, vmm_out);
+
+            alignas(64) static const constexpr uint8_t even_vector[32]
+                    = {0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                            0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                            0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                            0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0};
+            mov(reg_tmp, (size_t)even_vector);
+            vmovdqu(vmm_mask, ptr[reg_tmp]);
+            vpand(vmm_high, vmm_high, vmm_mask);
+            vpsrld(vmm_high, vmm_high, 4);
+
+            alignas(64) static const constexpr uint8_t odd_vector[32]
+                    = {0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+                            0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+                            0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+                            0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F};
+            mov(reg_tmp, (size_t)odd_vector);
+            vmovdqu(vmm_mask, ptr[reg_tmp]);
+            vpand(vmm_low, vmm_low, vmm_mask);
+
+            vpunpcklbw(vmm_mask, vmm_low, vmm_high);
+            vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 0);
+            vpunpckhbw(vmm_mask, vmm_low, vmm_high);
+            vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 1);
+            signed_mask_int4(vmm_data, Vmm(vmm_mask.getIdx()),
+                    Vmm(vmm_low.getIdx()), dt);
+            // Clean Ymm scratch regs
+            uni_vpxor(vmm_low, vmm_low, vmm_low);
+            uni_vpxor(vmm_mask, vmm_mask, vmm_mask);
+        }
+        // Restore vmm_comp_mul if it was saved
+        if (data_is_tmp && do_compute_compensation_) {
+            uni_vmovups(vmm_comp_mul, ptr[rsp]);
+            add(rsp, simd_w_);
+        }
         // Clean vmm_zero
         uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
     }
 
-    /**
-    * @brief Converts packed u4/s4 to u8/s8 integers using AVX2.
-    *
-    * This method extracts low and high nibbles from each byte, unpacks them into separate
-    * bytes, and then applies(if needed) sign extension.
-    *
-    * Steps:
-    * 1. Copy source into low and high vectors.
-    * 2. Mask and shift high nibble, mask low nibble.
-    * 3. Interleave low and high bytes using vpunpcklbw/vpunpckhbw.
-    * 4. Apply sign extension via signed_mask_int4().
-    *
-    * @param vmm_src Ymm register containing packed int4 values.
-    */
+    // Convenience wrappers for weight int4 conversion (existing call sites).
+    inline void cvt_int4_to_int8(const Zmm &vmm_src) {
+        if (!is_src_int4_) return;
+        cvt_int4_to_int8(Vmm(vmm_src.getIdx()), conf_->orig_wei_dt);
+    }
     inline void cvt_int4_to_int8(const Ymm &vmm_src) {
         if (!is_src_int4_) return;
+        cvt_int4_to_int8(Vmm(vmm_src.getIdx()), conf_->orig_wei_dt);
+    }
 
-        const auto vmm_out = Ymm(vmm_src.getIdx());
-        const auto vmm_low = Ymm(vmm_tmp1.getIdx());
-        const auto vmm_high = Ymm(vmm_zero.getIdx());
-        const auto vmm_mask = Ymm(vmm_tmp.getIdx());
+    /*
+     * @brief Applies zero point shift for per-K.
+     * @param vmm_src Source data vector
+     * @param inner_k The offset inside the K-block
+     * @param is_tail Tail flag over N-dimension
+     * @param ncolumns Number of columns
+     * @param inner_n_offs Offset for inner N dimension, used for AVX2
+    */
+    inline void maybe_apply_ic_zero_points(const Vmm &vmm_src,
+            const int inner_k, bool is_tail, const int ncolumns,
+            const int inner_n_offs = 0) {
+        if (!conf_->has_zero_point_b || !conf_->is_wei_zp_per_k) return;
 
-        uni_vmovups(vmm_low, vmm_out);
-        uni_vmovups(vmm_high, vmm_out);
+        const bool mask_supported = isa_has_masks(conf_->isa);
+        auto &vmm_zp = vmm_tmp;
 
-        alignas(64) static const constexpr uint8_t even_vector[32]
-                = {0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-                        0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-                        0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
-                        0xF0, 0xF0, 0xF0, 0xF0};
-        mov(reg_tmp, (size_t)even_vector);
-        vmovdqu(vmm_mask, ptr[reg_tmp]);
-        vpand(vmm_high, vmm_high, vmm_mask);
-        vpsrld(vmm_high, vmm_high, 4);
+        mov(reg_tmp, ptr[rsp + reg_cur_k_offs_]);
+        mov(ptr[rsp + reg_src_offs_], reg_src); // utilize rax for division
+        const bool need_comp = conf_->s8s8_compensation_required;
+        if (need_comp)
+            mov(ptr[rsp + reg_comp_ptr_offs_],
+                    reg_comp_ptr); // utilize rdx for division
+        // Locate the current K group
+        // Based on current K position and inner k index.
+        xor_(rdx, rdx); // zero rdx for division
+        mov(rax, reg_tmp);
+        mov(reg_tmp, conf_->wei_zp_k_gsize);
+        add(rax, inner_k);
+        div(reg_tmp);
+        mov(reg_tmp, conf_->N);
+        mul(reg_tmp);
+        // For int4 ZP, each element is half a byte so adjust offset
+        if (is_zp_int4_) shr(rax, 1);
+        // Load zero points for current K group
+        mov(rdx, ptr[rsp + reg_zp_ptr_offs_]);
+        add(rdx, rax);
+        if (is_zp_int4_)
+            add(rdx, inner_n_offs / 2);
+        else
+            add(rdx, inner_n_offs);
+        const auto addr = ptr[rdx];
+        if (is_zp_int4_) {
+            // Load packed int4 data (half-size) into lower half of vmm_zp
+            const auto ncolumns_packed = div_up(ncolumns, 2);
+            if (is_tail && !mask_supported) {
+                load_bytes(vmm_zp, addr, ncolumns_packed);
+            } else if (mask_supported) {
+                const auto half_ncolumns = ncolumns / 2;
+                kmovq(kTail, size_t(((size_t)1 << half_ncolumns) - 1));
+                vmovdqu8(vmm_zp | kTail | T_z, addr);
+                // Restore tail mask for ncolumns
+                kmovq(kTail,
+                        size_t(((size_t)1
+                                       << div_up(ncolumns, src_elems_per_byte_))
+                                - 1));
+            } else {
+                load_bytes(vmm_zp, addr, ncolumns_packed);
+            }
+            cvt_int4_to_int8(vmm_zp, conf_->wei_zp_dt);
+        } else {
+            if (is_tail && !mask_supported) {
+                load_bytes(vmm_zp, addr, ncolumns);
+            } else if (mask_supported) {
+                const auto masked_vmm = maybe_mask(vmm_zp, is_tail);
+                vmovdqu8(masked_vmm, addr);
+            } else {
+                uni_vmovdqu(vmm_zp, addr);
+            }
+        }
+        // Apply zero point shift
+        uni_vpsubb(vmm_src, vmm_src, vmm_zp);
+        // Restore regs
+        mov(reg_src, ptr[rsp + reg_src_offs_]);
+        if (need_comp) mov(reg_comp_ptr, ptr[rsp + reg_comp_ptr_offs_]);
+    }
 
-        alignas(64) static const constexpr uint8_t odd_vector[32] = {0x0F, 0x0F,
-                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
-                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
-                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F};
-        mov(reg_tmp, (size_t)odd_vector);
-        vmovdqu(vmm_mask, ptr[reg_tmp]);
-        vpand(vmm_low, vmm_low, vmm_mask);
+    /**
+     * @brief Applies zero point shift for per-N.
+     * @param vmm_src Source data vector
+     * @param is_tail Tail flag over N-dimension
+     * @param ncolumns Number of columns
+     * @param inner_n_offs Offset for inner N dimension, used for AVX2
+     */
+    inline void maybe_apply_oc_zero_points(const Vmm &vmm_src, bool is_tail,
+            const int ncolumns, const int inner_n_offs = 0) {
+        if (!conf_->has_zero_point_b || !conf_->is_wei_zp_per_n
+                || conf_->is_wei_zp_per_k)
+            return;
 
-        vpunpcklbw(vmm_mask, vmm_low, vmm_high);
-        vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 0);
-        vpunpckhbw(vmm_mask, vmm_low, vmm_high);
-        vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 1);
-        signed_mask_int4(vmm_out);
-        // Clean tmp regs
-        uni_vpxor(vmm_low, vmm_low, vmm_low);
-        uni_vpxor(vmm_high, vmm_high, vmm_high);
-        uni_vpxor(vmm_mask, vmm_mask, vmm_mask);
+        const bool mask_supported = isa_has_masks(conf_->isa);
+        auto &vmm_zp = vmm_tmp;
+        // Use reg_src (rax) to hold ZP pointer to avoid reg_tmp corruption
+        // by kmovq which internally uses reg_tmp as scratch.
+        mov(ptr[rsp + reg_src_offs_], reg_src);
+        mov(reg_src, ptr[rsp + reg_zp_ptr_offs_]);
+        if (is_zp_int4_)
+            add(reg_src, inner_n_offs / 2);
+        else
+            add(reg_src, inner_n_offs);
+        const auto addr = ptr[reg_src];
+        if (is_zp_int4_) {
+            const auto ncolumns_packed = div_up(ncolumns, 2);
+            if (is_tail && !mask_supported) {
+                load_bytes(vmm_zp, addr, ncolumns_packed);
+            } else if (mask_supported) {
+                const auto half_ncolumns = ncolumns / 2;
+                kmovq(kTail, size_t(((size_t)1 << half_ncolumns) - 1));
+                vmovdqu8(vmm_zp | kTail | T_z, addr);
+                kmovq(kTail,
+                        size_t(((size_t)1
+                                       << div_up(ncolumns, src_elems_per_byte_))
+                                - 1));
+            } else {
+                load_bytes(vmm_zp, addr, ncolumns_packed);
+            }
+            cvt_int4_to_int8(vmm_zp, conf_->wei_zp_dt);
+        } else {
+            if (is_tail && !mask_supported) {
+                load_bytes(vmm_zp, addr, ncolumns);
+            } else if (mask_supported) {
+                const auto masked_vmm = maybe_mask(vmm_zp, is_tail);
+                vmovdqu8(masked_vmm, addr);
+            } else {
+                uni_vmovdqu(vmm_zp, addr);
+            }
+        }
+        // Apply zero point shift
+        uni_vpsubb(vmm_src, vmm_src, vmm_zp);
+        // Restore reg_src
+        mov(reg_src, ptr[rsp + reg_src_offs_]);
+    }
+
+    /**
+     * @brief Applies common zero point shift.
+     * @param vmm_src Source data vector
+    */
+    inline void maybe_apply_common_zero_points(const Vmm &vmm_src) {
+        if (!conf_->has_zero_point_b || !conf_->is_wei_zp_common) return;
+
+        auto &vmm_zp = vmm_tmp;
+        mov(reg_tmp, ptr[rsp + reg_zp_ptr_offs_]);
+        const auto addr = byte[reg_tmp];
+        mov(reg_tmp.cvt8(), addr);
+        if (is_zp_int4_) {
+            // Extract int4 value from the low nibble of the byte
+            and_(reg_tmp.cvt32(), 0x0F);
+            if (conf_->wei_zp_dt == data_type::s4) {
+                // Sign extend: shift left 28, arithmetic shift right 28
+                shl(reg_tmp.cvt32(), 28);
+                sar(reg_tmp.cvt32(), 28);
+            }
+        }
+        uni_vpbroadcastb(vmm_zp, reg_tmp.cvt8());
+        uni_vpsubb(vmm_src, vmm_src, vmm_zp);
+    }
+
+    /**
+     * @brief Optionally applies zero point shift if the configuration requires it.
+     * @param vmm_src Source data vector
+     * @param inner_k Inner K dimension index
+     * @param is_tail Tail flag over N-dimension
+     * @param ncolumns Number of columns
+     * @param inner_n_offs Offset for inner N dimension, used for AVX2
+     */
+    inline void maybe_apply_zero_points(const Vmm &vmm_src, const int inner_k,
+            bool is_tail, const int ncolumns, const int inner_n_offs = 0) {
+        if (!conf_->with_wei_decompression
+                && !conf_->with_int8_dynamic_quantization)
+            return;
+
+        maybe_apply_common_zero_points(vmm_src);
+
+        if (is_src_int4_ && is_tail && isa_has_masks(conf_->isa))
+            kmovq(kTail, size_t(((size_t)1 << ncolumns) - 1));
+
+        maybe_apply_oc_zero_points(vmm_src, is_tail, ncolumns, inner_n_offs);
+        maybe_apply_ic_zero_points(
+                vmm_src, inner_k, is_tail, ncolumns, inner_n_offs);
+
+        if (is_src_int4_ && is_tail && isa_has_masks(conf_->isa)) {
+            const auto tail_size = div_up(ncolumns, src_elems_per_byte_);
+            kmovq(kTail, size_t(((size_t)1 << tail_size) - 1));
+        }
     }
 
     void generate() override;
@@ -3308,8 +3486,11 @@ private:
             dim_t tr_src_off_base = (kb * max_unroll + k) * tr_src_stride_;
 
             if (!zeropad) {
-                for (int i = row_start; i < row_end; i++)
+                for (int i = row_start; i < row_end; i++) {
                     load(k, i, is_tail);
+                    maybe_apply_zero_points(
+                            get_vmm(k, i % k_blk_step_), i, is_tail, ncolumns);
+                }
                 if (row_end == nrows && nrows % k_blk_step_ > 0) {
                     for (int i = nrows; i < rnd_up(nrows, k_blk_step_); i++) {
                         auto src_reg = get_vmm(k, i % k_blk_step_);
@@ -3440,11 +3621,10 @@ private:
 
     void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
         const bool is_tail = ncolumns < n_blk_step_;
-        if (is_tail) {
-            const auto tail_size = div_up(ncolumns, src_elems_per_byte_);
-            const auto tail_mask = size_t(((size_t)1 << tail_size) - 1);
-            kmovq(kTail, tail_mask);
-        }
+        const auto tail_size = div_up(ncolumns, src_elems_per_byte_);
+        const auto tail_mask = size_t(((size_t)1 << tail_size) - 1);
+
+        if (is_tail) kmovq(kTail, tail_mask);
 
         const int max_unroll = (do_compute_compensation_ ? 21 : 25) / blk_sz_;
 
@@ -3458,8 +3638,11 @@ private:
             dim_t tr_src_off_base = (kb * max_unroll + k) * tr_src_stride_;
 
             if (!zeropad) {
-                for (int i = row_start; i < row_end; i++)
+                for (int i = row_start; i < row_end; i++) {
                     load(k, i, is_tail);
+                    maybe_apply_zero_points(
+                            get_vmm(k, i % k_blk_step_), i, is_tail, ncolumns);
+                }
                 if (row_end == nrows && nrows % k_blk_step_ > 0) {
                     for (int i = nrows; i < rnd_up(nrows, k_blk_step_); i++) {
                         auto src_reg = get_vmm(k, i % k_blk_step_);
@@ -3583,10 +3766,12 @@ private:
                         auto offset = (is_dynamic_stride_ ? 0 : i * src_stride_)
                                 + pass * simd_w_;
                         offset /= src_elems_per_byte_;
+                        const auto tail_elements = ncolumns - pass * simd_w_;
                         const auto tail_size
-                                = div_up((ncolumns - pass * simd_w_),
-                                        src_elems_per_byte_);
+                                = div_up(tail_elements, src_elems_per_byte_);
                         load_ymm(i % 4, offset, do_tail, tail_size);
+                        maybe_apply_zero_points(get_ymm(i % 4), i, do_tail,
+                                tail_elements, pass * simd_w_);
                         if (is_dynamic_stride_) add(reg_src, reg_src_stride);
                     } else {
                         const auto src_ymm_1 = get_ymm(i % 4);
@@ -3663,6 +3848,24 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         vpbroadcastw(vmm_ones_words, reg_tmp.cvt16());
     }
 
+    if (conf_->has_zero_point_b
+            && (conf_->with_wei_decompression
+                    || conf_->with_int8_dynamic_quantization)) {
+        mov(reg_tmp, ptr[param1 + GET_OFF(zp_b_value_ptr)]);
+        mov(ptr[rsp + reg_zp_ptr_offs_], reg_tmp);
+
+        if (conf_->is_wei_zp_per_k) {
+            // Used for grouped zero-point applying
+            // Shift current K starting from group start.
+            // Since `brgmm_ctx.get_wei_zp_ptr(n, k);`
+            mov(reg_tmp, conf_->wei_zp_k_gsize);
+            xor_(rdx, rdx);
+            mov(rax, ptr[param1 + GET_OFF(current_K_start)]);
+            div(reg_tmp);
+            mov(ptr[rsp + reg_cur_k_offs_], rdx);
+        }
+    }
+
     uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
     mov(reg_src, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
@@ -3694,6 +3897,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
             add(reg_src,
                     k_unroll * k_blk_step_ * src_stride_ / src_elems_per_byte_);
         add(reg_tr_src, k_unroll * tr_src_stride_);
+        add(dword[rsp + reg_cur_k_offs_], k_unroll * k_blk_step_);
 
         sub(reg_K, k_unroll * k_blk_step_);
         cmp(reg_K, k_unroll * k_blk_step_);
@@ -3707,6 +3911,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         if (!zeropad && !is_dynamic_stride_)
             add(reg_src, k_blk_step_ * src_stride_ / src_elems_per_byte_);
         add(reg_tr_src, tr_src_stride_);
+        add(dword[rsp + reg_cur_k_offs_], k_blk_step_);
 
         sub(reg_K, k_blk_step_);
         jmp(K_loop_single, T_NEAR);

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
@@ -61,10 +61,12 @@ struct jit_brgemm_matmul_copy_a_t {
         const void *zp_a_compensation_result_ptr = nullptr;
         const void *zp_b_neg_val_ptr = nullptr;
         const void *zp_ab_comp_ptr = nullptr;
+        const void *zp_a_value_ptr = nullptr;
 
         dim_t current_K_start = 0;
         dim_t current_K_blk = 0;
         dim_t current_M_blk = 0;
+        dim_t current_M_start = 0;
         dim_t dynamic_src_ld = 0;
     };
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -478,8 +478,14 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
             const int default_n_block = init_n_tag
                     ? get_default_n_block(format_tag::undef)
                     : bgmmc.N_blk;
-            bgmmc.wei_tag = blocked_B_layouts_allowed && !bgmmc.is_runtime_N
-                            && !bgmmc.is_int4_weights
+            // Prevent blocked B layout when int8 dynamic quantization uses
+            // weight zero points: blocked_B sets use_buffer_b=false, so
+            // copy_b (which applies the ZP subtraction) never runs.
+            const bool can_use_blocked_B = blocked_B_layouts_allowed
+                    && !bgmmc.is_runtime_N && !bgmmc.is_int4_weights
+                    && !(with_int8_dynamic_quantization()
+                            && bgmmc.wei_zp_type != brgemm_broadcast_t::none);
+            bgmmc.wei_tag = can_use_blocked_B
                     ? this->pick_blocked_B_layout(default_n_block)
                     : bgmmc.is_int4_weights && bgmmc.N % 2 != 0
                     ? transposed_tensor_layout_tag
@@ -720,10 +726,39 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
     return format_tag::undef;
 }
 
-brgemm_broadcast_t get_zp_type(const primitive_attr_t &attr, int arg) {
-    return attr.zero_points_.has_default_values(arg)
-            ? brgemm_broadcast_t::none
-            : brgemm_broadcast_t::per_tensor;
+brgemm_broadcast_t get_zp_type(
+        const primitive_attr_t &attr, int arg, int ndims) {
+    if (attr.zero_points_.has_default_values(arg)) {
+        return brgemm_broadcast_t::none;
+    }
+
+    const auto &zp = attr.zero_points_.get(arg);
+    const int mask = zp.get_mask();
+
+    // Non-grouped zero points (per_oc, per_tensor, etc.) are all treated
+    // as per_tensor from the brgemm compensation perspective.  The finer
+    // per_n / per_k distinction is only meaningful for grouped (per_ocic)
+    // zero points used in the dynamic quantization path.
+    if (zp.has_default_groups()) { return brgemm_broadcast_t::per_tensor; }
+
+    const int k_bit_wei = 1 << (ndims - 2); // K-dim bit for weights
+    const int n_bit_wei = 1 << (ndims - 1); // N-dim bit for weights
+    const int k_bit_src = 1 << (ndims - 1); // K-dim bit for src
+
+    // Grouped zero points: classify by mask.
+    if (mask == 0) {
+        return brgemm_broadcast_t::per_tensor;
+    } else if ((mask & n_bit_wei) != 0
+            && utils::one_of(arg, DNNL_ARG_WEIGHTS, DNNL_ARG_DST)) {
+        return brgemm_broadcast_t::per_n;
+    } else if ((mask & k_bit_wei) != 0
+            && utils::one_of(arg, DNNL_ARG_WEIGHTS)) {
+        return brgemm_broadcast_t::per_k;
+    } else if ((mask & k_bit_src) != 0 && utils::one_of(arg, DNNL_ARG_SRC)) {
+        return brgemm_broadcast_t::per_k;
+    } else {
+        return brgemm_broadcast_t::none;
+    }
 }
 
 // Returns the minimum IC group size across all per-K scales (wei and src).
@@ -1560,6 +1595,11 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                 IMPLICATION(bgmmc.is_wei_zp_per_k && bgmmc.is_wei_scale_per_k,
                         bgmmc.wei_zp_k_gsize == bgmmc.wei_scales_k_gsize),
                 VERBOSE_UNSUPPORTED_ZP_CFG);
+
+        VCONDCHECK_BG(
+                IMPLICATION(bgmmc.with_int8_dynamic_quantization,
+                        !one_of(bgmmc.wei_zp_dt, data_type::s4, data_type::u4)),
+                VERBOSE_UNSUPPORTED_ZP_CFG);
     }
 
     const auto &p = attr.post_ops_;
@@ -1570,13 +1610,15 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     const int prelu_ind = p.find(primitive_kind::prelu);
     bgmmc.with_binary = !everyone_is(-1, binary_ind, prelu_ind);
 
-    bgmmc.src_zp_type = get_zp_type(attr, DNNL_ARG_SRC);
-    bgmmc.wei_zp_type = get_zp_type(attr, DNNL_ARG_WEIGHTS);
-    bgmmc.dst_zp_type = get_zp_type(attr, DNNL_ARG_DST);
+    bgmmc.src_zp_type = get_zp_type(attr, DNNL_ARG_SRC, bgmmc.ndims);
+    bgmmc.wei_zp_type = get_zp_type(attr, DNNL_ARG_WEIGHTS, bgmmc.ndims);
+    bgmmc.dst_zp_type = get_zp_type(attr, DNNL_ARG_DST, bgmmc.ndims);
 
     VCONDCHECK_BG(
-            IMPLICATION(!(bm_conf_utils.is_int8()
-                                || bm_conf_utils.with_weights_decompression()),
+            IMPLICATION(
+                    !(bm_conf_utils.is_int8()
+                            || bm_conf_utils.with_weights_decompression()
+                            || bm_conf_utils.with_int8_dynamic_quantization()),
                     everyone_is(brgemm_broadcast_t::none, bgmmc.src_zp_type,
                             bgmmc.wei_zp_type, bgmmc.dst_zp_type)),
             VERBOSE_UNSUPPORTED_ZP_CFG);
@@ -1607,6 +1649,18 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                     ? utils::div_up(bgmmc.K, bgmmc.wei_scales_k_gsize)
                     : 1;
             bgmmc.wei_scales_batch_stride = num_k_groups * bgmmc.N;
+        }
+    }
+    // Same for weight zero points: per_tensor grouped ZP on 4D tensors
+    // has batch bits in the mask. Compute the stride between ZP planes.
+    if (has_wei_zp && bgmmc.batch > 1) {
+        const int kn_mask = (1 << (bgmmc.ndims - 1)) | (1 << (bgmmc.ndims - 2));
+        const bool has_batch_bits = (wei_zp.get_mask() & ~kn_mask) != 0;
+        if (has_batch_bits) {
+            const dim_t num_k_groups = bgmmc.is_wei_zp_per_k
+                    ? utils::div_up(bgmmc.K, bgmmc.wei_zp_k_gsize)
+                    : 1;
+            bgmmc.wei_zp_batch_stride = num_k_groups * bgmmc.N;
         }
     }
     // Due to hardware restrictions of AMX the effective group size should
@@ -1823,7 +1877,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                                 || bm_conf_utils.is_f16_with_int_wei())
                             && isa == avx512_core_fp16)
                     || (bgmmc.wei_zp_type != brgemm_broadcast_t::none
-                            && !bm_conf_utils.with_weights_decompression())
+                            && !(bm_conf_utils.with_weights_decompression()
+                                    || bm_conf_utils
+                                               .with_int8_dynamic_quantization()))
                     || bgmmc.transposed_A);
 
     bgmmc.use_buffer_a = is_copy_a_required;
@@ -2328,7 +2384,8 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
                     && !bgmmc.apply_scales_in_buffer_b,
             bgmmc.with_eltwise, bgmmc.with_binary, bgmmc.acc_dt != bgmmc.dst_dt,
             bgmmc.s8s8_compensation_required, bgmmc.has_zero_point_a,
-            bgmmc.has_zero_point_b && !bgmmc.with_wei_decompression,
+            bgmmc.has_zero_point_b && !bgmmc.with_wei_decompression
+                    && !bgmmc.with_int8_dynamic_quantization,
             bgmmc.has_zero_point_c, bgmmc.with_dst_scales);
 
     bgmmc.zp_a_comp_shift_n = bgmmc.wei_n_blk;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1593,7 +1593,24 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     const auto &src_zp = attr.zero_points_.get(DNNL_ARG_SRC);
     const auto has_src_zp = !src_zp.has_default_values();
-    if (has_src_zp) { bgmmc.src_zp_dt = src_zp.get_data_type(); }
+    if (has_src_zp) {
+        bgmmc.src_zp_dt = src_zp.get_data_type();
+        const auto src_zp_mask = src_zp.get_mask();
+        // src per_ocic grouped zero points: mask has K bit set and groups
+        bgmmc.is_src_zp_per_k = (src_zp_mask & (1 << (bgmmc.ndims - 1))) != 0
+                && !src_zp.has_default_groups();
+        if (bgmmc.is_src_zp_per_k) {
+            bgmmc.src_zp_k_gsize = src_zp.get_group(1);
+        }
+        // Src per_ocic (IC-grouped) zero points are only supported for
+        // dynamic quantization (s8 src with int4 weights).
+        // u8 source is not supported because vpsubb + vpdpbusd interaction
+        // produces incorrect results when the subtracted value wraps.
+        VCONDCHECK_BG(IMPLICATION(bgmmc.is_src_zp_per_k,
+                              bgmmc.with_int8_dynamic_quantization
+                                      && bgmmc.src_dt == data_type::s8),
+                VERBOSE_UNSUPPORTED_ZP_CFG);
+    }
 
     const auto &wei_zp = attr.zero_points_.get(DNNL_ARG_WEIGHTS);
     const auto has_wei_zp = !wei_zp.has_default_values();
@@ -1615,11 +1632,6 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                 IMPLICATION(bgmmc.is_wei_zp_per_k && bgmmc.is_wei_scale_per_k,
                         bgmmc.wei_zp_k_gsize == bgmmc.wei_scales_k_gsize),
                 VERBOSE_UNSUPPORTED_ZP_CFG);
-
-        VCONDCHECK_BG(
-                IMPLICATION(bgmmc.with_int8_dynamic_quantization,
-                        !one_of(bgmmc.wei_zp_dt, data_type::s4, data_type::u4)),
-                VERBOSE_UNSUPPORTED_ZP_CFG);
     }
 
     const auto &p = attr.post_ops_;
@@ -1631,8 +1643,16 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.with_binary = !everyone_is(-1, binary_ind, prelu_ind);
 
     bgmmc.src_zp_type = get_zp_type(attr, DNNL_ARG_SRC, bgmmc.ndims);
+    // For src per_ocic zp, the shift is applied directly in copy_a kernel
+    if (bgmmc.is_src_zp_per_k) bgmmc.src_zp_type = brgemm_broadcast_t::none;
     bgmmc.wei_zp_type = get_zp_type(attr, DNNL_ARG_WEIGHTS, bgmmc.ndims);
     bgmmc.dst_zp_type = get_zp_type(attr, DNNL_ARG_DST, bgmmc.ndims);
+
+    // int8 only supports per_ocic (grouped) src zero points handled
+    // via copy_a kernel.
+    VCONDCHECK_BG(IMPLICATION(bm_conf_utils.with_int8_dynamic_quantization(),
+                          bgmmc.src_zp_type == brgemm_broadcast_t::none),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
 
     VCONDCHECK_BG(
             IMPLICATION(
@@ -1689,9 +1709,15 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     VCONDCHECK_BG(IMPLICATION(bgmmc.is_wei_scale_per_k && bgmmc.is_amx,
                           bgmmc.wei_scales_k_gsize % 64 == 0),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
-    VCONDCHECK_BG(IMPLICATION(bgmmc.is_src_scale_per_k && bgmmc.is_amx,
+    VCONDCHECK_BG(IMPLICATION(bgmmc.is_src_scale_per_k && bgmmc.is_amx
+                                  && bgmmc.with_int8_dynamic_quantization,
                           bgmmc.src_scales_k_gsize % 64 == 0),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
+    // When src_zp group size covers the entire K dimension, downgrade.
+    if (bgmmc.is_src_zp_per_k && !bgmmc.is_runtime_K
+            && bgmmc.src_zp_k_gsize >= bgmmc.K) {
+        bgmmc.is_src_zp_per_k = false;
+    }
 
     bgmmc.is_gemv = is_gemv_applicable(
             bgmmc, bm_conf_utils, src_md, weights_md, attr);
@@ -1903,7 +1929,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                             && !(bm_conf_utils.with_weights_decompression()
                                     || bm_conf_utils
                                                .with_int8_dynamic_quantization()))
-                    || bgmmc.transposed_A);
+                    || bgmmc.is_src_zp_per_k || bgmmc.transposed_A);
 
     bgmmc.use_buffer_a = is_copy_a_required;
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -726,6 +726,16 @@ brgemm_broadcast_t get_zp_type(const primitive_attr_t &attr, int arg) {
             : brgemm_broadcast_t::per_tensor;
 }
 
+// Returns the minimum IC group size across all per-K scales (wei and src).
+// Returns 0 if no IC-grouped scales are configured.
+dim_t get_min_ic_group_size(const brgemm_matmul_conf_t &bgmmc) {
+    dim_t sz = 0;
+    if (bgmmc.is_wei_scale_per_k && bgmmc.wei_scales_k_gsize > 0)
+        sz = sz == 0 ? bgmmc.wei_scales_k_gsize
+                     : nstl::min(sz, bgmmc.wei_scales_k_gsize);
+    return sz;
+}
+
 struct matmul_avx512_blocking_params_t {
     struct matmul_params_t {
         matmul_params_t(dim_t m, dim_t n, dim_t k, dim_t od)
@@ -1254,6 +1264,17 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
         bgmmc.brgemm_batch_size
                 = nstl::max(bgmmc.K / bgmmc.K_blk, static_cast<dim_t>(1));
 
+        // Force K_blk alignment to scales group size for AMX IC scales.
+        // Use the MINIMUM group size so that no brgemm call straddles
+        // more than one group for any of the scales.
+        if (bgmmc.with_int8_dynamic_quantization) {
+            const auto ic_group_sz = get_min_ic_group_size(bgmmc);
+            if (ic_group_sz > 0) {
+                bgmmc.K_blk = ic_group_sz;
+                bgmmc.brgemm_batch_size = 1;
+            }
+        }
+
         matmul_amx_blocking_params_micro_t best_blocking(bgmmc);
 
         matmul_amx_blocking_params_micro_t::find_best_blocking(
@@ -1333,6 +1354,19 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
         VCONDCHECK_BG(best_imbalance != 1.f, VERBOSE_BLOCKING_FAIL, "")
 
         best_blocking.update_configuration(bgmmc);
+    }
+
+    // For non-AMX paths with IC scales, also align K_blk to the minimum
+    // group size so each brgemm call covers exactly one K-group.
+    // The AMX paths handle this in their own blocking sections above.
+    if (!bgmmc.is_amx && bgmmc.with_int8_dynamic_quantization) {
+        const auto ic_group_sz = get_min_ic_group_size(bgmmc);
+        if (ic_group_sz > 0 && bgmmc.K_blk > ic_group_sz) {
+            bgmmc.K_blk = ic_group_sz;
+            bgmmc.brgemm_batch_size = 1;
+            bgmmc.K_chunk_size = 1;
+            bgmmc.use_buffer_c = bgmmc.use_buffer_c || bgmmc.K > bgmmc.K_blk;
+        }
     }
 
     return status::success;
@@ -1450,7 +1484,11 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.tr_b_dt_sz = types::data_type_size(s8);
     }
 
-    bgmmc.acc_dt = bm_conf_utils.is_int8() ? s32 : f32;
+    // Dynamic quantization always accumulates in f32 to perform accuracy.
+    bgmmc.acc_dt
+            = (bm_conf_utils.is_int8() && !bgmmc.with_int8_dynamic_quantization)
+            ? s32
+            : f32;
 
     bgmmc.c_dt_sz = types::data_type_size(bgmmc.dst_dt);
     bgmmc.acc_dt_sz = types::data_type_size(bgmmc.acc_dt);
@@ -1468,20 +1506,25 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.is_wei_scale_per_k = wei_scale_mask & 1 << (bgmmc.ndims - 2);
         bgmmc.is_wei_scale_per_n = wei_scale_mask & 1 << (bgmmc.ndims - 1);
         bgmmc.apply_scales_in_buffer_b = bgmmc.is_wei_scale_per_k
-                && bgmmc.with_wei_decompression && bgmmc.N * bgmmc.K != 1;
+                && bgmmc.with_wei_decompression && bgmmc.N * bgmmc.K != 1
+                && !bgmmc.with_int8_dynamic_quantization;
         bgmmc.wei_scales_dt = wei_scales.get_data_type();
         bgmmc.wei_scales_dt_sz = types::data_type_size(bgmmc.wei_scales_dt);
         bgmmc.wei_scales_k_gsize = wei_scales.get_group(0);
 
         // only common and per-oc-channel scales are supported
-        // only per-ic-channel scales is supprted with weight decompression
+        // per-ic-channel scales is supported with weight decompression
+        // or dynamic quantization (int8 src with int4 weights)
         VCONDCHECK_BG(bgmmc.is_wei_scale_common || bgmmc.is_wei_scale_per_n
                         || IMPLICATION(bgmmc.is_wei_scale_per_k,
-                                bgmmc.with_wei_decompression),
+                                bgmmc.with_wei_decompression
+                                        || bgmmc.with_int8_dynamic_quantization),
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-        // Check if isa has support for f16/bf16 weights scales
-        VCONDCHECK_BG(IMPLICATION(bgmmc.wei_scales_dt == f16, isa_has_f16(isa))
+        // Check if isa has support for f16/bf16 weights scales.
+        VCONDCHECK_BG(IMPLICATION(bgmmc.wei_scales_dt == f16,
+                              bgmmc.with_int8_dynamic_quantization
+                                      || isa_has_f16(isa))
                         && IMPLICATION(
                                 bgmmc.wei_scales_dt == bf16, isa_has_bf16(isa)),
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
@@ -1548,6 +1591,30 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.is_runtime_M = is_runtime_value(bgmmc.M);
     bgmmc.is_runtime_N = is_runtime_value(bgmmc.N);
     bgmmc.is_runtime_K = is_runtime_value(bgmmc.K);
+
+    // Downgrade to per_oc to avoid the expensive IC-scales JIT path which
+    // is not needed for this case.
+    if (bgmmc.is_wei_scale_per_k && !bgmmc.is_runtime_K
+            && bgmmc.wei_scales_k_gsize >= bgmmc.K) {
+        bgmmc.is_wei_scale_per_k = false;
+    }
+
+    if (bgmmc.with_wei_scales && bgmmc.batch > 1) {
+        const int kn_mask = (1 << (bgmmc.ndims - 1)) | (1 << (bgmmc.ndims - 2));
+        const bool has_batch_bits = (wei_scales.get_mask() & ~kn_mask) != 0;
+        if (has_batch_bits) {
+            const dim_t num_k_groups = bgmmc.is_wei_scale_per_k
+                    ? utils::div_up(bgmmc.K, bgmmc.wei_scales_k_gsize)
+                    : 1;
+            bgmmc.wei_scales_batch_stride = num_k_groups * bgmmc.N;
+        }
+    }
+    // Due to hardware restrictions of AMX the effective group size should
+    // be divisible by tile-size 64
+    // Otherwise fallback to AVX512 kernels.
+    VCONDCHECK_BG(IMPLICATION(bgmmc.is_wei_scale_per_k && bgmmc.is_amx,
+                          bgmmc.wei_scales_k_gsize % 64 == 0),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     bgmmc.is_gemv = is_gemv_applicable(
             bgmmc, bm_conf_utils, src_md, weights_md, attr);
@@ -1648,10 +1715,12 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.tr_b_dt_sz = types::data_type_size(f32);
     }
 
-    // int4 weights decompression only supports plain and transpose layouts
+    // int4 weights decompression/dynamic quantization only supports plain
+    // and transpose layouts.
     // TODO: enable int4 reorder and extend support to blocked weights
     // layout when needed
-    if (bgmmc.with_wei_decompression && bgmmc.is_int4_weights)
+    if ((bgmmc.with_wei_decompression || bgmmc.with_int8_dynamic_quantization)
+            && bgmmc.is_int4_weights)
         VCONDCHECK_BG(bm_conf_utils.check_is_plain(bgmmc.wei_tag)
                         || bm_conf_utils.check_is_transposed(bgmmc.wei_tag),
                 VERBOSE_UNSUPPORTED_TAG);
@@ -1938,7 +2007,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
             || bm_conf_utils.is_bf16_with_int_wei()
             || bm_conf_utils.is_f16_with_int_wei()
-            || bm_conf_utils.is_f32_with_int_wei()) {
+            || bm_conf_utils.is_f32_with_int_wei()
+            || bm_conf_utils.with_int8_dynamic_quantization()) {
         // empirical observation for performance breakpoint between amx and vnni
         // bf16/f16
         const dim_t buffer_a_chunk_sz_limit = 126;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -234,7 +234,8 @@ status_t check_isa_with_datatype(
             = IMPLICATION(bm_conf_utils.is_f32(),
                       one_of(isa, avx512_core, avx2) || bm_conf_utils.is_bf32()
                               || bm_conf_utils.is_tf32())
-            && IMPLICATION(bm_conf_utils.is_int8(),
+            && IMPLICATION(bm_conf_utils.is_int8()
+                            || bm_conf_utils.with_int8_dynamic_quantization(),
                     is_superset(isa, avx512_core)
                             || is_superset(isa, avx2_vnni))
             && IMPLICATION(bm_conf_utils.is_bf16(),
@@ -280,7 +281,8 @@ status_t check_datatype_cfg(const brgemm_matmul_conf_utils_t &bm_conf_utils) {
                       bm_conf_utils.is_tf32(),
                       bm_conf_utils.is_bf16_with_int_wei(),
                       bm_conf_utils.is_f16_with_int_wei(),
-                      bm_conf_utils.is_f32_with_int_wei())
+                      bm_conf_utils.is_f32_with_int_wei(),
+                      bm_conf_utils.with_int8_dynamic_quantization())
             && IMPLICATION(bm_conf_utils.is_bf16_with_int_wei()
                             || bm_conf_utils.is_f16_with_int_wei(),
                     bm_conf_utils.with_weights_decompression());
@@ -321,7 +323,7 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
               && IMPLICATION(attr.fpmath_.mode_ == fpmath_mode::bf16,
                       bgmmc.src_dt == bf16)
               && IMPLICATION(attr.fpmath_.mode_ == fpmath_mode::strict,
-                      bgmmc.src_dt == f32)
+                      one_of(bgmmc.src_dt, f32, u8, s8))
               && attr.fpmath_.apply_to_int_)
     , bf16_with_int_wei_dt(weights_decompression_support && bgmmc.src_dt == bf16
               && one_of(bgmmc.dst_dt, bf16, f32))
@@ -337,6 +339,9 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
               && one_of(bgmmc.dst_dt, f16, f32))
     , f32_with_int_wei_dt(weights_decompression_support
               && everyone_is(f32, bgmmc.src_dt, bgmmc.dst_dt))
+    , int8_dynamic_quantization_dt(one_of(bgmmc.src_dt, u8, s8)
+              && one_of(bgmmc.wei_dt, s4, u4, s8, u8)
+              && one_of(bgmmc.dst_dt, f16, bf16, f32))
     , A_any_layout(A_any_layout)
     , B_any_layout(B_any_layout)
     , C_any_layout(C_any_layout)
@@ -674,7 +679,7 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
 
     if (bgmmc.ndims > 3) return format_tag::undef;
 
-    if (is_int8() || is_f8()) {
+    if (is_int8() || is_f8() || with_int8_dynamic_quantization()) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c4b : BA16a64b4a;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c4b : BA16a48b4a;
@@ -1397,6 +1402,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.with_wei_decompression = bm_conf_utils.with_weights_decompression();
     bgmmc.is_int4_weights = one_of(bgmmc.wei_dt, data_type::s4, data_type::u4);
     bgmmc.is_f4_via_convert = bm_conf_utils.is_f4_via_convert();
+    bgmmc.with_int8_dynamic_quantization
+            = bm_conf_utils.with_int8_dynamic_quantization();
 
     if (bgmmc.is_f4_via_convert) {
         bgmmc.wei_dt = f32;
@@ -1437,6 +1444,10 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.wei_dt = f16;
         bgmmc.tr_a_dt_sz = types::data_type_size(f16);
         bgmmc.tr_b_dt_sz = types::data_type_size(f16);
+    } else if (bgmmc.with_int8_dynamic_quantization) {
+        bgmmc.wei_dt = s8;
+        bgmmc.tr_a_dt_sz = types::data_type_size(bgmmc.src_dt);
+        bgmmc.tr_b_dt_sz = types::data_type_size(s8);
     }
 
     bgmmc.acc_dt = bm_conf_utils.is_int8() ? s32 : f32;
@@ -1644,6 +1655,12 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         VCONDCHECK_BG(bm_conf_utils.check_is_plain(bgmmc.wei_tag)
                         || bm_conf_utils.check_is_transposed(bgmmc.wei_tag),
                 VERBOSE_UNSUPPORTED_TAG);
+
+    // Transposed weights (ba/acb/abdc) are not supported for dynamic
+    // quantization
+    if (bgmmc.with_int8_dynamic_quantization
+            && bm_conf_utils.check_is_transposed(bgmmc.wei_tag))
+        VCONDCHECK_BG(false, VERBOSE_UNSUPPORTED_TAG);
 
     const bool transposed_A = bm_conf_utils.check_is_transposed(bgmmc.src_tag);
     // When M == 1, MatMul always treats A as non-transposed, even if the A

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -768,6 +768,9 @@ dim_t get_min_ic_group_size(const brgemm_matmul_conf_t &bgmmc) {
     if (bgmmc.is_wei_scale_per_k && bgmmc.wei_scales_k_gsize > 0)
         sz = sz == 0 ? bgmmc.wei_scales_k_gsize
                      : nstl::min(sz, bgmmc.wei_scales_k_gsize);
+    if (bgmmc.is_src_scale_per_k && bgmmc.src_scales_k_gsize > 0)
+        sz = sz == 0 ? bgmmc.src_scales_k_gsize
+                     : nstl::min(sz, bgmmc.src_scales_k_gsize);
     return sz;
 }
 
@@ -1535,6 +1538,23 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     bgmmc.with_src_scales = !src_scales.has_default_values();
     bgmmc.with_wei_scales = !wei_scales.has_default_values();
+    if (bgmmc.with_src_scales) {
+        const auto &src_scale_mask = src_scales.get_mask();
+        // src per_ocic grouped scales: mask has K bit set and groups are used
+        bgmmc.is_src_scale_per_k
+                = (src_scale_mask & (1 << (bgmmc.ndims - 1))) != 0
+                && !src_scales.has_default_groups();
+        if (bgmmc.is_src_scale_per_k) {
+            bgmmc.src_scales_k_gsize = src_scales.get_group(1);
+            bgmmc.src_scales_dt = src_scales.get_data_type();
+            bgmmc.src_scales_dt_sz = types::data_type_size(bgmmc.src_scales_dt);
+        }
+        // Src per_ocic (IC-grouped) scales are only supported for
+        // dynamic quantization (int8 src with int4 weights)
+        VCONDCHECK_BG(IMPLICATION(bgmmc.is_src_scale_per_k,
+                              bgmmc.with_int8_dynamic_quantization),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
+    }
     if (bgmmc.with_wei_scales) {
         const auto &wei_scale_mask = wei_scales.get_mask();
         bgmmc.is_wei_scale_common = wei_scale_mask == 0;
@@ -1668,6 +1688,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     // Otherwise fallback to AVX512 kernels.
     VCONDCHECK_BG(IMPLICATION(bgmmc.is_wei_scale_per_k && bgmmc.is_amx,
                           bgmmc.wei_scales_k_gsize % 64 == 0),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VCONDCHECK_BG(IMPLICATION(bgmmc.is_src_scale_per_k && bgmmc.is_amx,
+                          bgmmc.src_scales_k_gsize % 64 == 0),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     bgmmc.is_gemv = is_gemv_applicable(

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -212,6 +212,7 @@ struct brgemm_matmul_conf_t {
     bool is_int4_weights = false;
     bool is_f4_via_convert = false;
     bool is_tf32 = false;
+    bool with_int8_dynamic_quantization = false;
     bool req_wei_vnni_downconvert = false;
     bool is_runtime_M = false;
     bool is_runtime_N = false;
@@ -300,6 +301,10 @@ struct brgemm_matmul_conf_utils_t {
         if (bgmmc.is_bf16_with_int_wei) return true;
         if (bgmmc.is_f16_with_int_wei) return true;
         if (bgmmc.is_f32_with_int_wei) return true;
+        if (bgmmc.with_int8_dynamic_quantization
+                && (bgmmc.is_int4_weights
+                        || bgmmc.wei_zp_type != brgemm_broadcast_t::none))
+            return true;
         if (bgmmc.apply_scales_in_buffer_b) return true;
         if (bgmmc.is_gemv) return false;
 
@@ -391,6 +396,10 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool is_f32_with_int_wei() const { return f32_with_int_wei_dt; }
 
+    inline bool with_int8_dynamic_quantization() const {
+        return int8_dynamic_quantization_dt;
+    }
+
     inline bool with_weights_decompression() const {
         return !utils::one_of(bgmmc.src_dt, data_type::s8, data_type::u8,
                        data_type::s4, data_type::u4)
@@ -432,7 +441,8 @@ private:
     const bool f32_dt, bf16_dt, f16_dt, f4_via_convert_dt, f8_dt, bf8_dt,
             int8_dt, bf32_dt, tf32_dt;
     const bool weights_decompression_support, bf16_with_int_wei_dt, f32_f16_dt,
-            f32_bf16_dt, f16_with_int_wei_dt, f32_with_int_wei_dt;
+            f32_bf16_dt, f16_with_int_wei_dt, f32_with_int_wei_dt,
+            int8_dynamic_quantization_dt;
     const bool A_any_layout;
     const bool B_any_layout;
     const bool C_any_layout;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -235,6 +235,12 @@ struct brgemm_matmul_conf_t {
     data_type_t wei_scales_dt = data_type::undef;
     dim_t wei_scales_batch_stride = 0;
 
+    // Src scales (per_ocic grouped along K)
+    bool is_src_scale_per_k = false;
+    dim_t src_scales_k_gsize = 0;
+    data_type_t src_scales_dt = data_type::undef;
+    size_t src_scales_dt_sz = 0;
+
     // Zero points
     bool has_zero_point_a;
     bool has_zero_point_b;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -250,6 +250,7 @@ struct brgemm_matmul_conf_t {
     bool is_wei_zp_per_n = false;
     bool is_wei_zp_common = false;
     data_type_t wei_zp_dt = data_type::undef;
+    dim_t wei_zp_batch_stride = 0;
 
     dim_t zp_a_comp_shift_n;
     dim_t zp_a_comp_elems_per_thr;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -233,6 +233,7 @@ struct brgemm_matmul_conf_t {
     bool is_wei_scale_common = false;
     dim_t wei_scales_k_gsize = 0;
     data_type_t wei_scales_dt = data_type::undef;
+    dim_t wei_scales_batch_stride = 0;
 
     // Zero points
     bool has_zero_point_a;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -251,6 +251,10 @@ struct brgemm_matmul_conf_t {
 
     data_type_t src_zp_dt = data_type::undef;
 
+    // Src zero points (per_ocic grouped along K)
+    bool is_src_zp_per_k = false;
+    dim_t src_zp_k_gsize = 0;
+
     dim_t wei_zp_k_gsize = 0;
     bool is_wei_zp_per_k = false;
     bool is_wei_zp_per_n = false;


### PR DESCRIPTION
Implements feature request: [MFDNN-11991](https://jira.devtools.intel.com/browse/MFDNN-11991).
What was done:
1. int4->int8 upconversion for the quantized weights. Implemented in `brgemm_matmul_copy_utils.cpp`
2. Weight zero points shift grouped, common, per_oc, per_ocic. Implemented in `brgemm_matmul_copy_utils.cpp`
3. Weight scales application: grouped, per_ocic. Implemented in `jit_brgemm_kernel.cpp`, `jit_brgemm_amx_uker.cpp`
4. Source zero points shift grouped, per_ocic. Implemented in  `brgemm_matmul_copy_utils.cpp`
5. Source scales application grouped, per_ocic. Implemented in `jit_brgemm_kernel.cpp`, `jit_brgemm_amx_uker.cpp`


Performance testing on SPR:
TBD.