### PR TITLE
Support matrix and ISA naming update

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,14 @@ The library is optimized for the following GPUs:
   * Intel Data Center GPU Max Series (formerly Ponte Vecchio)
   * Intel Arc B-Series Graphics and Intel Arc Pro B-Series Graphics
    (formerly Battlemage)
+  * future discrete GPUs based on Xe3p-XPC architecture (code name Crescent Island)
 * Intel Graphics integrated with:
   * 11th-14th Generation Intel Core Processors
   * Intel Graphics for Intel Core Ultra Series 1 processors (formerly Meteor Lake)
   * Intel Graphics for Intel Core Ultra Series 2 processors (formerly Arrow Lake and Lunar Lake)
   * Intel Graphics for Intel Core Ultra Series 3 processors (formerly Panther Lake)
+  * Intel Graphics for future Intel Core Series 3 processors (formerly Wildcat Lake)
+  * Intel Graphics for future Intel Core Ultra processors (code name Nova Lake)
 
 [CPU dispatcher control]: https://uxlfoundation.github.io/oneDNN/dev_guide_cpu_dispatcher_control.html
 [Linking Guide]: https://uxlfoundation.github.io/oneDNN/dev_guide_link.html

--- a/doc/performance_considerations/dispatcher_control.md
+++ b/doc/performance_considerations/dispatcher_control.md
@@ -27,22 +27,22 @@ environment variable doesn't take any effect but: 1) the detection will still
 happen following the default behavior; 2) functions to control the behavior
 still take effect.
 
-| Environment variable | Value                                        | Description                                                                                                                                                           |
-|:---------------------|:---------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ONEDNN_MAX_CPU_ISA   | SSE41                                        | Intel Streaming SIMD Extensions 4.1 (Intel SSE4.1)                                                                                                                    |
-| \                    | AVX                                          | Intel Advanced Vector Extensions (Intel AVX)                                                                                                                          |
-| \                    | AVX2                                         | Intel Advanced Vector Extensions 2 (Intel AVX2)                                                                                                                       |
-| \                    | AVX2_VNNI                                    | Intel AVX2 with Intel Deep Learning Boost (Intel DL Boost)                                                                                                            |
-| \                    | AVX512_CORE                                  | Intel AVX-512 with AVX512BW, AVX512VL, and AVX512DQ extensions                                                                                                        |
-| \                    | AVX512_CORE_VNNI                             | Intel AVX-512 with Intel DL Boost                                                                                                                                     |
-| \                    | AVX512_CORE_BF16                             | Intel AVX-512 with Intel DL Boost and bfloat16 support                                                                                                                |
-| \                    | AVX10_1_512 or AVX512_CORE_FP16              | Intel AVX10.1/512 with float16 and Intel DL Boost and bfloat16                                                                                                        |
-| \                    | AVX10_1_512_AMX or AVX512_CORE_AMX           | Intel AVX10.1/512 with float16, Intel DL Boost and bfloat16 support and Intel Advanced Matrix Extensions (Intel AMX) with 8-bit integer and bfloat16 support          |
-| \                    | AVX2_VNNI_2                                  | Intel AVX2 with Intel DL Boost with 8-bit integer, float16 and bfloat16 support                                                                                       |
-| \                    | AVX10_1_512_AMX_FP16 or AVX512_CORE_AMX_FP16 | Intel AVX10.1/512 with float16, Intel DL Boost and bfloat16 support and Intel AMX with 8-bit integer, bfloat16 and float16 support                                    |
-| \                    | AVX10_2 or AVX10_2_512                       | Intel AVX10.2                                                                                                                                                         |
-| \                    | AVX10_2_AMX_2 or AVX10_2_512_AMX_2           | Intel AVX10.2 and Intel AMX with 8-bit integer, bfloat16, float16, float8 support                                                                                     |
-| \                    | **DEFAULT**                                  | **No restrictions on the above ISAs, but excludes the below ISAs with preview support in the library (default)**                                                      |
+| Environment variable | Value                                        | Description                                                                                                      |
+|:---------------------|:---------------------------------------------|:-----------------------------------------------------------------------------------------------------------------|
+| ONEDNN_MAX_CPU_ISA   | SSE41                                        | Intel Streaming SIMD Extensions 4.1 (Intel SSE4.1)                                                               |
+| \                    | AVX                                          | Intel Advanced Vector Extensions (Intel AVX)                                                                     |
+| \                    | AVX2                                         | Intel Advanced Vector Extensions 2 (Intel AVX2)                                                                  |
+| \                    | AVX2_VNNI                                    | Intel AVX2 with Intel Deep Learning Boost (Intel DL Boost)                                                       |
+| \                    | AVX512_CORE                                  | Intel AVX-512 with AVX512BW, AVX512VL, and AVX512DQ extensions                                                   |
+| \                    | AVX512_CORE_VNNI                             | Intel AVX-512 with Intel DL Boost                                                                                |
+| \                    | AVX512_CORE_BF16                             | Intel AVX-512 with Intel DL Boost and bfloat16 support                                                           |
+| \                    | AVX10_1_512 or AVX512_CORE_FP16              | Intel AVX10.1                                                                                                    |
+| \                    | AVX10_1_512_AMX or AVX512_CORE_AMX           | Intel AVX10.1 and Intel Advanced Matrix Extensions (Intel AMX) with 8-bit integer and bfloat16 support           |
+| \                    | AVX2_VNNI_2                                  | Intel AVX2 with Intel DL Boost with 8-bit integer, float16 and bfloat16 support                                  |
+| \                    | AVX10_1_512_AMX_FP16 or AVX512_CORE_AMX_FP16 | Intel AVX10.1 and Intel AMX with 8-bit integer, bfloat16 and float16 support                                     |
+| \                    | AVX10_2 or AVX10_2_512                       | Intel AVX10.2                                                                                                    |
+| \                    | AVX10_2_AMX_2 or AVX10_2_512_AMX_2           | Intel AVX10.2 and Intel AMX with 8-bit integer, bfloat16, float16, float8 support                                |
+| \                    | **DEFAULT**                                  | **No restrictions on the above ISAs, but excludes the below ISAs with preview support in the library (default)** |
 
 @note The ISAs are partially ordered:
 * SSE41 < AVX < AVX2 < AVX2_VNNI < AVX2_VNNI_2,

