### PR TITLE
[GPU] Use f32 accumulator for f16 input in convolution

### DIFF
--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -149,7 +149,7 @@ status_t problem_t::init(
     wei_data_type = conv_pd->invariant_wei_md()->data_type;
     bia_data_type = conv_pd->invariant_bia_md()->data_type;
     dst_data_type = conv_pd->invariant_dst_md()->data_type;
-    fpmath_mode = attr->fpmath_.mode_;
+    accumulation_mode = attr->acc_mode_;
 
     ndims = conv_pd->ndims();
 

--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -1264,9 +1264,8 @@ dsl::type_t get_accumulation_type(
     if (a.is_int()) return dsl::type_t::s32();
     if (a.is_f64()) return dsl::type_t::f64();
     if (cfg.fma_kind() == fma_kind_t::mad && a.is_f16() && b.is_f16()
-            && !cfg.prb().is_bwd_w) {
-        // FIXME: f16 must use f32 accumulator according to documentation.
-        // Temporarily keeping f16 to avoid regressions.
+            && !cfg.prb().is_bwd_w
+            && cfg.prb().accumulation_mode == accumulation_mode::any) {
         return dsl::type_t::f16();
     }
     return dsl::type_t::f32();

--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -1263,9 +1263,9 @@ dsl::type_t get_accumulation_type(
     if (a.is_int()) return dsl::type_t::s32();
     if (a.is_f64()) return dsl::type_t::f64();
     if (cfg.fma_kind() == fma_kind_t::mad && a.is_f16() && b.is_f16()
-            && !cfg.prb().is_bwd_w) {
-        // FIXME: f16 must use f32 accumulator according to documentation.
-        // Temporarily keeping f16 to avoid regressions.
+            && !cfg.prb().is_bwd_w
+            && utils::one_of(cfg.prb().fpmath_mode, fpmath_mode::f16,
+                    fpmath_mode::any)) {
         return dsl::type_t::f16();
     }
     return dsl::type_t::f32();

--- a/src/gpu/intel/conv/jit/problem.hpp
+++ b/src/gpu/intel/conv/jit/problem.hpp
@@ -192,7 +192,7 @@ public:
     data_type_t wei_data_type = data_type::undef;
     data_type_t dst_data_type = data_type::undef;
     data_type_t bia_data_type = data_type::undef;
-    fpmath_mode_t fpmath_mode = fpmath_mode::strict;
+    accumulation_mode_t accumulation_mode = accumulation_mode::strict;
 
     bool is_fwd = false;
     bool is_bwd_d = false;

--- a/tests/benchdnn/conv/cfg.cpp
+++ b/tests/benchdnn/conv/cfg.cpp
@@ -31,13 +31,6 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
     }
 
     acc_mode_ = prb->attr.acc_mode;
-    bool inputs_f16 = true;
-    for (auto dk : {SRC, WEI, DST}) {
-        if (dk == output_data_kind_) continue;
-        inputs_f16 = inputs_f16 && get_dt(dk) == dnnl_f16;
-    }
-    // XXX: GPU convolution can use f16 accumulator when both inputs are f16.
-    if (is_gpu() && inputs_f16) acc_mode_ = dnnl_accumulation_mode_f16;
 
     // Keep legacy filling for Wino.
     if (prb->alg == WINO) {


### PR DESCRIPTION
PR fixes [MFDNN-14864](https://jira.devtools.intel.com/browse/MFDNN-14864).

## Background

According to the [documentation](https://uxlfoundation.github.io/oneDNN/dev_guide_attributes_accumulation_mode.html), oneDNN must use an f32 accumulator with f16 data type inputs. GPU convolution deviates from that in some cases due to historical and performance reasons:

-	f16 small-channel convolution (including depthwise) may use mad instructions with a half-precision accumulator for better performance. Why: systolic uses an f32 accumulator but requires larger chains: 16 elements per reduction, which adds extra overhead.
-	Xe-LP(G) platforms may use an f16 accumulator for f16 inputs in convolution. Why: no systolic support, and f32 accumulator mad has 2x lower throughput.

PR fixes this mismatch by switching to an f32 accumulator with f16 data types in GPU convolution by default. The driver of this change is the recent bug report about poor f16 accuracy in convolution: [MFDNN-14864](https://jira.devtools.intel.com/browse/MFDNN-14864).

## Impact
- Accuracy: improved on the affected paths
- Performance: default f16 convolution may be slower than before. This is relevant for depthwise and small-channel f16 shapes for forward and backward by data.
    - oneDNN performance testing shows up to ~20% E2E regressions; however, these are limited to ~10 KPIs out of hundreds tracked. Individual layers show regressions up to 2x.

## Mitigation: how to opt in to the old (faster) behavior

Set the accumulation_mode primitive attribute to any:

```c++
attr.set_accumulation_mode(dnnl::accumulation_mode::any);
```

No code changes are needed beyond setting the attribute on convolution primitives where reduced-precision accumulation is acceptable.