### PR TITLE
[backport v3.10] cpu: x64: matmul: fix VDISPATCH_REORDER_IC use with memory_desc_reshape

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -80,10 +80,12 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
 
     memory_desc_t src_md_reduced, dst_md_reduced;
     VDISPATCH_REORDER_IC(memory_desc_reshape(src_md_reduced, src_md,
-                                 non_unit_dim, non_unit_dims),
+                                 non_unit_dim, non_unit_dims)
+                    == status::success,
             VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "src");
     VDISPATCH_REORDER_IC(memory_desc_reshape(dst_md_reduced, dst_md,
-                                 non_unit_dim, non_unit_dims),
+                                 non_unit_dim, non_unit_dims)
+                    == status::success,
             VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "dst");
 
     const memory_desc_wrapper id(src_md_reduced), od(dst_md_reduced);


### PR DESCRIPTION
Backport #5020 