### PR TITLE
[GPU][GEMM] Loosen register allocation restrictions

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/alloc_utils.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/alloc_utils.cpp
@@ -26,7 +26,7 @@ using namespace ngen;
 using std::vector;
 
 
-GRFMultirange tryChunkAlloc(int nreg, int chunk, Bundle hint, BundleGroup mask, CommonState &state)
+GRFMultirange tryChunkAlloc(int nreg, int chunk, BundleGroup hint, BundleGroup mask, CommonState &state)
 {
     GRFMultirange r;
     bool ok = true;
@@ -43,7 +43,7 @@ GRFMultirange tryChunkAlloc(int nreg, int chunk, Bundle hint, BundleGroup mask, 
     return r;
 }
 
-GRFMultirange chunkAlloc(int nreg, int chunk, Bundle hint, BundleGroup mask, CommonState &state)
+GRFMultirange chunkAlloc(int nreg, int chunk, BundleGroup hint, BundleGroup mask, CommonState &state)
 {
     auto r = tryChunkAlloc(nreg, chunk, hint, mask, state);
     if (r.empty() && nreg > 0)
@@ -51,7 +51,7 @@ GRFMultirange chunkAlloc(int nreg, int chunk, Bundle hint, BundleGroup mask, Com
     return r;
 }
 
-GRFMultirange trySplitAlloc(HW hw, Type T, const RegisterLayout &layout, std::array<Bundle, 2> hints,
+GRFMultirange trySplitAlloc(HW hw, Type T, const RegisterLayout &layout, std::array<BundleGroup, 2> hints,
                             BundleGroup mask, CommonState &state, int copies)
 {
     auto oddHint = Bundle(0, 0).group_size(hw) * elementsPerGRF(hw, T);
@@ -99,7 +99,7 @@ GRFMultirange trySplitAlloc(HW hw, Type T, const RegisterLayout &layout, std::ar
     bool ok = true;
     for (size_t i = 0; i < requests.size(); i++) {
         for (int c = 0; c < copies; c++) {
-            auto newRange = state.ra.try_alloc_range(requests[i].length, hints[requests[i].hint], mask);
+            auto newRange = state.ra.tryAllocRange(requests[i].length, hints[requests[i].hint], mask);
             r.ranges[requests[i].index + c * requests.size()] = newRange;
             ok &= newRange.isValid();
         }
@@ -114,7 +114,7 @@ GRFMultirange trySplitAlloc(HW hw, Type T, const RegisterLayout &layout, std::ar
     return r;
 }
 
-GRFMultirange splitOrChunkAlloc(HW hw, Type T, const RegisterLayout &layout, int chunk, std::array<Bundle, 2> hints,
+GRFMultirange splitOrChunkAlloc(HW hw, Type T, const RegisterLayout &layout, int chunk, std::array<BundleGroup, 2> hints,
                                 BundleGroup mask, CommonState &state, bool forceChunk)
 {
     if (!forceChunk) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/alloc_utils.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/alloc_utils.hpp
@@ -82,26 +82,26 @@ static inline void reclaimRanges(const std::vector<GRFMultirange> &ranges, Commo
 
 
 // Allocate nreg registers in chunks of a fixed size `chunk`.
-GRFMultirange chunkAlloc(int nreg, int chunk, ngen::Bundle hint, ngen::BundleGroup mask, CommonState &state);
+GRFMultirange chunkAlloc(int nreg, int chunk, ngen::BundleGroup hint, ngen::BundleGroup mask, CommonState &state);
 
-static inline GRFMultirange chunkAlloc(int nreg, int chunk, ngen::Bundle hint, CommonState &state) {
+static inline GRFMultirange chunkAlloc(int nreg, int chunk, ngen::BundleGroup hint, CommonState &state) {
     return chunkAlloc(nreg, chunk, hint, ngen::BundleGroup::AllBundles(), state);
 }
 
 static inline GRFMultirange chunkAlloc(int nreg, int chunk, CommonState &state) {
-    return chunkAlloc(nreg, chunk, ngen::Bundle(), state);
+    return chunkAlloc(nreg, chunk, ngen::BundleGroup::AllBundles(), state);
 }
 
 // Like chunkAlloc, but returns an empty GRFMultirange on failure instead of throwing.
-GRFMultirange tryChunkAlloc(int nreg, int chunk, ngen::Bundle hint, ngen::BundleGroup mask, CommonState &state);
+GRFMultirange tryChunkAlloc(int nreg, int chunk, ngen::BundleGroup hint, ngen::BundleGroup mask, CommonState &state);
 
 // Attempt to allocate data registers for a layout, using one contiguous allocation per block.
 // Returns an empty GRFMultirange on failure.
-GRFMultirange trySplitAlloc(ngen::HW hw, Type T, const RegisterLayout &layout, std::array<ngen::Bundle, 2> hints,
+GRFMultirange trySplitAlloc(ngen::HW hw, Type T, const RegisterLayout &layout, std::array<ngen::BundleGroup, 2> hints,
                             ngen::BundleGroup mask, CommonState &state, int copies = 1);
 
 // Split allocate if possible, otherwise chunk allocate.
-GRFMultirange splitOrChunkAlloc(ngen::HW hw, Type T, const RegisterLayout &layout, int chunk, std::array<ngen::Bundle, 2> hints,
+GRFMultirange splitOrChunkAlloc(ngen::HW hw, Type T, const RegisterLayout &layout, int chunk, std::array<ngen::BundleGroup, 2> hints,
                                 ngen::BundleGroup mask, CommonState &state, bool forceChunk = false);
 
 GEMMSTONE_NAMESPACE_END

--- a/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
@@ -2562,7 +2562,7 @@ void Generator<hw>::gemmDotReduce(const GEMMProblem &problem, const GEMMStrategy
     GRFMultirange temps;
 
     if (needSwizzle)
-        temps = tryChunkAlloc(nx * ny, 1, Bundle(), BundleGroup::AllBundles(), state);
+        temps = tryChunkAlloc(nx * ny, 1, BundleGroup::AllBundles(), BundleGroup::AllBundles(), state);
 
     for (int cvl = vl; cvl > 1; ) {
         int simd = (cvl > ne) ? ne : (cvl >> 1);

--- a/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
@@ -348,7 +348,7 @@ void Generator<hw>::gemmDequantizeOperation(bool doA, Type T, Type Tq, BinaryOp 
 
     if (bfSpecialPath) {
         for (npairs = 8; npairs > 0; npairs >>= 1) {
-            qPairs = tryChunkAlloc(npairs, 1, Bundle(), BundleGroup::AllBundles(), state);
+            qPairs = tryChunkAlloc(npairs, 1, BundleGroup::AllBundles(), BundleGroup::AllBundles(), state);
             if (!qPairs.empty()) break;
         }
         if (qPairs.empty()) throw out_of_registers_exception();

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
@@ -330,11 +330,11 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
             // Test allocation. Put A earlier if it has more registers.
             int A_regTotal = A_regCount * A_copies + Ar_regCount;
             int B_regTotal = B_regCount * B_copies + Br_regCount;
-            auto hintA = getHint(HintType::A0, strategy);
-            auto hintB = getHint(HintType::B0, strategy);
-            auto hintC = getHint(HintType::C, strategy);
-            auto testA = state.ra.alloc_range(8, hintA);
-            auto testB = state.ra.alloc_range(8, hintB);
+            auto hintA = BundleGroup(raHW) | getHint(HintType::A0, strategy);
+            auto hintB = BundleGroup(raHW) | getHint(HintType::B0, strategy);
+            auto hintC = BundleGroup(raHW) | getHint(HintType::C, strategy);
+            auto testA = state.ra.allocRange(8, hintA);
+            auto testB = state.ra.allocRange(8, hintB);
             if ((testA.getBase() < testB.getBase()) == (A_regTotal < B_regTotal))
                 std::swap(hintA, hintB);
             state.ra.safeRelease(testA);
@@ -348,7 +348,7 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
                 state.B_regs[copy] = chunkAlloc(B_regCount, chunk, hintB, state);
             if (Br_regCount > 0)
                 state.Br_regs = chunkAlloc(Br_regCount, chunk, hintB, state);
-            C_regs = state.ra.alloc_range(C_regCount - state.C_accCount, hintC);
+            C_regs = state.ra.allocRange(C_regCount - state.C_accCount, hintC);
             break;
         }
         case GEMMStrategy::NSeparate: {
@@ -372,11 +372,11 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
                                       div_up(N_nregs, bregs));
             BundleGroup N_bundles(raHW), VC_bundles(raHW);
 
-            auto hintV0 = getHint(HintType::A0, strategy);
-            auto hintV1 = getHint(HintType::A1, strategy);
-            auto hintN = getHint(HintType::A0Broadcast, strategy);
-            auto hintC0 = getHint(HintType::C, strategy);
-            auto hintC1 = getHint(HintType::C1, strategy);
+            auto hintV0 = BundleGroup(raHW) | getHint(HintType::A0, strategy);
+            auto hintV1 = BundleGroup(raHW) | getHint(HintType::A1, strategy);
+            auto hintN = BundleGroup(raHW) | getHint(HintType::A0Broadcast, strategy);
+            auto hintC0 = BundleGroup(raHW) | getHint(HintType::C, strategy);
+            auto hintC1 = BundleGroup(raHW) | getHint(HintType::C1, strategy);
 
             // Give bundles starting at the end to broadcast matrix.
             for (int bundle = Bundle::bundle_count(raHW) - 1; bundle >= 0; bundle--) {
@@ -401,10 +401,18 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
             else for (int copy = 0; copy < N_copies; copy++)
                 N_regs[copy] = splitOrChunkAlloc(raHW, Tn_load, N_layout, N_chunk, {hintN, hintN}, N_bundles, state, forceVNChunk);
 
-            if (repackV) for (int copy = 0; copy < V_copies; copy++)
-                V_regs[copy] = splitOrChunkAlloc(raHW, Tv_load, V_layout, V_chunk, {Bundle(), Bundle()}, BundleGroup::AllBundles(), state);
-            if (repackN) for (int copy = 0; copy < N_copies; copy++)
-                N_regs[copy] = splitOrChunkAlloc(raHW, Tn_load, N_layout, N_chunk, {Bundle(), Bundle()}, BundleGroup::AllBundles(), state);
+            if (repackV)
+              for (int copy = 0; copy < V_copies; copy++)
+                V_regs[copy] = splitOrChunkAlloc(
+                    raHW, Tv_load, V_layout, V_chunk,
+                    {BundleGroup::AllBundles(), BundleGroup::AllBundles()},
+                    BundleGroup::AllBundles(), state);
+            if (repackN)
+              for (int copy = 0; copy < N_copies; copy++)
+                N_regs[copy] = splitOrChunkAlloc(
+                    raHW, Tn_load, N_layout, N_chunk,
+                    {BundleGroup::AllBundles(), BundleGroup::AllBundles()},
+                    BundleGroup::AllBundles(), state);
             break;
         }
         case GEMMStrategy::VAvoid: {
@@ -439,11 +447,11 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
             vector<GRFMultirange> C_extra(state.C_buffers - 1);
             auto allocSlice = [&]() {
                 if (sliceRegs <= 0) return;
-                auto C_bundles = ~V_bundles;
+                auto C_bundles = ~V_bundles & hintC;
 
-                C_regs.append(chunkAlloc(sliceRegs, C_chunk, hintC, C_bundles, state));
+                C_regs.append(chunkAlloc(sliceRegs, C_chunk, C_bundles, BundleGroup::AllBundles(), state));
                 for (int copy = 1; copy < state.C_buffers; copy++)
-                    C_extra[copy - 1].append(chunkAlloc(sliceRegs, C_chunk, hintC, C_bundles, state));
+                   C_extra[copy - 1].append(chunkAlloc(sliceRegs, C_chunk, C_bundles, BundleGroup::AllBundles(), state));
 
                 sliceRegs = 0;
             };
@@ -488,7 +496,7 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
         state.Cr_regs = C_regs;
         C_regCountPerBuffer = state.C_layout.regs();
         C_regCount = state.C_buffers * C_regCountPerBuffer;
-        C_regs = chunkAlloc(C_regCount, C_chunk, Bundle(), BundleGroup::AllBundles(), state);
+        C_regs = chunkAlloc(C_regCount, C_chunk, state);
     }
 
     // Assign C_regs, adding in GRFs (in place of accumulators) to use later.

--- a/third_party/ngen/ngen_register_allocator.hpp
+++ b/third_party/ngen/ngen_register_allocator.hpp
@@ -101,6 +101,13 @@ struct BundleGroup {
             regMasks[rchunk] |= rhs.regMask(hw, int(rchunk));
         return *this;
     }
+    
+    friend BundleGroup operator&(BundleGroup lhs, Bundle rhs) { lhs &= rhs; return lhs; }
+    BundleGroup &operator&=(Bundle rhs) {
+        for (size_t rchunk = 0; rchunk < regMasks.size(); rchunk++)
+            regMasks[rchunk] &= rhs.regMask(hw, int(rchunk));
+        return *this;
+    }
 
     BundleGroup operator~() {
         auto result = *this;
@@ -132,6 +139,8 @@ public:
     // Allocation functions: sub-GRFs, full GRFs, and GRF ranges.
     inline GRFRange allocRange(int nregs, Bundle baseBundle = Bundle(),
                                BundleGroup bundleMask = BundleGroup::AllBundles());
+    inline GRFRange allocRange(int nregs, BundleGroup baseBundle,
+                               BundleGroup bundleMask = BundleGroup::AllBundles());
     GRF alloc(Bundle bundle = Bundle()) { return allocRange(1, bundle)[0]; }
 
     inline Subregister allocSub(DataType type, Bundle bundle = Bundle());
@@ -145,6 +154,8 @@ public:
 
     // Attempted allocation. Return value is invalid if allocation failed.
     inline GRFRange tryAllocRange(int nregs, Bundle baseBundle = Bundle(),
+                                  BundleGroup bundleMask = BundleGroup::AllBundles());
+    inline GRFRange tryAllocRange(int nregs, BundleGroup baseBundle,
                                   BundleGroup bundleMask = BundleGroup::AllBundles());
     inline GRF tryAlloc(Bundle bundle = Bundle());
 
@@ -509,6 +520,11 @@ bool RegisterAllocator::isFree(Subregister subreg) const
 
 GRFRange RegisterAllocator::allocRange(int nregs, Bundle baseBundle, BundleGroup bundleMask)
 {
+    return allocRange(nregs, BundleGroup(hw) | baseBundle, bundleMask);
+}
+
+GRFRange RegisterAllocator::allocRange(int nregs, BundleGroup baseBundle, BundleGroup bundleMask)
+{
     auto result = tryAllocRange(nregs, baseBundle, bundleMask);
     if (result.isInvalid())
         throw out_of_registers_exception();
@@ -533,16 +549,30 @@ FlagRegister RegisterAllocator::allocFlag(bool sub)
 
 GRFRange RegisterAllocator::tryAllocRange(int nregs, Bundle baseBundle, BundleGroup bundleMask)
 {
+    return tryAllocRange(nregs, BundleGroup(hw) | baseBundle, bundleMask);
+}
+
+// Allocate a contiguous range of GRFs. baseBundle restricts the choice of first GRF, while bundleMask
+// restricts the choice of all GRFs in the range (i.e. no GRF allocated can be outside of bundleMask).
+GRFRange RegisterAllocator::tryAllocRange(int nregs, BundleGroup baseBundle, BundleGroup bundleMask)
+{
     if (nregs == 0) return GRFRange(0, 0);
 
     uint64_t freeGRF64[sizeof(freeGRF) / sizeof(uint64_t)];
     std::memcpy(freeGRF64, freeGRF, sizeof(freeGRF));
-    bool ok = false;
 
-    for (int rchunk = 0; rchunk < (GRF::maxRegs() >> 6); rchunk++) {
-        uint64_t baseMask = baseBundle.regMask(hw, rchunk);
+    auto checkFree = [](uint64_t freeMask, int firstBit, int lastBit) -> bool {
+        // (1 << (lastBit-1)) << 1 avoids undefined behavior when lastBit == 64
+        uint64_t regMask = ((uint64_t(1) << (lastBit - 1)) << 1) - (uint64_t(1) << firstBit);
+        return !(regMask & ~freeMask);
+    };
 
-        uint64_t free = freeGRF64[rchunk] & bundleMask.regMask(rchunk);
+    int chunkCount = GRF::maxRegs() >> 6;
+    for (int rchunk = 0; rchunk < chunkCount; rchunk++) {
+        uint64_t baseMask = baseBundle.regMask(rchunk);
+        uint64_t regMask = bundleMask.regMask(rchunk);
+
+        uint64_t free = freeGRF64[rchunk] & regMask;
         uint64_t freeBase = free & baseMask;
 
         while (freeBase) {
@@ -551,22 +581,15 @@ GRFRange RegisterAllocator::tryAllocRange(int nregs, Bundle baseBundle, BundleGr
             int rbase = firstBit + (rchunk << 6);
 
             // Check if required # of registers are available.
-            int lastBit = firstBit + nregs;
-            if (lastBit <= 64) {
-                // Range to check doesn't cross 64-GRF boundary. Fast check using bitmasks.
-                uint64_t mask = ((uint64_t(1) << (lastBit - 1)) << 1) - (uint64_t(1) << firstBit);
-                ok = !(mask & ~free);
-            } else {
-                // Range to check crosses 64-GRF boundary. Check first part using bitmasks,
-                // Check the rest using a loop (ho hum).
-                uint64_t mask = ~uint64_t(0) << firstBit;
-                ok = !(mask & ~free) && (rbase + nregs <= (int)(sizeof(freeSub) / sizeof(freeSub[0])));
-                if (ok) for (int rr = 64 - firstBit; rr < nregs; rr++) {
-                    if (freeSub[rbase + rr] != fullSubMask) {
-                        ok = false;
-                        break;
-                    }
-                }
+            bool ok = true;
+            int regsLeft = nregs;
+            int startBit = firstBit;
+            for (int rc = rchunk; ok && regsLeft > 0; rc++) {
+                if (rc >= chunkCount) { ok = false; break; }
+                int endBit = std::min(startBit + regsLeft, 64);
+                ok = checkFree(freeGRF64[rc] & bundleMask.regMask(rc), startBit, endBit);
+                regsLeft -= (endBit - startBit);
+                startBit = 0;
             }
 
             if (ok) {


### PR DESCRIPTION
Updates ngen to include changes to `tryAllocRange` that add separate restrictions for the first register and all other registers in the allocated region (and fixes a bug where these restrictions were not always being followed). Also updates gemmstone code to move restrictions in `vav` to apply only to the first register, not the following ones.