### PR TITLE
xe: gated_mlp: fix include path

### DIFF
--- a/src/gpu/intel/gated_mlp/micro_horz.hpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.hpp
@@ -19,9 +19,9 @@
 
 #include "common/c_types_map.hpp"
 #include "common/gated_mlp_pd.hpp"
-#include "common/gemm_utils.hpp"
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
+#include "gpu/intel/gemm/utils.hpp"
 
 #include "gemmstone/microkernel/package.hpp"
 #include "gpu/intel/compute/kernel.hpp"


### PR DESCRIPTION
# Description

Fix build error in main:

```
 --> ninja -j32 benchdnn
[425/1036] Building CXX object src/gpu/CMakeFiles/dnnl_gpu.dir/gpu_gated_mlp_list.cpp.o
In file included from /kealanba/dnn-ws/dnn/src/gpu/gpu_gated_mlp_list.cpp:22:
0/kealanba/dnn-ws/dnn/src/gpu/intel/gated_mlp/micro_horz.hpp:22:10: fatal error: common/gemm_utils.hpp: No such file or directory
   22 | #include "common/gemm_utils.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?