### PR TITLE
cpu: x64: matmul: Enable int8 grouped quantization

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -166,6 +166,9 @@ enum {
     key_brgemm_primitive_buffer_d,
     key_brgemm_primitive_zp_comp_a,
     key_brgemm_primitive_zp_comp_b,
+    // Per-(M,N) f32 compensation tile for int8 grouped quantization with
+    // src and/or wei zero points (consumed by apply_per_mn_compensation).
+    key_brgemm_primitive_per_mn_comp,
     key_brgemm_primitive_buffer_reduce,
     key_concat_iptrs,
     key_concat_istrides,

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -166,6 +166,7 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
     brgemm_p.a_zp_compensations = post_ops_data.a_zp_compensations;
     brgemm_p.b_zp_compensations = post_ops_data.b_zp_compensations;
     brgemm_p.c_zp_values = post_ops_data.c_zp_values;
+    brgemm_p.ptr_per_mn_compensation = post_ops_data.per_mn_compensation;
     if (dynamic_values) {
         brgemm_p.dynamic_LDA = dynamic_values->dynamic_LDA;
         brgemm_p.dynamic_LDB = dynamic_values->dynamic_LDB;
@@ -210,6 +211,7 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
     brgemm_p.b_zp_compensations = post_ops_data.b_zp_compensations;
     brgemm_p.a_zp_values = post_ops_data.a_zp_values;
     brgemm_p.c_zp_values = post_ops_data.c_zp_values;
+    brgemm_p.ptr_per_mn_compensation = post_ops_data.per_mn_compensation;
     if (dynamic_values) {
         brgemm_p.dynamic_LDA = dynamic_values->dynamic_LDA;
         brgemm_p.dynamic_LDB = dynamic_values->dynamic_LDB;
@@ -529,7 +531,8 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         zp_type = brgemm_broadcast_t::none;
 
         const bool skip_zero_point
-                = mem_arg == DNNL_ARG_WEIGHTS && brg->skip_zp_b_compensation;
+                = (mem_arg == DNNL_ARG_WEIGHTS && brg->skip_zp_b_compensation)
+                || (mem_arg == DNNL_ARG_SRC && brg->skip_zp_a_compensation);
         if (skip_zero_point) return status::success;
 
         if (!zp.has_default_values(mem_arg)) {

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -486,6 +486,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     const auto &src_scales = attr->scales_.get(DNNL_ARG_SRC);
     const auto &wei_scales = attr->scales_.get(DNNL_ARG_WEIGHTS);
     brg->with_src_scales = !src_scales.has_default_values();
+    if (brg->with_src_scales) brg->dt_src_scales = src_scales.get_data_type();
     brg->with_wei_scales
             = !brg->skip_wei_scales && !wei_scales.has_default_values();
 
@@ -516,7 +517,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     const bool scales_ok = attr->scales_.has_default_values({DNNL_ARG_SRC,
                                    DNNL_ARG_WEIGHTS, DNNL_ARG_DST})
             && IMPLICATION(!src_scales.has_default_values(),
-                    src_scales.get_mask() == 0)
+                    src_scales.get_mask() == 0 || brg->is_per_k_src_scales)
             && IMPLICATION(!dst_scales.has_default_values(),
                     dst_scales.get_mask() == 0);
     if (!scales_ok) return status::unimplemented;
@@ -839,6 +840,9 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(is_per_n_wei_scales);
     CMP_BRGEMM_FIELD(is_per_k_wei_scales);
     CMP_BRGEMM_FIELD(with_src_scales);
+    CMP_BRGEMM_FIELD(is_per_k_src_scales);
+    CMP_BRGEMM_FIELD(src_scale_m_stride);
+    CMP_BRGEMM_FIELD(dt_src_scales);
     CMP_BRGEMM_FIELD(with_wei_scales);
     CMP_BRGEMM_FIELD(with_dst_scales);
     CMP_BRGEMM_FIELD(dt_wei_scales);

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -488,7 +488,10 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     brg->with_src_scales = !src_scales.has_default_values();
     brg->with_wei_scales
             = !brg->skip_wei_scales && !wei_scales.has_default_values();
-    if (brg->with_wei_scales) {
+
+    bool wei_scales_are_set = brg->is_single_wei_scale
+            || brg->is_per_n_wei_scales || brg->is_per_k_wei_scales;
+    if (brg->with_wei_scales && !wei_scales_are_set) {
         // Note. the current version supports only two different wei scales
         // types:
         //     1) common (mask = 0)
@@ -500,7 +503,11 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         // So if wei_scales.get_mask() > 0 (not common) it's assumed here that
         // scale type is per_n_dim_scale and driver which calls brgemm kernel
         // checked that mask has correct value for this case
-        brg->is_oc_scale = wei_scales.get_mask() > 0;
+
+        const auto &wei_scales_mask = wei_scales.get_mask();
+        brg->is_single_wei_scale = wei_scales_mask == 0;
+        brg->is_per_n_wei_scales = wei_scales_mask > 0;
+        brg->is_per_k_wei_scales = false;
         brg->dt_wei_scales = wei_scales.get_data_type();
     }
 
@@ -828,7 +835,9 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(zp_type_c);
 
     CMP_BRGEMM_FIELD(skip_wei_scales);
-    CMP_BRGEMM_FIELD(is_oc_scale);
+    CMP_BRGEMM_FIELD(is_single_wei_scale);
+    CMP_BRGEMM_FIELD(is_per_n_wei_scales);
+    CMP_BRGEMM_FIELD(is_per_k_wei_scales);
     CMP_BRGEMM_FIELD(with_src_scales);
     CMP_BRGEMM_FIELD(with_wei_scales);
     CMP_BRGEMM_FIELD(with_dst_scales);

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -297,6 +297,7 @@ struct brgemm_desc_t {
     bool with_eltwise = false;
     bool with_binary = false;
     bool skip_zp_b_compensation = false;
+    bool skip_zp_a_compensation = false;
     bool n_bcast_1_load = false;
 
     brgemm_broadcast_t zp_type_a = brgemm_broadcast_t::none;
@@ -311,6 +312,8 @@ struct brgemm_desc_t {
     bool is_per_k_src_scales = false;
     dim_t src_scale_m_stride = 0;
     data_type_t dt_src_scales = data_type::undef;
+
+    bool with_per_mn_compensation = false;
 
     bool has_per_k_scales() const {
         return is_per_k_wei_scales || is_per_k_src_scales;
@@ -488,9 +491,11 @@ struct brgemm_desc_t {
 
     // Determines if the accumulator dt is integer.
     //
-    // When the per-k scales are present, need to accumulate
-    // in f32 due to precision loss.
-    bool is_integer_acc() const { return is_int8 && !has_per_k_scales(); }
+    // When the per-k scales or per-MN compensation are present, need to
+    // accumulate in f32 due to precision loss.
+    bool is_integer_acc() const {
+        return is_int8 && !has_per_k_scales() && !with_per_mn_compensation;
+    }
 
     // Determines if the DQ2PS conversion is needed for the accumulator.
     bool do_dq2ps_cvt() const {
@@ -756,6 +761,7 @@ struct brgemm_kernel_params_t {
     const void *b_zp_compensations = nullptr;
     const void *a_zp_values = nullptr;
     const void *c_zp_values = nullptr;
+    const void *ptr_per_mn_compensation = nullptr;
     size_t skip_accm = 0;
     int32_t zp_a_val = 1;
     dim_t dynamic_LDA = 0;
@@ -881,7 +887,8 @@ struct brgemm_post_ops_data_t {
             int32_t zp_a_val = 1, bool do_only_comp = false,
             bool do_only_zp_a_val = false, const void *src_scales = nullptr,
             const void *wei_scales = nullptr, const void *dst_scales = nullptr,
-            const void *a_zp_values = nullptr)
+            const void *a_zp_values = nullptr,
+            const void *per_mn_compensation = nullptr)
         : bias(bias)
         , binary_post_ops_rhs(binary_post_ops_rhs)
         , oc_logical_off(oc_logical_off)
@@ -898,7 +905,8 @@ struct brgemm_post_ops_data_t {
         , src_scales(src_scales)
         , wei_scales(wei_scales)
         , dst_scales(dst_scales)
-        , a_zp_values(a_zp_values) {}
+        , a_zp_values(a_zp_values)
+        , per_mn_compensation(per_mn_compensation) {}
 
     const void *bias = nullptr;
     const void *binary_post_ops_rhs = nullptr;
@@ -917,6 +925,7 @@ struct brgemm_post_ops_data_t {
     const void *wei_scales = nullptr;
     const void *dst_scales = nullptr;
     const void *a_zp_values = nullptr;
+    const void *per_mn_compensation = nullptr;
 };
 
 } // namespace x64

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -308,7 +308,14 @@ struct brgemm_desc_t {
     bool is_per_n_wei_scales = false;
     bool is_per_k_wei_scales = false;
     bool with_src_scales = false;
-    bool has_per_k_scales() const { return is_per_k_wei_scales; }
+    bool is_per_k_src_scales = false;
+    dim_t src_scale_m_stride = 0;
+    data_type_t dt_src_scales = data_type::undef;
+
+    bool has_per_k_scales() const {
+        return is_per_k_wei_scales || is_per_k_src_scales;
+    }
+
     bool with_wei_scales = false;
     // `dst_scales` passed as a bare pointer making kernel change multiplication
     // to division was proved to be significantly slower, both for pure divps

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -303,11 +303,12 @@ struct brgemm_desc_t {
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_c = brgemm_broadcast_t::none;
 
-    // `skip_wei_scales` is controlled by the implementation and not by kernel
-    // API.
     bool skip_wei_scales = false;
-    int is_oc_scale = 0;
+    bool is_single_wei_scale = false;
+    bool is_per_n_wei_scales = false;
+    bool is_per_k_wei_scales = false;
     bool with_src_scales = false;
+    bool has_per_k_scales() const { return is_per_k_wei_scales; }
     bool with_wei_scales = false;
     // `dst_scales` passed as a bare pointer making kernel change multiplication
     // to division was proved to be significantly slower, both for pure divps
@@ -475,7 +476,18 @@ struct brgemm_desc_t {
         assert(is_gemv);
         // Per-N scales collapse to a single scalar unless `y` is treated as a
         // row.
-        return !is_oc_scale || !treat_y_as_row;
+        return !is_per_n_wei_scales || !treat_y_as_row;
+    }
+
+    // Determines if the accumulator dt is integer.
+    //
+    // When the per-k scales are present, need to accumulate
+    // in f32 due to precision loss.
+    bool is_integer_acc() const { return is_int8 && !has_per_k_scales(); }
+
+    // Determines if the DQ2PS conversion is needed for the accumulator.
+    bool do_dq2ps_cvt() const {
+        return is_integer_acc() && (alpha != 1.f || beta != 1.f);
     }
 
     // return 'true' when FP8 MAC is not natively supported by the CPU ISA
@@ -705,33 +717,33 @@ struct brgemm_dynamic_values_t {
 };
 
 struct brgemm_kernel_params_t {
-    const void *ptr_A;
-    const void *ptr_B;
-    const brgemm_batch_element_t *batch;
-    void *ptr_C;
+    const void *ptr_A = nullptr;
+    const void *ptr_B = nullptr;
+    const brgemm_batch_element_t *batch = nullptr;
+    void *ptr_C = nullptr;
 
-    const void *ptr_bias;
-    void *ptr_D;
+    const void *ptr_bias = nullptr;
+    void *ptr_D = nullptr;
 
     const void *ptr_src_scales = nullptr;
     const void *ptr_wei_scales = nullptr;
     const void *ptr_dst_scales = nullptr;
-    void *ptr_buf;
+    void *ptr_buf = nullptr;
 
-    size_t do_post_ops;
-    size_t do_apply_comp;
-    size_t BS;
+    size_t do_post_ops = 0;
+    size_t do_apply_comp = 0;
+    size_t BS = 0;
 
     /*
      * ptr to table of void * elements that are pointers to post_op binary
      * src1 tensors
      */
-    const void *post_ops_binary_rhs_arg_vec;
-    size_t oc_logical_off;
-    size_t first_mb_matrix_addr_off;
-    size_t dst_row_logical_off;
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    size_t oc_logical_off = 0;
+    size_t first_mb_matrix_addr_off = 0;
+    size_t dst_row_logical_off = 0;
 
-    const char *data_C_ptr_;
+    const char *data_C_ptr_ = nullptr;
 
     const void *a_zp_compensations = nullptr;
     const void *b_zp_compensations = nullptr;
@@ -822,7 +834,7 @@ private:
 
 /// @param bias Vector of bias (vector length is N)
 /// @param scales - Vector of scale factor values which represents combination
-///     scale factors for matrixes A and B. If brgemm_desc_t::is_oc_scale = true
+///     scale factors for matrixes A and B. If brgemm_desc_t::is_per_n_scale = true
 ///     vector length is N otherwise it must be broadcasted to vector of simd
 ///     width length
 /// @param binary_post_ops_rhs - Ptr to table of pointers to tensors used as rhs

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -398,8 +398,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     if (brg.with_wei_scales) {
         reg_aux_wei_scales.restore();
-        const bool is_single_scale = !brg.is_oc_scale;
-        if (!is_single_scale) {
+        if (!brg.is_single_wei_scale) {
             assert(brg.dt_wei_scales == data_type::f32);
             lea(reg_aux_wei_scales,
                     ptr[reg_aux_wei_scales + reg_aux_N * sizeof(float)]);
@@ -420,7 +419,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
             const Vmm vmm_wei_scales = vmm_tmp(0);
             const auto addr
                     = ptr[reg_aux_wei_scales + wei_scales_offset(n, v_i)];
-            if (is_single_scale) {
+            if (brg.is_single_wei_scale) {
                 if (has_ptr_b_support) {
                     // No need to check for mask support separately, as masks
                     // are supported with the same isa that introduced address

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -403,7 +403,8 @@ private:
         return brg.typesize_bias * (n * n_block1() + v * simd_w_);
     }
     int wei_scales_offset(int n, int v) {
-        return sizeof(float) * brg.is_oc_scale * (n * n_block1() + v * simd_w_);
+        return sizeof(float) * brg.is_per_n_wei_scales
+                * (n * n_block1() + v * simd_w_);
     }
     size_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -577,7 +577,8 @@ private:
         const bool need_to_apply_post_ops
                 = are_post_ops_applicable_ && apply_post_ops;
         const auto store_by_vectors = need_to_apply_alpha_beta_
-                || need_to_apply_post_ops || brg.brgattr.bd_mask_level;
+                || need_to_apply_post_ops || brg.brgattr.bd_mask_level
+                || brg.has_per_k_scales();
         return store_by_vectors;
     }
     bool actual_ils(bool apply_post_ops, bool skip_accumulation = false) const {
@@ -829,7 +830,7 @@ dim_t jit_brgemm_amx_uker_base_t::bias_offset(int ldb) const noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::scales_offset(int ldb) const noexcept {
-    return brg.is_oc_scale * ldb * ld_block_scales_size_;
+    return brg.is_per_n_wei_scales * ldb * ld_block_scales_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(int ldb) const noexcept {
@@ -975,8 +976,9 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     const bool apply_beta = brg.beta != 0.f;
     if (!apply_alpha && !apply_beta) return;
 
-    const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
-    const bool use_vadd_for_beta = brg.beta == 1.f && !dq2ps_required;
+    // When K-scales (wei or src) are applied, accumulator is already
+    // converted to float (dq2ps + scales before alpha_beta), C stores floats.
+    const bool use_vadd_for_beta = brg.beta == 1.f && !brg.do_dq2ps_cvt();
 
     if (apply_beta && !use_vadd_for_beta) {
         mov(reg_tmp_gpr, float2int(static_cast<float>(brg.beta)));
@@ -988,12 +990,12 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
         vmovq(Xmm(zmm_alpha.getIdx()), reg_tmp_gpr);
         vbroadcastss(zmm_alpha, Xmm(zmm_alpha.getIdx()));
     }
-    if (dq2ps_required) vcvtdq2ps(zmm, zmm);
+    if (brg.do_dq2ps_cvt()) vcvtdq2ps(zmm, zmm);
     if (apply_alpha) vmulps(zmm, zmm, zmm_alpha);
     if (apply_beta) {
         if (use_vadd_for_beta) {
             auto zmm_masked = zmm | k_mask | T_z;
-            if (brg.is_int8)
+            if (brg.is_integer_acc())
                 vpaddd(zmm_masked, zmm, addr);
             else
                 vaddps(zmm_masked, zmm, addr);
@@ -1131,8 +1133,42 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         brgemm_iteration_t &bi) {
-    if (!bi.apply_postops) return;
     const auto ldi = bi.ldi;
+
+    // Load wei_scales for per K-block application (is_per_k_wei_scales).
+    // This must happen for both apply_postops and non-apply_postops paths.
+    if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
+        mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+            auto scales_ptr = EVEX_compress_addr(
+                    reg_scales, scales_offset(ldi->pos(ldb)));
+            auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
+            if (brg.is_single_wei_scale) {
+                // Broadcast a single scale value — handle non-f32 types.
+                switch (brg.dt_wei_scales) {
+                    case data_type::f32:
+                        vbroadcastss(zmm_scales(ldb), scales_ptr);
+                        break;
+                    case data_type::bf16:
+                        vpbroadcastw(zmm_scales(ldb), scales_ptr);
+                        vpslld(zmm_scales(ldb), zmm_scales(ldb), 16);
+                        break;
+                    case data_type::f16:
+                        vpbroadcastw(zmm_scales(ldb), scales_ptr);
+                        vcvtph2ps(zmm_scales(ldb),
+                                Xbyak::Ymm(zmm_scales(ldb).getIdx()));
+                        break;
+                    default: vbroadcastss(zmm_scales(ldb), scales_ptr); break;
+                }
+            } else {
+                // Load a vector of scale values with proper type conversion.
+                cvt2ps(brg.dt_wei_scales, zmm_scales(ldb), scales_ptr, true,
+                        false, k_mask);
+            }
+        }
+    }
+
+    if (!bi.apply_postops) return;
 
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
@@ -1156,18 +1192,17 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
     }
 
-    if (brg.with_wei_scales) {
+    if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
-            const bool is_single_scale = !brg.is_oc_scale;
 
             const auto zmm_scale = zmm_scales(ldb);
             const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
 
-            if (is_single_scale) {
+            if (brg.is_single_wei_scale) {
                 if (brg.with_src_scales) {
                     // Single value is not anticipated to be of any other type
                     // when both scales are defined.
@@ -1457,6 +1492,18 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
             vmovups(vreg_acc, ptr[reg_buf + buf_offset + wsp_offset]);
         }
 
+        // For K-scales (wei and/or src), convert int32->float and apply
+        // the current K-group's scales BEFORE alpha_beta accumulation.
+        if (brg.has_per_k_scales() && !bi.skip_accumulation) {
+            vcvtdq2ps(zmm, zmm);
+
+            if (brg.is_per_k_wei_scales) {
+                const Xbyak::Zmm scaled_zmm
+                        = vmm_mask(zmm, true, false, k_mask);
+                vmulps(scaled_zmm, scaled_zmm, zmm_scales(ldb));
+            }
+        }
+
         if (need_to_apply_alpha_beta_ || bi.skip_accumulation) {
             const auto c_offset = C_offset(bi, bdb, bd, bi.ldi->pos(ldb));
             const auto ptr_C
@@ -1467,7 +1514,8 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
         if (!bi.apply_postops) continue;
 
-        if (dq2ps_required) vcvtdq2ps(zmm, zmm);
+        // When K-scales (wei or src) are used, dq2ps already applied above.
+        if (dq2ps_required && !brg.has_per_k_scales()) vcvtdq2ps(zmm, zmm);
 
         if (brg.req_comp_pads_with_bcast)
             apply_comp_pad_to_vector(bi, bdb, bd, ldb, zmm.getIdx());
@@ -1503,7 +1551,11 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         }
     }
 
-    if (brg.with_src_scales || brg.with_wei_scales) {
+    // When K-scales (wei) are used, they were already applied
+    // per K-block above. Only apply the remaining scales (non-K) in postops.
+    const bool apply_scales_in_postops = brg.with_src_scales
+            || (brg.with_wei_scales && !brg.is_per_k_wei_scales);
+    if (apply_scales_in_postops) {
         for (auto bd = bd_start; bd < bd_finish; bd++) {
             if (!is_out_bd(bi.bdi, bdb, bd)) continue;
 
@@ -2944,7 +2996,7 @@ void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
                 = brg.alpha != 1.0f || brg.beta != 0.f;
         const bool beta_uses_vadd = brg.beta == 1.f
                 && IMPLICATION(brg.is_int8, brg.alpha == 1.0f);
-        dt_requires_saturation_ = brg.is_int8
+        dt_requires_saturation_ = brg.is_int8 && !brg.has_per_k_scales()
                 && !IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd);
     }
     use_sat_cvt_ = dt_requires_saturation_

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -191,6 +191,7 @@ private:
     const reg64_savable_t reg_zp_comp_b {regscratchpad_, rbx, r19};
     const reg64_savable_t reg_zp_c_values {regscratchpad_, rbx, r20};
     const reg64_savable_t reg_src_scales_per_k {regscratchpad_, rbx, r21};
+    const reg64_savable_t reg_per_mn_comp {regscratchpad_, rbx, r22};
     const reg64_t reg_ptr_sum_zp = rbx;
     const reg64_t reg_converted_stride = rsi;
     const reg64_t reg_zp_comp_pad_a = rsi;
@@ -579,7 +580,7 @@ private:
                 = are_post_ops_applicable_ && apply_post_ops;
         const auto store_by_vectors = need_to_apply_alpha_beta_
                 || need_to_apply_post_ops || brg.brgattr.bd_mask_level
-                || brg.has_per_k_scales();
+                || brg.has_per_k_scales() || brg.with_per_mn_compensation;
         return store_by_vectors;
     }
     bool actual_ils(bool apply_post_ops, bool skip_accumulation = false) const {
@@ -619,6 +620,8 @@ private:
             int inp_bd, int ldb) const noexcept;
     dim_t zp_comp_b_offset(int bd) const noexcept;
     dim_t zp_c_values_offset(brgemm_iteration_t &bi, int ldb) const noexcept;
+    dim_t per_mn_comp_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
+            int ldb) const noexcept;
     bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
     int get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
 
@@ -862,6 +865,20 @@ dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
     return 0;
 }
 
+dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
+        const brgemm_iteration_t &bi, int bdb, int inp_bd,
+        int ldb) const noexcept {
+    const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
+    const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
+    const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
+    const dim_t ldc_elem = (dim_t)ldb * brg.ld_block;
+    const dim_t bloc_idx = ldc_elem / brg.LDC;
+    const dim_t in_block = ldc_elem % brg.LDC;
+    return (dim_t)sizeof(float)
+            * ((dim_t)bd_shift * brg.LDC2_M + (dim_t)bloc_idx * brg.LDC2_N
+                    + in_block);
+}
+
 bool jit_brgemm_amx_uker_base_t::is_out_bd(
         const bd_iteration_t *bdi, int bdb, int inp_bd) const {
     const auto bd = bdi->pos(bdb) + inp_bd;
@@ -940,6 +957,11 @@ void jit_brgemm_amx_uker_base_t::read_params() {
     if (brg.is_per_k_src_scales) {
         mov(reg_src_scales_per_k, ptr[param1 + GET_OFF(ptr_src_scales)]);
         reg_src_scales_per_k.save();
+    }
+
+    if (brg.with_per_mn_compensation) {
+        mov(reg_per_mn_comp, ptr[param1 + GET_OFF(ptr_per_mn_compensation)]);
+        reg_per_mn_comp.save();
     }
 }
 
@@ -1172,6 +1194,26 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                         false, k_mask);
             }
         }
+
+        if (brg.with_src_scales && !brg.is_per_k_src_scales) {
+            mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
+            auto zmm_src_sc = zmm_tmp_1();
+            auto src_sc_addr = EVEX_compress_addr(reg_scales, 0);
+            switch (brg.dt_src_scales) {
+                case data_type::bf16:
+                    vpbroadcastw(zmm_src_sc, src_sc_addr);
+                    vpslld(zmm_src_sc, zmm_src_sc, 16);
+                    break;
+                case data_type::f16:
+                    vpbroadcastw(zmm_src_sc, src_sc_addr);
+                    vcvtph2ps(zmm_src_sc, Xbyak::Ymm(zmm_src_sc.getIdx()));
+                    break;
+                case data_type::f32:
+                default: vbroadcastss(zmm_src_sc, src_sc_addr); break;
+            }
+            for (int ldb = 0; ldb < ldi->block2(); ldb++)
+                vmulps(zmm_scales(ldb), zmm_scales(ldb), zmm_src_sc);
+        }
     }
 
     if (!bi.apply_postops) return;
@@ -1187,7 +1229,8 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
     }
 
-    if (brg.with_src_scales && !brg.is_per_k_src_scales) {
+    if (brg.with_src_scales && !brg.is_per_k_src_scales
+            && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
@@ -1515,10 +1558,28 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
             vmovups(vreg_acc, ptr[reg_buf + buf_offset + wsp_offset]);
         }
 
-        // For K-scales (wei and/or src), convert int32->float and apply
-        // the current K-group's scales BEFORE alpha_beta accumulation.
-        if (brg.has_per_k_scales() && !bi.skip_accumulation) {
+        // Per-(M,N) compensation: convert int32->float and subtract the
+        // unscaled delta BEFORE per-K scale multiply.
+        if (brg.with_per_mn_compensation && !bi.skip_accumulation) {
             vcvtdq2ps(zmm, zmm);
+
+            reg_per_mn_comp.restore();
+            const auto global_ldb = bi.ldi->pos(ldb);
+            const auto delta_off = per_mn_comp_offset(bi, bdb, bd, global_ldb);
+            const auto delta_ptr = EVEX_compress_addr_safe(
+                    reg_per_mn_comp, delta_off, reg_long_offt);
+            const auto zmm_delta = zmm_tmp_1();
+            const Xbyak::Zmm zmm_delta_masked
+                    = vmm_mask(zmm_delta, true, false, k_mask);
+            vmovups(zmm_delta_masked, delta_ptr);
+            vsubps(zmm, zmm, zmm_delta);
+        }
+
+        // For K-scales (wei and/or src), convert int32->float (if not
+        // already done by per-MN compensation) and apply the current
+        // K-group's scales BEFORE alpha_beta accumulation.
+        if (brg.has_per_k_scales() && !bi.skip_accumulation) {
+            if (!brg.with_per_mn_compensation) vcvtdq2ps(zmm, zmm);
 
             const Xbyak::Zmm scaled_zmm = vmm_mask(zmm, true, false, k_mask);
             // Apply K-wei_scales if present (pre-loaded per-ldb vector).
@@ -1561,14 +1622,18 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
         if (!bi.apply_postops) continue;
 
-        // When K-scales (wei or src) are used, dq2ps already applied above.
-        if (dq2ps_required && !brg.has_per_k_scales()) vcvtdq2ps(zmm, zmm);
+        // When K-scales or per-MN comp are used, dq2ps already applied above.
+        if (dq2ps_required && !brg.has_per_k_scales()
+                && !brg.with_per_mn_compensation)
+            vcvtdq2ps(zmm, zmm);
 
         if (brg.req_comp_pads_with_bcast)
             apply_comp_pad_to_vector(bi, bdb, bd, ldb, zmm.getIdx());
     }
 
-    if (!bi.apply_postops || !some_bd_mask) return;
+    if (!some_bd_mask) return;
+
+    if (!bi.apply_postops) return;
 
     if (brg.zp_type_a != brgemm_broadcast_t::none
             && !brg.req_comp_pads_with_bcast) {
@@ -1600,8 +1665,11 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
     // When K-scales (wei) are used, they were already applied
     // per K-block above. Only apply the remaining scales (non-K) in postops.
-    const bool src_scales_in_postops
-            = brg.with_src_scales && !brg.is_per_k_src_scales;
+    // For per-K wei + common src, the common src scalar was folded into the
+    // per-K wei load in `prepare_post_ops_registers` so it has already been
+    // applied per K-block; skip the postop apply to avoid double-multiply.
+    const bool src_scales_in_postops = brg.with_src_scales
+            && !brg.is_per_k_src_scales && !brg.is_per_k_wei_scales;
     const bool wei_scales_in_postops
             = brg.with_wei_scales && !brg.is_per_k_wei_scales;
     const bool apply_scales_in_postops

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -190,6 +190,7 @@ private:
     const reg64_savable_t reg_zp_a_values {regscratchpad_, rbx, r18};
     const reg64_savable_t reg_zp_comp_b {regscratchpad_, rbx, r19};
     const reg64_savable_t reg_zp_c_values {regscratchpad_, rbx, r20};
+    const reg64_savable_t reg_src_scales_per_k {regscratchpad_, rbx, r21};
     const reg64_t reg_ptr_sum_zp = rbx;
     const reg64_t reg_converted_stride = rsi;
     const reg64_t reg_zp_comp_pad_a = rsi;
@@ -935,6 +936,11 @@ void jit_brgemm_amx_uker_base_t::read_params() {
         mov(reg_zp_c_values, ptr[param1 + GET_OFF(c_zp_values)]);
         reg_zp_c_values.save();
     }
+
+    if (brg.is_per_k_src_scales) {
+        mov(reg_src_scales_per_k, ptr[param1 + GET_OFF(ptr_src_scales)]);
+        reg_src_scales_per_k.save();
+    }
 }
 
 void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
@@ -1181,14 +1187,31 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
     }
 
-    if (brg.with_src_scales) {
+    if (brg.with_src_scales && !brg.is_per_k_src_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
-            vbroadcastss(zmm_scales(ldb) | k_mask | T_z, scales_ptr);
+            const auto zmm_scale = zmm_scales(ldb);
+            const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
+            switch (brg.dt_src_scales) {
+                case data_type::f32:
+                    vbroadcastss(zmm_scale_masked, scales_ptr);
+                    break;
+                case data_type::bf16:
+                    vpbroadcastw(zmm_scale, scales_ptr);
+                    uni_vpslld(zmm_scale_masked, zmm_scale, 16);
+                    break;
+                case data_type::f16:
+                    vpbroadcastw(zmm_scale, scales_ptr);
+                    vcvtph2psx(
+                            Xmm(zmm_scale.getIdx()), Xmm(zmm_scale.getIdx()));
+                    vbroadcastss(zmm_scale_masked, Xmm(zmm_scale.getIdx()));
+                    break;
+                default: assert(!"unsupported src_scales data type");
+            }
         }
     }
 
@@ -1203,7 +1226,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
             const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
 
             if (brg.is_single_wei_scale) {
-                if (brg.with_src_scales) {
+                if (brg.with_src_scales && !brg.is_per_k_src_scales) {
                     // Single value is not anticipated to be of any other type
                     // when both scales are defined.
                     assert(brg.dt_wei_scales == data_type::f32);
@@ -1248,7 +1271,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 default: assert(!"unsupported wei_scales data type");
             }
 
-            if (brg.with_src_scales) {
+            if (brg.with_src_scales && !brg.is_per_k_src_scales) {
                 // Src scales are set, need to multiply by their value.
                 vmulps(zmm_scale_masked, zmm_scale, zmm_wei_scale);
             } else {
@@ -1497,10 +1520,34 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         if (brg.has_per_k_scales() && !bi.skip_accumulation) {
             vcvtdq2ps(zmm, zmm);
 
+            const Xbyak::Zmm scaled_zmm = vmm_mask(zmm, true, false, k_mask);
+            // Apply K-wei_scales if present (pre-loaded per-ldb vector).
             if (brg.is_per_k_wei_scales) {
-                const Xbyak::Zmm scaled_zmm
-                        = vmm_mask(zmm, true, false, k_mask);
                 vmulps(scaled_zmm, scaled_zmm, zmm_scales(ldb));
+            }
+            // Apply K-src_scales per-bd: each M-row has its own scalar.
+            if (brg.is_per_k_src_scales) {
+                reg_src_scales_per_k.restore();
+                const auto out_bd = get_out_bd(bi.bdi, bdb, bd);
+                const auto src_sc_offset = out_bd * brg.src_scale_m_stride;
+                const auto src_sc_ptr = EVEX_compress_addr(
+                        reg_src_scales_per_k, src_sc_offset);
+                const auto zmm_src_sc = zmm_tmp_1();
+                switch (brg.dt_src_scales) {
+                    case data_type::f32:
+                        vbroadcastss(zmm_src_sc, src_sc_ptr);
+                        break;
+                    case data_type::bf16:
+                        vpbroadcastw(zmm_src_sc, src_sc_ptr);
+                        vpslld(zmm_src_sc, zmm_src_sc, 16);
+                        break;
+                    case data_type::f16:
+                        vpbroadcastw(zmm_src_sc, src_sc_ptr);
+                        vcvtph2ps(zmm_src_sc, Xbyak::Ymm(zmm_src_sc.getIdx()));
+                        break;
+                    default: assert(!"unsupported src_scales data type");
+                }
+                vmulps(scaled_zmm, scaled_zmm, zmm_src_sc);
             }
         }
 
@@ -1553,8 +1600,12 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
     // When K-scales (wei) are used, they were already applied
     // per K-block above. Only apply the remaining scales (non-K) in postops.
-    const bool apply_scales_in_postops = brg.with_src_scales
-            || (brg.with_wei_scales && !brg.is_per_k_wei_scales);
+    const bool src_scales_in_postops
+            = brg.with_src_scales && !brg.is_per_k_src_scales;
+    const bool wei_scales_in_postops
+            = brg.with_wei_scales && !brg.is_per_k_wei_scales;
+    const bool apply_scales_in_postops
+            = src_scales_in_postops || wei_scales_in_postops;
     if (apply_scales_in_postops) {
         for (auto bd = bd_start; bd < bd_finish; bd++) {
             if (!is_out_bd(bi.bdi, bdb, bd)) continue;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -439,10 +439,11 @@ private:
     void apply_compensation(dim_t bd_block, dim_t ld_block, bool is_ld_tail);
     void apply_alpha_beta(
             dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
+    void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail,
+            bool dq2ps_required, bool &dq2ps_cvt_done);
+    void apply_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail);
     void apply_post_ops(dim_t bd_block, dim_t ld_block2,
             dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
-    void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool dq2ps_required,
-            bool dq2ps_cvt_done, bool is_ld_tail);
     void gemv_apply_bias(dim_t bd_block, bool is_bdb_tail);
     void gemv_apply_wei_scales(dim_t bd_block, bool is_bdb_tail);
 
@@ -461,6 +462,8 @@ private:
             matrix_kind_t mk);
     void maybe_tileloadd_nt(matrix_kind_t matrix_kind, dim_t idx, dim_t offset,
             bool is_rd_tail, bool is_tail, bool last_bdb);
+    void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
+            const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
     void gemm_microkernel(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
             bool is_rd_tail, bool is_ld_tail, dim_t vpad,
@@ -715,7 +718,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
                 * types::data_type_size(brg.dt_wei_scales);
 
     const dim_t ld_offset = is_tail ? brg.ldb_tail : ld * brg.ld_block;
-    return ld_offset * brg.is_oc_scale
+    return ld_offset * brg.is_per_n_wei_scales
             * types::data_type_size(brg.dt_wei_scales);
 }
 
@@ -1359,7 +1362,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
  *
  * Unlike bias, weight scales have two scale modes:
  *   - common: one scalar scale for the whole operation
- *   - per-N (`is_oc_scale`): one scale value per element along N
+ *   - per-N (`is_per_n_wei_scales`): one scale value per element along N
  *
  * In GEMV, per-N scales collapse to a single scalar only when `y` is treated
  * as a column vector.
@@ -1468,70 +1471,9 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
-        bool dq2ps_required, bool dq2ps_cvt_done, bool is_ld_tail) {
-
-    auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
-
-    reg_aux_wei_scales.restore();
-
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
-        const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(ld)];
-        const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-        const bool is_single_scale = !brg.is_oc_scale;
-
-        const Vmm vmm_wei_scales = vmm_tmp(0);
-        const Vmm vmm_wei_scales_masked
-                = vmm_mask(vmm_wei_scales, is_tail, false, k_mask);
-        if (is_single_scale) {
-            switch (brg.dt_wei_scales) {
-                case data_type::f32: vbroadcastss(vmm_wei_scales, addr); break;
-                case data_type::bf16:
-                    vpbroadcastw(vmm_wei_scales, addr);
-                    uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
-                    break;
-                case data_type::f16:
-                    vpbroadcastw(vmm_wei_scales, addr);
-                    vcvtph2ps(Xmm(vmm_wei_scales.getIdx()),
-                            Xmm(vmm_wei_scales.getIdx()));
-                    vbroadcastss(vmm_wei_scales, Xmm(vmm_wei_scales.getIdx()));
-                    break;
-                default: assert(!"unsupported wei_scales data type");
-            }
-        } else {
-            if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
-                switch (brg.dt_wei_scales) {
-                    case data_type::f32:
-                        uni_vmovups(vmm_wei_scales_masked, addr);
-                        break;
-                    case data_type::bf16:
-                        uni_vpmovzxwd(vmm_wei_scales_masked, addr);
-                        uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
-                        break;
-                    case data_type::f16:
-                        vcvtph2ps(vmm_wei_scales_masked, addr);
-                        break;
-                    default: assert(!"unsupported wei_scales data type");
-                }
-            } else {
-                assert(brg.dt_wei_scales == data_type::f32);
-                vmaskmovps(vmm_wei_scales, vmm_tail_mask(), addr);
-            }
-        }
-
-        for (dim_t bd = 0; bd < bd_block; bd++) {
-            auto vmm = accm(ld_block2, bd, ld);
-            if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
-            uni_vmulps(vmm, vmm, vmm_wei_scales);
-        }
-    }
-}
-
-template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
         dim_t bd_block, dim_t ld_block2, bool is_ld_tail, bool is_bdb_tail) {
     const bool apply_alpha = brg.alpha != 1.f;
-    const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
 
     auto vmm_alpha = vmm_tmp(0);
     if (apply_alpha) {
@@ -1543,12 +1485,12 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
     for_(dim_t bd = 0; bd < bd_block; bd++)
     for (dim_t ld = 0; ld < ld_block2; ld++) {
         auto vmm = accm(ld_block2, bd, ld);
-        if (dq2ps_required) uni_vcvtdq2ps(vmm, vmm);
+        if (brg.do_dq2ps_cvt()) uni_vcvtdq2ps(vmm, vmm);
         if (apply_alpha) uni_vmulps(vmm, vmm, vmm_alpha);
     }
 
     if (brg.beta == 0.f) return;
-    const bool use_vadd_for_beta = brg.beta == 1.f && !dq2ps_required;
+    const bool use_vadd_for_beta = brg.beta == 1.f && !brg.do_dq2ps_cvt();
     const bool need_init_beta_vmm = brg.beta != 1.f;
     auto vmm_prev_dst = vmm_tmp(0);
     if (need_init_beta_vmm) {
@@ -1583,21 +1525,19 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
                 } else {
                     uni_vaddss(Xmm(vmm.getIdx()), Xmm(vmm.getIdx()), ptr_C);
                 }
+            } else if (IMPLICATION(is_tail,
+                               is_superset(brg.isa_impl, avx512_core))) {
+                auto vmm_masked = vmm_mask(vmm, is_tail, false, k_mask);
+                if (brg.is_integer_acc())
+                    uni_vpaddd(vmm_masked, vmm, ptr_C);
+                else
+                    uni_vaddps(vmm_masked, vmm, ptr_C);
             } else {
-                if (IMPLICATION(
-                            is_tail, is_superset(brg.isa_impl, avx512_core))) {
-                    auto vmm_masked = vmm_mask(vmm, is_tail, false, k_mask);
-                    if (brg.is_int8)
-                        uni_vpaddd(vmm_masked, vmm, ptr_C);
-                    else
-                        uni_vaddps(vmm_masked, vmm, ptr_C);
-                } else {
-                    vmaskmovps(vmm_prev_dst, vmm_tail_mask(), ptr_C);
-                    if (brg.is_int8)
-                        uni_vpaddd(vmm, vmm, vmm_prev_dst);
-                    else
-                        uni_vaddps(vmm, vmm, vmm_prev_dst);
-                }
+                vmaskmovps(vmm_prev_dst, vmm_tail_mask(), ptr_C);
+                if (brg.is_integer_acc())
+                    uni_vpaddd(vmm, vmm, vmm_prev_dst);
+                else
+                    uni_vaddps(vmm, vmm, vmm_prev_dst);
             }
         } else {
             assert(!brg.is_gemv && "int8 data type is not supported for gemv");
@@ -1760,6 +1700,96 @@ void jit_brgemm_kernel_t<Wmm>::reduce_gemv_accumulators(dim_t bd_block) {
     }
 }
 
+/** Loads scales to a given vmm, applying masking if needed.
+* Used in multiple places for loading scales for variety of supported data types.
+* @param type_in data type of the scales to be loaded.
+* @param vmm_scales vmm register to load the scales to.
+* @param op an operand to load the scales from, must point to memory.
+* @param is_ld_tail tail flag used for applying tail mask
+* @param is_single_scale single scale flag, broadcasting if it's true.
+*/
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::load_scales_to_vmm(const data_type_t type_in,
+        const Vmm &vmm_scales, const Xbyak::Operand &op, bool is_ld_tail,
+        bool is_single_scale) {
+    const auto k_mask = is_ld_tail ? ld_tail_mask : ld_full_mask;
+    if (is_single_scale) {
+        switch (type_in) {
+            case data_type::f32: vbroadcastss(vmm_scales, op); break;
+            case data_type::bf16:
+                vpbroadcastw(vmm_scales, op);
+                uni_vpslld(vmm_scales, vmm_scales, 16);
+                break;
+            case data_type::f16:
+                vpbroadcastw(vmm_scales, op);
+                vcvtph2ps(Xmm(vmm_scales.getIdx()), Xmm(vmm_scales.getIdx()));
+                vbroadcastss(vmm_scales, Xmm(vmm_scales.getIdx()));
+                break;
+            default: assert(!"unsupported scales data type");
+        }
+    } else if (IMPLICATION(is_ld_tail, isa_has_masks(brg.isa_impl))) {
+        const Vmm vmm_scales_masked
+                = vmm_mask(vmm_scales, is_ld_tail, false, k_mask);
+        const auto addr = op.getAddress();
+        switch (type_in) {
+            case data_type::f32:
+                if (brg.is_gemv) {
+                    if (!brg.treat_y_as_row)
+                        uni_vmovss(vmm_scales_masked, addr);
+                } else {
+                    uni_vmovups(vmm_scales_masked, addr);
+                }
+                break;
+            case data_type::bf16:
+                uni_vpmovzxwd(vmm_scales_masked, addr);
+                uni_vpslld(vmm_scales, vmm_scales, 16);
+                break;
+            case data_type::f16: vcvtph2ps(vmm_scales_masked, addr); break;
+            default: assert(!"unsupported scales data type");
+        }
+    } else {
+        assert(one_of(
+                type_in, data_type::f32, data_type::bf16, data_type::f16));
+        load_data(type_in, vmm_scales, op.getAddress(), brg.ldb_tail);
+    }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
+        bool is_ld_tail, bool dq2ps_required, bool &dq2ps_cvt_done) {
+    reg_aux_wei_scales.restore();
+    for (dim_t ld = 0; ld < ld_block2; ld++) {
+        const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(ld)];
+        const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+
+        const Vmm vmm_wei_scales = vmm_tmp(0);
+        load_scales_to_vmm(brg.dt_wei_scales, vmm_wei_scales, addr, is_tail,
+                brg.is_single_wei_scale);
+
+        for (dim_t bd = 0; bd < bd_block; bd++) {
+            auto vmm = accm(ld_block2, bd, ld);
+            if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
+            uni_vmulps(vmm, vmm, vmm_wei_scales);
+        }
+    }
+    dq2ps_cvt_done = true;
+}
+
+// Sibling stage to post-ops; called every brgemm K-call when per-K scales
+// are active. Driver shifts scale pointers per call. Leaves accumulator as
+// f32 so apply_alpha_beta uses vaddps against f32 buffer C.
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::apply_scales(
+        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+    assert(brg.has_per_k_scales());
+    const bool dq2ps_required = brg.is_int8;
+    bool dq2ps_cvt_done = false;
+
+    if (brg.is_per_k_wei_scales)
+        apply_wei_scales(bd_block, ld_block2, is_ld_tail, dq2ps_required,
+                dq2ps_cvt_done);
+}
+
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         dim_t ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail,
@@ -1771,14 +1801,16 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     const bool beta_uses_vadd
             = brg.beta == 1.f && IMPLICATION(brg.is_int8, brg.alpha == 1.0f);
     const bool dq2ps_required = brg.is_int8
-            && IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd);
+            && IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd)
+            && !brg.has_per_k_scales();
     const bool has_ptr_b_support = is_superset(brg.isa_impl, avx512_core);
 
     // This flag tracks whether the conversion has happened, since it must be
     // done only once despite all scales and bias applications requiring it.
     // TODO: perform conversion in a dedicated loop if it is required as it is
     // done in brgemm_post_ops kernel?
-    bool dq2ps_cvt_done = false;
+    // Pre-set when apply_scales() already did the int->f32 conversion.
+    bool dq2ps_cvt_done = brg.has_per_k_scales();
 
     if (brg.with_src_scales) {
         reg_src_scales.restoreTo(reg_aux_src_scales);
@@ -1800,11 +1832,10 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         dq2ps_cvt_done = true;
     }
 
-    if (brg.with_wei_scales) {
+    if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         if (!brg.is_gemv) {
-            apply_wei_scales(bd_block, ld_block2, dq2ps_required,
-                    dq2ps_cvt_done, is_ld_tail);
-            dq2ps_cvt_done = true;
+            apply_wei_scales(bd_block, ld_block2, is_ld_tail, dq2ps_required,
+                    dq2ps_cvt_done);
         } else {
             gemv_apply_wei_scales(bd_block, is_bdb_tail);
         }
@@ -2409,6 +2440,9 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
             L_aligned(label_store_without_comp);
         }
+
+        if (brg.has_per_k_scales())
+            apply_scales(bd_block, ld_block2, is_ld_tail);
 
         if (need_to_apply_alpha_beta)
             apply_alpha_beta(bd_block, ld_block2, is_ld_tail, is_bdb_tail);

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -242,6 +242,11 @@ private:
     const reg64_savable_backup_t reg_buf_aux_backup {reg_buf_aux};
     const reg64_savable_t reg_aux_compensation {regscratchpad_, rbx, r29};
 
+    // Base / working pointers for the per-(M,N) f32 compensation buffer used
+    // by apply_per_mn_compensation. Lifecycle mirrors reg_C / reg_aux_C.
+    const reg64_savable_t reg_per_mn_comp {regscratchpad_, rbx};
+    const reg64_savable_t reg_aux_per_mn_comp {regscratchpad_, rbx};
+
     const reg64_savable_t reg_D {regscratchpad_, r11};
     const reg64_savable_t reg_aux_D {regscratchpad_, rax, r27};
     const reg64_savable_backup_t reg_aux_D_backup {reg_aux_D, r28};
@@ -436,7 +441,10 @@ private:
             dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
     void store_accumulators_apply_post_ops(dim_t bd_block, dim_t ld_block,
             dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
-    void apply_compensation(dim_t bd_block, dim_t ld_block, bool is_ld_tail);
+    void apply_zp_s8s8_compensation(
+            dim_t bd_block, dim_t ld_block, bool is_ld_tail);
+    void apply_per_mn_compensation(
+            dim_t bd_block, dim_t ld_block, bool is_ld_tail);
     void apply_alpha_beta(
             dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
     void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail,
@@ -521,6 +529,13 @@ private:
     dim_t zp_comp_b_offset(dim_t bd) const noexcept;
     dim_t bdb_zp_comp_b_offset(dim_t bd_block2) const noexcept;
     dim_t zp_c_values_offset(dim_t ld, bool is_tail = false) const noexcept;
+
+    // Offsets into the per-(M,N) f32 compensation buffer. The buffer mirrors
+    // buf_C layout but with f32 stride (= brg.LDC elements).
+    dim_t per_mn_comp_offset(dim_t bd, dim_t ld) const noexcept;
+    dim_t ldb_per_mn_comp_offset(
+            dim_t ld_block2, bool is_tail = false) const noexcept;
+    dim_t bdb_per_mn_comp_offset(dim_t bd_block2) const noexcept;
 
     bool vpad_exist = false;
     bool need_comp_pads = false;
@@ -765,6 +780,25 @@ dim_t jit_brgemm_kernel_t<Wmm>::zp_c_values_offset(
 
     return 0;
 }
+
+template <typename Wmm>
+dim_t jit_brgemm_kernel_t<Wmm>::per_mn_comp_offset(
+        dim_t bd, dim_t ld) const noexcept {
+    return sizeof(float) * (bd * brg.LDC + ld * brg.ld_block);
+}
+
+template <typename Wmm>
+dim_t jit_brgemm_kernel_t<Wmm>::ldb_per_mn_comp_offset(
+        dim_t ld_block2, bool is_tail) const noexcept {
+    return (is_tail) ? sizeof(float) * brg.ldb_tail
+                     : sizeof(float) * ld_block2 * brg.ld_block;
+}
+
+template <typename Wmm>
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_per_mn_comp_offset(
+        dim_t bd_block2) const noexcept {
+    return sizeof(float) * bd_block2 * brg.bd_block * brg.LDC;
+}
 template <typename Wmm>
 template <typename U>
 U jit_brgemm_kernel_t<Wmm>::vmm_mask(const U vmm_in, bool mask_flag, bool store,
@@ -838,6 +872,11 @@ void jit_brgemm_kernel_t<Wmm>::advance_ldb_post_op_regs() {
         add(reg_aux_zp_c_values, zp_c_values_offset(1));
         reg_aux_zp_c_values.save();
     }
+    if (brg.with_per_mn_compensation) {
+        reg_aux_per_mn_comp.restore();
+        add(reg_aux_per_mn_comp, ldb_per_mn_comp_offset(1));
+        reg_aux_per_mn_comp.save();
+    }
 }
 
 template <typename Wmm>
@@ -861,6 +900,11 @@ void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(dim_t ld_block2) {
         reg_aux_zp_c_values.restore();
         sub(reg_aux_zp_c_values, zp_c_values_offset(ld_block2 - 1));
         reg_aux_zp_c_values.save();
+    }
+    if (brg.with_per_mn_compensation) {
+        reg_aux_per_mn_comp.restore();
+        sub(reg_aux_per_mn_comp, ldb_per_mn_comp_offset(ld_block2 - 1));
+        reg_aux_per_mn_comp.save();
     }
 }
 
@@ -945,6 +989,13 @@ void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(dim_t ld_block2, bool is_tail) {
                           : zp_c_values_offset(ld_block2));
         reg_aux_zp_c_values.save();
     }
+    if (brg.with_per_mn_compensation) {
+        reg_aux_per_mn_comp.restore();
+        add(reg_aux_per_mn_comp,
+                (is_tail) ? ldb_per_mn_comp_offset(1, true)
+                          : ldb_per_mn_comp_offset(ld_block2));
+        reg_aux_per_mn_comp.save();
+    }
 }
 
 template <typename Wmm>
@@ -966,6 +1017,11 @@ void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(dim_t bd_block2) {
         reg_zp_comp_b.restore();
         add(reg_zp_comp_b, bdb_zp_comp_b_offset(bd_block2));
         reg_zp_comp_b.save();
+    }
+    if (brg.with_per_mn_compensation) {
+        reg_per_mn_comp.restore();
+        add(reg_per_mn_comp, bdb_per_mn_comp_offset(bd_block2));
+        reg_per_mn_comp.save();
     }
 }
 
@@ -997,6 +1053,10 @@ void jit_brgemm_kernel_t<Wmm>::copy_post_ops_stack_values_to_aux(
         if (brg.zp_type_c != brgemm_broadcast_t::none) {
             reg_zp_c_values.restore();
             reg_zp_c_values.saveTo(reg_aux_zp_c_values);
+        }
+        if (brg.with_per_mn_compensation) {
+            reg_per_mn_comp.restore();
+            reg_per_mn_comp.saveTo(reg_aux_per_mn_comp);
         }
     }
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
@@ -1061,6 +1121,11 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
     if (brg.zp_type_c != brgemm_broadcast_t::none) {
         mov(reg_zp_c_values, ptr[param1 + GET_OFF(c_zp_values)]);
         reg_zp_c_values.save();
+    }
+
+    if (brg.with_per_mn_compensation) {
+        mov(reg_per_mn_comp, ptr[param1 + GET_OFF(ptr_per_mn_compensation)]);
+        reg_per_mn_comp.save();
     }
 
     if (brg.with_dst_scales) {
@@ -1805,7 +1870,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_scales(
         dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
     assert(brg.has_per_k_scales());
     const bool dq2ps_required = brg.is_int8;
-    bool dq2ps_cvt_done = false;
+    // When per-MN compensation was applied before this call, dq2ps is
+    // already done by apply_per_mn_compensation.
+    bool dq2ps_cvt_done = brg.with_per_mn_compensation;
 
     if (brg.is_per_k_wei_scales)
         apply_wei_scales(bd_block, ld_block2, is_ld_tail, dq2ps_required,
@@ -1827,6 +1894,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         dim_t ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail,
         bool is_bdb_tail) {
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
+
     // if (brg.is_int8 && alpha_or_beta_applicable && !beta_uses_vadd) ->
     // accumulated values are already converted to ps in apply_alpha_beta()
     const bool alpha_or_beta_applicable = brg.alpha != 1.0f || brg.beta != 0.f;
@@ -1843,8 +1911,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     // done only once despite all scales and bias applications requiring it.
     // TODO: perform conversion in a dedicated loop if it is required as it is
     // done in brgemm_post_ops kernel?
-    // Pre-set when apply_scales() already did the int->f32 conversion.
-    bool dq2ps_cvt_done = brg.has_per_k_scales();
+    bool dq2ps_cvt_done
+            = brg.has_per_k_scales() || brg.with_per_mn_compensation;
 
     if (brg.with_src_scales && !brg.is_per_k_src_scales) {
         reg_src_scales.restoreTo(reg_aux_src_scales);
@@ -2100,7 +2168,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_compensation(
+void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
         dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
     assert(!brg.is_gemv && "compensation is not supported for gemv");
     // apply compensation to accumulated values
@@ -2181,6 +2249,42 @@ void jit_brgemm_kernel_t<Wmm>::apply_compensation(
             }
         }
     }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::apply_per_mn_compensation(
+        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+    assert(brg.with_per_mn_compensation);
+    assert(!brg.is_gemv && "per-(M,N) compensation is not supported for gemv");
+    assert(!brg.is_integer_acc()
+            && "per-(M,N) compensation is not supported for int accumulation");
+
+    if (brg.is_int8) {
+        for_(dim_t bd = 0; bd < bd_block; bd++)
+        for (dim_t ld = 0; ld < ld_block2; ld++) {
+            auto vmm = accm(ld_block2, bd, ld);
+            uni_vcvtdq2ps(vmm, vmm);
+        }
+    }
+
+    const auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
+    reg_aux_per_mn_comp.restore();
+    const auto vmm_delta = vmm_tmp(0);
+    for_(dim_t bd = 0; bd < bd_block; bd++)
+    for (dim_t ld = 0; ld < ld_block2; ld++) {
+        const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+        const auto delta_addr
+                = ptr[reg_aux_per_mn_comp + per_mn_comp_offset(bd, ld)];
+        if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
+            auto vmm_delta_masked = vmm_mask(vmm_delta, is_tail, false, k_mask);
+            uni_vmovups(vmm_delta_masked, delta_addr);
+        } else {
+            vmaskmovps(vmm_delta, vmm_tail_mask(), delta_addr);
+        }
+        auto vmm = accm(ld_block2, bd, ld);
+        uni_vsubps(vmm, vmm, vmm_delta);
+    }
+    maybe_set_avx_mask(is_ld_tail);
 }
 
 template <typename Wmm>
@@ -2350,7 +2454,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                         }
 
                         if (apply_zp_a_compensation)
-                            apply_compensation(adj_bd_block, 1, is_ld_tail);
+                            apply_zp_s8s8_compensation(
+                                    adj_bd_block, 1, is_ld_tail);
 
                         if (need_to_apply_alpha_beta)
                             apply_alpha_beta(
@@ -2472,11 +2577,13 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
             reg_do_comp.restore();
             cmp(reg_do_comp, 0);
             jz(label_store_without_comp, T_NEAR);
-            apply_compensation(bd_block, ld_block2, is_ld_tail);
+            apply_zp_s8s8_compensation(bd_block, ld_block2, is_ld_tail);
 
             L_aligned(label_store_without_comp);
         }
 
+        if (brg.with_per_mn_compensation)
+            apply_per_mn_compensation(bd_block, ld_block2, is_ld_tail);
         if (brg.has_per_k_scales())
             apply_scales(bd_block, ld_block2, is_ld_tail);
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -441,6 +441,8 @@ private:
             dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
     void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail,
             bool dq2ps_required, bool &dq2ps_cvt_done);
+    void apply_src_scales_per_k(dim_t bd_block, dim_t ld_block2,
+            bool dq2ps_required, bool &dq2ps_cvt_done);
     void apply_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail);
     void apply_post_ops(dim_t bd_block, dim_t ld_block2,
             dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
@@ -715,6 +717,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
         dim_t ld, bool is_tail) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return ld * (brg.bd_block / brg.gemv_bd_block())
+                * brg.is_per_n_wei_scales
                 * types::data_type_size(brg.dt_wei_scales);
 
     const dim_t ld_offset = is_tail ? brg.ldb_tail : ld * brg.ld_block;
@@ -1775,6 +1778,25 @@ void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
     dq2ps_cvt_done = true;
 }
 
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(dim_t bd_block,
+        dim_t ld_block2, bool dq2ps_required, bool &dq2ps_cvt_done) {
+    reg_src_scales.restoreTo(reg_aux_src_scales);
+    const auto vmm_src_sc = vmm_tmp(0);
+    for (dim_t bd = 0; bd < bd_block; bd++) {
+        const auto src_sc_addr
+                = ptr[reg_aux_src_scales + bd * brg.src_scale_m_stride];
+        load_scales_to_vmm(brg.dt_src_scales, vmm_src_sc, src_sc_addr,
+                /*is_ld_tail=*/false, /*is_single_scale=*/true);
+        for (dim_t ld = 0; ld < ld_block2; ld++) {
+            auto vmm = accm(ld_block2, bd, ld);
+            if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
+            uni_vmulps(vmm, vmm, vmm_src_sc);
+        }
+    }
+    dq2ps_cvt_done = true;
+}
+
 // Sibling stage to post-ops; called every brgemm K-call when per-K scales
 // are active. Driver shifts scale pointers per call. Leaves accumulator as
 // f32 so apply_alpha_beta uses vaddps against f32 buffer C.
@@ -1788,6 +1810,16 @@ void jit_brgemm_kernel_t<Wmm>::apply_scales(
     if (brg.is_per_k_wei_scales)
         apply_wei_scales(bd_block, ld_block2, is_ld_tail, dq2ps_required,
                 dq2ps_cvt_done);
+    if (brg.is_per_k_src_scales)
+        apply_src_scales_per_k(
+                bd_block, ld_block2, dq2ps_required, dq2ps_cvt_done);
+    if (dq2ps_required && !dq2ps_cvt_done) {
+        for_(dim_t ld = 0; ld < ld_block2; ld++)
+        for (dim_t bd = 0; bd < bd_block; bd++) {
+            auto vmm = accm(ld_block2, bd, ld);
+            uni_vcvtdq2ps(vmm, vmm);
+        }
+    }
 }
 
 template <typename Wmm>
@@ -1803,7 +1835,9 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     const bool dq2ps_required = brg.is_int8
             && IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd)
             && !brg.has_per_k_scales();
-    const bool has_ptr_b_support = is_superset(brg.isa_impl, avx512_core);
+    // vmulps with memory op is supported only with avx512 + f32 dt.
+    const bool has_ptr_b_support = is_superset(brg.isa_impl, avx512_core)
+            && brg.dt_src_scales == data_type::f32;
 
     // This flag tracks whether the conversion has happened, since it must be
     // done only once despite all scales and bias applications requiring it.
@@ -1812,11 +1846,13 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     // Pre-set when apply_scales() already did the int->f32 conversion.
     bool dq2ps_cvt_done = brg.has_per_k_scales();
 
-    if (brg.with_src_scales) {
+    if (brg.with_src_scales && !brg.is_per_k_src_scales) {
         reg_src_scales.restoreTo(reg_aux_src_scales);
         auto vmm_src_scales = vmm_tmp(0);
         if (!has_ptr_b_support)
-            vbroadcastss(vmm_src_scales, ptr[reg_aux_src_scales]);
+            load_scales_to_vmm(brg.dt_src_scales, vmm_src_scales,
+                    ptr[reg_aux_src_scales],
+                    /*is_ld_tail=*/false, /*is_single_scale=*/true);
 
         for_(dim_t ld = 0; ld < ld_block2; ld++)
         for (dim_t bd = 0; bd < bd_block; bd++) {
@@ -3483,6 +3519,15 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
             add(reg_D, bdb_D_offset(bd_block2));
         }
         add(reg_a_offset, bdb_A_offset(bd_block2));
+
+        if (brg.is_per_k_src_scales) {
+            const auto adj_bd_block = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
+            const auto src_scales_stack_ptr
+                    = reg_src_scales.getStoragePtr().getRegExp();
+            const auto src_scales_offset
+                    = adj_bd_block * bd_block2 * brg.src_scale_m_stride;
+            add(dword[src_scales_stack_ptr], src_scales_offset);
+        }
 
         if (brg.is_gemv && brg.treat_y_as_row) {
             if (brg.with_bias) {

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -822,9 +822,10 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
             const auto addr = ptr[aux_reg_wei_scales
-                    + brg_.is_oc_scale * sizeof(float) * (n * brg_.ld_block)];
+                    + brg_.is_per_n_wei_scales * sizeof(float)
+                            * (n * brg_.ld_block)];
             const bool is_tail = tail > 0;
-            const bool is_single_scale = !brg_.is_oc_scale;
+            const bool is_single_scale = brg_.is_single_wei_scale;
 
             const auto vmm = vector(m, n);
             const auto vmm_wei_scales = vmm_tmp(0);
@@ -1060,7 +1061,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * sizeof(float) * oc_l_offset);
+                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
         }
     }
     if (nb2_tail > 0) {
@@ -1088,7 +1089,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * sizeof(float) * oc_l_offset);
+                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
         }
     }
     if (nb_tail > 0) {
@@ -1114,7 +1115,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * bia_typesize_ * (nb_tail));
+                        brg_.is_per_n_wei_scales * bia_typesize_ * (nb_tail));
         }
         add(aux_reg_out, out_typesize_ * (nb_tail));
     }

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -23,6 +23,7 @@
 
 #include "cpu/cpu_primitive.hpp"
 #include "cpu/matmul/matmul_utils.hpp"
