### PR TITLE
cpu: aarch64: make softmax SVE instantiation vector length agnostic

### DIFF
--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -16,23 +16,21 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <assert.h>
+#include <cassert>
 #include <memory>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
-#include "common/math_utils.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/nstl.hpp"
-#include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
+#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_uni_softmax.hpp"
 #include "cpu/cpu_primitive.hpp"
 
-#include "cpu/aarch64/jit_generator.hpp"
-
-#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
-#include "cpu/aarch64/jit_uni_softmax.hpp"
+#include "xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h"
 
 namespace dnnl {
 namespace impl {
@@ -167,7 +165,7 @@ size_t jit_softmax_base_t::compute_axis_stride(
 
 void jit_softmax_base_t::load_common_params() {
     mov(W_TMP_0, float2int(-FLT_MAX));
-    if (vlen_ > cpu_isa_traits<sve_128>::vlen) {
+    if (vlen_ > util::SVE_128) {
         fmov(ZReg(vone_idx).s, 1.0);
         dup(ZReg(vneg_flt_max_idx).s, W_TMP_0);
     } else {
@@ -930,21 +928,9 @@ template <cpu_isa_t isa>
 struct jit_softmax_t;
 
 template <>
-struct jit_softmax_t<sve_512> : public jit_softmax_sve_t {
+struct jit_softmax_t<sve> : public jit_softmax_sve_t {
     jit_softmax_t(const softmax_pd_t *pd)
-        : jit_softmax_sve_t(pd, cpu_isa_traits<sve_512>::vlen) {}
-};
-
-template <>
-struct jit_softmax_t<sve_256> : public jit_softmax_sve_t {
-    jit_softmax_t(const softmax_pd_t *pd)
-        : jit_softmax_sve_t(pd, cpu_isa_traits<sve_256>::vlen) {}
-};
-
-template <>
-struct jit_softmax_t<sve_128> : public jit_softmax_sve_t {
-    jit_softmax_t(const softmax_pd_t *pd)
-        : jit_softmax_sve_t(pd, cpu_isa_traits<sve_128>::vlen) {}
+        : jit_softmax_sve_t(pd, simd_bytes(sve)) {}
 };
 
 template <>
@@ -1093,13 +1079,10 @@ private:
 } // namespace softmax_impl
 
 /* struct instantiation */
-template struct jit_uni_softmax_fwd_t<sve_512>;
-template struct jit_uni_softmax_bwd_t<sve_512>;
-template struct jit_uni_softmax_fwd_t<sve_256>;
-template struct jit_uni_softmax_bwd_t<sve_256>;
-template struct jit_uni_softmax_fwd_t<sve_128>;
-template struct jit_uni_softmax_bwd_t<sve_128>;
+template struct jit_uni_softmax_fwd_t<sve>;
 template struct jit_uni_softmax_fwd_t<asimd>;
+
+template struct jit_uni_softmax_bwd_t<sve>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -19,13 +19,11 @@
 #ifndef CPU_AARCH64_JIT_UNI_SOFTMAX_HPP
 #define CPU_AARCH64_JIT_UNI_SOFTMAX_HPP
 
-#include <assert.h>
 #include <memory>
 
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
-#include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
 #include "cpu/aarch64/cpu_isa_traits.hpp"
@@ -61,7 +59,7 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
 
                 // It is fine to use float here as the kernel uses halfs of
                 // vector registers.
-                const auto blk_size = cpu_isa_traits<isa>::vlen / sizeof(float);
+                const int blk_size = simd_elems(data_type_t::dnnl_f32, isa);
                 // 31 is a general limit, 4 is for unroll_regs_ = 16;
                 const size_t max_stride = (1LL << (31 - 4)) - 1;
                 const int last_blk = bd.inner_nblks - 1;
@@ -146,7 +144,7 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
 
                 // It is fine to use float here as the kernel uses halfs of
                 // vector registers.
-                const auto blk_size = cpu_isa_traits<isa>::vlen / sizeof(float);
+                const int blk_size = simd_elems(data_type_t::dnnl_f32, isa);
                 if (dst_d.is_plain())
                     return bd.strides[axis()] == 1;
                 else {
@@ -169,8 +167,6 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
                                            diff_dst_md()->data_type,
                                            diff_src_md()->data_type),
                             mayiuse_bf16())
-                    && (mayiuse(sve_512) || mayiuse(sve_256)
-                            || mayiuse(sve_128))
                     && attr()->has_default_values()
                     && set_default_formats() == status::success;
 

--- a/src/cpu/cpu_softmax_list.cpp
+++ b/src/cpu/cpu_softmax_list.cpp
@@ -49,9 +49,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
     static std::map<pk_impl_key_t, std::vector<impl_list_item_t>> the_map =  REG_SOFTMAX_P({
         {{forward}, {
             CPU_INSTANCE_X64(jit_uni_softmax_fwd_t)
-            CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve_512>)
-            CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve_128>)
+            CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve>)
             CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<asimd>)
             CPU_INSTANCE_AARCH64_ACL(acl_softmax_fwd_t)
             CPU_INSTANCE_RV64GCV(rvv_softmax_fwd_t)
@@ -60,9 +58,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
         }},
         {{backward}, REG_BWD_PK({
             CPU_INSTANCE_X64(jit_uni_softmax_bwd_t)
-            CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve_512>)
-            CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve_128>)
+            CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve>)
             CPU_INSTANCE(ref_softmax_bwd_t)
             nullptr,
         })},


### PR DESCRIPTION
# Description

Makes jit softmax vector-length agnostic for SVE.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?