### PR TITLE
graph: backend: dnnl: exec: gated_mlp uses unique_ptr instead of raw ptr

### DIFF
--- a/src/graph/backend/dnnl/executables/base.hpp
+++ b/src/graph/backend/dnnl/executables/base.hpp
@@ -116,6 +116,7 @@ struct op_executable_t {
     virtual void execute(const stream &stream,
             const std::unordered_map<int, memory> &args) const
             = 0;
+    virtual bool is_initialized() const = 0;
 #ifdef DNNL_WITH_SYCL
     virtual ::sycl::event execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
@@ -238,6 +239,8 @@ struct dummy_impl_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return true; }
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/executables/batch_norm.hpp
+++ b/src/graph/backend/dnnl/executables/batch_norm.hpp
@@ -80,6 +80,15 @@ struct bn_folding_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override {
+        return add_prim_ && mul_prim_ && sub_prim_
+#if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
+        && DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
+                && sqrt_prim_
+#endif
+                ;
+    }
+
 private:
     desc_t desc_;
     dnnl::binary add_prim_;
@@ -125,6 +134,8 @@ struct batchnorm_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::batch_normalization_forward prim_;
     bool is_training_ {false};
@@ -167,6 +178,8 @@ struct batchnorm_bwd_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::batch_normalization_backward prim_;

--- a/src/graph/backend/dnnl/executables/concat.hpp
+++ b/src/graph/backend/dnnl/executables/concat.hpp
@@ -60,6 +60,8 @@ struct concat_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::concat prim_;
 };

--- a/src/graph/backend/dnnl/executables/const_memory_filler.hpp
+++ b/src/graph/backend/dnnl/executables/const_memory_filler.hpp
@@ -105,6 +105,8 @@ struct const_memory_filler_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return true; }
+
 private:
     std::vector<target_dt> get_attr_data(
             const std::vector<attr_dt> &orig_data, std::true_type) {

--- a/src/graph/backend/dnnl/executables/conv.hpp
+++ b/src/graph/backend/dnnl/executables/conv.hpp
@@ -53,6 +53,8 @@ struct conv_fwd_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::convolution_forward prim_;
     bool with_sum_ {false};
@@ -95,6 +97,8 @@ struct conv_bwd_data_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::convolution_backward_data prim_;
 };
@@ -135,6 +139,8 @@ struct conv_bwd_weights_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::convolution_backward_weights prim_;

--- a/src/graph/backend/dnnl/executables/deconv.hpp
+++ b/src/graph/backend/dnnl/executables/deconv.hpp
@@ -53,6 +53,8 @@ struct deconv_fwd_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::deconvolution_forward prim_;
     bool with_sum_ {false};
@@ -95,6 +97,8 @@ struct deconv_bwd_data_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::deconvolution_backward_data prim_;
 };
@@ -135,6 +139,8 @@ struct deconv_bwd_weights_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::deconvolution_backward_weights prim_;

--- a/src/graph/backend/dnnl/executables/deleter_util.hpp
+++ b/src/graph/backend/dnnl/executables/deleter_util.hpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2026 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#ifndef GRAPH_BACKEND_DNNL_EXECUTABLES_DELETER_UTIL_HPP
+#define GRAPH_BACKEND_DNNL_EXECUTABLES_DELETER_UTIL_HPP
+
+#include "oneapi/dnnl/dnnl_types.h"
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+struct pd_deleter_t {
+    void operator()(dnnl_primitive_desc_t pd) const {
+        dnnl_primitive_desc_destroy(pd);
+    }
+};
+
+struct prim_deleter_t {
+    void operator()(dnnl_primitive_t prim) const {
+        dnnl_primitive_destroy(prim);
+    }
+};
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl
+
+#endif // GRAPH_BACKEND_DNNL_EXECUTABLES_DELETER_UTIL_HPP

--- a/src/graph/backend/dnnl/executables/eltwise.hpp
+++ b/src/graph/backend/dnnl/executables/eltwise.hpp
@@ -59,6 +59,8 @@ struct eltwise_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::eltwise_forward prim_;
 };
@@ -98,6 +100,8 @@ struct eltwise_bwd_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::eltwise_backward prim_;
@@ -142,6 +146,8 @@ struct binary_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::binary prim_;
     bool with_sum_ {false};
@@ -185,6 +191,8 @@ struct prelu_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::prelu_forward prim_;
 };
