### PR TITLE
cpu: aarch64: enable binary op and binary post-ops on ASIMD

### DIFF
--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -157,8 +157,10 @@ conditional_register_preserve_guard_t<
                                 vmm_to_preserve}
                       : register_preserve_guard_t<isa> {nullptr, {}, {}}} {};
 
+template class register_preserve_guard_t<asimd>;
 template class register_preserve_guard_t<sve>;
 template class conditional_register_preserve_guard_t<sve>;
+template class conditional_register_preserve_guard_t<asimd>;
 
 } // namespace injector_utils
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1364,6 +1364,12 @@ void jit_uni_binary_injector_t<isa>::calculate_w_cspn(
     calculate_w_nspc(strides, tmp_reg);
 }
 
+template <>
+void jit_uni_binary_injector_t<cpu_isa_t::asimd>::cvt_to_f32(
+        const Xbyak_aarch64::VReg &tmp_vmm) const {
+    host_->scvtf(tmp_vmm.s, tmp_vmm.s);
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::inject_binary(
         const dnnl_post_ops::entry_t &post_op, Vmm dst,
@@ -1408,6 +1414,38 @@ void jit_uni_binary_injector_t<isa>::inject_binary(
         }
 
         execute_binary(alg, dst, mask, lhs, rhs_addr);
+    }
+}
+
+template <>
+void jit_uni_binary_injector_t<asimd>::inject_binary(
+        const dnnl_post_ops::entry_t &post_op, Xbyak_aarch64::VReg dst,
+        const rhs_address_t &rhs_addr, bool with_tail,
+        const tail_lode_mode_t tail_load_mode) const {
+
+    const auto &alg = post_op.binary.alg;
+    const bool div_op = alg == alg_kind::binary_div;
+    const auto &rhs_arg_data_type = post_op.binary.src1_desc.data_type;
+    const bool process_rhs_arg_using_tmp = with_tail
+            || rhs_arg_data_type != data_type::f32
+            || !binary_op_with_unaligned_mem_operand_allowed_ || div_op;
+
+    if (process_rhs_arg_using_tmp) {
+        const Xbyak_aarch64::VReg tmp = Xbyak_aarch64::VReg(
+                rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+
+        if (rhs_addr.isBroadcast())
+            execute_broadcast(rhs_arg_data_type, tmp,
+                    remove_bcast_bit(rhs_addr), tail_load_mode, with_tail);
+        else
+            load_rhs(rhs_arg_data_type, tmp, rhs_addr, tail_load_mode,
+                    with_tail);
+
+        if (rhs_arg_data_type != data_type::f32) cvt_to_f32(tmp);
+
+        execute_binary(alg, dst, host_->P_ALL_ONE, dst, tmp);
+    } else {
+        execute_binary(alg, dst, host_->P_ALL_ONE, dst, rhs_addr);
     }
 }
 
@@ -1476,6 +1514,27 @@ void jit_uni_binary_injector_t<isa>::execute_broadcast_no_tail(
     }
 }
 
+template <>
+void jit_uni_binary_injector_t<asimd>::execute_broadcast_s8u8_no_tail(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    assert(utils::one_of(data_type, data_type::s8, data_type::u8)
+            && "unsupported data type");
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(rhs_addr.base_,
+            rhs_addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+
+    if (data_type == data_type::s8) {
+        // load byte from memory into wtmp and sign-extend
+        host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+    } else if (data_type == data_type::u8) {
+        // unsigned load
+        host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+    }
+    // broadcast into 4x32-bit
+    host_->dup(tmp_vmm.s4, host_->W_TMP_0);
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::execute_broadcast_s8u8_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
@@ -1529,6 +1588,41 @@ void jit_uni_binary_injector_t<isa>::execute_broadcast_tail_with_opmask(
     }
 }
 
+template <>
+void jit_uni_binary_injector_t<asimd>::execute_broadcast_tail_with_opmask(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(
+            rhs_addr.base_, rhs_addr.offt_, host_->X_TMP_1, host_->X_TMP_0);
+
+    host_->uni_clear(tmp_vmm);
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+            host_->ld1(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[0],
+                    Xbyak_aarch64::ptr(x_addr));
+            for (size_t i = 1; i < rhs_arg_static_params_.tail_size; ++i) {
+                host_->ins(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[0]);
+            }
+            break;
+        case data_type::s8:
+        case data_type::u8:;
+            if (data_type == data_type::s8) {
+                host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+            } else {
+                host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+            }
+            for (size_t i = 0; i < rhs_arg_static_params_.tail_size; ++i) {
+                host_->ins(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        host_->W_TMP_0);
+            }
+            break;
+        default: assert(!"unsupported data type");
+    }
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::load_rhs_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
@@ -1548,6 +1642,28 @@ void jit_uni_binary_injector_t<isa>::load_rhs_no_tail(
     }
 }
 
+template <>
+void jit_uni_binary_injector_t<asimd>::load_rhs_i8_no_tail(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    assert(utils::one_of(data_type, data_type::s8, data_type::u8)
+            && "unsupported data type");
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(rhs_addr.base_,
+            rhs_addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+
+    for (size_t i = 0; i < 4; ++i) {
+        const Xbyak_aarch64::XReg lane_addr = host_->addr_off(x_addr,
+                i * sizeof(int8_t), host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+        if (data_type == data_type::s8) {
+            host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(lane_addr));
+        } else {
+            host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(lane_addr));
+        }
+        host_->ins(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i], host_->W_TMP_0);
+    }
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::load_rhs_i8_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
@@ -1564,6 +1680,45 @@ void jit_uni_binary_injector_t<isa>::load_rhs_i8_no_tail(
                 Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
     } else
         assert(!"unsupported data type");
+}
+
+template <>
+void jit_uni_binary_injector_t<asimd>::load_rhs_tail_dynamically_with_opmask(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(
+            rhs_addr.base_, rhs_addr.offt_, host_->X_TMP_1, host_->X_TMP_0);
+
+    host_->uni_clear(tmp_vmm);
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+            for (size_t i = 0; i < rhs_arg_static_params_.tail_size; ++i) {
+                const Xbyak_aarch64::XReg lane_addr
+                        = host_->addr_off(x_addr, i * sizeof(float),
+                                host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+                host_->ld1(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        Xbyak_aarch64::ptr(lane_addr));
+            }
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            for (size_t i = 0; i < rhs_arg_static_params_.tail_size; ++i) {
+                const Xbyak_aarch64::XReg lane_addr
+                        = host_->addr_off(x_addr, i * sizeof(int8_t),
+                                host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+                if (data_type == data_type::s8) {
+                    host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(lane_addr));
+                } else {
+                    host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(lane_addr));
+                }
+                host_->ins(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        host_->W_TMP_0);
+            }
+            break;
+        default: assert(!"unsupported data type");
+    }
 }
 
 template <cpu_isa_t isa>
@@ -1797,6 +1952,42 @@ void get_v_rhs_value(
     }
 }
 
+template <>
+void jit_uni_binary_injector_t<asimd>::execute_cmp_binary(
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::PReg &mask,
+        const Xbyak_aarch64::VReg &lhs, const Xbyak_aarch64::VReg &rhs,
+        const unsigned int cmp_predicate) const {
+    UNUSED(mask);
+
+    switch (cmp_predicate) {
+        case jit_generator_t::_cmp_nlt_us:
+            host_->fcmge(dst.s, lhs.s, rhs.s);
+            break;
+        case jit_generator_t::_cmp_nle_us:
+            host_->fcmgt(dst.s, lhs.s, rhs.s);
+            break;
+        case jit_generator_t::_cmp_le_os:
+            host_->fcmge(dst.s, rhs.s, lhs.s);
+            break;
+        case jit_generator_t::_cmp_lt_os:
+            host_->fcmgt(dst.s, rhs.s, lhs.s);
+            break;
+        case jit_generator_t::_cmp_eq_oq:
+            host_->fcmeq(dst.s, lhs.s, rhs.s);
+            break;
+        case jit_generator_t::_cmp_neq_uq:
+            host_->fcmeq(dst.s, lhs.s, rhs.s);
+            host_->not_(dst.b, dst.b);
+            break;
+        default: assert(!"unsupported compare mode"); break;
+    }
+
+    // ASIMD compare instructions produce all-ones/all-zeros integer masks.
+    // Convert them to the expected 1.0f / 0.0f compare result in place.
+    host_->ushr(dst.s, dst.s, 31);
+    host_->scvtf(dst.s, dst.s);
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::execute_cmp_binary(const Vmm &dst,
         const Xbyak_aarch64::PReg &mask, const Vmm &lhs, const Vmm &rhs,
@@ -1814,6 +2005,100 @@ void jit_uni_binary_injector_t<isa>::execute_cmp_binary(const Vmm &dst,
     pop_opmask(host_, cmp_mask);
 }
 
+template <>
+template <typename T>
+void jit_uni_binary_injector_t<asimd>::execute_binary(alg_kind_t binary_alg,
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::PReg &mask,
+        const Xbyak_aarch64::VReg &lhs, const T &rhs) const {
+    const int SIMD_SZ = simd_bytes(asimd);
+    const bool isAddr = std::is_same<T, rhs_address_t>::value;
+    Xbyak_aarch64::VReg v_rhs(0);
+
+    if (isAddr) {
+        const rhs_address_t &addr = (rhs_address_t &)rhs;
+        for (size_t i = 0; i < 32; i++) {
+            // Look for a temporary vector register whose index isn’t the same as lhs.
+            if (lhs.getIdx() != i) {
+                // Pick the SIMD vector register with index i to be the scratch register.
+                v_rhs = Xbyak_aarch64::VReg(i);
+                // Allocate space on stack
+                host_->sub(host_->X_SP, host_->X_SP, SIMD_SZ);
+                // Store the scratch register into the stack so it's safe to clobber it.
+                host_->str(Xbyak_aarch64::QReg(i),
+                        Xbyak_aarch64::ptr(host_->X_SP));
+                // Compute the effective address we want to load from.
+                Xbyak_aarch64::XReg x_addr = host_->addr_off(addr.base_,
+                        addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+                // Load into the scratch vector, with or without broadcast.
+                if (addr.isBroadcast_)
+                    host_->ld1r(v_rhs.s, Xbyak_aarch64::ptr(x_addr));
+                else
+                    host_->ld1(v_rhs.s, Xbyak_aarch64::ptr(x_addr));
+                // The temporary register was found, therefore there is no need to keep searching.
+                break;
+            }
+        }
+    } else {
+        const Xbyak_aarch64::VReg tmp = (Xbyak_aarch64::VReg &)rhs;
+        v_rhs = tmp;
+    }
+
+    switch (binary_alg) {
+        case alg_kind::binary_add:
+            host_->uni_fadd(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_mul:
+            host_->uni_fmul(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_max:
+            host_->uni_fmax(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_min:
+            host_->uni_fmin(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_div:
+            host_->uni_fdiv(dst.s, lhs.s, v_rhs.s,
+                    Xbyak_aarch64::VReg(jit_generator_t::DUMMY_IDX).s, mask);
+            break;
+        case alg_kind::binary_sub:
+            host_->uni_fsub(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_ge:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_nlt_us);
+            break;
+        case alg_kind::binary_gt:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_nle_us);
+            break;
+        case alg_kind::binary_le:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_le_os);
+            break;
+        case alg_kind::binary_lt:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_lt_os);
+            break;
+        case alg_kind::binary_eq:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_eq_oq);
+            break;
+        case alg_kind::binary_ne:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_neq_uq);
+            break;
+        default: assert(!"unsupported algorithm");
+    }
+
+    if (isAddr) {
+        // Restore the scratch register's initial content from the stack.
+        host_->ldr(Xbyak_aarch64::QReg(v_rhs.getIdx()),
+                Xbyak_aarch64::ptr(host_->X_SP));
+        // Free allocated stack space.
+        host_->add(host_->X_SP, host_->X_SP, SIMD_SZ);
+    }
+}
+
 template <cpu_isa_t isa>
 template <typename T>
 void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
@@ -1825,20 +2110,23 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
     if (isAddr) {
         const rhs_address_t &addr = (rhs_address_t &)rhs;
         for (size_t i = 0; i < 32; i++) {
+            // Look for a temporary vector register whose index isn’t the same as lhs.
             if (lhs.getIdx() != i) {
+                // Pick the SVE vector register with index i to be the scratch register.
                 z_rhs = Vmm(i);
-                host_->str(z_rhs,
-                        Xbyak_aarch64::ptr(
-                                host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
-
+                // Allocate 1 VL space on stack
+                host_->addvl(host_->X_SP, host_->X_SP, -1);
+                // Store the scratch register into the stack so it's safe to clobber it.
+                host_->str(z_rhs, Xbyak_aarch64::ptr(host_->X_SP));
+                // Compute the effective address we want to load from.
                 Xbyak_aarch64::XReg x_addr = host_->addr_off(addr.base_,
                         addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
-
+                // Load into the scratch vector, with or without broadcast.
                 if (addr.isBroadcast_)
                     host_->ld1rw(z_rhs.s, mask, Xbyak_aarch64::ptr(x_addr));
                 else
                     host_->ld1w(z_rhs.s, mask, Xbyak_aarch64::ptr(x_addr));
-
+                // The temporary register was found, therefore there is no need to keep searching.
                 break;
             }
         }
@@ -1862,8 +2150,7 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
             break;
         case alg_kind::binary_div:
             host_->uni_fdiv(dst.s, lhs.s, z_rhs.s,
-                    Vmm(dnnl::impl::cpu::aarch64::jit_generator_t::DUMMY_IDX).s,
-                    mask);
+                    Vmm(jit_generator_t::DUMMY_IDX).s, mask);
             break;
         case alg_kind::binary_sub:
             host_->uni_fsub(dst.s, lhs.s, z_rhs.s);
@@ -1896,8 +2183,10 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
     }
 
     if (isAddr) {
-        host_->ldr(z_rhs,
-                Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+        // Restore the scratch register's initial content from the stack.
+        host_->ldr(z_rhs, Xbyak_aarch64::ptr(host_->X_SP));
+        // Free allocated stack space.
+        host_->addvl(host_->X_SP, host_->X_SP, 1);
     }
 }
 
@@ -1909,6 +2198,7 @@ void jit_uni_binary_injector_t<isa>::compute_vector(size_t idx,
 }
 
 template class jit_uni_binary_injector_t<sve>;
+template class jit_uni_binary_injector_t<asimd>;
 
 } // namespace binary_injector
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1375,7 +1375,8 @@ void jit_uni_binary_injector_t<isa>::inject_binary(
     const auto &rhs_arg_data_type = post_op.binary.src1_desc.data_type;
     const bool scalar_f32
             = rhs_addr.isBroadcast() && rhs_arg_data_type == data_type::f32;
-    const bool with_tail_not_fusable_to_binary_op = with_tail && !scalar_f32;
+    const bool with_tail_not_fusable_to_binary_op
+            = with_tail && (isa == asimd || !scalar_f32);
     const bool process_rhs_arg_using_tmp_vmm
             = rhs_arg_data_type != data_type::f32
             || with_tail_not_fusable_to_binary_op
@@ -1404,7 +1405,10 @@ void jit_uni_binary_injector_t<isa>::inject_binary(
                     && "Opmask is not set for tail loading on SVE");
             const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
             mask = tail_opmask;
-            host_->mov(dst.s, mask / Xbyak_aarch64::T_z, dst.s);
+            // zero inactive lanes
+            host_->mov(Xbyak_aarch64::ZRegS(dst.getIdx()),
+                    mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ZRegS(dst.getIdx()));
         }
 
         execute_binary(alg, dst, mask, lhs, rhs_addr);
@@ -1448,7 +1452,7 @@ rhs_address_t jit_uni_binary_injector_t<isa>::remove_bcast_bit(
 
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::cvt_to_f32(const Vmm &tmp_vmm) const {
-    host_->scvtf(tmp_vmm.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, tmp_vmm.s);
+    host_->uni_scvtf(tmp_vmm.s, tmp_vmm.s);
 }
 
 template <cpu_isa_t isa>
@@ -1474,6 +1478,27 @@ void jit_uni_binary_injector_t<isa>::execute_broadcast_no_tail(
             break;
         default: assert(!"unsupported data type");
     }
+}
+
+template <>
+void jit_uni_binary_injector_t<asimd>::execute_broadcast_s8u8_no_tail(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    assert(utils::one_of(data_type, data_type::s8, data_type::u8)
+            && "unsupported data type");
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(rhs_addr.base_,
+            rhs_addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+
+    if (data_type == data_type::s8) {
+        // load byte from memory into wtmp and sign-extend
+        host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+    } else if (data_type == data_type::u8) {
+        // unsigned load
+        host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+    }
+    // broadcast into 4x32-bit
+    host_->dup(tmp_vmm.s4, host_->W_TMP_0);
 }
 
 template <cpu_isa_t isa>
@@ -1529,6 +1554,41 @@ void jit_uni_binary_injector_t<isa>::execute_broadcast_tail_with_opmask(
     }
 }
 
+template <>
+void jit_uni_binary_injector_t<asimd>::execute_broadcast_tail_with_opmask(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(
+            rhs_addr.base_, rhs_addr.offt_, host_->X_TMP_1, host_->X_TMP_0);
+
+    host_->uni_clear(tmp_vmm);
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+            host_->ld1(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[0],
+                    Xbyak_aarch64::ptr(x_addr));
+            for (size_t i = 1; i < rhs_arg_static_params_.tail_size; ++i) {
+                host_->ins(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[0]);
+            }
+            break;
+        case data_type::s8:
+        case data_type::u8:;
+            if (data_type == data_type::s8) {
+                host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+            } else {
+                host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(x_addr));
+            }
+            for (size_t i = 0; i < rhs_arg_static_params_.tail_size; ++i) {
+                host_->ins(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        host_->W_TMP_0);
+            }
+            break;
+        default: assert(!"unsupported data type");
+    }
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::load_rhs_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
@@ -1548,6 +1608,30 @@ void jit_uni_binary_injector_t<isa>::load_rhs_no_tail(
     }
 }
 
+template <>
+void jit_uni_binary_injector_t<asimd>::load_rhs_i8_no_tail(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    assert(utils::one_of(data_type, data_type::s8, data_type::u8)
+            && "unsupported data type");
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(rhs_addr.base_,
+            rhs_addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+
+    host_->ld1(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[0],
+            Xbyak_aarch64::ptr(x_addr));
+    if (data_type == data_type::u8) {
+        host_->uxtl(tmp_vmm.h8,
+                tmp_vmm.b8); // zero-extend low 8 bytes to 8 uint16 lanes
+        host_->uxtl(tmp_vmm.s4, tmp_vmm.h4); // low four u16 -> u32
+    } else if (data_type == data_type::s8) {
+        host_->sxtl(tmp_vmm.h8,
+                tmp_vmm.b8); // zero-extend low 8 bytes to 8 int16 lanes
+        host_->sxtl(tmp_vmm.s4, tmp_vmm.h4); // low four s16 -> s32
+    } else
+        assert(!"unsupported data type");
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::load_rhs_i8_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
@@ -1564,6 +1648,45 @@ void jit_uni_binary_injector_t<isa>::load_rhs_i8_no_tail(
                 Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
     } else
         assert(!"unsupported data type");
+}
+
+template <>
+void jit_uni_binary_injector_t<asimd>::load_rhs_tail_dynamically_with_opmask(
+        const data_type_t &data_type, const Xbyak_aarch64::VReg &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(
+            rhs_addr.base_, rhs_addr.offt_, host_->X_TMP_1, host_->X_TMP_0);
+
+    host_->uni_clear(tmp_vmm);
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+            for (size_t i = 0; i < rhs_arg_static_params_.tail_size; ++i) {
+                const Xbyak_aarch64::XReg lane_addr
+                        = host_->addr_off(x_addr, i * sizeof(float),
+                                host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+                host_->ld1(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        Xbyak_aarch64::ptr(lane_addr));
+            }
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            for (size_t i = 0; i < rhs_arg_static_params_.tail_size; ++i) {
+                const Xbyak_aarch64::XReg lane_addr
+                        = host_->addr_off(x_addr, i * sizeof(int8_t),
+                                host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+                if (data_type == data_type::s8) {
+                    host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(lane_addr));
+                } else {
+                    host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(lane_addr));
+                }
+                host_->ins(Xbyak_aarch64::VReg4S(tmp_vmm.getIdx())[i],
+                        host_->W_TMP_0);
+            }
+            break;
+        default: assert(!"unsupported data type");
+    }
 }
 
 template <cpu_isa_t isa>
@@ -1797,6 +1920,42 @@ void get_v_rhs_value(
     }
 }
 