+#include "cpu/ref_io_helper.hpp"
 #include "cpu/scale_utils.hpp"
 
 #include "cpu/x64/amx_tile_configure.hpp"
@@ -317,6 +318,23 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                              bgmmc_.N % 8 == 0),
             "unsupported configuration");
 
+    // ZP per M,N compensation doesn't support strided cases yet.
+    if (bgmmc_.with_per_mn_compensation) {
+        VDISPATCH_MATMUL(bgmmc_.A_strides[0] == 1 && bgmmc_.B_strides[0] == 1,
+                VERBOSE_UNSUPPORTED_TAG);
+        const bool wei_is_subbyte = utils::one_of(wei_dt, s4, u4);
+        if (wei_is_subbyte) {
+            VDISPATCH_MATMUL(
+                    bgmmc_.N_blk % 2 == 0 && bgmmc_.B_strides[1] % 2 == 0,
+                    VERBOSE_UNSUPPORTED_TAG);
+        }
+        // Pre-validate the per-(M, N) JIT kernel constraints
+        VDISPATCH_MATMUL(
+                per_mn_comp_kernel_t::is_applicable(&bgmmc_) == status::success,
+                VERBOSE_UNSUPPORTED_FEATURE,
+                "per-mn-comp jit kernel not applicable");
+    }
+
     const float alpha = 1.0;
     const float beta = 1.0;
     const float beta_init = 0.0;
