### PR TITLE
[WIP] [Graph] tests: benchdnn: in: graph: add f16 sample for GQA dropout bwd variant

### DIFF
--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
@@ -37,6 +37,7 @@
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+15:f16+104:f16+10:f16+30:f16+33:f16+31:f16+35:f16 --case=complex_fusion/mha/gqa-plain-training-backward-w-dmask-bf16-f32.json
 --reset --dt=200:f16+201:f16+202:f16+203:f16+204:f16+11:f16+12:f16 --case=complex_fusion/mha/gqa-plain-training-fwd-w-dropout-bf16-f32.json
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+15:f16+104:f16+10:f16+30:f16+33:f16+31:f16+35:f16 --case=complex_fusion/mha/gqa-plain-training-bwd-w-dropout-bf16-f32.json
+--reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+15:f16+104:f16+10:f16+131:f16+135:f16+115:f16 --case=complex_fusion/mha/gqa-plain-training-bwd-w-dropout-f32-internal-bf16-out.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --op-kind=1:Multiply,1:Divide --dt=1:bf16+2:bf16+3:bf16+4:bf16+5:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/gqa-plain-training-bwd-w-dropout-f32-internal-bf16-out.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/gqa-plain-training-bwd-w-dropout-f32-internal-bf16-out.json
@@ -1,0 +1,1589 @@
+{
+  "version": "3.13.0",
+  "engine_kind": "gpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    100,
+    101,
+    102,
+    103,
+    8,
+    105,
+    104,
+    208,
+    209,
+    210,
+    10,
+    105,
+    102,
+    101,
+    100,
+    205,
+    206,
+    207,
+    105
+  ],
+  "output_ports": [
+    131,
+    135,
+    115
+  ],
+  "graph": [
+    {
+      "id": 2,
+      "name": "bmm1",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 1
+        }
+      },
+      "inputs": [
+        {
+          "id": 100,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 101,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 1,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "scale_mul",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 1,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 102,
+          "dtype": "bf16",
+          "shape": [
+            1
+          ],
+          "stride": [
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 3,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "mask_add",
+      "kind": "Add",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 3,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 103,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "name": "subtract",
+      "kind": "Subtract",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 8,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            1
+          ],
+          "stride": [
+            4096,
+            2048,
+            256,
+            1,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "name": "exp",
+      "kind": "Exp",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "name": "bmm_dprobs",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 1
+        }
+      },
+      "inputs": [
+        {
+          "id": 105,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 104,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 17,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 42,
+      "name": "dropout",
+      "kind": "Dropout",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 17,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 208,
+          "dtype": "s64",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "host_scalar"
+        },
+        {
+          "id": 209,
+          "dtype": "s64",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "host_scalar"
+        },
+        {
+          "id": 210,
+          "dtype": "f32",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "host_scalar"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 43,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "name": "mul_o_do",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 10,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 105,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 19,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "name": "reducesum_correction",
+      "kind": "ReduceSum",
+      "attrs": {
+        "keep_dims": {
+          "type": "bool",
+          "value": 1
+        },
+        "axes": {
+          "type": "s64[]",
+          "value": [
+            4
+          ]
+        }
+      },
+      "inputs": [
+        {
+          "id": 19,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 21,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            1
+          ],
+          "stride": [
+            4096,
+            2048,
+            256,
+            1,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "name": "sub_dp_corrected",
+      "kind": "Subtract",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 43,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 21,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            1
+          ],
+          "stride": [
+            4096,
+            2048,
+            256,
+            1,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 23,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "name": "mul_softmax_bwd",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 23,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 25,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 28,
+      "name": "scale_mul",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 25,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 102,
+          "dtype": "bf16",
+          "shape": [
+            1
+          ],
+          "stride": [
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 27,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "name": "typecast",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 27,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 30,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "name": "bmm_dq",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 30,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 101,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 31,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 34,
+      "name": "bmm_dk",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        },
+        "transpose_a": {
+          "type": "bool",
+          "value": 1
+        }
+      },
+      "inputs": [
+        {
+          "id": 30,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 100,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 33,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 40,
+      "name": "dropout",
+      "kind": "Dropout",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 205,
+          "dtype": "s64",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "host_scalar"
+        },
+        {
+          "id": 206,
+          "dtype": "s64",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "host_scalar"
+        },
+        {
+          "id": 207,
+          "dtype": "f32",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "host_scalar"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 41,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 36,
+      "name": "reduce_dk",
+      "kind": "ReduceSum",
+      "attrs": {
+        "keep_dims": {
+          "type": "bool",
+          "value": 1
+        },
+        "axes": {
+          "type": "s64[]",
+          "value": [
+            2
+          ]
+        }
+      },
+      "inputs": [
+        {
+          "id": 33,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 35,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "name": "typecast",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 41,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 12,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "name": "bmm_dv",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        },
+        "transpose_a": {
+          "type": "bool",
+          "value": 1
+        }
+      },
+      "inputs": [
+        {
+          "id": 12,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            256
+          ],
+          "stride": [
+            1048576,
+            524288,
+            65536,
+            256,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 105,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 13,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "name": "reduce_dv",
+      "kind": "ReduceSum",
+      "attrs": {
+        "keep_dims": {
+          "type": "bool",
+          "value": 1
+        },
+        "axes": {
+          "type": "s64[]",
+          "value": [
+            2
+          ]
+        }
+      },
+      "inputs": [
+        {
+          "id": 13,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 15,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 44,
+      "name": "typecast_out_dq",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 31,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 131,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            256,
+            64
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 45,
+      "name": "typecast_out_dk",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 35,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 135,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 46,
+      "name": "typecast_out_dv",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 15,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 115,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            1,
+            256,
+            64
+          ],
+          "stride": [
+            32768,
+            16384,
+            16384,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This is a suggestion to fix the f16 graph test cases. Currently, in the graph input we are treating some internal nodes as f16 whereas in the fused path, everything internally is f32. The final output gets typecast to f16 if input is f16.

Fixes # (https://jira.devtools.intel.com/browse/MFDNN-14955)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

