### PR TITLE
xe: gmlp: Fix errors in  gated mlp tests without cpu runtime

### DIFF
--- a/tests/gtests/internals/test_gated_mlp.cpp
+++ b/tests/gtests/internals/test_gated_mlp.cpp
@@ -177,7 +177,7 @@ std::string PrintToString(const ::testing::TestParamInfo<mlp_dims_t> &info) {
     return ss.str();
 }
 
-gmlp_tensors_t get_descriptors(engine &eng, mlp_dims_t p) {
+gmlp_tensors_t get_descriptors(engine &eng, stream &strm, mlp_dims_t p) {
     gmlp_tensors_t out;
 
     // Prepare input and output shapes to construct the swiglu graph.
@@ -408,27 +408,35 @@ gmlp_tensors_t get_descriptors(engine &eng, mlp_dims_t p) {
     }
 
     // Write data to tensor object's handle.
-    move_data(x_data, out.m_x);
-    move_data(w_gate_data, out.m_w_gate);
-    move_data(w_up_data, out.m_w_up);
-    move_data(w_down_data, out.m_w_down);
+    write_to_dnnl_memory(x_data.data(), out.m_x, eng, strm);
+    write_to_dnnl_memory(w_gate_data.data(), out.m_w_gate, eng, strm);
+    write_to_dnnl_memory(w_up_data.data(), out.m_w_up, eng, strm);
+    write_to_dnnl_memory(w_down_data.data(), out.m_w_down, eng, strm);
 
     if (p.qtype == quantize_type::no_quantization) {
-        move_data(w_gate_data, out.m_w_gate_quantized);
-        move_data(w_up_data, out.m_w_up_quantized);
-        move_data(w_down_data, out.m_w_down_quantized);
+        write_to_dnnl_memory(
+                w_gate_data.data(), out.m_w_gate_quantized, eng, strm);
+        write_to_dnnl_memory(w_up_data.data(), out.m_w_up_quantized, eng, strm);
+        write_to_dnnl_memory(
+                w_down_data.data(), out.m_w_down_quantized, eng, strm);
     } else {
-        move_data(w_gate_quantized_data, out.m_w_gate_quantized);
-        move_data(w_up_quantized_data, out.m_w_up_quantized);
-        move_data(w_down_quantized_data, out.m_w_down_quantized);
+        write_to_dnnl_memory(w_gate_quantized_data.data(),
+                out.m_w_gate_quantized, eng, strm);
+        write_to_dnnl_memory(
+                w_up_quantized_data.data(), out.m_w_up_quantized, eng, strm);
+        write_to_dnnl_memory(w_down_quantized_data.data(),
+                out.m_w_down_quantized, eng, strm);
 
-        move_data(w_gate_zp_data, out.m_w_gate_zp);
-        move_data(w_up_zp_data, out.m_w_up_zp);
-        move_data(w_down_zp_data, out.m_w_down_zp);
+        write_to_dnnl_memory(w_gate_zp_data.data(), out.m_w_gate_zp, eng, strm);
+        write_to_dnnl_memory(w_up_zp_data.data(), out.m_w_up_zp, eng, strm);
+        write_to_dnnl_memory(w_down_zp_data.data(), out.m_w_down_zp, eng, strm);
 
-        move_data(w_gate_scales_data, out.m_w_gate_scales);
-        move_data(w_up_scales_data, out.m_w_up_scales);
-        move_data(w_down_scales_data, out.m_w_down_scales);
+        write_to_dnnl_memory(
+                w_gate_scales_data.data(), out.m_w_gate_scales, eng, strm);
+        write_to_dnnl_memory(
+                w_up_scales_data.data(), out.m_w_up_scales, eng, strm);
+        write_to_dnnl_memory(
+                w_down_scales_data.data(), out.m_w_down_scales, eng, strm);
     }
     if (verbose)
         printf("memory data types?? %d %d %d\n",
@@ -588,10 +596,10 @@ void bench_gated_mlp_primitives(std::vector<float> &res, double &avg_time,
 
 #ifndef ENABLE_UP_ONLY
     res.resize(product(m_FC_down.get_desc().get_dims()));
-    move_data(res, m_FC_down, false);
+    move_data(eng, strm, res, m_FC_down, false);
 #else
     res.resize(product(m_FC_up.get_desc().get_dims()));
-    move_data(res, m_FC_up, false);
+    move_data(eng, strm, res, m_FC_up, false);
 #endif
 }
 
@@ -795,7 +803,7 @@ void bench_gated_mlp_internal(std::vector<float> &res, double &avg_time,
     }
 
     res.resize(product(m_FC_gate_t.get_desc().get_dims()));
-    move_data(res, m_FC_gate_t, false);
+    move_data(eng, strm, res, m_FC_gate_t, false);
 }
 
 enum class api_kind { primitive, graph, internal_hack };
@@ -840,7 +848,7 @@ public:
         p = GetParam();
         eng = engine(engine::kind::gpu, 0);
         strm = stream(eng);
-        t = get_descriptors(eng, p);
+        t = get_descriptors(eng, strm, p);
     }
 
 protected:

--- a/tests/gtests/internals/test_utils.hpp
+++ b/tests/gtests/internals/test_utils.hpp
@@ -73,7 +73,8 @@ void transpose_strides(
         const dnnl::engine &eng, dnnl::memory &out, dnnl::memory &in);
 
 template <typename T>
-void move_data(std::vector<T> &v, dnnl::memory &mem, bool to_mem = true) {
+void move_data(dnnl::engine &eng, dnnl::stream &strm, std::vector<T> &v,
+        dnnl::memory &mem, bool to_mem = true) {
     dnnl::memory::data_type vdt = dnnl::memory::data_type::undef;
     if (std::is_same<T, bfloat16_t>::value) vdt = dnnl::memory::data_type::bf16;
     if (std::is_same<T, float16_t>::value) vdt = dnnl::memory::data_type::f16;
@@ -81,12 +82,24 @@ void move_data(std::vector<T> &v, dnnl::memory &mem, bool to_mem = true) {
     if (std::is_same<T, int>::value) vdt = dnnl::memory::data_type::s32;
     if (std::is_same<T, int8_t>::value) vdt = dnnl::memory::data_type::s8;
     if (std::is_same<T, uint8_t>::value) vdt = dnnl::memory::data_type::u8;
-    dnnl::memory::desc vmd(
-            mem.get_desc().get_dims(), vdt, mem.get_desc().get_strides());
-    dnnl::memory vmem(vmd, dnnl::engine(dnnl::engine::kind::cpu, 0), v.data());
-    auto strm = dnnl::stream(mem.get_engine());
-    dnnl::reorder((to_mem) ? vmem : mem, (to_mem) ? mem : vmem)
-            .execute(strm, (to_mem) ? vmem : mem, (to_mem) ? mem : vmem);
+    if (to_mem) {
+        dnnl::memory::desc vmd(
+                mem.get_desc().get_dims(), vdt, mem.get_desc().get_strides());
+        dnnl::memory vmem(
+                vmd, dnnl::engine(dnnl::engine::kind::cpu, 0), v.data());
+        auto strm = dnnl::stream(mem.get_engine());
+        dnnl::reorder((to_mem) ? vmem : mem, (to_mem) ? mem : vmem)
+                .execute(strm, (to_mem) ? vmem : mem, (to_mem) ? mem : vmem);
+    } else {
+        strm.wait();
+        T *ptr = static_cast<T *>(mem.map_data());
+        if (!ptr) throw std::runtime_error("get_data_handle returned nullptr.");
+        for (size_t i = 0; i < v.size(); ++i) {
+            v[i] = ptr[i];
+        }
+        mem.unmap_data(ptr);
+        strm.wait();
+    }
 }
 
 /// TODO: substitute this with move_data, replace vector<unsigned> with vector<int>


### PR DESCRIPTION
# Description

Fix errors in gated mlp test when no CPU runtime is available. The moved_data required the cpu runtime to function. This PR changes the transfer function from move_data to write_to_dnnl_memory used by other tests.