@@ -392,6 +410,14 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         auto LDD = bgmmc_.LDD;
         if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
             brg.skip_zp_b_compensation = true;
+        // The per-(M, N) compensation tile carries the full src+wei zero
+        // point correction in f32 (post per-K scales). Skip the kernel's
+        // built-in vpaddd-based zp_a path so it isn't applied twice.
+        if (bgmmc_.with_per_mn_compensation) {
+            brg.with_per_mn_compensation = true;
+            brg.skip_zp_a_compensation = true;
+            brg.skip_zp_b_compensation = true;
+        }
         brg.skip_wei_scales = bgmmc_.apply_scales_in_buffer_b;
         // Fill up the scales info in case it's computing in brgemm
         if (!brg.skip_wei_scales && bgmmc_.with_wei_scales) {
@@ -533,6 +559,10 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
         CHECK(safe_ptr_assign(sparse_decompress_kernel_,
                 new jit_avx512_sparse_decompress_kernel_t(bgmmc)));
         CHECK(sparse_decompress_kernel_->create_kernel());
+    }
+
+    if (bgmmc.with_per_mn_compensation) {
+        CHECK(per_mn_comp_kernel_t::create(per_mn_comp_kernel_, &bgmmc));
     }
 
     return status::success;
@@ -795,16 +825,30 @@ void brgemm_matmul_t<isa>::compute_kernel(
     // The `do_only_*` flags map to {do_post_ops, do_apply_comp} as {0,1} (comp
     // only) and {1,1} (epilogue).
     auto execute_brgemm = [&](const brgemm_kernel_t *kernel, const int brg_idx,
-                                  const int bs, const bool need_postops) {
-        const bool per_k_scales
-                = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b;
+                                  const int bs, const bool need_postops,
+                                  const bool is_tail) {
+        const bool per_k_scales = bgmmc.is_src_scale_per_k
+                || (bgmmc.is_wei_scale_per_k
+                        && !bgmmc.apply_scales_in_buffer_b);
         const auto k = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
         const auto m = brgmm_ctx.get_M_idx(m_blk_idx, true);
 
+        // Symmetric src/wei zp + 128-shift compensation tile for this
+        // brgemm K-block call
+        if (bgmmc.with_per_mn_compensation) {
+            fill_per_mn_compensation(brgmm_ctx, ithr, m_blk_idx, n_blk_idx,
+                    A_data_batch_ptr, B_data_batch_ptr,
+                    brgmm_ctx.get_M_kernel_size(m_blk_idx),
+                    brgmm_ctx.get_N_kernel_size(n_blk_idx), k_blk_idx, is_tail);
+        }
+        const void *per_mn_comp = bgmmc.with_per_mn_compensation
+                ? static_cast<const void *>(brgmm_ctx.get_per_mn_comp_ptr(ithr))
+                : nullptr;
+
         if (!need_postops) {
             // Intermediate K-block: plain accumulation unless per-K scales
-            // must be applied during accumulation.
-            if (!per_k_scales) {
+            // or per-MN compensation must be applied during accumulation.
+            if (!per_k_scales && !bgmmc.with_per_mn_compensation) {
                 void *scratch
                         = is_brg_amx(brg_idx) ? (void *)wsp_tile : nullptr;
                 brgemm_kernel_execute(kernel, bs, addr_batch, (void *)ptr_C,
@@ -813,7 +857,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
             }
             const void *src_scales = bgmmc.is_src_scale_per_k
                     ? brgmm_ctx.get_src_scales_ptr(m, k)
-                    : nullptr;
+                    : (bgmmc.is_wei_scale_per_k && bgmmc.with_src_scales
+                                      ? brgmm_ctx.get_src_scales_ptr()
+                                      : nullptr);
             const void *wei_scales = bgmmc.is_wei_scale_per_k
                             && !bgmmc.apply_scales_in_buffer_b
                     ? brgmm_ctx.get_wei_scales_ptr(n, k)
@@ -828,7 +874,8 @@ void brgemm_matmul_t<isa>::compute_kernel(
                     /*skip_accumulation=*/false, /*zp_a_val=*/1,
                     /*do_only_comp=*/false,
                     /*do_only_zp_a_val=*/true, src_scales, wei_scales,
-                    /*dst_scales=*/nullptr};
+                    /*dst_scales=*/nullptr, /*a_zp_values=*/nullptr,
+                    /*per_mn_compensation=*/per_mn_comp};
             brgemm_kernel_execute_postops(kernel, bs, addr_batch, (void *)ptr_C,
                     (void *)ptr_D, post_ops_data, scratch, &leading_dimensions);
             return;
@@ -866,7 +913,8 @@ void brgemm_matmul_t<isa>::compute_kernel(
                 /*c_zp_values=*/brgmm_ctx.get_zp_c_ptr(),
                 /*skip_accumulation=*/false, /*zp_a_val=*/1,
                 /*do_only_comp=*/false, /*do_only_zp_a_val=*/false, src_scales,
-                wei_scales, dst_scales};
+                wei_scales, dst_scales, /*a_zp_values=*/nullptr,
+                /*per_mn_compensation=*/per_mn_comp};
 
         brgemm_kernel_execute_postops(kernel, bs, addr_batch, (void *)ptr_C,
                 (void *)ptr_D, post_ops_data, scratch, &leading_dimensions);
@@ -883,7 +931,8 @@ void brgemm_matmul_t<isa>::compute_kernel(
                 n_blk_idx);
         const bool need_postops
                 = post_ops_applicable && is_last_K_blk && !is_K_tail;
-        execute_brgemm(brg_kernel, brg_ker_idx, gemm_batch, need_postops);
+        execute_brgemm(brg_kernel, brg_ker_idx, gemm_batch, need_postops,
+                /*is_tail=*/false);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail, /* do_K_tail */ false);
@@ -904,8 +953,8 @@ void brgemm_matmul_t<isa>::compute_kernel(
                 is_brg_amx(brg_ker_idx), prev_ker_idx, brg_ker_idx);
         const auto brg_kernel_k_tail = brg_kernels_[brg_ker_idx].get();
 
-        execute_brgemm(
-                brg_kernel_k_tail, brg_ker_idx, /*bs=*/1, post_ops_applicable);
+        execute_brgemm(brg_kernel_k_tail, brg_ker_idx, /*bs=*/1,
+                post_ops_applicable, /*is_tail=*/true);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail,
@@ -914,6 +963,112 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
     brgmm_ctx.maybe_restore_dst_values_from_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
+}
+
+template <cpu_isa_t isa>
+void brgemm_matmul_t<isa>::fill_per_mn_compensation(
+        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, int m_blk_idx,
+        int n_blk_idx, const char *A_data_batch_ptr,
+        const char *B_data_batch_ptr, int m_kernel_size, int n_kernel_size,
+        int k_blk_idx, bool is_tail) const {
+    const auto &bgmmc = pd()->get_brgemm_matmul_conf();
+    if (!bgmmc.with_per_mn_compensation) return;
+    assert(per_mn_comp_kernel_ != nullptr);
+
+    const dim_t batch_size = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
+    const dim_t k_start = static_cast<dim_t>(k_blk_idx) * bgmmc.K_blk
+                    * bgmmc.brgemm_batch_size
+            + (is_tail ? batch_size * bgmmc.K_blk : dim_t {0});
+    const dim_t k_len = is_tail ? bgmmc.K_tail : batch_size * bgmmc.K_blk;
+
+    const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
+    const dim_t n = brgmm_ctx.get_N_idx(n_blk_idx, true);
+
+    // Resolve per-N / per-K-group base pointers via existing getters.
+    // For sub-byte src ZP (s4/u4), get_src_zp_ptr byte-aligns the pointer
+    // and returns the nibble index so the kernel picks the right nibble.
+    int src_zp_nibble_idx = 0;
+    const void *src_zp_ptr
+            = brgmm_ctx.get_src_zp_ptr(m, k_start, &src_zp_nibble_idx);
+    const void *wei_zp_ptr = brgmm_ctx.get_wei_zp_ptr(n, k_start);
+
+    const bool wei_is_subbyte
+            = utils::one_of(bgmmc.orig_wei_dt, data_type::s4, data_type::u4);
+    const dim_t wei_k_stride
+            = wei_is_subbyte ? bgmmc.B_strides[1] / 2 : bgmmc.B_strides[1];
+
+    per_mn_comp_kernel_t::ctx_t kctx;
+    kctx.src_batch_ptr = A_data_batch_ptr + k_start * bgmmc.A_strides[0];
+    kctx.wei_batch_ptr = B_data_batch_ptr + k_start * wei_k_stride;
+    kctx.src_zp_ptr = src_zp_ptr;
+    kctx.src_zp_nibble_idx = src_zp_nibble_idx;
+    kctx.wei_zp_ptr = wei_zp_ptr;
+    kctx.delta_ptr = brgmm_ctx.get_per_mn_comp_ptr(ithr);
+    kctx.m_base = m;
+    kctx.n_base = n;
+    kctx.M_blk = m_kernel_size;
+    kctx.N_blk = n_kernel_size;
+    kctx.k_len = k_len;
+
+    // Zero the per-thread delta tile to guard the brgemm consumer
+    // against reading unwritten rows when bd_block > M_blk (the AMX
+    // tile iterates over bd_block, not M_blk).
+    const size_t per_thr_elems = static_cast<size_t>(bgmmc.M_blk)
+            * static_cast<size_t>(rnd_up(bgmmc.N_blk, bgmmc.LDC));
+    std::memset(kctx.delta_ptr, 0, per_thr_elems * sizeof(float));
+
+    const bool has_src_zp
+            = bgmmc.has_zero_point_a && kctx.src_zp_ptr != nullptr;
+    const bool has_wei_zp
+            = bgmmc.has_zero_point_b && kctx.wei_zp_ptr != nullptr;
+    const bool wei_zp_per_n = has_wei_zp && bgmmc.is_wei_zp_per_n;
+    const bool src_zp_per_m = has_src_zp && bgmmc.is_src_zp_per_m;
+    const bool src_zp_per_k = has_src_zp && bgmmc.is_src_zp_per_k;
+    const dim_t src_zp_m_stride_elems = src_zp_per_m
+            ? (src_zp_per_k ? utils::div_up(bgmmc.K, bgmmc.src_zp_k_gsize)
+                            : dim_t {1})
+            : dim_t {0};
+    const bool wei_zp_scalar = has_wei_zp && !wei_zp_per_n;
+    const float wei_zp_f32 = wei_zp_scalar
+            ? io::load_float_value(bgmmc.wei_zp_dt, kctx.wei_zp_ptr, 0)
+            : 0.0f;
+
+    const dim_t num_stripes = utils::div_up(kctx.N_blk, bgmmc.LDC);
+    const dim_t m_step = src_zp_per_m ? dim_t {1} : kctx.M_blk;
+
+    for (dim_t s = 0; s < num_stripes; ++s) {
+        const dim_t n_origin = s * bgmmc.LDC;
+        const dim_t stripe_w = nstl::min(bgmmc.LDC, kctx.N_blk - n_origin);
+        float *const delta_stripe
+                = kctx.delta_ptr + s * bgmmc.M_blk * bgmmc.LDC;
+
+        for (dim_t m_off = 0; m_off < kctx.M_blk; m_off += m_step) {
+            per_mn_comp_kernel_t::ctx_t call_ctx = kctx;
+            const dim_t rows = nstl::min(m_step, kctx.M_blk - m_off);
+
+            call_ctx.m_base = kctx.m_base + m_off;
+            call_ctx.n_base = kctx.n_base + n_origin;
+            call_ctx.M_blk = rows;
+            call_ctx.delta_ptr = delta_stripe + m_off * bgmmc.LDC;
+            call_ctx.stripe_w = stripe_w;
+            call_ctx.wei_zp_ptr = wei_zp_per_n
+                    ? reinterpret_cast<const uint8_t *>(kctx.wei_zp_ptr)
+                            + types::elements_to_bytes(
+                                    bgmmc.wei_zp_dt, n_origin)
+                    : nullptr;
+            call_ctx.wei_zp_f32 = wei_zp_f32;
+            call_ctx.src_zp_f32 = has_src_zp
+                    ? io::load_float_value(bgmmc.src_zp_dt, kctx.src_zp_ptr,
+                              kctx.src_zp_nibble_idx
+                                      + m_off * src_zp_m_stride_elems)
+                    : 0.0f;
+            call_ctx.g_sz_f32 = (has_src_zp && has_wei_zp)
+                    ? call_ctx.src_zp_f32 * static_cast<float>(k_len)
+                    : 0.0f;
+
+            (*per_mn_comp_kernel_)(&call_ctx);
+        }
+    }
 }
 
 template <cpu_isa_t isa>
@@ -1282,11 +1437,11 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     // Note: instead of passing an address to a stack variable, a kernel may be
     // changed to take just zp_b value and perform negation itself, but updating
     // kernels is not straightforward for all platforms.
-    int32_t neg_zp_b
-            = !bgmmc.with_wei_decompression ? brgmm_ctx.get_neg_zp_b() : 0;
-    int32_t neg_zp_ab_comp = !bgmmc.with_wei_decompression
-            ? bgmmc.K * brgmm_ctx.get_neg_zp_a()
-            : 0;
+    const bool use_legacy_zp_a_path
+            = !bgmmc.with_wei_decompression && !bgmmc.with_per_mn_compensation;
+    int32_t neg_zp_b = use_legacy_zp_a_path ? brgmm_ctx.get_neg_zp_b() : 0;
+    int32_t neg_zp_ab_comp
+            = use_legacy_zp_a_path ? bgmmc.K * brgmm_ctx.get_neg_zp_a() : 0;
     ctx.zp_b_neg_val_ptr = &neg_zp_b;
     ctx.zp_ab_comp_ptr = &neg_zp_ab_comp;
 
@@ -1543,6 +1698,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         zero_point_b_compensations_ptr_ = bgmmc.has_zero_point_b
                 ? scratchpad.template get<int32_t>(
                           key_brgemm_primitive_zp_comp_b)
+                : nullptr;
+
+        per_mn_comp_ptr_ = bgmmc.with_per_mn_compensation
+                ? scratchpad.template get<float>(
+                          key_brgemm_primitive_per_mn_comp)
                 : nullptr;
 
         post_ops_binary_rhs_arg_vec_ = binary_injector::prepare_binary_args(
@@ -2164,12 +2324,19 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     const void *get_src_scales_ptr(dim_t m = 0, dim_t k = 0) const {
-        if (!bgmmc_.is_src_scale_per_k) return src_scales_;
+        if (!bgmmc_.is_src_scale_per_k && !bgmmc_.is_src_scale_per_m)
+            return src_scales_;
 
-        const auto &k_group_sz = bgmmc_.src_scales_k_gsize;
-        const auto k_idx = k / k_group_sz;
-        const auto num_k_groups = utils::div_up(bgmmc_.K, k_group_sz);
-        auto offset = (m * num_k_groups + k_idx) * bgmmc_.src_scales_dt_sz;
+        const auto k_group_sz = bgmmc_.is_src_scale_per_k
+                ? bgmmc_.src_scales_k_gsize
+                : bgmmc_.K;
+        const auto k_idx
+                = bgmmc_.is_src_scale_per_k ? (k / k_group_sz) : dim_t {0};
+        const auto num_k_groups = bgmmc_.is_src_scale_per_k
+                ? utils::div_up(bgmmc_.K, k_group_sz)
+                : dim_t {1};
+        const auto m_idx = bgmmc_.is_src_scale_per_m ? m : dim_t {0};
+        auto offset = (m_idx * num_k_groups + k_idx) * bgmmc_.src_scales_dt_sz;
         return ((const char *)src_scales_ + offset);
     }
 
@@ -2213,6 +2380,35 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return -cpu::io::load_int_value(bgmmc_.wei_zp_dt, wei_zp_ptr_, 0);
     }
 
+    const void *get_src_zp_ptr(
+            dim_t m = 0, dim_t k = 0, int *nibble_idx = nullptr) const {
+        if (!bgmmc_.has_zero_point_a) return nullptr;
+
+        dim_t elem_idx = 0;
+        if (bgmmc_.is_src_zp_per_k || bgmmc_.is_src_zp_per_m) {
+            const auto k_group_sz
+                    = bgmmc_.is_src_zp_per_k ? bgmmc_.src_zp_k_gsize : bgmmc_.K;
+            const auto k_idx
+                    = bgmmc_.is_src_zp_per_k ? (k / k_group_sz) : dim_t {0};
+            const auto num_k_groups = bgmmc_.is_src_zp_per_k
+                    ? utils::div_up(bgmmc_.K, k_group_sz)
+                    : dim_t {1};
+            const auto m_idx = bgmmc_.is_src_zp_per_m ? m : dim_t {0};
+            elem_idx = m_idx * num_k_groups + k_idx;
+        }
+
+        const auto dt_sz = types::data_type_size(bgmmc_.src_zp_dt);
+        const auto elems_per_byte
+                = one_of(bgmmc_.src_zp_dt, data_type::s4, data_type::u4) ? 2
+                                                                         : 1;
+        // Expose nibble parity so the caller can pass the correct element
+        // index to load_float_value() for sub-byte (s4/u4) types.
+        if (nibble_idx)
+            *nibble_idx = static_cast<int>(elem_idx % elems_per_byte);
+        const auto byte_off = elem_idx * dt_sz / elems_per_byte;
+        return (const char *)src_zp_ptr_ + byte_off;
+    }
+
     const void *get_wei_zp_ptr(dim_t n, dim_t k = 0) const {
         if (!bgmmc_.has_zero_point_b) return nullptr;
         if (bgmmc_.is_wei_zp_common)
@@ -2235,6 +2431,18 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     const void *get_zp_c_ptr() const { return dst_zp_ptr_; }
+
+    // Returns the per-thread f32 tile (M_blk × LDC elements) used by the
+    // per-(M, N) compensation kernel hook. Caller fills it just before the
+    // final K-block brgemm call.
+    float *get_per_mn_comp_ptr(int ithr) const {
+        if (!bgmmc_.with_per_mn_compensation) return nullptr;
+        // Per-thread tile mirrors buffer_c's stripe layout for AMX:
+        // ceil(N_blk / LDC) stripes of M_blk × LDC floats.
+        const size_t per_thr_elems = static_cast<size_t>(bgmmc_.M_blk)
+                * static_cast<size_t>(rnd_up(bgmmc_.N_blk, bgmmc_.LDC));
+        return per_mn_comp_ptr_ + ithr * per_thr_elems;
+    }
 
     int32_t *get_zp_a_compensation_ptr(
             int ithr, int b_idx, int n_blk_idx) const {
@@ -2580,6 +2788,8 @@ private:
     int32_t *zero_point_a_compensations_ptr_;
     int32_t *zero_point_b_compensations_ptr_;
     int32_t *reorder_zp_a_comp_ptr_;
+    // Per-thread f32 tile (size M_blk × LDC)
+    float *per_mn_comp_ptr_;
 
     const void *src_zp_ptr_;
     const void *wei_zp_ptr_;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -405,6 +405,15 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             brg.is_per_k_wei_scales = bgmmc_.is_wei_scale_per_k;
             brg.dt_wei_scales = bgmmc_.wei_scales_dt;
         }
+        if (bgmmc_.with_src_scales) {
+            brg.dt_src_scales = bgmmc_.src_scales_dt;
+            if (bgmmc_.is_src_scale_per_k) {
+                brg.is_per_k_src_scales = true;
+                const auto num_k_groups
+                        = utils::div_up(bgmmc_.K, bgmmc_.src_scales_k_gsize);
+                brg.src_scale_m_stride = num_k_groups * bgmmc_.src_scales_dt_sz;
+            }
+        }
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 
@@ -802,8 +811,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
                         scratch, &leading_dimensions);
                 return;
             }