--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -229,6 +229,12 @@ have specialized optimizations in the library:
    * Intel Arc B-Series Graphics (formerly Battlemage)
  * Xe3-LPG
    * Intel Graphics for Intel Core Ultra Series 3 processors (formerly Panther Lake)
+   * Intel Graphics for future Intel Core Series 3 processors (code name Wildcat Lake)
+   * Intel Graphics for future Intel Core Ultra processors (code name Nova Lake S)
+ * Xe3p-LPG
+   * Intel Graphics for future Intel Core Ultra processors (code name Nova Lake P)
+ * Xe3p-XPC
+   * future discrete GPUs based on Xe3p-XPC architecture (code name Crescent Island)
 
 The following table indicates the data types support for each uArch supported by oneDNN.
 
@@ -241,6 +247,8 @@ The following table indicates the data types support for each uArch supported by
 | Xe2-LPG  | `+`     | `+`     | `+`     | `+`     | `+`     | `.`     | `.`     | `.`     |
 | Xe2-HPG  | `+`     | `+`     | `+`     | `+`     | `+`     | `.`     | `.`     | `.`     |
 | Xe3-LPG  | `+`     | `+`     | `+`     | `+`     | `+`     | `.`     | `.`     | `.`     |
+| Xe3p-LPG | `+`     | `+`     | `+`     | `+`     | `+`     | `+`     | `.`     | `.`     |
+| Xe3p-XPC | `+`     | `+`     | `+`     | `+`     | `+`     | `+`     | `+`     | `.`     |
 
 Legend:
 * `+` indicates oneDNN uses hardware-native compute support for this data type.

--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -186,8 +186,8 @@ table indicates data types support for every supported ISA:
 | Intel AVX-512 with Intel DL Boost (int8)             |         | `+`     | `.`(2)  |         | `+`     |         |         |         |         |
 | Intel AVX-512 with Intel DL Boost (int8, bf16)       |         | `+`     | `+`     |         | `+`     |         |         |         |         |
 | Intel AVX2 with Intel DL Boost (int8) and NE_CONVERT |         | `+`     | `.`     | `.`     | `+`     |         |         |         |         |
-| Intel AVX10.1/512 with Intel AMX (int8, bf16)        |         | `+`     | `+`     | `.`(3)  | `+`     |         |         |         | `.`     |
-| Intel AVX10.1/512 with Intel AMX (int8, bf16, f16)   |         | `+`     | `+`     | `+`     | `+`     | `.`     | `.`     |         | `.`     |
+| Intel AVX10.1 with Intel AMX (int8, bf16)            |         | `+`     | `+`     | `.`(3)  | `+`     |         |         |         | `.`     |
+| Intel AVX10.1 with Intel AMX (int8, bf16, f16)       |         | `+`     | `+`     | `+`     | `+`     | `.`     | `.`     |         | `.`     |
 | Intel AVX10.2                                        |         | `+`     | `+`     | `+`     | `+`     | `.`     |         |         | `.`     |
 | Intel AVX10.2 with Intel AMX (int8, bf16, fp16, fp8) |         | `+`     | `+`     | `+`     | `+`     | `+`     | `+`     |         | `.`     |
 

--- a/src/cpu/x64/cpu_isa_traits.cpp
+++ b/src/cpu/x64/cpu_isa_traits.cpp
@@ -136,16 +136,12 @@ struct isa_info_t {
                        "bfloat16 and 8-bit integer support";
             case avx10_2: return "Intel AVX10.2";
             case avx512_core_amx_fp16:
-                return "Intel AVX-512 with float16, Intel DL Boost and "
-                       "bfloat16 support and Intel AMX with bfloat16, float16 "
+                return "Intel AVX10.1 and Intel AMX with bfloat16, float16 "
                        "and 8-bit integer support";
             case avx512_core_amx:
-                return "Intel AVX-512 with float16, Intel DL Boost and "
-                       "bfloat16 support and Intel AMX with bfloat16 and 8-bit "
+                return "Intel AVX10.1 and Intel AMX with bfloat16 and 8-bit "
                        "integer support";
-            case avx512_core_fp16:
-                return "Intel AVX-512 with float16, Intel DL Boost and "
-                       "bfloat16 support ";
+            case avx512_core_fp16: return "Intel AVX 10.1";
             case avx512_core_bf16_ymm:
                 return "Intel AVX-512 with Intel DL Boost and bfloat16 support "
                        "on Ymm/Zmm";


### PR DESCRIPTION
This PR introduces two change to oneDNN README and developer guide:
* Adds CRI and NVL-P to the list of supported hardware and data types tables.
* Cleans up naming for Intel AVX-512 ISA rebranded into Intel AVX10.1.
