### PR TITLE
[GPU][NVL-P] Add acc mode restriction on atomic acc

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -86,6 +86,7 @@ bool useAutoAtomic(HW hw, const GEMMProblem &problem, const GEMMStrategy &strate
     return (hw >= HW::XeHPG)
             && (ignoreBeta || problem.beta1())
             && hasNativeAtomicAdd(hw, problem.Tc_ext.real(), problem.C, strategy.C)
+            && (problem.Tacc_min == Type::invalid || problem.Tacc_min.isSubsetOf(problem.Tc_ext))
             && !strategy.cLoadAhead
             && (problem.postOps.len() == 0 || problem.hasSum1PostOpAtEnd())
             && (problem.cOffset != COffset::Post)

--- a/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
@@ -169,6 +169,7 @@ struct GEMMProblem : public CommonProblem {
     Type Tao, Tbo, Tco;                             // Types for A/B/C offsets.
     Type Ta_scale, Tb_scale, Tc_scale;              // Types for A/B/C scales.
     Type Tag, Tbg;                                  // Types for A/B group sums.
+    Type Tacc_min;                                  // Type for minimum C accumulation precision.
 
     Scalar alpha, beta;                             // Scaling factors for A*B and C, respectively.
     MatrixAddressing A, B, C;                       // Addressing information for A/B/C matrices.
@@ -301,6 +302,7 @@ struct GEMMProblem : public CommonProblem {
     bool usesCOPtr() const { return (hasCOffsetPtr() && cOffset != COffset::None) || sumA || sumB; }
     bool allowMatrixOffset() const { return (cOffset == COffset::Pre); }
 
+    // Data type of dst registers for dpas/mad/dp4a.
     Type Tc_compute() const {
         if (Ta.isInteger() && Tb.isInteger() && Tc == Type::f32)
             return Type::s32;

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -630,16 +630,28 @@ status_t pd_t::init_GEMMProblem(
             || (post_ops_.find(primitive_kind::prelu) != -1);
 
     bool need_x32_acc = with_binary || !IMPLICATION(with_sum_, sum_at_begin_);
+    auto acc_mode = attr()->acc_mode_;
 
-    switch (attr()->acc_mode_) {
+    // Strict acc mode default.
+    auto Tacc_mode = problem.Tc_ext.isFP() ? data_type::f32 : data_type::s32;
+
+    // Initialize non-strict acc mode.
+    switch (acc_mode) {
         case accumulation_mode::any:
-            if (!need_x32_acc) acc_type = data_type::undef;
+            if (!need_x32_acc) Tacc_mode = data_type::undef;
             break;
-        case accumulation_mode::f16: acc_type = data_type::f16; break;
-        case accumulation_mode::f32: acc_type = data_type::f32; break;
-        case accumulation_mode::s32: acc_type = data_type::s32; break;
+        case accumulation_mode::f16: Tacc_mode = data_type::f16; break;
+        case accumulation_mode::f32: Tacc_mode = data_type::f32; break;
+        case accumulation_mode::s32: Tacc_mode = data_type::s32; break;
         default: break;
     }
+
+    // Minimum precision type for applying post-ops based on acc mode.
+    // Limits use of atomic add.
+    problem.Tacc_min = convert_dnnl_to_kernel_type(Tacc_mode);
+
+    if (acc_mode != accumulation_mode::strict) acc_type = Tacc_mode;
+
     if (wei_decomp_) { acc_type = data_type::f32; }
 
     auto trans_co = trans_bias();


### PR DESCRIPTION
# Description

Since NVL-P supports f16/bf16 atomic acc we need to restrict atomic accumulation to avoid precision issues.

Fixes # [MFDNN-14692](https://jira.devtools.intel.com/browse/MFDNN-14692)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?