### PR TITLE
common: move gemm utils to gpu/intel

### DIFF
--- a/src/common/gemm_pd.hpp
+++ b/src/common/gemm_pd.hpp
@@ -20,7 +20,6 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "common/c_types_map.hpp"
-#include "common/gemm_utils.hpp"
 #include "common/primitive_desc.hpp"
 #include "common/utils.hpp"
 

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -22,7 +22,6 @@
 #include <memory>
 
 #include "common/c_types_map.hpp"
-#include "common/gemm_utils.hpp"
 #include "common/utils.hpp"
 #include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/compute/kernel.hpp"
@@ -30,6 +29,7 @@
 #include "gpu/intel/gemm/jit/gen_kernel.hpp"
 #include "gpu/intel/gemm/jit/pd.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -19,6 +19,7 @@
 #include "common/primitive_attr_quant.hpp"
 #include "gpu/intel/gemm/exec_types.hpp"
 #include "gpu/intel/gemm/jit/gen_kernel.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/jit/eltwise_injector.hpp"
 #include "gpu/intel/jit/utils/type_bridge.hpp"
 #include "gpu/intel/utils.hpp"

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -21,6 +21,7 @@
 #include "common/verbose_msg.hpp"
 #include "gpu/intel/compute/utils.hpp"
 #include "gpu/intel/gemm/jit/walk_orders.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/gemm/xe_systolic_copy_kernel.hpp"
 
 namespace dnnl {

--- a/src/gpu/intel/gemm/utils.hpp
+++ b/src/gpu/intel/gemm/utils.hpp
@@ -14,10 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef COMMON_GEMM_UTILS_HPP
-#define COMMON_GEMM_UTILS_HPP
-
-#include "oneapi/dnnl/dnnl.h"
+#ifndef GPU_INTEL_GEMM_UTILS_HPP
+#define GPU_INTEL_GEMM_UTILS_HPP
 
 #include "common/c_types_map.hpp"
 #include "common/nstl.hpp"
@@ -169,4 +167,4 @@ static inline bool is_md_gemm_compatible_plain_format(
 } // namespace impl
 } // namespace dnnl
 
-#endif
+#endif // GPU_INTEL_GEMM_UTILS_HPP

--- a/src/gpu/intel/ip/gemm.hpp
+++ b/src/gpu/intel/ip/gemm.hpp
@@ -20,11 +20,11 @@
 #include <assert.h>
 
 #include "common/c_types_map.hpp"
-#include "common/gemm_utils.hpp"
 #include "common/memory_desc.hpp"
 #include "common/primitive.hpp"
 #include "common/primitive_desc_iterator.hpp"
 #include "common/reduction_pd.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/ip/config.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/primitive_attr.hpp"

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -18,13 +18,12 @@
 #define GPU_INTEL_MATMUL_GEMM_HPP
 
 #include "common/c_types_map.hpp"
-#include "common/gemm_utils.hpp"
 #include "common/matmul_pd.hpp"
 #include "common/memory_desc.hpp"
-#include "common/memory_desc_wrapper.hpp"
 #include "common/primitive.hpp"
 #include "common/primitive_attr_quant.hpp"
 #include "common/primitive_desc_iterator.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/matmul/config.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/utils.hpp"

--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -29,9 +29,9 @@
 #include "gpu/intel/rnn/grid.hpp"
 
 #include "common/c_types_map.hpp"
-#include "common/gemm_utils.hpp"
 #include "common/type_helpers.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/primitive_attr.hpp"
 #include "gpu/intel/rnn/config.hpp"
 

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -21,13 +21,12 @@
 
 #include "common/c_types_map.hpp"
 #include "common/gemm_types.hpp"
-#include "common/gemm_utils.hpp"
 #include "common/math_utils.hpp"
 #include "common/primitive.hpp"
 #include "common/sdpa_pd.hpp"
 #include "common/utils.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/primitive.hpp"
-#include "gpu/intel/sdpa/config.hpp"
 #include "gpu/intel/sdpa/configs.hpp"
 
 namespace dnnl {


### PR DESCRIPTION
In #4867 @vpirogov Asked me to move some gemm-related code into the GPU folder. Here's the summary:
- `common/gemm_utils.h`: Moved in this PR. This is the code I touched in the previous PR, and it's the only gemm code in `common/` used exclusively by the GPU team.
- `common/gemm_types.h`: Cannot be moved up due to common-level primitive hashing dependencies.
- `common/gemm_pd.h`: Cannot be moved up due to common-level verbose logging dependencies.
- `common/gemm.cpp`: Should probably be moved to the `cpu/` folder, but I'll leave someone on CPU/Arch teams to do that one.