### PR TITLE
oneDNN v3.11.3 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.11.2")
+set(PROJECT_VERSION "3.11.3")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.11.2:
* Fixed undefined behavior in matmul implementation on Intel64/AMD64 CPUs (bd117e4438b240df7c8162ece744685672686f18)
* Fixed performance regression in `f32` reorder on Intel64/AMD64 CPUs (a4acece010b8618d06a09feea0c5319da1ea3040)
* Fixed a `SEGFAULT` in binary primitive with large sizes on Intel GPUs (157cba5eb115a17927b262bad7f9a451233a8774, 1a8bc113ae46a31475d3f71cc668c03f34dcec24)
* Fixed performance regression in `f32` convolution with small number of input channels on processors with Intel AVX-512 instruction set support (e1f4a614a0b27b8f0b5d7deadd56fc9b6864bbeb)
