### PR TITLE
cpu: aarch64: fix acl lnorm dispatch logic

### DIFF
--- a/src/cpu/aarch64/acl_layer_normalization.cpp
+++ b/src/cpu/aarch64/acl_layer_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023, 2025 Arm Ltd. and affiliates
+* Copyright 2023, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,101 +14,18 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "common/memory_desc_wrapper.hpp"
+
 #include "cpu/aarch64/acl_layer_normalization.hpp"
+#include "cpu/aarch64/acl_utils.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
-
-acl_layer_normalization_fwd_t::acl_layer_normalization_fwd_t(const pd_t *apd)
-    : primitive_t(apd)
-    , acl_obj_(std::make_unique<
-              arm_compute::experimental::op::CpuMeanStdDevNormalization>()) {}
-
-status_t acl_layer_normalization_fwd_t::pd_t::init(engine_t *engine) {
-
-    // dir and flags
-    ACL_CHECK_SUPPORT(!is_fwd(), "ACL lnorm supports forward propagation only");
-    ACL_CHECK_SUPPORT(is_training(), "ACL supports inference only for lnorm");
-    ACL_CHECK_SUPPORT(
-            use_global_stats(), "ACL does not support global stats with lnorm");
-    ACL_CHECK_SUPPORT(use_scale() || use_shift(),
-            "ACL does not support lnorm scale and shift");
-
-    // attr-scales
-    ACL_CHECK_SUPPORT(!attr()->has_default_values(),
-            "ACL does not support scales attribute");
-
-    // tag and stat_tag
-    ACL_CHECK_SUPPORT(src_md()->ndims < 2 || src_md()->ndims > 5,
-            "src tensor must have between 2 and 5 (inclusive) "
-            "dimensions");
-
-    // skip_mean is set for root-mean-square normalization mode.
-    ACL_CHECK_SUPPORT(skip_mean(), "rms normalization is not supported");
-
-    // msdNorm only supports lnorm for src in a channels last format.
-    // So if channels aren't last (ie. if they aren't dense),
-    // then reorder into a channels last format
-    std::string ref_implementation_guess = "simple:any";
-    if (src_md()->format_desc.blocking.strides[ndims() - 1] != 1) {
-        CHECK(memory_desc_init_by_tag(
-                src_md_, get_channels_last_format(src_md_.ndims)));
-        ref_implementation_guess = "ref:any";
-    }
-    if (dst_md_ != src_md_)
-        // Make sure dst and src share a format
-        CHECK(memory_desc_init_by_md_and_dt(
-                dst_md_, src_md_, src_md()->data_type));
-    if (!set_default_stat_md_format(src_md_)) return status::unimplemented;
-
-    const memory_desc_wrapper src_d(src_md_);
-    const memory_desc_wrapper dst_d(dst_md_);
-
-    ACL_CHECK_SUPPORT(src_d.has_zero_dim() || dst_d.has_zero_dim(),
-            "data tensor(s) must not have a zero dimension");
-
-    // data type
-    ACL_CHECK_SUPPORT(
-            src_d.data_type() != data_type::f32, "ACL Lnorm only supports F32");
-    ACL_CHECK_SUPPORT(dst_d.data_type() != src_d.data_type(),
-            "src and dst must share data types");
-
-    // Problem shape
-    int C = norm_axis(); // Channel dim size
-    int X = src_d.nelems() / C; // Non-channel dims size
-
-    ACL_CHECK_SUPPORT(!use_acl_heuristic(X, C, dnnl_get_max_threads(),
-                              is_training(), ref_implementation_guess),
-            "ACL is unoptimal in this case");
-
-    anp_data_info = arm_compute::TensorInfo(
-            arm_compute::TensorShape(C, X), 1, arm_compute::DataType::F32);
-
-    ACL_CHECK_VALID(
-            arm_compute::experimental::op::CpuMeanStdDevNormalization::validate(
-                    &anp_data_info, &anp_data_info,
-                    desc()->layer_norm_epsilon));
-
-    return status::success;
-}
-
-format_tag_t acl_layer_normalization_fwd_t::pd_t::get_channels_last_format(
-        size_t ndim) const {
-    assert(ndim > 1 && ndim < 6);
-    switch (ndim) {
-        case 2: return format_tag::nc;
-        case 3: return format_tag::tnc;
-        case 4: return format_tag::ldnc;
-        case 5: return format_tag::abcde;
-        default: return format_tag::undef;
-    }
-}
-
-bool acl_layer_normalization_fwd_t::pd_t::use_acl_heuristic(int X, int C,
-        int threads, bool ref_has_stats,
-        const std::string &ref_implementation_guess) const {
+namespace {
+bool use_acl_heuristic(int X, int C, int threads, bool ref_has_stats,
+        const std::string &ref_implementation_guess) {
     // Above a certain C, ACL is always faster, and below a certain C,
     // ACL is always slower. for C in between these two, whether ACL is
     // faster can be approximated with the workload (X*C) per thread.
@@ -164,17 +81,89 @@ bool acl_layer_normalization_fwd_t::pd_t::use_acl_heuristic(int X, int C,
     return C > acl_competitive_C
             && (C > acl_better_C || X * C > acl_better_XC_per_thread * threads);
 }
+} // namespace
 
-const acl_layer_normalization_fwd_t::pd_t *
-acl_layer_normalization_fwd_t::pd() const {
-    return (const pd_t *)primitive_t::pd().get();
+acl_layer_normalization_fwd_t::acl_layer_normalization_fwd_t(const pd_t *apd)
+    : primitive_t(apd)
+    , acl_obj_(std::make_unique<
+              arm_compute::experimental::op::CpuMeanStdDevNormalization>()) {}
+
+status_t acl_layer_normalization_fwd_t::pd_t::init(engine_t *engine) {
+
+    // dir and flags
+    ACL_CHECK_SUPPORT(!is_fwd(), "ACL lnorm supports forward propagation only");
+    ACL_CHECK_SUPPORT(is_training(), "ACL supports inference only for lnorm");
+    ACL_CHECK_SUPPORT(
+            use_global_stats(), "ACL does not support global stats with lnorm");
+    ACL_CHECK_SUPPORT(use_scale() || use_shift(),
+            "ACL does not support lnorm scale and shift");
+
+    // attr-scales
+    ACL_CHECK_SUPPORT(!attr()->has_default_values(),
+            "ACL does not support scales attribute");
+
+    // tag and stat_tag
+    ACL_CHECK_SUPPORT(src_md()->ndims < 2 || src_md()->ndims > 5,
+            "src tensor must have between 2 and 5 (inclusive) "
+            "dimensions");
+
+    // skip_mean is set for root-mean-square normalization mode.
+    ACL_CHECK_SUPPORT(skip_mean(), "rms normalization is not supported");
+
+    if (!set_default_stat_md_format(src_md_)) return status::unimplemented;
+
+    const memory_desc_wrapper src_d(src_md_);
+    const memory_desc_wrapper dst_d(dst_md_);
+
+    ACL_CHECK_SUPPORT(src_d.has_zero_dim() || dst_d.has_zero_dim(),
+            "data tensor(s) must not have a zero dimension");
+
+    if (dst_md_.format_kind == format_kind::any) {
+        memory_desc_init_by_md_and_dt(dst_md_, src_md_, dst_md_.data_type);
+    }
+
+    ACL_CHECK_SUPPORT(dst_md_ != src_md_,
+            "src and dst must have the same memory description");
+
+    // msdNorm only supports lnorm for src in a channels last format.
+    // So if channels aren't last (ie. if they aren't dense),
+    // then reorder into a channels last format
+    std::string ref_implementation_guess = "simple:any";
+    ACL_CHECK_SUPPORT(src_md_.format_kind == format_kind::blocked
+                    && src_md()->format_desc.blocking.strides[ndims() - 1] != 1,
+            "unsupported src format description");
+
+    ACL_CHECK_SUPPORT(
+            !utils::one_of(src_md_.data_type, data_type::f16, data_type::f32),
+            "ACL only supports f16, and f32");
+
+    // Problem shape
+    int C = norm_axis(); // Channel dim size
+    int X = src_d.nelems() / C; // Non-channel dims size
+
+    ACL_CHECK_SUPPORT(!use_acl_heuristic(X, C, dnnl_get_max_threads(),
+                              is_training(), ref_implementation_guess),
+            "ACL is unoptimal in this case");
+
+    acl_lnorm_conf.src_info = {arm_compute::TensorShape(C, X), 1,
+            acl_utils::get_acl_data_t(src_md_.data_type)};
+
+    acl_lnorm_conf.dst_info = {arm_compute::TensorShape(C, X), 1,
+            acl_utils::get_acl_data_t(dst_md_.data_type)};
+
+    ACL_CHECK_VALID(
+            arm_compute::experimental::op::CpuMeanStdDevNormalization::validate(
+                    &acl_lnorm_conf.src_info, &acl_lnorm_conf.dst_info,
+                    desc()->layer_norm_epsilon));
+
+    return status::success;
 }
 
 status_t acl_layer_normalization_fwd_t::init(engine_t *engine) {
-    auto *anp_data_info
-            = const_cast<arm_compute::TensorInfo *>(&pd()->anp_data_info);
-    acl_obj_->configure(
-            anp_data_info, anp_data_info, pd()->desc()->layer_norm_epsilon);
+    auto *acl_lnorm_conf
+            = const_cast<acl_layer_norm_conf_t *>(&pd()->acl_lnorm_conf);
+    acl_obj_->configure(&acl_lnorm_conf->src_info, &acl_lnorm_conf->dst_info,
+            pd()->desc()->layer_norm_epsilon);
     return status::success;
 }
 
@@ -187,9 +176,9 @@ status_t acl_layer_normalization_fwd_t::execute_forward(
     arm_compute::Tensor src_tensor;
     arm_compute::Tensor dst_tensor;
 
-    src_tensor.allocator()->init(pd()->anp_data_info);
+    src_tensor.allocator()->init(pd()->acl_lnorm_conf.src_info);
     src_tensor.allocator()->import_memory(const_cast<float *>(src));
-    dst_tensor.allocator()->init(pd()->anp_data_info);
+    dst_tensor.allocator()->init(pd()->acl_lnorm_conf.dst_info);
     dst_tensor.allocator()->import_memory(dst);
 
     arm_compute::ITensorPack act_pack;

--- a/src/cpu/aarch64/acl_layer_normalization.hpp
+++ b/src/cpu/aarch64/acl_layer_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2025 Arm Ltd. and affiliates
+* Copyright 2023-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,15 +17,23 @@
 #ifndef CPU_AARCH64_ACL_LAYER_NORMALIZATION_HPP
 #define CPU_AARCH64_ACL_LAYER_NORMALIZATION_HPP
 
-#include "arm_compute/runtime/experimental/operators/CpuMeanStdDevNormalization.h"
+#include "common/primitive.hpp"
 
-#include "cpu/aarch64/acl_utils.hpp"
 #include "cpu/cpu_layer_normalization_pd.hpp"
+
+#include "arm_compute/core/TensorInfo.h"
+#include "arm_compute/runtime/experimental/operators/CpuMeanStdDevNormalization.h"
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
+
+struct acl_layer_norm_conf_t {
+    arm_compute::TensorInfo src_info;
+    arm_compute::TensorInfo dst_info;
+};
+
 struct acl_layer_normalization_fwd_t : public primitive_t {
     struct pd_t : public cpu_layer_normalization_fwd_pd_t {
         using cpu_layer_normalization_fwd_pd_t::
@@ -35,10 +43,8 @@ struct acl_layer_normalization_fwd_t : public primitive_t {
 
         status_t init(engine_t *engine);
         format_tag_t get_channels_last_format(size_t ndim) const;
-        bool use_acl_heuristic(int X, int C, int threads, bool ref_has_stats,
-                const std::string &ref_implementation_guess) const;
 
-        arm_compute::TensorInfo anp_data_info;
+        acl_layer_norm_conf_t acl_lnorm_conf;
     }; // pd_t
 
     acl_layer_normalization_fwd_t(const pd_t *apd);
@@ -50,7 +56,9 @@ struct acl_layer_normalization_fwd_t : public primitive_t {
 
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
-    const pd_t *pd() const;
+
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
     std::unique_ptr<arm_compute::experimental::op::CpuMeanStdDevNormalization>
             acl_obj_;
 };


### PR DESCRIPTION
# Description
The main issues fixed:

- Overwriting the `dst` `data_type` with the `src` `data_type`
- Overwriting the `src` `format_tag`
- Incorrectly rejecting `--dt=f16:f16`

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

# Correctness:
Instead of simply rejecting unsupported `data_types` and `format_tags` we were previously overwriting them.
Overwriting the `format_tag` when the innermost dimension is not dense:
https://github.com/uxlfoundation/oneDNN/blob/f2a4710ba4625ba11277880286dcd0310bd857fd/src/cpu/aarch64/acl_layer_normalization.cpp#L55-L57
Overwriting the `data_type` when unsupported:
https://github.com/uxlfoundation/oneDNN/blob/f2a4710ba4625ba11277880286dcd0310bd857fd/src/cpu/aarch64/acl_layer_normalization.cpp#L60-L63

This means that unsupported `data_type` combinations such as `f32:u8` would be silently overwritten to the supported `f32:f32` and executed.

```
# Note that the executed dst has type f32 even though u8 was requested.

$ ONEDNN_VERBOSE=profile_exec ./build/tests/benchdnn/benchdnn --lnorm --mode=R --dir=FWD_I --dt=f32:u8 1280x2x10240 
...
onednn_verbose,v1,primitive,exec,cpu,layer_normalization,acl,forward_inference,src:f32::blocked:abc::f0 dst:f32:a:blocked:abc::f0 stats:undef::undef:::,,flags:,1280x2x10240,3.35889
...
```
The same issue can happen when we use an unsupported format tag like `ctn`:
```
# Note that that src tag is abc even though cab was requested.

$ ONEDNN_VERBOSE=profile_exec ./build/tests/benchdnn/benchdnn --lnorm --mode=R --dir=FWD_I --tag=cab:any 1280x2x10240
...
onednn_verbose,v1,primitive,exec,cpu,layer_normalization,acl,forward_inference,src:f32::blocked:abc::f0 dst:f32:a:blocked:abc::f0 stats:undef::undef:::,,flags:,1280x2x10240,1.87598
...
```

# Performance
On the other hand, `--dt=f16:f16` was being rejected even though support exists. The speedups gained are as follows:
|old impl|new impl|prb|old avg|new avg|speedup ratio (old avg / new avg)|
|---------|---------|---------|---------|---------|---------|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 5120x1024|6.23511|0.0852051|73.1777x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef --inplace=true 5120x1024|4.47095|0.0915527|48.8347x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef 5120x1024|6.23193|0.0856934|72.7236x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx --inplace=true 5120x1024|4.47095|0.0917969|48.7048x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx 5120x1024|6.23242|0.0859375|72.5227x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --inplace=true 64x30x512|0.816895|0.0205078|39.8334x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 64x30x512|1.16675|0.0202637|57.5783x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef --inplace=true 64x30x512|0.815918|0.0205078|39.7857x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef 64x30x512|1.16797|0.0202637|57.6385x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx --inplace=true 64x30x512|0.81665|0.0205078|39.8214x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx 64x30x512|1.16724|0.0202637|57.6025x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --inplace=true 128x40x1024|4.47046|0.0917969|48.6995x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 128x40x1024|6.23413|0.0847168|73.5879x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef --inplace=true 128x40x1024|4.47144|0.0915527|48.8401x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef 128x40x1024|6.23242|0.0842285|73.9942x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx --inplace=true 128x40x1024|4.47192|0.0915527|48.8453x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx 128x40x1024|6.23291|0.0852051|73.1518x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --inplace=true 6x2x128x1024|1.34302|0.0300293|44.7237x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 6x2x128x1024|1.86646|0.0280762|66.4784x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef --inplace=true 6x2x128x1024|1.34253|0.0300293|44.7073x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=undef 6x2x128x1024|1.8667|0.0280762|66.4869x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx --inplace=true 6x2x128x1024|1.34326|0.0302734|44.3710x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=abx 6x2x128x1024|1.86792|0.0280762|66.5304x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --inplace=true 64x30x512|0.816162|0.0202637|40.2770x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc 64x30x512|1.16772|0.0200195|58.3291x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=undef --inplace=true 64x30x512|0.817139|0.0205078|39.8453x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=undef 64x30x512|1.16821|0.0205078|56.9642x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=abx --inplace=true 64x30x512|0.815674|0.0202637|40.2530x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=abx 64x30x512|1.16626|0.0205078|56.8691x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=xba --inplace=true 64x30x512|0.817627|0.0202637|40.3493x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=xba 64x30x512|1.16699|0.0202637|57.5902x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --inplace=true 128x40x1024|4.46973|0.0917969|48.6915x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc 128x40x1024|6.23535|0.0849609|73.3908x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=undef --inplace=true 128x40x1024|4.46997|0.0917969|48.6941x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=undef 128x40x1024|6.23511|0.0844727|73.8121x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=abx --inplace=true 128x40x1024|4.4707|0.0917969|48.7021x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=abx 128x40x1024|6.23267|0.0847168|73.5706x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=xba --inplace=true 128x40x1024|4.47144|0.0917969|48.7101x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --tag=ntc --stat_tag=xba 128x40x1024|6.23218|0.0852051|73.1433x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=ntc --inplace=true 6x2x128x1024|1.34277|0.0302734|44.3548x|
|simple:any|acl|--mode=P --lnorm --dir=FWD_I --dt=f16:f16 --stat_tag=ntc 6x2x128x1024|1.8689|0.0280762|66.5653x|