### PR TITLE
benchdnn: support SDPA primitive in verbose output

### DIFF
--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -885,6 +885,64 @@ class ZeroPadConverter(Converter):
         return f"--tag={maybe_make_any_tag(self.entry.mds[0])}"
 
 
+class SDPAConverter(Converter):
+    driver: str = "sdpa"
+
+    @property
+    def aux(self):
+        parts = []
+        # Mask type
+        msk = self.entry.aux.get("msk")
+        if msk is not None:
+            parts.append(f"--mask={msk}")
+
+        # If a mask md is present but no auxiliary mask info, default to
+        # --mask=buffer.
+        for md in self.entry.mds:
+            if md.arg == "msk":
+                if msk is None:
+                    parts.append("--mask=buffer")
+                break
+
+        # Scale type: scl:mul is the default (library mode), only emit
+        # --scale= for non-default values like "div".
+        scl = self.entry.aux.get("scl")
+        if scl is not None:
+            scale_mode = scl.split(":")[0]  # "mul" or "div"
+            if scale_mode != "mul":
+                parts.append(f"--scale={scale_mode}")
+
+        return " ".join(parts)
+
+    @property
+    def dts(self):
+        dt_map = {}
+        mdt = None
+        for md in self.entry.mds:
+            if md.arg in ("query", "key", "val", "dst"):
+                dt_map[md.arg] = md.data_type
+            elif md.arg == "msk":
+                mdt = md.data_type
+        q_dt = dt_map.get("query", "f32")
+        k_dt = dt_map.get("key", q_dt)
+        v_dt = dt_map.get("val", q_dt)
+        d_dt = dt_map.get("dst", q_dt)
+        if q_dt == k_dt == v_dt == d_dt:
+            dt = f"--dt={q_dt}"
+        else:
+            dt = f"--dt={q_dt}:{k_dt}:{v_dt}:{d_dt}"
+        return f"{dt} --mdt={mdt}" if mdt else dt
+
+    @property
+    def tags(self):
+        parts = []
+        for md in self.entry.mds:
+            if md.arg in ("query", "key", "val", "dst"):
+                tag = maybe_make_any_tag(md)
+                parts.append(f"--{md.arg[0]}tag={tag}")
+        return " ".join(parts)
+
+
 def get_converter(primitive: str) -> ConverterMeta:
     converters: Dict[str, ConverterMeta] = {
         "batch_normalization": BatchNormalizationConverter,
@@ -905,6 +963,7 @@ def get_converter(primitive: str) -> ConverterMeta:
         "reorder": ReorderConverter,
         "resampling": ResamplingConverter,
         "rnn": RNNConverter,
+        "sdpa": SDPAConverter,
         "shuffle": ShuffleConverter,
         "softmax": SoftmaxConverter,
         "sum": SumConverter,

--- a/scripts/verbose_converter/tests/dataset_ci
+++ b/scripts/verbose_converter/tests/dataset_ci
@@ -35,6 +35,7 @@ reorder,test_reorder_ci
 rnn,test_lstm_ci
 rnn,test_gru_ci
 rnn,test_rnn_ci
+sdpa,test_sdpa_smoke
 shuffle,test_shuffle_ci
 softmax,test_softmax_ci
 sum,test_sum_ci

--- a/scripts/verbose_converter/tests/dataset_simple
+++ b/scripts/verbose_converter/tests/dataset_simple
@@ -32,6 +32,7 @@ prelu,shapes_ci
 reduction,shapes_ci
 resampling,shapes_ci
 rnn,shapes_small
+sdpa,test_sdpa_smoke
 shuffle,option_set_min
 softmax,shapes_ci
 sum,test_sum_ci

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1673,13 +1673,13 @@ std::string init_info_sdpa(const engine_t *e, const pd_t *pd) {
     ss << ",alg:" << desc->softmax_alg;
     if (pd->with_attn_mask()) {
         auto *md = desc->attn_mask_md();
-        ss << delimiter << "msk:" << (md->dims[2] == 1 ? 1 : 2) << 'd';
+        ss << delimiter << "msk:buffer_" << (md->dims[2] == 1 ? 1 : 2) << 'd';
     } else if (pd->with_causal_mask()) {
         ss << delimiter;
         if (desc->mask_type == attn_mask_type::top_left)
-            ss << "msk:causal:top_left";
+            ss << "msk:causal_top_left";
         else
-            ss << "msk:causal:bottom_right";
+            ss << "msk:causal_bottom_right";
     }
     if (pd->with_attn_scale()) {
         ss << delimiter << "scl:";


### PR DESCRIPTION
### This PR builds on the SDPA support in benchdnn (#4884) and adds verbose log conversion, enabling SDPA verbose output to be translated into benchdnn reproducer commands.

**JIRA:** [MFDNN-14131](https://jira.devtools.intel.com/browse/MFDNN-14131)
**Depends on:** #4884 (SDPA benchdnn driver)

---

### Problem description

The verbose converter (`scripts/verbose_converter/`) parses `ONEDNN_VERBOSE` output and generates benchdnn command lines for reproduction and debugging. After the SDPA benchdnn driver was added, the converter had **no support for `sdpa` primitive verbose lines** encountering them caused a `KeyError` and the line was silently skipped.

---

### Proposed Solution

Add an `SDPAConverter` class to the benchdnn generator that maps SDPA verbose fields to the `--sdpa` driver flags.

**Verbose to benchdnn mapping:**

| Verbose aux/MD field | benchdnn flag | Notes |
|---|---|---|
| `msk:buffer_1d`, `buffer_2d`, `causal_top_left`, `causal_bottom_right` | `--mask={value}` | Direct passthrough after verbose.cpp fix |
| `msk` MD present, no aux `msk` field | `--mask=buffer` | Fallback for untyped buffer mask |
| `msk` MD data type | `--mdt=DT` | Only emitted when buffer mask present |
| `scl:div:*` | `--scale=div` | `scl:mul` always present in verbose (benchdnn unconditionally passes scale_md), so not emitted |
| query/key/val/dst DTs | `--dt=Q:K:V:DST` | Compressed when all equal |
| query/key/val/dst tags | `--qtag=`, `--ktag=`, `--vtag=`, `--dtag=` | |
| `prop_kind` | `--dir=` | Inherited from base `Converter` |

**Key design decisions:**
- `scl:mul:f32:host` in verbose is the default state (benchdnn always passes a host scalar scale even in library mode). The converter does **not** emit `--scale=mul` to match the benchdnn default.
- `msk:2d` maps to `--mask=buffer_2d` (not `buffer`) because benchdnn distinguishes mask broadcasting semantics.
- No changes to the parser (`parse.py`) were needed. Existing `parse_aux()` and `parse_md()` handle SDPA fields natively.

---

### Files changed

| File | Description |
|------|-------------|
| `src/common/verbose.cpp` | Fix mask format: `msk:buffer_1d` (was `msk:1d`), `msk:causal_top_left` (was `msk:causal:top_left`), aligns with benchdnn `str2mask_type()` |
| `verbose_converter/src/benchdnn_generator.py` | New `SDPAConverter` class + registration |
| `verbose_converter/tests/dataset_ci` | Add `sdpa,test_sdpa_smoke` |
| `verbose_converter/tests/dataset_simple` | Add `sdpa,test_sdpa_smoke` |

---

### Results

**Before this PR**, converting SDPA verbose output silently skips SDPA lines:
```bash
# 1. Capture SDPA verbose output
set ONEDNN_VERBOSE=profile_create
benchdnn --engine=gpu --sdpa --mode=I --dt=f16 --mask=causal_top_left 1x2x8x16:1x2x16x8:1x2x8x16 > verbose.log 2>&1

# 2. Try to convert — SDPA lines are silently dropped, empty output
python scripts/verbose_converter/verbose_converter.py -i verbose.log -a generate
# Output:
# (no output for sdpa)
```

**After this PR**, the converter generates a valid benchdnn reproducer:
```bash
# 1. Same verbose capture
set ONEDNN_VERBOSE=profile_create
./benchdnn --engine=gpu --sdpa --mode=I --dt=f16 --mask=causal_top_left 1x2x8x16:1x2x16x8:1x2x8x16 > verbose.log 2>&1

# 2. Convert verbose → benchdnn input
python scripts/verbose_converter/verbose_converter.py -i verbose.log -a generate
# Output:
# --sdpa --reset --allow-enum-tags-only=0 --engine=gpu --dir=FWD_I --mask=causal_top_left --dt=f16 --qtag=abcd --ktag=abcd --vtag=abcd --dtag=abcd 1x2x8x16:1x2x16x8:1x2x8x16

# 3. Run the generated reproducer
./benchdnn --engine=gpu --sdpa --reset --allow-enum-tags-only=0 --dir=FWD_I --mask=causal_top_left --dt=f16 1x2x8x16:1x2x16x8:1x2x8x16
```

**Round-trip validation** (automated):
```bash
python scripts/verbose_converter/tests/benchdnn_test.py -e gpu -d dataset_ci
# BENCHDNN TEST: gpu, sdpa, test_sdpa_smoke: PASSED
```