-            const void *src_scales
-                    = nullptr; // Will be introduced on next commit
+            const void *src_scales = bgmmc.is_src_scale_per_k
+                    ? brgmm_ctx.get_src_scales_ptr(m, k)
+                    : nullptr;
             const void *wei_scales = bgmmc.is_wei_scale_per_k
                             && !bgmmc.apply_scales_in_buffer_b
                     ? brgmm_ctx.get_wei_scales_ptr(n, k)
@@ -826,7 +836,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
         // Final K-block: apply scales, compensation and post-ops. Per-K scales
         // take precedence over the common ones.
-        const void *src_scales = brgmm_ctx.get_src_scales_ptr();
+        const void *src_scales = bgmmc.is_src_scale_per_k
+                ? brgmm_ctx.get_src_scales_ptr(m, k)
+                : brgmm_ctx.get_src_scales_ptr();
         const void *wei_scales
                 = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b
                 ? brgmm_ctx.get_wei_scales_ptr(n, k)
@@ -2151,7 +2163,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 + n_blk_local * bgmmc_.s8s8_comp_n_str;
     }
 
-    const void *get_src_scales_ptr() const { return src_scales_; }
+    const void *get_src_scales_ptr(dim_t m = 0, dim_t k = 0) const {
+        if (!bgmmc_.is_src_scale_per_k) return src_scales_;
+
+        const auto &k_group_sz = bgmmc_.src_scales_k_gsize;
+        const auto k_idx = k / k_group_sz;
+        const auto num_k_groups = utils::div_up(bgmmc_.K, k_group_sz);
+        auto offset = (m * num_k_groups + k_idx) * bgmmc_.src_scales_dt_sz;
+        return ((const char *)src_scales_ + offset);
+    }
 
     // Returns a pointer to the weights scales for the correspondent block based
     // on @p n and @p k.

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -392,7 +392,19 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         auto LDD = bgmmc_.LDD;
         if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
             brg.skip_zp_b_compensation = true;
-        if (bgmmc_.apply_scales_in_buffer_b) brg.skip_wei_scales = true;
+        brg.skip_wei_scales = bgmmc_.apply_scales_in_buffer_b;
+        // Fill up the scales info in case it's computing in brgemm
+        if (!brg.skip_wei_scales && bgmmc_.with_wei_scales) {
+            brg.is_single_wei_scale = bgmmc_.is_wei_scale_common;
+            brg.is_per_n_wei_scales = bgmmc_.is_wei_scale_per_n;
+            // For grouped (per-K) wei scales: K_blk == group_size and
+            // brgemm_batch_size == 1, so each brgemm call covers exactly one
+            // K-group. The matmul driver shifts `ptr_wei_scales` to the
+            // current group's per-N vector before each call. Brgemm just
+            // applies it as per-N at C-accumulation time.
+            brg.is_per_k_wei_scales = bgmmc_.is_wei_scale_per_k;
+            brg.dt_wei_scales = bgmmc_.wei_scales_dt;
+        }
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 
@@ -763,51 +775,103 @@ void brgemm_matmul_t<isa>::compute_kernel(
     brgmm_ctx.maybe_backup_dst_values_to_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
 
+    auto is_brg_amx = [&](const int brg_idx) {
+        return is_superset(
+                pd()->get_brg_desc(brg_idx).isa_impl, avx512_core_amx);
+    };
+
+    // Execute the kernel for one K-block. Pure accumulation into C goes through
+    // the plain execute API. Accumulation-time scales / grouped s8s8
+    // compensation and the final-block epilogue go through the post-ops API.
+    // The `do_only_*` flags map to {do_post_ops, do_apply_comp} as {0,1} (comp
+    // only) and {1,1} (epilogue).
+    auto execute_brgemm = [&](const brgemm_kernel_t *kernel, const int brg_idx,
+                                  const int bs, const bool need_postops) {
+        const bool per_k_scales
+                = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b;
+        const auto k = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
+        const auto m = brgmm_ctx.get_M_idx(m_blk_idx, true);
+
+        if (!need_postops) {
+            // Intermediate K-block: plain accumulation unless per-K scales
+            // must be applied during accumulation.
+            if (!per_k_scales) {
+                void *scratch
+                        = is_brg_amx(brg_idx) ? (void *)wsp_tile : nullptr;
+                brgemm_kernel_execute(kernel, bs, addr_batch, (void *)ptr_C,
+                        scratch, &leading_dimensions);
+                return;
+            }
+            const void *src_scales
+                    = nullptr; // Will be introduced on next commit
+            const void *wei_scales = bgmmc.is_wei_scale_per_k
+                            && !bgmmc.apply_scales_in_buffer_b
+                    ? brgmm_ctx.get_wei_scales_ptr(n, k)
+                    : nullptr;
+            void *scratch = is_brg_amx(brg_idx) ? (void *)wsp_tile : nullptr;
+            const brgemm_post_ops_data_t post_ops_data {/*bias=*/nullptr,
+                    /*binary_post_ops_rhs=*/nullptr, /*oc_logical_off=*/0,
+                    /*dst_row_logical_off=*/0, /*data_C_ptr_=*/nullptr,
+                    /*first_mb_matrix_addr_off=*/0,
+                    /*a_zp_compensations=*/nullptr,
+                    /*b_zp_compensations=*/nullptr, /*c_zp_values=*/nullptr,
+                    /*skip_accumulation=*/false, /*zp_a_val=*/1,
+                    /*do_only_comp=*/false,
+                    /*do_only_zp_a_val=*/true, src_scales, wei_scales,
+                    /*dst_scales=*/nullptr};
+            brgemm_kernel_execute_postops(kernel, bs, addr_batch, (void *)ptr_C,
+                    (void *)ptr_D, post_ops_data, scratch, &leading_dimensions);
+            return;
+        }
+
+        // Final K-block: apply scales, compensation and post-ops. Per-K scales
+        // take precedence over the common ones.
+        const void *src_scales = brgmm_ctx.get_src_scales_ptr();
+        const void *wei_scales
+                = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b
+                ? brgmm_ctx.get_wei_scales_ptr(n, k)
+                : brgmm_ctx.get_wei_scales_ptr(n, /*k=*/0);
+        const void *dst_scales = brgmm_ctx.get_dst_scales_inv_ptr(ithr);
+        void *scratch = is_brg_amx(brg_idx)
+                ? (void *)wsp_tile
+                : (void *)brgmm_ctx.get_s8s8_comp_ptr(ithr, b_idx, n_blk_idx);
+
+        const size_t dst_row_logical_off = m;
+        const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
+                ? b_idx / bgmmc.batch_without_first_dim
+                : 0;
+        const size_t first_mb_matrix_addr_off
+                = batch_first_dim_idx * (M * N) + (dst_row_logical_off * N + n);
+
+        const brgemm_post_ops_data_t post_ops_data {
+                /*bias=*/static_cast<const void *>(ptr_bias),
+                /*binary_post_ops_rhs=*/post_ops_binary_rhs_arg_vec.data(),
+                /*oc_logical_off=*/static_cast<size_t>(n), dst_row_logical_off,
+                /*data_C_ptr_=*/brgmm_ctx.get_data_C_ptr(0, 0, 0),
+                first_mb_matrix_addr_off,
+                /*a_zp_compensations=*/static_cast<const void *>(zp_comp_a),
+                /*b_zp_compensations=*/static_cast<const void *>(zp_comp_b),
+                /*c_zp_values=*/brgmm_ctx.get_zp_c_ptr(),
+                /*skip_accumulation=*/false, /*zp_a_val=*/1,
+                /*do_only_comp=*/false, /*do_only_zp_a_val=*/false, src_scales,
+                wei_scales, dst_scales};
+
+        brgemm_kernel_execute_postops(kernel, bs, addr_batch, (void *)ptr_C,
+                (void *)ptr_D, post_ops_data, scratch, &leading_dimensions);
+    };
+
     if (gemm_batch > 0 && brg_ker_idx >= 0) {
-        const bool is_amx = is_superset(
-                pd()->get_brg_desc(brg_ker_idx).isa_impl, avx512_core_amx);
         const auto brg_kernel = brg_kernels_[brg_ker_idx].get();
         assert(brg_kernel != nullptr);
         brgemm_palettes_.maybe_tile_configure(
-                is_amx, prev_ker_idx, brg_ker_idx);
+                is_brg_amx(brg_ker_idx), prev_ker_idx, brg_ker_idx);
 
         brgmm_ctx.init_brgemm_batch_elements_values(ithr, 0, gemm_batch,
                 A_data_batch_ptr, B_data_batch_ptr, b_idx, m_blk_idx, k_blk_idx,
                 n_blk_idx);
-        if (post_ops_applicable && is_last_K_blk && !is_K_tail) {
-            void *scratch = is_amx
-                    ? static_cast<void *>(wsp_tile)
-                    : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                              ithr, b_idx, n_blk_idx));
-
-            const size_t dst_row_logical_off
-                    = brgmm_ctx.get_M_idx(m_blk_idx, true);
-            const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
-                    ? b_idx / bgmmc.batch_without_first_dim
-                    : 0;
-            const size_t first_mb_matrix_addr_off
-                    = batch_first_dim_idx * (M * N)
-                    + (dst_row_logical_off * N + n);
-            const char *dst_anchor_point = brgmm_ctx.get_data_C_ptr(0, 0, 0);
-            const brgemm_post_ops_data_t post_ops_data {
-                    static_cast<const void *>(ptr_bias),
-                    post_ops_binary_rhs_arg_vec.data(), static_cast<size_t>(n),
-                    dst_row_logical_off, dst_anchor_point,
-                    first_mb_matrix_addr_off,
-                    static_cast<const void *>(zp_comp_a),
-                    static_cast<const void *>(zp_comp_b),
-                    brgmm_ctx.get_zp_c_ptr(), false, 1, false, false,
-                    brgmm_ctx.get_src_scales_ptr(),
-                    brgmm_ctx.get_wei_scales_ptr(n),
-                    brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
-            brgemm_kernel_execute_postops(brg_kernel, gemm_batch, addr_batch,
-                    (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch,
-                    &leading_dimensions);
-        } else {
-            brgemm_kernel_execute(brg_kernel, gemm_batch, addr_batch,
-                    (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
-                    &leading_dimensions);
-        }
+        const bool need_postops
+                = post_ops_applicable && is_last_K_blk && !is_K_tail;
+        execute_brgemm(brg_kernel, brg_ker_idx, gemm_batch, need_postops);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail, /* do_K_tail */ false);
@@ -824,47 +888,12 @@ void brgemm_matmul_t<isa>::compute_kernel(
             assert(!"Requested brgemm kernel was not created.");
             return;
         }
-        const bool is_amx = is_superset(
-                pd()->get_brg_desc(brg_ker_idx).isa_impl, avx512_core_amx);
         brgemm_palettes_.maybe_tile_configure(
-                is_amx, prev_ker_idx, brg_ker_idx);
+                is_brg_amx(brg_ker_idx), prev_ker_idx, brg_ker_idx);
         const auto brg_kernel_k_tail = brg_kernels_[brg_ker_idx].get();
 
-        if (post_ops_applicable) {
-            void *scratch = is_amx
-                    ? static_cast<void *>(wsp_tile)
-                    : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                              ithr, b_idx, n_blk_idx));
-
-            const size_t dst_row_logical_off
-                    = brgmm_ctx.get_M_idx(m_blk_idx, true);
-            const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
-                    ? b_idx / bgmmc.batch_without_first_dim
-                    : 0;
-            const size_t first_mb_matrix_addr_off
-                    = batch_first_dim_idx * (M * N)
-                    + (dst_row_logical_off * N + n);
-            const char *dst_anchor_point = brgmm_ctx.get_data_C_ptr(0, 0, 0);
-            const brgemm_post_ops_data_t post_ops_data {
-                    static_cast<const void *>(ptr_bias),
-                    post_ops_binary_rhs_arg_vec.data(), static_cast<size_t>(n),
-                    dst_row_logical_off, dst_anchor_point,
-                    first_mb_matrix_addr_off,
-                    static_cast<const void *>(zp_comp_a),
-                    static_cast<const void *>(zp_comp_b),
-                    brgmm_ctx.get_zp_c_ptr(), false, 1, false, false,
-                    brgmm_ctx.get_src_scales_ptr(),
-                    brgmm_ctx.get_wei_scales_ptr(n),
-                    brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
-
-            brgemm_kernel_execute_postops(brg_kernel_k_tail, 1, addr_batch,
-                    (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch,
-                    &leading_dimensions);
-        } else {
-            brgemm_kernel_execute(brg_kernel_k_tail, 1, addr_batch,
-                    (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
-                    &leading_dimensions);
-        }
+        execute_brgemm(
+                brg_kernel_k_tail, brg_ker_idx, /*bs=*/1, post_ops_applicable);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail,
@@ -1195,7 +1224,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                             static_cast<const void *>(zp_comp_b),
                             brgmm_ctx.get_zp_c_ptr(), skip_accumulation, 1,
                             false, false, brgmm_ctx.get_src_scales_ptr(),
-                            brgmm_ctx.get_wei_scales_ptr(n),
+                            brgmm_ctx.get_wei_scales_ptr(n, /*k=*/0),
                             brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
 
                     brgemm_kernel_execute_postops(brg_kernel, 0, nullptr,

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -161,6 +161,19 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             = utils::one_of(wei_dt, data_type::f4_e2m1, data_type::f4_e3m0);
     const bool is_f32_with_int_wei
             = src_dt == f32 && one_of(wei_dt, s8, u8, s4, u4) && dst_dt == f32;
+    // int8 grouped (dynamic) quantization: int8 src x {s4,u4,s8,u8} wei,
+    // dst in {f16,bf16,f32}, with any grouped scales/ZP attribute (or int4
+    // weights, which are always per-OC grouped).
+    const auto &attr_scales = attr()->scales_;
+    const auto &attr_zps = attr()->zero_points_;
+    const bool has_grouped_quant_attrs = utils::one_of(wei_dt, s4, u4)
+            || !attr_scales.get(DNNL_ARG_SRC).has_default_groups()
+            || !attr_scales.get(DNNL_ARG_WEIGHTS).has_default_groups()
+            || !attr_zps.get(DNNL_ARG_SRC).has_default_groups()
+            || !attr_zps.get(DNNL_ARG_WEIGHTS).has_default_groups();
+    const bool with_int8_grouped_quantization = one_of(src_dt, u8, s8)
+            && one_of(wei_dt, s4, u4, s8) && one_of(dst_dt, f16, bf16, f32)
+            && has_grouped_quant_attrs;
 
     auto check_bias = [&]() -> bool {
         const auto bia_dt = weights_md(1)->data_type;
@@ -205,8 +218,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             if (is_runtime_value(N())) ok = false;
         }
         // Impl suppports f32 scales only for non-weight decompression
-        if (!(is_bf16_with_int_wei || is_f16_with_int_wei
-                    || is_f32_with_int_wei)) {
+        if (!(is_bf16_with_int_wei || is_f16_with_int_wei || is_f32_with_int_wei
+                    || with_int8_grouped_quantization)) {
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_SRC), undef, f32);
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_WEIGHTS), undef, f32);
             ok = ok && one_of(asc.get_data_type(DNNL_ARG_DST), undef, f32);
@@ -237,14 +250,23 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         return ok;
     };
 