+template <>
+void jit_uni_binary_injector_t<asimd>::execute_cmp_binary(
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::PReg &mask,
+        const Xbyak_aarch64::VReg &lhs, const Xbyak_aarch64::VReg &rhs,
+        const unsigned int cmp_predicate) const {
+    UNUSED(mask);
+
+    switch (cmp_predicate) {
+        case jit_generator_t::_cmp_nlt_us:
+            host_->fcmge(dst.s, lhs.s, rhs.s);
+            break;
+        case jit_generator_t::_cmp_nle_us:
+            host_->fcmgt(dst.s, lhs.s, rhs.s);
+            break;
+        case jit_generator_t::_cmp_le_os:
+            host_->fcmge(dst.s, rhs.s, lhs.s);
+            break;
+        case jit_generator_t::_cmp_lt_os:
+            host_->fcmgt(dst.s, rhs.s, lhs.s);
+            break;
+        case jit_generator_t::_cmp_eq_oq:
+            host_->fcmeq(dst.s, lhs.s, rhs.s);
+            break;
+        case jit_generator_t::_cmp_neq_uq:
+            host_->fcmeq(dst.s, lhs.s, rhs.s);
+            host_->not_(dst.b, dst.b);
+            break;
+        default: assert(!"unsupported compare mode"); break;
+    }
+
+    // ASIMD compare instructions produce all-ones/all-zeros integer masks.
+    // Convert them to the expected 1.0f / 0.0f compare result in place.
+    host_->ushr(dst.s, dst.s, 31);
+    host_->scvtf(dst.s, dst.s);
+}
+
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::execute_cmp_binary(const Vmm &dst,
         const Xbyak_aarch64::PReg &mask, const Vmm &lhs, const Vmm &rhs,
@@ -1814,6 +1973,100 @@ void jit_uni_binary_injector_t<isa>::execute_cmp_binary(const Vmm &dst,
     pop_opmask(host_, cmp_mask);
 }
 
+template <>
+template <typename T>
+void jit_uni_binary_injector_t<asimd>::execute_binary(alg_kind_t binary_alg,
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::PReg &mask,
+        const Xbyak_aarch64::VReg &lhs, const T &rhs) const {
+    const int SIMD_SZ = simd_bytes(asimd);
+    const bool isAddr = std::is_same<T, rhs_address_t>::value;
+    Xbyak_aarch64::VReg v_rhs(0);
+
+    if (isAddr) {
+        const rhs_address_t &addr = (rhs_address_t &)rhs;
+        for (size_t i = 0; i < 32; i++) {
+            // Look for a temporary vector register whose index isn’t the same as lhs.
+            if (lhs.getIdx() != i) {
+                // Pick the SIMD vector register with index i to be the scratch register.
+                v_rhs = Xbyak_aarch64::VReg(i);
+                // Allocate space on stack
+                host_->sub(host_->X_SP, host_->X_SP, SIMD_SZ);
+                // Store the scratch register into the stack so it's safe to clobber it.
+                host_->str(Xbyak_aarch64::QReg(i),
+                        Xbyak_aarch64::ptr(host_->X_SP));
+                // Compute the effective address we want to load from.
+                Xbyak_aarch64::XReg x_addr = host_->addr_off(addr.base_,
+                        addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+                // Load into the scratch vector, with or without broadcast.
+                if (addr.isBroadcast_)
+                    host_->ld1r(v_rhs.s, Xbyak_aarch64::ptr(x_addr));
+                else
+                    host_->ld1(v_rhs.s, Xbyak_aarch64::ptr(x_addr));
+                // The temporary register was found, therefore there is no need to keep searching.
+                break;
+            }
+        }
+    } else {
+        const Xbyak_aarch64::VReg tmp = (Xbyak_aarch64::VReg &)rhs;
+        v_rhs = tmp;
+    }
+
+    switch (binary_alg) {
+        case alg_kind::binary_add:
+            host_->uni_fadd(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_mul:
+            host_->uni_fmul(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_max:
+            host_->uni_fmax(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_min:
+            host_->uni_fmin(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_div:
+            host_->uni_fdiv(dst.s, lhs.s, v_rhs.s,
+                    Xbyak_aarch64::VReg(jit_generator_t::DUMMY_IDX).s, mask);
+            break;
+        case alg_kind::binary_sub:
+            host_->uni_fsub(dst.s, lhs.s, v_rhs.s);
+            break;
+        case alg_kind::binary_ge:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_nlt_us);
+            break;
+        case alg_kind::binary_gt:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_nle_us);
+            break;
+        case alg_kind::binary_le:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_le_os);
+            break;
+        case alg_kind::binary_lt:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_lt_os);
+            break;
+        case alg_kind::binary_eq:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_eq_oq);
+            break;
+        case alg_kind::binary_ne:
+            execute_cmp_binary(
+                    dst, mask, lhs, v_rhs, jit_generator_t::_cmp_neq_uq);
+            break;
+        default: assert(!"unsupported algorithm");
+    }
+
+    if (isAddr) {
+        // Restore the scratch register's initial content from the stack.
+        host_->ldr(Xbyak_aarch64::QReg(v_rhs.getIdx()),
+                Xbyak_aarch64::ptr(host_->X_SP));
+        // Free allocated stack space.
+        host_->add(host_->X_SP, host_->X_SP, SIMD_SZ);
+    }
+}
+
 template <cpu_isa_t isa>
 template <typename T>
 void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
@@ -1825,20 +2078,23 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
     if (isAddr) {
         const rhs_address_t &addr = (rhs_address_t &)rhs;
         for (size_t i = 0; i < 32; i++) {
+            // Look for a temporary vector register whose index isn’t the same as lhs.
             if (lhs.getIdx() != i) {
+                // Pick the SVE vector register with index i to be the scratch register.
                 z_rhs = Vmm(i);
-                host_->str(z_rhs,
-                        Xbyak_aarch64::ptr(
-                                host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
-
+                // Allocate 1 VL space on stack
+                host_->addvl(host_->X_SP, host_->X_SP, -1);
+                // Store the scratch register into the stack so it's safe to clobber it.
+                host_->str(z_rhs, Xbyak_aarch64::ptr(host_->X_SP));
+                // Compute the effective address we want to load from.
                 Xbyak_aarch64::XReg x_addr = host_->addr_off(addr.base_,
                         addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
-
+                // Load into the scratch vector, with or without broadcast.
                 if (addr.isBroadcast_)
                     host_->ld1rw(z_rhs.s, mask, Xbyak_aarch64::ptr(x_addr));
                 else
                     host_->ld1w(z_rhs.s, mask, Xbyak_aarch64::ptr(x_addr));
-
+                // The temporary register was found, therefore there is no need to keep searching.
                 break;
             }
         }
@@ -1862,8 +2118,7 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
             break;
         case alg_kind::binary_div:
             host_->uni_fdiv(dst.s, lhs.s, z_rhs.s,
-                    Vmm(dnnl::impl::cpu::aarch64::jit_generator_t::DUMMY_IDX).s,
-                    mask);
+                    Vmm(jit_generator_t::DUMMY_IDX).s, mask);
             break;
         case alg_kind::binary_sub:
             host_->uni_fsub(dst.s, lhs.s, z_rhs.s);
@@ -1896,8 +2151,10 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
     }
 
     if (isAddr) {
-        host_->ldr(z_rhs,
-                Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+        // Restore the scratch register's initial content from the stack.
+        host_->ldr(z_rhs, Xbyak_aarch64::ptr(host_->X_SP));
+        // Free allocated stack space.
+        host_->addvl(host_->X_SP, host_->X_SP, 1);
     }
 }
 
@@ -1909,6 +2166,7 @@ void jit_uni_binary_injector_t<isa>::compute_vector(size_t idx,
 }
 
 template class jit_uni_binary_injector_t<sve>;
+template class jit_uni_binary_injector_t<asimd>;
 
 } // namespace binary_injector
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -242,7 +242,7 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
                     }
                     break;
                 case binary:
-                    if (entry.is_binary()) { return false; }
+                    if (entry.is_binary()) { return isa == asimd; }
                     break;
                 default: assert(false && "Unhandled post_op type");
             }
@@ -258,6 +258,7 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
 }
 
 template class jit_uni_postops_injector_t<sve>;
+template class jit_uni_postops_injector_t<asimd>;
 
 } // namespace injector
 } // namespace aarch64

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -482,6 +482,16 @@ public:
         fmax(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src2);
     }
 
+    void uni_fmax(const Xbyak_aarch64::VReg4S &dst,
+            const Xbyak_aarch64::VReg4S &src,
+            const Xbyak_aarch64::VReg4S &src2) {
+        uint32_t dstIdx = dst.getIdx();
+        uint32_t srcIdx = src.getIdx();
+        if (dstIdx != srcIdx)
+            mov(Xbyak_aarch64::ZRegD(dstIdx), Xbyak_aarch64::ZRegD(srcIdx));
+        fmax(dst, src, src2);
+    }
+
     template <typename T>
     void uni_fmaxnm(const T &dst, const T &src, const T &src2) {
         uint32_t dstIdx = dst.getIdx();
@@ -504,6 +514,16 @@ public:
         if (dstIdx != srcIdx)
             mov(Xbyak_aarch64::ZRegD(dstIdx), Xbyak_aarch64::ZRegD(srcIdx));
         fmin(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src2);
+    }
+
+    void uni_fmin(const Xbyak_aarch64::VReg4S &dst,
+            const Xbyak_aarch64::VReg4S &src,
+            const Xbyak_aarch64::VReg4S &src2) {
+        uint32_t dstIdx = dst.getIdx();
+        uint32_t srcIdx = src.getIdx();
+        if (dstIdx != srcIdx)
+            mov(Xbyak_aarch64::ZRegD(dstIdx), Xbyak_aarch64::ZRegD(srcIdx));
+        fmin(dst, src, src2);
     }
 
     template <typename T>

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -482,6 +482,16 @@ public:
         fmax(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src2);
     }
 
+    void uni_fmax(const Xbyak_aarch64::VReg4S &dst,
+            const Xbyak_aarch64::VReg4S &src,
+            const Xbyak_aarch64::VReg4S &src2) {
+        uint32_t dstIdx = dst.getIdx();
+        uint32_t srcIdx = src.getIdx();
+        if (dstIdx != srcIdx)
+            mov(Xbyak_aarch64::VReg16B(dstIdx), Xbyak_aarch64::VReg16B(srcIdx));
+        fmax(dst, src, src2);
+    }
+
     template <typename T>
     void uni_fmaxnm(const T &dst, const T &src, const T &src2) {
         uint32_t dstIdx = dst.getIdx();
@@ -506,9 +516,42 @@ public:
         fmin(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src2);
     }
 
