### PR TITLE
cpu: aarch64: shuffle: make SVE instantiation vector-length agnostic

### DIFF
--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,8 +17,8 @@
 *******************************************************************************/
 
 #include <cassert>
+#include <cstdint>
 
-#include "common/bfloat16.hpp"
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/math_utils.hpp"
@@ -25,6 +26,7 @@
 
 #include "cpu/aarch64/jit_generator.hpp"
 #include "cpu/aarch64/shuffle/jit_uni_shuffle.hpp"
+#include "cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -67,7 +69,7 @@ status_t jit_uni_shuffle_t<isa>::pd_t::init(engine_t *engine) {
     /* Because "ST1H { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, UXTW #1]" is used
        to gather data for bf16, simd_w must be calculated
        with sizeof(uint32_t). */
-    conf_.simd_w = cpu_isa_traits<isa>::vlen / sizeof(uint32_t);
+    conf_.simd_w = simd_bytes(isa) / sizeof(uint32_t);
 
     const bool has_spatial = utils::one_of(ndims(), 3, 4, 5);
     const dim_t HW = H() * W();
@@ -214,9 +216,7 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
     return status::success;
 }
 
-template struct jit_uni_shuffle_t<sve_512>;
-template struct jit_uni_shuffle_t<sve_256>;
-template struct jit_uni_shuffle_t<sve_128>;
+template struct jit_uni_shuffle_t<sve>;
 template struct jit_uni_shuffle_t<asimd>;
 
 } // namespace aarch64

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #include "cpu/cpu_shuffle_pd.hpp"
 
 #include "cpu/aarch64/cpu_isa_traits.hpp"
-#include "cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@
 
 #include <cassert>
 
-#include "common/bfloat16.hpp"
 #include "common/c_types_map.hpp"
 
 #include "cpu/aarch64/jit_generator.hpp"
 #include "cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp"
+
+#include "xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h"
 
 namespace dnnl {
 namespace impl {
@@ -53,16 +54,16 @@ void jit_uni_shuffle_kernel_t<isa>::prepare_mask() {
         /* Because "ST1H { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, UXTW #1]" is used
 	 to gather data for bf16, simd_tail must be evaluated
 	 with sizeof(unsigned). */
-        assert(conf_.simd_tail < isa_sveLen / sizeof(uint32_t));
+        assert(conf_.simd_tail < sve_length_ / sizeof(uint32_t));
         index(vmm_tmp_.s, 0, 1);
         cmplt(k_tail_mask_.s, P_ALL_ONE / T_z, vmm_tmp_.s, conf_.simd_tail);
     }
 
-    if (isa_sveLen == util::SVE_512)
+    if (sve_length_ == util::SVE_512)
         ptrue(k_full_mask_.s, VL16);
-    else if (isa_sveLen == util::SVE_256)
+    else if (sve_length_ == util::SVE_256)
         ptrue(k_full_mask_.s, VL8);
-    else if (isa_sveLen == util::SVE_128)
+    else if (sve_length_ == util::SVE_128)
         ptrue(k_full_mask_.s, VL4);
 }
 
@@ -125,8 +126,8 @@ void jit_uni_shuffle_kernel_t<isa>::store_data(const int data_idx,
             st1h(TRegS(data_idx), mask, ptr(X_DEFAULT_ADDR));
     }
 
-    append_zero_padding(
-            reg_dst_, isa_sveLen > 128 ? extend_for_padding : false);
+    append_zero_padding(reg_dst_,
+            sve_length_ >= util::SVE_256 ? extend_for_padding : false);
 }
 
 template <>
