### PR TITLE
xe: sdpa: Replace VCHECK_SDPA_COND with VDISPATCH_SDPA

### DIFF
--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -175,13 +175,12 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     bool use_fma_config = !use_systolic_ukernel_;
     bool is_f16_accumulate_gemm = (kq_acc_dt() == data_type::f16)
             || (vs_acc_dt() == data_type::f16);
-    VCHECK_SDPA_COND(
-            IMPLICATION(is_f16_accumulate_gemm, !use_systolic_ukernel_),
+    VDISPATCH_SDPA(IMPLICATION(is_f16_accumulate_gemm, !use_systolic_ukernel_),
             "f16 accumulate only available with FMA matmul."); //TODO: update once matmul primitive supports systolic f16 accumulate for testing
     config = choose_config(arch_, d->head_size(), d->keys(), thin_q, quantized,
             is_integrated, use_fma_config, is_f32, is_f16_accumulate_gemm);
 
-    VCHECK_SDPA_COND(config != nullptr,
+    VDISPATCH_SDPA(config != nullptr,
             "No suitable kernel configuration found for the given problem "
             "size and attributes.");
 
@@ -201,7 +200,7 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             config->unroll_n_vs * config->wg_n_vs, config->unroll_m_vs,
             config->unroll_n_vs, config->wg_m_vs, config->wg_n_vs);
 
-    VCHECK_SDPA_COND(config->unroll_n_kq * config->wg_n_kq
+    VDISPATCH_SDPA(config->unroll_n_kq * config->wg_n_kq
                             == config->unroll_n_vs * config->wg_n_vs
                     && config->unroll_n_kq % config->unroll_n_vs == 0,
             "[CONFIG] The config KQ work_group tile N(%d) axis must equal "
@@ -211,7 +210,7 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             config->unroll_n_vs * config->wg_n_vs, config->unroll_n_kq,
             config->unroll_n_vs);
 
-    VCHECK_SDPA_COND(config->unroll_m_vs * config->wg_m_vs >= d->head_size(),
+    VDISPATCH_SDPA(config->unroll_m_vs * config->wg_m_vs >= d->head_size(),
             "The vs matmul config work_group tile M(%d*%d=%d) axis must be "
             "greater than or equal to head size(%ld)",
             config->unroll_m_vs, config->wg_m_vs,
@@ -424,7 +423,7 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     arch_ = dev_info->gpu_arch();
     auto *d = desc();
 
-    VCHECK_SDPA_COND(compute::mayiuse_microkernels(intel_engine),
+    VDISPATCH_SDPA(compute::mayiuse_microkernels(intel_engine),
             "Microkernels not supported by the OpenCL driver.");
 
     /* Retrieve pre-tuned kernel configuration */
@@ -447,7 +446,7 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     config = choose_bwd_config(arch_, d->head_size(), d->queries(), d->keys(),
             thin_q, quantized, is_integrated, use_fma_config, is_f32);
 
-    VCHECK_SDPA_COND(config != nullptr,
+    VDISPATCH_SDPA(config != nullptr,
             "No suitable kernel configuration found for the given problem "
             "size and attributes.");
 
@@ -472,11 +471,10 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             config->unroll_n_DBr, config->wg_m_DBr, config->wg_n_DBr);
 
     // Bc(Br) == (D)Bc
-    VCHECK_SDPA_COND(
-            ((config->unroll_m_BcBr * config->wg_m_BcBr
-                     == config->unroll_n_DBc * config->wg_n_DBc)
-                    && ((config->wg_m_DBc * config->wg_n_DBc)
-                            <= (config->wg_m_BcBr * config->wg_n_BcBr))),
+    VDISPATCH_SDPA(((config->unroll_m_BcBr * config->wg_m_BcBr
+                            == config->unroll_n_DBc * config->wg_n_DBc)
+                           && ((config->wg_m_DBc * config->wg_n_DBc)
+                                   <= (config->wg_m_BcBr * config->wg_n_BcBr))),
             "[CONFIG] The config BcBr work_group tile M(%d) axis must equal "
             "DBc work_group tile N(%d) axis and number of total subgroups "
             "should be less than BcBr subgroups (%d ?<= %d)",
@@ -486,7 +484,7 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             config->wg_m_BcBr * config->wg_n_BcBr);
 
     // D(Bc) >= head size
-    VCHECK_SDPA_COND(config->unroll_m_DBc * config->wg_m_DBc >= d->head_size(),
+    VDISPATCH_SDPA(config->unroll_m_DBc * config->wg_m_DBc >= d->head_size(),
             "The DBc matmul config work_group tile N(%d*%d=%d) axis must be "
             "greater than or equal to head size(%ld)",
             config->unroll_m_DBc, config->wg_m_DBc,
@@ -494,10 +492,10 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             static_cast<long int>(d->head_size()));
 
     // (Bc)Br == (D)Br, ngroups <= BcBr ngroups
-    VCHECK_SDPA_COND(((config->unroll_n_BcBr * config->wg_n_BcBr
-                              == config->unroll_n_DBr * config->wg_n_DBr)
-                             && (config->wg_m_DBr * config->wg_n_DBr
-                                     <= config->wg_m_BcBr * config->wg_n_BcBr)),
+    VDISPATCH_SDPA(((config->unroll_n_BcBr * config->wg_n_BcBr
+                            == config->unroll_n_DBr * config->wg_n_DBr)
+                           && (config->wg_m_DBr * config->wg_n_DBr
+                                   <= config->wg_m_BcBr * config->wg_n_BcBr)),
             "[CONFIG] The config BcBr work_group tile N(%d) axis must equal "
             "DBr work_group tile N(%d) axis and number of total subgroups "
             "should be less than BcBr subgroups (%d ?<= %d)",
@@ -507,7 +505,7 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             config->wg_m_BcBr * config->wg_n_BcBr);
 
     // D(Br) >= head size
-    VCHECK_SDPA_COND(config->unroll_m_DBr * config->wg_m_DBr >= d->head_size(),
+    VDISPATCH_SDPA(config->unroll_m_DBr * config->wg_m_DBr >= d->head_size(),
             "The DBr matmul config work_group tile M(%d*%d=%d) axis must be "
             "greater than or equal to head size(%ld)",
             config->unroll_m_DBr, config->wg_m_DBr,
@@ -574,9 +572,8 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     } else if (desc()->qry_md()->data_type == data_type::f32) {
         problem.Ta = problem.Tb = Type::f32;
     } else {
-        VCHECK_SDPA_COND(
-                utils::one_of(desc()->qry_md()->data_type, data_type::f16,
-                        data_type::bf16, data_type::f32),
+        VDISPATCH_SDPA(utils::one_of(desc()->qry_md()->data_type,
+                               data_type::f16, data_type::bf16, data_type::f32),
                 "Q tensor's data type must be bf16, f16, or f32");
     }
     problem.Tc = problem.Tc_ext = Type::f32;

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -175,7 +175,7 @@ struct micro_fwd_t : public primitive_t {
                     utils::everyone_is(4, qry_mdw.ndims(), key_mdw.ndims(),
                             val_mdw.ndims(), dst_mdw.ndims()),
                     VERBOSE_SHAPE_RESTRICTION
-                    ": qry(%d) key(%d) val(%d) and dst(%d) must equal 4.",
+                    ": qry(%d) key(%d) val(%d) and dst(%d) must be 4d",
                     qry_mdw.ndims(), key_mdw.ndims(), val_mdw.ndims(),
                     dst_mdw.ndims());
 
@@ -187,7 +187,8 @@ struct micro_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_DROPOUT);
             if (with_attn_mask()) {
                 VDISPATCH_SDPA(desc()->attn_mask_md()->ndims == 4,
-                        VERBOSE_UNSUPPORTED_TAG);
+                        VERBOSE_SHAPE_RESTRICTION ": attn_mask(%d) must be 4d",
+                        desc()->attn_mask_md()->ndims);
                 VDISPATCH_SDPA(
                         utils::one_of(
                                 desc()->attn_mask_md()->dims[mask_q_index],
@@ -404,15 +405,23 @@ struct micro_bwd_t : public primitive_t {
             VDISPATCH_SDPA(utils::everyone_is(4, desc()->qry_md()->ndims,
                                    desc()->key_md()->ndims,
                                    desc()->val_md()->ndims, dst_md()->ndims),
-                    VERBOSE_UNSUPPORTED_TAG);
+                    VERBOSE_SHAPE_RESTRICTION
+                    ": qry(%d) key(%d) val(%d) dst(%d) must be 4d",
+                    desc()->qry_md()->ndims, desc()->key_md()->ndims,
+                    desc()->val_md()->ndims, dst_md()->ndims);
             VDISPATCH_SDPA(
                     utils::everyone_is(4, desc()->diff_qry_md()->ndims,
                             desc()->diff_key_md()->ndims,
                             desc()->diff_val_md()->ndims, diff_dst_md()->ndims),
-                    VERBOSE_UNSUPPORTED_TAG);
+                    VERBOSE_SHAPE_RESTRICTION
+                    ": diff_qry(%d) diff_key(%d) diff_val(%d) diff_dst(%d) "
+                    "must be 4d",
+                    desc()->diff_qry_md()->ndims, desc()->diff_key_md()->ndims,
+                    desc()->diff_val_md()->ndims, diff_dst_md()->ndims);
             if (with_attn_mask()) {
                 VDISPATCH_SDPA(desc()->attn_mask_md()->ndims == 4,
-                        VERBOSE_UNSUPPORTED_TAG);
+                        VERBOSE_SHAPE_RESTRICTION ": attn_mask(%d) must be 4d",
+                        desc()->attn_mask_md()->ndims);
                 VDISPATCH_SDPA(
                         utils::one_of(
                                 desc()->attn_mask_md()->dims[mask_q_index],

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -35,6 +35,11 @@ namespace gpu {
 namespace intel {
 namespace sdpa {
 
+#define VDISPATCH_SDPA(cond, msg, ...) \
+    VCONDCHECK(primitive, create, dispatch, sdpa, (cond), \
+            status::unimplemented, "%s," msg, this->info(engine), \
+            ##__VA_ARGS__)
+
 struct micro_fwd_params_t : trivially_serializable_t<micro_fwd_params_t> {
 
     const std::vector<const char *> &get_kernel_names() const {
@@ -161,43 +166,46 @@ struct micro_fwd_t : public primitive_t {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 
-            VCHECK_SDPA_COND(is_fwd(), VERBOSE_BAD_PROPKIND);
-            VCHECK_SDPA_COND(utils::everyone_is(4, desc()->qry_md()->ndims,
-                                     desc()->key_md()->ndims,
-                                     desc()->val_md()->ndims, dst_md()->ndims),
-                    VERBOSE_UNSUPPORTED_TAG);
-
+            VDISPATCH_SDPA(is_fwd(), VERBOSE_BAD_PROPKIND);
             memory_desc_wrapper qry_mdw(desc()->qry_md());
             memory_desc_wrapper key_mdw(desc()->key_md());
             memory_desc_wrapper val_mdw(desc()->val_md());
             memory_desc_wrapper dst_mdw(dst_md());
-            VCHECK_SDPA_COND(utils::everyone_is(true, qry_mdw.is_plain(),
-                                     key_mdw.is_plain(), val_mdw.is_plain(),
-                                     dst_mdw.is_plain()),
+            VDISPATCH_SDPA(
+                    utils::everyone_is(4, qry_mdw.ndims(), key_mdw.ndims(),
+                            val_mdw.ndims(), dst_mdw.ndims()),
+                    VERBOSE_SHAPE_RESTRICTION
+                    ": qry(%d) key(%d) val(%d) and dst(%d) must equal 4.",
+                    qry_mdw.ndims(), key_mdw.ndims(), val_mdw.ndims(),
+                    dst_mdw.ndims());
+
+            VDISPATCH_SDPA(utils::everyone_is(true, qry_mdw.is_plain(),
+                                   key_mdw.is_plain(), val_mdw.is_plain(),
+                                   dst_mdw.is_plain()),
                     VERBOSE_UNSUPPORTED_TAG);
-            VCHECK_SDPA_COND(attr()->has_default_values(smask_t::dropout),
-                    VERBOSE_UNSUPPORTED_ATTR);
+            VDISPATCH_SDPA(attr()->has_default_values(smask_t::dropout),
+                    VERBOSE_UNSUPPORTED_DROPOUT);
             if (with_attn_mask()) {
-                VCHECK_SDPA_COND(desc()->attn_mask_md()->ndims == 4,
+                VDISPATCH_SDPA(desc()->attn_mask_md()->ndims == 4,
                         VERBOSE_UNSUPPORTED_TAG);
-                VCHECK_SDPA_COND(
+                VDISPATCH_SDPA(
                         utils::one_of(
                                 desc()->attn_mask_md()->dims[mask_q_index],
                                 desc()->queries(), 1),
                         VERBOSE_INVALID_BROADCAST, "attn_mask", mask_q_index);
-                VCHECK_SDPA_COND(desc()->attn_mask_md()->dims[mask_k_index]
+                VDISPATCH_SDPA(desc()->attn_mask_md()->dims[mask_k_index]
                                 == desc()->keys(),
                         VERBOSE_INVALID_BROADCAST, "attn_mask", mask_k_index);
                 if (desc()->qry_md()->data_type == data_type::f32) {
-                    VCHECK_SDPA_COND(desc()->attn_mask_md()->data_type
+                    VDISPATCH_SDPA(desc()->attn_mask_md()->data_type
                                     == desc()->qry_md()->data_type,
                             "Mask data type(%s) should match Qry/Dst data "
                             "type(%s).",
                             dnnl_dt2str(desc()->attn_mask_md()->data_type),
                             dnnl_dt2str(desc()->qry_md()->data_type));
                 } else {
-                    VCHECK_SDPA_COND((desc()->attn_mask_md()->data_type
-                                             == desc()->qry_md()->data_type)
+                    VDISPATCH_SDPA((desc()->attn_mask_md()->data_type
+                                           == desc()->qry_md()->data_type)
                                     || (desc()->attn_mask_md()->data_type
                                             == data_type::f32),
                             "Mask data type(%s) should be xf16 or f32 when "
@@ -206,7 +214,7 @@ struct micro_fwd_t : public primitive_t {
                             dnnl_dt2str(desc()->qry_md()->data_type));
                 }
             }
-            VCHECK_SDPA_COND(
+            VDISPATCH_SDPA(
                     (utils::everyone_is(data_type::f16,
                              desc()->qry_md()->data_type, dst_md()->data_type)
                             || utils::everyone_is(data_type::bf16,
@@ -216,30 +224,30 @@ struct micro_fwd_t : public primitive_t {
                                     desc()->qry_md()->data_type,
                                     dst_md()->data_type)),
                     VERBOSE_UNSUPPORTED_DT);
-            VCHECK_SDPA_COND(utils::one_of(desc()->key_md()->data_type, f32,
-                                     bf16, f16, u8, s8, u4, s4),
+            VDISPATCH_SDPA(utils::one_of(desc()->key_md()->data_type, f32, bf16,
+                                   f16, u8, s8, u4, s4),
                     VERBOSE_UNSUPPORTED_DT);
-            VCHECK_SDPA_COND(utils::one_of(desc()->val_md()->data_type, f32,
-                                     bf16, f16, u8, s8, u4, s4),
+            VDISPATCH_SDPA(utils::one_of(desc()->val_md()->data_type, f32, bf16,
+                                   f16, u8, s8, u4, s4),
                     VERBOSE_UNSUPPORTED_DT);
-            VCHECK_SDPA_COND(set_default_formats() == status::success,
+            VDISPATCH_SDPA(set_default_formats() == status::success,
                     VERBOSE_UNSUPPORTED_TAG);
-            VCHECK_SDPA_COND(desc()->values() == desc()->head_size(),
+            VDISPATCH_SDPA(desc()->values() == desc()->head_size(),
                     "values does not match head size");
 
             if (utils::one_of(desc()->key_md()->data_type, u4, s4)) {
-                VCHECK_SDPA_COND(desc()->keys() % 2 == 0,
+                VDISPATCH_SDPA(desc()->keys() % 2 == 0,
                         "The number of keys must be an even size with the data "
                         "type is u4 or s4.");
             }
 
             if (utils::one_of(desc()->val_md()->data_type, u4, s4)) {
-                VCHECK_SDPA_COND(desc()->values() % 2 == 0,
+                VDISPATCH_SDPA(desc()->values() % 2 == 0,
                         "The number of values must be an even size with the "
                         "data type is u4 or s4.");
             }
 
-            VCHECK_SDPA_COND(
+            VDISPATCH_SDPA(
                     desc()->qry_md()->dims[1] >= desc()->key_md()->dims[1]
                             && desc()->qry_md()->dims[1]
                                     >= desc()->val_md()->dims[1],
@@ -250,26 +258,26 @@ struct micro_fwd_t : public primitive_t {
                     static_cast<long int>(desc()->key_md()->dims[1]),
                     static_cast<long int>(desc()->val_md()->dims[1]));
 
-            VCHECK_SDPA_COND(utils::one_of(kq_acc_dt(), f16, f32),
+            VDISPATCH_SDPA(utils::one_of(kq_acc_dt(), f16, f32),
                     "KQ accumulation data type should be f16 or f32");
-            VCHECK_SDPA_COND(utils::one_of(vs_acc_dt(), f16, f32),
+            VDISPATCH_SDPA(utils::one_of(vs_acc_dt(), f16, f32),
                     "VS accumulation data type should be f16 or f32");
 
             int kq_scales_mask = desc()->kq_scales.get_mask();
             int kq_zp_mask = desc()->kq_zero_points.get_mask();
             if (!desc()->kq_scales.has_default_values()
                     && !desc()->kq_zero_points.has_default_values())
-                VCHECK_SDPA_COND(kq_scales_mask == kq_zp_mask,
+                VDISPATCH_SDPA(kq_scales_mask == kq_zp_mask,
                         "kq scales mask(%d) must equal kq zero point(%d) "
                         "mask",
                         kq_scales_mask, kq_zp_mask);
             if (!desc()->kq_scales.has_default_values())
-                VCHECK_SDPA_COND(utils::one_of(kq_scales_mask, 0, 1, 3, 11, 15),
+                VDISPATCH_SDPA(utils::one_of(kq_scales_mask, 0, 1, 3, 11, 15),
                         "unsupported mask for kq matmul(%d). must be 0, 1, 3, "
                         "11, or 15",
                         kq_scales_mask);
             if (!desc()->kq_zero_points.has_default_values())
-                VCHECK_SDPA_COND(utils::one_of(kq_zp_mask, 0, 1, 3, 11, 15),
+                VDISPATCH_SDPA(utils::one_of(kq_zp_mask, 0, 1, 3, 11, 15),
                         "unsupported mask for kq matmul(%d). must be 0, 1, 3, "
                         "11, or 15",
                         kq_zp_mask);
@@ -278,24 +286,24 @@ struct micro_fwd_t : public primitive_t {
             int vs_zp_mask = desc()->vs_zero_points.get_mask();
             if (!desc()->vs_scales.has_default_values()
                     && !desc()->vs_zero_points.has_default_values())
-                VCHECK_SDPA_COND(vs_scales_mask == vs_zp_mask,
+                VDISPATCH_SDPA(vs_scales_mask == vs_zp_mask,
                         "vs scales mask(%d) must equal vs zero point(%d) "
                         "mask",
                         vs_scales_mask, vs_zp_mask);
             if (!desc()->vs_scales.has_default_values())
-                VCHECK_SDPA_COND(utils::one_of(vs_scales_mask, 0, 1, 3, 7, 15),
+                VDISPATCH_SDPA(utils::one_of(vs_scales_mask, 0, 1, 3, 7, 15),
                         "unsupported mask for vs matmul(%d). must be 0, 1, 3, "
                         "7, or 15",
                         vs_scales_mask);
             if (!desc()->vs_zero_points.has_default_values())
-                VCHECK_SDPA_COND(utils::one_of(vs_zp_mask, 0, 1, 3, 7, 15),
+                VDISPATCH_SDPA(utils::one_of(vs_zp_mask, 0, 1, 3, 7, 15),
                         "unsupported mask for vs matmul(%d). must be 0, 1, 3, "
                         "7, or 15",
                         vs_zp_mask);
 
             /// NOTE: Limitation of microkernels
             if (utils::one_of(desc()->vs_zero_points.get_data_type(), s4, u4)) {
-                VCHECK_SDPA_COND(value_group_size() == 16,
+                VDISPATCH_SDPA(value_group_size() == 16,
                         "if vs zero points data type is s4 or u4 then the "
                         "group size(%d) must be 16.",
                         value_group_size());
@@ -304,7 +312,7 @@ struct micro_fwd_t : public primitive_t {
             if (!desc()->vs_scales.has_default_values()
                     || !desc()->vs_zero_points.has_default_values()) {
                 int vgs = value_group_size();
-                VCHECK_SDPA_COND(utils::one_of(vs_scales_mask, 0, 1, 3)
+                VDISPATCH_SDPA(utils::one_of(vs_scales_mask, 0, 1, 3)
                                 || (math::is_pow2<int>(vgs)
                                         || vgs == desc()->val_md()->dims[3]),
                         "the value group size(%d) must be a power of 2 or "
@@ -314,10 +322,10 @@ struct micro_fwd_t : public primitive_t {
 
             CHECK(init_conf_microkernels(engine));
             CHECK(init_conf(engine));
-            VCHECK_SDPA_COND(IMPLICATION((arch() == compute::gpu_arch_t::xe_hpc)
-                                             && (desc()->qry_md()->data_type
-                                                     == data_type::f32),
-                                     with_causal_mask()),
+            VDISPATCH_SDPA(IMPLICATION((arch() == compute::gpu_arch_t::xe_hpc)
+                                           && (desc()->qry_md()->data_type
+                                                   == data_type::f32),
+                                   with_causal_mask()),
                     "fused f32 SDPA only optimized for causal mask"); //TODO: update when performance improved
 
             return status::success;
@@ -391,33 +399,33 @@ struct micro_bwd_t : public primitive_t {
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
 
-            VCHECK_SDPA_COND(!is_fwd(), VERBOSE_BAD_PROPKIND);
+            VDISPATCH_SDPA(!is_fwd(), VERBOSE_BAD_PROPKIND);
 
-            VCHECK_SDPA_COND(utils::everyone_is(4, desc()->qry_md()->ndims,
-                                     desc()->key_md()->ndims,
-                                     desc()->val_md()->ndims, dst_md()->ndims),
+            VDISPATCH_SDPA(utils::everyone_is(4, desc()->qry_md()->ndims,
+                                   desc()->key_md()->ndims,
+                                   desc()->val_md()->ndims, dst_md()->ndims),
                     VERBOSE_UNSUPPORTED_TAG);
-            VCHECK_SDPA_COND(
+            VDISPATCH_SDPA(
                     utils::everyone_is(4, desc()->diff_qry_md()->ndims,
                             desc()->diff_key_md()->ndims,
                             desc()->diff_val_md()->ndims, diff_dst_md()->ndims),
                     VERBOSE_UNSUPPORTED_TAG);
             if (with_attn_mask()) {
-                VCHECK_SDPA_COND(desc()->attn_mask_md()->ndims == 4,
+                VDISPATCH_SDPA(desc()->attn_mask_md()->ndims == 4,
                         VERBOSE_UNSUPPORTED_TAG);
-                VCHECK_SDPA_COND(
+                VDISPATCH_SDPA(
                         utils::one_of(
                                 desc()->attn_mask_md()->dims[mask_q_index],
                                 desc()->queries(), 1),
                         VERBOSE_INVALID_BROADCAST, "attn_mask", mask_q_index);
-                VCHECK_SDPA_COND(desc()->attn_mask_md()->dims[mask_k_index]
+                VDISPATCH_SDPA(desc()->attn_mask_md()->dims[mask_k_index]
                                 == desc()->keys(),
                         VERBOSE_INVALID_BROADCAST, "attn_mask", mask_k_index);
-                VCHECK_SDPA_COND(desc()->attn_mask_md()->data_type
+                VDISPATCH_SDPA(desc()->attn_mask_md()->data_type
                                 == desc()->qry_md()->data_type,
                         "Mask data type should match Qry/Dst data type.");
             }
-            VCHECK_SDPA_COND(
+            VDISPATCH_SDPA(
                     (utils::everyone_is(data_type::f16,
                              desc()->qry_md()->data_type, dst_md()->data_type)
                             || utils::everyone_is(data_type::bf16,
@@ -427,18 +435,18 @@ struct micro_bwd_t : public primitive_t {
                                     desc()->qry_md()->data_type,
                                     dst_md()->data_type)),
                     VERBOSE_UNSUPPORTED_DT);
-            VCHECK_SDPA_COND(
+            VDISPATCH_SDPA(
                     utils::one_of(desc()->key_md()->data_type, f32, bf16, f16),
                     VERBOSE_UNSUPPORTED_DT);
-            VCHECK_SDPA_COND(
+            VDISPATCH_SDPA(
                     utils::one_of(desc()->val_md()->data_type, f32, bf16, f16),
                     VERBOSE_UNSUPPORTED_DT);
-            VCHECK_SDPA_COND(set_default_formats() == status::success,
+            VDISPATCH_SDPA(set_default_formats() == status::success,
                     VERBOSE_UNSUPPORTED_TAG);
-            VCHECK_SDPA_COND(desc()->values() == desc()->head_size(),
+            VDISPATCH_SDPA(desc()->values() == desc()->head_size(),
                     "values does not match head size");
 
-            VCHECK_SDPA_COND(
+            VDISPATCH_SDPA(
                     desc()->qry_md()->dims[1] >= desc()->key_md()->dims[1]
                             && desc()->qry_md()->dims[1]
                                     >= desc()->val_md()->dims[1],
@@ -453,19 +461,18 @@ struct micro_bwd_t : public primitive_t {
                 memory_desc_wrapper diff_key_mdw(desc()->diff_key_md());
                 memory_desc_wrapper diff_val_mdw(desc()->diff_val_md());
                 memory_desc_wrapper diff_dst_mdw(diff_dst_md());
-                VCHECK_SDPA_COND(
-                        utils::everyone_is(true, diff_qry_mdw.is_plain(),
-                                diff_key_mdw.is_plain(),
-                                diff_val_mdw.is_plain(),
-                                diff_dst_mdw.is_plain()),
+                VDISPATCH_SDPA(utils::everyone_is(true, diff_qry_mdw.is_plain(),
+                                       diff_key_mdw.is_plain(),
+                                       diff_val_mdw.is_plain(),
+                                       diff_dst_mdw.is_plain()),
                         VERBOSE_UNSUPPORTED_TAG);
             }
 
-            VCHECK_SDPA_COND(utils::everyone_is(desc()->qry_md()->data_type,
-                                     desc()->diff_qry_md()->data_type,
-                                     desc()->diff_key_md()->data_type,
-                                     desc()->diff_val_md()->data_type,
-                                     diff_dst_md()->data_type),
+            VDISPATCH_SDPA(utils::everyone_is(desc()->qry_md()->data_type,
+                                   desc()->diff_qry_md()->data_type,
+                                   desc()->diff_key_md()->data_type,
+                                   desc()->diff_val_md()->data_type,
+                                   diff_dst_md()->data_type),
                     "diff tensor data types must match qry data type(%s) "
                     " ?= dQ(%s), dK(%s), dV(%s), dO(%s)",
                     dnnl_dt2str(desc()->qry_md()->data_type),
@@ -475,9 +482,9 @@ struct micro_bwd_t : public primitive_t {
                     dnnl_dt2str(diff_dst_md()->data_type));
 
             CHECK(init_default_ws());
-            VCHECK_SDPA_COND(compare_ws(hint_fwd_pd_), VERBOSE_WS_MISMATCH);
+            VDISPATCH_SDPA(compare_ws(hint_fwd_pd_), VERBOSE_WS_MISMATCH);
 
-            VCHECK_SDPA_COND(arch() != compute::gpu_arch_t::xe_hpg,
+            VDISPATCH_SDPA(arch() != compute::gpu_arch_t::xe_hpg,
                     "fused SDPA BWD not supported for xe_hpg");
             CHECK(init_conf_microkernels(engine));
             CHECK(init_conf(engine));

--- a/src/gpu/intel/sdpa/ref.hpp
+++ b/src/gpu/intel/sdpa/ref.hpp
@@ -47,10 +47,14 @@ struct ref_fwd_t : public primitive_t {
             VDISPATCH_SDPA(utils::everyone_is(4, desc()->qry_md()->ndims,
                                    desc()->key_md()->ndims,
                                    desc()->val_md()->ndims, dst_md()->ndims),
-                    VERBOSE_UNSUPPORTED_TAG);
+                    VERBOSE_SHAPE_RESTRICTION
+                    ": qry(%d) key(%d) val(%d) dst(%d) must be 4d",
+                    desc()->qry_md()->ndims, desc()->key_md()->ndims,
+                    desc()->val_md()->ndims, dst_md()->ndims);
             if (with_attn_mask()) {
                 VDISPATCH_SDPA(desc()->attn_mask_md()->ndims == 4,
-                        VERBOSE_UNSUPPORTED_TAG);
+                        VERBOSE_SHAPE_RESTRICTION ": attn_mask(%d) must be 4d",
+                        desc()->attn_mask_md()->ndims);
             }
             VDISPATCH_SDPA(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
 


### PR DESCRIPTION
## Summary

- Replaces uses of \`VCHECK_SDPA_COND\` with \`VDISPATCH_SDPA\`, which uses the standard \`VCONDCHECK\` dispatch logging macro
- Defines the \`VDISPATCH_SDPA\` macro in \`micro.hpp\`
- Fixes 6 checks in \`micro.hpp\` and \`ref.hpp\` that used \`VERBOSE_UNSUPPORTED_TAG\` (format tag message) for ndims validation — replaced with \`VERBOSE_SHAPE_RESTRICTION\` with informative messages that report actual tensor ndims values