### PR TITLE
Dispatch swish via ACL

### DIFF
--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -120,6 +120,9 @@ status_t convert_to_acl_act(alg_kind_t eltwise_alg, float alpha, float beta,
         case eltwise_gelu_erf:
             act_info = ActivationLayerInfo(act_func::GELU);
             break;
+        case eltwise_swish:
+            act_info = ActivationLayerInfo(act_func::SWISH, alpha, beta);
+            break;
         default: act_info = ActivationLayerInfo(); return status::unimplemented;
     }
 


### PR DESCRIPTION
# Description

Enables the `eltwise_swish` activation function to be dispatched through Arm Compute Library (ACL) in `convert_to_acl_act`. This allows convolution primitives with a swish post-op to use ACL's fused activation path (`indirect_gemm:acl`) instead of falling back to the JIT SVE path (`brgconv:sve_128`), avoiding a separate pass over the output data.

[ACL's `SWISH` activation](https://github.com/ARM-software/ComputeLibrary/blob/v52.8.0/src/cpu/kernels/activation/generic/neon/fp_impl.h#L169-L177) computes `x / (1 + exp(-a*x))`, which is equivalent to oneDNN's `eltwise_swish` definition `x * logistic(alpha * x)`. The `alpha` parameter maps directly to ACL's `a` parameter.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

### Performance Data
Benchmarked on AArch64 SVE (128-bit), f32, across 19 convolution shapes (described below) with `OMP_NUM_THREADS=1,4,8`.

| Threads | Geomean Speedup | Best | Worst | N |
|---------|----------------|------|-------|---|
| 1T | 1.07x | 1.19x | 1.00x | 19 |
| 4T | 1.05x | 1.19x | 0.95x | 19 |
| 8T | 1.04x | 1.16x | 0.88x | 19 |

<details>
  <summary>Benchmark input data</summary>

  ```
# ResNet-like
--attr-post-ops=swish:1
ic3oc64_ih224oh112kh7sh2ph3n"resnet_first_7x7"
ic64oc64_ih56oh56kh3ph1n"resnet_3x3_small"
ic64oc128_ih56oh28kh3sh2ph1n"resnet_downsample"
ic128oc128_ih28oh28kh3ph1n"resnet_mid"
ic256oc256_ih14oh14kh3ph1n"resnet_deep"
ic512oc512_ih7oh7kh3ph1n"resnet_final"
# 1x1 pointwise
ic64oc256_ih56oh56kh1n"resnet_1x1_expand"
ic256oc64_ih56oh56kh1n"resnet_1x1_squeeze"
ic512oc2048_ih7oh7kh1n"resnet_1x1_large"
# MobileNet-like depthwise
g64ic64oc64_ih56oh56kh3ph1n"mobilenet_dw_3x3"
g128ic128oc128_ih28oh28kh3ph1n"mobilenet_dw_mid"
g256ic256oc256_ih14oh14kh3ph1n"mobilenet_dw_deep"
# Larger batch
mb8ic64oc64_ih56oh56kh3ph1n"batch8_3x3"
mb16ic128oc128_ih28oh28kh3ph1n"batch16_mid"
mb32ic256oc256_ih14oh14kh3ph1n"batch32_deep"
# 5x5 kernels
ic32oc32_ih28oh28kh5ph2n"efficientnet_5x5"
ic64oc64_ih14oh14kh5ph2n"efficientnet_5x5_deep"
# Wide channels
ic1024oc1024_ih7oh7kh3ph1n"wide_7x7"
ic2048oc512_ih7oh7kh1n"wide_1x1_reduce"
```
</details>