-    auto check_attr_zero_points = [&](bool allow_multiple_wei_zp) -> bool {
+    auto check_attr_zero_points
+            = [&](bool allow_multiple_wei_zp,
+                      bool allow_grouped_src_zp = false) -> bool {
         const auto &zp = attr()->zero_points_;
-        static const std::vector<int> supported_args {
-                DNNL_ARG_SRC, DNNL_ARG_DST};
-        for (int arg : supported_args) {
-            if (!zp.has_default_values(arg)) {
-                const int mask = zp.get_mask(arg);
-                if (mask > 0) return false;
+        if (!zp.has_default_values(DNNL_ARG_DST)) {
+            const int mask = zp.get_mask(DNNL_ARG_DST);
+            if (mask > 0) return false;
+        }
+        if (!zp.has_default_values(DNNL_ARG_SRC)) {
+            const auto mask = zp.get_mask(DNNL_ARG_SRC);
+            if (allow_grouped_src_zp) {
+                const int mk_mask = src_qmask_M() + src_qmask_K();
+                const bool zp_over_batch = (mask & mk_mask) != mask;
+                const bool mask_ok = (mask & ~mk_mask) == 0;
+                return !(zp_over_batch && batch() > 1) && mask_ok;
+            } else {
+                return mask == 0;
             }
         }
         if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
@@ -262,7 +284,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     };
     const bool problem_dt_correct = one_of(true, is_f4, is_int8, is_f8, is_bf16,
             is_f32, is_f16, is_f32_f16, is_f32_bf16, is_bf16_with_int_wei,
-            is_f16_with_int_wei, is_f32_with_int_wei);
+            is_f16_with_int_wei, is_f32_with_int_wei,
+            with_int8_grouped_quantization);
 
     auto src_d = memory_desc_wrapper(src_md_);
     auto weights_d = memory_desc_wrapper(weights_md_);
@@ -302,8 +325,11 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_POSTOP);
 
     VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
-    VDISPATCH_MATMUL(check_attr_zero_points(is_bf16_with_int_wei
-                             || is_f16_with_int_wei || is_f32_with_int_wei),
+    VDISPATCH_MATMUL(
+            check_attr_zero_points(is_bf16_with_int_wei || is_f16_with_int_wei
+                            || is_f32_with_int_wei
+                            || with_int8_grouped_quantization,
+                    with_int8_grouped_quantization),
             VERBOSE_UNSUPPORTED_ZP_CFG);
     VDISPATCH_MATMUL(check_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
     VDISPATCH_MATMUL(check_reduce(), VERBOSE_UNSUPPORTED_FEATURE,

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -31,6 +31,7 @@
 #include "cpu/x64/jit_brgemm_post_ops.hpp"
 #include "cpu/x64/matmul/brgemm_matmul_copy_utils.hpp"
 #include "cpu/x64/matmul/brgemm_matmul_utils.hpp"
+#include "cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -91,6 +92,11 @@ private:
             const char *A_data_batch_ptr, const char *B_data_batch_ptr,
             int ithr, int b_idx, int m_blk_idx, int n_blk_idx, int k_blk_idx,
             bool do_init, int &prev_ker_idx, bool prefetch) const;
+    void fill_per_mn_compensation(const brg_matmul_exec_ctx_t &brgmm_ctx,
+            int ithr, int m_blk_idx, int n_blk_idx,
+            const char *A_data_batch_ptr, const char *B_data_batch_ptr,
+            int m_kernel_size, int n_kernel_size, int k_blk_idx,
+            bool is_tail) const;
 
     bool determine_prefetch(const int mc, const int m_end, const int nc,
             const int n_end, const brgemm_matmul_conf_t &bgmmc,
@@ -122,6 +128,9 @@ private:
     std::unique_ptr<cpu_accumulator_1d_t<data_type::s32>> acc_ker_s32_;
     std::unique_ptr<jit_avx512_sparse_decompress_kernel_t>
             sparse_decompress_kernel_;
+
+    // Per-(M, N) compensation kernel
+    std::unique_ptr<per_mn_comp_kernel_t> per_mn_comp_kernel_;
 
     using reducer_t = x64::jit_brgemm_kernel_diff_bias_t<
             typename cpu_isa_traits_t<isa>::Vmm>;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -2435,7 +2435,6 @@ protected:
             // TODO: Unify register usage over kernels
             const auto mask_vmm = Vmm(conf_->transposed_B ? 13 : 0);
             const auto tmp_vmm = vmm_permd;
-            // const auto tmp_vmm2 = Vmm(conf_->transposed_B ? 13: 4);
             // f32 and transposed used the same register for regq_tmp
             const auto reg_tmp = r15;
             alignas(64) static constexpr const uint32_t odd_indices[8] = {
@@ -2818,13 +2817,12 @@ protected:
 };
 
 template <typename Vmm>
-struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
-                                         public jit_generator_t {
+struct jit_brgemm_matmul_copy_b_int8_t
+    : public jit_brgemm_matmul_copy_b_common_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_b_int8_t)
 
     jit_brgemm_matmul_copy_b_int8_t(const brgemm_matmul_conf_t *conf)
-        : jit_brgemm_matmul_copy_b_t(conf)
-        , jit_generator_t(jit_name())
+        : jit_brgemm_matmul_copy_b_common_t(conf)
         , src_stride_(conf->copy_B_wei_stride)
         , tr_src_stride_(conf->LDB * k_blk_step_ * sizeof(int8_t))
         , is_amx_(mayiuse(avx512_core_amx))
@@ -2834,9 +2832,14 @@ struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
                   do_compute_compensation_ && !isa_has_int8_vnni(conf->isa))
         , is_dynamic_stride_(is_runtime_value(src_stride_))
         , is_dynamic_N_(conf->is_runtime_N)
-        , comp_acc_idx_(is_ymm_                      ? 13
+        , is_src_int4_(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
+        , has_vpermb_(cpu().has(Xbyak::util::Cpu::tAVX512_VBMI))
+        , comp_acc_idx_(is_ymm_ && is_src_int4_      ? 11
+                          : is_src_int4_             ? 23
+                          : is_ymm_                  ? 13
                           : avx512_core_dot_product_ ? 23
-                                                     : 25) {}
+                                                     : 25)
+        , src_elems_per_byte_(is_src_int4_ ? 2 : 1) {}
 
     void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
     status_t create_kernel() override {
@@ -2860,15 +2863,15 @@ protected:
     const bool avx512_core_dot_product_;
     const bool is_dynamic_stride_;
     const bool is_dynamic_N_;
+    const bool is_src_int4_;
+    const bool has_vpermb_;
+    const int comp_acc_idx_;
+    const dim_t src_elems_per_byte_;
 
     constexpr static int reg_src_offs_ = 0;
     constexpr static int reg_tr_src_offs_ = 8;
     constexpr static int reg_current_K_pad_offs_ = 16;
     constexpr static int stack_space_needed_ = 24;
-
-    const int comp_acc_idx_;
-
-    const Xbyak::Opmask kTail = k7;
 
     reg64_t reg_src = rax;
     reg64_t reg_tr_src = rbx;
@@ -2893,6 +2896,7 @@ protected:
     Vmm vmm_dot_product_temp = Vmm(25);
 
     // ZMM stuff
+    Vmm int4_permute_table = Vmm(24);
     Vmm vreg_idx_lo_256 = Vmm(26);
     Vmm vreg_idx_hi_256 = Vmm(27);
     Vmm vreg_idx_lo_128 = Vmm(28);
@@ -2901,6 +2905,9 @@ protected:
     // Shared
     Vmm vmm_comp_mul = Vmm(is_ymm_ ? 14 : 30);
     Vmm vmm_zero = Vmm(is_ymm_ ? 15 : 31);
+    // Only used for decompressing int4 values
+    Vmm vmm_tmp = Vmm(is_ymm_ ? 13 : 25);
+    Vmm vmm_tmp1 = Vmm(12); // Only for Ymm
 
     Vmm get_comp_acc(int i) { return Vmm(comp_acc_idx_ - i); }
     Vmm get_vmm_zp_comp_res(int i) { return get_comp_acc(i); }
@@ -2937,6 +2944,179 @@ protected:
             vpaddd(v1, v1, vmm_dot_product_temp);
         }
     }
+
+    /**
+    * @brief Applies sign extension for 4-bit signed integers stored in 8-bit lanes using AVX-512.
+    * Due to lack of byte-wise right arithmetic shift(vpsrad) this method is used.
+    * This method checks the sign bit (bit 3) of each byte and fills the upper nibble with 0xF0
+    * if the sign bit is set, preserving the signed semantics after conversion from int4 to int8.
+    *
+    * Steps:
+    * 1. Broadcast LUT (0xF0) across Zmm register.
+    * 2. Isolate sign bit using left shift vpslld.
+    * 3. XOR and shuffle with LUT to generate the correct fill pattern.
+    * 4. OR the result back into the original vector.
+    *
+    * @param vmm_src Zmm register containing int8 values derived from int4.
+    */
+    inline void signed_mask_int4(const Zmm &vmm_src) {
+        if (conf_->orig_wei_dt != data_type::s4) return;
+
+        const auto &vmm_sign_extend = vmm_tmp;
+        const auto &vmm_lut = vmm_zero;
+
+        mov(reg_tmp, 0xF0);
+        uni_vpbroadcastb(vmm_lut, reg_tmp.cvt8());
+
+        uni_vmovups(vmm_sign_extend, vmm_src);
+        vpslld(vmm_sign_extend, vmm_sign_extend, 4);
+
+        uni_vpxor(vmm_sign_extend, vmm_sign_extend, vmm_lut);
+        vpshufb(vmm_sign_extend, vmm_lut, vmm_sign_extend);
+        vpord(vmm_src, vmm_src, vmm_sign_extend);
+    }
+
+    /**
+    * @brief Applies sign extension for 4-bit signed integers stored in 8-bit lanes using AVX2.
+    * Due to lack of byte-wise right arithmetic shift(vpsrad) this method is used.
+    * This method uses a lookup table (LUT) and vpshufb to map sign bit presence to the correct
+    * upper nibble fill (0xF0 for negative, 0x00 for positive).
+    *
+    * Steps:
+    * 1. Load LUT into Ymm register.
+    * 2. Isolate sign bit using left shift vpslld.
+    * 3. Shuffle using LUT to replicate sign into upper nibble.
+    * 4. OR the result back into the original vector.
+    *
+    * @param vmm_src Ymm register containing int8 values derived from int4.
+    */
+    inline void signed_mask_int4(const Ymm &vmm_src) {
+        if (conf_->orig_wei_dt != data_type::s4) return;
+
+        const auto &vmm_sign_extend = Ymm(vmm_tmp.getIdx());
+        const auto &vmm_lut = Ymm(vmm_tmp1.getIdx());
+        // No matter which index at lut, for signed (7bit==1)
+        // vpshufb will select the same mask
+        alignas(64) static const constexpr uint8_t lut[32] = {0xF0, 0xF0, 0xF0,
+                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0};
+
+        mov(reg_tmp, (size_t)lut);
+        vmovdqu(vmm_lut, ptr[reg_tmp]);
+
+        uni_vmovups(vmm_sign_extend, vmm_src);
+        vpslld(vmm_sign_extend, vmm_sign_extend, 4);
+
+        uni_vpxor(vmm_sign_extend, vmm_sign_extend, vmm_lut);
+        vpshufb(vmm_sign_extend, vmm_lut, vmm_sign_extend);
+        vpor(vmm_src, vmm_src, vmm_sign_extend);
+    }
+
+    /**
+    * @brief Converts packed u4/s4 integers to u8/s8 using AVX-512.
+    *
+    * This method splits the original packed int4 values into low and high nibbles,
+    * expands them into separate bytes, and then applies(if needed) sign extension.
+    *
+    * Steps:
+    * 1. Duplicate source into low and high vectors.
+    * 2. Mask and shift high nibble, mask low nibble.
+    * 3. Merge low and high into full bytes:
+    *    - With AVX512_VBMI: vpermb byte permute.
+    *    - Without VBMI: vpunpcklbw/vpunpckhbw + vpermt2d.
+    * 4. Apply sign extension via signed_mask_int4().
+    *
+    * @param vmm_src Zmm register containing packed int4 values.
+    */
+    inline void cvt_int4_to_int8(const Zmm &vmm_src) {
+        if (!is_src_int4_) return;
+
+        using Vmm_lower_t = typename vreg_traits_t<Vmm>::Vmm_lower_t;
+
+        const auto &vmm_low = vmm_src; // Aliases for readability
+        const auto &vmm_high = vmm_zero;
+        const auto &vmm_mask = vmm_tmp;
+
+        uni_vmovups(vmm_high, vmm_low);
+
+        mov(reg_tmp, 0xF0);
+        uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
+        uni_vpand(vmm_high, vmm_high, vmm_mask);
+        vpsrld(vmm_high, vmm_high, 4);
+
+        mov(reg_tmp, 0x0F);
+        uni_vpbroadcastb(vmm_mask, reg_tmp.cvt8());
+        uni_vpand(vmm_low, vmm_low, vmm_mask);
+
+        if (has_vpermb_) {
+            copy_half_reg(vmm_low, Vmm_lower_t(vmm_high.getIdx()));
+            vpermb(vmm_src, int4_permute_table, vmm_src);
+        } else {
+            vpunpcklbw(vmm_mask, vmm_low, vmm_high);
+            vpunpckhbw(vmm_low, vmm_low, vmm_high);
+            vpermt2d(vmm_mask, int4_permute_table, vmm_low);
+            uni_vmovups(vmm_src, vmm_mask);
+        }
+        signed_mask_int4(vmm_src);
+        // Clean vmm_zero
+        uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
+    }
+
+    /**
+    * @brief Converts packed u4/s4 to u8/s8 integers using AVX2.
+    *
+    * This method extracts low and high nibbles from each byte, unpacks them into separate
+    * bytes, and then applies(if needed) sign extension.
+    *
+    * Steps:
+    * 1. Copy source into low and high vectors.
+    * 2. Mask and shift high nibble, mask low nibble.
+    * 3. Interleave low and high bytes using vpunpcklbw/vpunpckhbw.
+    * 4. Apply sign extension via signed_mask_int4().
+    *
+    * @param vmm_src Ymm register containing packed int4 values.
+    */
+    inline void cvt_int4_to_int8(const Ymm &vmm_src) {
+        if (!is_src_int4_) return;
+
+        const auto vmm_out = Ymm(vmm_src.getIdx());
+        const auto vmm_low = Ymm(vmm_tmp1.getIdx());
+        const auto vmm_high = Ymm(vmm_zero.getIdx());
+        const auto vmm_mask = Ymm(vmm_tmp.getIdx());
+
+        uni_vmovups(vmm_low, vmm_out);
+        uni_vmovups(vmm_high, vmm_out);
+
+        alignas(64) static const constexpr uint8_t even_vector[32]
+                = {0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                        0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                        0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0,
+                        0xF0, 0xF0, 0xF0, 0xF0};
+        mov(reg_tmp, (size_t)even_vector);
+        vmovdqu(vmm_mask, ptr[reg_tmp]);
+        vpand(vmm_high, vmm_high, vmm_mask);
+        vpsrld(vmm_high, vmm_high, 4);
+
+        alignas(64) static const constexpr uint8_t odd_vector[32] = {0x0F, 0x0F,
+                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+                0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F};
+        mov(reg_tmp, (size_t)odd_vector);
+        vmovdqu(vmm_mask, ptr[reg_tmp]);
+        vpand(vmm_low, vmm_low, vmm_mask);
+
+        vpunpcklbw(vmm_mask, vmm_low, vmm_high);
+        vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 0);
+        vpunpckhbw(vmm_mask, vmm_low, vmm_high);
+        vinserti128(vmm_out, vmm_out, Xmm(vmm_mask.getIdx()), 1);
+        signed_mask_int4(vmm_out);
+        // Clean tmp regs
+        uni_vpxor(vmm_low, vmm_low, vmm_low);
+        uni_vpxor(vmm_high, vmm_high, vmm_high);
+        uni_vpxor(vmm_mask, vmm_mask, vmm_mask);
+    }
+
     void generate() override;
 };
 
@@ -2945,8 +3125,16 @@ inline void jit_brgemm_matmul_copy_b_int8_t<Zmm>::load(
         int blk, int i, bool is_tail) {
     auto vmm_src = get_vmm(blk, i % k_blk_step_);
     auto src_load = is_tail ? vmm_src | kTail | T_z : vmm_src;
-    const auto offset = is_dynamic_stride_ ? 0 : i * src_stride_;
-    vmovdqu8(src_load, EVEX_compress_addr(reg_src, offset));
+    const auto offset
+            = is_dynamic_stride_ ? 0 : i * src_stride_ / src_elems_per_byte_;
+    const auto addr = maybe_EVEX_compress_addr(reg_src, offset);
+    if (is_src_int4_) {
+        const auto ymm_src_load = maybe_mask(Ymm(src_load.getIdx()), is_tail);
+        vmovdqu8(ymm_src_load, addr);
+        cvt_int4_to_int8(vmm_src);
+    } else {
+        vmovdqu8(src_load, addr);
+    }
     if (is_dynamic_stride_) add(reg_src, reg_src_stride);
 }
 
@@ -3005,6 +3193,23 @@ private:
         vmovdqa64(vreg_idx_hi_256, (const void *)idx_hi_16);
         vmovdqa64(vreg_idx_lo_128, (const void *)idx_lo_8);
         vmovdqa64(vreg_idx_hi_128, (const void *)idx_hi_8);
+
+        if (is_src_int4_) {
+            if (has_vpermb_) {
+                alignas(64) static constexpr const uint8_t int4_permute[64] = {
+                        0, 32, 1, 33, 2, 34, 3, 35, 4, 36, 5, 37, 6, 38, 7, 39,
+                        8, 40, 9, 41, 10, 42, 11, 43, 12, 44, 13, 45, 14, 46,
+                        15, 47, 16, 48, 17, 49, 18, 50, 19, 51, 20, 52, 21, 53,
+                        22, 54, 23, 55, 24, 56, 25, 57, 26, 58, 27, 59, 28, 60,
+                        29, 61, 30, 62, 31, 63};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute);
+            } else {
+                alignas(64) static constexpr const uint32_t int4_permute_dw[16]
+                        = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22,
+                                23};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute_dw);
+            }
+        }
     }
 
     void copy_block(
@@ -3034,8 +3239,9 @@ private:
             mov(ptr[rsp + reg_src_offs_], reg_src);
             add(reg_src, reg_copy_block_n_shift);
             copy_4x64(nrows, n_blk_step_, zeropad);
-            add(reg_copy_block_n_shift, n_blk_step_ * typesize);
-            add(reg_src, n_blk_step_ * typesize);
+            add(reg_copy_block_n_shift,
+                    n_blk_step_ * typesize / src_elems_per_byte_);
+            add(reg_src, n_blk_step_ * typesize / src_elems_per_byte_);
 
             if (do_N_loop_)
                 // (n_blk_step_ /conf_->LDB) --> # of LDBs handled by copy_4x64
@@ -3083,7 +3289,8 @@ private:
         };
 
         const bool is_tail = ncolumns < n_blk_step_;
-        const auto tail_mask = size_t(((size_t)1 << ncolumns) - 1);
+        const auto tail_size = div_up(ncolumns, src_elems_per_byte_);
+        const auto tail_mask = size_t(((size_t)1 << tail_size) - 1);
 
         if (is_tail) kmovq(kTail, tail_mask);
 
@@ -3210,12 +3417,30 @@ private:
         vmovdqa64(vreg_idx_hi_256, (const void *)idx_hi_256);
         vmovdqa64(vreg_idx_lo_128, (const void *)idx_lo_128);
         vmovdqa64(vreg_idx_hi_128, (const void *)idx_hi_128);
+
+        if (is_src_int4_) {
+            if (has_vpermb_) {
+                alignas(64) static constexpr const uint8_t int4_permute[64] = {
+                        0, 32, 1, 33, 2, 34, 3, 35, 4, 36, 5, 37, 6, 38, 7, 39,
+                        8, 40, 9, 41, 10, 42, 11, 43, 12, 44, 13, 45, 14, 46,
+                        15, 47, 16, 48, 17, 49, 18, 50, 19, 51, 20, 52, 21, 53,
+                        22, 54, 23, 55, 24, 56, 25, 57, 26, 58, 27, 59, 28, 60,
+                        29, 61, 30, 62, 31, 63};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute);
+            } else {
+                alignas(64) static constexpr const uint32_t int4_permute_dw[16]
+                        = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22,
+                                23};
+                vmovdqa64(int4_permute_table, (const void *)int4_permute_dw);
+            }
+        }
     }
 
     void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
         const bool is_tail = ncolumns < n_blk_step_;
         if (is_tail) {
-            const auto tail_mask = size_t(((size_t)1 << ncolumns) - 1);
+            const auto tail_size = div_up(ncolumns, src_elems_per_byte_);
+            const auto tail_mask = size_t(((size_t)1 << tail_size) - 1);
             kmovq(kTail, tail_mask);
         }
 
@@ -3327,8 +3552,11 @@ private:
         Xbyak::Ymm vmm_src = Xbyak::Ymm(ymm_idx);
         if (is_tail) {
             load_bytes(vmm_src, reg_src, offset, tail_sz);
+        } else if (is_src_int4_) {
+            load_bytes(vmm_src, reg_src, offset, simd_w_ / src_elems_per_byte_);
         } else
             uni_vmovups(vmm_src, ptr[reg_src + offset]);
+        cvt_int4_to_int8(vmm_src);
     }
 
     void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
@@ -3350,11 +3578,13 @@ private:
                     if (do_load) {
                         const bool do_tail = is_tail
                                 && IMPLICATION(pass == 0, ncolumns < simd_w_);
-                        const auto offset
-                                = (is_dynamic_stride_ ? 0 : i * src_stride_)
+                        auto offset = (is_dynamic_stride_ ? 0 : i * src_stride_)
                                 + pass * simd_w_;
-                        load_ymm(i % 4, offset, do_tail,
-                                ncolumns - pass * simd_w_);
+                        offset /= src_elems_per_byte_;
+                        const auto tail_size
+                                = div_up((ncolumns - pass * simd_w_),
+                                        src_elems_per_byte_);
+                        load_ymm(i % 4, offset, do_tail, tail_size);
                         if (is_dynamic_stride_) add(reg_src, reg_src_stride);
                     } else {
                         const auto src_ymm_1 = get_ymm(i % 4);
@@ -3459,7 +3689,8 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         L(K_loop_unrolled);
         copy_block(k_unroll * k_blk_step_, ncolumns, is_N_tail, zeropad);
         if (!zeropad && !is_dynamic_stride_)
-            add(reg_src, k_unroll * k_blk_step_ * src_stride_);
+            add(reg_src,
+                    k_unroll * k_blk_step_ * src_stride_ / src_elems_per_byte_);
         add(reg_tr_src, k_unroll * tr_src_stride_);
 
         sub(reg_K, k_unroll * k_blk_step_);
@@ -3472,7 +3703,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
 
         copy_block(k_blk_step_, ncolumns, is_N_tail, zeropad);
         if (!zeropad && !is_dynamic_stride_)
-            add(reg_src, k_blk_step_ * src_stride_);
+            add(reg_src, k_blk_step_ * src_stride_ / src_elems_per_byte_);
         add(reg_tr_src, tr_src_stride_);
 
         sub(reg_K, k_blk_step_);

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -4724,6 +4724,10 @@ struct jit_brgemm_matmul_copy_b_transposed_t
         , req_s8s8_comp_(conf_->s8s8_compensation_required)
         , req_zp_b_shift_(
                   conf_->has_zero_point_b && conf_->with_wei_decompression)
+        , req_int8_zp_b_shift_(conf_->has_zero_point_b
+                  && conf_->with_int8_grouped_quantization)
+        , is_zp_int4_(one_of(conf->wei_zp_dt, data_type::s4, data_type::u4))
+        , has_vpermb_(cpu().has(Xbyak::util::Cpu::tAVX512_VBMI))
         , req_apply_wei_scales_(conf_->apply_scales_in_buffer_b)
         , avx512_core_dot_product_(
                   do_compute_compensation_ && !isa_has_int8_vnni(conf->isa))
@@ -4739,10 +4743,15 @@ struct jit_brgemm_matmul_copy_b_transposed_t
         , max_tmp_idx(16
                   - (avx512_core_dot_product_
                                   ? 8
-                                  : (do_compute_compensation_         ? 6
-                                                    : is_src_int4_    ? 2
-                                                    : req_zp_b_shift_ ? 1
-                                                                      : 0)))
+                                  : (do_compute_compensation_      ? 6
+                                                    : is_src_int4_ ? 2
+                                                    : req_zp_b_shift_
+                                                            || req_int8_zp_b_shift_
+                                                    ? 1
+                                                    : 0))
+                  - ((req_int8_zp_b_shift_ && do_compute_compensation_)
+                                  ? (is_src_int4_ ? 2 : 1)
+                                  : 0))
         , src_stride_(conf_->copy_B_wei_stride)
         , tr_src_stride_(conf_->LDB * vnni_granularity_ * tr_typesize_)
         , src_elems_per_byte_(is_src_int4_ ? 2 : 1)
@@ -4781,6 +4790,9 @@ private:
     const bool req_zp_comp_;
     const bool req_s8s8_comp_;
     const bool req_zp_b_shift_;
+    const bool req_int8_zp_b_shift_;
+    const bool is_zp_int4_;
+    const bool has_vpermb_;
     const bool req_apply_wei_scales_;
     const bool avx512_core_dot_product_;
     const bool use_fp16_instructions_;
@@ -4791,7 +4803,11 @@ private:
     const bool is_dynamic_N_;
 
     constexpr static int ldb_step_idx_offs = 0;
-    constexpr static int stack_space_needed = 8;
+    constexpr static int reg_zp_b_ptr_offs_ = 8;
+    constexpr static int reg_cur_k_offs_ = 16;
+    constexpr static int reg_src_save_offs_ = 24;
+    constexpr static int reg_init_k_rem_offs_ = 32;
+    constexpr static int stack_space_needed = 40;
 
     reg64_t reg_src_base = rax;
     reg64_t reg_tr_src_base = rbx;
@@ -4824,8 +4840,16 @@ private:
     Vmm vmm_ones_words = Vmm(max_vmm_regs_ - 7);
     Vmm vmm_dot_product_temp = Vmm(max_vmm_regs_ - 8);
 
-    Vmm vmm_zp_b_val = Vmm(max_vmm_regs_ - 1);
-    Vmm vmm_permd = Vmm(max_vmm_regs_ - 2);
+    // When int8-grouped-quant ZP runs alongside compensation, place
+    // these registers right above the (already-shrunk) tmp_vmm range
+    // so they never alias the comp registers at the top of the file.
+    Vmm vmm_zp_b_val = (req_int8_zp_b_shift_ && do_compute_compensation_)
+            ? Vmm(n_blk_step_ + max_tmp_idx)
+            : Vmm(max_vmm_regs_ - 1);
+    Vmm vmm_permd
+            = (req_int8_zp_b_shift_ && do_compute_compensation_ && is_src_int4_)
+            ? Vmm(n_blk_step_ + max_tmp_idx + 1)
+            : Vmm(max_vmm_regs_ - 2);
     // Collide with `vmm_zp_a_neg_val` as they shouldn't intersect in
     // functionality.
     Vmm vmm_wei_scales = Vmm(max_vmm_regs_ - 3);
@@ -4948,6 +4972,265 @@ private:
             case data_type::f16: vcvtph2psx(vmm_wei_scales, addr); break;
             default: assert(!"unsupported wei_scales data type");
         }
+    }
+
+    /**
+     * Converts packed int4 data in a Ymm (half-ZMM) to int8 in a full ZMM.
+     * Used for int8 grouped quantization with int4 weights in the transposed
+     * copy_b kernel. The conversion is done in-place, expanding the lower half
+     * (Ymm) into the full ZMM register.
+     *
+     * @param vmm_data The ZMM register containing packed int4 data in its
+     *                 lower half (Ymm portion).
+     */
+    void cvt_int4_to_int8_for_transposed(const Vmm &vmm_data) {
+        if (!is_src_int4_) return;
+
+        if (is_ymm_) {
+            const auto ymm_data = Ymm(vmm_data.getIdx());
+            const auto ymm_high = Ymm(vmm_permd.getIdx());
+            const auto ymm_tmp = Ymm(vmm_wei_scales.getIdx());
+
+            uni_vmovups(ymm_high, ymm_data);
+
+            mov(regq_tmp, 0xF0);
+            uni_vpbroadcastb(ymm_tmp, regq_tmp.cvt8());
+            uni_vpand(ymm_high, ymm_high, ymm_tmp);
+            vpsrld(ymm_high, ymm_high, 4);
+
+            mov(regq_tmp, 0x0F);
+            uni_vpbroadcastb(ymm_tmp, regq_tmp.cvt8());
+            uni_vpand(ymm_data, ymm_data, ymm_tmp);
+            uni_vpand(ymm_high, ymm_high, ymm_tmp);
+
+            vpunpcklbw(ymm_tmp, ymm_data, ymm_high);
+            vpunpckhbw(ymm_high, ymm_data, ymm_high);
+            vinserti128(ymm_data, ymm_tmp, Xmm(ymm_high.getIdx()), 0x1);
+
+            if (conf_->orig_wei_dt == data_type::s4) {
+                mov(regq_tmp, 0xF0);
+                uni_vpbroadcastb(ymm_tmp, regq_tmp.cvt8());
+                uni_vmovups(ymm_high, ymm_data);
+                vpslld(ymm_high, ymm_high, 4);
+                uni_vpxor(ymm_high, ymm_high, ymm_tmp);
+                vpshufb(ymm_high, ymm_tmp, ymm_high);
+                uni_vpxor(ymm_data, ymm_data, ymm_high);
+            }
+            return;
+        }
+
+        // Use tmp_vmm(2) and tmp_vmm(3) as scratch (0 and 1 are used by
+        // the transpose algorithm which may be active when loads are
+        // interleaved).
+        const auto vmm_high = tmp_vmm(2);
+        const auto vmm_mask_reg = tmp_vmm(3);
+
+        uni_vmovups(vmm_high, vmm_data);
+
+        mov(regq_tmp, 0xF0);
+        uni_vpbroadcastb(vmm_mask_reg, regq_tmp.cvt8());
+        uni_vpand(vmm_high, vmm_high, vmm_mask_reg);
+        vpsrld(vmm_high, vmm_high, 4);
+
+        mov(regq_tmp, 0x0F);
+        uni_vpbroadcastb(vmm_mask_reg, regq_tmp.cvt8());
+        uni_vpand(vmm_data, vmm_data, vmm_mask_reg);
+
+        if (has_vpermb_) {
+            copy_half_reg(
+                    Zmm(vmm_data.getIdx()), Vmm_lower_t(vmm_high.getIdx()));
+            // vmm_permd holds the int4 byte-interleave permute table
+            vpermb(Zmm(vmm_data.getIdx()), vmm_permd, Zmm(vmm_data.getIdx()));
+        } else {
+            vpunpcklbw(Zmm(vmm_mask_reg.getIdx()), Zmm(vmm_data.getIdx()),
+                    Zmm(vmm_high.getIdx()));
+            vpunpckhbw(Zmm(vmm_data.getIdx()), Zmm(vmm_data.getIdx()),
+                    Zmm(vmm_high.getIdx()));
+            vpermt2d(Zmm(vmm_mask_reg.getIdx()), vmm_permd,
+                    Zmm(vmm_data.getIdx()));
+            uni_vmovups(vmm_data, vmm_mask_reg);
+        }
+
+        // Sign-extend for s4 using LUT-based approach (same as
+        // signed_mask_int4 in jit_brgemm_matmul_copy_b_int8_t):
+        // For signed int4, values 8..15 should become -8..-1.
+        // After unpacking, each byte has value 0..15. Need to OR
+        // with 0xF0 for values >= 8 (bit 3 set).
+        if (conf_->orig_wei_dt == data_type::s4) {
+            // Broadcast 0xF0 into vmm_mask_reg (LUT)
+            mov(regq_tmp, 0xF0);
+            uni_vpbroadcastb(vmm_mask_reg, regq_tmp.cvt8());
+            // vmm_high = vmm_data << 4 (shift to make bit 3 into bit 7)
+            uni_vmovups(vmm_high, vmm_data);
+            vpslld(vmm_high, vmm_high, 4);
+            // XOR with 0xF0 to create lookup index
+            uni_vpxor(vmm_high, vmm_high, vmm_mask_reg);
+            // vpshufb: for each byte, if high bit set -> 0, else -> 0xF0
+            // This gives 0xF0 for values >= 8 and 0 for values < 8
+            vpshufb(vmm_high, vmm_mask_reg, vmm_high);
+            // OR into data to sign-extend
+            vpord(Zmm(vmm_data.getIdx()), Zmm(vmm_data.getIdx()),
+                    Zmm(vmm_high.getIdx()));
+        }
+    }
+
+    /**
+     * Applies common (broadcast) zero point shift for int8 grouped
+     * quantization. Subtracts a single ZP value from all bytes.
+     *
+     * @param vmm_src Source data register to apply ZP shift to.
+     */
+    void maybe_apply_int8_common_zp(const Vmm &vmm_src) {
+        if (!req_int8_zp_b_shift_ || !conf_->is_wei_zp_common) return;
+
+        const auto vmm_zp = vmm_zp_b_val;
+        // vmm_zp_b_val already loaded with broadcast common ZP value
+        // in generate() via load_int8_grouped_common_zp()
+        uni_vpsubb(vmm_src, vmm_src, vmm_zp);
+    }
+
+    /**
+     * Applies per-N zero point shift for int8 grouped quantization.
+     * For each row i (N dimension), loads the ZP byte and broadcasts+subtracts.
+     *
+     * @param vmm_src Source data register to apply ZP shift to.
+     * @param n The N-dimension local index (row within N block).
+     */
+    void maybe_apply_int8_per_n_zp(const Vmm &vmm_src, int n) {
+        if (!req_int8_zp_b_shift_ || !conf_->is_wei_zp_per_n
+                || conf_->is_wei_zp_per_k)
+            return;
+
+        const auto vmm_zp = vmm_zp_b_val;
+        // Save reg_src_base since we need rax for address computation
+        mov(ptr[rsp + reg_src_save_offs_], reg_src_base);
+        mov(reg_src_base, ptr[rsp + reg_zp_b_ptr_offs_]);
+
+        const auto zp_dt_sz = types::data_type_size(conf_->wei_zp_dt);
+        const auto elems_per_byte = is_zp_int4_ ? 2 : 1;
+        const auto offset = n * zp_dt_sz / elems_per_byte;
+
+        if (is_zp_int4_) {
+            const bool is_odd = n % 2 == 1;
+            movzx(regq_tmp.cvt32(), byte[reg_src_base + offset]);
+            if (is_odd)
+                shr(regq_tmp.cvt32(), 4);
+            else
+                and_(regq_tmp.cvt32(), 0x0F);
+            if (conf_->wei_zp_dt == data_type::s4) {
+                // Sign extend from 4-bit
+                shl(regq_tmp.cvt32(), 28);
+                sar(regq_tmp.cvt32(), 28);
+            }
+        } else {
+            movzx(regq_tmp.cvt32(), byte[reg_src_base + offset]);
+        }
+        uni_vpbroadcastb(vmm_zp, regq_tmp.cvt8());
+        uni_vpsubb(vmm_src, vmm_src, vmm_zp);
+        mov(reg_src_base, ptr[rsp + reg_src_save_offs_]);
+    }
+
+    /**
+     * Applies per-K (grouped) zero point shift for int8 grouped quantization.
+     * Computes the K-group offset, loads the ZP for the current (K-group, N),
+     * and applies vpsubb.
+     *
+     * @param vmm_src Source data register to apply ZP shift to.
+     * @param n The N-dimension local index (row within N block).
+     */
+    void maybe_apply_int8_per_k_zp(const Vmm &vmm_src, int n) {
+        if (!req_int8_zp_b_shift_ || !conf_->is_wei_zp_per_k) return;
+
+        const auto vmm_zp = vmm_zp_b_val;
+        // Save rax and rdx since division clobbers them.
+        // reg_src_base = rax, reg_comp_ptr/reg_zp_ptr = rdx
+        mov(ptr[rsp + reg_src_save_offs_], reg_src_base);
+        push(rdx);
+
+        // Locate the current K group:
+        // k_group_idx = current_K_position / wei_zp_k_gsize
+        // ZP offset = k_group_idx * N + n
+        xor_(rdx, rdx); // zero rdx for division
+        mov(rax, ptr[rsp + 8 /* push offset */ + reg_cur_k_offs_]);
+        mov(regq_tmp, conf_->wei_zp_k_gsize);
+        div(regq_tmp);
+        // rax = k_group_idx
+        mov(regq_tmp, conf_->N);
+        mul(regq_tmp);
+        // rax = k_group_idx * N
+
+        if (is_zp_int4_) shr(rax, 1);
+
+        // Load ZP pointer and add group offset + N offset
+        mov(regq_tmp, ptr[rsp + 8 /* push offset */ + reg_zp_b_ptr_offs_]);
+        add(regq_tmp, rax);
+        if (is_zp_int4_)
+            add(regq_tmp, n / 2);
+        else
+            add(regq_tmp, n);
+
+        if (is_zp_int4_) {
+            const bool is_odd = n % 2 == 1;
+            movzx(eax, byte[regq_tmp]);
+            if (is_odd)
+                shr(eax, 4);
+            else
+                and_(eax, 0x0F);
+            if (conf_->wei_zp_dt == data_type::s4) {
+                shl(eax, 28);
+                sar(eax, 28);
+            }
+            mov(regq_tmp, rax);
+            uni_vpbroadcastb(vmm_zp, regq_tmp.cvt8());
+        } else {
+            movzx(eax, byte[regq_tmp]);
+            mov(regq_tmp, rax);
+            uni_vpbroadcastb(vmm_zp, regq_tmp.cvt8());
+        }
+        uni_vpsubb(vmm_src, vmm_src, vmm_zp);
+        // Restore regs
+        pop(rdx);
+        mov(reg_src_base, ptr[rsp + reg_src_save_offs_]);
+    }
+
+    /**
+     * Top-level ZP shift dispatcher for int8 grouped quantization.
+     * Called from the load lambda after loading int8 data.
+     *
+     * @param vmm_src Source data register to apply ZP shift to.
+     * @param n The N-dimension local index (row within N block).
+     */
+    void maybe_apply_int8_grouped_zp(const Vmm &vmm_src, int n) {
+        if (!req_int8_zp_b_shift_) return;
+
+        maybe_apply_int8_common_zp(vmm_src);
+        maybe_apply_int8_per_n_zp(vmm_src, n);
+        maybe_apply_int8_per_k_zp(vmm_src, n);
+    }
+
+    /**
+     * Loads and broadcasts the common ZP value as a byte for int8 grouped
+     * quantization. Called from generate().
+     */
+    void load_int8_common_zp() {
+        if (!req_int8_zp_b_shift_) return;
+
+        const bool only_per_k
+                = conf_->is_wei_zp_per_k && !conf_->is_wei_zp_per_n;
+        const bool is_common_or_per_k = conf_->is_wei_zp_common || only_per_k;
+        if (!is_common_or_per_k) return;
+
+        mov(regq_tmp, ptr[rsp + reg_zp_b_ptr_offs_]);
+        mov(regq_tmp.cvt8(), byte[regq_tmp]);
+        if (is_zp_int4_) {
+            // Extract int4 value from the low nibble
+            and_(regq_tmp.cvt32(), 0x0F);
+            if (conf_->wei_zp_dt == data_type::s4) {
+                shl(regq_tmp.cvt32(), 28);
+                sar(regq_tmp.cvt32(), 28);
+            }
+        }
+        uni_vpbroadcastb(vmm_zp_b_val, regq_tmp.cvt8());
     }
 
     /** Stores half of the block using mask for the case when vnni_granularity == 2 */
