### PR TITLE
[rls-v3.12] xe: sdpa: Allow transposed qry for single token queries

### DIFF
--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -488,9 +488,12 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 
     /* Leading dimension for matrices */
     uint ldk = TRANSPOSE_K ? KEY_S3 : KEY_S2;
-    uint ldq = QRY_S2;
     uint ldv = VAL_S2;
-    uint lda = DST_S2;
+    // For single-token cases we allow the query and dst to be transposed.
+    // This workaround is needed because the gemm_desc::get_trans treats both
+    // cases equally. For Q>1 checks prevent transposed query and dst
+    uint ldq = (QRY_S2 == 1) ? QRY_S1 : QRY_S2;
+    uint lda = (DST_S2 == 1) ? DST_S1 : DST_S2;
 
 #if KEY_SCALES || KEY_ZERO_POINTS
     uint ldkq = KEY_D3;

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -83,6 +83,10 @@
                     1:1x16x1x512+2:1x16x2049x512+3:1x16x2049x512+5:1x1x1x2049
 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
 
+# Q=1 with transposed qry
+ --reset --in-shapes=1:1x16x1x512*abdc+2:1x16x2049x512+3:1x16x2049x512+5:1x1x1x2049
+--case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+
 # q_seq_len != kv_seq_len
 --reset --in-shapes=1:1x16x128x64+24:1x16x128x64 --case=complex_fusion/mha/sdpa-plain-bottom-right-implicit-causal-mask-f16-f32.json
 


### PR DESCRIPTION
## Summary

Backport of #5027 onto rls-v3.12.

Fixes: [MFDNN-14834](https://jira.devtools.intel.com/browse/MFDNN-14834)

This PR adds the ability to process single token queries with a transposed (abdc) layout. This addresses an issue in pytorch tests that passed in single token queries with inconsistent query layout.

## Original Change

- **Original PR:** #5027

---
(cherry picked from commit b2c04d59a434a25fad0cfff34371af9c4879f039)