### PR TITLE
cpu: x64: matmul: enable treat_as_plain for weights format

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -513,8 +513,10 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
                     = memory_desc_matches_tag(B_md, plain_tensor_layout_tag)
                     && memory_desc_matches_tag(
                             B_md, transposed_tensor_layout_tag);
+            const bool treat_as_plain = plain_transposed_matched && bgmmc.N == 1
+                    && !bgmmc.is_int4_weights;
             if (bgmmc.wei_tag == format_tag::undef
-                    || plain_transposed_matched) {
+                    || (plain_transposed_matched && !treat_as_plain)) {
                 if (gemm_based::check_gemm_input_format(B_md)) {
                     // Note: Here we batch layout may not be accurately represented
                     // by the wei_tag string, due to all the permutations of the


### PR DESCRIPTION
Fixes MFDNN-14900

Using plain format when N == 1 for transpose format, which works the same before guilty commit. And the TF confirms that the patch works fine on their end.

[CI tests](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f139abf2-8a32-f19c-b124-a4bf010d0e2d)