### PR TITLE
[GPU] ngen: emul: avoid mach/l on xe3p in qxqxw case. Backport

### DIFF
--- a/third_party/ngen/ngen_emulation.hpp
+++ b/third_party/ngen/ngen_emulation.hpp
@@ -593,10 +593,19 @@ struct EmulationImplementation {
                 = g.acc0.retype(dstDWType)[dstHi.getOffset()](dstHi.getHS());
 
             if(s1W) {
-                g.mul(mod, accLo, s0Lo, src1, loc);
-                g.mach(mod, dstLo, s0Lo, 0, loc);
-                g.mad(mod, dstHi, dstLo, s0Hi, src1, loc);
-                g.mov(mod, dstLo, accLo, loc);
+                if (emulateDWxDW) {
+                    g.mul(mod, accLo, s0Lo, src1, loc);
+                    g.mach(mod, dstLo, s0Lo, 0, loc);
+                    g.mad(mod, dstHi, dstLo, s0Hi, src1, loc);
+                    g.mov(mod, dstLo, accLo, loc);
+                } else {
+                    auto acc = g.acc0.retype(dst.getType())[dst.getOffset()](dst.getHS());
+                    dstHi.setType(isSigned(dst.getType()) ? DataType::d : DataType::ud);
+                    g.mov(mod, dst, 0);
+                    g.mul(mod, acc, s0Lo, src1, loc);
+                    g.mul(mod, dstHi, s0Hi, src1, loc);
+                    g.add(mod, dst, dst, acc);
+                }
             } else if(s1D) {
                 auto s1Lo = lowWord(src1);
                 if (emulateDWxDW){


### PR DESCRIPTION
backport https://github.com/uxlfoundation/oneDNN/pull/5016
