### PR TITLE
backport: cpu: aarch64: enable BF16 inner-product

### DIFF
--- a/src/cpu/aarch64/acl_inner_product.cpp
+++ b/src/cpu/aarch64/acl_inner_product.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022,2024-2025 Arm Ltd. and affiliates
+* Copyright 2021-2022,2024-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -100,11 +100,13 @@ status_t acl_inner_product_fwd_t::pd_t::init(engine_t *engine) {
     const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
             && attr()->has_default_values(
                     smask_t::post_ops | smask_t::fpmath_mode, f32);
+    const bool is_bf16_ok = expect_data_types(bf16, bf16, bf16, bf16, undef)
+            && attr()->has_default_values(smask_t::post_ops, bf16);
     const bool is_weights_md_format_ok
             = utils::one_of(weights_format_kind_received, format_kind::any,
                     format_kind::blocked);
     const bool ok = is_fwd() && !has_zero_dim_memory()
-            && utils::one_of(true, is_fp16_ok, is_fp32_ok)
+            && utils::one_of(true, is_fp16_ok, is_fp32_ok, is_bf16_ok)
             && is_weights_md_format_ok
             && set_default_params(true) == status::success;
 


### PR DESCRIPTION
This PR + https://github.com/ARM-software/ComputeLibrary/pull/1279 fix: https://github.com/pytorch/pytorch/issues/180447

# Description

Backport of: https://github.com/uxlfoundation/oneDNN/pull/5024

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