+    void uni_fmin(const Xbyak_aarch64::VReg4S &dst,
+            const Xbyak_aarch64::VReg4S &src,
+            const Xbyak_aarch64::VReg4S &src2) {
+        uint32_t dstIdx = dst.getIdx();
+        uint32_t srcIdx = src.getIdx();
+        if (dstIdx != srcIdx)
+            mov(Xbyak_aarch64::VReg16B(dstIdx), Xbyak_aarch64::VReg16B(srcIdx));
+        fmin(dst, src, src2);
+    }
+
     template <typename T>
     void uni_fmul(const T &dst, const T &src, const T &src2) {
         fmul(dst, src, src2);
+    }
+
+    void float_point_fused_multiply_add(const Xbyak_aarch64::ZReg &dst_vmm,
+            const Xbyak_aarch64::ZReg &src1_vmm,
+            const Xbyak_aarch64::ZReg &src2_vmm) {
+        fmla(dst_vmm.s, P_ALL_ONE / Xbyak_aarch64::T_m, src1_vmm.s, src2_vmm.s);
+    }
+
+    void float_point_fused_multiply_add(const Xbyak_aarch64::VReg &dst_vmm,
+            const Xbyak_aarch64::VReg &src1_vmm,
+            const Xbyak_aarch64::VReg &src2_vmm) {
+        fmla(dst_vmm.s, src1_vmm.s, src2_vmm.s);
+    }
+
+    void contiguous_load_unsigned_words(const Xbyak_aarch64::ZReg &src_vmm,
+            const Xbyak_aarch64::XReg &addr) {
+        ld1w(src_vmm.s, P_ALL_ONE / Xbyak_aarch64::T_z,
+                Xbyak_aarch64::ptr(addr));
+    }
+
+    void contiguous_load_unsigned_words(const Xbyak_aarch64::VReg &src_vmm,
+            const Xbyak_aarch64::XReg &addr) {
+        ld1(src_vmm.s, Xbyak_aarch64::ptr(addr));
     }
 
     void uni_frinti(

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -81,21 +81,13 @@ static bool data_type_supported(const data_type_t dtype) {
     return utils::one_of(dtype, f32, s8, u8);
 }
 
-static cpu_isa_t get_supported_isa() {
-    if (mayiuse(sve_512)) return sve_512;
-    if (mayiuse(sve_256)) return sve_256;
-    if (mayiuse(sve_128)) return sve_128;
-
-    return isa_undef;
-}
-
 static bool data_format_supported(
         const memory_desc_wrapper &mdw, const cpu_isa_t isa) {
     if (mdw.is_plain()) return true;
     const auto blk_size = mdw.blocking_desc().inner_blks[0];
     return (is_superset(isa, sve_512) && utils::one_of(blk_size, 16, 8, 4))
             || (is_superset(isa, sve_256) && utils::one_of(blk_size, 8, 4))
-            || (is_superset(isa, sve_128) && blk_size == 4);
+            || (is_superset(isa, asimd) && blk_size == 4);
 }
 
 status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
@@ -113,7 +105,7 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     const int elt_idx = po.find(primitive_kind::eltwise);
     conf_.is_i8 = utils::one_of(conf_.dst_type, s8, u8);
 
-    conf_.isa = get_supported_isa();
+    conf_.isa = get_max_cpu_isa();
 
     // This primitive currently (as of oneDNN v3.9) supports all binary
     // algorithms except binary_select. However we check the supported
@@ -468,7 +460,7 @@ bool jit_uni_binary_t::post_ops_ok(const primitive_attr_t *attr,
 
     const auto is_binary = [&](int idx) { return p.entry_[idx].is_binary(); };
 
-    if (!mayiuse(sve_128)) return false;
+    if (!mayiuse(asimd)) return false;
 
     for (int i = 0; i < p.len(); i++) {
         if (p.contain(primitive_kind::sum, i)) {
@@ -549,6 +541,10 @@ binary_kernel_t *create_binary_kernel(
     } else if (is_superset(conf.isa, sve_128)
             && (blk_size == 4 || is_plain_layout)) {
         using kernel_t = jit_uni_binary_kernel_t<sve_128>;
+        return new kernel_t(pd, conf, tail_kernel && !conf.is_i8);
+    } else if (is_superset(conf.isa, asimd)
+            && (blk_size == 4 || is_plain_layout)) {
+        using kernel_t = jit_uni_binary_kernel_t<asimd>;
         return new kernel_t(pd, conf, tail_kernel && !conf.is_i8);
     } else {
         assert(!"unreachable");

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -152,8 +152,9 @@ void jit_uni_binary_kernel_t<isa>::apply_postops(int unroll, bool tail) {
                     ->load(dst_ptr(offt
                                    * types::data_type_size(conf_.dst_type)),
                             offt, vreg_tmp, tail);
-            fmla(ZRegS(vreg_tmp_src0.getIdx()), P_ALL_ONE / Xbyak_aarch64::T_m,
-                    ZRegS(vreg_tmp.getIdx()), ZRegS(vreg_sum_scale_.getIdx()));
+            io_.at(conf_.src0_type)
+                    ->float_point_fused_multiply_add(
+                            vreg_tmp_src0, vreg_tmp, vreg_sum_scale_);
         }
     };
 
@@ -203,8 +204,8 @@ void jit_uni_binary_kernel_t<isa>::load_kernel_params() {
     mov(reg_offt_dst_, reg_dst_);
     if (conf_.is_src_different_layouts) {
         ldr(X_DEFAULT_ADDR, Xbyak_aarch64::ptr(reg_param_, PARAM_OFF(indices)));
-        ld1w(vmm_indices_.s, P_ALL_ONE / Xbyak_aarch64::T_z,
-                ptr(X_DEFAULT_ADDR));
+        io_.at(conf_.src1_type)
+                ->contiguous_load_unsigned_words(vmm_indices_, X_DEFAULT_ADDR);
         ldr(reg_src1_stride_range_,
                 ptr(reg_param_, PARAM_OFF(src1_stride_range)));
         mov(reg_reverse_src1_stride_range_, reg_src1_stride_range_);
@@ -237,140 +238,241 @@ XReg jit_uni_binary_kernel_t<isa>::dst_ptr(size_t offt) {
     return X_DEFAULT_ADDR;
 }
 
+namespace {
+enum class cmp_mode_t : unsigned int {
+    eq_oq,
+    lt_os,
+    le_os,
+    unord_q,
+    neq_uq,
+    nlt_us,
+    nle_us,
+    ord_q,
+    eq_uq,
+    nge_us,
+    ngt_us,
+    false_oq,
+    neq_oq,
+    ge_os,
+    gt_os,
+    true_uq,
+    eq_os,
+    lt_oq,
+    le_oq,
+    unord_s,
+    neq_us,
+    nlt_uq,
+    nle_uq,
+    ord_s,
+    eq_us,
+    nge_uq,
+    ngt_uq,
+    false_os,
+    neq_os,
+    ge_oq,
+    gt_oq,
+    true_us,
+};
+}
+
 template <cpu_isa_t isa>
-unsigned int jit_uni_binary_kernel_t<isa>::cmp_predicate(alg_kind_t alg) {
+unsigned int jit_uni_binary_kernel_t<isa>::get_cmp_alg_enum(alg_kind_t alg) {
     using namespace alg_kind;
     switch (alg) {
-        case binary_ge: return _cmp_nlt_us;
-        case binary_gt: return _cmp_nle_us;
-        case binary_le: return _cmp_le_os;
-        case binary_lt: return _cmp_lt_os;
-        case binary_eq: return _cmp_eq_oq;
-        case binary_ne: return _cmp_neq_uq;
-        default: assert(!"not supported operation!"); return -1;
+        case binary_ge: return static_cast<unsigned int>(cmp_mode_t::nlt_us);
+        case binary_gt: return static_cast<unsigned int>(cmp_mode_t::nle_us);
+        case binary_le: return static_cast<unsigned int>(cmp_mode_t::le_os);
+        case binary_lt: return static_cast<unsigned int>(cmp_mode_t::lt_os);
+        case binary_eq: return static_cast<unsigned int>(cmp_mode_t::eq_oq);
+        case binary_ne: return static_cast<unsigned int>(cmp_mode_t::neq_uq);
+        default:
+            assert(!"not supported operation!");
+            return static_cast<unsigned int>(cmp_mode_t::eq_oq);
+    }
+}
+
+template <>
+template <>
+void jit_uni_binary_kernel_t<asimd>::compute_cmp_alg(const VReg &dst,
+        const VReg &src, const VReg &src2, const unsigned int uimm) {
+    switch (static_cast<cmp_mode_t>(uimm)) {
+        case cmp_mode_t::eq_oq: // this code repeats several times...
+            fcmeq(dst.s, src.s, src2.s);
+            break;
+        case cmp_mode_t::lt_os:
+            // a < b equal false implies that b > a equal true
+            fcmgt(dst.s, src2.s, src.s);
+            break;
+        case cmp_mode_t::le_os:
+            // a <= b equal false implies that b >= a equal true
+            fcmge(dst.s, src2.s, src.s);
+            break;
+        case cmp_mode_t::neq_uq:
+            // use fcmeq to compare for equality and then "not" the mask to get !=
+            fcmeq(dst.s, src.s, src2.s);
+            not_(dst.b, dst.b);
+            break;
+        case cmp_mode_t::nlt_us: fcmge(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::nle_us: fcmgt(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::eq_uq: fcmeq(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::nge_us: fcmgt(dst.s, src2.s, src.s); break;
+        case cmp_mode_t::ngt_us: fcmge(dst.s, src2.s, src.s); break;
+        case cmp_mode_t::neq_oq:
+            fcmeq(dst.s, src.s, src2.s);
+            not_(dst.b, dst.b);
+            break;
+        case cmp_mode_t::ge_os: fcmge(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::gt_os: fcmgt(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::eq_os: fcmeq(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::lt_oq: fcmgt(dst.s, src2.s, src.s); break;
+        case cmp_mode_t::le_oq: fcmge(dst.s, src2.s, src.s); break;
+        case cmp_mode_t::neq_us:
+            fcmeq(dst.s, src.s, src2.s);
+            not_(dst.b, dst.b);
+            break;
+        case cmp_mode_t::nlt_uq: fcmge(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::nle_uq: fcmgt(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::eq_us: fcmeq(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::nge_uq: fcmgt(dst.s, src2.s, src.s); break;
+        case cmp_mode_t::ngt_uq: fcmge(dst.s, src2.s, src.s); break;
+        case cmp_mode_t::neq_os:
+            fcmeq(dst.s, src.s, src2.s);
+            not_(dst.b, dst.b);
+            break;
+        case cmp_mode_t::ge_oq: fcmge(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::gt_oq: fcmgt(dst.s, src.s, src2.s); break;
+        case cmp_mode_t::unord_q:
+        case cmp_mode_t::ord_q:
+        case cmp_mode_t::false_oq:
+        case cmp_mode_t::true_uq:
+        case cmp_mode_t::unord_s:
+        case cmp_mode_t::ord_s:
+        case cmp_mode_t::false_os:
+        case cmp_mode_t::true_us: assert(!"unsupported compare mode"); break;
     }
 }
 
 template <cpu_isa_t isa>
-void jit_uni_binary_kernel_t<isa>::compute_cmp_mask(
-        const Xbyak_aarch64::PReg &dst, const Vmm &src, const Vmm &src2,
-        const unsigned int uimm) {
-    enum {
-        EQ_OQ = 0,
-        LT_OS = 1,
-        LE_OS = 2,
-        UNORD_Q = 3,
-        NEQ_UQ = 4,
-        NLT_US = 5,
-        NLE_US = 6,
-        ORD_Q = 7,
-        EQ_UQ = 8,
-        NGE_US = 9,
-        NGT_US = 10,
-        FALSE_OQ = 11,
-        NEQ_OQ = 12,
-        GE_OS = 13,
-        GT_OS = 14,
-        TRUE_UQ = 15,
-        EQ_OS = 16,
-        LT_OQ = 17,
-        LE_OQ = 18,
-        UNORD_S = 19,
-        NEQ_US = 20,
-        NLT_UQ = 21,
-        NLE_UQ = 22,
-        ORD_S = 23,
-        EQ_US = 24,
-        NGE_UQ = 25,
-        NGT_UQ = 26,
-        FALSE_OS = 27,
-        NEQ_OS = 28,
-        GE_OQ = 29,
-        GT_OQ = 30,
-        TRUE_US = 31,
-    };
+template <typename T>
+void jit_uni_binary_kernel_t<isa>::compute_cmp_alg(const T &dst, const Vmm &src,
+        const Vmm &src2, const unsigned int uimm) {
+    switch (static_cast<cmp_mode_t>(uimm)) {
+        case cmp_mode_t::eq_oq:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::lt_os:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::le_os:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::neq_uq:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::nlt_us:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::nle_us:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::eq_uq:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::nge_us:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::ngt_us:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::neq_oq:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::ge_os:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::gt_os:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::eq_os:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::lt_oq:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::le_oq:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::neq_us:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::nlt_uq:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::nle_uq:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::eq_us:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::nge_uq:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::ngt_uq:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::neq_os:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::ge_oq:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::gt_oq:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case cmp_mode_t::unord_q:
+        case cmp_mode_t::ord_q:
+        case cmp_mode_t::false_oq:
+        case cmp_mode_t::true_uq:
+        case cmp_mode_t::unord_s:
+        case cmp_mode_t::ord_s:
+        case cmp_mode_t::false_os:
+        case cmp_mode_t::true_us: assert(!"unsupported compare mode"); break;
+    }
+}
 
-    switch (uimm) {
-        case EQ_OQ:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LT_OS:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LE_OS:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_UQ:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLT_US:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLE_US:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case EQ_UQ:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGE_US:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGT_US:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_OQ:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GE_OS:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GT_OS:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case EQ_OS:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LT_OQ:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LE_OQ:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_US:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLT_UQ:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLE_UQ:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case EQ_US:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGE_UQ:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGT_UQ:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_OS:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GE_OQ:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GT_OQ:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case UNORD_Q:
-        case ORD_Q:
-        case FALSE_OQ:
-        case TRUE_UQ:
-        case UNORD_S:
-        case ORD_S:
-        case FALSE_OS:
-        case TRUE_US: assert(!"unsupported compare mode"); break;
+template <>
+void jit_uni_binary_kernel_t<asimd>::perform_op(const VReg &v0, const VReg &v1,
+        const VReg &s_src0, const VReg &s_src1) {
+    using namespace alg_kind;
+    const auto alg = pd_->desc()->alg_kind;
+    const bool cmp_op = utils::one_of(alg, alg_kind::binary_ge,
+            alg_kind::binary_gt, alg_kind::binary_le, alg_kind::binary_lt,
+            alg_kind::binary_eq, alg_kind::binary_ne);
+    if (conf_.do_scale_src0) uni_fmul(v0.s, v0.s, s_src0.s);
+    if (conf_.do_scale_src1 && offt_src1_ != 0 && !conf_.broadcast_src1_value)
+        uni_fmul(v1.s, v1.s, s_src1.s);
+
+    if (alg == binary_add)
+        uni_fadd(v0.s, v0.s, v1.s);
+    else if (alg == binary_mul)
+        uni_fmul(v0.s, v0.s, v1.s);
+    else if (alg == binary_max)
+        uni_fmax(v0.s, v0.s, v1.s);
+    else if (alg == binary_min)
+        uni_fmin(v0.s, v0.s, v1.s);
+    else if (alg == binary_div)
+        uni_fdiv(v0.s, v0.s, v1.s);
+    else if (alg == binary_sub)
+        uni_fsub(v0.s, v0.s, v1.s);
+    else if (cmp_op) {
+        const unsigned int alg_enum = get_cmp_alg_enum(alg);
+        compute_cmp_alg(v0, v0, v1, alg_enum);
+        // ASIMD compare instructions produce all-ones/all-zeros integer masks.
+        // Convert them to the expected 1.0f / 0.0f compare result in place.
+        ushr(v0.s, v0.s, 31);
+        scvtf(v0.s, v0.s);
+    } else {
+        assert(!"not supported operation!");
     }
 }
 
@@ -399,9 +501,9 @@ void jit_uni_binary_kernel_t<isa>::perform_op(
     else if (alg == binary_sub)
         uni_fsub(v0.s, v0.s, v1.s);
     else if (cmp_op) {
-        const unsigned int predicate = cmp_predicate(alg);
+        const unsigned int alg_enum = get_cmp_alg_enum(alg);
         if (is_superset(isa, sve_128)) {
-            compute_cmp_mask(cmp_mask, v0, v1, predicate);
+            compute_cmp_alg(cmp_mask, v0, v1, alg_enum);
             eor(v0.d, v0.d, v0.d);
             fmov(v0.s, cmp_mask / Xbyak_aarch64::T_m, 1.0);
         } else {
@@ -442,7 +544,7 @@ void jit_uni_binary_kernel_t<isa>::pop(const Xbyak_aarch64::XReg &reg) {
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::uni_broadcast(
         const Vmm &dst, const Xbyak_aarch64::XReg &addr) {
-    ld1rw(ZRegS(dst.getIdx()), P_ALL_ONE, Xbyak_aarch64::ptr(addr));
+    io_.at(conf_.dst_type)->load_and_broadcast(dst, addr);
 }
 
 template <cpu_isa_t isa>
@@ -498,7 +600,6 @@ void jit_uni_binary_kernel_t<isa>::store(int unroll, bool tail) {
 
             if (zero_pad_left >= simd_w_ - tail_size_) {
                 uni_clear(vreg_zero_);
-                movprfx(vreg_zero_.s, tail_opmask_ / T_m, vreg_tmp_src0.s);
                 io_.at(conf_.dst_type)
                         ->store(vreg_zero_, dst_ptr(offt * dt_size), 0, false);
                 off_base = simd_w_ * dt_size;
@@ -558,7 +659,9 @@ void jit_uni_binary_kernel_t<isa>::compute_dst_body(int unroll, bool tail) {
 
         // avoid multiple multiplication on input scale for broadcasted vreg
         // not needed for different layouts
-        if (!conf_.is_src_different_layouts) mov(vreg_tmp.d, vreg_tmp_src1.d);
+        if (!conf_.is_src_different_layouts) {
+            mov(VReg16B(vreg_tmp.getIdx()), VReg16B(vreg_tmp_src1.getIdx()));
+        }
         perform_op(
                 vreg_tmp_src0, vreg_tmp, vreg_scales_src0_, vreg_scales_src1_);
     }
@@ -584,7 +687,11 @@ void jit_uni_binary_kernel_t<isa>::forward() {
     // if outer dims tail, do it outside outer dims loop
     if (!is_src1_outer_dims_tail_) {
         if (conf_.is_i8) {
-            uni_clear(ZReg(vreg_zero_.getIdx()));
+            if (isa == asimd) {
+                uni_clear(VReg(vreg_zero_.getIdx()));
+            } else {
+                uni_clear(ZReg(vreg_zero_.getIdx()));
+            }
             io_.init_saturate_f32({conf_.dst_type});
             eor(reg_offt_dst_, reg_offt_dst_,
                     reg_offt_dst_); // offt_dst to get addr of dst
@@ -606,10 +713,13 @@ void jit_uni_binary_kernel_t<isa>::forward() {
     const bool treat_each_compute_step_as_tail
             = !conf_.is_i8 && is_tail_kernel_ && tail_size_;
 
-    if (conf_.do_scale_src0)
-        ld1rw(vreg_scales_src0_.s, P_ALL_ONE / T_z, ptr(reg_scales_src0_));
+    if (conf_.do_scale_src0) {
+        io_.at(conf_.src0_type)
+                ->load_and_broadcast(vreg_scales_src0_, reg_scales_src0_);
+    }
     if (conf_.do_scale_src1) {
-        ld1rw(vreg_scales_src1_.s, P_ALL_ONE / T_z, ptr(reg_scales_src1_));
+        io_.at(conf_.src1_type)
+                ->load_and_broadcast(vreg_scales_src1_, reg_scales_src1_);
         if (conf_.broadcast_src1_value || offt_src1_ == 0)
             uni_fmul(vreg_bcast_src1_.s, vreg_bcast_src1_.s,
                     vreg_scales_src1_.s);
@@ -700,7 +810,11 @@ void jit_uni_binary_kernel_t<isa>::forward_over_outer_dims() {
             = conf_.outer_dims * types::data_type_size(conf_.dst_type);
 
     if (conf_.is_i8) {
-        uni_clear(ZReg(vreg_zero_.getIdx()));
+        if (isa == asimd) {
+            uni_clear(VReg(vreg_zero_.getIdx()));
+        } else {
+            uni_clear(ZReg(vreg_zero_.getIdx()));
+        }
         io_.init_saturate_f32({conf_.dst_type});
         eor(reg_offt_dst_, reg_offt_dst_,
                 reg_offt_dst_); // offt_dst to get addr of dst
@@ -748,6 +862,7 @@ void jit_uni_binary_kernel_t<isa>::generate() {
 
 #undef PARAM_OFF
 
+template struct jit_uni_binary_kernel_t<asimd>;
 template struct jit_uni_binary_kernel_t<sve_512>;
 template struct jit_uni_binary_kernel_t<sve_256>;
 template struct jit_uni_binary_kernel_t<sve_128>;

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -152,8 +152,8 @@ void jit_uni_binary_kernel_t<isa>::apply_postops(int unroll, bool tail) {
                     ->load(dst_ptr(offt
                                    * types::data_type_size(conf_.dst_type)),
                             offt, vreg_tmp, tail);
-            fmla(ZRegS(vreg_tmp_src0.getIdx()), P_ALL_ONE / Xbyak_aarch64::T_m,
-                    ZRegS(vreg_tmp.getIdx()), ZRegS(vreg_sum_scale_.getIdx()));
+            this->float_point_fused_multiply_add(
+                    vreg_tmp_src0, vreg_tmp, vreg_sum_scale_);
         }
     };
 
@@ -203,8 +203,7 @@ void jit_uni_binary_kernel_t<isa>::load_kernel_params() {
     mov(reg_offt_dst_, reg_dst_);
     if (conf_.is_src_different_layouts) {
         ldr(X_DEFAULT_ADDR, Xbyak_aarch64::ptr(reg_param_, PARAM_OFF(indices)));
-        ld1w(vmm_indices_.s, P_ALL_ONE / Xbyak_aarch64::T_z,
-                ptr(X_DEFAULT_ADDR));
+        this->contiguous_load_unsigned_words(vmm_indices_, X_DEFAULT_ADDR);
         ldr(reg_src1_stride_range_,
                 ptr(reg_param_, PARAM_OFF(src1_stride_range)));
         mov(reg_reverse_src1_stride_range_, reg_src1_stride_range_);
@@ -237,140 +236,91 @@ XReg jit_uni_binary_kernel_t<isa>::dst_ptr(size_t offt) {
     return X_DEFAULT_ADDR;
 }
 
-template <cpu_isa_t isa>
-unsigned int jit_uni_binary_kernel_t<isa>::cmp_predicate(alg_kind_t alg) {
+template <>
+template <>
+void jit_uni_binary_kernel_t<asimd>::compute_cmp_alg(
+        const VReg &dst, const VReg &src, const VReg &src2, alg_kind_t alg) {
     using namespace alg_kind;
     switch (alg) {
-        case binary_ge: return _cmp_nlt_us;
-        case binary_gt: return _cmp_nle_us;
-        case binary_le: return _cmp_le_os;
-        case binary_lt: return _cmp_lt_os;
-        case binary_eq: return _cmp_eq_oq;
-        case binary_ne: return _cmp_neq_uq;
-        default: assert(!"not supported operation!"); return -1;
+        case binary_ge: fcmge(dst.s, src.s, src2.s); break;
+        case binary_gt: fcmgt(dst.s, src.s, src2.s); break;
+        case binary_le:
+            // Express a <= b as b >= a.
+            fcmge(dst.s, src2.s, src.s);
+            break;
+        case binary_lt:
+            // Express a < b as b > a.
+            fcmgt(dst.s, src2.s, src.s);
+            break;
+        case binary_eq: fcmeq(dst.s, src.s, src2.s); break;
+        case binary_ne:
+            // use fcmeq to compare for equality and then "not" the mask to get !=
+            fcmeq(dst.s, src.s, src2.s);
+            not_(dst.b, dst.b);
+            break;
+        default: assert(!"unsupported compare mode"); break;
     }
 }
 
 template <cpu_isa_t isa>
-void jit_uni_binary_kernel_t<isa>::compute_cmp_mask(
-        const Xbyak_aarch64::PReg &dst, const Vmm &src, const Vmm &src2,
-        const unsigned int uimm) {
-    enum {
-        EQ_OQ = 0,
-        LT_OS = 1,
-        LE_OS = 2,
-        UNORD_Q = 3,
-        NEQ_UQ = 4,
-        NLT_US = 5,
-        NLE_US = 6,
-        ORD_Q = 7,
-        EQ_UQ = 8,
-        NGE_US = 9,
-        NGT_US = 10,
-        FALSE_OQ = 11,
-        NEQ_OQ = 12,
-        GE_OS = 13,
-        GT_OS = 14,
-        TRUE_UQ = 15,
-        EQ_OS = 16,
-        LT_OQ = 17,
-        LE_OQ = 18,
-        UNORD_S = 19,
-        NEQ_US = 20,
-        NLT_UQ = 21,
-        NLE_UQ = 22,
-        ORD_S = 23,
-        EQ_US = 24,
-        NGE_UQ = 25,
-        NGT_UQ = 26,
-        FALSE_OS = 27,
-        NEQ_OS = 28,
-        GE_OQ = 29,
-        GT_OQ = 30,
-        TRUE_US = 31,
-    };
+template <typename T>
+void jit_uni_binary_kernel_t<isa>::compute_cmp_alg(
+        const T &dst, const Vmm &src, const Vmm &src2, alg_kind_t alg) {
+    using namespace alg_kind;
+    switch (alg) {
+        case binary_ge:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case binary_gt:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case binary_le:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case binary_lt:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case binary_eq:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case binary_ne:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        default: assert(!"unsupported compare mode"); break;
+    }
+}
 
-    switch (uimm) {
-        case EQ_OQ:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LT_OS:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LE_OS:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_UQ:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLT_US:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLE_US:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case EQ_UQ:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGE_US:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGT_US:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_OQ:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GE_OS:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GT_OS:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case EQ_OS:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LT_OQ:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case LE_OQ:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_US:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLT_UQ:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NLE_UQ:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case EQ_US:
-            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGE_UQ:
-            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NGT_UQ:
-            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case NEQ_OS:
-            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GE_OQ:
-            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case GT_OQ:
-            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
-            break;
-        case UNORD_Q:
-        case ORD_Q:
-        case FALSE_OQ:
-        case TRUE_UQ:
-        case UNORD_S:
-        case ORD_S:
-        case FALSE_OS:
-        case TRUE_US: assert(!"unsupported compare mode"); break;
+template <>
+void jit_uni_binary_kernel_t<asimd>::perform_op(const VReg &v0, const VReg &v1,
+        const VReg &s_src0, const VReg &s_src1) {
+    using namespace alg_kind;
+    const auto alg = pd_->desc()->alg_kind;
+    const bool cmp_op = utils::one_of(alg, alg_kind::binary_ge,
+            alg_kind::binary_gt, alg_kind::binary_le, alg_kind::binary_lt,
+            alg_kind::binary_eq, alg_kind::binary_ne);
+    if (conf_.do_scale_src0) uni_fmul(v0.s, v0.s, s_src0.s);
+    if (conf_.do_scale_src1 && offt_src1_ != 0 && !conf_.broadcast_src1_value)
+        uni_fmul(v1.s, v1.s, s_src1.s);
+
+    if (alg == binary_add)
+        uni_fadd(v0.s, v0.s, v1.s);
+    else if (alg == binary_mul)
+        uni_fmul(v0.s, v0.s, v1.s);
+    else if (alg == binary_max)
+        uni_fmax(v0.s, v0.s, v1.s);
+    else if (alg == binary_min)
+        uni_fmin(v0.s, v0.s, v1.s);
+    else if (alg == binary_div)
+        uni_fdiv(v0.s, v0.s, v1.s);
+    else if (alg == binary_sub)
+        uni_fsub(v0.s, v0.s, v1.s);
+    else if (cmp_op) {
+        compute_cmp_alg(v0, v0, v1, alg);
+        // ASIMD compare instructions produce all-ones/all-zeros integer masks.
+        // Convert them to the expected 1.0f / 0.0f compare result in place.
+        and_(v0.b16, v0.b16, vreg_one_.b16);
+    } else {
+        assert(!"not supported operation!");
     }
 }
 
@@ -399,9 +349,8 @@ void jit_uni_binary_kernel_t<isa>::perform_op(
     else if (alg == binary_sub)
         uni_fsub(v0.s, v0.s, v1.s);
     else if (cmp_op) {
-        const unsigned int predicate = cmp_predicate(alg);
         if (is_superset(isa, sve_128)) {
-            compute_cmp_mask(cmp_mask, v0, v1, predicate);
+            compute_cmp_alg(cmp_mask, v0, v1, alg);
             eor(v0.d, v0.d, v0.d);
             fmov(v0.s, cmp_mask / Xbyak_aarch64::T_m, 1.0);
         } else {
@@ -413,6 +362,7 @@ void jit_uni_binary_kernel_t<isa>::perform_op(
 
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::prepare_isa_kernel() {
+    fmov(vreg_one_.s, 1.0);
     if (tail_size_ > 0) io_.prepare_tail_mask();
     if (conf_.is_src_different_layouts && is_superset(isa, sve_128)) {
         io_.init_full_mask();
@@ -442,7 +392,7 @@ void jit_uni_binary_kernel_t<isa>::pop(const Xbyak_aarch64::XReg &reg) {
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::uni_broadcast(
         const Vmm &dst, const Xbyak_aarch64::XReg &addr) {
-    ld1rw(ZRegS(dst.getIdx()), P_ALL_ONE, Xbyak_aarch64::ptr(addr));
+    uni_ld1rw(dst.s, addr, 0);
 }
 
 template <cpu_isa_t isa>
@@ -496,9 +446,10 @@ void jit_uni_binary_kernel_t<isa>::store(int unroll, bool tail) {
             auto off_base = 0;
             auto zero_pad_left = padding_tail_size_;
 
-            if (zero_pad_left >= simd_w_ - tail_size_) {
+            if (zero_pad_left >= simd_w_ - tail_size_ && isa != asimd) {
                 uni_clear(vreg_zero_);
-                movprfx(vreg_zero_.s, tail_opmask_ / T_m, vreg_tmp_src0.s);
+                movprfx(ZReg(vreg_zero_.getIdx()).s, tail_opmask_ / T_m,
+                        ZReg(vreg_tmp_src0.getIdx()).s);
                 io_.at(conf_.dst_type)
                         ->store(vreg_zero_, dst_ptr(offt * dt_size), 0, false);
                 off_base = simd_w_ * dt_size;
@@ -558,7 +509,13 @@ void jit_uni_binary_kernel_t<isa>::compute_dst_body(int unroll, bool tail) {
 
         // avoid multiple multiplication on input scale for broadcasted vreg
         // not needed for different layouts
-        if (!conf_.is_src_different_layouts) mov(vreg_tmp.d, vreg_tmp_src1.d);
+        if (!conf_.is_src_different_layouts) {
+            if (isa == asimd)
+                mov(VReg16B(vreg_tmp.getIdx()),
+                        VReg16B(vreg_tmp_src1.getIdx()));
+            else
+                mov(ZRegD(vreg_tmp.getIdx()), ZRegD(vreg_tmp_src1.getIdx()));
+        }
         perform_op(
                 vreg_tmp_src0, vreg_tmp, vreg_scales_src0_, vreg_scales_src1_);
     }
@@ -584,7 +541,11 @@ void jit_uni_binary_kernel_t<isa>::forward() {
     // if outer dims tail, do it outside outer dims loop
     if (!is_src1_outer_dims_tail_) {
         if (conf_.is_i8) {
-            uni_clear(ZReg(vreg_zero_.getIdx()));
+            if (isa == asimd) {
+                uni_clear(VReg(vreg_zero_.getIdx()));
+            } else {
+                uni_clear(ZReg(vreg_zero_.getIdx()));
+            }
             io_.init_saturate_f32({conf_.dst_type});
             eor(reg_offt_dst_, reg_offt_dst_,
                     reg_offt_dst_); // offt_dst to get addr of dst
@@ -606,10 +567,11 @@ void jit_uni_binary_kernel_t<isa>::forward() {
     const bool treat_each_compute_step_as_tail
             = !conf_.is_i8 && is_tail_kernel_ && tail_size_;
 
-    if (conf_.do_scale_src0)
-        ld1rw(vreg_scales_src0_.s, P_ALL_ONE / T_z, ptr(reg_scales_src0_));
+    if (conf_.do_scale_src0) {
+        uni_ld1rw(vreg_scales_src0_.s, reg_scales_src0_, 0);
+    }
     if (conf_.do_scale_src1) {
-        ld1rw(vreg_scales_src1_.s, P_ALL_ONE / T_z, ptr(reg_scales_src1_));
+        uni_ld1rw(vreg_scales_src1_.s, reg_scales_src1_, 0);
         if (conf_.broadcast_src1_value || offt_src1_ == 0)
             uni_fmul(vreg_bcast_src1_.s, vreg_bcast_src1_.s,
                     vreg_scales_src1_.s);
@@ -700,7 +662,11 @@ void jit_uni_binary_kernel_t<isa>::forward_over_outer_dims() {
             = conf_.outer_dims * types::data_type_size(conf_.dst_type);
 
     if (conf_.is_i8) {
-        uni_clear(ZReg(vreg_zero_.getIdx()));
+        if (isa == asimd) {
+            uni_clear(VReg(vreg_zero_.getIdx()));
+        } else {
+            uni_clear(ZReg(vreg_zero_.getIdx()));
+        }
         io_.init_saturate_f32({conf_.dst_type});
         eor(reg_offt_dst_, reg_offt_dst_,
                 reg_offt_dst_); // offt_dst to get addr of dst
@@ -748,6 +714,7 @@ void jit_uni_binary_kernel_t<isa>::generate() {
 
 #undef PARAM_OFF
 
+template struct jit_uni_binary_kernel_t<asimd>;
 template struct jit_uni_binary_kernel_t<sve_512>;
 template struct jit_uni_binary_kernel_t<sve_256>;
 template struct jit_uni_binary_kernel_t<sve_128>;

--- a/src/cpu/aarch64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.hpp
@@ -131,7 +131,7 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     XReg src0_ptr(size_t offt = 0);
     XReg src1_ptr(size_t offt = 0);
     XReg dst_ptr(size_t offt = 0);
-    unsigned int cmp_predicate(alg_kind_t alg);
+    unsigned int get_cmp_alg_enum(alg_kind_t alg);
     void perform_op(
             const Vmm &v0, const Vmm &v1, const Vmm &s_src0, const Vmm &s_src1);
     void prepare_isa_kernel();
@@ -144,8 +144,9 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     void forward_over_outer_dims();
     void generate() override;
 
-    void compute_cmp_mask(const Xbyak_aarch64::PReg &cmp_dst,
-            const Vmm &cmp_src, const Vmm &cmp_src2, const unsigned int uimm);
+    template <typename T>
+    void compute_cmp_alg(const T &cmp_dst, const Vmm &cmp_src,
+            const Vmm &cmp_src2, const unsigned int uimm);
 
     void push(const XReg &reg);
     void pop(const XReg &reg);

--- a/src/cpu/aarch64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.hpp
@@ -131,7 +131,6 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     XReg src0_ptr(size_t offt = 0);
     XReg src1_ptr(size_t offt = 0);
     XReg dst_ptr(size_t offt = 0);
-    unsigned int cmp_predicate(alg_kind_t alg);
     void perform_op(
             const Vmm &v0, const Vmm &v1, const Vmm &s_src0, const Vmm &s_src1);
     void prepare_isa_kernel();
@@ -144,8 +143,9 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     void forward_over_outer_dims();
     void generate() override;
 
-    void compute_cmp_mask(const Xbyak_aarch64::PReg &cmp_dst,
-            const Vmm &cmp_src, const Vmm &cmp_src2, const unsigned int uimm);
+    template <typename T>
+    void compute_cmp_alg(const T &cmp_dst, const Vmm &cmp_src,
+            const Vmm &cmp_src2, alg_kind_t alg);
 
     void push(const XReg &reg);
     void pop(const XReg &reg);

--- a/src/cpu/aarch64/utils/jit_io_helper.cpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,6 +87,18 @@ jit_io_helper_t<Vmm>::jit_io_helper_t(jit_generator_t *host,
 template <typename Vmm>
 jit_io_helper_t<Vmm>::~jit_io_helper_t() = default;
 
+// That is ok for ASIMD paths because we handle tail manually with tail_conf_->tail_size_.
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::prepare_opmask(
+        const std::size_t how_many_bits_to_set,
+        const Xbyak_aarch64::XReg &reg_tmp0,
+        const Xbyak_aarch64::XReg &reg_tmp1, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(how_many_bits_to_set);
+    UNUSED(reg_tmp0);
+    UNUSED(reg_tmp1);
+    UNUSED(mask);
+}
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::prepare_opmask(
         const std::size_t how_many_bits_to_set,
@@ -104,7 +116,7 @@ void jit_io_helper_t<Vmm>::prepare_tail_mask() {
 
     if (!tail_conf_->tail_size_) return;
 
-    assert(is_superset(isa_, sve_128));
+    assert(is_superset(isa_, asimd));
 
     prepare_opmask(tail_conf_->tail_size_, tail_conf_->reg_tmp_,
             tail_conf_->reg_tmp1_, tail_conf_->tail_opmask_);
@@ -114,7 +126,7 @@ template <typename Vmm>
 void jit_io_helper_t<Vmm>::prepare_full_mask() {
     assert(gather_conf_.has_value() && "Config for loading with the use of gather instruction is not set.");
 
-    assert(is_superset(isa_, sve_128));
+    assert(is_superset(isa_, asimd));
 
     prepare_opmask(gather_conf_->simd_w_, gather_conf_->reg_tmp_,
             gather_conf_->reg_tmp1_, gather_conf_->full_opmask_);
@@ -143,6 +155,58 @@ void jit_io_helper_t<Vmm>::init_saturate_f32() const {
                 Vmm(saturation_conf_->vreg_zero_saturation_idx_),
                 Vmm(saturation_conf_->vreg_saturation_ubound_idx_),
                 saturation_conf_->reg_tmp_, data_type::f32, data_type_);
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::gather(
+        const Xbyak_aarch64::XReg &src_reg,
+        const Xbyak_aarch64::VReg &indices_vmm,
+        const Xbyak_aarch64::VReg &dst_vmm, const bool tail) {
+    assert(gather_conf_.has_value() && "Config for loading with the use of gather instruction is not set.");
+    assert(IMPLICATION(tail, tail_conf_.has_value())
+            && "Config for tail processing is not set.");
+
+    const unsigned number_of_values_to_load = tail ? tail_conf_->tail_size_ : 4;
+
+    host_->movi(dst_vmm.b16, 0); // zeroing dst_vmm for tail processing
+
+    switch (data_type_) {
+        case data_type::f32:
+        case data_type::s32:
+            for (unsigned i = 0; i < number_of_values_to_load; i++) {
+                host_->mov(host_->W_TMP_0,
+                        Xbyak_aarch64::VReg4S(indices_vmm.getIdx())[i]);
+                host_->add(host_->X_DEFAULT_ADDR, src_reg, host_->X_TMP_0);
+                host_->ld1(Xbyak_aarch64::VReg4S(dst_vmm.getIdx())[i],
+                        Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            }
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            for (unsigned i = 0; i < number_of_values_to_load; i++) {
+                host_->mov(host_->W_TMP_0,
+                        Xbyak_aarch64::VReg4S(indices_vmm.getIdx())[i]);
+                host_->add(host_->X_DEFAULT_ADDR, src_reg, host_->X_TMP_0);
+                host_->ld1(Xbyak_aarch64::VReg16B(dst_vmm.getIdx())[i],
+                        Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            }
+            if (data_type_ == data_type::s8) {
+                // sign-extend 8x8-bit -> 8x16-bit
+                host_->sxtl(dst_vmm.h8, dst_vmm.b8);
+                // sign-extend low 4x16-bit -> 4x32-bit
+                host_->sxtl(dst_vmm.s4, dst_vmm.h4);
+            } else {
+                // unsign-extend 8x8-bit -> 8x16-bit
+                host_->uxtl(dst_vmm.h8, dst_vmm.b8);
+                // unsign-extend low 4x16-bit -> 4x32-bit
+                host_->uxtl(dst_vmm.s4, dst_vmm.h4);
+            }
+            break;
+        default: assert(!"Unsupported data type.");
+    }
+
+    if (utils::one_of(data_type_, data_type::s8, data_type::u8))
+        convert_to_f32(dst_vmm, dst_vmm, data_type::s32);
 }
 
 template <typename Vmm>
@@ -198,9 +262,52 @@ void jit_io_helper_t<Vmm>::load(const Xbyak_aarch64::XReg &src_addr,
             load_s32(src_addr, offt, dst_raw_vmm, tail, mask);
             break;
         case data_type::s8:
-        case data_type::u8: load_i8(src_addr, offt, dst_raw_vmm, mask); break;
+        case data_type::u8:
+            load_i8(src_addr, offt, dst_raw_vmm, tail, mask);
+            break;
         default: assert(!"Unsupported data type.");
     }
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::ZReg>::load_and_broadcast(
+        const Xbyak_aarch64::ZReg &src_vmm, const Xbyak_aarch64::XReg &addr) {
+    host_->ld1rw(src_vmm.s, host_->P_ALL_ONE / Xbyak_aarch64::T_z,
+            Xbyak_aarch64::ptr(addr));
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::load_and_broadcast(
+        const Xbyak_aarch64::VReg &src_vmm, const Xbyak_aarch64::XReg &addr) {
+    host_->ld1r(src_vmm.s, Xbyak_aarch64::ptr(addr));
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::ZReg>::float_point_fused_multiply_add(
+        const Xbyak_aarch64::ZReg &dst_vmm, const Xbyak_aarch64::ZReg &src1_vmm,
+        const Xbyak_aarch64::ZReg &src2_vmm) {
+    host_->fmla(dst_vmm.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, src1_vmm.s,
+            src2_vmm.s);
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::float_point_fused_multiply_add(
+        const Xbyak_aarch64::VReg &dst_vmm, const Xbyak_aarch64::VReg &src1_vmm,
+        const Xbyak_aarch64::VReg &src2_vmm) {
+    host_->fmla(dst_vmm.s, src1_vmm.s, src2_vmm.s);
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::ZReg>::contiguous_load_unsigned_words(
+        const Xbyak_aarch64::ZReg &src_vmm, const Xbyak_aarch64::XReg &addr) {
+    host_->ld1w(src_vmm.s, host_->P_ALL_ONE / Xbyak_aarch64::T_z,
+            Xbyak_aarch64::ptr(addr));
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::contiguous_load_unsigned_words(
+        const Xbyak_aarch64::VReg &src_vmm, const Xbyak_aarch64::XReg &addr) {
+    host_->ld1(src_vmm.s, Xbyak_aarch64::ptr(addr));
 }
 
 #if 0
@@ -497,12 +604,69 @@ void jit_io_helper_t<Xbyak_aarch64::VReg>::load_f32(
         const Xbyak_aarch64::XReg &src_addr, const int offt,
         const Xbyak_aarch64::VReg &dst_vmm, const bool tail,
         const Xbyak_aarch64::PReg &mask) {
-    UNUSED(src_addr);
-    UNUSED(offt);
-    UNUSED(dst_vmm);
-    UNUSED(tail);
 
-    assert(!"under construction");
+    if (tail && tail_conf_->tail_size_ > 0) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        const int SZ = sizeof(float);
+        switch (tail_conf_->tail_size_) {
+            case 1:
+                host_->ld1(dst_vmm.s[0], Xbyak_aarch64::ptr(src_addr));
+                break;
+            case 2:
+                host_->ld1(dst_vmm.s[0], Xbyak_aarch64::ptr(src_addr));
+                host_->add(src_addr, src_addr, SZ);
+                host_->ld1(dst_vmm.s[1], Xbyak_aarch64::ptr(src_addr));
+                host_->sub(src_addr, src_addr, SZ);
+                break;
+            case 3:
+                host_->ld1(dst_vmm.s[0], Xbyak_aarch64::ptr(src_addr));
+                host_->add(src_addr, src_addr, SZ);
+                host_->ld1(dst_vmm.s[1], Xbyak_aarch64::ptr(src_addr));
+                host_->add(src_addr, src_addr, SZ);
+                host_->ld1(dst_vmm.s[2], Xbyak_aarch64::ptr(src_addr));
+                host_->sub(src_addr, src_addr, SZ * 2);
+                break;
+            default: assert(!"unreachable");
+        }
+    } else {
+        host_->ld1(dst_vmm.s, Xbyak_aarch64::ptr(src_addr));
+    }
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::load_s32(
+        const Xbyak_aarch64::XReg &src_addr, const int offt,
+        const Xbyak_aarch64::VReg &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    if (tail && tail_conf_->tail_size_ > 0) {
+        const int SZ = sizeof(float);
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        switch (tail_conf_->tail_size_) {
+            case 1:
+                host_->ld1(dst_vmm.s[0], Xbyak_aarch64::ptr(src_addr));
+                break;
+            case 2:
+                host_->ld1(dst_vmm.s[0], Xbyak_aarch64::ptr(src_addr));
+                host_->add(src_addr, src_addr, SZ);
+                host_->ld1(dst_vmm.s[1], Xbyak_aarch64::ptr(src_addr));
+                host_->sub(src_addr, src_addr, SZ);
+                break;
+            case 3:
+                host_->ld1(dst_vmm.s[0], Xbyak_aarch64::ptr(src_addr));
+                host_->add(src_addr, src_addr, SZ);
+                host_->ld1(dst_vmm.s[1], Xbyak_aarch64::ptr(src_addr));
+                host_->add(src_addr, src_addr, SZ);
+                host_->ld1(dst_vmm.s[2], Xbyak_aarch64::ptr(src_addr));
+                host_->sub(src_addr, src_addr, SZ * 2);
+                break;
+            default: assert(!"unreachable");
+        }
+    } else {
+        host_->ld1(dst_vmm.s, Xbyak_aarch64::ptr(src_addr));
+    }
+    host_->scvtf(dst_vmm.s, dst_vmm.s);
 }
 
 template <typename Vmm>
@@ -514,9 +678,39 @@ void jit_io_helper_t<Vmm>::load_s32(const Xbyak_aarch64::XReg &src_addr,
     host_->scvtf(dst_vmm.s, host_->P_TMP / Xbyak_aarch64::T_m, dst_vmm.s);
 }
 
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::load_i8(
+        const Xbyak_aarch64::XReg &src_addr, const int offt,
+        const Xbyak_aarch64::VReg &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
+    UNUSED(mask);
+
+    const unsigned number_of_values_to_load = tail ? tail_conf_->tail_size_ : 4;
+    const auto &reg_tmp = tail_conf_->reg_tmp_;
+
+    host_->movi(dst_vmm.s4, 0);
+
+    for (size_t i = 0; i < number_of_values_to_load; ++i) {
+        const Xbyak_aarch64::XReg addr
+                = host_->addr_off(src_addr, i, reg_tmp, host_->X_TMP_0);
+        if (data_type_ == data_type::s8) {
+            host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(addr));
+        } else {
+            host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(addr));
+        }
+        host_->ins(Xbyak_aarch64::VReg4S(dst_vmm.getIdx())[i], host_->W_TMP_0);
+    }
+
+    convert_to_f32(dst_vmm, dst_vmm, data_type::s32);
+}
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::load_i8(const Xbyak_aarch64::XReg &src_addr,
-        const int offt, const Vmm &dst_vmm, const Xbyak_aarch64::PReg &mask) {
+        const int offt, const Vmm &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
+    UNUSED(tail);
 
     if (data_type_ == data_type::s8)
         host_->ld1sb(dst_vmm.s, mask / Xbyak_aarch64::T_z,
@@ -550,10 +744,23 @@ void jit_io_helper_t<Vmm>::store(const Vmm &src_raw_vmm,
             break;
         case data_type::s8:
         case data_type::u8:
-            store_i8(src_raw_vmm, dst_raw_addr, offt, mask);
+            store_i8(src_raw_vmm, dst_raw_addr, offt, tail, mask);
             break;
         default: assert(!"Unsupported data type.");
     }
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::saturate(
+        const Xbyak_aarch64::VReg &vmm) {
+    assert(saturation_conf_.has_value() && "Config for saturation is not set.");
+
+    host_->saturate_f32(vmm,
+            Xbyak_aarch64::VReg(saturation_conf_->vreg_zero_saturation_idx_),
+            Xbyak_aarch64::VReg(saturation_conf_->vreg_saturation_ubound_idx_),
+            data_type_, host_->P_ALL_ONE);
+    host_->frintn(vmm.s, vmm.s); // Round to nearest even
+    host_->fcvtzs(vmm.s, vmm.s); // Floating-point convert to signed integer
 }
 
 template <typename Vmm>
@@ -575,8 +782,25 @@ void jit_io_helper_t<Vmm>::store_f32(const Vmm &src_vmm,
     if (io_conf_.nt_stores_enabled_) {
         host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
                 Xbyak_aarch64::ptr(dst_addr));
-    } else if (!is_superset(isa_, sve_128) && tail) {
-        // ASIMD 128-bit
+    } else {
+        host_->st1w(Xbyak_aarch64::ZRegS(src_vmm.getIdx()), mask,
+                Xbyak_aarch64::ptr(dst_addr));
+    }
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::store_f32(
+        const Xbyak_aarch64::VReg &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
+        const int offt, const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
+    UNUSED(mask);
+    if (io_conf_.nt_stores_enabled_) {
+        host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
+                Xbyak_aarch64::ptr(dst_addr));
+    } else if (isa_ == asimd && tail && tail_conf_->tail_size_ > 0) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        const int SZ = sizeof(float);
         switch (tail_conf_->tail_size_) {
             case 1:
                 host_->str(Xbyak_aarch64::SReg(src_vmm.getIdx()),
@@ -589,22 +813,129 @@ void jit_io_helper_t<Vmm>::store_f32(const Vmm &src_vmm,
             case 3:
                 host_->str(Xbyak_aarch64::DReg(src_vmm.getIdx()),
                         Xbyak_aarch64::ptr(dst_addr));
-                host_->add(dst_addr, dst_addr, 8);
+                host_->add(dst_addr, dst_addr, SZ * 2);
                 host_->st1(Xbyak_aarch64::VReg4S(src_vmm.getIdx())[2],
                         Xbyak_aarch64::ptr(dst_addr));
-                host_->sub(dst_addr, dst_addr, 8);
+                host_->sub(dst_addr, dst_addr, SZ * 2);
                 break;
             default: assert(!"unreachable");
         }
     } else {
-        host_->st1w(Xbyak_aarch64::ZRegS(src_vmm.getIdx()), mask,
-                Xbyak_aarch64::ptr(dst_addr));
+        host_->st1(src_vmm.s, Xbyak_aarch64::ptr(dst_addr));
     }
+}
+
+template <>
+int jit_io_helper_t<Xbyak_aarch64::VReg>::allocate_temp_register(
+        const Xbyak_aarch64::VReg &reg) {
+    const int SIMD_SZ = 16; // SIMD register length in bytes
+
+    for (size_t i = 0; i < 32; i++) {
+        // Look for a temporary vector register whose index isn’t the same as lhs.
+        if (reg.getIdx() != i) {
+            // Allocate space on stack
+            host_->sub(host_->X_SP, host_->X_SP, SIMD_SZ);
+            // Store the scratch register into the stack so it's safe to clobber it.
+            host_->str(Xbyak_aarch64::QReg(i), Xbyak_aarch64::ptr(host_->X_SP));
+            // The temporary register was found, therefore there is no need to keep searching.
+            return i;
+        }
+    }
+    assert("cannot find temporary register to allocate");
+    return -1;
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::deallocate_temp_register(
+        const int idx) {
+    const int SIMD_SZ = 16; // SIMD register length in bytes
+
+    // Restore the scratch register's initial content from the stack.
+    host_->ldr(Xbyak_aarch64::QReg(idx), Xbyak_aarch64::ptr(host_->X_SP));
+    // Free allocated stack space
+    host_->add(host_->X_SP, host_->X_SP, SIMD_SZ);
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::umin(
+        Xbyak_aarch64::VReg &dst, const int32_t imm) {
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(dst));
+    host_->mov_imm(host_->W_TMP_0, imm);
+    host_->dup(v_tmp.s, host_->W_TMP_0);
+    host_->umin(dst.s4, dst.s4, v_tmp.s4);
+    deallocate_temp_register(v_tmp.getIdx());
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::smin(
+        Xbyak_aarch64::VReg &dst, const int32_t imm) {
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(dst));
+    host_->mov_imm(host_->W_TMP_0, imm);
+    host_->dup(v_tmp.s, host_->W_TMP_0);
+    host_->smin(dst.s4, dst.s4, v_tmp.s4);
+    deallocate_temp_register(v_tmp.getIdx());
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::smax(
+        Xbyak_aarch64::VReg &dst, const int32_t imm) {
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(dst));
+    host_->mov_imm(host_->W_TMP_0, imm);
+    host_->dup(v_tmp.s, host_->W_TMP_0);
+    host_->smax(dst.s4, dst.s4, v_tmp.s4);
+    deallocate_temp_register(v_tmp.getIdx());
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::store_i8_sdb(
+        Xbyak_aarch64::XReg addr, const Xbyak_aarch64::VReg &src_vmm,
+        const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(mask);
+
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(src_vmm));
+    host_->mov(v_tmp.b16, Xbyak_aarch64::VReg(src_vmm.getIdx()).b16);
+    smin(v_tmp, 127);
+    smax(v_tmp, -128);
+
+    const int SZ = sizeof(int);
+    if (tail && tail_conf_->tail_size_ > 0 && tail_conf_->tail_size_ < 4) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        switch (tail_conf_->tail_size_) {
+            case 1: host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr)); break;
+            case 2:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 1);
+                break;
+            case 3:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 2);
+                break;
+            default: assert(!"unreachable");
+        }
+    } else {
+        host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 3], Xbyak_aarch64::ptr(addr));
+        host_->sub(addr, addr, 3);
+    }
+    deallocate_temp_register(v_tmp.getIdx());
 }
 
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::store_i8_sdb(Xbyak_aarch64::XReg addr,
-        const Vmm &src_vmm, const Xbyak_aarch64::PReg &mask) {
+        const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(tail);
     host_->str(host_->z31,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
@@ -617,9 +948,58 @@ void jit_io_helper_t<Vmm>::store_i8_sdb(Xbyak_aarch64::XReg addr,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
 }
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::store_i8_udb(
+        Xbyak_aarch64::XReg addr, const Xbyak_aarch64::VReg &src_vmm,
+        const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(mask);
+
+    const uint32_t idx = allocate_temp_register(src_vmm);
+    Xbyak_aarch64::VReg v_tmp(idx);
+    host_->mov(v_tmp.b16, Xbyak_aarch64::VReg16B(src_vmm.getIdx()));
+    umin(v_tmp, 255);
+
+    const int SZ = sizeof(int);
+    if (tail && tail_conf_->tail_size_ > 0 && tail_conf_->tail_size_ < 4) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        switch (tail_conf_->tail_size_) {
+            case 1: host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr)); break;
+            case 2:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 1);
+                break;
+            case 3:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 2);
+                break;
+            default: assert(!"unreachable");
+        }
+    } else {
+        host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 3], Xbyak_aarch64::ptr(addr));
+        host_->sub(addr, addr, 3);
+    }
+
+    deallocate_temp_register(idx);
+}
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::store_i8_udb(Xbyak_aarch64::XReg addr,
-        const Vmm &src_vmm, const Xbyak_aarch64::PReg &mask) {
+        const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(tail);
     host_->str(host_->z31,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
@@ -631,17 +1011,19 @@ void jit_io_helper_t<Vmm>::store_i8_udb(Xbyak_aarch64::XReg addr,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
 }
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::store_i8(const Vmm &src_vmm,
-        const Xbyak_aarch64::XReg &dst_addr, const int offt,
+        const Xbyak_aarch64::XReg &dst_addr, const int offt, const bool tail,
         const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
     using namespace std::placeholders;
     static constexpr bool is_zmm
             = std::is_same<Vmm, Xbyak_aarch64::ZReg>::value;
 
     auto store_i8_fn = data_type_ == data_type::s8
-            ? std::bind(&jit_io_helper_t::store_i8_sdb, this, _1, _2, _3)
-            : std::bind(&jit_io_helper_t::store_i8_udb, this, _1, _2, _3);
+            ? std::bind(&jit_io_helper_t::store_i8_sdb, this, _1, _2, _3, _4)
+            : std::bind(&jit_io_helper_t::store_i8_udb, this, _1, _2, _3, _4);
 
     if (io_conf_.nt_stores_enabled_ && is_zmm) {
         host_->not_(
@@ -649,12 +1031,23 @@ void jit_io_helper_t<Vmm>::store_i8(const Vmm &src_vmm,
         host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
                 Xbyak_aarch64::ptr(dst_addr));
     } else {
-        store_i8_fn(dst_addr, src_vmm, mask);
+        store_i8_fn(dst_addr, src_vmm, tail, mask);
     }
 }
 
+void uni_expand_s8_to_s32(jit_generator_t *host_,
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::VReg &src) {
+    host_->zip1(dst.b, src.b, src.b);
+    host_->zip1(dst.h, dst.h, dst.h);
+    // sign-extend 8x8-bit -> 8x16-bit
+    host_->sxtl(dst.h8, dst.b8);
+    // sign-extend low 4x16-bit -> 4x32-bit
+    host_->sxtl(dst.s4, dst.h4);
+}
+
 template <typename Vmm>
-void uni_vpmovsxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
+void uni_expand_s8_to_s32(
+        jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     Xbyak_aarch64::ZReg z_dst(dst.getIdx());
     Xbyak_aarch64::ZReg z_src(src.getIdx());
     host_->zip1(z_dst.b, z_src.b, z_src.b);
@@ -662,8 +1055,19 @@ void uni_vpmovsxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     host_->sxtb(z_dst.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, z_dst.s);
 }
 
+void uni_expand_u8_to_s32(jit_generator_t *host_,
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::VReg &src) {
+    host_->zip1(dst.b, src.b, src.b);
+    host_->zip1(dst.h, dst.h, dst.h);
+    // zero-extend 8x8-bit -> 8x16-bit
+    host_->uxtl(dst.h8, dst.b8);
+    // zero-extend low 4x16-bit -> 4x32-bit
+    host_->uxtl(dst.s4, dst.h4);
+}
+
 template <typename Vmm>
-void uni_vpmovzxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
+void uni_expand_u8_to_s32(
+        jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     Xbyak_aarch64::ZReg z_dst(dst.getIdx());
     Xbyak_aarch64::ZReg z_src(src.getIdx());
     host_->zip1(z_dst.b, z_src.b, z_src.b);
@@ -683,12 +1087,12 @@ void jit_io_helper_t<Vmm>::convert_to_f32(const Vmm &dst_vmm,
             break;
         }
         case data_type::s8: {
-            uni_vpmovsxbd(host_, dst_vmm, src_vmm);
+            uni_expand_s8_to_s32(host_, dst_vmm, src_vmm);
             host_->uni_scvtf(dst_vmm.s, dst_vmm.s);
             break;
         }
         case data_type::u8: {
-            uni_vpmovzxbd(host_, dst_vmm, src_vmm);
+            uni_expand_u8_to_s32(host_, dst_vmm, src_vmm);
             host_->uni_scvtf(dst_vmm.s, dst_vmm.s);
             break;
         }
@@ -696,26 +1100,32 @@ void jit_io_helper_t<Vmm>::convert_to_f32(const Vmm &dst_vmm,
     }
 }
 
+void uni_broadcast(jit_generator_t *host_, const Xbyak_aarch64::VReg &dst,
+        const Xbyak_aarch64::XReg &src) {
+    host_->ld1r(dst.s4, Xbyak_aarch64::ptr(src));
+}
+
 template <typename Vmm>
-void uni_vbroadcastss(jit_generator_t *host_, const Vmm &dst,
+void uni_broadcast(jit_generator_t *host_, const Vmm &dst,
         const Xbyak_aarch64::XReg &src) {
     uint8_t dstIdx = dst.getIdx();
     host_->ld1rw(Xbyak_aarch64::ZRegS(dstIdx),
             host_->P_ALL_ONE / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(src));
 }
+
 template <typename Vmm>
-void uni_vbroadcastss(jit_generator_t *host_, const Vmm &dst,
+void uni_broadcast(jit_generator_t *host_, const Vmm &dst,
         const Xbyak_aarch64::VReg &src) {
     uint8_t dstIdx = dst.getIdx();
     uint8_t srcIdx = src.getIdx();
-    host_->dup(Xbyak_aarch64::ZRegS(dstIdx), Xbyak_aarch64::ZRegS(srcIdx)[0]);
+    host_->dup(Xbyak_aarch64::VReg4S(dstIdx), Xbyak_aarch64::VReg4S(srcIdx)[0]);
 }
 
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
         const int offt, const Vmm &dst_vmm) {
     switch (data_type_) {
-        case data_type::f32: uni_vbroadcastss(host_, dst_vmm, src_addr); break;
+        case data_type::f32: uni_broadcast(host_, dst_vmm, src_addr); break;
         case data_type::s32: {
             if (is_superset(isa_, sve_512)) {
                 if (host_->cpu_sveLen == sve_128) {
@@ -735,7 +1145,7 @@ void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
                                 host_->P_NOT_256 / Xbyak_aarch64::T_m, 0);
                 }
             } else {
-                uni_vbroadcastss(host_, dst_vmm, src_addr);
+                uni_broadcast(host_, dst_vmm, src_addr);
                 convert_to_f32(dst_vmm, dst_vmm, data_type_);
             }
             break;
@@ -744,10 +1154,9 @@ void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
         case data_type::u8: {
             const Xbyak_aarch64::VReg dst_xmm {dst_vmm.getIdx()};
             host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(src_addr));
-            host_->mov(dst_xmm.b16, dst_xmm.b16);
             host_->ins(dst_xmm.b16[0], host_->W_TMP_0);
             convert_to_f32(dst_vmm, dst_vmm, data_type_);
-            uni_vbroadcastss(host_, dst_vmm, dst_xmm);
+            uni_broadcast(host_, dst_vmm, dst_xmm);
 
             break;
         }
@@ -825,6 +1234,8 @@ jit_io_multi_dt_helper_t<Vmm>::~jit_io_multi_dt_helper_t() = default;
 
 template class jit_io_helper_t<Xbyak_aarch64::ZReg>;
 template class jit_io_multi_dt_helper_t<Xbyak_aarch64::ZReg>;
+template class jit_io_helper_t<Xbyak_aarch64::VReg>;
+template class jit_io_multi_dt_helper_t<Xbyak_aarch64::VReg>;
 
 } // namespace io
 } // namespace aarch64

--- a/src/cpu/aarch64/utils/jit_io_helper.cpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,6 +87,18 @@ jit_io_helper_t<Vmm>::jit_io_helper_t(jit_generator_t *host,
 template <typename Vmm>
 jit_io_helper_t<Vmm>::~jit_io_helper_t() = default;
 
+// That is ok for ASIMD paths because we handle tail manually with tail_conf_->tail_size_.
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::prepare_opmask(
+        const std::size_t how_many_bits_to_set,
+        const Xbyak_aarch64::XReg &reg_tmp0,
+        const Xbyak_aarch64::XReg &reg_tmp1, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(how_many_bits_to_set);
+    UNUSED(reg_tmp0);
+    UNUSED(reg_tmp1);
+    UNUSED(mask);
+}
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::prepare_opmask(
         const std::size_t how_many_bits_to_set,
@@ -104,7 +116,7 @@ void jit_io_helper_t<Vmm>::prepare_tail_mask() {
 
     if (!tail_conf_->tail_size_) return;
 
-    assert(is_superset(isa_, sve_128));
+    assert(is_superset(isa_, asimd));
 
     prepare_opmask(tail_conf_->tail_size_, tail_conf_->reg_tmp_,
             tail_conf_->reg_tmp1_, tail_conf_->tail_opmask_);
@@ -114,7 +126,7 @@ template <typename Vmm>
 void jit_io_helper_t<Vmm>::prepare_full_mask() {
     assert(gather_conf_.has_value() && "Config for loading with the use of gather instruction is not set.");
 
-    assert(is_superset(isa_, sve_128));
+    assert(is_superset(isa_, asimd));
 
     prepare_opmask(gather_conf_->simd_w_, gather_conf_->reg_tmp_,
             gather_conf_->reg_tmp1_, gather_conf_->full_opmask_);
@@ -143,6 +155,60 @@ void jit_io_helper_t<Vmm>::init_saturate_f32() const {
                 Vmm(saturation_conf_->vreg_zero_saturation_idx_),
                 Vmm(saturation_conf_->vreg_saturation_ubound_idx_),
                 saturation_conf_->reg_tmp_, data_type::f32, data_type_);
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::gather(
+        const Xbyak_aarch64::XReg &src_reg,
+        const Xbyak_aarch64::VReg &indices_vmm,
+        const Xbyak_aarch64::VReg &dst_vmm, const bool tail) {
+    assert(gather_conf_.has_value() && "Config for loading with the use of gather instruction is not set.");
+    assert(IMPLICATION(tail, tail_conf_.has_value())
+            && "Config for tail processing is not set.");
+
+    const unsigned number_of_values_to_load = tail ? tail_conf_->tail_size_ : 4;
+
+    host_->uni_clear(dst_vmm);
+
+    switch (data_type_) {
+        case data_type::f32:
+        case data_type::s32:
+            for (unsigned i = 0; i < number_of_values_to_load; i++) {
+                // Calculate address of the i-th element to load: src_reg + indices_vmm[i]
+                host_->mov(host_->W_TMP_0,
+                        Xbyak_aarch64::VReg4S(indices_vmm.getIdx())[i]);
+                host_->add(host_->X_DEFAULT_ADDR, src_reg, host_->X_TMP_0);
+                // Load the i-th element to the i-th lane of dst_vmm
+                host_->ld1(Xbyak_aarch64::VReg4S(dst_vmm.getIdx())[i],
+                        Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            }
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            for (unsigned i = 0; i < number_of_values_to_load; i++) {
+                host_->mov(host_->W_TMP_0,
+                        Xbyak_aarch64::VReg4S(indices_vmm.getIdx())[i]);
+                host_->add(host_->X_DEFAULT_ADDR, src_reg, host_->X_TMP_0);
+                host_->ld1(Xbyak_aarch64::VReg16B(dst_vmm.getIdx())[i],
+                        Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            }
+            if (data_type_ == data_type::s8) {
+                // sign-extend 8x8-bit -> 8x16-bit
+                host_->sxtl(dst_vmm.h8, dst_vmm.b8);
+                // sign-extend low 4x16-bit -> 4x32-bit
+                host_->sxtl(dst_vmm.s4, dst_vmm.h4);
+            } else {
+                // unsign-extend 8x8-bit -> 8x16-bit
+                host_->uxtl(dst_vmm.h8, dst_vmm.b8);
+                // unsign-extend low 4x16-bit -> 4x32-bit
+                host_->uxtl(dst_vmm.s4, dst_vmm.h4);
+            }
+            break;
+        default: assert(!"Unsupported data type.");
+    }
+
+    if (utils::one_of(data_type_, data_type::s8, data_type::u8))
+        convert_to_f32(dst_vmm, dst_vmm, data_type::s32);
 }
 
 template <typename Vmm>
@@ -198,7 +264,9 @@ void jit_io_helper_t<Vmm>::load(const Xbyak_aarch64::XReg &src_addr,
             load_s32(src_addr, offt, dst_raw_vmm, tail, mask);
             break;
         case data_type::s8:
-        case data_type::u8: load_i8(src_addr, offt, dst_raw_vmm, mask); break;
+        case data_type::u8:
+            load_i8(src_addr, offt, dst_raw_vmm, tail, mask);
+            break;
         default: assert(!"Unsupported data type.");
     }
 }
@@ -497,12 +565,38 @@ void jit_io_helper_t<Xbyak_aarch64::VReg>::load_f32(
         const Xbyak_aarch64::XReg &src_addr, const int offt,
         const Xbyak_aarch64::VReg &dst_vmm, const bool tail,
         const Xbyak_aarch64::PReg &mask) {
-    UNUSED(src_addr);
-    UNUSED(offt);
-    UNUSED(dst_vmm);
-    UNUSED(tail);
 
-    assert(!"under construction");
+    if (tail && tail_conf_->tail_size_ > 0) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        const int SZ = sizeof(int32_t);
+        switch (tail_conf_->tail_size_) {
+            case 1:
+                host_->ld1(dst_vmm.s[0], Xbyak_aarch64::ptr(src_addr));
+                break;
+            case 2:
+                host_->ld1(dst_vmm.d[0], Xbyak_aarch64::ptr(src_addr));
+                break;
+            case 3:
+                host_->ld1(dst_vmm.d[0], Xbyak_aarch64::ptr(src_addr));
+                host_->add(src_addr, src_addr, SZ * 2);
+                host_->ld1(dst_vmm.s[2], Xbyak_aarch64::ptr(src_addr));
+                host_->sub(src_addr, src_addr, SZ * 2);
+                break;
+            default: assert(!"unreachable");
+        }
+    } else {
+        host_->ld1(dst_vmm.s, Xbyak_aarch64::ptr(src_addr));
+    }
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::load_s32(
+        const Xbyak_aarch64::XReg &src_addr, const int offt,
+        const Xbyak_aarch64::VReg &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    load_f32(src_addr, offt, dst_vmm, tail, mask);
+    host_->scvtf(dst_vmm.s, dst_vmm.s);
 }
 
 template <typename Vmm>
@@ -514,9 +608,39 @@ void jit_io_helper_t<Vmm>::load_s32(const Xbyak_aarch64::XReg &src_addr,
     host_->scvtf(dst_vmm.s, host_->P_TMP / Xbyak_aarch64::T_m, dst_vmm.s);
 }
 
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::load_i8(
+        const Xbyak_aarch64::XReg &src_addr, const int offt,
+        const Xbyak_aarch64::VReg &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
+    UNUSED(mask);
+
+    const unsigned number_of_values_to_load = tail ? tail_conf_->tail_size_ : 4;
+    const auto &reg_tmp = tail_conf_->reg_tmp_;
+
+    host_->movi(dst_vmm.s4, 0);
+
+    for (size_t i = 0; i < number_of_values_to_load; ++i) {
+        const Xbyak_aarch64::XReg addr
+                = host_->addr_off(src_addr, i, reg_tmp, host_->X_TMP_0);
+        if (data_type_ == data_type::s8) {
+            host_->ldrsb(host_->W_TMP_0, Xbyak_aarch64::ptr(addr));
+        } else {
+            host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(addr));
+        }
+        host_->ins(Xbyak_aarch64::VReg4S(dst_vmm.getIdx())[i], host_->W_TMP_0);
+    }
+
+    convert_to_f32(dst_vmm, dst_vmm, data_type::s32);
+}
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::load_i8(const Xbyak_aarch64::XReg &src_addr,
-        const int offt, const Vmm &dst_vmm, const Xbyak_aarch64::PReg &mask) {
+        const int offt, const Vmm &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
+    UNUSED(tail);
 
     if (data_type_ == data_type::s8)
         host_->ld1sb(dst_vmm.s, mask / Xbyak_aarch64::T_z,
@@ -550,10 +674,23 @@ void jit_io_helper_t<Vmm>::store(const Vmm &src_raw_vmm,
             break;
         case data_type::s8:
         case data_type::u8:
-            store_i8(src_raw_vmm, dst_raw_addr, offt, mask);
+            store_i8(src_raw_vmm, dst_raw_addr, offt, tail, mask);
             break;
         default: assert(!"Unsupported data type.");
     }
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::saturate(
+        const Xbyak_aarch64::VReg &vmm) {
+    assert(saturation_conf_.has_value() && "Config for saturation is not set.");
+
+    host_->saturate_f32(vmm,
+            Xbyak_aarch64::VReg(saturation_conf_->vreg_zero_saturation_idx_),
+            Xbyak_aarch64::VReg(saturation_conf_->vreg_saturation_ubound_idx_),
+            data_type_, host_->P_ALL_ONE);
+    host_->frintn(vmm.s, vmm.s); // Round to nearest even
+    host_->fcvtzs(vmm.s, vmm.s); // Floating-point convert to signed integer
 }
 
 template <typename Vmm>
@@ -575,8 +712,25 @@ void jit_io_helper_t<Vmm>::store_f32(const Vmm &src_vmm,
     if (io_conf_.nt_stores_enabled_) {
         host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
                 Xbyak_aarch64::ptr(dst_addr));
-    } else if (!is_superset(isa_, sve_128) && tail) {
-        // ASIMD 128-bit
+    } else {
+        host_->st1w(Xbyak_aarch64::ZRegS(src_vmm.getIdx()), mask,
+                Xbyak_aarch64::ptr(dst_addr));
+    }
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::store_f32(
+        const Xbyak_aarch64::VReg &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
+        const int offt, const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
+    UNUSED(mask);
+    if (io_conf_.nt_stores_enabled_) {
+        host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
+                Xbyak_aarch64::ptr(dst_addr));
+    } else if (isa_ == asimd && tail && tail_conf_->tail_size_ > 0) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        const int SZ = sizeof(float);
         switch (tail_conf_->tail_size_) {
             case 1:
                 host_->str(Xbyak_aarch64::SReg(src_vmm.getIdx()),
@@ -589,22 +743,129 @@ void jit_io_helper_t<Vmm>::store_f32(const Vmm &src_vmm,
             case 3:
                 host_->str(Xbyak_aarch64::DReg(src_vmm.getIdx()),
                         Xbyak_aarch64::ptr(dst_addr));
-                host_->add(dst_addr, dst_addr, 8);
+                host_->add(dst_addr, dst_addr, SZ * 2);
                 host_->st1(Xbyak_aarch64::VReg4S(src_vmm.getIdx())[2],
                         Xbyak_aarch64::ptr(dst_addr));
-                host_->sub(dst_addr, dst_addr, 8);
+                host_->sub(dst_addr, dst_addr, SZ * 2);
                 break;
             default: assert(!"unreachable");
         }
     } else {
-        host_->st1w(Xbyak_aarch64::ZRegS(src_vmm.getIdx()), mask,
-                Xbyak_aarch64::ptr(dst_addr));
+        host_->st1(src_vmm.s, Xbyak_aarch64::ptr(dst_addr));
     }
+}
+
+template <>
+int jit_io_helper_t<Xbyak_aarch64::VReg>::allocate_temp_register(
+        const Xbyak_aarch64::VReg &reg) {
+    const int SIMD_SZ = 16; // SIMD register length in bytes
+
+    for (size_t i = 0; i < 32; i++) {
+        // Look for a temporary vector register whose index isn’t the same as lhs.
+        if (reg.getIdx() != i) {
+            // Allocate space on stack
+            host_->sub(host_->X_SP, host_->X_SP, SIMD_SZ);
+            // Store the scratch register into the stack so it's safe to clobber it.
+            host_->str(Xbyak_aarch64::QReg(i), Xbyak_aarch64::ptr(host_->X_SP));
+            // The temporary register was found, therefore there is no need to keep searching.
+            return i;
+        }
+    }
+    assert("cannot find temporary register to allocate");
+    return -1;
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::deallocate_temp_register(
+        const int idx) {
+    const int SIMD_SZ = 16; // SIMD register length in bytes
+
+    // Restore the scratch register's initial content from the stack.
+    host_->ldr(Xbyak_aarch64::QReg(idx), Xbyak_aarch64::ptr(host_->X_SP));
+    // Free allocated stack space
+    host_->add(host_->X_SP, host_->X_SP, SIMD_SZ);
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::umin(
+        Xbyak_aarch64::VReg &dst, const int32_t imm) {
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(dst));
+    host_->mov_imm(host_->W_TMP_0, imm);
+    host_->dup(v_tmp.s, host_->W_TMP_0);
+    host_->umin(dst.s4, dst.s4, v_tmp.s4);
+    deallocate_temp_register(v_tmp.getIdx());
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::smin(
+        Xbyak_aarch64::VReg &dst, const int32_t imm) {
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(dst));
+    host_->mov_imm(host_->W_TMP_0, imm);
+    host_->dup(v_tmp.s, host_->W_TMP_0);
+    host_->smin(dst.s4, dst.s4, v_tmp.s4);
+    deallocate_temp_register(v_tmp.getIdx());
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::smax(
+        Xbyak_aarch64::VReg &dst, const int32_t imm) {
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(dst));
+    host_->mov_imm(host_->W_TMP_0, imm);
+    host_->dup(v_tmp.s, host_->W_TMP_0);
+    host_->smax(dst.s4, dst.s4, v_tmp.s4);
+    deallocate_temp_register(v_tmp.getIdx());
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::store_i8_sdb(
+        Xbyak_aarch64::XReg addr, const Xbyak_aarch64::VReg &src_vmm,
+        const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(mask);
+
+    Xbyak_aarch64::VReg v_tmp(allocate_temp_register(src_vmm));
+    host_->mov(v_tmp.b16, Xbyak_aarch64::VReg(src_vmm.getIdx()).b16);
+    smin(v_tmp, 127);
+    smax(v_tmp, -128);
+
+    const int SZ = sizeof(int);
+    if (tail && tail_conf_->tail_size_ > 0 && tail_conf_->tail_size_ < 4) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        switch (tail_conf_->tail_size_) {
+            case 1: host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr)); break;
+            case 2:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 1);
+                break;
+            case 3:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 2);
+                break;
+            default: assert(!"unreachable");
+        }
+    } else {
+        host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 3], Xbyak_aarch64::ptr(addr));
+        host_->sub(addr, addr, 3);
+    }
+    deallocate_temp_register(v_tmp.getIdx());
 }
 
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::store_i8_sdb(Xbyak_aarch64::XReg addr,
-        const Vmm &src_vmm, const Xbyak_aarch64::PReg &mask) {
+        const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(tail);
     host_->str(host_->z31,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
@@ -617,9 +878,58 @@ void jit_io_helper_t<Vmm>::store_i8_sdb(Xbyak_aarch64::XReg addr,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
 }
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::store_i8_udb(
+        Xbyak_aarch64::XReg addr, const Xbyak_aarch64::VReg &src_vmm,
+        const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(mask);
+
+    const uint32_t idx = allocate_temp_register(src_vmm);
+    Xbyak_aarch64::VReg v_tmp(idx);
+    host_->mov(v_tmp.b16, Xbyak_aarch64::VReg16B(src_vmm.getIdx()));
+    umin(v_tmp, 255);
+
+    const int SZ = sizeof(int);
+    if (tail && tail_conf_->tail_size_ > 0 && tail_conf_->tail_size_ < 4) {
+        // tail_size_ = nelems % simd_w_, so it cannot be greater than (simd_w_ - 1), which is 4 for VReg.
+        // Refer to binary_kernel_t::get_tail_size().
+        switch (tail_conf_->tail_size_) {
+            case 1: host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr)); break;
+            case 2:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 1);
+                break;
+            case 3:
+                host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+                host_->add(addr, addr, 1);
+                host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+                host_->sub(addr, addr, 2);
+                break;
+            default: assert(!"unreachable");
+        }
+    } else {
+        host_->st1(v_tmp.b16[0], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 2], Xbyak_aarch64::ptr(addr));
+        host_->add(addr, addr, 1);
+        host_->st1(v_tmp.b16[SZ * 3], Xbyak_aarch64::ptr(addr));
+        host_->sub(addr, addr, 3);
+    }
+
+    deallocate_temp_register(idx);
+}
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::store_i8_udb(Xbyak_aarch64::XReg addr,
-        const Vmm &src_vmm, const Xbyak_aarch64::PReg &mask) {
+        const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
+    UNUSED(tail);
     host_->str(host_->z31,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
@@ -631,17 +941,19 @@ void jit_io_helper_t<Vmm>::store_i8_udb(Xbyak_aarch64::XReg addr,
             Xbyak_aarch64::ptr(
                     host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
 }
+
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::store_i8(const Vmm &src_vmm,
-        const Xbyak_aarch64::XReg &dst_addr, const int offt,
+        const Xbyak_aarch64::XReg &dst_addr, const int offt, const bool tail,
         const Xbyak_aarch64::PReg &mask) {
+    UNUSED(offt);
     using namespace std::placeholders;
     static constexpr bool is_zmm
             = std::is_same<Vmm, Xbyak_aarch64::ZReg>::value;
 
     auto store_i8_fn = data_type_ == data_type::s8
-            ? std::bind(&jit_io_helper_t::store_i8_sdb, this, _1, _2, _3)
-            : std::bind(&jit_io_helper_t::store_i8_udb, this, _1, _2, _3);
+            ? std::bind(&jit_io_helper_t::store_i8_sdb, this, _1, _2, _3, _4)
+            : std::bind(&jit_io_helper_t::store_i8_udb, this, _1, _2, _3, _4);
 
     if (io_conf_.nt_stores_enabled_ && is_zmm) {
         host_->not_(
@@ -649,12 +961,23 @@ void jit_io_helper_t<Vmm>::store_i8(const Vmm &src_vmm,
         host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
                 Xbyak_aarch64::ptr(dst_addr));
     } else {
-        store_i8_fn(dst_addr, src_vmm, mask);
+        store_i8_fn(dst_addr, src_vmm, tail, mask);
     }
 }
 
+void uni_expand_s8_to_s32(jit_generator_t *host_,
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::VReg &src) {
+    host_->zip1(dst.b, src.b, src.b);
+    host_->zip1(dst.h, dst.h, dst.h);
+    // sign-extend 8x8-bit -> 8x16-bit
+    host_->sxtl(dst.h8, dst.b8);
+    // sign-extend low 4x16-bit -> 4x32-bit
+    host_->sxtl(dst.s4, dst.h4);
+}
+
 template <typename Vmm>
-void uni_vpmovsxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
+void uni_expand_s8_to_s32(
+        jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     Xbyak_aarch64::ZReg z_dst(dst.getIdx());
     Xbyak_aarch64::ZReg z_src(src.getIdx());
     host_->zip1(z_dst.b, z_src.b, z_src.b);
@@ -662,8 +985,19 @@ void uni_vpmovsxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     host_->sxtb(z_dst.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, z_dst.s);
 }
 
+void uni_expand_u8_to_s32(jit_generator_t *host_,
+        const Xbyak_aarch64::VReg &dst, const Xbyak_aarch64::VReg &src) {
+    host_->zip1(dst.b, src.b, src.b);
+    host_->zip1(dst.h, dst.h, dst.h);
+    // zero-extend 8x8-bit -> 8x16-bit
+    host_->uxtl(dst.h8, dst.b8);
+    // zero-extend low 4x16-bit -> 4x32-bit
+    host_->uxtl(dst.s4, dst.h4);
+}
+
 template <typename Vmm>
-void uni_vpmovzxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
+void uni_expand_u8_to_s32(
+        jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     Xbyak_aarch64::ZReg z_dst(dst.getIdx());
     Xbyak_aarch64::ZReg z_src(src.getIdx());
     host_->zip1(z_dst.b, z_src.b, z_src.b);
@@ -683,12 +1017,12 @@ void jit_io_helper_t<Vmm>::convert_to_f32(const Vmm &dst_vmm,
             break;
         }
         case data_type::s8: {
-            uni_vpmovsxbd(host_, dst_vmm, src_vmm);
+            uni_expand_s8_to_s32(host_, dst_vmm, src_vmm);
             host_->uni_scvtf(dst_vmm.s, dst_vmm.s);
             break;
         }
         case data_type::u8: {
-            uni_vpmovzxbd(host_, dst_vmm, src_vmm);
+            uni_expand_u8_to_s32(host_, dst_vmm, src_vmm);
             host_->uni_scvtf(dst_vmm.s, dst_vmm.s);
             break;
         }
@@ -696,15 +1030,26 @@ void jit_io_helper_t<Vmm>::convert_to_f32(const Vmm &dst_vmm,
     }
 }
 
+void uni_broadcast(jit_generator_t *host_, const Xbyak_aarch64::VReg &dst,
+        const Xbyak_aarch64::XReg &src) {
+    host_->ld1r(dst.s4, Xbyak_aarch64::ptr(src));
+}
+
+void uni_broadcast(jit_generator_t *host_, const Xbyak_aarch64::VReg &dst,
+        const Xbyak_aarch64::VReg &src) {
+    host_->dup(dst.s4, src.s4[0]);
+}
+
 template <typename Vmm>
-void uni_vbroadcastss(jit_generator_t *host_, const Vmm &dst,
+void uni_broadcast(jit_generator_t *host_, const Vmm &dst,
         const Xbyak_aarch64::XReg &src) {
     uint8_t dstIdx = dst.getIdx();
     host_->ld1rw(Xbyak_aarch64::ZRegS(dstIdx),
             host_->P_ALL_ONE / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(src));
 }
+
 template <typename Vmm>
-void uni_vbroadcastss(jit_generator_t *host_, const Vmm &dst,
+void uni_broadcast(jit_generator_t *host_, const Vmm &dst,
         const Xbyak_aarch64::VReg &src) {
     uint8_t dstIdx = dst.getIdx();
     uint8_t srcIdx = src.getIdx();
@@ -715,7 +1060,7 @@ template <typename Vmm>
 void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
         const int offt, const Vmm &dst_vmm) {
     switch (data_type_) {
-        case data_type::f32: uni_vbroadcastss(host_, dst_vmm, src_addr); break;
+        case data_type::f32: uni_broadcast(host_, dst_vmm, src_addr); break;
         case data_type::s32: {
             if (is_superset(isa_, sve_512)) {
                 if (host_->cpu_sveLen == sve_128) {
@@ -735,7 +1080,7 @@ void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
                                 host_->P_NOT_256 / Xbyak_aarch64::T_m, 0);
                 }
             } else {
-                uni_vbroadcastss(host_, dst_vmm, src_addr);
+                uni_broadcast(host_, dst_vmm, src_addr);
                 convert_to_f32(dst_vmm, dst_vmm, data_type_);
             }
             break;
@@ -744,10 +1089,9 @@ void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
         case data_type::u8: {
             const Xbyak_aarch64::VReg dst_xmm {dst_vmm.getIdx()};
             host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(src_addr));
-            host_->mov(dst_xmm.b16, dst_xmm.b16);
             host_->ins(dst_xmm.b16[0], host_->W_TMP_0);
             convert_to_f32(dst_vmm, dst_vmm, data_type_);
-            uni_vbroadcastss(host_, dst_vmm, dst_xmm);
+            uni_broadcast(host_, dst_vmm, dst_xmm);
 
             break;
         }
@@ -825,6 +1169,8 @@ jit_io_multi_dt_helper_t<Vmm>::~jit_io_multi_dt_helper_t() = default;
 
 template class jit_io_helper_t<Xbyak_aarch64::ZReg>;
 template class jit_io_multi_dt_helper_t<Xbyak_aarch64::ZReg>;
+template class jit_io_helper_t<Xbyak_aarch64::VReg>;
+template class jit_io_multi_dt_helper_t<Xbyak_aarch64::VReg>;
 
 } // namespace io
 } // namespace aarch64

--- a/src/cpu/aarch64/utils/jit_io_helper.hpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -138,6 +138,12 @@ public:
             const Vmm &dst_vmm, const bool tail);
     void store(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
             const int offt, const bool tail);
+    void load_and_broadcast(
+            const Vmm &src_vmm, const Xbyak_aarch64::XReg &addr);
+    void float_point_fused_multiply_add(
+            const Vmm &dst_vmm, const Vmm &src1_vmm, const Vmm &src2_vmm);
+    void contiguous_load_unsigned_words(
+            const Vmm &src_vmm, const Xbyak_aarch64::XReg &addr);
 
 private:
     void compute_cmp_mask(const Vmm &cmp_dst, const Vmm &cmp_src,
@@ -154,19 +160,27 @@ private:
             const Vmm &dst_vmm, const bool tail,
             const Xbyak_aarch64::PReg &mask);
     void load_i8(const Xbyak_aarch64::XReg &src_addr, const int offt,
-            const Vmm &dst_vmm, const Xbyak_aarch64::PReg &mask);
+            const Vmm &dst_vmm, const bool tail,
+            const Xbyak_aarch64::PReg &mask);
     void saturate(const Vmm &vmm);
     void store_f32(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
             const int offt, const bool tail, const Xbyak_aarch64::PReg &mask);
     void store_i8(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
-            const int offt, const Xbyak_aarch64::PReg &mask);
+            const int offt, const bool tail, const Xbyak_aarch64::PReg &mask);
     void convert_to_f32(const Vmm &dst_vmm, const Vmm &src_vmm,
             const data_type_t src_data_type);
 
     void store_i8_sdb(Xbyak_aarch64::XReg addr, const Vmm &src_vmm,
-            const Xbyak_aarch64::PReg &mask);
+            const bool tail, const Xbyak_aarch64::PReg &mask);
     void store_i8_udb(Xbyak_aarch64::XReg addr, const Vmm &src_vmm,
-            const Xbyak_aarch64::PReg &mask);
+            const bool tail, const Xbyak_aarch64::PReg &mask);
+
+    void umin(Vmm &dst_vmm, const int imm);
+    void smin(Vmm &dst_vmm, const int imm);
+    void smax(Vmm &dst_vmm, const int imm);
+
+    int allocate_temp_register(const Vmm &reg);
+    void deallocate_temp_register(const int idx);
 
     jit_generator_t *host_;
     const cpu_isa_t isa_;

--- a/src/cpu/aarch64/utils/jit_io_helper.hpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -154,19 +154,27 @@ private:
             const Vmm &dst_vmm, const bool tail,
             const Xbyak_aarch64::PReg &mask);
     void load_i8(const Xbyak_aarch64::XReg &src_addr, const int offt,
-            const Vmm &dst_vmm, const Xbyak_aarch64::PReg &mask);
+            const Vmm &dst_vmm, const bool tail,
+            const Xbyak_aarch64::PReg &mask);
     void saturate(const Vmm &vmm);
     void store_f32(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
             const int offt, const bool tail, const Xbyak_aarch64::PReg &mask);
     void store_i8(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
-            const int offt, const Xbyak_aarch64::PReg &mask);
+            const int offt, const bool tail, const Xbyak_aarch64::PReg &mask);
     void convert_to_f32(const Vmm &dst_vmm, const Vmm &src_vmm,
             const data_type_t src_data_type);
 
     void store_i8_sdb(Xbyak_aarch64::XReg addr, const Vmm &src_vmm,
-            const Xbyak_aarch64::PReg &mask);
+            const bool tail, const Xbyak_aarch64::PReg &mask);
     void store_i8_udb(Xbyak_aarch64::XReg addr, const Vmm &src_vmm,
-            const Xbyak_aarch64::PReg &mask);
+            const bool tail, const Xbyak_aarch64::PReg &mask);
+
+    void umin(Vmm &dst_vmm, const int imm);
+    void smin(Vmm &dst_vmm, const int imm);
+    void smax(Vmm &dst_vmm, const int imm);
+
+    int allocate_temp_register(const Vmm &reg);
+    void deallocate_temp_register(const int idx);
 
     jit_generator_t *host_;
     const cpu_isa_t isa_;


### PR DESCRIPTION
# Description

This PR enables JIT `binary` and binary `post-ops` for ASIMD. Previously, they were routed to `ref:any`, and now they are routed to `jit:uni`.

Fixes # (github issue)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

All the NIGHTLY tests are passing when the command below is executed: 
`ctest -j$(nproc) -E $(../.github/automation/aarch64/skipped-tests.sh)`

- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

```
Number of tests                    : 3372
Number of threads                  : 16
Average JIT speedup (mean time)    : 5.7059
Average JIT speedup (min time)     : 6.0998

Top 15 JIT speedups by mean time
| mean_time_speedup | min_time_speedup | mean_time_ms_jit | mean_time_ms_ref | prb                                                                                                                                                   
-----------+-------------------+------------------+------------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------
| 131.6289          | 139.5362         | 0.0811           | 10.6792          | --mode=P --binary --stag=abcde:abcde --dtag=abcde --alg=ge 1x2x6x407x407:1x2x6x407x407                                                                
| 119.2072          | 127.7289         | 0.0127           | 1.5120           | --mode=P --binary --stag=axb:any --attr-post-ops=mul:s8+add:f32:common+sum:0.5+abs 32x65x2x3x2x3:32x65x1x1x1x1                                        
| 100.5980          | 107.3243         | 0.0097           | 0.9782           | --mode=P --binary --stag=axb:any --inplace=true --attr-post-ops=ge:f32 32x65x2x3x2x3:32x65x1x1x1x1                                                    
| 99.9313           | 107.0304         | 0.0088           | 0.8829           | --mode=P --binary --attr-post-ops=mul:s8+add:f32:common+sum:0.5+abs 1000x60:1000x60                                                                   
| 97.1838           | 103.2106         | 0.0100           | 0.9675           | --mode=P --binary --stag=axb:any --attr-post-ops=ge:f32 32x65x2x3x2x3:32x65x1x1x1x1                                                                   
| 91.1309           | 95.7048          | 0.0114           | 1.0344           | --mode=P --binary --stag=axb:any --attr-post-ops=sum:0.25+relu:-0.01+gt:f32 32x65x2x3x2x3:32x65x1x1x1x1                                               
| 83.4453           | 84.1845          | 0.7605           | 63.4622          | --mode=P --binary --sdt=s8:f32 --ddt=u8 --stag=axb:axb --alg=sub --attr-post-ops=div:f32:per_oc+add:f32:per_oc+mul:f32:per_oc 8x1024x19x19:1x1024x1x1 
| 82.9788           | 90.9999          | 0.0068           | 0.5605           | --mode=P --binary --inplace=true --attr-post-ops=ge:f32 1000x60:1000x60                                                                               
| 82.3568           | 83.1222          | 0.7628           | 62.8225          | --mode=P --binary --sdt=u8:f32 --ddt=u8 --stag=axb:axb --alg=sub --attr-post-ops=div:f32:per_oc+add:f32:per_oc+mul:f32:per_oc 8x1024x19x19:1x1024x1x1 
| 81.3736           | 81.6808          | 0.8397           | 68.3260          | --mode=P --binary --sdt=u8:f32 --ddt=u8 --stag=axb:axb --alg=sub --attr-post-ops=div:f32:per_oc+add:f32:per_oc+mul:f32:per_oc 16x2048x10x10:1x2048x1x1
| 81.2526           | 85.9788          | 0.0122           | 0.9953           | --mode=P --binary --stag=axb:any --attr-post-ops=add:f32:per_oc+linear:2:1 32x65x2x3x2x3:32x65x1x1x1x1                                                
| 81.1151           | 84.2705          | 0.0123           | 1.0003           | --mode=P --binary --stag=axb:any --inplace=true --attr-post-ops=add:f32:per_oc+linear:2:1 32x65x2x3x2x3:32x65x1x1x1x1                                 
| 81.0118           | 87.5384          | 0.0069           | 0.5609           | --mode=P --binary --attr-post-ops=ge:f32 1000x60:1000x60                                                                                              
| 80.9378           | 81.5603          | 0.3825           | 30.9554          | --mode=P --binary --sdt=u8:f32 --ddt=u8 --stag=axb:axb --alg=sub --attr-post-ops=div:f32:per_oc+add:f32:per_oc+mul:f32:per_oc 2x512x38x38:1x512x1x1   
| 80.6038           | 80.6693          | 0.3786           | 30.5133          | --mode=P --binary --sdt=u8:f32 --ddt=u8 --stag=axb:axb --alg=sub --attr-post-ops=div:f32:per_oc+add:f32:per_oc+mul:f32:per_oc 1x256x75x75:1x256x1x1   

```