@@ -5199,17 +5482,27 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::copy_row_x_col(
             // Upconvert: load 16 bits and move them 16 bits left.
             uni_vpmovzxwd(src_masked_reg, addr);
             uni_vpslld(src_masked_reg, src_masked_reg, 16);
+        } else if (conf_->with_int8_grouped_quantization && is_src_int4_) {
+            // Int8 grouped quantization with int4 weights:
+            // Load packed int4 data into Ymm (half of Zmm), then
+            // unpack to full int8 in Zmm and apply ZP shift.
+            auto ymm_src = Ymm(src_reg.getIdx());
+            auto ymm_src_load = maybe_mask(ymm_src, is_tail);
+            vmovdqu8(ymm_src_load, addr);
+            cvt_int4_to_int8_for_transposed(src_reg);
+            maybe_apply_int8_grouped_zp(src_reg, i);
         } else {
             vmovdqu8(src_masked_reg, addr);
+            if (req_int8_zp_b_shift_) maybe_apply_int8_grouped_zp(src_reg, i);
         }
         L(load_done);
     };
 
-    auto store = [this, columns_tail, ncolumns, cur_k_blk_step](Zmm r, int i) {
+    auto store = [this, ncolumns](Zmm r, int i) {
         auto addr = EVEX_compress_addr(reg_tr_src, i * tr_src_stride_);
         if (is_wei_grouped_over_k_) {
-            const bool is_tail = columns_tail > 0 && ncolumns < cur_k_blk_step;
-            if (is_tail && i >= columns_tail) return;
+            const int valid_stores = utils::div_up(ncolumns, vnni_granularity_);
+            if (i >= valid_stores) return;
             if (vnni_granularity_ == 2 && ncolumns == 1)
                 store_half_block(r, addr);
             else
@@ -5398,6 +5691,40 @@ void jit_brgemm_matmul_copy_b_transposed_t<Ymm>::copy_row_x_col(
             load_scales(i, is_tail);
             decompress_reg(
                     vmm_src, vmm_zp_b_val, vmm_wei_scales, conf_->orig_wei_dt);
+        } else if (conf_->with_int8_grouped_quantization && is_src_int4_) {
+            const auto src_offset = (i * src_stride_) / src_elems_per_byte_;
+            const auto addr = maybe_EVEX_compress_addr(reg_src, src_offset);
+            const int packed_load_sz = is_tail
+                    ? div_up(columns_tail * typesize_, src_elems_per_byte_)
+                    : (k_blk_step_ * typesize_) / src_elems_per_byte_;
+
+            uni_vpxor(vmm_src, vmm_src, vmm_src);
+
+            // Int4 rows may start from an odd nibble, so align packed bytes
+            // before expanding nibbles to signed/unsigned int8 values.
+            const bool need_align_half_byte = (i * src_stride_) % 2 != 0;
+            const auto xmm_src = Xmm(vmm_src.getIdx());
+            if (need_align_half_byte) {
+                if (packed_load_sz < 16 || is_tail) {
+                    load_bytes(xmm_src, addr, packed_load_sz);
+                    vpsrlq(xmm_src, xmm_src, 4);
+                } else {
+                    const auto xmm_tmp = Xmm(vmm_permd.getIdx());
+                    load_bytes(xmm_src, addr, packed_load_sz);
+                    load_bytes(xmm_tmp,
+                            maybe_EVEX_compress_addr(reg_src, src_offset + 1),
+                            packed_load_sz);
+                    vpsrlq(xmm_src, xmm_src, 4);
+                    vpsllq(xmm_tmp, xmm_tmp, 4);
+                    vpor(xmm_src, xmm_src, xmm_tmp);
+                }
+            } else {
+                load_bytes(xmm_src, addr, packed_load_sz);
+            }
+
+            cvt_int4_to_int8_for_transposed(vmm_src);
+
+            maybe_apply_int8_grouped_zp(vmm_src, i);
         } else if (is_tail) {
             load_bytes(vmm_src, reg_src, i * src_stride_,
                     columns_tail * typesize_);
@@ -5522,6 +5849,13 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_K_loop(bool is_N_tail,
     Label K_loop, K_loop_tail_or_done;
     mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
 
+    // Reset the K-within-group counter to its initial value before each
+    // N iteration's K loop, since the K loop increments it.
+    if (req_int8_zp_b_shift_ && conf_->is_wei_zp_per_k) {
+        mov(regq_tmp, ptr[rsp + reg_init_k_rem_offs_]);
+        mov(ptr[rsp + reg_cur_k_offs_], regq_tmp);
+    }
+
     mov(reg_src, reg_src_base);
     mov(reg_tr_src, reg_tr_src_base);
 
@@ -5534,6 +5868,8 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_K_loop(bool is_N_tail,
     copy_row_x_col(nrows, k_blk_step_);
     add(reg_src, (k_blk_step_ * typesize_) / src_elems_per_byte_);
     add(reg_tr_src, k_blk_step_ / vnni_granularity_ * tr_src_stride_);
+    if (req_int8_zp_b_shift_ && conf_->is_wei_zp_per_k)
+        add(qword[rsp + reg_cur_k_offs_], k_blk_step_);
 
     sub(reg_K_iters, k_blk_step_);
     cmp(reg_K_iters, k_blk_step_);
@@ -5543,14 +5879,23 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_K_loop(bool is_N_tail,
 
     if (curr_K_tail > 0) copy_row_x_col(nrows, curr_K_tail);
 
+    // For int8 grouped quantization the compensation buffer has a separate
+    // slot per K-chunk (driver passes a different `compensation_ptr` for
+    // each chunk via `s8s8_comp_k_str`). Each call must therefore produce
+    // a complete, finalized comp value (raw sum * 128, sign-flipped, +1)
+    // independent of other chunks.
+    const bool comp_per_chunk = conf_->with_int8_grouped_quantization;
+    const bool do_first = comp_per_chunk || is_first_K_iter;
+    const bool do_last = comp_per_chunk || is_last_K_iter;
+
     if (req_s8s8_comp_) {
         const auto addr = ptr[reg_comp_ptr];
-        if (!is_first_K_iter)
+        if (!do_first)
             uni_vpaddd(vmm_s8s8_comp_acc, vmm_comp_acc, addr);
         else
             uni_vmovups(vmm_s8s8_comp_acc, vmm_comp_acc);
 
-        if (is_last_K_iter) {
+        if (do_last) {
             // multiply by 128
             uni_vpslld(vmm_s8s8_comp_acc, vmm_s8s8_comp_acc, 7);
             // change sign
@@ -5561,9 +5906,8 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_K_loop(bool is_N_tail,
     }
     if (req_zp_comp_) {
         const auto addr = ptr[reg_zp_comp_ptr];
-        if (!is_first_K_iter) vpaddd(vmm_comp_acc, vmm_comp_acc, addr);
-        if (is_last_K_iter)
-            uni_vpmulld(vmm_comp_acc, vmm_comp_acc, vmm_zp_a_neg_val);
+        if (!do_first) vpaddd(vmm_comp_acc, vmm_comp_acc, addr);
+        if (do_last) uni_vpmulld(vmm_comp_acc, vmm_comp_acc, vmm_zp_a_neg_val);
         uni_vmovups(addr, vmm_comp_acc);
     }
 }
@@ -5622,7 +5966,16 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
         const auto elems_per_byte
                 = one_of(zp_dt, data_type::s4, data_type::u4) ? 2 : 1;
         const auto offset = n_blk_step_ * zp_dt_sz / elems_per_byte;
-        add(reg_zp_ptr, offset);
+        // For int8 grouped quantization the zp pointer is consumed via the
+        // stack-saved copy (because `reg_zp_ptr` aliases `reg_comp_ptr` and
+        // gets repurposed by the s8s8/src-zp compensation code path inside
+        // `compute_body`). Updating `reg_zp_ptr` here would corrupt the
+        // compensation pointer. Only the stack-saved ZP pointer needs to
+        // advance per N-block in that case.
+        if (req_int8_zp_b_shift_)
+            add(qword[rsp + reg_zp_b_ptr_offs_], offset);
+        else
+            add(reg_zp_ptr, offset);
     }
 
     if (req_zp_comp_) add(reg_zp_comp_ptr, comp_shift_);
@@ -5653,6 +6006,22 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
         vpbroadcastw(vmm_ones_words, regq_tmp.cvt16());
     }
 
+    // Compute the K-within-group remainder BEFORE loading reg_src_base (rax)
+    // and reg_zp_ptr (rdx), since division clobbers both rax and rdx.
+    if (req_int8_zp_b_shift_ && conf_->is_wei_zp_per_k) {
+        // Store the K position within the current group (remainder).
+        // Since zp_b_value_ptr already points to the current K group,
+        // we need the intra-group offset to compute relative group
+        // crossings during the K loop.
+        mov(regq_tmp, conf_->wei_zp_k_gsize);
+        xor_(rdx, rdx);
+        mov(rax, ptr[param1 + GET_OFF(current_K_start)]);
+        div(regq_tmp);
+        // rdx = current_K_start % k_gsize (position within group)
+        mov(ptr[rsp + reg_cur_k_offs_], rdx);
+        mov(ptr[rsp + reg_init_k_rem_offs_], rdx);
+    }
+
     mov(reg_src_base, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src_base, ptr[param1 + GET_OFF(tr_src)]);
     mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
@@ -5660,6 +6029,14 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
     mov(reg_wei_scales, ptr[param1 + GET_OFF(wei_scales_ptr)]);
     mov(reg_zp_ptr, ptr[param1 + GET_OFF(zp_b_value_ptr)]);
     mov(reg_K_start, ptr[param1 + GET_OFF(current_K_start)]);
+
+    // Save ZP pointer for int8 grouped quantization.
+    if (req_int8_zp_b_shift_) {
+        mov(ptr[rsp + reg_zp_b_ptr_offs_], reg_zp_ptr);
+        if (!conf_->is_wei_zp_per_k) {
+            mov(ptr[rsp + reg_cur_k_offs_], reg_K_start);
+        }
+    }
 
     if (!is_ymm_) {
         // 64-bit mask is also used when is_wei_[zp\scales]_per_k
@@ -5672,7 +6049,29 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
         kmovw(kF0F0, 0xf0f0);
     }
     if (is_src_int4_) {
-        if (is_superset(conf_->isa, avx512_core)) {
+        if (conf_->with_int8_grouped_quantization
+                && is_superset(conf_->isa, avx512_core)) {
+            // For int8 grouped quantization with int4 weights, we need a
+            // byte-level interleave permute table for cvt_int4_to_int8.
+            if (has_vpermb_) {
+                alignas(64) static constexpr const uint8_t
+                        int4_permute_bytes[64]
+                        = {0, 32, 1, 33, 2, 34, 3, 35, 4, 36, 5, 37, 6, 38, 7,
+                                39, 8, 40, 9, 41, 10, 42, 11, 43, 12, 44, 13,
+                                45, 14, 46, 15, 47, 16, 48, 17, 49, 18, 50, 19,
+                                51, 20, 52, 21, 53, 22, 54, 23, 55, 24, 56, 25,
+                                57, 26, 58, 27, 59, 28, 60, 29, 61, 30, 62, 31,
+                                63};
+                mov(regq_tmp, reinterpret_cast<size_t>(int4_permute_bytes));
+                vmovdqa64(vmm_permd, ptr[regq_tmp]);
+            } else {
+                alignas(64) static constexpr const uint32_t int4_permute_dw[16]
+                        = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22,
+                                23};
+                mov(regq_tmp, reinterpret_cast<size_t>(int4_permute_dw));
+                vmovdqa32(vmm_permd, ptr[regq_tmp]);
+            }
+        } else if (is_superset(conf_->isa, avx512_core)) {
             alignas(64) static constexpr const uint32_t int4_permute[16]
                     = {0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15};
             mov(regq_tmp, reinterpret_cast<size_t>(int4_permute));
@@ -5687,6 +6086,8 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
 
     load_common_zp_value(vmm_zp_b_val, reg_zp_ptr);
     load_common_scale_value(vmm_wei_scales, reg_wei_scales);
+    // For int8 grouped quantization, load common ZP as byte broadcast
+    load_int8_common_zp();
 
     const dim_t N_chunk_elems = conf_->N_chunk_elems;
     assert(N_chunk_elems % n_blk_step_ == 0 || N_chunk_elems == conf_->N);
@@ -5702,7 +6103,12 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
             : 0;
 
     auto compute_body = [&](bool is_first_K_iter, bool is_last_K_iter) {
-        if (is_last_K_iter) {
+        // For int8 grouped quantization, every call finalizes its own
+        // per-chunk comp (see comment in compute_K_loop), so the comp
+        // constants must be available regardless of is_last_K_iter.
+        const bool need_comp_constants
+                = is_last_K_iter || conf_->with_int8_grouped_quantization;
+        if (need_comp_constants) {
             if (req_s8s8_comp_) {
                 mov(imm_addr64, 0xffffffff);
                 uni_vpbroadcastd(vmm_all_bits_1, imm_addr64.cvt32());

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -4725,7 +4725,8 @@ struct jit_brgemm_matmul_copy_b_transposed_t
         , req_zp_b_shift_(
                   conf_->has_zero_point_b && conf_->with_wei_decompression)
         , req_int8_zp_b_shift_(conf_->has_zero_point_b
-                  && conf_->with_int8_grouped_quantization)
+                  && conf_->with_int8_grouped_quantization
+                  && !conf_->with_per_mn_compensation)
         , is_zp_int4_(one_of(conf->wei_zp_dt, data_type::s4, data_type::u4))
         , has_vpermb_(cpu().has(Xbyak::util::Cpu::tAVX512_VBMI))
         , req_apply_wei_scales_(conf_->apply_scales_in_buffer_b)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -367,6 +367,8 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
               && one_of(bgmmc.dst_dt, f16, f32))
     , f32_with_int_wei_dt(weights_decompression_support
               && everyone_is(f32, bgmmc.src_dt, bgmmc.dst_dt))
+    , int8_grouped_quantization_dt(
+              false) // will be enabled in last commit in the PR
     , A_any_layout(A_any_layout)
     , B_any_layout(B_any_layout)
     , C_any_layout(C_any_layout)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1744,6 +1744,18 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     bgmmc.with_src_scales = !src_scales.has_default_values();
     bgmmc.with_wei_scales = !wei_scales.has_default_values();
+    if (bgmmc.with_src_scales) {
+        const auto &src_scale_mask = src_scales.get_mask();
+        // src per-k grouped scales: mask has K bit set and groups are used
+        bgmmc.is_src_scale_per_k
+                = (src_scale_mask & (1 << (bgmmc.ndims - 1))) != 0
+                && !src_scales.has_default_groups();
+        bgmmc.src_scales_dt = src_scales.get_data_type();
+        bgmmc.src_scales_dt_sz = types::data_type_size(bgmmc.src_scales_dt);
+        if (bgmmc.is_src_scale_per_k) {
+            bgmmc.src_scales_k_gsize = src_scales.get_group(1);
+        }
+    }
     if (bgmmc.with_wei_scales) {
         const auto &wei_scale_mask = wei_scales.get_mask();
         bgmmc.is_wei_scale_common = wei_scale_mask == 0;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1831,6 +1831,13 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.is_runtime_N = is_runtime_value(bgmmc.N);
     bgmmc.is_runtime_K = is_runtime_value(bgmmc.K);
 
+    // Downgrade to per-N to avoid the expensive K-scales JIT path which
+    // is not needed for this case.
+    if (bgmmc.is_wei_scale_per_k && !bgmmc.is_runtime_K
+            && bgmmc.wei_scales_k_gsize >= bgmmc.K) {
+        bgmmc.is_wei_scale_per_k = false;
+    }
+
     bgmmc.is_gemv = is_gemv_applicable(
             bgmmc, bm_conf_utils, src_md, weights_md, dst_md, attr);
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -17,6 +17,7 @@
 #include <unordered_set>
 
 #include "common/dnnl_thread.hpp"
+#include "common/math_utils.hpp"
 #include "cpu/binary_injector_utils.hpp"
 #include "cpu/matmul/gemm_based_common.hpp"
 #include "cpu/matmul/matmul_utils.hpp"
@@ -24,6 +25,7 @@
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/x64/matmul/amx_blocking_heuristics.hpp"
 #include "cpu/x64/matmul/brgemm_matmul_utils.hpp"
+#include "cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.hpp"
 #include "cpu/x64/matmul/postops_estimator.hpp"
 #include "oneapi/dnnl/dnnl_debug.h"
 
@@ -243,7 +245,8 @@ status_t check_isa_with_datatype(
             = IMPLICATION(bm_conf_utils.is_f32(),
                       one_of(isa, avx512_core, avx2) || bm_conf_utils.is_bf32()
                               || bm_conf_utils.is_tf32())
-            && IMPLICATION(bm_conf_utils.is_int8(),
+            && IMPLICATION(bm_conf_utils.is_int8()
+                            || bm_conf_utils.with_int8_grouped_quantization(),
                     is_superset(isa, avx512_core)
                             || is_superset(isa, avx2_vnni))
             && IMPLICATION(bm_conf_utils.is_bf16(),
@@ -310,7 +313,8 @@ status_t check_datatype_cfg(const brgemm_matmul_conf_utils_t &bm_conf_utils) {
                       bm_conf_utils.is_tf32(),
                       bm_conf_utils.is_bf16_with_int_wei(),
                       bm_conf_utils.is_f16_with_int_wei(),
-                      bm_conf_utils.is_f32_with_int_wei())
+                      bm_conf_utils.is_f32_with_int_wei(),
+                      bm_conf_utils.with_int8_grouped_quantization())
             && IMPLICATION(bm_conf_utils.is_bf16_with_int_wei()
                             || bm_conf_utils.is_f16_with_int_wei(),
                     bm_conf_utils.with_weights_decompression());
@@ -367,8 +371,24 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
               && one_of(bgmmc.dst_dt, f16, f32))
     , f32_with_int_wei_dt(weights_decompression_support
               && everyone_is(f32, bgmmc.src_dt, bgmmc.dst_dt))
-    , int8_grouped_quantization_dt(
-              false) // will be enabled in last commit in the PR
+    // int8 grouped quantization: any grouped scales/ZP attribute on
+    // int8 src x {s4,u4,s8} wei, dst in {f16,bf16,f32,s8,u8}.
+    , int8_grouped_quantization_dt(one_of(bgmmc.src_dt, u8, s8)
+              && one_of(bgmmc.wei_dt, s4, u4, s8)
+              && one_of(bgmmc.dst_dt, f16, bf16, f32, s8, u8)
+              && (!attr.zero_points_.get(DNNL_ARG_SRC).has_default_values()
+                      || !attr.zero_points_.get(DNNL_ARG_WEIGHTS)
+                                  .has_default_values())
+              && (utils::one_of(bgmmc.wei_dt, s4, u4)
+                      || !attr.scales_.get(DNNL_ARG_SRC).has_default_groups()
+                      || !attr.scales_.get(DNNL_ARG_WEIGHTS)
+                                  .has_default_groups()
+                      || !attr.zero_points_.get(DNNL_ARG_SRC)
+                                  .has_default_groups()
+                      || !attr.zero_points_.get(DNNL_ARG_WEIGHTS)
+                                  .has_default_groups())
+              && bgmmc.ndims
+                      == 2) // 3D/4D cases will be enabled in separate PRs.
     , A_any_layout(A_any_layout)
     , B_any_layout(B_any_layout)
     , C_any_layout(C_any_layout)
@@ -812,7 +832,7 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
 
     if (bgmmc.ndims > 3) return format_tag::undef;
 
-    if (is_int8() || is_f8()) {
+    if (is_int8() || is_f8() || with_int8_grouped_quantization()) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c4b : BA16a64b4a;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c4b : BA16a48b4a;
@@ -1692,6 +1712,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.with_wei_decompression = bm_conf_utils.with_weights_decompression();
     bgmmc.is_int4_weights = one_of(bgmmc.wei_dt, data_type::s4, data_type::u4);
     bgmmc.is_f4_via_convert = bm_conf_utils.is_f4_via_convert();
+    bgmmc.with_int8_grouped_quantization
+            = bm_conf_utils.with_int8_grouped_quantization();
 
     if (bgmmc.is_f4_via_convert) {
         bgmmc.wei_dt = f32;
@@ -1732,9 +1754,27 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.wei_dt = f16;
         bgmmc.tr_a_dt_sz = types::data_type_size(f16);
         bgmmc.tr_b_dt_sz = types::data_type_size(f16);
+    } else if (bgmmc.with_int8_grouped_quantization) {
+
+        bgmmc.wei_dt = one_of(bgmmc.wei_dt, s8, u8) ? bgmmc.wei_dt : s8;
+        const bool has_src_zp
+                = !attr.zero_points_.get(DNNL_ARG_SRC).has_default_values();
+        bgmmc.src_dt = one_of(bgmmc.src_dt, s8, u8)   ? bgmmc.src_dt
+                : (bgmmc.src_dt == u4 && !has_src_zp) ? u8
+                                                      : s8;
+        bgmmc.tr_a_dt_sz = types::data_type_size(bgmmc.src_dt);
+        bgmmc.tr_b_dt_sz = types::data_type_size(bgmmc.wei_dt);
+        bgmmc.s8s8_compensation_required
+                = bgmmc.src_dt == s8 && !isa_has_s8s8(isa);
     }
 
-    bgmmc.acc_dt = bm_conf_utils.is_int8() ? s32 : f32;
+    // Grouped int8 quantization accumulates in f32: per-K scale/ZP
+    // application happens between brgemm calls and requires float
+    // accumulation (per-MN comp subtracts a float delta each K-group).
+    bgmmc.acc_dt
+            = (bm_conf_utils.is_int8() && !bgmmc.with_int8_grouped_quantization)
+            ? s32
+            : f32;
 
     bgmmc.c_dt_sz = types::data_type_size(bgmmc.dst_dt);
     bgmmc.acc_dt_sz = types::data_type_size(bgmmc.acc_dt);
@@ -1752,6 +1792,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.is_src_scale_per_k
                 = (src_scale_mask & (1 << (bgmmc.ndims - 1))) != 0
                 && !src_scales.has_default_groups();
+        // src per-m scales: mask has M bit set (last-but-one src dim).
+        bgmmc.is_src_scale_per_m
+                = (src_scale_mask & (1 << (bgmmc.ndims - 2))) != 0;
         bgmmc.src_scales_dt = src_scales.get_data_type();
         bgmmc.src_scales_dt_sz = types::data_type_size(bgmmc.src_scales_dt);
         if (bgmmc.is_src_scale_per_k) {
@@ -1791,7 +1834,19 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     const auto &src_zp = attr.zero_points_.get(DNNL_ARG_SRC);
     const auto has_src_zp = !src_zp.has_default_values();
-    if (has_src_zp) { bgmmc.src_zp_dt = src_zp.get_data_type(); }
+    if (has_src_zp) {
+        bgmmc.src_zp_dt = src_zp.get_data_type();
+        const auto src_zp_mask = src_zp.get_mask();
+        // src per-K grouped ZP: K bit set (the last dim for src is K) and
+        // an explicit group size. Only meaningful for grouped int8 paths.
+        bgmmc.is_src_zp_per_k = (src_zp_mask & (1 << (bgmmc.ndims - 1))) != 0
+                && !src_zp.has_default_groups();
+        // src per-M zp: M bit set (last-but-one src dim).
+        bgmmc.is_src_zp_per_m = (src_zp_mask & (1 << (bgmmc.ndims - 2))) != 0;
+        if (bgmmc.is_src_zp_per_k) bgmmc.src_zp_k_gsize = src_zp.get_group(1);
+        VCONDCHECK_BG(IMPLICATION(bgmmc.is_src_zp_per_k, bgmmc.is_int4_weights),
+                VERBOSE_UNSUPPORTED_ZP_CFG);
+    }
 
     const auto &wei_zp = attr.zero_points_.get(DNNL_ARG_WEIGHTS);
     const auto has_wei_zp = !wei_zp.has_default_values();
@@ -1827,9 +1882,21 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.wei_zp_type = get_zp_type(attr, DNNL_ARG_WEIGHTS);
     bgmmc.dst_zp_type = get_zp_type(attr, DNNL_ARG_DST);
 
+    // Non-default src zero points (per-tensor, common, host_scalar) with
+    // int8 grouped quantization: the per-(M,N) compensation tile (set via
+    // bgmmc.with_per_mn_compensation later in init) covers the remaining
+    // cases. The legacy restrictions below are kept only for paths that the
+    // per-(M,N) compensation does not yet cover.
+
+    // Wei zero points with int8 grouped quantization are now supported for
+    // any mask (common, per_n, per_k) — the post-brgemm per-(M,N)
+    // compensation handles non-per-K cases that the existing copy_b path
+    // does not.
     VCONDCHECK_BG(
-            IMPLICATION(!(bm_conf_utils.is_int8()
-                                || bm_conf_utils.with_weights_decompression()),
+            IMPLICATION(
+                    !(bm_conf_utils.is_int8()
+                            || bm_conf_utils.with_weights_decompression()
+                            || bm_conf_utils.with_int8_grouped_quantization()),
                     everyone_is(brgemm_broadcast_t::none, bgmmc.src_zp_type,
                             bgmmc.wei_zp_type, bgmmc.dst_zp_type)),
             VERBOSE_UNSUPPORTED_ZP_CFG);
@@ -2104,6 +2171,43 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     // - nthr_K
     VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
             VERBOSE_BLOCKING_FAIL, "");
+
+    // Per-K (grouped) scales/ZP applied at kernel time (i.e. not folded into
+    // buffer B) require each brgemm call to cover at most a single K-group
+    // of every active per-K axis.
+    if (!bgmmc.is_runtime_K) {
+        dim_t k_group = 0;
+        auto fold_group = [&](bool active, dim_t g) {
+            if (!active || g <= 0) return;
+            k_group = (k_group == 0) ? g : math::gcd(k_group, g);
+        };
+        fold_group(bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b,
+                bgmmc.wei_scales_k_gsize);
+        fold_group(bgmmc.is_src_scale_per_k, bgmmc.src_scales_k_gsize);
+
+        const bool wei_zp_folded_into_buffer_b = bgmmc.with_wei_decompression
+                && !bgmmc.with_int8_grouped_quantization;
+        fold_group(bgmmc.is_wei_zp_per_k && !wei_zp_folded_into_buffer_b,
+                bgmmc.wei_zp_k_gsize);
+        fold_group(bgmmc.is_src_zp_per_k, bgmmc.src_zp_k_gsize);
+        if (k_group > 0) {
+            const dim_t prev_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
+            if (bgmmc.K_blk > k_group) {
+                bgmmc.K_blk = rnd_up(nstl::min(bgmmc.K, k_group),
+                        bgmmc.required_k_granularity);
+                bgmmc.brgemm_batch_size = 1;
+            } else {
+                const dim_t max_bs = nstl::max<dim_t>(1, k_group / bgmmc.K_blk);
+                if (bgmmc.brgemm_batch_size > max_bs)
+                    bgmmc.brgemm_batch_size = max_bs;
+            }
+
+            const dim_t new_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
+            if (new_chunk_K < prev_chunk_K && new_chunk_K < bgmmc.K) {
+                bgmmc.use_buffer_c = true;
+            }
+        }
+    }
 
     if (bgmmc.wei_n_blk > bgmmc.N_blk && bgmmc.N != bgmmc.N_blk) {
         assert(!bgmmc.is_runtime_N
@@ -2557,6 +2661,8 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.has_zero_point_a = bgmmc.src_zp_type != brgemm_broadcast_t::none;
     bgmmc.has_zero_point_b = bgmmc.wei_zp_type != brgemm_broadcast_t::none;
     bgmmc.has_zero_point_c = bgmmc.dst_zp_type != brgemm_broadcast_t::none;
+    bgmmc.with_per_mn_compensation = bgmmc.with_int8_grouped_quantization
+            && (bgmmc.has_zero_point_a || bgmmc.has_zero_point_b);
     bgmmc.post_ops_applicable = one_of(true, bgmmc.with_sum, bgmmc.with_bias,
             bgmmc.with_src_scales,
             bgmmc.with_wei_scales && !bgmmc.apply_scales_in_buffer_b,
@@ -2568,6 +2674,11 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.zp_a_comp_shift_n = bgmmc.wei_n_blk;
     bgmmc.zp_a_comp_elems_per_thr
             = bgmmc.N_chunk_size * bgmmc.zp_a_comp_shift_n;
+
+    if (bgmmc.is_src_zp_per_k && bgmmc.src_zp_k_gsize > 0) {
+        const dim_t num_k_groups = utils::div_up(bgmmc.K, bgmmc.src_zp_k_gsize);
+        bgmmc.zp_a_comp_elems_per_thr *= num_k_groups;
+    }
 
     const int s32_elems_in_cacheline = 16;
     bgmmc.zp_b_comp_result_shift_m = bgmmc.M_blk;
@@ -2625,6 +2736,15 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
         scratchpad.book(key_brgemm_primitive_zp_comp_b,
                 bgmmc.nthr * bgmmc.zp_b_comp_elems_per_thr,
                 types::data_type_size(s32));
+
+    if (bgmmc.with_per_mn_compensation) {
+        // f32 tile that mirrors buffer_c's stripe layout
+        const size_t per_thr_elems = static_cast<size_t>(bgmmc.M_blk)
+                * static_cast<size_t>(rnd_up(bgmmc.N_blk, bgmmc.LDC));
+        scratchpad.book(key_brgemm_primitive_per_mn_comp,
+                static_cast<size_t>(bgmmc.nthr) * per_thr_elems,
+                types::data_type_size(f32));
+    }
 
     if (is_superset(bgmmc.isa, avx512_core_amx))
         scratchpad.book(key_conv_amx_tile_buffer,

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -243,6 +243,7 @@ struct brgemm_matmul_conf_t {
     bool is_int4_weights = false;
     bool is_f4_via_convert = false;
     bool is_tf32 = false;
+    bool with_int8_grouped_quantization = false;
     bool req_wei_vnni_downconvert = false;
     bool is_runtime_M = false;
     bool is_runtime_N = false;
@@ -334,6 +335,10 @@ struct brgemm_matmul_conf_utils_t {
         if (bgmmc.is_bf16_with_int_wei) return true;
         if (bgmmc.is_f16_with_int_wei) return true;
         if (bgmmc.is_f32_with_int_wei) return true;
+        if (bgmmc.with_int8_grouped_quantization
+                && (bgmmc.is_int4_weights
+                        || bgmmc.wei_zp_type != brgemm_broadcast_t::none))
+            return true;
         if (bgmmc.apply_scales_in_buffer_b) return true;
         if (bgmmc.is_gemv) return false;
 
@@ -425,6 +430,10 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool is_f32_with_int_wei() const { return f32_with_int_wei_dt; }
 
+    inline bool with_int8_grouped_quantization() const {
+        return int8_grouped_quantization_dt;
+    }
+
     inline bool with_weights_decompression() const {
         return !utils::one_of(bgmmc.src_dt, data_type::s8, data_type::u8,
                        data_type::s4, data_type::u4)
@@ -469,7 +478,8 @@ private:
     const bool f32_dt, bf16_dt, f16_dt, f4_via_convert_dt, f8_dt, bf8_dt,
             int8_dt, bf32_dt, tf32_dt;
     const bool weights_decompression_support, bf16_with_int_wei_dt, f32_f16_dt,
-            f32_bf16_dt, f16_with_int_wei_dt, f32_with_int_wei_dt;
+            f32_bf16_dt, f16_with_int_wei_dt, f32_with_int_wei_dt,
+            int8_grouped_quantization_dt;
     const bool A_any_layout;
     const bool B_any_layout;
     const bool C_any_layout;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -244,6 +244,10 @@ struct brgemm_matmul_conf_t {
     bool is_f4_via_convert = false;
     bool is_tf32 = false;
     bool with_int8_grouped_quantization = false;
+    // Enables the driver-side per-(M, N) f32 compensation tile that captures
+    // the symmetric src/wei zero-point + 128-shift correction in the grouped
+    // int8 quantization path. Mirrors brgemm_desc_t::with_per_mn_compensation.
+    bool with_per_mn_compensation = false;
     bool req_wei_vnni_downconvert = false;
     bool is_runtime_M = false;
     bool is_runtime_N = false;
@@ -267,6 +271,7 @@ struct brgemm_matmul_conf_t {
 
     // Src scales per-K
     bool is_src_scale_per_k = false;
+    bool is_src_scale_per_m = false;
     dim_t src_scales_k_gsize = 0;
     data_type_t src_scales_dt = data_type::undef;
     size_t src_scales_dt_sz = 0;
@@ -280,6 +285,12 @@ struct brgemm_matmul_conf_t {
     brgemm_broadcast_t dst_zp_type;
 
     data_type_t src_zp_dt = data_type::undef;
+
+    // Per-K src zero-points: stride between K-group slots (in
+    // elements). Used by the per-mn compensation src ZP gather.
+    bool is_src_zp_per_k = false;
+    bool is_src_zp_per_m = false;
+    dim_t src_zp_k_gsize = 0;
 
     dim_t wei_zp_k_gsize = 0;
     bool is_wei_zp_per_k = false;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -264,6 +264,12 @@ struct brgemm_matmul_conf_t {
     dim_t wei_scales_k_gsize = 0;
     data_type_t wei_scales_dt = data_type::undef;
 
+    // Src scales per-K
+    bool is_src_scale_per_k = false;
+    dim_t src_scales_k_gsize = 0;
+    data_type_t src_scales_dt = data_type::undef;
+    size_t src_scales_dt_sz = 0;
+
     // Zero points
     bool has_zero_point_a;
     bool has_zero_point_b;

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -1,0 +1,796 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.hpp"
+
+#include "common/c_types_map.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "cpu/ref_io_helper.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace matmul {
+
+using namespace Xbyak;
+
+namespace {
+
+alignas(64) constexpr uint32_t int4_interleave_dw[16]
+        = {0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23};
+
+// JIT generator: fill one delta-tile (K-group, N-stripe).
+//
+// Math:
+//   delta[m,n] += ss * sw * ( zs*S[n] + (T[m] - G*zs)*zw )
+//   with  T[m] = sum_K src[m,k],  S[n] = sum_K wei[k,n],  G = K-group length.
+//
+// Per-axis (src zp/sc, wei zp/sc) supply:
+//   * scalar f32 (per-tensor or per-K-only)  -> cpp-side pre-converts
+//   * vector load from typed user buffer    -> JIT loads, casts to f32
+//
+// The delta tile is the only output buffer.
+template <typename Vmm>
+struct jit_per_mn_comp_kernel_t : public per_mn_comp_kernel_t,
+                                  public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_per_mn_comp_kernel_t)
+
+    using ctx_t = per_mn_comp_kernel_t::ctx_t;
+
+    jit_per_mn_comp_kernel_t(
+            const brgemm_matmul_conf_t *bgmmc, bool wei_zp_per_n)
+        : per_mn_comp_kernel_t(bgmmc, wei_zp_per_n)
+        , jit_generator_t(jit_name())
+        , isa_(bgmmc->isa)
+        , has_src_zp_(bgmmc->has_zero_point_a)
+        , has_wei_zp_(bgmmc->has_zero_point_b)
+        , wei_zp_dt_(bgmmc->wei_zp_dt)
+        , wei_zp_is_int4_(
+                  utils::one_of(bgmmc->wei_zp_dt, data_type::s4, data_type::u4))
+        , src_is_signed_(bgmmc->orig_src_dt == data_type::s8)
+        , wei_is_signed_(bgmmc->orig_wei_dt == data_type::s8
+                  || bgmmc->orig_wei_dt == data_type::s4)
+        , wei_is_subbyte_(utils::one_of(
+                  bgmmc->orig_wei_dt, data_type::s4, data_type::u4))
+        , has_vnni_(is_superset(bgmmc->isa, avx512_core_vnni)
+                  || is_superset(bgmmc->isa, avx2_vnni))
+        , src_m_stride_bytes_(bgmmc->A_strides[1])
+        , src_k_stride_bytes_(bgmmc->A_strides[0])
+        , wei_k_stride_bytes_(wei_is_subbyte_ ? bgmmc->B_strides[1] / 2
+                                              : bgmmc->B_strides[1])
+        , LDC_(bgmmc->LDC)
+        , stripe_w_(
+                  static_cast<int>(nstl::min<dim_t>(bgmmc->LDC, bgmmc->N_blk)))
+        , chunks_(static_cast<int>(utils::div_up(stripe_w_, simd_w))) {}
+
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
+    void operator()(const ctx_t *ctx) const override;
+
+private:
+    using reg64_t = const Xbyak::Reg64;
+
+#define GET_OFF(x) offsetof(ctx_t, x)
+
+    const cpu_isa_t isa_;
+    const bool has_src_zp_;
+    const bool has_wei_zp_;
+    const data_type_t wei_zp_dt_;
+    const bool wei_zp_is_int4_;
+    const bool src_is_signed_;
+    const bool wei_is_signed_;
+    const bool wei_is_subbyte_;
+    const bool has_vnni_;
+    const dim_t src_m_stride_bytes_;
+    const dim_t src_k_stride_bytes_;
+    const dim_t wei_k_stride_bytes_;
+    const dim_t LDC_;
+    const int stripe_w_;
+    const int chunks_;
+
+    static constexpr int f32_sz = sizeof(float);
+    static constexpr int i32_sz = sizeof(int32_t);
+    static constexpr int simd_w = vreg_traits_t<Vmm>::vlen / i32_sz;
+    static constexpr int vmm_bytes = vreg_traits_t<Vmm>::vlen;
+    static constexpr bool is_zmm = std::is_same<Vmm, Xbyak::Zmm>::value;
+
+    reg64_t reg_param = abi_param1;
+
+    reg64_t reg_M_blk = r12;
+    reg64_t reg_stripe_w = r13;
+    reg64_t reg_k_len = r14;
+
+    reg64_t reg_a = r8;
+    reg64_t reg_b = r9;
+    reg64_t reg_iter = r10;
+    reg64_t reg_k_iter = r11;
+    reg64_t reg_m = rdx;
+    reg64_t reg_n = rax;
+    reg64_t reg_delta = r15;
+    reg64_t reg_tmp = rsi;
+    reg64_t reg_T = rbx;
+
+    Opmask k_mask = k1;
+    Opmask k_byte_mask = k2;
+
+    // [0 .. chunks_-1]   S_v[chunks_] (lives across the whole m-loop, f32)
+    // [chunks_ + 0..+7]  8 reserved slots for persistents + per-chunk temps:
+    //                      +0 zs_bc        persistent f32 broadcast
+    //                      +1 zw           persistent OR per-chunk
+    //                      +2 Gzs_bc       persistent f32 broadcast
+    //                      +3 T_bc         per-m f32 broadcast (= T_eff)
+    //                      +4 int4_perm    persistent (wei_zp s4/u4 vector)
+    //                      +5 int4_0F      persistent (wei_zp s4/u4 vector)
+    //                      +6 term         per-chunk temp
+    //                      +7 delta        per-chunk temp
+    // top                AVX2 mask aux (Vmm(14)/Vmm(15))
+    Vmm vmm_S(int c) const { return Vmm(c); }
+    Vmm vmm_zs_bc() const { return Vmm(chunks_ + 0); }
+    Vmm vmm_zw() const { return Vmm(chunks_ + 1); }
+    Vmm vmm_g_sz_bc() const { return Vmm(chunks_ + 2); }
+    Vmm vmm_T_bc() const { return Vmm(chunks_ + 3); }
+    Vmm vmm_int4_perm() const { return Vmm(chunks_ + 4); }
+    Vmm vmm_int4_0F() const { return Vmm(chunks_ + 5); }
+    Vmm vmm_term() const { return Vmm(chunks_ + 6); }
+    Vmm vmm_delta() const { return Vmm(chunks_ + 7); }
+    // Aliases used inside S-reduce only (persistents not yet loaded).
+    Vmm vmm_acc_sr() const { return Vmm(chunks_ + 0); }
+    Vmm vmm_data_sr() const { return Vmm(chunks_ + 1); }
+    Vmm vmm_t1_sr() const { return Vmm(chunks_ + 2); }
+    Vmm vmm_t2_sr() const { return Vmm(chunks_ + 3); }
+    Vmm vmm_perm_sr() const { return Vmm(chunks_ + 4); }
+    Vmm vmm_0f_sr() const { return Vmm(chunks_ + 5); }
+    // Aliases used inside T-reduce only (T_bc reloaded right after).
+    Vmm vmm_acc_tr() const { return Vmm(chunks_ + 6); } // shares with term
+    Vmm vmm_data_tr() const { return Vmm(chunks_ + 7); } // shares with delta
+    Vmm vmm_ones_tr() const { return Vmm(chunks_ + 3); } // shares with T_bc
+
+    // AVX2-only auxiliaries.
+    Vmm vmm_idx_ = Vmm(15);
+    Vmm vmm_tail_ = Vmm(14);
+
+    Xbyak::Label idx_table_;
+
+    void load_param(reg64_t r, int off) { mov(r, ptr[reg_param + off]); }
+
+    // Mask primitives
+    void set_full_mask() {
+        if (isa_has_masks(isa_)) {
+            mov(reg_tmp, simd_w == 16 ? 0xFFFF : 0xFF);
+            kmovw(k_mask, reg_tmp.cvt32());
+        } else {
+            vpcmpeqd(vmm_tail_, vmm_tail_, vmm_tail_);
+        }
+    }
+
+    void build_low_bits_opmask(Opmask kdst, reg64_t count_reg) {
+        assert(isa_has_masks(isa_));
+        mov(reg_tmp, -1);
+        bzhi(reg_tmp, reg_tmp, count_reg);
+        kmovq(kdst, reg_tmp);
+    }
+
+    void build_low_bits_mask(reg64_t count_reg) {
+        if (isa_has_masks(isa_)) {
+            build_low_bits_opmask(k_mask, count_reg);
+        } else {
+            vmovd(Xbyak::Xmm(vmm_tail_.getIdx()), count_reg.cvt32());
+            vpbroadcastd(vmm_tail_, Xbyak::Xmm(vmm_tail_.getIdx()));
+            vpcmpgtd(vmm_tail_, vmm_tail_, vmm_idx_);
+        }
+    }
+
+    void build_kbyte_mask() {
+        cmp(reg_iter, simd_w);
+        Label cap_ok;
+        jle(cap_ok, T_NEAR);
+        mov(reg_iter, simd_w);
+        L(cap_ok);
+        inc(reg_iter);
+        shr(reg_iter, 1);
+        mov(reg_n, -1);
+        bzhi(reg_n, reg_n, reg_iter);
+        kmovw(k_byte_mask, reg_n.cvt32());
+    }
+
+    void init_int4_helpers() {
+        mov(reg_tmp,
+                reinterpret_cast<uintptr_t>(
+                        static_cast<const void *>(int4_interleave_dw)));
+        vmovdqu32(vmm_int4_perm(), ptr[reg_tmp]);
+        mov(reg_tmp.cvt32(), 0x0F);
+        vpbroadcastd(vmm_int4_0F(), reg_tmp.cvt32());
+    }
+
+    void masked_load_f32(Vmm dst, const Xbyak::Address &addr) {
+        if (isa_has_masks(isa_))
+            vmovups(dst | k_mask | T_z, addr);
+        else
+            vmaskmovps(dst, vmm_tail_, addr);
+    }
+    void masked_store_f32(const Xbyak::Address &addr, Vmm src) {
+        if (isa_has_masks(isa_))
+            vmovups(addr | k_mask, src);
+        else
+            vmaskmovps(addr, vmm_tail_, src);
+    }
+
+    // Build a mask covering `count` low lanes, capped at simd_w.
+    // Caller must ensure `count_reg` > 0.
+    void build_chunk_mask(reg64_t count_reg) {
+        Label use_full, done;
+        cmp(count_reg, simd_w);
+        jge(use_full, T_NEAR);
+        build_low_bits_mask(count_reg);
+        jmp(done, T_NEAR);
+        L(use_full);
+        set_full_mask();
+        L(done);
+    }
+
+    // VNNI helpers (T-reduce)
+    void vpdpbusd_ones(Vmm acc, Vmm data, bool data_is_signed) {
+        const auto enc = is_zmm ? Xbyak::EvexEncoding : Xbyak::VexEncoding;
+        if (data_is_signed)
+            vpdpbusd(acc, vmm_ones_tr(), data, enc);
+        else
+            vpdpbusd(acc, data, vmm_ones_tr(), enc);
+    }
+
+    void broadcast_byte_ones(Vmm v) {
+        mov(reg_tmp, 1);
+        if (isa_has_masks(isa_)) {
+            vpbroadcastb(v, reg_tmp.cvt8());
+        } else {
+            const Xbyak::Xmm ones_x(v.getIdx());
+            vmovd(ones_x, reg_tmp.cvt32());
+            vpbroadcastb(v, ones_x);
+        }
+    }
+
+    void hreduce_dword(Vmm src) {
+        const Xbyak::Ymm src_y(src.getIdx());
+        const Xbyak::Ymm tmp_y(vmm_data_tr().getIdx());
+        const Xbyak::Xmm src_x(src.getIdx());
+        const Xbyak::Xmm tmp_x(vmm_data_tr().getIdx());
+        if (is_zmm) {
+            vextracti64x4(tmp_y, Xbyak::Zmm(src.getIdx()), 1);
+            vpaddd(src_y, src_y, tmp_y);
+        }
+        vextracti128(tmp_x, src_y, 1);
+        vpaddd(src_x, src_x, tmp_x);
+        vpshufd(tmp_x, src_x, 0x4E);
+        vpaddd(src_x, src_x, tmp_x);
+        vpshufd(tmp_x, src_x, 0xB1);
+        vpaddd(src_x, src_x, tmp_x);
+    }
+
+    // Broadcast f32 scalar from call_params field
+    void bcast_f32_param(Vmm dst, int off) {
+        vbroadcastss(dst, ptr[reg_param + off]);
+    }
+
+    // Loads simd_w int values (zps) of dt from addr, converts to f32.
+    // Supports s8 / u8 / s32 / s4 / u4 (int4 path is AVX-512 only).
+    // tail_size_bytes: exact byte count for AVX2 byte tails (0 means full load).
+    void load_vec_zps_f32(Vmm dst, data_type_t dt, const Xbyak::Address &addr,
+            bool tail, int tail_size_bytes = 0) {
+        using namespace data_type;
+        switch (dt) {
+            case s32:
+                if (isa_has_masks(isa_)) {
+                    if (tail)
+                        vmovdqu32(dst | k_mask | T_z, addr);
+                    else
+                        vmovdqu32(dst, addr);
+                } else {
+                    if (tail)
+                        vpmaskmovd(dst, vmm_tail_, addr);
+                    else
+                        vmovdqu(dst, addr);
+                }
+                vcvtdq2ps(dst, dst);
+                break;
+            case s8:
+            case u8: {
+                if (isa_has_masks(isa_) && tail) {
+                    // simd_w bytes, mask is on dword lanes.
+                    if (dt == s8)
+                        vpmovsxbd(dst | k_mask | T_z, addr);
+                    else
+                        vpmovzxbd(dst | k_mask | T_z, addr);
+                } else if (!isa_has_masks(isa_) && tail) {
+                    // AVX2: avoid OOB read on tails by loading exact byte count first.
+                    assert(tail_size_bytes > 0 && tail_size_bytes < simd_w);
+                    const Xbyak::Xmm xmm_data(dst.getIdx());
+                    load_bytes(xmm_data, addr, tail_size_bytes);
+                    if (dt == s8)
+                        vpmovsxbd(dst, xmm_data);
+                    else
+                        vpmovzxbd(dst, xmm_data);
+                } else {
+                    if (dt == s8)
+                        vpmovsxbd(dst, addr);
+                    else
+                        vpmovzxbd(dst, addr);
+                }
+                vcvtdq2ps(dst, dst);
+                break;
+            }
+            case s4:
+            case u4: {
+                assert(is_zmm); // sub-byte vector load is AVX-512 only.
+                // Load (simd_w/2) bytes (zero-extended) -> 8 dwords (Ymm).
+                const Xbyak::Ymm ymm_low(vmm_delta().getIdx());
+                if (tail) {
+                    // k_byte_mask is set up by the caller.
+                    vpmovzxbd(ymm_low | k_byte_mask | T_z, addr);
+                } else {
+                    vpmovzxbd(ymm_low, addr);
+                }
+                // Promote to Zmm view; ymm_low has high half == 0.
+                const Vmm v_low = vmm_delta();
+                // Low nibbles into v_low's low 4 bits of each dword,
+                // high nibbles into vmm_term().
+                vpandd(vmm_term(), v_low, vmm_int4_0F());
+                vpsrld(v_low, v_low, 4);
+                vpandd(v_low, v_low, vmm_int4_0F());
+                if (dt == s4) {
+                    vpslld(vmm_term(), vmm_term(), 28);
+                    vpsrad(vmm_term(), vmm_term(), 28);
+                    vpslld(v_low, v_low, 28);
+                    vpsrad(v_low, v_low, 28);
+                }
+                // Interleave: dst = {term[0], v_low[0], term[1], v_low[1],...}
+                vmovdqu32(dst, vmm_term());
+                vpermt2d(dst, vmm_int4_perm(), v_low);
+                vcvtdq2ps(dst, dst);
+                break;
+            }
+            default: assert(!"unsupported wei zp dt"); break;
+        }
+    }
+
+    // Phase B: S-reduce (vectorized integer, then convert to f32)
+    void emit_s_reduce() {
+        if (wei_is_subbyte_) {
+            emit_s_reduce_subbyte();
+            return;
+        }
+        for (int c = 0; c < chunks_; ++c)
+            uni_vpxor(vmm_S(c), vmm_S(c), vmm_S(c));
+
+        load_param(reg_a, GET_OFF(wei_batch_ptr));
+        load_param(reg_tmp, GET_OFF(n_base));
+        add(reg_a, reg_tmp);
+
+        mov(reg_k_iter, reg_k_len);
+        Label k_loop, k_done;
+        L(k_loop);
+        test(reg_k_iter, reg_k_iter);
+        jz(k_done, T_NEAR);
+        for (int c = 0; c < chunks_; ++c) {
+            Label skip_chunk;
+            mov(reg_iter, reg_stripe_w);
+            if (c > 0) {
+                sub(reg_iter, c * simd_w);
+                jle(skip_chunk, T_NEAR);
+            }
+            const auto addr = ptr[reg_a + c * simd_w];
+            if (isa_has_masks(isa_)) {
+                build_chunk_mask(reg_iter);
+                if (wei_is_signed_)
+                    vpmovsxbd(vmm_data_sr() | k_mask | T_z, addr);
+                else
+                    vpmovzxbd(vmm_data_sr() | k_mask | T_z, addr);
+            } else {
+                // AVX2: only the final chunk may need a short-byte load.
+                const int rem = stripe_w_ - c * simd_w;
+                const bool is_last_chunk = (c == chunks_ - 1);
+                const bool need_preload
+                        = is_last_chunk && rem > 0 && rem < simd_w;
+                if (need_preload) {
+                    const Xbyak::Xmm xmm_data(vmm_data_sr().getIdx());
+                    load_bytes(xmm_data, addr, rem);
+                }
+                const auto &src_op = need_preload
+                        ? static_cast<const Xbyak::Operand &>(vmm_data_sr())
+                        : static_cast<const Xbyak::Operand &>(addr);
+                if (wei_is_signed_)
+                    vpmovsxbd(vmm_data_sr(), src_op);
+                else
+                    vpmovzxbd(vmm_data_sr(), src_op);
+            }
+            vpaddd(vmm_S(c), vmm_S(c), vmm_data_sr());
+            L(skip_chunk);
+        }
+        add(reg_a, wei_k_stride_bytes_);
+        dec(reg_k_iter);
+        jmp(k_loop, T_NEAR);
+        L(k_done);
+
+        // Integer -> f32 once per accumulator.
+        for (int c = 0; c < chunks_; ++c)
+            vcvtdq2ps(vmm_S(c), vmm_S(c));
+    }
+
+    // Sub-byte (s4/u4) S-reduce. AVX-512 only (factory enforces).
+    void emit_s_reduce_subbyte() {
+        assert(is_zmm);
+        for (int c = 0; c < chunks_; ++c)
+            uni_vpxor(vmm_S(c), vmm_S(c), vmm_S(c));
+
+        init_int4_helpers();
+
+        load_param(reg_a, GET_OFF(wei_batch_ptr));
+        load_param(reg_tmp, GET_OFF(n_base));
+        sar(reg_tmp, 1);
+        add(reg_a, reg_tmp);
+
+        mov(reg_k_iter, reg_k_len);
+        Label k_loop, k_done;
+        L(k_loop);
+        test(reg_k_iter, reg_k_iter);
+        jz(k_done, T_NEAR);
+        for (int c = 0; c < chunks_; ++c) {
+            Label skip_chunk;
+            mov(reg_iter, reg_stripe_w);
+            if (c > 0) {
+                sub(reg_iter, c * simd_w);
+                jle(skip_chunk, T_NEAR);
+            }
+            // Cap at simd_w, then byte_count = (rem + 1) >> 1.
+            build_kbyte_mask();
+
+            const Xbyak::Ymm ymm_data(vmm_data_sr().getIdx());
+            vpmovzxbd(ymm_data | k_byte_mask | T_z,
+                    ptr[reg_a + c * (simd_w / 2)]);
+
+            vpandd(vmm_t1_sr(), vmm_data_sr(), vmm_0f_sr());
+            vpsrld(vmm_t2_sr(), vmm_data_sr(), 4);
+            vpandd(vmm_t2_sr(), vmm_t2_sr(), vmm_0f_sr());
+            if (wei_is_signed_) {
+                vpslld(vmm_t1_sr(), vmm_t1_sr(), 28);
+                vpsrad(vmm_t1_sr(), vmm_t1_sr(), 28);
+                vpslld(vmm_t2_sr(), vmm_t2_sr(), 28);
+                vpsrad(vmm_t2_sr(), vmm_t2_sr(), 28);
+            }
+            vpermt2d(vmm_t1_sr(), vmm_perm_sr(), vmm_t2_sr());
+            vpaddd(vmm_S(c), vmm_S(c), vmm_t1_sr());
+            L(skip_chunk);
+        }
+        add(reg_a, wei_k_stride_bytes_);
+        dec(reg_k_iter);
+        jmp(k_loop, T_NEAR);
+        L(k_done);
+
+        for (int c = 0; c < chunks_; ++c)
+            vcvtdq2ps(vmm_S(c), vmm_S(c));
+    }
+
+    // Phase D (inside m-loop): scalar T_m -> f32 broadcast in vmm_T_bc
+    // Caller has set `reg_a` to src + (m_base + m) * src_m_stride.
+    // After return: vmm_T_bc holds the f32 broadcast of T_eff (= T_m on src-zp-only path).
+    void emit_t_reduce_into_T_bc(bool subtract_Gzs) {
+        if (has_vnni_) broadcast_byte_ones(vmm_ones_tr());
+        uni_vpxor(vmm_acc_tr(), vmm_acc_tr(), vmm_acc_tr());
+        mov(reg_tmp, reg_a);
+        mov(reg_k_iter, reg_k_len);
+
+        Label k_bulk, k_bulk_done;
+        L(k_bulk);
+        cmp(reg_k_iter, vmm_bytes);
+        jl(k_bulk_done, T_NEAR);
+        if (has_vnni_) {
+            uni_vmovdqu(vmm_data_tr(), ptr[reg_tmp]);
+            vpdpbusd_ones(vmm_acc_tr(), vmm_data_tr(), src_is_signed_);
+        } else {
+            for (int off = 0; off < vmm_bytes; off += simd_w) {
+                if (src_is_signed_)
+                    vpmovsxbd(vmm_data_tr(), ptr[reg_tmp + off]);
+                else
+                    vpmovzxbd(vmm_data_tr(), ptr[reg_tmp + off]);
+                vpaddd(vmm_acc_tr(), vmm_acc_tr(), vmm_data_tr());
+            }
+        }
+        add(reg_tmp, vmm_bytes);
+        sub(reg_k_iter, vmm_bytes);
+        jmp(k_bulk, T_NEAR);
+        L(k_bulk_done);
+
+        Label k_tail_done;
+        test(reg_k_iter, reg_k_iter);
+        jz(k_tail_done, T_NEAR);
+        if (has_vnni_ && isa_has_masks(isa_)) {
+            push(reg_tmp);
+            build_low_bits_mask(reg_k_iter);
+            pop(reg_tmp);
+            vmovdqu8(Xbyak::Zmm(vmm_data_tr().getIdx()) | k_mask | T_z,
+                    ptr[reg_tmp]);
+            vpdpbusd_ones(vmm_acc_tr(), vmm_data_tr(), src_is_signed_);
+        } else {
+            const Xbyak::Xmm acc_x(vmm_acc_tr().getIdx());
+            xor_(reg_n, reg_n);
+            Label scalar_loop;
+            L(scalar_loop);
+            if (src_is_signed_)
+                movsx(reg_b.cvt32(), byte[reg_tmp + reg_n]);
+            else
+                movzx(reg_b.cvt32(), byte[reg_tmp + reg_n]);
+            vmovd(Xbyak::Xmm(vmm_data_tr().getIdx()), reg_b.cvt32());
+            vpaddd(acc_x, acc_x, Xbyak::Xmm(vmm_data_tr().getIdx()));
+            inc(reg_n);
+            cmp(reg_n, reg_k_iter);
+            jl(scalar_loop, T_NEAR);
+        }
+        L(k_tail_done);
+
+        hreduce_dword(vmm_acc_tr());
+        vmovd(reg_T.cvt32(), Xmm(vmm_acc_tr().getIdx()));
+
+        // Broadcast int32 -> vmm_T_bc; convert to f32.
+        if (isa_has_masks(isa_)) {
+            vpbroadcastd(vmm_T_bc(), reg_T.cvt32());
+        } else {
+            const Xbyak::Xmm x(vmm_T_bc().getIdx());
+            vmovd(x, reg_T.cvt32());
+            vpbroadcastd(vmm_T_bc(), x);
+        }
+        vcvtdq2ps(vmm_T_bc(), vmm_T_bc());
+        if (subtract_Gzs) vsubps(vmm_T_bc(), vmm_T_bc(), vmm_g_sz_bc());
+    }
+
+    // Phase C: m-loop -- T_m, combine, write delta
+    void emit_m_combine_loop() {
+        load_param(reg_delta, GET_OFF(delta_ptr));
+
+        const bool emit_T = has_wei_zp_;
+        const bool subtract_Gzs = has_src_zp_ && has_wei_zp_;
+
+        // Per-mn delta is computed afresh for one brgemm K-call;
+        // the brgemm post-ops epilogue subtracts the resulting tile
+        // each call and the C-buffer accumulates the per-K-block deltas
+        // across calls. The JIT always overwrites — no accumulate path.
+        emit_m_loop_body(emit_T, subtract_Gzs);
+    }
+
+    void emit_m_loop_body(bool emit_T, bool subtract_Gzs) {
+        xor_(reg_m, reg_m);
+        Label m_loop, m_done;
+        L(m_loop);
+        cmp(reg_m, reg_M_blk);
+        jge(m_done, T_NEAR);
+
+        if (emit_T) {
+            load_param(reg_a, GET_OFF(src_batch_ptr));
+            load_param(reg_tmp, GET_OFF(m_base));
+            add(reg_tmp, reg_m);
+            imul(reg_tmp, reg_tmp, src_m_stride_bytes_);
+            add(reg_a, reg_tmp);
+            emit_t_reduce_into_T_bc(subtract_Gzs);
+        }
+
+        // delta row base = delta + m * LDC * 4.
+        push(reg_m);
+        imul(reg_m, reg_m, LDC_ * f32_sz);
+        add(reg_m, reg_delta);
+
+        for (int c = 0; c < chunks_; ++c) {
+            mov(reg_iter, reg_stripe_w);
+            sub(reg_iter, c * simd_w);
+            Label skip;
+            cmp(reg_iter, 0);
+            jle(skip, T_NEAR);
+            build_chunk_mask(reg_iter);
+
+            // Load (or use persistent) per-N wei_zp input.
+            if (has_wei_zp_ && wei_zp_per_n_) {
+                load_param(reg_tmp, GET_OFF(wei_zp_ptr));
+                if (wei_zp_is_int4_) {
+                    push(reg_iter);
+                    build_kbyte_mask();
+                    pop(reg_iter);
+                    const dim_t byte_off = c * (simd_w / 2);
+                    load_vec_zps_f32(vmm_zw(), wei_zp_dt_,
+                            ptr[reg_tmp + byte_off], /* tail = */ true);
+                } else if (isa_has_masks(isa_)) {
+                    const dim_t off
+                            = c * simd_w * types::data_type_size(wei_zp_dt_);
+                    load_vec_zps_f32(vmm_zw(), wei_zp_dt_, ptr[reg_tmp + off],
+                            /* tail = */ true);
+                } else {
+                    // AVX2
+                    const int rem = stripe_w_ - c * simd_w;
+                    const bool has_tail = rem > 0 && rem < simd_w;
+                    const dim_t off
+                            = c * simd_w * types::data_type_size(wei_zp_dt_);
+                    const int tail_bytes = has_tail
+                            ? rem * types::data_type_size(wei_zp_dt_)
+                            : 0;
+                    load_vec_zps_f32(vmm_zw(), wei_zp_dt_, ptr[reg_tmp + off],
+                            has_tail, tail_bytes);
+                }
+            }
+
+            // term = zs*S[c] + T_eff*zw          (both zps)
+            //      = zs*S[c]                     (src zp only)
+            //      = T_eff*zw                    (wei zp only)
+            if (has_src_zp_ && has_wei_zp_) {
+                vmulps(vmm_term(), vmm_zs_bc(), vmm_S(c));
+                vfmadd231ps(vmm_term(), vmm_T_bc(), vmm_zw());
+            } else if (has_src_zp_) {
+                vmulps(vmm_term(), vmm_zs_bc(), vmm_S(c));
+            } else { // has_wei_zp_ only
+                vmulps(vmm_term(), vmm_T_bc(), vmm_zw());
+            }
+
+            masked_store_f32(ptr[reg_m + c * simd_w * f32_sz], vmm_term());
+
+            L(skip);
+        }
+
+        pop(reg_m);
+        inc(reg_m);
+        jmp(m_loop, T_NEAR);
+        L(m_done);
+    }
+
+    void generate() override {
+        preamble();
+
+        load_param(reg_M_blk, GET_OFF(M_blk));
+        load_param(reg_stripe_w, GET_OFF(stripe_w));
+        load_param(reg_k_len, GET_OFF(k_len));
+
+        if (!isa_has_masks(isa_)) { vmovups(vmm_idx_, ptr[rip + idx_table_]); }
+
+        // (B) S-reduce (lives across the m-loop). Uses slots chunks_+0..+5
+        //     as scratch; persistents loaded AFTER S-reduce.
+        if (has_src_zp_) emit_s_reduce();
+
+        // Persistent f32 broadcasts loaded once for the whole call.
+        if (has_src_zp_) bcast_f32_param(vmm_zs_bc(), GET_OFF(src_zp_f32));
+        if (has_src_zp_ && has_wei_zp_)
+            bcast_f32_param(vmm_g_sz_bc(), GET_OFF(g_sz_f32));
+        if (has_wei_zp_ && !wei_zp_per_n_)
+            bcast_f32_param(vmm_zw(), GET_OFF(wei_zp_f32));
+
+        // int4 wei_zp helpers: load perm table & 0x0F broadcast.
+        if (wei_zp_per_n_ && wei_zp_is_int4_) init_int4_helpers();
+
+        // (C) m-loop with per-m T-reduce and combine.
+        emit_m_combine_loop();
+
+        postamble();
+
+        align(64);
+        L(idx_table_);
+        for (int i = 0; i < simd_w; ++i)
+            dd(i);
+    }
+
+#undef GET_OFF
+};
+
+template <typename Vmm>
+void jit_per_mn_comp_kernel_t<Vmm>::operator()(const ctx_t *ctx) const {
+    assert(ctx != nullptr);
+    assert(ctx->delta_ptr != nullptr);
+    assert(ctx->M_blk > 0 && ctx->stripe_w > 0);
+    assert(ctx->k_len > 0);
+
+    jit_generator_t::operator()(const_cast<ctx_t *>(ctx));
+}
+
+} // namespace
+
+// Factory
+status_t per_mn_comp_kernel_t::is_applicable(
+        const brgemm_matmul_conf_t *bgmmc) {
+    const cpu_isa_t isa = bgmmc->isa;
+    if (!is_superset(isa, avx2)) return status::unimplemented;
+
+    // Source / weights dtypes (byte / sub-byte int).
+    if (!utils::one_of(bgmmc->orig_src_dt, data_type::s8, data_type::u8))
+        return status::unimplemented;
+    if (!utils::one_of(bgmmc->orig_wei_dt, data_type::s8, data_type::u8,
+                data_type::s4, data_type::u4))
+        return status::unimplemented;
+    if (bgmmc->a_dt_sz != 1 || bgmmc->b_dt_sz != 1)
+        return status::unimplemented;
+
+    if (bgmmc->A_strides[0] != 1) return status::unimplemented;
+    if (bgmmc->B_strides[0] != 1) return status::unimplemented;
+
+    const bool wei_is_subbyte
+            = utils::one_of(bgmmc->orig_wei_dt, data_type::s4, data_type::u4);
+    if (wei_is_subbyte) {
+        if (!isa_has_masks(isa)) return status::unimplemented;
+        if (bgmmc->N_blk % 2 != 0) return status::unimplemented;
+        if (bgmmc->B_strides[1] % 2 != 0) return status::unimplemented;
+    }
+
+    if (bgmmc->LDC <= 0 || bgmmc->M_blk <= 0 || bgmmc->N_blk <= 0)
+        return status::unimplemented;
+
+    // Vmm map: chunks_ + 8. AVX-512 -> chunks < 24; AVX2 -> chunks < 6.
+    // Current limitation. TODO.
+    const bool zmm_path = isa_has_masks(isa);
+    const int simd_w_local = zmm_path ? 16 : 8;
+    const dim_t max_stripe_w = nstl::min<dim_t>(bgmmc->LDC, bgmmc->N_blk);
+    const int chunks
+            = static_cast<int>(utils::div_up(max_stripe_w, simd_w_local));
+    const int chunks_cap = zmm_path ? 24 : 6;
+    if (chunks > chunks_cap) return status::unimplemented;
+
+    if (!bgmmc->has_zero_point_a && !bgmmc->has_zero_point_b)
+        return status::unimplemented;
+
+    // Per-axis activation:
+    const bool wei_zp_per_n = bgmmc->has_zero_point_b && bgmmc->is_wei_zp_per_n;
+
+    // Vector-load dtype constraints (broadcast scalars accept any dtype via
+    // ref_io_helper; vector paths require the JIT to implement the load).
+    if (wei_zp_per_n) {
+        if (!utils::one_of(bgmmc->wei_zp_dt, data_type::s8, data_type::u8,
+                    data_type::s32, data_type::s4, data_type::u4))
+            return status::unimplemented;
+        const bool wei_zp_is_int4
+                = utils::one_of(bgmmc->wei_zp_dt, data_type::s4, data_type::u4);
+        if (wei_zp_is_int4 && !zmm_path) return status::unimplemented;
+    }
+
+    return status::success;
+}
+
+status_t per_mn_comp_kernel_t::create(
+        std::unique_ptr<per_mn_comp_kernel_t> &kernel,
+        const brgemm_matmul_conf_t *bgmmc) {
+    CHECK(is_applicable(bgmmc));
+
+    const cpu_isa_t isa = bgmmc->isa;
+    const bool zmm_path = isa_has_masks(isa);
+
+    // Re-derive per-axis activation flags consumed by the JIT impl ctor.
+    const bool wei_zp_per_n = bgmmc->has_zero_point_b && bgmmc->is_wei_zp_per_n;
+
+    if (zmm_path) {
+        auto jit = utils::make_unique<jit_per_mn_comp_kernel_t<Xbyak::Zmm>>(
+                bgmmc, wei_zp_per_n);
+        if (!jit) return status::out_of_memory;
+        CHECK(jit->create_kernel());
+        kernel = std::move(jit);
+    } else {
+        auto jit = utils::make_unique<jit_per_mn_comp_kernel_t<Xbyak::Ymm>>(
+                bgmmc, wei_zp_per_n);
+        if (!jit) return status::out_of_memory;
+        CHECK(jit->create_kernel());
+        kernel = std::move(jit);
+    }
+    return status::success;
+}
+
+} // namespace matmul
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.hpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.hpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_MATMUL_JIT_BRGEMM_MATMUL_PER_MN_COMP_HPP
+#define CPU_X64_MATMUL_JIT_BRGEMM_MATMUL_PER_MN_COMP_HPP
+
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "cpu/x64/matmul/brgemm_matmul_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace matmul {
+
+// JIT fill of the per-(M, N) f32 compensation tile consumed by the brgemm
+// post-ops epilogue. For one (m_blk, n_blk) tile over one brgemm K-block
+// of length k_len:
+//
+//   delta[m, n] = z_src * S[n] + z_wei * T[m] - k_len * z_src * z_wei
+//
+// with T[m] = sum_{k=0}^{k_len-1} src[m,k] and
+//      S[n] = sum_{k=0}^{k_len-1} wei[k,n].
+struct per_mn_comp_kernel_t {
+    struct ctx_t {
+        const void *src_batch_ptr = nullptr;
+        const void *wei_batch_ptr = nullptr;
+
+        // Batch-adjusted zero-point pointers (or null).
+        const void *src_zp_ptr = nullptr;
+        // Base index in elements into src_zp_ptr for this K-group / M-slice.
+        int src_zp_nibble_idx = 0;
+        const void *wei_zp_ptr = nullptr;
+
+        // f32 delta tile output (size M_blk * rnd_up(N_blk, LDC)).
+        float *delta_ptr = nullptr;
+
+        // Tile coordinates.
+        dim_t m_base = 0;
+        dim_t n_base = 0;
+        dim_t M_blk = 0;
+        dim_t N_blk = 0;
+
+        // Length of the K-block
+        dim_t k_len = 0;
+
+        // Internal sub-call state consumed directly by the JIT.
+        dim_t stripe_w = 0;
+        float src_zp_f32 = 0.0f;
+        float wei_zp_f32 = 0.0f;
+        float g_sz_f32 = 0.0f;
+    };
+
+    // Dispatch-time validation: returns `status::unimplemented` when
+    // the JIT cannot be built for `bgmmc` (unsupported ISA / dtype / stride
+    // / LDC combo). Call from `pd_t::init()` via `VDISPATCH_MATMUL`.
+    static status_t is_applicable(const brgemm_matmul_conf_t *bgmmc);
+
+    // Factory. Returns `status::unimplemented` when the JIT cannot be built
+    // for `bgmmc` (unsupported ISA / dtype / stride / LDC combo). Internally
+    // re-runs `is_applicable()` so failures stay graceful.
+    static status_t create(std::unique_ptr<per_mn_comp_kernel_t> &kernel,
+            const brgemm_matmul_conf_t *bgmmc);
+
+    virtual void operator()(const ctx_t *ctx) const = 0;
+    virtual ~per_mn_comp_kernel_t() = default;
+
+protected:
+    per_mn_comp_kernel_t(const brgemm_matmul_conf_t *conf, bool wei_zp_per_n)
+        : conf_(conf), wei_zp_per_n_(wei_zp_per_n) {}
+
+    const brgemm_matmul_conf_t *conf_;
+    const bool wei_zp_per_n_;
+};
+
+} // namespace matmul
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/tests/benchdnn/inputs/matmul/harness_matmul_decompression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_decompression
@@ -8,6 +8,20 @@
 --attr-fpmath=bf16:true
 --batch=shapes_2d
 
+# Int8 grouped-quantized attrs in 2D, N-tail regression tests (per-MN comp).
+# Per-K grouped wei zero-points activate the AVX2 per-MN compensation JIT
+# kernel. N=3,8,15 exercise the N-tail (sub-register) path that was fixed.
+--reset
+--skip-impl=ref
+--dt=u8:s8:f32
+--stag=ab
+--wtag=ab
+--dtag=ab
+--attr-zero-points=src:common:1+wei:per_ocic:s8:32x1
+32x64:64x3
+32x64:64x8
+32x64:64x15
+
 --reset
 --skip-impl=ref
 --wtag=any,ab,ba


### PR DESCRIPTION
### Implements feature request: [MFDNN-11991](https://jira.devtools.intel.com/browse/MFDNN-11991).
### What was done:
1. int4->int8 upconversion for the quantized weights. Implemented in `brgemm_matmul_copy_utils.cpp`
2. Weight zero points shift grouped, common, per_oc, per_ocic. Implemented in `brgemm_matmul_copy_utils.cpp`
3. Weight scales application: grouped, per_ocic. Implemented in `jit_brgemm_kernel.cpp`, `jit_brgemm_amx_uker.cpp`
4. Source zero points shift grouped, per_ocic. Implemented in  `brgemm_matmul_copy_utils.cpp`
5. Source scales application grouped, per_ocic. Implemented in `jit_brgemm_kernel.cpp`, `jit_brgemm_amx_uker.cpp`

### Details of implementation: 
Grouped scales for both src and wei are applied in brgemm kernel, AMX requires the group size being divisible by 64. Other cases are handled via non-AMX brgemm kernel.  

Grouped zero points for both src and wei are applied in copy routines and require buffer B (buffer A for src) usage. 
### Test coverage
is already in the main branch, was using reference implementation before or skipped:
Implementation statistics in comparison to main: 
 

#### Implementation dispatch (`harness_matmul_decompression`)

| Implementation                 |  main | branch | delta |
| ------------------------------ | ----: | -----: | ----: |
| `brg_matmul:avx10_1_512`       |  1659 |   1676 |   +17 |
| `brg_matmul:avx10_1_512_amx`   |   489 |    540 |   +51 |
| `brg_matmul:avx512_core`       |   184 |    184 |     0 |
| `brg_matmul:avx512_core_bf16`  |    48 |     48 |     0 |
| `ref:any`                      |    18 |     16 |    −2 |
| **TOTAL (dispatched)**         |  **2398** | **2464** | **+66** |

#### Test outcomes

|            | tests | passed | skipped | mistrusted | unimplemented | invalid_arguments | failed |
| ---------- | ----: | -----: | ------: | ---------: | ------------: | ----------------: | -----: |
| **main**   |  2842 |   2398 |     444 |          0 |             0 |                 0 |      0 |
| **branch** |  2842 |   2464 |     378 |          0 |             0 |                 0 |      0 |
| **delta**  |     0 |    +66 |     −66 |          0 |             0 |                 0 |      0 |

The cases with dynamic quantization in `harness_matmul_weight_decompression` are passing now. 

Supported ISAs: AVX512+, AVX2-VNNI, AMX.

### Performance testing on SPR:
[grouped_quantization_report.pdf](https://github.com/user-attachments/files/28267679/grouped_quantization_report.pdf)