@@ -224,6 +232,8 @@ struct prelu_bwd_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::prelu_backward prim_;

--- a/src/graph/backend/dnnl/executables/gated_mlp.cpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.cpp
@@ -37,22 +37,18 @@ gated_mlp_executable_t::gated_mlp_executable_t(std::shared_ptr<op_t> &op,
             ? static_cast<dnnl::algorithm>(
                       op->get_attr<int64_t>(op_attr::alg_kind))
             : dnnl::algorithm::undef;
-    auto ret = dnnl_gated_mlp_primitive_desc_create(&pd_, p_engine.get(),
+    dnnl_primitive_desc_t pd = nullptr;
+    // create primitive desc.
+    auto ret = dnnl_gated_mlp_primitive_desc_create(&pd, p_engine.get(),
             src_md.get(), wei0_md.get(), wei1_md.get(), wei2_md.get(),
             dst_md.get(), static_cast<dnnl_alg_kind_t>(act_algo), attr);
-
-    dnnl::error::wrap_c_api(ret,
-            "could not create a primitive descriptor for a gated mlp "
-            "primitive");
-
-    ret = dnnl_primitive_create(&prim_, pd_);
-    dnnl::error::wrap_c_api(
-            ret, "could not create a primitive for a gated mlp primitive");
-}
-
-gated_mlp_executable_t::~gated_mlp_executable_t() {
-    if (prim_) dnnl_primitive_destroy(prim_);
-    if (pd_) dnnl_primitive_desc_destroy(pd_);
+    if (pd && ret == dnnl_success) {
+        pd_.reset(pd);
+        // create primitive
+        dnnl_primitive_t prim = nullptr;
+        ret = dnnl_primitive_create(&prim, pd_.get());
+        if (prim && ret == dnnl_success) { prim_.reset(prim); }
+    }
 }
 
 void gated_mlp_executable_t::execute(const stream &stream,
@@ -72,7 +68,7 @@ void gated_mlp_executable_t::execute(const stream &stream,
         c_args.push_back({a.first, a.second.get()});
 
     sycl::event return_event;
-    auto ret = dnnl_sycl_interop_primitive_execute(prim_, stream.get(),
+    auto ret = dnnl_sycl_interop_primitive_execute(prim_.get(), stream.get(),
             c_args.size(), c_args.data(), &deps, &return_event);
     dnnl::error::wrap_c_api(
             ret, "could not execute gated mlp primitive with sycl runtime");
@@ -93,7 +89,7 @@ cl_event gated_mlp_executable_t::execute_ocl(const stream &stream,
     const cl_event *c_deps = deps.empty() ? nullptr : deps.data();
 
     cl_event return_event = nullptr;
-    auto ret = dnnl_ocl_interop_primitive_execute(prim_, stream.get(),
+    auto ret = dnnl_ocl_interop_primitive_execute(prim_.get(), stream.get(),
             static_cast<int>(c_args.size()), c_args.data(), c_deps,
             static_cast<int>(deps.size()), &return_event);
     dnnl::error::wrap_c_api(

--- a/src/graph/backend/dnnl/executables/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.hpp
@@ -18,6 +18,7 @@
 #define GRAPH_BACKEND_DNNL_EXECUTABLES_GATED_MLP_HPP
 
 #include "graph/backend/dnnl/executables/base.hpp"
+#include "graph/backend/dnnl/executables/deleter_util.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -30,8 +31,6 @@ struct gated_mlp_executable_t : public op_executable_t {
     gated_mlp_executable_t(std::shared_ptr<op_t> &op,
             const dnnl::engine &p_engine, pd_cache_t &pd_cache,
             const fpmath_t &fpmath, bool use_block_layout);
-
-    ~gated_mlp_executable_t() override;
 
     void execute(const stream &stream,
             const std::unordered_map<int, memory> &args) const override;
@@ -51,8 +50,8 @@ struct gated_mlp_executable_t : public op_executable_t {
     bool is_initialized() const override { return pd_ && prim_; }
 
 private:
-    dnnl_primitive_desc_t pd_ = nullptr;
-    dnnl_primitive_t prim_ = nullptr;
+    std::unique_ptr<dnnl_primitive_desc, pd_deleter_t> pd_;
+    std::unique_ptr<dnnl_primitive, prim_deleter_t> prim_;
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/executables/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.hpp
@@ -48,6 +48,8 @@ struct gated_mlp_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return pd_ && prim_; }
+
 private:
     dnnl_primitive_desc_t pd_ = nullptr;
     dnnl_primitive_t prim_ = nullptr;

--- a/src/graph/backend/dnnl/executables/gen_index.cpp
+++ b/src/graph/backend/dnnl/executables/gen_index.cpp
@@ -28,7 +28,10 @@ namespace dnnl_impl {
 genindex_executable_t::genindex_executable_t(std::shared_ptr<op_t> &op,
         const dnnl::engine &p_engine, pd_cache_t &pd_cache,
         const fpmath_t &fpmath, bool use_block_layout)
-    : axis_(op->get_attr<int64_t>(op_attr::axis)) {
+    : axis_(op->get_attr<int64_t>(op_attr::axis))
+    , nelems_(0)
+    , ndims_(0)
+    , ekind_(p_engine.get_kind()) {
     using ltw = logical_tensor_wrapper_t;
     const auto &input_lt = op->get_input_logical_tensor(0);
     nelems_ = ltw(input_lt).nelems();
@@ -39,11 +42,11 @@ genindex_executable_t::genindex_executable_t(std::shared_ptr<op_t> &op,
         output_strides_[i] = output_lt.layout.strides[i];
     }
     info_ = std::string(dnnl_engine_kind2str(
-                    static_cast<dnnl_engine_kind_t>(p_engine.get_kind())))
+                    static_cast<dnnl_engine_kind_t>(ekind_)))
             + "," + op->str();
 #if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
         && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
-    if (p_engine.get_kind() == engine::kind::gpu) {
+    if (ekind_ == engine::kind::gpu) {
         compute::kernel_ctx_t kernel_ctx;
         kernel_ctx.define_int("NDIMS", ndims_);
         for (int d = 0; d < MAX_NDIMS; ++d) {

--- a/src/graph/backend/dnnl/executables/gen_index.hpp
+++ b/src/graph/backend/dnnl/executables/gen_index.hpp
@@ -59,9 +59,19 @@ struct genindex_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const;
 #endif
 
+    bool is_initialized() const override {
+#if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE) \
+        && (DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
+        return ekind_ == dnnl::engine::kind::gpu ? bool(kernel_) : true;
+#else
+        return true;
+#endif
+    }
+
 private:
     int axis_, nelems_, ndims_;
     dims_t output_dims_, output_strides_;
+    dnnl::engine::kind ekind_;
     std::string info_;
 
 #if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE) \

--- a/src/graph/backend/dnnl/executables/group_norm.hpp
+++ b/src/graph/backend/dnnl/executables/group_norm.hpp
@@ -61,6 +61,8 @@ struct groupnorm_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::group_normalization_forward prim_;
 };

--- a/src/graph/backend/dnnl/executables/host_scalar.hpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.hpp
@@ -51,6 +51,8 @@ struct host_scalar_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args,
             const std::vector<cl_event> &deps) const override;
 #endif
+
+    bool is_initialized() const override { return true; }
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/executables/layer_norm.hpp
+++ b/src/graph/backend/dnnl/executables/layer_norm.hpp
@@ -61,6 +61,8 @@ struct layernorm_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::layer_normalization_forward prim_;
 };
@@ -101,6 +103,8 @@ struct layernorm_bwd_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::layer_normalization_backward prim_;

--- a/src/graph/backend/dnnl/executables/matmul.hpp
+++ b/src/graph/backend/dnnl/executables/matmul.hpp
@@ -47,6 +47,8 @@ struct matmul_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::matmul prim_;
     bool with_sum_ {false};

--- a/src/graph/backend/dnnl/executables/pool.hpp
+++ b/src/graph/backend/dnnl/executables/pool.hpp
@@ -59,6 +59,8 @@ struct pool_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::pooling_forward prim_;
 };
@@ -98,6 +100,8 @@ struct pool_bwd_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::pooling_backward prim_;

--- a/src/graph/backend/dnnl/executables/reduction.hpp
+++ b/src/graph/backend/dnnl/executables/reduction.hpp
@@ -54,6 +54,8 @@ struct reduction_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::reduction prim_;
     bool with_sum_ {false};

--- a/src/graph/backend/dnnl/executables/reorder.hpp
+++ b/src/graph/backend/dnnl/executables/reorder.hpp
@@ -53,6 +53,8 @@ struct reorder_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::reorder prim_;
     bool with_sum_ {false};

--- a/src/graph/backend/dnnl/executables/resampling.hpp
+++ b/src/graph/backend/dnnl/executables/resampling.hpp
@@ -53,6 +53,8 @@ struct resampling_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::resampling_forward prim_;
     bool with_sum_ {false};
@@ -93,6 +95,8 @@ struct resampling_bwd_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::resampling_backward prim_;

--- a/src/graph/backend/dnnl/executables/sdpa.cpp
+++ b/src/graph/backend/dnnl/executables/sdpa.cpp
@@ -96,18 +96,12 @@ sdpa_executable_t::sdpa_executable_t(std::shared_ptr<op_t> &op,
     if (pd && ret == dnnl_success) {
         pd_.reset(pd);
     } else {
-        is_initialized_ = false;
         return;
     }
 
     dnnl_primitive_t prim = nullptr;
     ret = dnnl_primitive_create(&prim, pd_.get());
-    if (prim && ret == dnnl_success) {
-        prim_.reset(prim);
-        is_initialized_ = true;
-    } else {
-        is_initialized_ = false;
-    }
+    if (prim && ret == dnnl_success) { prim_.reset(prim); }
 }
 
 void sdpa_executable_t::execute(const stream &stream,
@@ -289,7 +283,6 @@ sdpa_bwd_executable_t::sdpa_bwd_executable_t(std::shared_ptr<op_t> &op,
     if (hint_pd && ret == dnnl_success) {
         hint_pd_.reset(hint_pd);
     } else {
-        is_initialized_ = false;
         return;
     }
 
@@ -304,18 +297,12 @@ sdpa_bwd_executable_t::sdpa_bwd_executable_t(std::shared_ptr<op_t> &op,
     if (pd && ret == dnnl_success) {
         pd_.reset(pd);
     } else {
-        is_initialized_ = false;
         return;
     }
 
     dnnl_primitive_t prim = nullptr;
     ret = dnnl_primitive_create(&prim, pd_.get());
-    if (prim && ret == dnnl_success) {
-        prim_.reset(prim);
-        is_initialized_ = true;
-    } else {
-        is_initialized_ = false;
-    }
+    if (prim && ret == dnnl_success) { prim_.reset(prim); }
 }
 
 void sdpa_bwd_executable_t::execute(const stream &stream,

--- a/src/graph/backend/dnnl/executables/sdpa.hpp
+++ b/src/graph/backend/dnnl/executables/sdpa.hpp
@@ -18,6 +18,7 @@
 #define GRAPH_BACKEND_DNNL_EXECUTABLES_SDPA_HPP
 
 #include "graph/backend/dnnl/executables/base.hpp"
+#include "graph/backend/dnnl/executables/deleter_util.hpp"
 
 #include "common/sdpa_utils.hpp"
 
@@ -26,26 +27,12 @@ namespace impl {
 namespace graph {
 namespace dnnl_impl {
 
-struct pd_deleter_t {
-    void operator()(dnnl_primitive_desc_t pd) const {
-        dnnl_primitive_desc_destroy(pd);
-    }
-};
-
-struct prim_deleter_t {
-    void operator()(dnnl_primitive_t prim) const {
-        dnnl_primitive_destroy(prim);
-    }
-};
-
 struct sdpa_executable_t : public op_executable_t {
     DECLARE_ARG_INDICES_GETTER;
 
     sdpa_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
             pd_cache_t &pd_cache, const fpmath_t &fpmath,
             bool use_block_layout);
-
-    bool is_initialized() const { return is_initialized_; }
 
     void execute(const stream &stream,
             const std::unordered_map<int, memory> &args) const override;
@@ -61,6 +48,8 @@ struct sdpa_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args,
             const std::vector<cl_event> &deps) const override;
 #endif
+
+    bool is_initialized() const override { return is_initialized_; }
 
 private:
     std::unique_ptr<dnnl_primitive_desc, pd_deleter_t> pd_;
@@ -82,8 +71,6 @@ struct sdpa_bwd_executable_t : public op_executable_t {
             const dnnl::engine &p_engine, pd_cache_t &pd_cache,
             const fpmath_t &fpmath, bool use_block_layout);
 
-    bool is_initialized() const { return is_initialized_; }
-
     void execute(const stream &stream,
             const std::unordered_map<int, memory> &args) const override;
 
@@ -98,6 +85,8 @@ struct sdpa_bwd_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args,
             const std::vector<cl_event> &deps) const override;
 #endif
+
+    bool is_initialized() const override { return is_initialized_; }
 
 private:
     std::unique_ptr<dnnl_primitive_desc, pd_deleter_t> hint_pd_;

--- a/src/graph/backend/dnnl/executables/sdpa.hpp
+++ b/src/graph/backend/dnnl/executables/sdpa.hpp
@@ -49,7 +49,7 @@ struct sdpa_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
-    bool is_initialized() const override { return is_initialized_; }
+    bool is_initialized() const override { return pd_ && prim_; }
 
 private:
     std::unique_ptr<dnnl_primitive_desc, pd_deleter_t> pd_;
@@ -60,7 +60,6 @@ private:
     bool with_explicit_mask_;
     attn_mask_type_t mask_type_;
     bool is_invert_scale_;
-    bool is_initialized_;
     bool with_dropout_;
 };
 
@@ -86,7 +85,7 @@ struct sdpa_bwd_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
-    bool is_initialized() const override { return is_initialized_; }
+    bool is_initialized() const override { return hint_pd_ && pd_ && prim_; }
 
 private:
     std::unique_ptr<dnnl_primitive_desc, pd_deleter_t> hint_pd_;
@@ -96,7 +95,6 @@ private:
     attn_mask_type_t mask_type_;
     bool is_invert_scale_;
     bool with_explicit_mask_;
-    bool is_initialized_;
     bool with_dropout_;
 };
 

--- a/src/graph/backend/dnnl/executables/shuffle.hpp
+++ b/src/graph/backend/dnnl/executables/shuffle.hpp
@@ -60,6 +60,8 @@ struct shuffle_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::shuffle_forward prim_;
 };

--- a/src/graph/backend/dnnl/executables/softmax.hpp
+++ b/src/graph/backend/dnnl/executables/softmax.hpp
@@ -60,6 +60,8 @@ struct softmax_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::softmax_forward prim_;
 };
@@ -99,6 +101,8 @@ struct softmax_bwd_executable_t : public op_executable_t {
         return e;
     }
 #endif
+
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
     dnnl::softmax_backward prim_;

--- a/src/graph/backend/dnnl/executables/sum.hpp
+++ b/src/graph/backend/dnnl/executables/sum.hpp
@@ -60,6 +60,8 @@ struct sum_executable_t : public op_executable_t {
     }
 #endif
 
+    bool is_initialized() const override { return bool(prim_); }
+
 private:
     dnnl::sum prim_;
 };

--- a/src/graph/backend/dnnl/passes/compile_ops.cpp
+++ b/src/graph/backend/dnnl/passes/compile_ops.cpp
@@ -55,20 +55,9 @@ status_t compile_ops(std::shared_ptr<subgraph_t> &sg) {
         VCHECK_COMPILE_OPS(exec != nullptr, status::invalid_graph_op,
                 "unimplemented op, can't compile op %s",
                 op->get_name().c_str());
-        if (cur_op->get_kind() == op_kind::_sdpa) {
-            auto sdpa_exec = std::dynamic_pointer_cast<sdpa_executable_t>(exec);
-            VCHECK_COMPILE_OPS(sdpa_exec->is_initialized(),
-                    status::unimplemented,
-                    "failed to create executable for op %s",
-                    op->get_name().c_str());
-        } else if (cur_op->get_kind() == op_kind::_sdpa_bwd) {
-            auto sdpa_bwd_exec
-                    = std::dynamic_pointer_cast<sdpa_bwd_executable_t>(exec);
-            VCHECK_COMPILE_OPS(sdpa_bwd_exec->is_initialized(),
-                    status::unimplemented,
-                    "failed to create executable for op %s",
-                    op->get_name().c_str());
-        }
+        VCHECK_COMPILE_OPS(exec->is_initialized(), status::invalid_graph_op,
+                "failed to create executable for op %s",
+                op->get_name().c_str());
 
         sg->execs_.emplace_back(exec);
 


### PR DESCRIPTION
1. Similar to what was discussed at https://github.com/uxlfoundation/oneDNN/pull/4839#discussion_r3029309642, here we also apply the `unique_ptr` changes to gated_mlp code.
2. Add `is_initialized()` function to all executables as we have more and more subclasses need to check the initialization status. It simplifies the code logic in `compiles_ops` by avoiding per op kind checks.