### PR TITLE
[rls-v3.11] cpu: x64: matmul: fixed undefined behavior for trivial dimensions case

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -501,25 +501,14 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
                     : memory_desc_matches_one_of_tag(B_md,
                               plain_tensor_layout_tag,
                               transposed_tensor_layout_tag, acbd, adbc);
-            const bool plain_transposed_matched
-                    = memory_desc_matches_tag(B_md, plain_tensor_layout_tag)
-                    && memory_desc_matches_tag(
-                            B_md, transposed_tensor_layout_tag);
-            if (bgmmc.wei_tag == format_tag::undef
-                    || plain_transposed_matched) {
+            // Plain copy-B kernel does not handle odd sizes for subbyte types correctly.
+            // Using transposed version for these cases.
+            if (bgmmc.is_int4_weights && bgmmc.N % 2 != 0) {
+                bgmmc.wei_tag = transposed_tensor_layout_tag;
+            }
+            if (bgmmc.wei_tag == format_tag::undef) {
                 if (gemm_based::check_gemm_input_format(B_md)) {
-                    // Note: Here we batch layout may not be accurately represented
-                    // by the wei_tag string, due to all the permutations of the
-                    // batch. Only the gemm dimensions "n, k" are accurately
-                    // represented in the string representing transposed or not
-                    // TODO: update helper.transB() to handle the case that
-                    // wei tag can be represented in both plain and transposed
                     bgmmc.wei_tag = helper.transB() == 'N'
-                                    || (plain_transposed_matched
-                                            && B_d.blocking_desc()
-                                                            .strides[bgmmc.ndims
-                                                                    - 1]
-                                                    == 1)
                             ? plain_tensor_layout_tag
                             : transposed_tensor_layout_tag;
                 }


### PR DESCRIPTION
This PR removes explicit stride check in `brgemm_matmul_conf_utils_t::set_or_check_B_tag` method. This check resulted in undefined behavior for memory descriptors with a trivial dimension (e.g. `N=1`). In particular, a tensor may be interpreted as plain or transposed based on a stride value for trivial dimension despite having the same physical layout. This undefined behavior resulted in primitive cache hash collision and eventual segfault due to different requirements to scratchpad size between implementations for plain and transposed cases.

The fix is confirmed by a Tensorflow test.

Orphan CI: https://intel-ci.intel.com/f13a7e9e-6ba1-f1c3-8889-a4bf010d0e2d

Fixes MFDNN-14900