@@ -162,7 +163,7 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
         const int simd_to_process
                 = is_blk_tail ? simd_in_tail_blk : simd_in_blk;
         for (int i = 0; i < simd_to_process; ++i) {
-            if (is_superset(isa, sve_128))
+            if (is_superset(isa, sve))
                 ld1w(ZRegS(vmm_tmp[i].getIdx()), P_ALL_ONE,
                         ptr(addr_off(reg_indices_,
                                 i * conf_.simd_w * conf_.el_size_of_indices,
@@ -310,7 +311,7 @@ void jit_uni_shuffle_kernel_t<isa>::append_zero_padding(
         for (; off + simd_w_byte < padding_to_add; off += simd_w_byte) {
             add_imm(X_DEFAULT_ADDR, reg_dst_addr, off_start + off, X_TMP_0);
 
-            if (is_superset(isa, sve_128))
+            if (is_superset(isa, sve))
                 st1w(ZRegS(vmm_zero_.getIdx()), P_ALL_ONE, ptr(X_DEFAULT_ADDR));
             else
                 uni_str(vmm_zero_, X_DEFAULT_ADDR);
@@ -337,9 +338,9 @@ void jit_uni_shuffle_kernel_t<isa>::generate() {
     preamble();
 
     /* Overwrite P_ALL_ONE, if required sve size < 512. */
-    if (isa_sveLen == util::SVE_128)
+    if (sve_length_ == util::SVE_128)
         ptrue(P_ALL_ONE.b, VL16);
-    else if (isa_sveLen == util::SVE_256)
+    else if (sve_length_ == util::SVE_256)
         ptrue(P_ALL_ONE.b, VL32);
 
     uni_clear(vmm_zero_);
@@ -360,9 +361,7 @@ void jit_uni_shuffle_kernel_t<isa>::generate() {
     postamble();
 }
 
-template struct jit_uni_shuffle_kernel_t<sve_512>;
-template struct jit_uni_shuffle_kernel_t<sve_256>;
-template struct jit_uni_shuffle_kernel_t<sve_128>;
+template struct jit_uni_shuffle_kernel_t<sve>;
 template struct jit_uni_shuffle_kernel_t<asimd>;
 
 #undef GET_OFF

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,11 +19,7 @@
 #ifndef CPU_AARCH64_SHUFFLE_JIT_UNI_SHUFFLE_KERNEL_HPP
 #define CPU_AARCH64_SHUFFLE_JIT_UNI_SHUFFLE_KERNEL_HPP
 
-#include "common/c_types_map.hpp"
-#include "common/type_helpers.hpp"
 #include "common/utils.hpp"
-
-#include "cpu/cpu_shuffle_pd.hpp"
 
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
@@ -57,7 +53,7 @@ struct jit_uni_shuffle_kernel_t : public jit_generator_t {
     void prepare_mask();
 
     /*
-     * Emulates the behavior of vgatherdps for architectures
+     * Emulates the behavior of gather-load for architectures
      * that do not support this instruction.
      */
     void emu_gather_data(const XReg &reg_src_addr, const int indices_idx,
@@ -98,12 +94,11 @@ struct jit_uni_shuffle_kernel_t : public jit_generator_t {
     const XReg &reg_tmp4_ = x11;
     const XReg &reg_tmp5_ = x12;
     const XReg &reg_tmp6_ = x13;
-    const XReg &reg_padded_block = x14; //WReg(x14.getIdx());
+    const XReg &reg_padded_block = x14;
 
     const jit_shuffle_conf_t conf_;
     const size_t padding_size_;
-    const uint64_t isa_sveLen
-            = is_superset(isa, sve_128) ? cpu_isa_traits<isa>::vlen : 0;
+    const uint64_t sve_length_ = is_superset(isa, sve) ? simd_bytes(isa) : 0;
 };
 
 } // namespace aarch64

--- a/src/cpu/cpu_shuffle_list.cpp
+++ b/src/cpu/cpu_shuffle_list.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,9 +41,7 @@ constexpr impl_list_item_t impl_list[] = REG_SHUFFLE_P({
         CPU_INSTANCE_X64(jit_uni_shuffle_t<avx512_core>)
         CPU_INSTANCE_X64(jit_uni_shuffle_t<avx>)
         CPU_INSTANCE_X64(jit_uni_shuffle_t<sse41>)
-        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve_512>)
-        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve_256>)
-        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve_128>)
+        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve>)
         CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<asimd>)
         CPU_INSTANCE(ref_shuffle_t)
         /* eol */


### PR DESCRIPTION
# Description
Makes jit shuffle vector-length agnostic for SVE.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?