### PR TITLE
xe: remove with_punning

### DIFF
--- a/src/gpu/intel/binary/common.h
+++ b/src/gpu/intel/binary/common.h
@@ -30,13 +30,13 @@
 #define SRC2_OFF(x0, x1, x2, x3, x4, x5) OFF_MD(SRC2, x0, x1, x2, x3, x4, x5)
 
 #if SRC1_DT_BF16
-#define SRC1_TO_FLOAT cvt_bf16_to_f32
+#define SRC1_TO_FLOAT into_float
 #else
 #define SRC1_TO_FLOAT CONVERT_FLOAT_T
 #endif
 
 #if SRC0_DT_BF16
-#define SRC0_TO_FLOAT cvt_bf16_to_f32
+#define SRC0_TO_FLOAT into_float
 #else
 #define SRC0_TO_FLOAT CONVERT_FLOAT_T
 #endif
@@ -206,7 +206,8 @@
 
 #if SRC0_DT_BF16
 #define SRC0_BLOCK_READ(src) \
-    as_ushort(intel_sub_group_block_read_us((const __global ushort *)(src)))
+    as_bf16((short)intel_sub_group_block_read_us( \
+            (const __global ushort *)(src)))
 #define SRC0_BLOCK_READ2(src) \
     as_ushort2(intel_sub_group_block_read_us2((const __global ushort *)(src)))
 #define SRC0_BLOCK_READ4(src) \
@@ -217,7 +218,8 @@
 
 #if SRC1_DT_BF16
 #define SRC1_BLOCK_READ(src) \
-    as_ushort(intel_sub_group_block_read_us((const __global ushort *)(src)))
+    as_bf16((short)intel_sub_group_block_read_us( \
+            (const __global ushort *)(src)))
 #define SRC1_BLOCK_READ2(src) \
     as_ushort2(intel_sub_group_block_read_us2((const __global ushort *)(src)))
 #define SRC1_BLOCK_READ4(src) \
@@ -342,7 +344,8 @@
 
 #if DST_DT_BF16
 #define DST_BLOCK_READ(src) \
-    as_ushort(intel_sub_group_block_read_us((const __global ushort *)(src)))
+    as_bf16((short)intel_sub_group_block_read_us( \
+            (const __global ushort *)(src)))
 #define DST_BLOCK_READ2(src) \
     as_ushort2(intel_sub_group_block_read_us2((const __global ushort *)(src)))
 #define DST_BLOCK_READ4(src) \
@@ -350,14 +353,14 @@
 #define DST_BLOCK_READ8(src) \
     as_ushort8(intel_sub_group_block_read_us8((const __global ushort *)(src)))
 #define DST_BLOCK_WRITE(dst, val) \
-    intel_sub_group_block_write_us((__global ushort *)(dst), as_ushort(val))
+    intel_sub_group_block_write_us((__global ushort *)(dst), (ushort)(val).data)
 #define DST_BLOCK_WRITE2(dst, val) \
     intel_sub_group_block_write_us2((__global ushort *)(dst), as_ushort2(val))
 #define DST_BLOCK_WRITE4(dst, val) \
     intel_sub_group_block_write_us4((__global ushort *)(dst), as_ushort4(val))
 #define DST_BLOCK_WRITE8(dst, val) \
     intel_sub_group_block_write_us8((__global ushort *)(dst), as_ushort8(val))
-#endif // SRC_DT_F16
+#endif // DST_DT_BF16
 
 #if NVECT == 1 || IS_PLAIN_LAYOUT
 #define ELEM_DATA_T float

--- a/src/gpu/intel/bnorm/ref.cpp
+++ b/src/gpu/intel/bnorm/ref.cpp
@@ -121,7 +121,7 @@ static void init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
         const conf_t &conf, const compute::dispatch_t &dispatch,
         const offsets_t &off) {
     kernel_ctx.require_stateless_addressing(conf.require_stateless_addressing);
-    kernel_ctx.set_data_type(conf.data_type, false);
+    kernel_ctx.set_data_type(conf.data_type);
 
     kernel_ctx.define_int("NDIMS", conf.ndims);
     kernel_ctx.define_int("MB", conf.mb);

--- a/src/gpu/intel/bnorm/reusable.cpp
+++ b/src/gpu/intel/bnorm/reusable.cpp
@@ -207,7 +207,7 @@ static status_t init_conf_common(reusable_params_t &conf,
 
 static void init_kernel_ctx_common(
         compute::kernel_ctx_t &kernel_ctx, const reusable_params_t &conf) {
-    kernel_ctx.set_data_type(conf.data_type, false);
+    kernel_ctx.set_data_type(conf.data_type);
     kernel_ctx.require_stateless_addressing(conf.require_stateless_addressing);
 
     kernel_ctx.define_int("WITH_RELU", conf.with_relu);

--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -122,7 +122,7 @@ public:
         return has_macro(name.c_str());
     }
 
-    void set_data_type(data_type_t dt, bool with_punning = true) {
+    void set_data_type(data_type_t dt) {
         switch (dt) {
             case data_type::bf16: define_int("DT_BF16", 1); break;
             case data_type::f16: define_int("DT_F16", 1); break;
@@ -135,9 +135,10 @@ public:
             case data_type::f4_e2m1: define_int("DT_F4_E2M1", 1); break;
             case data_type::f4_e3m0: define_int("DT_F4_E3M0", 1); break;
             case data_type::s32: define_int("DT_S32", 1); break;
+            case data_type::s4: define_int("DT_S4", 1); break;
+            case data_type::u4: define_int("DT_U4", 1); break;
             default: assert(!"unknown data type"); break;
         }
-        define_int("WITH_PUNNING", with_punning);
     }
 
     std::string data_type() const {

--- a/src/gpu/intel/concat/xe.cpp
+++ b/src/gpu/intel/concat/xe.cpp
@@ -171,16 +171,14 @@ status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
 
 static status_t init_kernel_ctx_common(
         compute::kernel_ctx_t &kernel_ctx, const conf_t &conf) {
-    constexpr bool with_punning = false;
-
     for (int i = 0; i < conf.n; ++i) {
         kernel_ctx.define_int(utils::format("SRC%d_END", i), conf.offset[i]);
         def_memory_desc_info(kernel_ctx, conf.src_md_infos[i],
-                utils::format("SRC%d", i).c_str(), with_punning);
+                utils::format("SRC%d", i).c_str());
     }
-    def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST", with_punning);
+    def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");
 
-    kernel_ctx.set_data_type(conf.src_type, with_punning);
+    kernel_ctx.set_data_type(conf.src_type);
     kernel_ctx.require_stateless_addressing(conf.require_stateless_addressing);
 
     kernel_ctx.define_int("NDIMS", conf.ndims);

--- a/src/gpu/intel/conv/ref.cpp
+++ b/src/gpu/intel/conv/ref.cpp
@@ -129,22 +129,22 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int(
             "IS_BWD_W", conf.prop_kind == prop_kind::backward_weights);
 
-    def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC", false);
-    def_memory_desc_info(kernel_ctx, conf.wei_md_info, "WEI", false);
-    def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST", false);
+    def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC");
+    def_memory_desc_info(kernel_ctx, conf.wei_md_info, "WEI");
+    def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");
 
     def_dispatch(kernel_ctx, conf.dispatch);
 
     switch (conf.prop_kind) {
         case prop_kind::forward_training:
         case prop_kind::forward_inference:
-            kernel_ctx.set_data_type(conf.dst_data_type, false);
+            kernel_ctx.set_data_type(conf.dst_data_type);
             break;
         case prop_kind::backward_data:
-            kernel_ctx.set_data_type(conf.src_data_type, false);
+            kernel_ctx.set_data_type(conf.src_data_type);
             break;
         case prop_kind::backward_weights:
-            kernel_ctx.set_data_type(conf.weights_data_type, false);
+            kernel_ctx.set_data_type(conf.weights_data_type);
             break;
         default: break;
     }
@@ -153,18 +153,18 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("DST_DT_DIGITS",
             dnnl::impl::types::digits<uint32_t>(conf.dst_data_type));
 
-    def_data_type(kernel_ctx, conf.src_data_type, "SRC", false);
-    def_data_type(kernel_ctx, conf.weights_data_type, "WEI", false);
-    def_data_type(kernel_ctx, conf.bias_data_type, "BIA", false);
-    def_data_type(kernel_ctx, conf.dst_data_type, "DST", false);
-    def_data_type(kernel_ctx, conf.acc_data_type, "ACC", false);
+    def_data_type(kernel_ctx, conf.src_data_type, "SRC");
+    def_data_type(kernel_ctx, conf.weights_data_type, "WEI");
+    def_data_type(kernel_ctx, conf.bias_data_type, "BIA");
+    def_data_type(kernel_ctx, conf.dst_data_type, "DST");
+    def_data_type(kernel_ctx, conf.acc_data_type, "ACC");
     def_data_type(kernel_ctx,
             conf.attr_info.sum_data_type == dnnl_data_type_undef
                     ? conf.dst_data_type
                     : conf.attr_info.sum_data_type,
-            "SUM", false);
+            "SUM");
 
-    CHECK(def_attr_info(kernel_ctx, conf.attr_info, post_ops, *dst_md, false));
+    CHECK(def_attr_info(kernel_ctx, conf.attr_info, post_ops, *dst_md));
     return status::success;
 }
 

--- a/src/gpu/intel/dynamic_scale.cl
+++ b/src/gpu/intel/dynamic_scale.cl
@@ -40,10 +40,10 @@ inline float fp_recipe(float group_max) {
 #endif
 
 __kernel void dynamic_scale_dst(__global float *restrict src,
-        __global uchar *restrict dst, __global uchar *restrict dst_scales,
-        long groupSize, long D0, long D1, long D2, long c_stride_d3,
-        long c_stride_d2, long c_stride_d1, long c_stride_d0, long c_stride_m,
-        long c_stride_n) {
+        __global DST_DATA_T *restrict dst,
+        __global DST_SCALES_DATA_T *restrict dst_scales, long groupSize,
+        long D0, long D1, long D2, long c_stride_d3, long c_stride_d2,
+        long c_stride_d1, long c_stride_d0, long c_stride_m, long c_stride_n) {
     long m = get_global_id(0);
     long n = get_global_id(1);
     long mb = get_global_id(2);

--- a/src/gpu/intel/eltwise/ref.cpp
+++ b/src/gpu/intel/eltwise/ref.cpp
@@ -86,11 +86,11 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int(
             "USE_GWS_GET", conf.with_zero_padding || with_binary_post_ops);
 
-    def_data_type(kernel_ctx, conf.data_md_info.data_type, "SRC", false);
-    def_memory_desc_info(kernel_ctx, conf.data_md_info, "DST", false);
+    def_data_type(kernel_ctx, conf.data_md_info.data_type, "SRC");
+    def_memory_desc_info(kernel_ctx, conf.data_md_info, "DST");
 
     if (!conf.is_forward) {
-        def_memory_desc_info(kernel_ctx, conf.data_diff_md_info, "DIFF", false);
+        def_memory_desc_info(kernel_ctx, conf.data_diff_md_info, "DIFF");
     } else {
         kernel_ctx.define_int("IS_FWD", 1);
     }

--- a/src/gpu/intel/eltwise/xe.cl
+++ b/src/gpu/intel/eltwise/xe.cl
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "gpu/intel/include/eltwise.h"
+#include "gpu/intel/include/io.h"
 #include "gpu/intel/include/post_ops.h"
 
 __attribute__((intel_reqd_sub_group_size(SIMD))) __kernel void xe_eltwise_fwd(
@@ -25,47 +26,34 @@ __attribute__((intel_reqd_sub_group_size(SIMD))) __kernel void xe_eltwise_fwd(
     const dim_t sgid = get_sub_group_id();
     const dim_t lid = get_sub_group_local_id();
 
-    const dim_t gid = get_global_id(0);
-
     dim_t offset
             = (grid * grsize + sgid * get_max_sub_group_size()) * VECT_DT_N;
 
-    // grsize is a multiple of 16, SIMD is 16 -> offset mod 16 = 0
-    // -> read_pos correctly aligned for block reads
-    // -> write_pos correctly aligned for block writes
-    __global BLOCK_DATA_T *read_pos = (__global BLOCK_DATA_T *)src + offset;
-    __global BLOCK_DATA_T *write_pos = (__global BLOCK_DATA_T *)dst + offset;
-
-    VECT_DATA_T val;
+    FLT_ACC_DATA_T val[VECT_DT_N] = {0};
     const int nel_per_read = SIMD * VECT_DT_N;
 
     // READ
     if (!NELEMS_OVERFLOW || offset + nel_per_read < nelems) {
-        val = AS_VECT_DATA_T(VECT_BLOCK_READ(read_pos));
-
+        block_load(val, src + offset, VECT_DT_N);
     } else {
-        // read data in the same access pattern block_reads would
         dim_t pos = offset + lid;
         for (int i = 0; i < VECT_DT_N && pos < nelems; ++i) {
-            val[i] = src[pos];
+            val[i] = TO_FLT_ACC_DATA_T(src[pos]);
             pos += SIMD;
         }
     }
 
     // COMPUTE
-    for (int i = 0; i < VECT_DT_N; ++i) {
-        val[i] = CONVERT_DATA_T(
-                fwd_eltwise(DATA_TO_REF(val[i]), alpha, beta, 1.0f));
-    }
+    for (int i = 0; i < VECT_DT_N; ++i)
+        val[i] = fwd_eltwise(val[i], alpha, beta, 1.0f);
 
     // WRITE
     if (!NELEMS_OVERFLOW || offset + nel_per_read < nelems) {
-        VECT_BLOCK_WRITE(write_pos, AS_VECT_BLOCK_DATA_T(val));
-
+        block_write(dst + offset, val, VECT_DT_N);
     } else {
         dim_t pos = offset + lid;
         for (int i = 0; i < VECT_DT_N && pos < nelems; ++i) {
-            dst[pos] = val[i];
+            write(dst + pos, val + i);
             pos += SIMD;
         }
     }
@@ -80,52 +68,35 @@ __attribute__((intel_reqd_sub_group_size(SIMD))) __kernel void xe_eltwise_bwd(
     const dim_t lid = get_sub_group_local_id();
 
     dim_t offset = (grid * grsize + sgid * SIMD) * VECT_DT_N;
-    //TODO: It should be implemented two distinct offsets
-    //The one for src and the second for diff_src
 
-    // grsize is a multiple of 16, SIMD is 16 -> offset mod 16 = 0
-    // -> read_pos correctly aligned for block reads
-    // -> write_pos correctly aligned for block writes
-    __global BLOCK_DATA_T *src_pos = (__global BLOCK_DATA_T *)src + offset;
-    __global BLOCK_DATA_T *diff_pos
-            = (__global BLOCK_DATA_T *)diff_dst + offset;
-    __global BLOCK_DATA_T *write_pos
-            = (__global BLOCK_DATA_T *)diff_src + offset;
-
-    VECT_DATA_T val_dd;
-    VECT_DATA_T val_src;
+    FLT_ACC_DATA_T val_dd[VECT_DT_N] = {0};
+    FLT_ACC_DATA_T val_src[VECT_DT_N] = {0};
     const int nel_per_read = SIMD * VECT_DT_N;
 
     // READ
     if (!NELEMS_OVERFLOW || offset + nel_per_read < nelems) {
-        val_src = AS_VECT_DATA_T(VECT_BLOCK_READ(src_pos));
-        val_dd = AS_VECT_DATA_T(VECT_BLOCK_READ(diff_pos));
-
+        block_load(val_src, src + offset, VECT_DT_N);
+        block_load(val_dd, diff_dst + offset, VECT_DT_N);
     } else {
-        // read data in the same access pattern block_reads would
         dim_t pos = offset + lid;
         for (int i = 0; i < VECT_DT_N && pos < nelems; ++i) {
-            val_dd[i] = diff_dst[pos];
-            val_src[i] = src[pos];
+            val_src[i] = TO_FLT_ACC_DATA_T(src[pos]);
+            val_dd[i] = TO_FLT_ACC_DATA_T(diff_dst[pos]);
             pos += SIMD;
         }
     }
 
     // COMPUTE
-    for (int i = 0; i < VECT_DT_N; ++i) {
-        val_dd[i] = CONVERT_DATA_T(bwd_eltwise(
-                DATA_TO_REF(val_dd[i]), DATA_TO_REF(val_src[i]), alpha, beta));
-    }
+    for (int i = 0; i < VECT_DT_N; ++i)
+        val_dd[i] = bwd_eltwise(val_dd[i], val_src[i], alpha, beta);
 
     // WRITE
     if (!NELEMS_OVERFLOW || offset + nel_per_read < nelems) {
-        VECT_BLOCK_WRITE(write_pos, AS_VECT_BLOCK_DATA_T(val_dd));
-
+        block_write(diff_src + offset, val_dd, VECT_DT_N);
     } else {
-        // write data in the same access pattern block_writes would
         dim_t pos = offset + lid;
         for (int i = 0; i < VECT_DT_N && pos < nelems; ++i) {
-            diff_src[pos] = val_dd[i];
+            write(diff_src + pos, val_dd + i);
             pos += SIMD;
         }
     }

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -213,17 +213,17 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
         return info;
     }();
 
-    def_memory_desc_info(kernel_ctx, src_info, "SRC", false);
-    def_memory_desc_info(kernel_ctx, bias_info, "BIAS", false);
+    def_memory_desc_info(kernel_ctx, src_info, "SRC");
+    def_memory_desc_info(kernel_ctx, bias_info, "BIAS");
     if (dynamic_scales_) {
         dnnl_memory_desc d_md(*dst_md(0));
         d_md.data_type = acc_type_;
         memory_desc_wrapper d_mdw(d_md);
         def_memory_desc_info(
-                kernel_ctx, memory_desc_info_t::create(d_mdw), "DST", false);
+                kernel_ctx, memory_desc_info_t::create(d_mdw), "DST");
     } else {
-        def_memory_desc_info(kernel_ctx, memory_desc_info_t::create(dst_md(0)),
-                "DST", false);
+        def_memory_desc_info(
+                kernel_ctx, memory_desc_info_t::create(dst_md(0)), "DST");
     }
 
     int ndims = src_info.ndims;
@@ -250,7 +250,7 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
 
     kernel_ctx.define_int("NDIMS", ndims);
     CHECK(def_attr_info(
-            kernel_ctx, attr_info_, attr()->post_ops_, *pd_->dst_md(), false));
+            kernel_ctx, attr_info_, attr()->post_ops_, *pd_->dst_md()));
     kernel_ctx.define_int("A_SCALES", with_src_scales);
     kernel_ctx.define_int("B_SCALES", with_wei_scales);
     kernel_ctx.define_int("C_SCALES", with_dst_scales);

--- a/src/gpu/intel/gemm/with_post_ops.hpp
+++ b/src/gpu/intel/gemm/with_post_ops.hpp
@@ -82,12 +82,12 @@ struct with_post_ops_t : public primitive_t {
             dnnl_memory_desc dst_md(*(pd()->dst_md(0)));
             dst_md.data_type = pd()->dst_type_;
             memory_desc_wrapper dst_d(dst_md);
-            def_memory_desc_info(alt_ctx, src_info, "SRC", false);
+            def_memory_desc_info(alt_ctx, src_info, "SRC");
             def_memory_desc_info(
-                    alt_ctx, memory_desc_info_t::create(dst_d), "DST", false);
+                    alt_ctx, memory_desc_info_t::create(dst_d), "DST");
             def_data_type(alt_ctx,
                     pd()->attr()->scales_.get_data_type(DNNL_ARG_DST),
-                    "DST_SCALES", false);
+                    "DST_SCALES");
             const int ndims = dst_d.ndims();
             bool runtime_dims
                     = pd()->has_runtime_dims_or_strides() || ndims > 5;

--- a/src/gpu/intel/include/conversion.h
+++ b/src/gpu/intel/include/conversion.h
@@ -138,10 +138,10 @@ float8 __builtin_IB_bftof_8(short8 a) __attribute__((const));
 float16 __builtin_IB_bftof_16(short16 a) __attribute__((const));
 
 bf16 __attribute__((overloadable)) into_bf16(float x) {
-    return as_bf16(__builtin_IB_ftobf_1(x));
+    return as_bf16((ushort)__builtin_IB_ftobf_1(x));
 }
 float __attribute__((overloadable)) into_float(bf16 x) {
-    return __builtin_IB_bftof_1(x.data);
+    return __builtin_IB_bftof_1((short)x.data);
 }
 #else
 // Emulated conversions
@@ -202,7 +202,7 @@ f4_e2m1 __attribute__((overloadable)) into_f4_e2m1(float f) {
     return as_f4_e2m1(cvt_f32_to_f4_e2m1(f));
 }
 
-half __attribute__((overloadable)) into_float(f4_e2m1 b) {
+float __attribute__((overloadable)) into_float(f4_e2m1 b) {
     return cvt_f4_e2m1_to_f32(b.data);
 }
 
@@ -219,7 +219,7 @@ f4_e3m0 __attribute__((overloadable)) into_f4_e3m0(float f) {
     return as_f4_e3m0(cvt_f32_to_f4_e3m0(f));
 }
 
-half __attribute__((overloadable)) into_float(f4_e3m0 b) {
+float __attribute__((overloadable)) into_float(f4_e3m0 b) {
     return cvt_f4_e3m0_to_f32(b.data);
 }
 
@@ -231,9 +231,45 @@ IF_DOUBLE_SUPPORTED(def_two_step_conversion(f4_e3m0, double, float));
 IF_DOUBLE_SUPPORTED(def_two_step_conversion(double, f4_e3m0, float));
 #endif // MATH_UTILS_DECLARE_F4_E3M0
 
+s4 __attribute__((overloadable)) into_s4(s4 val) { return val; }
+
+s4 __attribute__((overloadable)) into_s4(float f) {
+    s4 res;
+    res.data = cvt_f32_to_s4(f);
+    return res;
+}
+
+float __attribute__((overloadable)) into_float(s4 b) {
+    return cvt_s4_to_f32(b.data);
+}
+
+u4 __attribute__((overloadable)) into_u4(u4 val) { return val; }
+
+u4 __attribute__((overloadable)) into_u4(float f) {
+    u4 res;
+    res.data = cvt_f32_to_u4(f);
+    return res;
+}
+
+float __attribute__((overloadable)) into_float(u4 b) {
+    return convert_float(b.data & 0x0f);
+}
+
+#ifdef cl_khr_fp16
+half __attribute__((overloadable)) into_half(s4 b) {
+    return (half)into_float(b);
+}
+half __attribute__((overloadable)) into_half(u4 b) {
+    return (half)into_float(b);
+}
+#endif
+
 #ifdef MATH_UTILS_DECLARE_E8M0
 float __attribute__((overloadable)) into_float(e8m0 b) {
     return cvt_e8m0_to_f32(b.data);
+}
+e8m0 __attribute__((overloadable)) into_e8m0(float f) {
+    return as_e8m0(cvt_f32_to_e8m0(f));
 }
 #endif
 

--- a/src/gpu/intel/include/custom_types.h
+++ b/src/gpu/intel/include/custom_types.h
@@ -29,10 +29,10 @@ typedef long off_t;
 #endif
 
 typedef struct {
-    short data;
+    ushort data;
 } bf16;
 
-bf16 as_bf16(short data) {
+bf16 as_bf16(ushort data) {
     bf16 res;
     res.data = data;
     return res;
@@ -41,10 +41,10 @@ bf16 as_bf16(short data) {
 /*****************************/
 
 typedef struct {
-    char data;
+    uchar data;
 } f8_e5m2;
 
-f8_e5m2 as_f8_e5m2(char data) {
+f8_e5m2 as_f8_e5m2(uchar data) {
     f8_e5m2 res;
     res.data = data;
     return res;
@@ -53,10 +53,10 @@ f8_e5m2 as_f8_e5m2(char data) {
 /*****************************/
 
 typedef struct {
-    char data;
+    uchar data;
 } f8_e4m3;
 
-f8_e4m3 as_f8_e4m3(char data) {
+f8_e4m3 as_f8_e4m3(uchar data) {
     f8_e4m3 res;
     res.data = data;
     return res;
@@ -77,7 +77,7 @@ e8m0 as_e8m0(unsigned char data) {
 /*****************************/
 
 typedef struct {
-    char data;
+    uchar data;
 } f4_e2m1;
 
 f4_e2m1 as_f4_e2m1(unsigned char data) {
@@ -89,11 +89,35 @@ f4_e2m1 as_f4_e2m1(unsigned char data) {
 /*****************************/
 
 typedef struct {
-    char data;
+    uchar data;
 } f4_e3m0;
 
 f4_e3m0 as_f4_e3m0(unsigned char data) {
     f4_e3m0 res;
+    res.data = data;
+    return res;
+}
+
+/*****************************/
+
+typedef struct {
+    char data;
+} s4;
+
+s4 as_s4(uchar data) {
+    s4 res;
+    res.data = (char)data;
+    return res;
+}
+
+/*****************************/
+
+typedef struct {
+    uchar data;
+} u4;
+
+u4 as_u4(uchar data) {
+    u4 res;
     res.data = data;
     return res;
 }

--- a/src/gpu/intel/include/eltwise.h
+++ b/src/gpu/intel/include/eltwise.h
@@ -62,7 +62,8 @@ POST_OP_DATA_T linear_bwd(POST_OP_DATA_T dd, float alpha) {
 
 POST_OP_DATA_T soft_relu_fwd(POST_OP_DATA_T s, float alpha) {
     s = alpha * s;
-    POST_OP_DATA_T v = (s < log((POST_OP_DATA_T)DATA_MAX) ? log1p(exp(s)) : s);
+    POST_OP_DATA_T v
+            = (s < log(CONVERT_POST_OP_DATA_T(DATA_MAX)) ? log1p(exp(s)) : s);
     return v / alpha;
 }
 POST_OP_DATA_T soft_relu_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {

--- a/src/gpu/intel/include/io.h
+++ b/src/gpu/intel/include/io.h
@@ -48,6 +48,8 @@
 #define SIZE_f8_e4m3 1
 #define SIZE_f4_e2m1 0
 #define SIZE_f4_e3m0 0
+#define SIZE_s4 0
+#define SIZE_u4 0
 #define SIZE_e8m0 1
 #define SIZE_bf16 2
 #define SIZE_half 2
@@ -80,6 +82,8 @@ DECLARE_AS_STRUCT_BLOCK(f4_e2m1)
 #ifdef MATH_UTILS_DECLARE_F4_E3M0
 DECLARE_AS_STRUCT_BLOCK(f4_e3m0)
 #endif
+DECLARE_AS_STRUCT_BLOCK(s4)
+DECLARE_AS_STRUCT_BLOCK(u4)
 DECLARE_AS_BLOCK(char)
 DECLARE_AS_BLOCK(uchar)
 DECLARE_AS_STRUCT_BLOCK(f8_e5m2)
@@ -349,11 +353,31 @@ DEF_write(f4_e3m0, int);
 
 #endif // MATH_UTILS_DECLARE_F4_E3M0
 
+// Loads
+DEF_load_half_byte(float, s4);
+#ifdef cl_khr_fp16
+DEF_load_half_byte(half, s4);
+#endif
+
+// Writes
+DEF_write(s4, float);
+DEF_write(s4, int);
+
+// Loads
+DEF_load_half_byte(float, u4);
+#ifdef cl_khr_fp16
+DEF_load_half_byte(half, u4);
+#endif
+
+// Writes
+DEF_write(u4, float);
+DEF_write(u4, int);
+
 #ifdef MATH_UTILS_DECLARE_E8M0
 // Loads
 DEF_load(float, e8m0);
 
-#endif
+#endif // MATH_UTILS_DECLARE_E8M0
 
 #endif // cl_khr_fp16
 

--- a/src/gpu/intel/include/math_utils.h
+++ b/src/gpu/intel/include/math_utils.h
@@ -404,12 +404,11 @@ ushort2  __attribute__((overloadable)) cvt_f32_to_bf16(float2  a) { return as_us
 ushort4  __attribute__((overloadable)) cvt_f32_to_bf16(float4  a) { return as_ushort4 (__builtin_IB_ftobf_4 (a)); }
 ushort8  __attribute__((overloadable)) cvt_f32_to_bf16(float8  a) { return as_ushort8 (__builtin_IB_ftobf_8 (a)); }
 ushort16 __attribute__((overloadable)) cvt_f32_to_bf16(float16 a) { return as_ushort16(__builtin_IB_ftobf_16(a)); }
-
-float   __attribute__((overloadable)) cvt_bf16_to_f32(ushort   a) { return __builtin_IB_bftof_1 (as_short  (a)); }
-float2  __attribute__((overloadable)) cvt_bf16_to_f32(ushort2  a) { return __builtin_IB_bftof_2 (as_short2 (a)); }
-float4  __attribute__((overloadable)) cvt_bf16_to_f32(ushort4  a) { return __builtin_IB_bftof_4 (as_short4 (a)); }
-float8  __attribute__((overloadable)) cvt_bf16_to_f32(ushort8  a) { return __builtin_IB_bftof_8 (as_short8 (a)); }
-float16 __attribute__((overloadable)) cvt_bf16_to_f32(ushort16 a) { return __builtin_IB_bftof_16(as_short16(a)); }
+float    __attribute__((overloadable)) cvt_bf16_to_f32(ushort   a) { return __builtin_IB_bftof_1 (as_short  (a)); }
+float2   __attribute__((overloadable)) cvt_bf16_to_f32(ushort2  a) { return __builtin_IB_bftof_2 (as_short2 (a)); }
+float4   __attribute__((overloadable)) cvt_bf16_to_f32(ushort4  a) { return __builtin_IB_bftof_4 (as_short4 (a)); }
+float8   __attribute__((overloadable)) cvt_bf16_to_f32(ushort8  a) { return __builtin_IB_bftof_8 (as_short8 (a)); }
+float16  __attribute__((overloadable)) cvt_bf16_to_f32(ushort16 a) { return __builtin_IB_bftof_16(as_short16(a)); }
 
 #ifdef cl_khr_fp64
 double   __attribute__((overloadable)) cvt_bf16_to_f64(ushort   a) { return convert_double(__builtin_IB_bftof_1 (as_short  (a))); }
@@ -687,8 +686,6 @@ inline float atomic_add_global(
 #endif
 #endif
 
-#if MATH_UTILS_DECLARE_S4 || MATH_UTILS_DECLARE_U4
-
 uchar __attribute__((overloadable)) cvt_f32_to_u4(float a) {
     uchar i = convert_uchar_sat_rte(a);
     return (i & 0xf0) ? 0x0f : i & 0x0f;
@@ -710,7 +707,16 @@ float __attribute__((overloadable)) cvt_s4_to_s32(char a) {
     return convert_int_sat_rte(val);
 }
 
-#endif
+float __attribute__((overloadable)) cvt_s4_to_f32(s4 a) {
+    return cvt_s4_to_f32(a.data);
+}
+float __attribute__((overloadable)) cvt_s4_to_s32(s4 a) {
+    return cvt_s4_to_s32(a.data);
+}
+
+int __attribute__((overloadable)) cvt_u4_to_s32(u4 a) {
+    return (int)(a.data & 0x0f);
+}
 
 #if MATH_UTILS_DECLARE_F4_E2M1
 
@@ -804,8 +810,6 @@ float __attribute__((overloadable)) cvt_f4_e3m0_to_f32(uchar a) {
 
 #endif
 
-#if MATH_UTILS_DECLARE_S4 || MATH_UTILS_DECLARE_U4 \
-        || MATH_UTILS_DECLARE_F4_E2M1 || MATH_UTILS_DECLARE_F4_E3M0
 #define GET_HALF_BYTE(x, y) get_half_byte(x, y)
 
 uchar __attribute__((overloadable)) get_half_byte(
@@ -838,5 +842,34 @@ void __attribute__((overloadable)) set_double_half_byte(
     x[y / 2] = z;
 }
 
+s4 __attribute__((overloadable)) get_half_byte(const __global s4 *x, off_t y) {
+    return as_s4(get_half_byte((__global const uchar *)x, y));
+}
+void __attribute__((overloadable)) set_double_half_byte(
+        __global s4 *x, off_t y, uchar z) {
+    set_double_half_byte((__global uchar *)x, y, z);
+}
+
+u4 __attribute__((overloadable)) get_half_byte(const __global u4 *x, off_t y) {
+    return as_u4(get_half_byte((__global const uchar *)x, y));
+}
+void __attribute__((overloadable)) set_double_half_byte(
+        __global u4 *x, off_t y, uchar z) {
+    set_double_half_byte((__global uchar *)x, y, z);
+}
+
+#if MATH_UTILS_DECLARE_F4_E2M1
+f4_e2m1 __attribute__((overloadable)) get_half_byte(
+        const __global f4_e2m1 *x, off_t y) {
+    return as_f4_e2m1(get_half_byte((__global const uchar *)x, y));
+}
 #endif
+
+#if MATH_UTILS_DECLARE_F4_E3M0
+f4_e3m0 __attribute__((overloadable)) get_half_byte(
+        const __global f4_e3m0 *x, off_t y) {
+    return as_f4_e3m0(get_half_byte((__global const uchar *)x, y));
+}
+#endif
+
 #endif

--- a/src/gpu/intel/include/tile_ops.h
+++ b/src/gpu/intel/include/tile_ops.h
@@ -394,14 +394,16 @@ __attribute__((enable_if(sg == 16, "wrong subgroup size"))) {
     } while (0)
 
 #define tile_copy_to_vec2(t, t_new, type) \
+    tile_copy_to_vec2_cvt(t, t_new, type, CONVERT_DATA_T)
+
+#define tile_copy_to_vec2_cvt(t, t_new, type, cvt) \
     do { \
         _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \
                                i++) { \
             _Pragma("unroll") for (int s = 0; \
                                    s < sizeof(t.x[0]) / sizeof(t.x[0][0]) / 2; \
                                    s++) { \
-                type v = {CONVERT_DATA_T(t.x[i][2 * s]), \
-                        CONVERT_DATA_T(t.x[i][2 * s + 1])}; \
+                type v = {cvt(t.x[i][2 * s]), cvt(t.x[i][2 * s + 1])}; \
                 t_new.x[i][s] = as_uint(v); \
             } \
         } \

--- a/src/gpu/intel/include/types.h
+++ b/src/gpu/intel/include/types.h
@@ -87,6 +87,7 @@
 #ifndef GPU_INTEL_INCLUDE_TYPES_H
 #define GPU_INTEL_INCLUDE_TYPES_H
 
+#include "gpu/intel/include/conversion.h"
 #include "gpu/intel/include/custom_types.h"
 #include "gpu/intel/include/math_utils.h"
 #include "gpu/intel/include/types_specific.h"
@@ -116,8 +117,10 @@
 
 #if DT_F64 == 1
 #define AS_POST_OP_DATA_T(v) v
+#define CONVERT_POST_OP_DATA_T convert_double
 #else
 #define AS_POST_OP_DATA_T(v) (float)(v)
+#define CONVERT_POST_OP_DATA_T CONVERT_FLOAT_T
 #endif
 
 #if DT_F32 == 1
@@ -295,36 +298,32 @@
 #define TO_FLT_ACC_DATA_T convert_float
 
 #elif DT_BF16 == 1
-#if WITH_PUNNING
-#define DATA_T ushort
-#else
 #define DATA_T bf16
-#endif
 #define DATA2_T ushort2
 #define POST_OP_DATA_T float
 #define DATA2_T ushort2
 #define DATA4_T ushort4
 #define DATA8_T ushort8
 #define DATA16_T ushort16
-#define DATA_MAX (ushort)0x7F7F
-#define DATA_MIN (ushort)0xFF7F
-#define DATA_ZERO (ushort)0x0000
-#define DATA_ONE (ushort)0x3F80
+#define DATA_MAX as_bf16((ushort)0x7F7F)
+#define DATA_MIN as_bf16((ushort)0xFF7F)
+#define DATA_ZERO as_bf16((ushort)0)
+#define DATA_ONE as_bf16((ushort)0x3F80)
 #define DEF_ACC_DATA_T float
 #define DEF_ACC_DATA2_T float2
 #define DEF_ACC_DATA4_T float4
 #define DEF_ACC_DATA8_T float8
-#define TO_DATA_T cvt_f32_to_bf16
-#define TO_DEF_ACC_DATA_T cvt_bf16_to_f32
+#define TO_DATA_T into_bf16
+#define TO_DEF_ACC_DATA_T into_float
 #define TO_DEF_ACC_DATA2_T cvt_bf16_to_f32
 #define TO_DEF_ACC_DATA4_T cvt_bf16_to_f32
 #define TO_DEF_ACC_DATA8_T cvt_bf16_to_f32
-#define DATA_TO_REF cvt_bf16_to_f32
-#define CONVERT_DATA_T(v) cvt_f32_to_bf16(convert_float(v))
+#define DATA_TO_REF into_float
+#define CONVERT_DATA_T(v) into_bf16(convert_float(v))
 #define CONVERT_DATA2_T(v) cvt_f32_to_bf16(convert_float2(v))
 #define CONVERT_DATA4_T(v) cvt_f32_to_bf16(convert_float4(v))
 #define CONVERT_DATA8_T(v) cvt_f32_to_bf16(convert_float8(v))
-#define CONVERT_FLOAT_T cvt_bf16_to_f32
+#define CONVERT_FLOAT_T into_float
 #define CONVERT_FLOAT2_T cvt_bf16_to_f32
 #define CONVERT_FLOAT4_T cvt_bf16_to_f32
 #define CONVERT_FLOAT8_T cvt_bf16_to_f32
@@ -337,7 +336,7 @@
 #define BLOCK_WRITE2 intel_sub_group_block_write_us2
 #define BLOCK_WRITE4 intel_sub_group_block_write_us4
 #define BLOCK_WRITE8 intel_sub_group_block_write_us8
-#define AS_DATA_T as_ushort
+#define AS_DATA_T as_bf16
 #define AS_DATA2_T as_ushort2
 #define AS_DATA4_T as_ushort4
 #define AS_DATA8_T as_ushort8
@@ -346,44 +345,40 @@
 #define BLOCK_DATA2_T ushort2
 #define BLOCK_DATA4_T ushort4
 #define BLOCK_DATA8_T ushort8
-#define AS_BLOCK_DATA_T as_ushort
+#define AS_BLOCK_DATA_T(v) (v).data
 #define AS_BLOCK_DATA2_T as_ushort2
 #define AS_BLOCK_DATA4_T as_ushort4
 #define AS_BLOCK_DATA8_T as_ushort8
 
 #define FLT_ACC_DATA_T float
-#define TO_FLT_ACC_DATA_T cvt_bf16_to_f32
+#define TO_FLT_ACC_DATA_T into_float
 
 #elif DT_BF8 == 1
-#if WITH_PUNNING
-#define DATA_T uchar
-#else
 #define DATA_T f8_e5m2
-#endif
 #define DATA2_T uchar2
 #define DATA4_T uchar4
 #define DATA8_T uchar8
 #define DATA16_T uchar16
-#define DATA_MAX (uchar)0x7B
-#define DATA_MIN (uchar)0xFB
-#define DATA_ZERO (uchar)0x00
-#define DATA_ONE (uchar)0x3C
+#define DATA_MAX as_f8_e5m2((uchar)0x7B)
+#define DATA_MIN as_f8_e5m2((uchar)0xFB)
+#define DATA_ZERO as_f8_e5m2((uchar)0x00)
+#define DATA_ONE as_f8_e5m2((uchar)0x3C)
 #define DEF_ACC_DATA_T float
 #define DEF_ACC_DATA2_T float2
 #define DEF_ACC_DATA4_T float4
 #define DEF_ACC_DATA8_T float8
 #define POST_OP_DATA_T float
-#define TO_DATA_T(v) cvt_hf_to_f8_e5m2(convert_half(v)
-#define TO_DEF_ACC_DATA_T(v) convert_float(cvt_f8_e5m2_to_hf(v))
+#define TO_DATA_T(v) into_f8_e5m2(v)
+#define TO_DEF_ACC_DATA_T(v) into_float(v)
 #define TO_DEF_ACC_DATA2_T(v) convert_float(cvt_f8_e5m2_to_hf(v))
 #define TO_DEF_ACC_DATA4_T(v) convert_float(cvt_f8_e5m2_to_hf(v))
 #define TO_DEF_ACC_DATA8_T(v) convert_float(cvt_f8_e5m2_to_hf(v))
-#define DATA_TO_REF(v) convert_float(cvt_f8_e5m2_to_hf(v))
-#define CONVERT_DATA_T(v) cvt_hf_to_f8_e5m2(convert_half(v))
+#define DATA_TO_REF(v) into_float(v)
+#define CONVERT_DATA_T(v) into_f8_e5m2(v)
 #define CONVERT_DATA2_T(v) cvt_hf_to_f8_e5m2(convert_half2(v))
 #define CONVERT_DATA4_T(v) cvt_hf_to_f8_e5m2(convert_half4(v))
 #define CONVERT_DATA8_T(v) cvt_hf_to_f8_e5m2(convert_half8(v))
-#define CONVERT_FLOAT_T(v) convert_float(cvt_f8_e5m2_to_hf(v))
+#define CONVERT_FLOAT_T(v) into_float(v)
 #define CONVERT_FLOAT2_T(v) convert_float2(cvt_f8_e5m2_to_hf(v))
 #define CONVERT_FLOAT4_T(v) convert_float4(cvt_f8_e5m2_to_hf(v))
 #define CONVERT_FLOAT8_T(v) convert_float8(cvt_f8_e5m2_to_hf(v))
@@ -396,7 +391,7 @@
 #define BLOCK_WRITE2 intel_sub_group_block_write_uc2
 #define BLOCK_WRITE4 intel_sub_group_block_write_uc4
 #define BLOCK_WRITE8 intel_sub_group_block_write_uc8
-#define AS_DATA_T as_uchar
+#define AS_DATA_T as_f8_e5m2
 #define AS_DATA2_T as_uchar2
 #define AS_DATA4_T as_uchar4
 #define AS_DATA8_T as_uchar8
@@ -406,7 +401,7 @@
 #define BLOCK_DATA2_T uchar2
 #define BLOCK_DATA4_T uchar4
 #define BLOCK_DATA8_T uchar8
-#define AS_BLOCK_DATA_T as_uchar
+#define AS_BLOCK_DATA_T(v) (v).data
 #define AS_BLOCK_DATA2_T as_uchar2
 #define AS_BLOCK_DATA4_T as_uchar4
 #define AS_BLOCK_DATA8_T as_uchar8
@@ -418,38 +413,34 @@
 #define MMAD_ACC_DATA8_T half8
 
 #define FLT_ACC_DATA_T float
-#define TO_FLT_ACC_DATA_T convert_float(cvt_f8_e5m2_to_hf(v))
+#define TO_FLT_ACC_DATA_T into_float
 
 #elif DT_HF8 == 1
-#if WITH_PUNNING
-#define DATA_T uchar
-#else
 #define DATA_T f8_e4m3
-#endif
 #define DATA2_T uchar2
 #define DATA4_T uchar4
 #define DATA8_T uchar8
 #define DATA16_T uchar16
-#define DATA_MAX (uchar)0x7E
-#define DATA_MIN (uchar)0xFE
-#define DATA_ZERO (uchar)0x00
-#define DATA_ONE (uchar)0x38
+#define DATA_MAX as_f8_e4m3((uchar)0x7E)
+#define DATA_MIN as_f8_e4m3((uchar)0xFE)
+#define DATA_ZERO as_f8_e4m3((uchar)0x00)
+#define DATA_ONE as_f8_e4m3((uchar)0x38)
 #define DEF_ACC_DATA_T float
 #define DEF_ACC_DATA2_T float2
 #define DEF_ACC_DATA4_T float4
 #define DEF_ACC_DATA8_T float8
 #define POST_OP_DATA_T float
-#define TO_DATA_T(v) cvt_hf_to_f8_e4m3(convert_half(v))
-#define TO_DEF_ACC_DATA_T(v) convert_float(cvt_f8_e4m3_to_hf(v))
+#define TO_DATA_T(v) into_f8_e4m3(v)
+#define TO_DEF_ACC_DATA_T(v) into_float(v)
 #define TO_DEF_ACC_DATA2_T(v) convert_float(cvt_f8_e4m3_to_hf(v))
 #define TO_DEF_ACC_DATA4_T(v) convert_float(cvt_f8_e4m3_to_hf(v))
 #define TO_DEF_ACC_DATA8_T(v) convert_float(cvt_f8_e4m3_to_hf(v))
-#define DATA_TO_REF(v) convert_float(cvt_f8_e4m3_to_hf(v))
-#define CONVERT_DATA_T(v) cvt_hf_to_f8_e4m3(convert_half(v))
+#define DATA_TO_REF(v) into_float(v)
+#define CONVERT_DATA_T(v) into_f8_e4m3(v)
 #define CONVERT_DATA2_T(v) cvt_hf_to_f8_e4m3(convert_half2(v))
 #define CONVERT_DATA4_T(v) cvt_hf_to_f8_e4m3(convert_half4(v))
 #define CONVERT_DATA8_T(v) cvt_hf_to_f8_e4m3(convert_half8(v))
-#define CONVERT_FLOAT_T(v) convert_float(cvt_f8_e4m3_to_hf(v))
+#define CONVERT_FLOAT_T(v) into_float(v)
 #define CONVERT_FLOAT2_T(v) convert_float2(cvt_f8_e4m3_to_hf(v))
 #define CONVERT_FLOAT4_T(v) convert_float4(cvt_f8_e4m3_to_hf(v))
 #define CONVERT_FLOAT8_T(v) convert_float8(cvt_f8_e4m3_to_hf(v))
@@ -462,7 +453,7 @@
 #define BLOCK_WRITE2 intel_sub_group_block_write_uc2
 #define BLOCK_WRITE4 intel_sub_group_block_write_uc4
 #define BLOCK_WRITE8 intel_sub_group_block_write_uc8
-#define AS_DATA_T as_uchar
+#define AS_DATA_T as_f8_e4m3
 #define AS_DATA2_T as_uchar2
 #define AS_DATA4_T as_uchar4
 #define AS_DATA8_T as_uchar8
@@ -472,7 +463,7 @@
 #define BLOCK_DATA2_T uchar2
 #define BLOCK_DATA4_T uchar4
 #define BLOCK_DATA8_T uchar8
-#define AS_BLOCK_DATA_T as_uchar
+#define AS_BLOCK_DATA_T(v) (v).data
 #define AS_BLOCK_DATA2_T as_uchar2
 #define AS_BLOCK_DATA4_T as_uchar4
 #define AS_BLOCK_DATA8_T as_uchar8
@@ -484,38 +475,34 @@
 #define MMAD_ACC_DATA8_T half8
 
 #define FLT_ACC_DATA_T float
-#define TO_FLT_ACC_DATA_T(v) convert_float(cvt_f8_e4m3_to_hf(v))
+#define TO_FLT_ACC_DATA_T(v) into_float(v)
 
 #elif DT_F4_E3M0 == 1
-#if WITH_PUNNING
-#define DATA_T uchar
-#else
 #define DATA_T f4_e3m0
-#endif
 #define DATA2_T uchar2
 #define DATA4_T uchar4
 #define DATA8_T uchar8
 #define DATA16_T uchar16
-#define DATA_MAX (uchar)0x07
-#define DATA_MIN (uchar)0x08
-#define DATA_ZERO (uchar)0x00
-#define DATA_ONE (uchar)0x03
+#define DATA_MAX as_f4_e3m0((uchar)0x07)
+#define DATA_MIN as_f4_e3m0((uchar)0x08)
+#define DATA_ZERO as_f4_e3m0((uchar)0x00)
+#define DATA_ONE as_f4_e3m0((uchar)0x03)
 #define DEF_ACC_DATA_T float
 #define DEF_ACC_DATA2_T float2
 #define DEF_ACC_DATA4_T float4
 #define DEF_ACC_DATA8_T float8
 #define POST_OP_DATA_T float
-#define TO_DATA_T(v) cvt_f32_to_f4_e3m0((v))
-#define TO_DEF_ACC_DATA_T(v) (cvt_f4_e3m0_to_f32(v))
+#define TO_DATA_T(v) into_f4_e3m0(v)
+#define TO_DEF_ACC_DATA_T(v) into_float(v)
 #define TO_DEF_ACC_DATA2_T(v) (cvt_f4_e3m0_to_f32(v))
 #define TO_DEF_ACC_DATA4_T(v) (cvt_f4_e3m0_to_f32(v))
 #define TO_DEF_ACC_DATA8_T(v) (cvt_f4_e3m0_to_f32(v))
-#define DATA_TO_REF(v) (cvt_f4_e3m0_to_f32(v))
-#define CONVERT_DATA_T(v) cvt_f32_to_f4_e3m0(v)
+#define DATA_TO_REF(v) into_float(v)
+#define CONVERT_DATA_T(v) into_f4_e3m0(v)
 #define CONVERT_DATA2_T(v) cvt_f32_to_f4_e3m0(v)
 #define CONVERT_DATA4_T(v) cvt_f32_to_f4_e3m0(v)
 #define CONVERT_DATA8_T(v) cvt_f32_to_f4_e3m0(v)
-#define CONVERT_FLOAT_T(v) cvt_f4_e3m0_to_f32(v)
+#define CONVERT_FLOAT_T(v) into_float(v)
 #define CONVERT_FLOAT2_T(v) cvt_f4_e3m0_to_f32(v)
 #define CONVERT_FLOAT4_T(v) cvt_f4_e3m0_to_f32(v)
 #define CONVERT_FLOAT8_T(v) cvt_f4_e3m0_to_f32(v)
@@ -528,7 +515,7 @@
 #define BLOCK_WRITE2 intel_sub_group_block_write_uc2
 #define BLOCK_WRITE4 intel_sub_group_block_write_uc4
 #define BLOCK_WRITE8 intel_sub_group_block_write_uc8
-#define AS_DATA_T as_uchar
+#define AS_DATA_T as_f4_e3m0
 #define AS_DATA2_T as_uchar2
 #define AS_DATA4_T as_uchar4
 #define AS_DATA8_T as_uchar8
@@ -544,44 +531,40 @@
 #define BLOCK_DATA2_T uchar2
 #define BLOCK_DATA4_T uchar4
 #define BLOCK_DATA8_T uchar8
-#define AS_BLOCK_DATA_T as_uchar
+#define AS_BLOCK_DATA_T(v) (v).data
 #define AS_BLOCK_DATA2_T as_uchar2
 #define AS_BLOCK_DATA4_T as_uchar4
 #define AS_BLOCK_DATA8_T as_uchar8
 
 #define FLT_ACC_DATA_T float
-#define TO_FLT_ACC_DATA_T(v) (cvt_f4_e3m0_to_f32(v))
+#define TO_FLT_ACC_DATA_T(v) into_float(v)
 
 #elif DT_F4_E2M1 == 1
-#if WITH_PUNNING
-#define DATA_T uchar
-#else
 #define DATA_T f4_e2m1
-#endif
 #define DATA2_T uchar2
 #define DATA4_T uchar4
 #define DATA8_T uchar8
 #define DATA16_T uchar16
-#define DATA_MAX (uchar)0x07
-#define DATA_MIN (uchar)0x01
-#define DATA_ZERO (uchar)0x00
-#define DATA_ONE (uchar)0x02
+#define DATA_MAX as_f4_e2m1((uchar)0x07)
+#define DATA_MIN as_f4_e2m1((uchar)0x01)
+#define DATA_ZERO as_f4_e2m1((uchar)0x00)
+#define DATA_ONE as_f4_e2m1((uchar)0x02)
 #define DEF_ACC_DATA_T float
 #define DEF_ACC_DATA2_T float2
 #define DEF_ACC_DATA4_T float4
 #define DEF_ACC_DATA8_T float8
 #define POST_OP_DATA_T float
-#define TO_DATA_T(v) cvt_f32_to_f4_e2m1((v))
-#define TO_DEF_ACC_DATA_T(v) (cvt_f4_e2m1_to_f32(v))
+#define TO_DATA_T(v) into_f4_e2m1(v)
+#define TO_DEF_ACC_DATA_T(v) into_float(v)
 #define TO_DEF_ACC_DATA2_T(v) (cvt_f4_e2m1_to_f32(v))
 #define TO_DEF_ACC_DATA4_T(v) (cvt_f4_e2m1_to_f32(v))
 #define TO_DEF_ACC_DATA8_T(v) (cvt_f4_e2m1_to_f32(v))
-#define DATA_TO_REF(v) (cvt_f4_e2m1_to_f32(v))
-#define CONVERT_DATA_T(v) cvt_f32_to_f4_e2m1(v)
+#define DATA_TO_REF(v) into_float(v)
+#define CONVERT_DATA_T(v) into_f4_e2m1(v)
 #define CONVERT_DATA2_T(v) cvt_f32_to_f4_e2m1(v)
 #define CONVERT_DATA4_T(v) cvt_f32_to_f4_e2m1(v)
 #define CONVERT_DATA8_T(v) cvt_f32_to_f4_e2m1(v)
-#define CONVERT_FLOAT_T(v) cvt_f4_e2m1_to_f32(v)
+#define CONVERT_FLOAT_T(v) into_float(v)
 #define CONVERT_FLOAT2_T(v) cvt_f4_e2m1_to_f32(v)
 #define CONVERT_FLOAT4_T(v) cvt_f4_e2m1_to_f32(v)
 #define CONVERT_FLOAT8_T(v) cvt_f4_e2m1_to_f32(v)
@@ -594,7 +577,7 @@
 #define BLOCK_WRITE2 intel_sub_group_block_write_uc2
 #define BLOCK_WRITE4 intel_sub_group_block_write_uc4
 #define BLOCK_WRITE8 intel_sub_group_block_write_uc8
-#define AS_DATA_T as_uchar
+#define AS_DATA_T as_f4_e2m1
 #define AS_DATA2_T as_uchar2
 #define AS_DATA4_T as_uchar4
 #define AS_DATA8_T as_uchar8
@@ -610,13 +593,13 @@
 #define BLOCK_DATA2_T uchar2
 #define BLOCK_DATA4_T uchar4
 #define BLOCK_DATA8_T uchar8
-#define AS_BLOCK_DATA_T as_uchar
+#define AS_BLOCK_DATA_T(v) (v).data
 #define AS_BLOCK_DATA2_T as_uchar2
 #define AS_BLOCK_DATA4_T as_uchar4
 #define AS_BLOCK_DATA8_T as_uchar8
 
 #define FLT_ACC_DATA_T float
-#define TO_FLT_ACC_DATA_T(v) (cvt_f4_e2m1_to_f32(v))
+#define TO_FLT_ACC_DATA_T(v) into_float(v)
 
 #elif DT_S8 == 1
 #define DATA_T char
@@ -1022,12 +1005,12 @@
 #define FLOAT_TO_HALF1 convert_half
 #define FLOAT_TO_HALF8 convert_half8
 
-#define BFLOAT_TO_DOUBLE1 cvt_bf16_to_f64
-#define BFLOAT_TO_DOUBLE8 cvt_bf16_to_f64
+#define BFLOAT_TO_DOUBLE1(v) convert_double(into_float(v))
+#define BFLOAT_TO_DOUBLE8(v) convert_double8(cvt_bf16_to_f32(v))
 
-#define BFLOAT_TO_FLOAT1 cvt_bf16_to_f32
+#define BFLOAT_TO_FLOAT1 into_float
 #define BFLOAT_TO_FLOAT8 cvt_bf16_to_f32
-#define FLOAT_TO_BFLOAT1 cvt_f32_to_bf16
+#define FLOAT_TO_BFLOAT1 into_bf16
 #define FLOAT_TO_BFLOAT8 cvt_f32_to_bf16
 
 #define FLOAT_TO_FLOAT1 convert_float

--- a/src/gpu/intel/include/types_specific.h
+++ b/src/gpu/intel/include/types_specific.h
@@ -39,50 +39,50 @@
 #define SRC_TO_REF8(x) convert_float8(x)
 #define REF_TO_SRC(x) convert_char(x)
 #elif SRC_DT_BF16
-#define SRC_TO_REF(x) cvt_bf16_to_f32(x)
-#define SRC_TO_REF8(x) cvt_bf16_to_f32(x)
-#define REF_TO_SRC(x) cvt_f32_to_bf16(x)
+#define SRC_TO_REF(x) into_float(x)
+#define SRC_TO_REF8(x) into_float(x)
+#define REF_TO_SRC(x) into_bf16(x)
 #elif SRC_DT_F16
 #define SRC_TO_REF(x) convert_float(x)
 #define SRC_TO_REF8(x) convert_float8(x)
 #define REF_TO_SRC(x) convert_half(x)
 #elif SRC_DT_BF8
-#define SRC_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define SRC_TO_REF8(x) convert_float8(cvt_f8_e5m2_to_hf(x))
-#define REF_TO_SRC(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define SRC_TO_REF(x) into_float(x)
+#define SRC_TO_REF8(x) into_float(x)
+#define REF_TO_SRC(x) into_f8_e5m2(x)
 #elif SRC_DT_HF8
-#define SRC_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define SRC_TO_REF8(x) convert_float8(cvt_f8_e4m3_to_hf(x))
-#define REF_TO_SRC(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define SRC_TO_REF(x) into_float(x)
+#define SRC_TO_REF8(x) into_float(x)
+#define REF_TO_SRC(x) into_f8_e4m3(x)
 #elif SRC_DT_F4_E2M1
-#define SRC_TO_REF(x) cvt_f4_e2m1_to_f32(x)
-#define SRC_TO_REF8(x) cvt_f4_e2m1_to_f32(x)
-#define REF_TO_SRC(x) cvt_f32_to_f4_e2m1(x)
+#define SRC_TO_REF(x) into_float(x)
+#define SRC_TO_REF8(x) into_float(x)
+#define REF_TO_SRC(x) into_f4_e2m1(x)
 #elif SRC_DT_F4_E3M0
-#define SRC_TO_REF(x) cvt_f4_e3m0_to_f32(x)
-#define SRC_TO_REF8(x) cvt_f4_e3m0_to_f32(x)
-#define REF_TO_SRC(x) cvt_f32_to_f4_e3m0(x)
+#define SRC_TO_REF(x) into_float(x)
+#define SRC_TO_REF8(x) into_float(x)
+#define REF_TO_SRC(x) into_f4_e3m0(x)
 #elif SRC_DT_U4
-#define SRC_TO_REF(x) convert_float(x)
+#define SRC_TO_REF(x) into_float(x)
 #elif SRC_DT_S4
-#define SRC_TO_REF(x) convert_float(cvt_s4_to_f32(x))
+#define SRC_TO_REF(x) into_float(x)
 #else
 #define SRC_TO_REF(x) (x)
 #define SRC_TO_REF8(x) (x)
 #define REF_TO_SRC(x) (x)
 #endif
 #if SRC_DT_BF16
-#define TO_SRC(x) cvt_f32_to_bf16(x)
+#define TO_SRC(x) into_bf16(x)
 #elif SRC_DT_F16
 #define TO_SRC(x) convert_half(x)
 #elif SRC_DT_BF8
-#define TO_SRC(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define TO_SRC(x) into_f8_e5m2(x)
 #elif SRC_DT_HF8
-#define TO_SRC(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define TO_SRC(x) into_f8_e4m3(x)
 #elif SRC_DT_F4_E2M1
-#define TO_SRC(x) cvt_f32_to_f4_e2m1(x)
+#define TO_SRC(x) into_f4_e2m1(x)
 #elif SRC_DT_F4_E3M0
-#define TO_SRC(x) cvt_f32_to_f4_e3m0(x)
+#define TO_SRC(x) into_f4_e3m0(x)
 #elif SRC_DT_U8
 #define TO_SRC(x) convert_uchar_sat_rte(x)
 #elif SRC_DT_S8
@@ -96,40 +96,40 @@
 
 #ifdef A_DATA_T
 #if A_DT_BF16
-#define A_TO_REF(x) cvt_bf16_to_f32(x)
-#define A_TO_REF8(x) cvt_bf16_to_f32(x)
-#define REF_TO_A(x) cvt_f32_to_bf16(x)
+#define A_TO_REF(x) into_float(x)
+#define A_TO_REF8(x) into_float(x)
+#define REF_TO_A(x) into_bf16(x)
 #elif A_DT_BF8
-#define A_TO_REF(x) cvt_f8_e5m2_to_hf(x)
-#define A_TO_REF8(x) cvt_f8_e5m2_to_hf(x)
-#define REF_TO_A(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define A_TO_REF(x) into_half(x)
+#define A_TO_REF8(x) into_half(x)
+#define REF_TO_A(x) into_f8_e5m2(x)
 #elif A_DT_HF8
-#define A_TO_REF(x) cvt_f8_e4m3_to_hf(x)
-#define A_TO_REF8(x) cvt_f8_e4m3_to_hf(x)
-#define REF_TO_A(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define A_TO_REF(x) into_half(x)
+#define A_TO_REF8(x) into_half(x)
+#define REF_TO_A(x) into_f8_e4m3(x)
 #elif A_DT_F4_E2M1
-#define A_TO_REF(x) cvt_f4_e2m1_to_f32(x)
-#define A_TO_REF8(x) cvt_f4_e2m1_to_f32(x)
-#define REF_TO_A(x) cvt_f32_to_f4_e2m1(x)
+#define A_TO_REF(x) into_float(x)
+#define A_TO_REF8(x) into_float(x)
+#define REF_TO_A(x) into_f4_e2m1(x)
 #elif A_DT_F4_E3M0
-#define A_TO_REF(x) cvt_f4_e3m0_to_f32(x)
-#define A_TO_REF8(x) cvt_f4_e3m0_to_f32(x)
-#define REF_TO_A(x) cvt_f32_to_f4_e3m0(x)
+#define A_TO_REF(x) into_float(x)
+#define A_TO_REF8(x) into_float(x)
+#define REF_TO_A(x) into_f4_e3m0(x)
 #else
 #define A_TO_REF(x) (x)
 #define A_TO_REF8(x) (x)
 #define REF_TO_A(x) (x)
 #endif
 #if A_DT_BF16
-#define TO_A(x) cvt_f32_to_bf16(x)
+#define TO_A(x) into_bf16(x)
 #elif A_DT_BF8
-#define TO_A(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define TO_A(x) into_f8_e5m2(x)
 #elif A_DT_HF8
-#define TO_A(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define TO_A(x) into_f8_e4m3(x)
 #elif A_DT_F4_E2M1
-#define TO_A(x) cvt_f32_to_f4_e2m1(x)
+#define TO_A(x) into_f4_e2m1(x)
 #elif A_DT_F4_E3M0
-#define TO_A(x) cvt_f32_to_f4_e3m0(x)
+#define TO_A(x) into_f4_e3m0(x)
 #elif A_DT_U8
 #define TO_A(x) convert_uchar_sat_rte(x)
 #elif A_DT_S8
@@ -143,20 +143,20 @@
 
 #ifdef WEI_DATA_T
 #if WEI_DT_BF16
-#define WEI_TO_REF(x) cvt_bf16_to_f32(x)
-#define REF_TO_WEI(x) cvt_f32_to_bf16(x)
+#define WEI_TO_REF(x) into_float(x)
+#define REF_TO_WEI(x) into_bf16(x)
 #elif WEI_DT_BF8
-#define WEI_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define REF_TO_WEI(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define WEI_TO_REF(x) into_float(x)
+#define REF_TO_WEI(x) into_f8_e5m2(x)
 #elif WEI_DT_HF8
-#define WEI_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define REF_TO_WEI(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define WEI_TO_REF(x) into_float(x)
+#define REF_TO_WEI(x) into_f8_e4m3(x)
 #elif WEI_DT_F4_E2M1
-#define WEI_TO_REF(x) cvt_f4_e2m1_to_f32(x)
-#define REF_TO_WEI(x) cvt_f32_to_f4_e2m1(x)
+#define WEI_TO_REF(x) into_float(x)
+#define REF_TO_WEI(x) into_f4_e2m1(x)
 #elif WEI_DT_F4_E3M0
-#define WEI_TO_REF(x) cvt_f4_e3m0_to_f32(x)
-#define REF_TO_WEI(x) cvt_f32_to_f4_e3m0(x)
+#define WEI_TO_REF(x) into_float(x)
+#define REF_TO_WEI(x) into_f4_e3m0(x)
 #elif WEI_DT_S8
 #define WEI_TO_REF(x) convert_int_sat_rte(x)
 #define REF_TO_WEI(x) convert_char_sat_rte(x)
@@ -166,21 +166,21 @@
 #elif WEI_DT_S4
 #define WEI_TO_REF(x) cvt_s4_to_s32(x)
 #elif WEI_DT_U4
-#define WEI_TO_REF(x) convert_int_sat_rte(x)
+#define WEI_TO_REF(x) cvt_u4_to_s32(x)
 #else
 #define WEI_TO_REF(x) (x)
 #define REF_TO_WEI(x) (x)
 #endif
 #if WEI_DT_BF16
-#define TO_WEI(x) cvt_f32_to_bf16(x)
+#define TO_WEI(x) into_bf16(x)
 #elif WEI_DT_BF8
-#define TO_WEI(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define TO_WEI(x) into_f8_e5m2(x)
 #elif WEI_DT_HF8
-#define TO_WEI(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define TO_WEI(x) into_f8_e4m3(x)
 #elif WEI_DT_F4_E2M1
-#define TO_WEI(x) cvt_f32_to_f4_e2m1(x)
+#define TO_WEI(x) into_f4_e2m1(x)
 #elif WEI_DT_F4_E3M0
-#define TO_WEI(x) cvt_f32_to_f4_e3m0(x)
+#define TO_WEI(x) into_f4_e3m0(x)
 #elif WEI_DT_U8
 #define TO_WEI(x) convert_uchar_sat_rte(x)
 #elif WEI_DT_S8
@@ -194,14 +194,14 @@
 
 #ifdef DIFF_WEI_DATA_T
 #if DIFF_WEI_DT_BF16
-#define DIFF_WEI_TO_REF(x) cvt_bf16_to_f32(x)
-#define REF_TO_DIFF_WEI(x) cvt_f32_to_bf16(x)
+#define DIFF_WEI_TO_REF(x) into_float(x)
+#define REF_TO_DIFF_WEI(x) into_bf16(x)
 #else
 #define DIFF_WEI_TO_REF(x) (x)
 #define REF_TO_DIFF_WEI(x) (x)
 #endif
 #if DIFF_WEI_DT_BF16
-#define TO_DIFF_WEI(x) cvt_f32_to_bf16(x)
+#define TO_DIFF_WEI(x) into_bf16(x)
 #elif DIFF_WEI_DT_U8
 #define TO_DIFF_WEI(x) convert_uchar_sat_rte(x)
 #elif DIFF_WEI_DT_S8
@@ -232,13 +232,13 @@
 #define CONVERT_WEI_FLOAT_T convert_float
 #define CONVERT_WEI_DATA_T convert_half
 #elif WEI_DT_BF16 == 1
-#define AS_WEI_DATA_T as_ushort
+#define AS_WEI_DATA_T as_bf16
 #define BLOCK_WEI_READ intel_sub_group_block_read_us
 #define BLOCK_WEI_WRITE intel_sub_group_block_write_us
 #define BLOCK_WEI_DATA_T ushort
-#define AS_BLOCK_WEI_DATA_T as_ushort
-#define CONVERT_WEI_FLOAT_T cvt_bf16_to_f32
-#define CONVERT_WEI_DATA_T cvt_f32_to_bf16
+#define AS_BLOCK_WEI_DATA_T(v) (v).data
+#define CONVERT_WEI_FLOAT_T into_float
+#define CONVERT_WEI_DATA_T into_bf16
 #endif
 #if VECT_DT_N == 1
 #define VECT_BLOCK_WEI_READ BLOCK_WEI_READ
@@ -250,12 +250,14 @@
 #else
 #define VECT_BLOCK_WEI_READ CONCAT2(BLOCK_WEI_READ, VECT_DT_N)
 #define VECT_BLOCK_WEI_WRITE CONCAT2(BLOCK_WEI_WRITE, VECT_DT_N)
+#if WEI_DT_BF16 == 1
+#define AS_VECT_WEI_DATA_T CONCAT2(as_ushort, VECT_DT_N)
+#define AS_VECT_BLOCK_WEI_DATA_T CONCAT2(as_ushort, VECT_DT_N)
+#define CONVERT_VECT_WEI_FLOAT_T cvt_bf16_to_f32
+#define CONVERT_VECT_WEI_DATA_T cvt_f32_to_bf16
+#else
 #define AS_VECT_WEI_DATA_T CONCAT2(AS_WEI_DATA_T, VECT_DT_N)
 #define AS_VECT_BLOCK_WEI_DATA_T CONCAT2(AS_BLOCK_WEI_DATA_T, VECT_DT_N)
-#if WEI_DT_BF16 == 1
-#define CONVERT_VECT_WEI_FLOAT_T CONVERT_WEI_FLOAT_T
-#define CONVERT_VECT_WEI_DATA_T CONVERT_WEI_DATA_T
-#else
 #define CONVERT_VECT_WEI_FLOAT_T CONCAT2(CONVERT_WEI_FLOAT_T, VECT_DT_N)
 #define CONVERT_VECT_WEI_DATA_T CONCAT2(CONVERT_WEI_DATA_T, VECT_DT_N)
 #endif
@@ -270,25 +272,25 @@
 
 #ifdef B_DATA_T
 #if B_DT_BF16
-#define B_TO_REF(x) cvt_bf16_to_f32(x)
-#define REF_TO_B(x) cvt_f32_to_bf16(x)
-#define TO_B(x) cvt_f32_to_bf16(x)
+#define B_TO_REF(x) into_float(x)
+#define REF_TO_B(x) into_bf16(x)
+#define TO_B(x) into_bf16(x)
 #elif B_DT_BF8
-#define B_TO_REF(x) cvt_f8_e5m2_to_hf(x)
-#define REF_TO_B(x) cvt_hf_to_f8_e5m2(convert_half(x))
-#define TO_B(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define B_TO_REF(x) into_half(x)
+#define REF_TO_B(x) into_f8_e5m2(x)
+#define TO_B(x) into_f8_e5m2(x)
 #elif B_DT_HF8
-#define B_TO_REF(x) cvt_f8_e4m3_to_hf(x)
-#define REF_TO_B(x) cvt_hf_to_f8_e4m3(convert_half(x))
-#define TO_B(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define B_TO_REF(x) into_half(x)
+#define REF_TO_B(x) into_f8_e4m3(x)
+#define TO_B(x) into_f8_e4m3(x)
 #elif B_DT_F4_E2M1
-#define B_TO_REF(x) cvt_f4_e2m1_to_f32(x)
-#define REF_TO_B(x) cvt_f32_to_f4_e2m1(x)
-#define TO_B(x) cvt_f32_to_f4_e2m1(x)
+#define B_TO_REF(x) into_float(x)
+#define REF_TO_B(x) into_f4_e2m1(x)
+#define TO_B(x) into_f4_e2m1(x)
 #elif B_DT_F4_E3M0
-#define B_TO_REF(x) cvt_f4_e3m0_to_f32(x)
-#define REF_TO_B(x) cvt_f32_to_f4_e3m0(x)
-#define TO_B(x) cvt_f32_to_f4_e3m0(x)
+#define B_TO_REF(x) into_float(x)
+#define REF_TO_B(x) into_f4_e3m0(x)
+#define TO_B(x) into_f4_e3m0(x)
 #elif B_DT_U8
 #define B_TO_REF(x) (x)
 #define REF_TO_B(x) (x)
@@ -311,35 +313,35 @@
 #ifdef BIA_DATA_T
 #define BIA_DATA2_T CONCAT2(BIA_DATA_T, 2)
 #if BIA_DT_BF16
-#define BIA_TO_REF(x) cvt_bf16_to_f32(x)
-#define REF_TO_BIA(x) cvt_f32_to_bf16(x)
+#define BIA_TO_REF(x) into_float(x)
+#define REF_TO_BIA(x) into_bf16(x)
 #elif BIA_DT_BF8
-#define BIA_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define REF_TO_BIA(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define BIA_TO_REF(x) into_float(x)
+#define REF_TO_BIA(x) into_f8_e5m2(x)
 #elif BIA_DT_HF8
-#define BIA_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define REF_TO_BIA(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define BIA_TO_REF(x) into_float(x)
+#define REF_TO_BIA(x) into_f8_e4m3(x)
 #elif BIA_DT_F4_E2M1
-#define BIA_TO_REF(x) cvt_f4_e2m1_to_f32(x)
-#define REF_TO_BIA(x) cvt_f32_to_f4_e2m1(x)
+#define BIA_TO_REF(x) into_float(x)
+#define REF_TO_BIA(x) into_f4_e2m1(x)
 #elif BIA_DT_F4_E3M0
-#define BIA_TO_REF(x) cvt_f4_e3m0_to_f32(x)
-#define REF_TO_BIA(x) cvt_f32_to_f4_e3m0(x)
+#define BIA_TO_REF(x) into_float(x)
+#define REF_TO_BIA(x) into_f4_e3m0(x)
 #else
 #define BIA_TO_REF(x) (x)
 #define REF_TO_BIA(x) (x)
 #endif
 
 #if BIA_DT_BF16
-#define TO_BIA(x) cvt_f32_to_bf16(x)
+#define TO_BIA(x) into_bf16(x)
 #elif BIA_DT_BF8
-#define TO_BIA(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define TO_BIA(x) into_f8_e5m2(x)
 #elif BIA_DT_HF8
-#define TO_BIA(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define TO_BIA(x) into_f8_e4m3(x)
 #elif BIA_DT_F4_E2M1
-#define TO_BIA(x) cvt_f32_to_f4_e2m1(x)
+#define TO_BIA(x) into_f4_e2m1(x)
 #elif BIA_DT_F4_E3M0
-#define TO_BIA(x) cvt_f32_to_f4_e3m0(x)
+#define TO_BIA(x) into_f4_e3m0(x)
 #elif BIA_DT_U8
 #define TO_BIA(x) convert_uchar_sat_rte(x)
 #elif BIA_DT_S8
@@ -411,9 +413,28 @@
 #define BLOCK_WRITE_DST16(ptr, v) \
     intel_sub_group_block_write_uc16((__global uchar *)ptr, as_uchar16(v))
 
-#elif DST_DT_F16 || DST_DT_BF16
+#elif DST_DT_F16
 #define BLOCK_WRITE_DST(ptr, v) \
     intel_sub_group_block_write_us((__global ushort *)ptr, as_ushort(v))
+
+#define BLOCK_WRITE_DST2(ptr, v) \
+    intel_sub_group_block_write_us2((__global ushort *)ptr, as_ushort2(v))
+
+#define BLOCK_WRITE_DST4(ptr, v) \
+    intel_sub_group_block_write_us4((__global ushort *)ptr, as_ushort4(v))
+
+#define BLOCK_WRITE_DST8(ptr, v) \
+    intel_sub_group_block_write_us8((__global ushort *)ptr, as_ushort8(v))
+
+#define BLOCK_WRITE_DST16(ptr, v) \
+    do { \
+        BLOCK_WRITE_DST8(ptr, (v).s01234567); \
+        BLOCK_WRITE_DST8(ptr + 8 * SUB_GROUP_SIZE, (v).s89abcdef); \
+    } while (0)
+
+#elif DST_DT_BF16
+#define BLOCK_WRITE_DST(ptr, v) \
+    intel_sub_group_block_write_us((__global ushort *)ptr, (v).data)
 
 #define BLOCK_WRITE_DST2(ptr, v) \
     intel_sub_group_block_write_us2((__global ushort *)ptr, as_ushort2(v))
@@ -473,74 +494,65 @@
 #endif
 
 #if DST_DT_BF16
-#define DST_TO_REF(x) cvt_bf16_to_f32(x)
-#define DST_TO_REF2(x) cvt_bf16_to_f32(x)
-#define DST_TO_REF8(x) cvt_bf16_to_f32(x)
-#define REF_TO_DST(x) cvt_f32_to_bf16(x)
-#define REF_TO_DST8(x) cvt_f32_to_bf16(convert_float8(x))
+#define DST_TO_REF(x) into_float(x)
+#define DST_TO_REF8(x) into_float(x)
+#define REF_TO_DST(x) into_bf16(x)
 #elif DST_DT_BF8
-#define DST_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define DST_TO_REF2(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define DST_TO_REF8(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define REF_TO_DST(x) cvt_hf_to_f8_e5m2(convert_half(x))
-#define REF_TO_DST8(x) cvt_hf_to_f8_e5m2(convert_half8(x))
+#define DST_TO_REF(x) into_float(x)
+#define DST_TO_REF8(x) into_float(x)
+#define REF_TO_DST(x) into_f8_e5m2(x)
 #elif DST_DT_HF8
-#define DST_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define DST_TO_REF2(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define DST_TO_REF8(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define REF_TO_DST(x) cvt_hf_to_f8_e4m3(convert_half(x))
-#define REF_TO_DST8(x) cvt_hf_to_f8_e4m3(convert_half8(x))
+#define DST_TO_REF(x) into_float(x)
+#define DST_TO_REF8(x) into_float(x)
+#define REF_TO_DST(x) into_f8_e4m3(x)
 #define DST_DATA_MAX (uchar)0x7B
 #define DST_DATA_MIN (uchar)0xFB
 #elif DST_DT_F4_E2M1
-#define DST_TO_REF(x) cvt_f4_e2m1_to_f32(x)
-#define DST_TO_REF2(x) cvt_f4_e2m1_to_f32(x)
-#define DST_TO_REF8(x) cvt_f4_e2m1_to_f32(x)
-#define REF_TO_DST(x) cvt_f32_to_f4_e2m1(x)
-#define REF_TO_DST8(x) cvt_f32_to_f4_e2m1(x)
+#define DST_TO_REF(x) into_float(x)
+#define DST_TO_REF8(x) into_float(x)
+#define REF_TO_DST(x) into_f4_e2m1(x)
 #define DST_DATA_MAX (uchar)0x07
 #define DST_DATA_MIN (uchar)0x01
 #elif DST_DT_F4_E3M0
-#define DST_TO_REF(x) cvt_f4_e3m0_to_f32(x)
-#define DST_TO_REF2(x) cvt_f4_e3m0_to_f32(x)
-#define DST_TO_REF8(x) cvt_f4_e3m0_to_f32(x)
-#define REF_TO_DST(x) cvt_f32_to_f4_e3m0(x)
-#define REF_TO_DST8(x) cvt_f32_to_f4_e3m0(x)
+#define DST_TO_REF(x) into_float(x)
+#define DST_TO_REF8(x) into_float(x)
+#define REF_TO_DST(x) into_f4_e3m0(x)
 #define DST_DATA_MAX (uchar)0x07
 #define DST_DATA_MIN (uchar)0x08
 #elif DST_DT_F16
 #define REF_TO_DST(x) convert_half(x)
 #define DST_TO_REF(x) convert_float(x)
-#define DST_TO_REF2(x) convert_float2(x)
 #define DST_TO_REF8(x) convert_float8(x)
 #elif DST_DT_U8
 #define DST_TO_REF(x) (x)
-#define DST_TO_REF2(x) (x)
 #define DST_TO_REF8(x) (x)
 #define REF_TO_DST(x) convert_uchar(x)
-#define REF_TO_DST8(x) convert_uchar8(x)
 #elif DST_DT_S8
 #define DST_TO_REF(x) (x)
-#define DST_TO_REF2(x) (x)
 #define DST_TO_REF8(x) (x)
 #define REF_TO_DST(x) convert_char(x)
-#define REF_TO_DST8(x) convert_char8(x)
+#elif DST_DT_S4
+#define DST_TO_REF(x) into_float(x)
+#define DST_TO_REF8(x) into_float(x)
+#define REF_TO_DST(x) into_s4(x)
+#elif DST_DT_U4
+#define DST_TO_REF(x) into_float(x)
+#define DST_TO_REF8(x) into_float(x)
+#define REF_TO_DST(x) into_u4(x)
 #else
 #define DST_TO_REF(x) (x)
-#define DST_TO_REF2(x) (x)
 #define DST_TO_REF8(x) (x)
 #define REF_TO_DST(x) (x)
-#define REF_TO_DST8(x) (x)
 #endif
 
 #if DST_DT_BF16
-#define TO_DST(x) cvt_f32_to_bf16(convert_float(x))
+#define TO_DST(x) into_bf16(into_float(x))
 #define TO_DST2(x) cvt_f32_to_bf16(convert_float2(x))
 #define TO_DST4(x) cvt_f32_to_bf16(convert_float4(x))
 #define TO_DST8(x) cvt_f32_to_bf16(convert_float8(x))
-#define DST_DATA_FMAX cvt_bf16_to_f32((ushort)0x7F7F)
-#define DST_DATA_FMIN cvt_bf16_to_f32((ushort)0x0080)
-#define DST_DATA_FLOW cvt_bf16_to_f32((ushort)0xFF7F)
+#define DST_DATA_FMAX into_float(as_bf16(0x7F7F))
+#define DST_DATA_FMIN into_float(as_bf16(0x0080))
+#define DST_DATA_FLOW into_float(as_bf16((ushort)0xFF7F))
 #elif DST_DT_F16
 #define TO_DST(x) convert_half(x)
 #define TO_DST2(x) convert_half2(x)
@@ -550,60 +562,42 @@
 #define DST_DATA_FMIN convert_float(HALF_MIN)
 #define DST_DATA_FLOW -DST_DATA_FMAX
 #elif DST_DT_BF8
-#define TO_DST(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define TO_DST(x) into_f8_e5m2(x)
 #define TO_DST2(x) cvt_hf_to_f8_e5m2(convert_half2(x))
 #define TO_DST4(x) cvt_hf_to_f8_e5m2(convert_half4(x))
 #define TO_DST8(x) cvt_hf_to_f8_e5m2(convert_half8(x))
-#define TO_DST16(x) cvt_hf_to_f8_e5m2(convert_half16(x))
-#define DST_DATA_FMAX convert_float(cvt_f8_e5m2_to_hf((uchar)0x7B))
-#define DST_DATA_FMIN convert_float(cvt_f8_e5m2_to_hf((uchar)0x04))
-#define DST_DATA_FLOW convert_float(cvt_f8_e5m2_to_hf((uchar)0xFB))
+#define DST_DATA_FMAX into_float(as_f8_e5m2((uchar)0x7B))
+#define DST_DATA_FMIN into_float(as_f8_e5m2((uchar)0x04))
+#define DST_DATA_FLOW into_float(as_f8_e5m2((uchar)0xFB))
 #elif DST_DT_HF8
-#define TO_DST(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define TO_DST(x) into_f8_e4m3(x)
 #define TO_DST2(x) cvt_hf_to_f8_e4m3(convert_half2(x))
 #define TO_DST4(x) cvt_hf_to_f8_e4m3(convert_half4(x))
 #define TO_DST8(x) cvt_hf_to_f8_e4m3(convert_half8(x))
-#define TO_DST16(x) cvt_hf_to_f8_e4m3(convert_half16(x))
-#define DST_DATA_FMAX convert_float(cvt_f8_e4m3_to_hf((uchar)0x7E))
-#define DST_DATA_FMIN convert_float(cvt_f8_e4m3_to_hf((uchar)0x08))
-#define DST_DATA_FLOW convert_float(cvt_f8_e4m3_to_hf((uchar)0xFE))
+#define DST_DATA_FMAX into_float(as_f8_e4m3((uchar)0x7E))
+#define DST_DATA_FMIN into_float(as_f8_e4m3((uchar)0x08))
+#define DST_DATA_FLOW into_float(as_f8_e4m3((uchar)0xFE))
 #elif DST_DT_U4
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
-#define TO_DST(x) cvt_f32_to_u4(convert_float(x))
-#define TO_DST2(x) cvt_f32_to_u4(convert_float2(x))
-#define TO_DST4(x) cvt_f32_to_u4(convert_float4(x))
-#define TO_DST8(x) cvt_f32_to_u4(convert_float8(x))
-#define TO_DST16(x) cvt_f32_to_u4(convert_float16(x))
+#define TO_DST(x) into_u4(convert_float(x))
 #define DST_DATA_FMAX 15.0
 #define DST_DATA_FMIN 0.0
 #define DST_DATA_FLOW DST_DATA_FMIN
 #elif DST_DT_S4
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
-#define TO_DST(x) cvt_f32_to_s4(convert_float(x))
-#define TO_DST2(x) cvt_f32_to_s4(convert_float2(x))
-#define TO_DST4(x) cvt_f32_to_s4(convert_float4(x))
-#define TO_DST8(x) cvt_f32_to_s4(convert_float8(x))
-#define TO_DST16(x) cvt_f32_to_s4(convert_float16(x))
+#define TO_DST(x) into_s4(convert_float(x))
 #define DST_DATA_FMAX 7.0
 #define DST_DATA_FMIN 1
 #define DST_DATA_FLOW -8.0
 #elif DST_DT_F4_E2M1
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
-#define TO_DST(x) cvt_f32_to_f4_e2m1(convert_float(x))
-#define TO_DST2(x) cvt_f32_to_f4_e2m1(convert_float2(x))
-#define TO_DST4(x) cvt_f32_to_f4_e2m1(convert_float4(x))
-#define TO_DST8(x) cvt_f32_to_f4_e2m1(convert_float8(x))
-#define TO_DST16(x) cvt_f32_to_f4_e2m1(convert_float16(x))
+#define TO_DST(x) into_f4_e2m1(convert_float(x))
 #define DST_DATA_FMAX 6.0
 #define DST_DATA_FMIN 1.0
 #define DST_DATA_FLOW -6.0
 #elif DST_DT_F4_E3M0
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
-#define TO_DST(x) cvt_f32_to_f4_e3m0(convert_float(x))
-#define TO_DST2(x) cvt_f32_to_f4_e3m0(convert_float2(x))
-#define TO_DST4(x) cvt_f32_to_f4_e3m0(convert_float4(x))
-#define TO_DST8(x) cvt_f32_to_f4_e3m0(convert_float8(x))
-#define TO_DST16(x) cvt_f32_to_f4_e3m0(convert_float16(x))
+#define TO_DST(x) into_f4_e3m0(convert_float(x))
 #define DST_DATA_FMAX 16.0
 #define DST_DATA_FMIN 0.25
 #define DST_DATA_FLOW -16.0
@@ -657,29 +651,29 @@
 #ifdef C_DATA_T
 #define C_DATA8_T CONCAT2(C_DATA_T, 8)
 #if C_DT_BF16
-#define C_TO_REF(x) cvt_bf16_to_f32(x)
-#define C_TO_REF8(x) cvt_bf16_to_f32(x)
-#define REF_TO_C(x) cvt_f32_to_bf16(x)
+#define C_TO_REF(x) into_float(x)
+#define C_TO_REF8(x) into_float(x)
+#define REF_TO_C(x) into_bf16(x)
 #define REF_TO_C8(x) cvt_f32_to_bf16(convert_float8(x))
 #elif C_DT_BF8
-#define C_TO_REF(x) cvt_f8_e5m2_to_hf(convert_half(x))
+#define C_TO_REF(x) into_half(x)
 #define C_TO_REF8(x) cvt_f8_e5m2_to_hf(convert_half8(x))
-#define REF_TO_C(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define REF_TO_C(x) into_f8_e5m2(x)
 #define REF_TO_C8(x) cvt_hf_to_f8_e5m2(convert_half8(x))
 #elif C_DT_HF8
-#define C_TO_REF(x) cvt_f8_e4m3_to_hf(convert_half(x))
+#define C_TO_REF(x) into_half(x)
 #define C_TO_REF8(x) cvt_f8_e4m3_to_hf(convert_half8(x))
-#define REF_TO_C(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define REF_TO_C(x) into_f8_e4m3(x)
 #define REF_TO_C8(x) cvt_hf_to_f8_e4m3(convert_half8(x))
 #elif C_DT_F4_E2M1
-#define C_TO_REF(x) cvt_f4_e2m1_to_f32(x)
+#define C_TO_REF(x) into_float(x)
 #define C_TO_REF8(x) cvt_f4_e2m1_to_f32(x)
-#define REF_TO_C(x) cvt_f32_to_f4_e2m1(x)
+#define REF_TO_C(x) into_f4_e2m1(x)
 #define REF_TO_C8(x) cvt_f32_to_f4_e2m1(x)
 #elif C_DT_F4_E3M0
-#define C_TO_REF(x) cvt_f4_e3m0_to_f32(x)
+#define C_TO_REF(x) into_float(x)
 #define C_TO_REF8(x) cvt_f4_e3m0_to_f32(x)
-#define REF_TO_C(x) cvt_f32_to_f4_e3m0(x)
+#define REF_TO_C(x) into_f4_e3m0(x)
 #define REF_TO_C8(x) cvt_f32_to_f4_e3m0(x)
 #else
 #define C_TO_REF(x) (x)
@@ -688,19 +682,19 @@
 #define REF_TO_C8(x) (x)
 #endif
 #if C_DT_BF16
-#define TO_C(x) cvt_f32_to_bf16(x)
+#define TO_C(x) into_bf16(x)
 #define TO_C8(x) cvt_f32_to_bf16(convert_float8(x))
 #elif C_DT_BF8
-#define TO_C(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define TO_C(x) into_f8_e5m2(x)
 #define TO_C8(x) cvt_hf_to_f8_e5m2(convert_half8(x))
 #elif C_DT_HF8
-#define TO_C(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define TO_C(x) into_f8_e4m3(x)
 #define TO_C8(x) cvt_hf_to_f8_e4m3(convert_half8(x))
 #elif C_DT_F4_E2M1
-#define TO_C(x) cvt_f32_to_f4_e2m1(x)
+#define TO_C(x) into_f4_e2m1(x)
 #define TO_C8(x) cvt_f32_to_f4_e2m1(x)
 #elif C_DT_F4_E3M0
-#define TO_C(x) cvt_f32_to_f4_e3m0(x)
+#define TO_C(x) into_f4_e3m0(x)
 #define TO_C8(x) cvt_f32_to_f4_e3m0(x)
 #elif C_DT_F16
 #define TO_C(x) convert_half(x)
@@ -754,15 +748,15 @@
 #define AS_SUM_DATA8_T CONCAT2(as_, SUM_DATA8_T)
 #define AS_SUM_DATA16_T CONCAT2(as_, SUM_DATA16_T)
 #if SUM_DT_BF16
-#define SUM_TO_REF cvt_bf16_to_f32
+#define SUM_TO_REF into_float
 #elif SUM_DT_BF8
-#define SUM_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
+#define SUM_TO_REF(x) into_float(x)
 #elif SUM_DT_HF8
-#define SUM_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
+#define SUM_TO_REF(x) into_float(x)
 #elif SUM_DT_F4_E2M1
-#define SUM_TO_REF(x) cvt_f4_e2m1_to_f32(x)
+#define SUM_TO_REF(x) into_float(x)
 #elif SUM_DT_F4_E3M0
-#define SUM_TO_REF(x) cvt_f4_e3m0_to_f32(x)
+#define SUM_TO_REF(x) into_float(x)
 #else
 #define SUM_TO_REF
 #endif
@@ -770,20 +764,20 @@
 
 #ifdef DST_SCALES_DATA_T
 #if DST_SCALES_DT_HF8
-#define DST_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define REF_TO_DST_SCALES(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define DST_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_DST_SCALES(x) into_f8_e4m3(x)
 #elif DST_SCALES_DT_BF8
-#define DST_SCALES_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define REF_TO_DST_SCALES(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define DST_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_DST_SCALES(x) into_f8_e5m2(x)
 #elif DST_SCALES_DT_F16
 #define DST_SCALES_TO_REF(x) convert_float(x)
 #define REF_TO_DST_SCALES(x) convert_half(x)
 #elif DST_SCALES_DT_BF16
-#define DST_SCALES_TO_REF(x) cvt_bf16_to_f32(x)
-#define REF_TO_DST_SCALES(x) cvt_f32_to_bf16(x)
+#define DST_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_DST_SCALES(x) into_bf16(x)
 #elif DST_SCALES_DT_E8M0
-#define DST_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
-#define REF_TO_DST_SCALES(x) cvt_f32_to_e8m0(x)
+#define DST_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_DST_SCALES(x) into_e8m0(x)
 #else
 #define DST_SCALES_TO_REF(x) (x)
 #endif
@@ -791,20 +785,20 @@
 
 #ifdef WEI_SCALES_DATA_T
 #if WEI_SCALES_DT_HF8
-#define WEI_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define REF_TO_WEI_SCALES(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define WEI_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_WEI_SCALES(x) into_f8_e4m3(x)
 #elif WEI_SCALES_DT_BF8
-#define WEI_SCALES_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define REF_TO_WEI_SCALES(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define WEI_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_WEI_SCALES(x) into_f8_e5m2(x)
 #elif WEI_SCALES_DT_F16
 #define WEI_SCALES_TO_REF(x) convert_float(x)
 #define REF_TO_WEI_SCALES(x) convert_half(x)
 #elif WEI_SCALES_DT_BF16
-#define WEI_SCALES_TO_REF(x) cvt_bf16_to_f32(x)
-#define REF_TO_WEI_SCALES(x) cvt_f32_to_bf16(x)
+#define WEI_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_WEI_SCALES(x) into_bf16(x)
 #elif WEI_SCALES_DT_E8M0
-#define WEI_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
-#define REF_TO_WEI_SCALES(x) cvt_f32_to_e8m0(x)
+#define WEI_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_WEI_SCALES(x) into_e8m0(x)
 #else
 #define WEI_SCALES_TO_REF(x) (x)
 #endif
@@ -812,20 +806,20 @@
 
 #ifdef SRC_SCALES_DATA_T
 #if SRC_SCALES_DT_HF8
-#define SRC_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
-#define REF_TO_SRC_SCALES(x) cvt_hf_to_f8_e4m3(convert_half(x))
+#define SRC_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_SRC_SCALES(x) into_f8_e4m3(x)
 #elif SRC_SCALES_DT_BF8
-#define SRC_SCALES_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#define REF_TO_SRC_SCALES(x) cvt_hf_to_f8_e5m2(convert_half(x))
+#define SRC_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_SRC_SCALES(x) into_f8_e5m2(x)
 #elif SRC_SCALES_DT_F16
 #define SRC_SCALES_TO_REF(x) convert_float(x)
 #define REF_TO_SRC_SCALES(x) convert_half(x)
 #elif SRC_SCALES_DT_BF16
-#define SRC_SCALES_TO_REF(x) cvt_bf16_to_f32(x)
-#define REF_TO_SRC_SCALES(x) cvt_f32_to_bf16(x)
+#define SRC_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_SRC_SCALES(x) into_bf16(x)
 #elif SRC_SCALES_DT_E8M0
-#define SRC_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
-#define REF_TO_SRC_SCALES(x) cvt_f32_to_e8m0(x)
+#define SRC_SCALES_TO_REF(x) into_float(x)
+#define REF_TO_SRC_SCALES(x) into_e8m0(x)
 #else
 #define SRC_SCALES_TO_REF(x) (x)
 #endif
@@ -839,7 +833,7 @@
 #elif WEI_ZP_DT_S4
 #define WEI_ZP_TO_REF(zp, off) cvt_s4_to_s32(GET_HALF_BYTE(zp, off))
 #elif WEI_ZP_DT_U4
-#define WEI_ZP_TO_REF(zp, off) convert_int_sat_rte(GET_HALF_BYTE(zp, off))
+#define WEI_ZP_TO_REF(zp, off) cvt_u4_to_s32(GET_HALF_BYTE(zp, off))
 #else
 #define WEI_ZP_TO_REF(zp, off) (zp[off])
 #endif
@@ -853,7 +847,7 @@
 #elif SRC_ZP_DT_S4
 #define SRC_ZP_TO_REF(zp, off) cvt_s4_to_s32(GET_HALF_BYTE(zp, off))
 #elif SRC_ZP_DT_U4
-#define SRC_ZP_TO_REF(zp, off) convert_int_sat_rte(GET_HALF_BYTE(zp, off))
+#define SRC_ZP_TO_REF(zp, off) cvt_u4_to_s32(GET_HALF_BYTE(zp, off))
 #else
 #define SRC_ZP_TO_REF(zp, off) (zp[off])
 #endif

--- a/src/gpu/intel/lnorm/ref.cl
+++ b/src/gpu/intel/lnorm/ref.cl
@@ -33,7 +33,7 @@ __kernel void ref_lnorm_fwd(__global DATA_T *src, __global float *mean,
         for (off_t c = 0; c < C; ++c) {
             x[NDIMS - 1] = c;
             off_t dst_off = DST_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
-            dst[dst_off] = TO_DST(CONVERT_DATA_T(0.f));
+            dst[dst_off] = TO_DST(0.f);
         }
         return;
     }

--- a/src/gpu/intel/lnorm/simple.cl
+++ b/src/gpu/intel/lnorm/simple.cl
@@ -34,7 +34,7 @@ __kernel void simple_lnorm_fwd(__global DATA_T *src, __global float *mean,
         for (int c = 0; c < C; c += SUB_GROUP_SIZE) {
             x[NDIMS - 1] = c + local_id;
             off_t dst_off = DST_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
-            dst[dst_off] = TO_DST(CONVERT_DATA_T(0.f));
+            dst[dst_off] = TO_DST(0.f);
         }
         return;
     }

--- a/src/gpu/intel/lrn/ref.hpp
+++ b/src/gpu/intel/lrn/ref.hpp
@@ -85,7 +85,7 @@ struct ref_fwd_t : public primitive_t {
 
         const auto *desc = pd()->desc();
 
-        kernel_ctx.set_data_type(desc->src_desc.data_type, false);
+        kernel_ctx.set_data_type(desc->src_desc.data_type);
         kernel_ctx.register_buffer_size(*pd()->src_md());
         kernel_ctx.require_stateless_addressing(pd()->has_large_buffers());
 
@@ -211,7 +211,7 @@ struct ref_bwd_t : public primitive_t {
 
         const auto *desc = pd()->desc();
 
-        kernel_ctx.set_data_type(desc->src_desc.data_type, false);
+        kernel_ctx.set_data_type(desc->src_desc.data_type);
         kernel_ctx.register_buffer_size(*pd()->src_md());
         kernel_ctx.require_stateless_addressing(pd()->has_large_buffers());
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -36,9 +36,19 @@ DECLARE_2D_TILE_VREDUCE(ugemm_grouped_c_type, SUBGROUP_SIZE,
         ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1,
         bias_tile_type, SUBGROUP_SIZE, bias_br, bias_bc, bias_nbr, bias_nbc)
 
+/* When BIA_DATA_T is a struct it cannot be used as an ext_vector_type
+ * element. Use the underlying scalar type for tile storage. */
+#ifdef BIA_DT_BF16
+#define BIA_TILE_DATA_T ushort
+#define BIA_TILE_TO_REF(v) into_float(as_bf16(v))
+#else
+#define BIA_TILE_DATA_T BIA_DATA_T
+#define BIA_TILE_TO_REF BIA_TO_REF
+#endif
+
 #ifndef BIA_DT_F32
-DECLARE_2D_TILE(bias_in_tile_type, BIA_DATA_T, SUBGROUP_SIZE, bias_br, bias_bc,
-        bias_nbr, bias_nbc)
+DECLARE_2D_TILE(bias_in_tile_type, BIA_TILE_DATA_T, SUBGROUP_SIZE, bias_br,
+        bias_bc, bias_nbr, bias_nbc)
 #endif
 
 void load_bias(
@@ -47,8 +57,9 @@ void load_bias(
     tile_load(tile, ptr, n, 1, 0, sg_i0, 0);
 #else
     bias_in_tile_type bias_in_tile;
-    tile_load(&bias_in_tile, ptr, n, 1, 0, sg_i0, 0);
-    tile_convert(bias_in_tile, (*tile), BIA_TO_REF);
+    tile_load(&bias_in_tile, (const global BIA_TILE_DATA_T *)ptr, n, 1, 0,
+            sg_i0, 0);
+    tile_convert(bias_in_tile, (*tile), BIA_TILE_TO_REF);
 #endif
 }
 #endif
@@ -117,20 +128,85 @@ void find_sparse_batch(off_t *batch, int2 *src_range,
 #define slm_sparse_total_size 0
 #endif
 
+/* When DST_DATA_T is a struct it cannot be used as an ext_vector_type
+ * element. Use the underlying scalar type for tile storage. */
+#ifdef DST_DT_BF16
+#define DST_TILE_DATA_T ushort
+#define CONVERT_TILE_DATA_T(v) (into_bf16(convert_float(v)).data)
+#else
+#define DST_TILE_DATA_T DST_DATA_T
+#define CONVERT_TILE_DATA_T CONVERT_DATA_T
+#endif
+
 #ifndef DST_DT_F32
-DECLARE_2D_TILE(c_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(c_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
         ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1)
 #endif
 
+/* FMA_TYPE: scalar type used by ugemm microkernels for bf16 matrix operands.
+ * bf16 is a struct in OpenCL C; the microkernel uses its punned ushort representation. */
+#if defined(WEI_DT_BF16) || defined(SRC_DT_BF16)
+#define FMA_TYPE ushort
+#endif
+
+/* Cast macros for ugemm_grouped pointer arguments: cast when the data type
+ * is a struct, since the ugemm microkernels use punned scalar types. */
+/* 4-bit and 8-bit struct types (BF8=f8_e5m2, HF8=f8_e4m3) are packed in uchar.
+ * bf16 uses its ushort representation (FMA_TYPE). */
+#if defined(WEI_DT_S4) || defined(WEI_DT_U4) || defined(WEI_DT_F4_E2M1) \
+        || defined(WEI_DT_F4_E3M0) || defined(WEI_DT_BF8) \
+        || defined(WEI_DT_HF8) || defined(WEI_DT_E8M0)
+#define AS_WEI_TILE_PTR(p) ((const global uchar *)(p))
+#elif defined(WEI_DT_BF16)
+#define AS_WEI_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#else
+#define AS_WEI_TILE_PTR(p) (p)
+#endif
+
+#if defined(SRC_DT_S4) || defined(SRC_DT_U4) || defined(SRC_DT_F4_E2M1) \
+        || defined(SRC_DT_F4_E3M0) || defined(SRC_DT_BF8) \
+        || defined(SRC_DT_HF8) || defined(SRC_DT_E8M0)
+#define AS_SRC_TILE_PTR(p) ((const global uchar *)(p))
+#elif defined(SRC_DT_BF16)
+#define AS_SRC_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#else
+#define AS_SRC_TILE_PTR(p) (p)
+#endif
+
+#if defined(WEI_SCALES_DT_BF16)
+#define AS_WEI_SCALES_PTR(p) ((const global ushort *)(p))
+#elif defined(WEI_SCALES_DT_E8M0) || defined(WEI_SCALES_DT_HF8)
+#define AS_WEI_SCALES_PTR(p) ((const global uchar *)(p))
+#else
+#define AS_WEI_SCALES_PTR(p) (p)
+#endif
+
+#if defined(SRC_SCALES_DT_BF16)
+#define AS_SRC_SCALES_PTR(p) ((const global ushort *)(p))
+#elif defined(SRC_SCALES_DT_E8M0) || defined(SRC_SCALES_DT_HF8)
+#define AS_SRC_SCALES_PTR(p) ((const global uchar *)(p))
+#else
+#define AS_SRC_SCALES_PTR(p) (p)
+#endif
+
+/* Subbyte zero-point types are packed in uchar. */
+#if defined(WEI_ZP_DT_U4) || defined(WEI_ZP_DT_S4)
+#define AS_WEI_ZP_PTR(p) ((const global uchar *)(p))
+#else
+#define AS_WEI_ZP_PTR(p) (p)
+#endif
+
 /* Optional quantization parameters */
 #define SRC_SCALE_ARGS \
-    OPTIONAL(AND(WITH_SRC_SCALES, SRC_SCALES_GROUPED), src_attr_scales)
+    OPTIONAL(AND(WITH_SRC_SCALES, SRC_SCALES_GROUPED), \
+            AS_SRC_SCALES_PTR(src_attr_scales))
 #define SRC_ZP_ARGS OPTIONAL(WITH_SRC_ZP, src_attr_zp)
 #define SRC_LD_ARGS OPTIONAL(OR(WITH_SRC_ZP, SRC_SCALES_GROUPED), ldsrcq)
 #define WEI_SCALE_ARGS \
-    OPTIONAL(AND(WITH_WEI_SCALES, WEI_SCALES_GROUPED), wei_attr_scales)
-#define WEI_ZP_ARGS OPTIONAL(WITH_WEI_ZP, wei_attr_zp)
+    OPTIONAL(AND(WITH_WEI_SCALES, WEI_SCALES_GROUPED), \
+            AS_WEI_SCALES_PTR(wei_attr_scales))
+#define WEI_ZP_ARGS OPTIONAL(WITH_WEI_ZP, AS_WEI_ZP_PTR(wei_attr_zp))
 #define WEI_LD_ARGS OPTIONAL(OR(WITH_WEI_ZP, WEI_SCALES_GROUPED), ldweiq)
 #define K_PARALLEL_LOCAL_ARGS OPTIONAL(K_PARALLEL_LOCAL, sg_k)
 
@@ -141,8 +217,9 @@ void store_results(ugemm_grouped_c_type *tile, global DST_DATA_T *ptr, int n,
     //tile_store_t_block2d(c_tile, dst, n, m, lddst, sg_j0, sg_i0);
 #else
     c_tile_type_dst tile_dst;
-    tile_convert((*tile), tile_dst, CONVERT_DATA_T);
-    tile_store(tile_dst, ptr, n, m, lddst, sg_i0, sg_j0);
+    tile_convert((*tile), tile_dst, CONVERT_TILE_DATA_T);
+    tile_store(
+            tile_dst, (global DST_TILE_DATA_T *)ptr, n, m, lddst, sg_i0, sg_j0);
     //tile_store_block2d(c_tile_dst, dst, n, m, lddst, sg_j0, sg_i0);
 #endif
 }
@@ -289,8 +366,9 @@ grouped_micro_gemm(const global SRC_DATA_T *src, long ldsrc,
     wei_attr_zp += batch * n * (k / WEI_GROUP_SIZE) / WEI_ZP_ELEMS_PER_BYTE;
 #endif
 
-    ugemm_grouped_c_type c_tile = ugemm_grouped(wei, ldwei, src, ldsrc, n, m, k,
-            wg_i0, wg_j0, 0, sg_i, sg_j K_PARALLEL_LOCAL_ARGS,
+    ugemm_grouped_c_type c_tile = ugemm_grouped(AS_WEI_TILE_PTR(wei), ldwei,
+            AS_SRC_TILE_PTR(src), ldsrc, n, m, k, wg_i0, wg_j0, 0, sg_i,
+            sg_j K_PARALLEL_LOCAL_ARGS,
             slm WEI_SCALE_ARGS WEI_ZP_ARGS WEI_LD_ARGS SRC_SCALE_ARGS
                     SRC_ZP_ARGS SRC_LD_ARGS);
 

--- a/src/gpu/intel/pool/xe.cl
+++ b/src/gpu/intel/pool/xe.cl
@@ -15,26 +15,36 @@
 *******************************************************************************/
 
 #include "gpu/intel/include/dispatch.h"
+#include "gpu/intel/include/io.h"
 #include "gpu/intel/include/post_ops.h"
 #include "gpu/intel/include/types.h"
 
-// Read functions.
-inline VECT_DATA_T read_vect_c_block(int idx, const __global DATA_T *ptr,
+// Read functions. All operate in float to avoid type-specific branches.
+inline float read_c_block_f(const __global DATA_T *ptr, off_t c);
+inline void read_vect_c_block_f(float *ret, int idx, const __global DATA_T *ptr,
         off_t c, off_t blocks_stride, int chunks_per_block);
-inline VECT_INT_T read_vect_c_block_int(int idx, const __global int *ptr,
+inline int read_c_block_int(const __global int *ptr, off_t c);
+inline void read_vect_c_block_int(int *ret, int idx, const __global int *ptr,
         off_t c, off_t blocks_stride, int chunks_per_block);
 
 // Write functions.
-inline void write_vect_c_block(int idx, __global DATA_T *ptr, off_t c,
-        off_t blocks_stride, int chunks_per_block, VECT_DATA_T block);
+inline void write_c_block_f(__global DATA_T *ptr, off_t c, float value);
+inline void write_vect_c_block_f(int idx, __global DATA_T *ptr, off_t c,
+        off_t blocks_stride, int chunks_per_block, float *block);
+inline void write_c_block_int(__global int *ptr, off_t c, int value);
 inline void write_vect_c_block_int(int idx, __global int *ptr, off_t c,
-        off_t blocks_stride, int chunks_per_block, VECT_INT_T block);
+        off_t blocks_stride, int chunks_per_block, int *block);
 
-#if DT_BF16 || DT_F16
-#define USE_FLOATS true
-#else
-#define USE_FLOATS (ALG_AVG_NP || ALG_AVG_P)
-#endif
+#define CALC_VECT_LEN() \
+    ({ \
+        off_t size; \
+        if (USE_ONLY_C_BLOCK == 1 \
+                && VECT_DT_N > C_WO_PADDING / SUB_GROUP_SIZE + 1) \
+            size = C_WO_PADDING / SUB_GROUP_SIZE + 1; \
+        else \
+            size = VECT_DT_N; \
+        size; \
+    })
 
 #if IS_FWD
 KERNEL_ATTR
@@ -72,12 +82,16 @@ __kernel void xe_pooling_fwd(__global DATA_T *src, __global int *ws,
     const int ws_chunks_per_c_block = dst_chunks_per_c_block;
 
     if (mb0 >= SRC_D0) {
-        VECT_DATA_T dst_zero = DATA_ZERO;
-        VECT_INT_T ws_zero = 0;
+        float dst_zero[VECT_DT_N];
+        for (int i = 0; i < VECT_DT_N; i++)
+            dst_zero[i] = 0.0f;
+        int ws_zero[VECT_DT_N];
+        for (int i = 0; i < VECT_DT_N; i++)
+            ws_zero[i] = 0;
         off_t off = DST_OFF(mb0, c, od, oh, ow);
-        write_vect_c_block(
+        write_vect_c_block_f(
                 0, &dst[off], c, dst_stride, dst_chunks_per_c_block, dst_zero);
-        write_vect_c_block(
+        write_vect_c_block_f(
                 1, &dst[off], c, dst_stride, dst_chunks_per_c_block, dst_zero);
 #if ALG_MAX && IS_TRAINING
         write_vect_c_block_int(
@@ -85,23 +99,20 @@ __kernel void xe_pooling_fwd(__global DATA_T *src, __global int *ws,
         write_vect_c_block_int(
                 1, &ws[off], c, ws_stride, ws_chunks_per_c_block, ws_zero);
 #endif // ALG_MAX && IS_TRAINING
-
         return;
     }
 
     const off_t id = od * SD - PD;
     const off_t ih = oh * SH - PH;
     const off_t iw = ow * SW - PW;
-#if USE_FLOATS
-    // Convert DATA_MIN to float instead of using -FLT_MAX to avoid -inf
-    // Can use 0.0f safely, however
-    VECT_FLOAT_T D0 = ALG_MAX ? CONVERT_FLOAT_T(DATA_MIN) : 0.0f;
-    VECT_FLOAT_T D1 = ALG_MAX ? CONVERT_FLOAT_T(DATA_MIN) : 0.0f;
-#else // USE_FLOATS
-    VECT_DATA_T D0 = ALG_MAX ? DATA_MIN : DATA_ZERO;
-    VECT_DATA_T D1 = ALG_MAX ? DATA_MIN : DATA_ZERO;
-#endif // USE_FLOATS
-    VECT_INT_T WS0 = 0, WS1 = 0;
+
+    const float d_init = ALG_MAX ? DATA_TO_REF(DATA_MIN) : 0.0f;
+    float D0[VECT_DT_N], D1[VECT_DT_N];
+    for (int i = 0; i < VECT_DT_N; i++)
+        D0[i] = D1[i] = d_init;
+    int WS0[VECT_DT_N], WS1[VECT_DT_N];
+    for (int i = 0; i < VECT_DT_N; i++)
+        WS0[i] = WS1[i] = 0;
 
     for (int kd = 0; kd < KD; ++kd) {
         if (id + kd < 0 || id + kd >= ID) continue;
@@ -114,54 +125,50 @@ __kernel void xe_pooling_fwd(__global DATA_T *src, __global int *ws,
 #if UNROLL_MB_COUNT > 1
                 off_t src_off1 = SRC_OFF(mb1, c, id + kd, ih + kh, iw + kw);
 #endif
-#if USE_FLOATS
-                VECT_FLOAT_T S0 = CONVERT_VECT_FLOAT_T(read_vect_c_block(0,
-                        &src[src_off0], c, src_stride, src_chunks_per_c_block));
+                float S0[VECT_DT_N], S1[VECT_DT_N];
+                read_vect_c_block_f(S0, 0, &src[src_off0], c, src_stride,
+                        src_chunks_per_c_block);
 #if UNROLL_MB_COUNT > 1
-                VECT_FLOAT_T S1 = CONVERT_VECT_FLOAT_T(read_vect_c_block(0,
-                        &src[src_off1], c, src_stride, src_chunks_per_c_block));
+                read_vect_c_block_f(S1, 0, &src[src_off1], c, src_stride,
+                        src_chunks_per_c_block);
 #else
-                VECT_FLOAT_T S1 = CONVERT_VECT_FLOAT_T(read_vect_c_block(1,
-                        &src[src_off0], c, src_stride, src_chunks_per_c_block));
+                read_vect_c_block_f(S1, 1, &src[src_off0], c, src_stride,
+                        src_chunks_per_c_block);
 #endif
-#else // USE_FLOATS
-                VECT_DATA_T S0 = read_vect_c_block(0, &src[src_off0], c,
-                        src_stride, src_chunks_per_c_block);
-#if UNROLL_MB_COUNT > 1
-                VECT_DATA_T S1 = read_vect_c_block(0, &src[src_off1], c,
-                        src_stride, src_chunks_per_c_block);
-#else
-                VECT_DATA_T S1 = read_vect_c_block(1, &src[src_off0], c,
-                        src_stride, src_chunks_per_c_block);
-#endif
-#endif // USE_FLOATS
 
 #if ALG_MAX
 #if IS_TRAINING
-                VECT_INT_T CMP0 = isless(D0, S0);
-                WS0 = select(WS0, kd * KH * KW + kh * KW + kw, CMP0);
-                D0 = select(D0, S0, CMP0);
-
-                VECT_INT_T CMP1 = isless(D1, S1);
-                WS1 = select(WS1, kd * KH * KW + kh * KW + kw, CMP1);
-                D1 = select(D1, S1, CMP1);
-
-#else // TRAINING
-                D0 = max(D0, S0);
-                D1 = max(D1, S1);
-#endif // TRAINING
+                for (int i = 0; i < VECT_DT_N; i++) {
+                    if (D0[i] < S0[i]) {
+                        WS0[i] = kd * KH * KW + kh * KW + kw;
+                        D0[i] = S0[i];
+                    }
+                    if (D1[i] < S1[i]) {
+                        WS1[i] = kd * KH * KW + kh * KW + kw;
+                        D1[i] = S1[i];
+                    }
+                }
+#else // IS_TRAINING
+                for (int i = 0; i < VECT_DT_N; i++) {
+                    D0[i] = max(D0[i], S0[i]);
+                    D1[i] = max(D1[i], S1[i]);
+                }
+#endif // IS_TRAINING
 #else // ALG_MAX
-                D0 += S0;
-                D1 += S1;
+                for (int i = 0; i < VECT_DT_N; i++) {
+                    D0[i] += S0[i];
+                    D1[i] += S1[i];
+                }
 #endif // ALG_MAX
             }
         }
     }
 
 #if ALG_AVG_P
-    D0 = D0 / (KD * KH * KW);
-    D1 = D1 / (KD * KH * KW);
-
+    for (int i = 0; i < VECT_DT_N; i++) {
+        D0[i] /= KD * KH * KW;
+        D1[i] /= KD * KH * KW;
+    }
 #endif // ALG_AVG_P
 
 #if ALG_AVG_NP
@@ -173,27 +180,30 @@ __kernel void xe_pooling_fwd(__global DATA_T *src, __global int *ws,
     const off_t iw_end = min(ow * SW - PW + KW, (off_t)IW);
     const int num_summands = (int)(ih_end - ih_start) * (int)(iw_end - iw_start)
             * (int)(id_end - id_start);
-    D0 = D0 / num_summands;
-    D1 = D1 / num_summands;
+    for (int i = 0; i < VECT_DT_N; i++) {
+        D0[i] /= num_summands;
+        D1[i] /= num_summands;
+    }
 #endif // ALG_AVG_NP
 
     off_t dst_off0 = DST_OFF(mb0, c, od, oh, ow);
 #if UNROLL_MB_COUNT > 1
     off_t dst_off1 = DST_OFF(mb1, c, od, oh, ow);
 #endif
-    VECT_DATA_T sum0;
-    VECT_DATA_T sum1;
+    float sum0[VECT_DT_N], sum1[VECT_DT_N];
+    for (int i = 0; i < VECT_DT_N; i++)
+        sum0[i] = sum1[i] = 0.0f;
 #if WITH_SUM
-    sum0 = read_vect_c_block(
-            0, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block);
+    read_vect_c_block_f(
+            sum0, 0, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block);
 #if UNROLL_MB_COUNT > 1
-    sum1 = read_vect_c_block(
-            0, &dst[dst_off1], c, dst_stride, dst_chunks_per_c_block);
+    read_vect_c_block_f(
+            sum1, 0, &dst[dst_off1], c, dst_stride, dst_chunks_per_c_block);
 #else
-    sum1 = read_vect_c_block(
-            1, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block);
+    read_vect_c_block_f(
+            sum1, 1, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block);
 #endif
-#endif
+#endif // WITH_SUM
 
     const int local_id = get_sub_group_local_id();
 
@@ -201,17 +211,13 @@ __kernel void xe_pooling_fwd(__global DATA_T *src, __global int *ws,
     const off_t po_mb = mb0;
     const off_t po_oc = c + local_id;
     if (po_oc < C_WO_PADDING) {
-        POST_OP_DATA_T po_sum0 = DATA_TO_REF(sum0);
-        float po_D0 = USE_FLOATS ? D0 : CONVERT_FLOAT_T(D0);
-        APPLY_POST_OPS_SERIAL(po_D0, po_sum0, po_mb, po_oc, 0, 0, 0, 0);
-        D0 = USE_FLOATS ? po_D0 : CONVERT_DATA_T(po_D0);
-
-        POST_OP_DATA_T po_sum1 = DATA_TO_REF(sum1);
-        float po_D1 = USE_FLOATS ? D1 : CONVERT_FLOAT_T(D1);
-        APPLY_POST_OPS_SERIAL(po_D1, po_sum1, po_mb, po_oc, 0, 0, 0, 0);
-        D1 = USE_FLOATS ? po_D1 : CONVERT_DATA_T(po_D1);
+        float po_D0 = D0[0];
+        APPLY_POST_OPS_SERIAL(po_D0, sum0[0], po_mb, po_oc, 0, 0, 0, 0);
+        D0[0] = po_D0;
+        float po_D1 = D1[0];
+        APPLY_POST_OPS_SERIAL(po_D1, sum1[0], po_mb, po_oc, 0, 0, 0, 0);
+        D1[0] = po_D1;
     }
-
 #else
     for (int idx = 0; idx < VECT_DT_N; ++idx) {
 #if USE_MB_C_BLOCK
@@ -224,50 +230,43 @@ __kernel void xe_pooling_fwd(__global DATA_T *src, __global int *ws,
         off_t po_mb = mb0;
 #endif // USE_MB_C_BLOCK
 
-        float d0_i = USE_FLOATS ? D0[idx] : CONVERT_FLOAT_T(D0[idx]);
-        POST_OP_DATA_T sum0_i = DATA_TO_REF(sum0[idx]);
         if (po_mb >= MB_WO_PADDING || po_oc >= C_WO_PADDING) {
-            D0[idx] = 0;
+            D0[idx] = 0.0f;
             WS0[idx] = 0;
         } else {
-            APPLY_POST_OPS_SERIAL(d0_i, sum0_i, po_mb, po_oc, 0, 0, 0, 0);
-            D0[idx] = USE_FLOATS ? d0_i : CONVERT_DATA_T(d0_i);
+            float d0 = D0[idx];
+            APPLY_POST_OPS_SERIAL(d0, sum0[idx], po_mb, po_oc, 0, 0, 0, 0);
+            D0[idx] = d0;
         }
 
-        float d1_i = USE_FLOATS ? D1[idx] : CONVERT_FLOAT_T(D1[idx]);
-        POST_OP_DATA_T sum1_i = DATA_TO_REF(sum1[idx]);
-        if (UNROLL_MB_COUNT > 1)
-            po_mb += MB / 2;
-        else {
-            if (USE_MB_C_BLOCK)
-                po_oc += (VECT_DT_N % CHUNKS_PER_C_BLOCK) * SUB_GROUP_SIZE;
-            else
-                po_oc += VECT_DT_N * SUB_GROUP_SIZE;
-        }
+#if UNROLL_MB_COUNT > 1
+        po_mb += MB / 2;
+#else
+#if USE_MB_C_BLOCK
+        po_oc += (VECT_DT_N % CHUNKS_PER_C_BLOCK) * SUB_GROUP_SIZE;
+#else
+        po_oc += VECT_DT_N * SUB_GROUP_SIZE;
+#endif
+#endif
         if (po_mb >= MB_WO_PADDING || po_oc >= C_WO_PADDING) {
-            D1[idx] = 0;
+            D1[idx] = 0.0f;
             WS1[idx] = 0;
         } else {
-            APPLY_POST_OPS_SERIAL(d1_i, sum1_i, po_mb, po_oc, 0, 0, 0, 0);
-            D1[idx] = USE_FLOATS ? d1_i : CONVERT_DATA_T(d1_i);
+            float d1 = D1[idx];
+            APPLY_POST_OPS_SERIAL(d1, sum1[idx], po_mb, po_oc, 0, 0, 0, 0);
+            D1[idx] = d1;
         }
     }
-#endif // #if VECT_DT_N == 1
-#if USE_FLOATS
-    VECT_DATA_T res0 = CONVERT_VECTOR_DATA_T(D0);
-    VECT_DATA_T res1 = CONVERT_VECTOR_DATA_T(D1);
-#else
-    VECT_DATA_T res0 = D0;
-    VECT_DATA_T res1 = D1;
-#endif
-    write_vect_c_block(
-            0, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block, res0);
+#endif // VECT_DT_N == 1
+
+    write_vect_c_block_f(
+            0, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block, D0);
 #if UNROLL_MB_COUNT > 1
-    write_vect_c_block(
-            0, &dst[dst_off1], c, dst_stride, dst_chunks_per_c_block, res1);
+    write_vect_c_block_f(
+            0, &dst[dst_off1], c, dst_stride, dst_chunks_per_c_block, D1);
 #else
-    write_vect_c_block(
-            1, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block, res1);
+    write_vect_c_block_f(
+            1, &dst[dst_off0], c, dst_stride, dst_chunks_per_c_block, D1);
 #endif
 
 #if ALG_MAX && IS_TRAINING
@@ -286,7 +285,7 @@ __kernel void xe_pooling_fwd(__global DATA_T *src, __global int *ws,
 #endif
 #endif // ALG_MAX && IS_TRAINING
 }
-#endif
+#endif // IS_FWD
 
 #if IS_BWD
 KERNEL_ATTR
@@ -327,10 +326,16 @@ __kernel void xe_pooling_bwd(__global DATA_T *diff_src, __global int *ws,
     const off_t ws_stride = dst_stride;
     const int ws_chunks_per_c_block = dst_chunks_per_c_block;
 
-    VECT_FLOAT_T S0 = 0, S1 = 0;
+    float S0[VECT_DT_N], S1[VECT_DT_N];
+    for (int i = 0; i < VECT_DT_N; i++)
+        S0[i] = S1[i] = 0.0f;
 #if UNROLL_MB_COUNT > 1
-    VECT_FLOAT_T S[UNROLL_MB_COUNT] = {0};
+    float S[UNROLL_MB_COUNT][VECT_DT_N];
+    for (int i = 0; i < UNROLL_MB_COUNT; i++)
+        for (int j = 0; j < VECT_DT_N; j++)
+            S[i][j] = 0.0f;
 #endif
+
     for (int kd = 0; kd < KD; kd++) {
         off_t od = (id + PD - kd);
         if (od % SD != 0) continue;
@@ -356,54 +361,46 @@ __kernel void xe_pooling_bwd(__global DATA_T *diff_src, __global int *ws,
                     dst_off[i] = DST_OFF(mb[i], c, od, oh, ow);
                 }
 #endif
-                VECT_FLOAT_T D0 = CONVERT_VECT_FLOAT_T(
-                        read_vect_c_block(0, &diff_dst[dst_off0], c, dst_stride,
-                                dst_chunks_per_c_block));
-                VECT_FLOAT_T D1 = CONVERT_VECT_FLOAT_T(
-                        read_vect_c_block(1, &diff_dst[dst_off0], c, dst_stride,
-                                dst_chunks_per_c_block));
+                float D0[VECT_DT_N], D1[VECT_DT_N];
+                read_vect_c_block_f(D0, 0, &diff_dst[dst_off0], c, dst_stride,
+                        dst_chunks_per_c_block);
+                read_vect_c_block_f(D1, 1, &diff_dst[dst_off0], c, dst_stride,
+                        dst_chunks_per_c_block);
 #if UNROLL_MB_COUNT > 1
-                VECT_FLOAT_T D[UNROLL_MB_COUNT];
+                float D[UNROLL_MB_COUNT][VECT_DT_N];
                 unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
-                    D[i] = CONVERT_VECT_FLOAT_T(
-                            read_vect_c_block(0, &diff_dst[dst_off[i]], c,
-                                    dst_stride, dst_chunks_per_c_block));
+                    read_vect_c_block_f(D[i], 0, &diff_dst[dst_off[i]], c,
+                            dst_stride, dst_chunks_per_c_block);
                 }
 #endif
 
 #if ALG_MAX
-                VECT_INT_T WS0 = read_vect_c_block_int(
-                        0, &ws[dst_off0], c, ws_stride, ws_chunks_per_c_block);
-                VECT_INT_T WS1 = read_vect_c_block_int(
-                        1, &ws[dst_off0], c, ws_stride, ws_chunks_per_c_block);
+                int WS0[VECT_DT_N], WS1[VECT_DT_N];
+                read_vect_c_block_int(WS0, 0, &ws[dst_off0], c, ws_stride,
+                        ws_chunks_per_c_block);
+                read_vect_c_block_int(WS1, 1, &ws[dst_off0], c, ws_stride,
+                        ws_chunks_per_c_block);
 #if UNROLL_MB_COUNT > 1
-                VECT_INT_T WS[UNROLL_MB_COUNT];
+                int WS[UNROLL_MB_COUNT][VECT_DT_N];
                 unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
-                    WS[i] = read_vect_c_block_int(0, &ws[dst_off[i]], c,
+                    read_vect_c_block_int(WS[i], 0, &ws[dst_off[i]], c,
                             ws_stride, ws_chunks_per_c_block);
                 }
 #endif
-
-                VECT_INT_T CMP0 = isnotequal(
-                        AS_VECT_FLOAT_T(WS0 - kd * KH * KW - kh * KW - kw),
-                        (VECT_FLOAT_T)0);
-                D0 = select(D0, (VECT_FLOAT_T)0, CMP0);
-
-                VECT_INT_T CMP1 = isnotequal(
-                        AS_VECT_FLOAT_T(WS1 - kd * KH * KW - kh * KW - kw),
-                        (VECT_FLOAT_T)0);
-                D1 = select(D1, (VECT_FLOAT_T)0, CMP1);
-
+                const int ws_target = kd * KH * KW + kh * KW + kw;
+                for (int i = 0; i < VECT_DT_N; i++) {
+                    if (WS0[i] != ws_target) D0[i] = 0.0f;
+                    if (WS1[i] != ws_target) D1[i] = 0.0f;
+                }
 #if UNROLL_MB_COUNT > 1
-                VECT_INT_T CMP[UNROLL_MB_COUNT];
                 unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
-                    CMP[i] = isnotequal(AS_VECT_FLOAT_T(WS[i] - kd * KH * KW
-                                                - kh * KW - kw),
-                            (VECT_FLOAT_T)0);
-                    D[i] = select(D[i], (VECT_FLOAT_T)0, CMP[i]);
+                    for (int j = 0; j < VECT_DT_N; j++) {
+                        if (WS[i][j] != ws_target) D[i][j] = 0.0f;
+                    }
                 }
 #endif
-#endif
+#endif // ALG_MAX
+
 #if ALG_AVG_NP
                 const off_t id_start = max(id - kd, (off_t)0);
                 const off_t ih_start = max(ih - kh, (off_t)0);
@@ -413,33 +410,46 @@ __kernel void xe_pooling_bwd(__global DATA_T *diff_src, __global int *ws,
                 const off_t iw_end = min(iw - kw + KW, (off_t)IW);
                 const int num_summands = (int)(ih_end - ih_start)
                         * (int)(iw_end - iw_start) * (int)(id_end - id_start);
-                D0 /= num_summands;
-                D1 /= num_summands;
+                for (int i = 0; i < VECT_DT_N; i++) {
+                    D0[i] /= num_summands;
+                    D1[i] /= num_summands;
+                }
 #if UNROLL_MB_COUNT > 1
                 unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
-                    D[i] /= num_summands;
+                    for (int j = 0; j < VECT_DT_N; j++)
+                        D[i][j] /= num_summands;
                 }
 #endif
-#endif
-                S0 += D0;
-                S1 += D1;
+#endif // ALG_AVG_NP
+
 #if UNROLL_MB_COUNT > 1
                 unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
-                    S[i] += D[i];
+                    for (int j = 0; j < VECT_DT_N; j++)
+                        S[i][j] += D[i][j];
+                }
+#else
+                for (int i = 0; i < VECT_DT_N; i++) {
+                    S0[i] += D0[i];
+                    S1[i] += D1[i];
                 }
 #endif
             }
         }
     }
+
 #if ALG_AVG_P
-    S0 /= KD * KH * KW;
-    S1 /= KD * KH * KW;
 #if UNROLL_MB_COUNT > 1
     unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
-        S[i] /= KD * KH * KW;
+        for (int j = 0; j < VECT_DT_N; j++)
+            S[i][j] /= KD * KH * KW;
+    }
+#else
+    for (int i = 0; i < VECT_DT_N; i++) {
+        S0[i] /= KD * KH * KW;
+        S1[i] /= KD * KH * KW;
     }
 #endif
-#endif
+#endif // ALG_AVG_P
 
     off_t src_off0 = SRC_OFF(mb0, c, id, ih, iw);
 #if UNROLL_MB_COUNT > 1
@@ -447,73 +457,59 @@ __kernel void xe_pooling_bwd(__global DATA_T *diff_src, __global int *ws,
     unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
         src_off[i] = SRC_OFF(mb[i], c, id, ih, iw);
     }
-#endif
-    write_vect_c_block(0, &diff_src[src_off0], c, src_stride,
-            src_chunks_per_c_block, CONVERT_VECTOR_DATA_T(S0));
-#if UNROLL_MB_COUNT > 1
     unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
-        write_vect_c_block(0, &diff_src[src_off[i]], c, src_stride,
-                src_chunks_per_c_block, CONVERT_VECTOR_DATA_T(S[i]));
+        write_vect_c_block_f(0, &diff_src[src_off[i]], c, src_stride,
+                src_chunks_per_c_block, S[i]);
     }
 #else
-    write_vect_c_block(1, &diff_src[src_off0], c, src_stride,
-            src_chunks_per_c_block, CONVERT_VECTOR_DATA_T(S1));
+    write_vect_c_block_f(
+            0, &diff_src[src_off0], c, src_stride, src_chunks_per_c_block, S0);
+    write_vect_c_block_f(
+            1, &diff_src[src_off0], c, src_stride, src_chunks_per_c_block, S1);
 #endif
 }
-#endif
+#endif // IS_BWD
 
-inline DATA_T read_c_block(const __global DATA_T *ptr, off_t c) {
+// ===== Helper function implementations =====
+
+inline float read_c_block_f(const __global DATA_T *ptr, off_t c) {
 #if C_W_PADDING % SUB_GROUP_SIZE != 0
     int local_id = get_sub_group_local_id();
     off_t tail = C_WO_PADDING - c;
-    return (local_id < tail) ? ptr[local_id] : 0;
+    return (local_id < tail) ? DATA_TO_REF(ptr[local_id]) : 0.0f;
 #else
-    return AS_DATA_T(BLOCK_READ((const __global BLOCK_DATA_T *)ptr));
+    float val;
+    block_load(&val, (__global DATA_T *)ptr);
+    return val;
 #endif
 }
 
-#define CALC_VECT_LEN() \
-    ({ \
-        off_t size; \
-        if (USE_ONLY_C_BLOCK == 1 \
-                && VECT_DT_N > C_WO_PADDING / SUB_GROUP_SIZE + 1) \
-            size = C_WO_PADDING / SUB_GROUP_SIZE + 1; \
-        else \
-            size = VECT_DT_N; \
-        size; \
-    })
-
-inline VECT_DATA_T read_vect_c_block(int idx, const __global DATA_T *ptr,
+inline void read_vect_c_block_f(float *ret, int idx, const __global DATA_T *ptr,
         off_t c, off_t blocks_stride, int chunks_per_block) {
-    if (idx >= NVECT) return 0;
-
+    if (idx >= NVECT) {
+        for (int i = 0; i < VECT_DT_N; i++)
+            ret[i] = 0.0f;
+        return;
+    }
     if ((blocks_stride == chunks_per_block * SUB_GROUP_SIZE)
             && (C_WO_PADDING % (chunks_per_block * SUB_GROUP_SIZE) == 0)) {
-        return AS_VECT_DATA_T(VECT_BLOCK_READ((const __global BLOCK_DATA_T *)ptr
-                + idx * VECT_DT_N * SUB_GROUP_SIZE));
+        block_load(ret,
+                (__global DATA_T *)ptr + idx * VECT_DT_N * SUB_GROUP_SIZE,
+                VECT_DT_N);
     } else {
-        VECT_DATA_T ret;
         for (int i = 0; i < CALC_VECT_LEN(); i++) {
             const int offset_index = (idx * VECT_DT_N + i);
             const int local_c_block_index = offset_index % chunks_per_block;
             const int global_c_block_index = offset_index / chunks_per_block;
             const off_t ptr_offset = local_c_block_index * SUB_GROUP_SIZE
                     + global_c_block_index * blocks_stride;
-            const int c_off
-                    = (USE_ONLY_C_BLOCK ? offset_index * SUB_GROUP_SIZE
-                                        : local_c_block_index * SUB_GROUP_SIZE);
-#if VECT_DT_N == 1
-            ret = read_c_block(ptr + ptr_offset, c + c_off);
-#else
-            ret[i] = read_c_block(ptr + ptr_offset, c + c_off);
-#endif
+            const int c_off = USE_ONLY_C_BLOCK
+                    ? offset_index * SUB_GROUP_SIZE
+                    : local_c_block_index * SUB_GROUP_SIZE;
+            ret[i] = read_c_block_f(ptr + ptr_offset, c + c_off);
         }
-#if VECT_DT_N > 1
-        for (int i = CALC_VECT_LEN(); i < VECT_DT_N; ++i) {
-            ret[i] = 0;
-        }
-#endif
-        return ret;
+        for (int i = CALC_VECT_LEN(); i < VECT_DT_N; i++)
+            ret[i] = 0.0f;
     }
 }
 
@@ -523,68 +519,65 @@ inline int read_c_block_int(const __global int *ptr, off_t c) {
     off_t tail = C_WO_PADDING - c;
     return (local_id < tail) ? ptr[local_id] : 0;
 #else
-    return as_int(intel_sub_group_block_read((const __global uint *)ptr));
+    int val;
+    block_load(&val, (__global int *)ptr);
+    return val;
 #endif
 }
 
-inline VECT_INT_T read_vect_c_block_int(int idx, const __global int *ptr,
+inline void read_vect_c_block_int(int *ret, int idx, const __global int *ptr,
         off_t c, off_t blocks_stride, int chunks_per_block) {
-    if (idx >= NVECT) return 0;
-
+    if (idx >= NVECT) {
+        for (int i = 0; i < VECT_DT_N; i++)
+            ret[i] = 0;
+        return;
+    }
     if ((blocks_stride == chunks_per_block * SUB_GROUP_SIZE)
             && (C_WO_PADDING % (chunks_per_block * SUB_GROUP_SIZE) == 0)) {
-        return AS_VECT_INT_T(VECT_UINT_READ(
-                (const __global uint *)ptr + idx * VECT_DT_N * SUB_GROUP_SIZE));
+        block_load(ret, (__global int *)ptr + idx * VECT_DT_N * SUB_GROUP_SIZE,
+                VECT_DT_N);
     } else {
-        VECT_INT_T ret;
         for (int i = 0; i < VECT_DT_N; i++) {
             const int offset_index = (idx * VECT_DT_N + i);
             const int local_c_block_index = offset_index % chunks_per_block;
             const int global_c_block_index = offset_index / chunks_per_block;
             const off_t ptr_offset = local_c_block_index * SUB_GROUP_SIZE
                     + global_c_block_index * blocks_stride;
-            const int c_off
-                    = (USE_ONLY_C_BLOCK ? offset_index * SUB_GROUP_SIZE
-                                        : local_c_block_index * SUB_GROUP_SIZE);
-#if VECT_DT_N == 1
-            ret = read_c_block_int(ptr + ptr_offset, c + c_off);
-#else
+            const int c_off = USE_ONLY_C_BLOCK
+                    ? offset_index * SUB_GROUP_SIZE
+                    : local_c_block_index * SUB_GROUP_SIZE;
             ret[i] = read_c_block_int(ptr + ptr_offset, c + c_off);
-#endif
         }
-        return ret;
     }
 }
 
-inline void write_c_block(__global DATA_T *ptr, off_t c, DATA_T value) {
+inline void write_c_block_f(__global DATA_T *ptr, off_t c, float value) {
 #if C_W_PADDING % SUB_GROUP_SIZE != 0
     int local_id = get_sub_group_local_id();
     off_t tail = C_WO_PADDING - c;
-
-    if (local_id < tail) ptr[local_id] = value;
+    if (local_id < tail) write(ptr + local_id, value);
 #else
 #if C_WO_PADDING % SUB_GROUP_SIZE != 0
     int local_id = get_sub_group_local_id();
-    if (local_id >= C_WO_PADDING - c && local_id < C_W_PADDING - c) value = 0;
+    if (local_id >= C_WO_PADDING - c && local_id < C_W_PADDING - c)
+        value = 0.0f;
 #endif
     if (c >= C_WO_PADDING) {
-        BLOCK_WRITE((__global BLOCK_DATA_T *)ptr,
-                AS_BLOCK_DATA_T(CONVERT_DATA_T(DATA_ZERO)));
+        float zero = 0.0f;
+        block_write(ptr, &zero, 1);
         return;
     }
-    BLOCK_WRITE((__global BLOCK_DATA_T *)ptr, AS_BLOCK_DATA_T(value));
+    block_write(ptr, &value, 1);
 #endif
 }
 
-inline void write_vect_c_block(int idx, __global DATA_T *ptr, off_t c,
-        off_t blocks_stride, int chunks_per_block, VECT_DATA_T block) {
+inline void write_vect_c_block_f(int idx, __global DATA_T *ptr, off_t c,
+        off_t blocks_stride, int chunks_per_block, float *block) {
     if (idx >= NVECT) return;
 
     if ((blocks_stride == chunks_per_block * SUB_GROUP_SIZE)
             && (C_WO_PADDING % (chunks_per_block * SUB_GROUP_SIZE) == 0)) {
-        VECT_BLOCK_WRITE(
-                (__global BLOCK_DATA_T *)ptr + idx * VECT_DT_N * SUB_GROUP_SIZE,
-                AS_VECT_BLOCK_DATA_T(block));
+        block_write(ptr + idx * VECT_DT_N * SUB_GROUP_SIZE, block, VECT_DT_N);
     } else {
         for (int i = 0; i < VECT_DT_N; i++) {
             const int offset_index = (idx * VECT_DT_N + i);
@@ -592,14 +585,10 @@ inline void write_vect_c_block(int idx, __global DATA_T *ptr, off_t c,
             const int global_c_block_index = offset_index / chunks_per_block;
             const off_t ptr_offset = local_c_block_index * SUB_GROUP_SIZE
                     + global_c_block_index * blocks_stride;
-            const int c_off
-                    = (USE_ONLY_C_BLOCK ? offset_index * SUB_GROUP_SIZE
-                                        : local_c_block_index * SUB_GROUP_SIZE);
-#if VECT_DT_N == 1
-            write_c_block(ptr + ptr_offset, c + c_off, block);
-#else
-            write_c_block(ptr + ptr_offset, c + c_off, block[i]);
-#endif
+            const int c_off = USE_ONLY_C_BLOCK
+                    ? offset_index * SUB_GROUP_SIZE
+                    : local_c_block_index * SUB_GROUP_SIZE;
+            write_c_block_f(ptr + ptr_offset, c + c_off, block[i]);
         }
     }
 }
@@ -610,27 +599,26 @@ inline void write_c_block_int(__global int *ptr, off_t c, int value) {
     off_t tail = C_WO_PADDING - c;
     if (local_id < tail)
         ptr[local_id] = value;
-    else if (local_id < C_W_PADDING - c) {
+    else if (local_id < C_W_PADDING - c)
         ptr[local_id] = 0;
-    } else
-        return;
 #else
     if (c >= C_WO_PADDING) {
-        intel_sub_group_block_write((__global uint *)ptr, 0);
+        int zero = 0;
+        block_write((__global int *)ptr, &zero, 1);
         return;
     }
-    intel_sub_group_block_write((__global uint *)ptr, as_uint(value));
+    block_write((__global int *)ptr, &value, 1);
 #endif
 }
 
 inline void write_vect_c_block_int(int idx, __global int *ptr, off_t c,
-        off_t blocks_stride, int chunks_per_block, VECT_INT_T block) {
+        off_t blocks_stride, int chunks_per_block, int *block) {
     if (idx >= NVECT) return;
 
     if ((blocks_stride == chunks_per_block * SUB_GROUP_SIZE)
             && (C_WO_PADDING % (chunks_per_block * SUB_GROUP_SIZE) == 0)) {
-        VECT_UINT_WRITE((__global uint *)ptr + idx * VECT_DT_N * SUB_GROUP_SIZE,
-                AS_VECT_UINT_T(block));
+        block_write((__global int *)ptr + idx * VECT_DT_N * SUB_GROUP_SIZE,
+                block, VECT_DT_N);
     } else {
         for (int i = 0; i < VECT_DT_N; i++) {
             const int offset_index = (idx * VECT_DT_N + i);
@@ -638,14 +626,10 @@ inline void write_vect_c_block_int(int idx, __global int *ptr, off_t c,
             const int global_c_block_index = offset_index / chunks_per_block;
             const off_t ptr_offset = local_c_block_index * SUB_GROUP_SIZE
                     + global_c_block_index * blocks_stride;
-            const int c_off
-                    = (USE_ONLY_C_BLOCK ? offset_index * SUB_GROUP_SIZE
-                                        : local_c_block_index * SUB_GROUP_SIZE);
-#if VECT_DT_N == 1
-            write_c_block_int(ptr + ptr_offset, c + c_off, block);
-#else
+            const int c_off = USE_ONLY_C_BLOCK
+                    ? offset_index * SUB_GROUP_SIZE
+                    : local_c_block_index * SUB_GROUP_SIZE;
             write_c_block_int(ptr + ptr_offset, c + c_off, block[i]);
-#endif
         }
     }
 }

--- a/src/gpu/intel/pool/xe_global.cl
+++ b/src/gpu/intel/pool/xe_global.cl
@@ -84,9 +84,13 @@ __kernel void xe_global_pooling_fwd(
 
 #if IS_BWD
 
-#if DT_BF16 || DT_F16
+#if DT_F16
 #define DST_BLOCK_WRITE(dst, val) \
     BLOCK_WRITE((__global ushort *)(dst), as_ushort(val))
+#endif // DT_F16
+#if DT_BF16
+#define DST_BLOCK_WRITE(dst, val) \
+    BLOCK_WRITE((__global ushort *)(dst), val.data)
 #endif // DT_BF16
 #if DT_F32
 #define DST_BLOCK_WRITE(dst, val) \

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -263,22 +263,22 @@ void def_block_offsets(const block_layout_t &layout,
     }
 }
 
-const char *get_type_name(data_type_t dt, bool with_punning) {
+const char *get_type_name(data_type_t dt) {
     switch (dt) {
         case data_type::undef: return "undef_data";
-        case data_type::bf16: return with_punning ? "ushort" : "bf16";
+        case data_type::bf16: return "bf16";
         case data_type::f16: return "half";
         case data_type::f32: return "float";
         case data_type::f64: return "double";
         case data_type::s8: return "char";
         case data_type::u8: return "uchar";
-        case data_type::f8_e4m3: return with_punning ? "uchar" : "f8_e4m3";
-        case data_type::f8_e5m2: return with_punning ? "uchar" : "f8_e5m2";
-        case data_type::f4_e2m1: return with_punning ? "uchar" : "f4_e2m1";
-        case data_type::f4_e3m0: return with_punning ? "uchar" : "f4_e3m0";
-        case data_type::e8m0: return with_punning ? "uchar" : "e8m0";
-        case data_type::s4: return with_punning ? "uchar" : "s4";
-        case data_type::u4: return with_punning ? "uchar" : "u4";
+        case data_type::f8_e4m3: return "f8_e4m3";
+        case data_type::f8_e5m2: return "f8_e5m2";
+        case data_type::f4_e2m1: return "f4_e2m1";
+        case data_type::f4_e3m0: return "f4_e3m0";
+        case data_type::e8m0: return "e8m0";
+        case data_type::s4: return "s4";
+        case data_type::u4: return "u4";
         case data_type::s32: return "int";
         case data_type::s64: return "long";
         default:
@@ -288,9 +288,9 @@ const char *get_type_name(data_type_t dt, bool with_punning) {
     }
 }
 
-void def_data_type(compute::kernel_ctx_t &kernel_ctx, data_type_t dt,
-        const char *str, bool with_punning) {
-    const char *name = get_type_name(dt, with_punning);
+void def_data_type(
+        compute::kernel_ctx_t &kernel_ctx, data_type_t dt, const char *str) {
+    const char *name = get_type_name(dt);
 
     switch (dt) {
         case data_type::undef:
@@ -364,14 +364,13 @@ void def_data_type(compute::kernel_ctx_t &kernel_ctx, data_type_t dt,
     }
 }
 void def_data_type(compute::kernel_ctx_t &kernel_ctx, data_type_t dt,
-        const std::string &str, bool with_punning) {
-    return def_data_type(kernel_ctx, dt, str.c_str(), with_punning);
+        const std::string &str) {
+    return def_data_type(kernel_ctx, dt, str.c_str());
 }
 
 void def_memory_desc_info(compute::kernel_ctx_t &kernel_ctx,
-        const memory_desc_info_t &md_info, const char *prefix,
-        bool with_punning) {
-    def_data_type(kernel_ctx, md_info.data_type, prefix, with_punning);
+        const memory_desc_info_t &md_info, const char *prefix) {
+    def_data_type(kernel_ctx, md_info.data_type, prefix);
     kernel_ctx.register_buffer_size(md_info);
 
     kernel_ctx.define_int(utils::format("%s_OFFSET0", prefix), md_info.offset0);
@@ -541,8 +540,7 @@ status_t def_post_ops_cfg(compute::kernel_ctx_t &kernel_ctx,
             set_post_op_uses(src_rmd.dt);
 
             po_kernel_args += std::string(", const __global ")
-                    + get_type_name(src_rmd.dt, false) + " *po" + idx
-                    + "_binary_arg";
+                    + get_type_name(src_rmd.dt) + " *po" + idx + "_binary_arg";
             for (int i = 0; i < dst_md.ndims; i++) {
                 if (!src_rmd.is_broadcast(i, dst_md.ndims)
                         && !src_rmd.is_inner_dim(i, dst_md.ndims))
@@ -668,7 +666,7 @@ bool post_ops_preserves_zeroes(
 
 status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md, bool with_punning) {
+        const memory_desc_t &dst_md) {
     gpu_assert(attr_info.initialized);
 
     kernel_ctx.define_int("WITH_POST_OP", post_ops.len() > 0);
@@ -689,12 +687,9 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("WITH_DST_SCALES", attr_info.with_dst_scales);
     kernel_ctx.define_int("WEI_SCALES_MASK", attr_info.wei_scales_mask);
     kernel_ctx.define_int("DST_SCALES_MASK", attr_info.dst_scales_mask);
-    def_data_type(kernel_ctx, attr_info.src_scales_data_type, "SRC_SCALES",
-            with_punning);
-    def_data_type(kernel_ctx, attr_info.wei_scales_data_type, "WEI_SCALES",
-            with_punning);
-    def_data_type(kernel_ctx, attr_info.dst_scales_data_type, "DST_SCALES",
-            with_punning);
+    def_data_type(kernel_ctx, attr_info.src_scales_data_type, "SRC_SCALES");
+    def_data_type(kernel_ctx, attr_info.wei_scales_data_type, "WEI_SCALES");
+    def_data_type(kernel_ctx, attr_info.dst_scales_data_type, "DST_SCALES");
 
     kernel_ctx.define_int("WITH_SRC_ZPOINTS", attr_info.with_src_zpoints);
     kernel_ctx.define_int("WITH_WEI_ZPOINTS", attr_info.with_wei_zpoints);
@@ -722,9 +717,8 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
 
 status_t def_attr_info(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md, bool with_punning) {
-    return def_attr_info_impl(
-            kernel_ctx, attr_info, post_ops, dst_md, with_punning);
+        const memory_desc_t &dst_md) {
+    return def_attr_info_impl(kernel_ctx, attr_info, post_ops, dst_md);
 }
 
 void def_dispatch(compute::kernel_ctx_t &kernel_ctx,

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -193,14 +193,13 @@ void def_offsets(const dim_t offs[4][MAX_NDIMS],
 void def_block_offsets(const block_layout_t &layout,
         compute::kernel_ctx_t &kernel_ctx, const char *str);
 
+void def_data_type(
+        compute::kernel_ctx_t &kernel_ctx, data_type_t dt, const char *str);
 void def_data_type(compute::kernel_ctx_t &kernel_ctx, data_type_t dt,
-        const char *str, bool with_punning = true);
-void def_data_type(compute::kernel_ctx_t &kernel_ctx, data_type_t dt,
-        const std::string &str, bool with_punning = true);
+        const std::string &str);
 
 void def_memory_desc_info(compute::kernel_ctx_t &kernel_ctx,
-        const memory_desc_info_t &md_info, const char *prefix,
-        bool with_punning = true);
+        const memory_desc_info_t &md_info, const char *prefix);
 
 bool post_ops_with_binary_ok(const primitive_attr_t *attr,
         const memory_desc_t &dst_md, const int max_ndims_supported = 2);
@@ -224,11 +223,11 @@ bool post_ops_preserves_zeroes(
 
 status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md, bool with_punning = true);
+        const memory_desc_t &dst_md);
 
 status_t def_attr_info(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md, bool with_punning = true);
+        const memory_desc_t &dst_md);
 
 void def_dispatch(
         compute::kernel_ctx_t &kernel_ctx, const compute::dispatch_t &dispatch);

--- a/src/gpu/intel/reduction/atomic.cl
+++ b/src/gpu/intel/reduction/atomic.cl
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "gpu/intel/include/dispatch.h"
+#include "gpu/intel/include/io.h"
 #include "gpu/intel/include/types.h"
 #include "gpu/intel/include/types_interop.h"
 #include "gpu/intel/reduction/common.h"
@@ -46,10 +47,6 @@ DEF_atomic_accumulate(float);
 #else
 #define MAYBE_ATOMIC(x) x
 #endif
-
-// Define how to read data
-#define BLOCK_READ_DATA_T(data_ptr) \
-    AS_VECT_DATA_T(VECT_BLOCK_READ((const __global BLOCK_DATA_T *)data_ptr))
 
 #if VECT_DT_N == 1
 #define GET_ELEM(x, idx) x
@@ -115,19 +112,21 @@ __kernel void atomic_reduce(__global SRC_DATA_T *src,
     if (beg < tail_count) {
         unroll_for_by(FULL_UNROLL_FACTOR)(off_t i = 0; i < iters; i++) {
             const off_t src_off = (beg + i * REDUCTION_WI_COUNT) * inner_size;
-            const VECT_DATA_T src_val = BLOCK_READ_DATA_T(&src[src_off]);
+            DEF_ACC_DATA_T src_val[VECT_DT_N];
+            block_load(src_val, &src[src_off], VECT_DT_N);
             unroll_for(uint i = 0; i < VECT_DT_N; i++) {
-                GET_ELEM(acc, i) = reduce(REDUCTION_ALG, GET_ELEM(acc, i),
-                        TO_DEF_ACC_DATA_T(GET_ELEM(src_val, i)), power);
+                GET_ELEM(acc, i) = reduce(
+                        REDUCTION_ALG, GET_ELEM(acc, i), src_val[i], power);
             }
         }
     } else {
         unroll_for_by(TAIL_UNROLL_FACTOR)(off_t i = 0; i < iters; i++) {
             const off_t src_off = (beg + i * REDUCTION_WI_COUNT) * inner_size;
-            const VECT_DATA_T src_val = BLOCK_READ_DATA_T(&src[src_off]);
+            DEF_ACC_DATA_T src_val[VECT_DT_N];
+            block_load(src_val, &src[src_off], VECT_DT_N);
             unroll_for(uint i = 0; i < VECT_DT_N; i++) {
-                GET_ELEM(acc, i) = reduce(REDUCTION_ALG, GET_ELEM(acc, i),
-                        TO_DEF_ACC_DATA_T(GET_ELEM(src_val, i)), power);
+                GET_ELEM(acc, i) = reduce(
+                        REDUCTION_ALG, GET_ELEM(acc, i), src_val[i], power);
             }
         }
     }
@@ -165,7 +164,7 @@ __kernel void atomic_reduce(__global SRC_DATA_T *src,
                 div, power, eps);
         DST_DATA_T vect_dst_data = TO_DST(f);
 #else
-        VECT_DST_DATA_T vect_dst_data;
+        DST_DATA_T vect_dst_data[VECT_DT_N];
         unroll_for(uint i = 0; i < VECT_DT_N; i++) {
             float f = finalize(REDUCTION_ALG,
                     convert_float(GET_ELEM(local_acc, i)), div, power, eps);

--- a/src/gpu/intel/reduction/combined.cl
+++ b/src/gpu/intel/reduction/combined.cl
@@ -311,7 +311,7 @@ combined_reduce(
             }
 #endif
             if (is_dst_zero_padded(dst_off)) res = 0.0f;
-            write_dst(dst + dst_off, IS_FINAL ? TO_DST(res) : res);
+            write_dst(dst + dst_off, TO_DST(res));
             DUMP("Wrote dst[%ld] = %f\n", dst_off, res);
             write_padded_zeros(dst + dst_off);
             DUMP("dst[%ld] <- %f\n", dst_off, TO_DST(res));

--- a/src/gpu/intel/reorder/custom.cl
+++ b/src/gpu/intel/reorder/custom.cl
@@ -72,7 +72,7 @@ __kernel void custom_reorder(__global SRC_DATA_T *restrict src,
         int pad_d4 = NDIMS > 4 && d4 >= SRC_D4;
         int pad_d5 = NDIMS > 5 && d5 >= SRC_D5;
         if (pad_d0 || pad_d1 || pad_d2 || pad_d3 || pad_d4 || pad_d5) {
-            dst[dst_off] = 0;
+            dst[dst_off] = TO_DST(0);
             continue;
         }
 #endif

--- a/src/gpu/intel/reorder/ref.cl
+++ b/src/gpu/intel/reorder/ref.cl
@@ -86,7 +86,7 @@ ref_reorder(__global SRC_DATA_T *restrict src,
         int pad_d4 = NDIMS > 4 && d4 >= SRC_D4;
         int pad_d5 = NDIMS > 5 && d5 >= SRC_D5;
         if (pad_d0 || pad_d1 || pad_d2 || pad_d3 || pad_d4 || pad_d5) {
-            dst[dst_off] = 0;
+            dst[dst_off] = TO_DST(0);
             continue;
         }
 #endif

--- a/src/gpu/intel/resampling/ref.cl
+++ b/src/gpu/intel/resampling/ref.cl
@@ -122,7 +122,7 @@ __kernel void ref_resampling_bwd(
     const off_t src_index = SRC_OFF(mb, c, id, ih, iw);
 
     if (mb >= DST_D0 || c >= DST_D1) {
-        diff_src[src_index] = TO_DST(0.f);
+        diff_src[src_index] = TO_DATA_T(0.f);
         return;
     }
 #if RESAMPLING_ALG_NEAREST

--- a/src/gpu/intel/rnn/cell_compute.h
+++ b/src/gpu/intel/rnn/cell_compute.h
@@ -171,6 +171,10 @@ inline void __attribute__((overloadable)) load(
         float *s, const __global ushort *data, bool is_valid) {
     *s = is_valid ? into_float(as_bf16(data[get_sub_group_local_id()])) : 0;
 }
+inline void __attribute__((overloadable)) load(
+        float *s, const __global bf16 *data, bool is_valid) {
+    *s = is_valid ? into_float(data[get_sub_group_local_id()]) : 0;
+}
 
 inline float __attribute__((overloadable)) sg_get(float s, int offset) {
     return intel_sub_group_shuffle(s, offset);

--- a/src/gpu/intel/rnn/common.h
+++ b/src/gpu/intel/rnn/common.h
@@ -26,12 +26,14 @@
 #define TO_OUTPUT(x) convert_char_sat_rte(x)
 #elif OUTPUT_DT_S32
 #define TO_OUTPUT(x) convert_int_sat_rte(x)
+#elif OUTPUT_DT_BF16
+#define TO_OUTPUT(x) into_bf16(x)
 #else
 #define TO_OUTPUT(x) (x)
 #endif
 
 #if INPUT_DT_BF16
-#define TO_REF(x) cvt_bf16_to_f32(x)
+#define TO_REF(x) into_float(x)
 #else
 #define TO_REF(x) convert_float(x)
 #endif

--- a/src/gpu/intel/rnn/grid.cl
+++ b/src/gpu/intel/rnn/grid.cl
@@ -129,7 +129,8 @@ __kernel void simple_rnn_copy_init_iter(__global WS_STATE_DATA_T *dst_base,
     if (s < sic) {
         off_t src_i_offset = src_i_off(src_iter_strides, lay, dir, b, s);
         dst[ws_state_offset] = src_base
-                ? (quantize ? TO_WS_STATE(src[src_i_offset] * scale + shift)
+                ? (quantize ? TO_WS_STATE(
+                                      TO_REF(src[src_i_offset]) * scale + shift)
                             : src[src_i_offset])
                 : TO_WS_STATE(0.0f);
     }
@@ -193,8 +194,8 @@ simple_rnn_copy_res_layer(
     if (lr) {
         bool dequantize_at_copy = dequantize && DIRECTION_KIND != SUM;
         dst[dst_l_off(strides, it, b, dir * dhc + s)] = dequantize_at_copy
-                ? TO_DST(((float)src[off_ws_state(n_layer, n_dir, n_iter, batch,
-                                  states_ws_ld, n_layer - 1, dir, it, b, s)]
+                ? TO_DST((TO_REF(src[off_ws_state(n_layer, n_dir, n_iter, batch,
+                                  states_ws_ld, n_layer - 1, dir, it, b, s)])
                                  - shift)
                           / scale)
                 : src[off_ws_state(n_layer, n_dir, n_iter, batch, states_ws_ld,
@@ -204,10 +205,10 @@ simple_rnn_copy_res_layer(
     if (rl) {
 #if DIRECTION_KIND == SUM
         if (dequantize) {
-            float val = (float)src[off_ws_state(n_layer, n_dir, n_iter, batch,
+            float val = TO_REF(src[off_ws_state(n_layer, n_dir, n_iter, batch,
                                 states_ws_ld, n_layer - 1, dir, n_iter - it - 1,
-                                b, s)]
-                    + dst[dst_l_off(strides, it, b, s)];
+                                b, s)])
+                    + DST_TO_REF(dst[dst_l_off(strides, it, b, s)]);
             val = min(max(val, 0.f), 255.f);
             dst[dst_l_off(strides, it, b, s)]
                     = TO_DST((val - 2 * shift) / scale);
@@ -228,9 +229,9 @@ simple_rnn_copy_res_layer(
         }
 #else
         dst[dst_l_off(strides, it, b, dir * dhc + s)] = dequantize
-                ? TO_DST(((float)src[off_ws_state(n_layer, n_dir, n_iter, batch,
+                ? TO_DST((TO_REF(src[off_ws_state(n_layer, n_dir, n_iter, batch,
                                   states_ws_ld, n_layer - 1, dir,
-                                  n_iter - it - 1, b, s)]
+                                  n_iter - it - 1, b, s)])
                                  - shift)
                           / scale)
                 : src[off_ws_state(n_layer, n_dir, n_iter, batch, states_ws_ld,
@@ -287,13 +288,13 @@ __kernel void simple_rnn_copy_res_iter(
 
     if (dst_base && s < dhc) {
         dst[dst_i_off(strides, lay, dir, b, s)] = dequantize
-                ? TO_OUTPUT(((float)src[off_ws_state(n_layer, n_dir, n_iter,
+                ? TO_OUTPUT((TO_REF(src[off_ws_state(n_layer, n_dir, n_iter,
                                      batch, states_ws_ld, lay, dir, n_iter - 1,
-                                     b, s)]
+                                     b, s)])
                                     - shift)
                           / scale)
-                : TO_OUTPUT(src[off_ws_state(n_layer, n_dir, n_iter, batch,
-                          states_ws_ld, lay, dir, n_iter - 1, b, s)]);
+                : TO_OUTPUT(TO_REF(src[off_ws_state(n_layer, n_dir, n_iter,
+                          batch, states_ws_ld, lay, dir, n_iter - 1, b, s)]));
     }
 #if WITH_DST_ITER_C
     __global AUX_DATA_T *src_c = src_c_base;
@@ -730,7 +731,7 @@ simple_rnn_elemwise_bwd(int dir, int lay, int iter,
                 convert_float(bias[off_ker_bias(dhc, 0, j)]), alpha, tm_scales);
 #endif
 #if IS_TESTMODE
-        float tmp = = dH * activation_bwd(g, tm_scales[0], 0.0f);
+        float tmp = dH * activation_bwd(g, tm_scales[0], 0.0f);
         scratch_diff_gates[cell_scratch_mem(
                 scratch_diff_gates_ld, dhc, i, 0, j)]
                 = TO_SRC(tmp);

--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -33,6 +33,59 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define DIV_UP(x, y) (((x) + (y) - 1) / (y))
 
+/* When a data type is a struct (e.g. bf16), it cannot be used as an
+ * ext_vector_type element. Use the underlying scalar type for tile storage
+ * and convert at tile boundaries. */
+#ifdef DST_DT_BF16
+#define DST_TILE_DATA_T ushort
+#define CONVERT_TILE_DATA_T(v) (into_bf16(v).data)
+#else
+#define DST_TILE_DATA_T DST_DATA_T
+#define CONVERT_TILE_DATA_T CONVERT_DATA_T
+#endif
+
+#ifdef MSK_DT_BF16
+#define MSK_TILE_DATA_T ushort
+#define CONVERT_TILE_FLOAT_MSK_T(v) into_float(as_bf16(v))
+#else
+#define MSK_TILE_DATA_T MSK_DATA_T
+#define CONVERT_TILE_FLOAT_MSK_T CONVERT_FLOAT_T
+#endif
+
+/* Punned conversion for FMA tile storage: produces FMA_TYPE (ushort when bf16)
+ * rather than the bf16 struct that CONVERT_DATA_T returns. */
+#ifdef QRY_DT_BF16
+#define CONVERT_TILE_FMA_T(v) (into_bf16(convert_float(v)).data)
+#else
+#define CONVERT_TILE_FMA_T CONVERT_DATA_T
+#endif
+
+/* Conditional casts for ugemm pointer arguments: cast when the data type
+ * is a struct, since the ugemm microkernels use punned scalar types. */
+#ifdef KEY_DT_BF16
+#define AS_KEY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#elif defined(KEY_DT_S4) || defined(KEY_DT_U4)
+#define AS_KEY_TILE_PTR(p) ((const global uchar *)(p))
+#else
+#define AS_KEY_TILE_PTR(p) (p)
+#endif
+
+#ifdef VAL_DT_BF16
+#define AS_VAL_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#elif defined(VAL_DT_S4) || defined(VAL_DT_U4)
+#define AS_VAL_TILE_PTR(p) ((const global uchar *)(p))
+#else
+#define AS_VAL_TILE_PTR(p) (p)
+#endif
+
+#ifdef QRY_DT_BF16
+#define AS_QRY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#define AS_QRY_SLM_TILE_PTR(p) ((const local FMA_TYPE *)(p))
+#else
+#define AS_QRY_TILE_PTR(p) (p)
+#define AS_QRY_SLM_TILE_PTR(p) (p)
+#endif
+
 #define sg_per_wg (ugemm_kq_sg_per_wg_m * ugemm_kq_sg_per_wg_n)
 #define q_tile_sg_n DIV_UP(ugemm_kq_wg_tile_n, sg_per_wg)
 
@@ -113,21 +166,25 @@ inline void apply_dropout_s_tile(
 #endif
 
 #ifdef SCALE_DT_BF16
-#define SCALES_TO_FLOAT cvt_bf16_to_f32
+#define SCALES_TO_FLOAT into_float
 #else
 #define SCALES_TO_FLOAT convert_float
 #endif
 
 #ifdef VAL_ATTR_SCALES_DT_BF16
-#define VAL_SCALES_TO_FLOAT cvt_bf16_to_f32
+#define VAL_SCALES_TO_FLOAT into_float
+#define AS_VAL_SCALES_PTR(p) ((const global ushort *)(p))
 #else
 #define VAL_SCALES_TO_FLOAT convert_float
+#define AS_VAL_SCALES_PTR(p) (p)
 #endif
 
 #if KEY_ATTR_SCALES_DT_BF16
-#define KEY_SCALES_TO_FLOAT cvt_bf16_to_f32
+#define KEY_SCALES_TO_FLOAT into_float
+#define AS_KEY_SCALES_PTR(p) ((const global ushort *)(p))
 #else
 #define KEY_SCALES_TO_FLOAT convert_float
+#define AS_KEY_SCALES_PTR(p) (p)
 #endif
 
 #if USE_SYSTOLIC_UKERNEL
@@ -156,11 +213,11 @@ DECLARE_2D_TILE_LOAD_PACKED_VEC(q_tile_type, QRY_DATA_T, VEC_TYPE2,
 #endif
 
 #if BLOCK_A
-DECLARE_2D_TILE(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE, ugemm_vs_sg_tile_m,
-        1, 1, ugemm_vs_sg_tile_n)
+DECLARE_2D_TILE(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 #else
-DECLARE_2D_TILE(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE, ugemm_vs_sg_tile_m,
-        8, 1, ugemm_vs_sg_tile_n / 8)
+DECLARE_2D_TILE(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+        ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
 #if KQ_F16_ACC
@@ -217,26 +274,26 @@ DECLARE_2D_TILE(kmask_tile_type_float, float, SUBGROUP_SIZE, ugemm_kq_sg_tile_m,
         1, 1, 1)
 
 #if WITH_ATTN_MASK
-DECLARE_2D_TILE(mask_tile_type, MSK_DATA_T, SUBGROUP_SIZE, mask_br, mask_bc,
-        mask_nbr, mask_nbc)
+DECLARE_2D_TILE(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE, mask_br,
+        mask_bc, mask_nbr, mask_nbc)
 
 #if BROADCAST_MASK_Q
-DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, MSK_DATA_T, SUBGROUP_SIZE, mask_br,
-        mask_bc, mask_nbr, mask_nbc)
+DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE,
+        mask_br, mask_bc, mask_nbr, mask_nbc)
 #endif
 DECLARE_2D_TILE(mask_tile_type_float, float, SUBGROUP_SIZE, mask_br, mask_bc,
         mask_nbr, mask_nbc)
 DECLARE_2D_TILE_COPY_REBLOCK(mask_tile_type, SUBGROUP_SIZE, mask_br, mask_bc,
         mask_nbr, mask_nbc, mask_tile_type_float, SUBGROUP_SIZE, mask_br,
-        mask_bc, mask_nbr, mask_nbc, CONVERT_FLOAT_T)
+        mask_bc, mask_nbr, mask_nbc, CONVERT_TILE_FLOAT_MSK_T)
 #endif
 
 #if BLOCK_A
-DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 #endif
 #if BLOCK_2D_A
-DECLARE_2D_TILE_BLOCK2D_OPS(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK2D_OPS(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
@@ -246,7 +303,7 @@ DECLARE_2D_TILE_COPY_REBLOCK(s_tile_type_float, SUBGROUP_SIZE,
         ugemm_kq_c_type_block0, ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
         ugemm_kq_c_type_nblock1, s_tile_type_reblock, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_n, 1, ugemm_kq_sg_tile_n / ugemm_vs_sg_tile_n,
-        ugemm_kq_sg_tile_m, CONVERT_DATA_T)
+        ugemm_kq_sg_tile_m, CONVERT_TILE_FMA_T)
 
 DECLARE_2D_TILE_VREDUCE(s_tile_type_float, SUBGROUP_SIZE,
         ugemm_kq_c_type_block0, ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
@@ -270,7 +327,7 @@ DECLARE_2D_TILE_COPY_REBLOCK(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
         ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
         ugemm_kq_c_type_nblock1, s_tile_type_reblock, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_n, 1, ugemm_kq_sg_tile_n / ugemm_vs_sg_tile_n,
-        ugemm_kq_sg_tile_m, CONVERT_DATA_T)
+        ugemm_kq_sg_tile_m, CONVERT_TILE_FMA_T)
 
 DECLARE_2D_TILE_VREDUCE(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
         ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
@@ -295,12 +352,12 @@ DECLARE_2D_TILE_HREDUCE(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type_float, SUBGROUP_SIZE,
         ugemm_vs_c_type_block0, ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
         ugemm_vs_c_type_nblock1, a_tile_type_dst, SUBGROUP_SIZE,
-        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n, CONVERT_DATA_T)
+        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n, CONVERT_TILE_DATA_T)
 #else
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type_float, SUBGROUP_SIZE,
         ugemm_vs_c_type_block0, ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
         ugemm_vs_c_type_nblock1, a_tile_type_dst, SUBGROUP_SIZE,
-        ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8, CONVERT_DATA_T)
+        ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8, CONVERT_TILE_DATA_T)
 #endif
 
 DECLARE_2D_TILE_HREDUCE(a_tile_type_float, SUBGROUP_SIZE,
@@ -314,12 +371,12 @@ DECLARE_2D_TILE_HREDUCE(a_tile_type_float, SUBGROUP_SIZE,
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
         ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
         ugemm_vs_c_type_nblock1, a_tile_type_dst, SUBGROUP_SIZE,
-        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n, CONVERT_DATA_T)
+        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n, CONVERT_TILE_DATA_T)
 #else
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
         ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
         ugemm_vs_c_type_nblock1, a_tile_type_dst, SUBGROUP_SIZE,
-        ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8, CONVERT_DATA_T)
+        ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8, CONVERT_TILE_DATA_T)
 #endif
 
 DECLARE_2D_TILE_HREDUCE(a_tile_type, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
@@ -401,15 +458,16 @@ inline void tile_load_src1(q_tile_type *Q_tile, const global QRY_DATA_T *Q,
 #else // FMA
 
 #if BLOCK_Q
-    tile_load_block_rem_q(Q_tile, Q, n, ldq, offset_r, offset_c);
+    tile_load_block_rem_q(
+            Q_tile, AS_QRY_TILE_PTR(Q), n, ldq, offset_r, offset_c);
 #else
-    tile_load(Q_tile, Q, m, n, ldq, offset_r, offset_c);
+    tile_load(Q_tile, AS_QRY_TILE_PTR(Q), m, n, ldq, offset_r, offset_c);
 #endif
 
 #endif
 }
 
-inline void tile_store_t_slm_src1(q_tile_type *Q_tile, local QRY_DATA_T *Q_slm,
+inline void tile_store_t_slm_src1(q_tile_type *Q_tile, local FMA_TYPE *Q_slm,
         int panel, int ld, int offset_r, int offset_c) {
 #if USE_SYSTOLIC_UKERNEL
     tile_store_t_sys_src1(
@@ -523,8 +581,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     local char slm[Q_slm_size + S_slm_size + S_sum_slm_size + S_max_slm_size
             + ugemm_slm_size];
 
-    local QRY_DATA_T *Q_slm = (local QRY_DATA_T *)&slm[0];
-    local QRY_DATA_T *S_slm = (local QRY_DATA_T *)&slm[Q_slm_size];
+    local FMA_TYPE *Q_slm = (local FMA_TYPE *)&slm[0];
+    local FMA_TYPE *S_slm = (local FMA_TYPE *)&slm[Q_slm_size];
     local float *S_sum_slm = (local float *)&slm[Q_slm_size + S_slm_size];
     local float *S_max_slm
             = (local float *)&slm[Q_slm_size + S_slm_size + S_sum_slm_size];
@@ -718,13 +776,15 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         mask_tile_type mask_tile;
 #if BROADCAST_MASK_Q
         if (block_msk) {
-            tile_load_block(&mask_tile, msk, MSK_S2, 0, k0 + sg_i0_kq, 0);
+            tile_load_block(&mask_tile, (const global MSK_TILE_DATA_T *)msk,
+                    MSK_S2, 0, k0 + sg_i0_kq, 0);
         } else {
-            tile_load(&mask_tile, msk, k, 1, MSK_S2, k0 + sg_i0_kq, 0);
+            tile_load(&mask_tile, (const global MSK_TILE_DATA_T *)msk, k, 1,
+                    MSK_S2, k0 + sg_i0_kq, 0);
         }
 #else
-        tile_load_t(
-                &mask_tile, msk, q, k, MSK_S2, sg_j0_kq + wg_j0, k0 + sg_i0_kq);
+        tile_load_t(&mask_tile, (const global MSK_TILE_DATA_T *)msk, q, k,
+                MSK_S2, sg_j0_kq + wg_j0, k0 + sg_i0_kq);
 #endif
 #endif
 
@@ -753,14 +813,15 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #else
         s_tile_type S_tile
 #endif
-                = ugemm_kq(K, ldk, Q_slm, D_MAX, k0end, ugemm_kq_wg_tile_n, d,
-                        k0, 0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm
+                = ugemm_kq(AS_KEY_TILE_PTR(K), ldk, AS_QRY_SLM_TILE_PTR(Q_slm),
+                        D_MAX, k0end, ugemm_kq_wg_tile_n, d, k0, 0, 0, sg_i_kq,
+                        sg_j_kq, (local char *)ugemm_slm
 #if KEY_SCALES == QUANTIZE_2D
                         ,
-                        K_scales
+                        AS_KEY_SCALES_PTR(K_scales)
 #endif
 #if KEY_ZERO_POINTS
-                        ,
+                                ,
                         K_zp
 #endif
 #if (KEY_SCALES == QUANTIZE_2D) || KEY_ZERO_POINTS
@@ -902,7 +963,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #if USE_SYSTOLIC_UKERNEL
         /* Convert to half or bf16, VNNI format */
         s_tile_type_packed S_tile_packed;
-        tile_copy_to_vec2(S_tile, S_tile_packed, VEC_TYPE2);
+        tile_copy_to_vec2_cvt(
+                S_tile, S_tile_packed, VEC_TYPE2, CONVERT_TILE_FMA_T);
 
         /* Store to SLM, in packed format */
         tile_store_t_sys_src2(S_tile_packed, (local uint *)S_slm,
@@ -1049,15 +1111,15 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #else
         a_tile_type A_tile1
 #endif
-                = ugemm_vs(V, ldv, S_slm, ugemm_kq_wg_tile_m, d,
-                        ugemm_kq_wg_tile_n, k_chunk, 0, 0, 0, sg_i_vs, sg_j_vs,
-                        (local char *)ugemm_slm
+                = ugemm_vs(AS_VAL_TILE_PTR(V), ldv, AS_QRY_SLM_TILE_PTR(S_slm),
+                        ugemm_kq_wg_tile_m, d, ugemm_kq_wg_tile_n, k_chunk, 0,
+                        0, 0, sg_i_vs, sg_j_vs, (local char *)ugemm_slm
 #if VAL_SCALES == QUANTIZE_2D
                         ,
-                        V_scales
+                        AS_VAL_SCALES_PTR(V_scales)
 #endif
 #if VAL_ZERO_POINTS
-                        ,
+                                ,
                         V_zp
 #endif
 #if (VAL_SCALES == QUANTIZE_2D) || VAL_ZERO_POINTS
@@ -1153,11 +1215,13 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     uint sg_j0_vs = sg_j_vs * ugemm_vs_sg_tile_n + wg_j0;
 
 #if BLOCK_2D_A
-    tile_store_block2d(A_tile_dst, A, d, q_group_size, lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block2d(A_tile_dst, (global DST_TILE_DATA_T *)A, d, q_group_size,
+            lda, sg_i0_vs, sg_j0_vs);
 #elif BLOCK_A
-    tile_store_block_rem_q(
-            A_tile_dst, A, q_group_size, lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block_rem_q(A_tile_dst, (global DST_TILE_DATA_T *)A,
+            q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #else
-    tile_store(A_tile_dst, A, d, q_group_size, lda, sg_i0_vs, sg_j0_vs);
+    tile_store(A_tile_dst, (global DST_TILE_DATA_T *)A, d, q_group_size, lda,
+            sg_i0_vs, sg_j0_vs);
 #endif
 }

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -1095,7 +1095,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     kernel_ctx.define_int("KEY_GROUP_SIZE", key_group_size);
     kernel_ctx.define_int("VAL_GROUP_SIZE", val_group_size);
 
-    def_data_type(kernel_ctx, scale_data_t, "SCALE", !with_host_scale);
+    def_data_type(kernel_ctx, scale_data_t, "SCALE");
     kernel_ctx.define_int("INVERT_SCALE", invert_scale);
     kernel_ctx.define_int("WITH_ATTN_SCALE", with_attn_scale);
     kernel_ctx.define_int("WITH_HOST_SCALE", with_host_scale);
@@ -1276,7 +1276,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
 
     kernel_ctx.define_int("TRANSPOSE_K", transpose_k);
 
-    def_data_type(kernel_ctx, scale_data_t, "SCALE", !with_host_scale);
+    def_data_type(kernel_ctx, scale_data_t, "SCALE");
     kernel_ctx.define_int("INVERT_SCALE", invert_scale);
     kernel_ctx.define_int("WITH_ATTN_SCALE", with_attn_scale);
     kernel_ctx.define_int("WITH_HOST_SCALE", with_host_scale);

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -111,9 +111,66 @@ inline void apply_dropout_dP_tile(p_tile_type *tile, int tile_offset_r,
 #endif
 
 #ifdef SCALE_DT_BF16
-#define SCALES_TO_FLOAT cvt_bf16_to_f32
+#define SCALES_TO_FLOAT into_float
 #else
 #define SCALES_TO_FLOAT convert_float
+#endif
+
+#ifdef DST_DT_BF16
+#define DST_TILE_DATA_T ushort
+#define CONVERT_TILE_DATA_T(v) into_bf16(convert_float(v)).data
+#else
+#define DST_TILE_DATA_T DST_DATA_T
+#define CONVERT_TILE_DATA_T CONVERT_DATA_T
+#endif
+
+#ifdef MSK_DT_BF16
+#define MSK_TILE_DATA_T ushort
+#define CONVERT_TILE_FLOAT_MSK_T(v) into_float(as_bf16(v))
+#else
+#define MSK_TILE_DATA_T MSK_DATA_T
+#define CONVERT_TILE_FLOAT_MSK_T CONVERT_FLOAT_T
+#endif
+
+#if defined(QRY_DT_BF16)
+#define CONVERT_TILE_FMA_T(v) into_bf16(convert_float(v)).data
+#define CONVERT_TILE_FLOAT_FMA_T(v) into_float(as_bf16(v))
+#else
+#define CONVERT_TILE_FMA_T CONVERT_DATA_T
+#define CONVERT_TILE_FLOAT_FMA_T CONVERT_FLOAT_T
+#endif
+
+/* Conditional casts for ugemm pointer arguments: cast when the data type
+ * is a struct, since the ugemm microkernels use punned scalar types. */
+#ifdef KEY_DT_BF16
+#define AS_KEY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#define AS_KEY_SLM_TILE_PTR(p) ((local FMA_TYPE *)(p))
+#elif defined(KEY_DT_S4) || defined(KEY_DT_U4)
+#define AS_KEY_TILE_PTR(p) ((const global uchar *)(p))
+#define AS_KEY_SLM_TILE_PTR(p) ((local uchar *)(p))
+#else
+#define AS_KEY_TILE_PTR(p) (p)
+#define AS_KEY_SLM_TILE_PTR(p) (p)
+#endif
+
+#ifdef VAL_DT_BF16
+#define AS_VAL_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#elif defined(VAL_DT_S4) || defined(VAL_DT_U4)
+#define AS_VAL_TILE_PTR(p) ((const global uchar *)(p))
+#else
+#define AS_VAL_TILE_PTR(p) (p)
+#endif
+
+#ifdef QRY_DT_BF16
+#define AS_QRY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#else
+#define AS_QRY_TILE_PTR(p) (p)
+#endif
+
+#ifdef DST_DT_BF16
+#define AS_DST_TILE_PTR(p) ((const global FMA_TYPE *)(p))
+#else
+#define AS_DST_TILE_PTR(p) (p)
 #endif
 
 DECLARE_2D_TILE(q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n)
@@ -123,7 +180,7 @@ DECLARE_2D_TILE_BLOCK_OPS(
         dq_tile_type, float, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n)
 DECLARE_2D_TILE_COPY_REBLOCK(q_tile_type, SUBGROUP_SIZE, D_MAX, 1, 1,
         q_tile_sg_n, dq_tile_type, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n,
-        CONVERT_FLOAT_T)
+        CONVERT_TILE_FLOAT_FMA_T)
 
 #if TRANSPOSE_K
 
@@ -192,64 +249,65 @@ DECLARE_2D_TILE(kmask_tile_type_float, float, SUBGROUP_SIZE, ugemm_kq_sg_tile_m,
         1, 1, 1)
 
 #if WITH_ATTN_MASK
-DECLARE_2D_TILE(mask_tile_type, MSK_DATA_T, SUBGROUP_SIZE, mask_br, mask_bc,
-        mask_nbr, mask_nbc)
+DECLARE_2D_TILE(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE, mask_br,
+        mask_bc, mask_nbr, mask_nbc)
 
 #if BROADCAST_MASK_Q
-DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, MSK_DATA_T, SUBGROUP_SIZE, mask_br,
-        mask_bc, mask_nbr, mask_nbc)
+DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE,
+        mask_br, mask_bc, mask_nbr, mask_nbc)
 #endif
 DECLARE_2D_TILE(mask_tile_type_float, float, SUBGROUP_SIZE, mask_br, mask_bc,
         mask_nbr, mask_nbc)
 DECLARE_2D_TILE_COPY_REBLOCK(mask_tile_type, SUBGROUP_SIZE, mask_br, mask_bc,
         mask_nbr, mask_nbc, mask_tile_type_float, SUBGROUP_SIZE, mask_br,
-        mask_bc, mask_nbr, mask_nbc, CONVERT_FLOAT_T)
+        mask_bc, mask_nbr, mask_nbc, CONVERT_TILE_FLOAT_MSK_T)
 #endif
 
-DECLARE_2D_TILE(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_qdSt_sg_tile_m, 1, 1, ugemm_qdSt_sg_tile_n)
-DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_qdSt_sg_tile_m, 1, 1, ugemm_qdSt_sg_tile_n)
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE,
         ugemm_qdSt_c_type_block0, ugemm_qdSt_c_type_block1,
         ugemm_qdSt_c_type_nblock0, ugemm_qdSt_c_type_nblock1, a_tile_type_dst,
         SUBGROUP_SIZE, ugemm_qdSt_sg_tile_m, 1, 1, ugemm_qdSt_sg_tile_n,
-        CONVERT_DATA_T)
+        CONVERT_TILE_DATA_T)
 
-DECLARE_2D_TILE(dv_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE, ugemm_vs_sg_tile_m,
-        1, 1, ugemm_vs_sg_tile_n)
-DECLARE_2D_TILE_BLOCK_OPS(dv_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(dv_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
+DECLARE_2D_TILE_BLOCK_OPS(dv_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 DECLARE_2D_TILE_COPY_REBLOCK(dv_tile_type, SUBGROUP_SIZE,
         ugemm_vs_c_type_block0, ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
         ugemm_vs_c_type_nblock1, dv_tile_type_dst, SUBGROUP_SIZE,
-        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n, CONVERT_DATA_T)
+        ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n, CONVERT_TILE_DATA_T)
 
-DECLARE_2D_TILE(dq_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(dq_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_ktq_sg_tile_m, 1, 1, ugemm_ktq_sg_tile_n)
-DECLARE_2D_TILE_BLOCK_OPS(dq_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(dq_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_ktq_sg_tile_m, 1, 1, ugemm_ktq_sg_tile_n)
 DECLARE_2D_TILE_COPY_REBLOCK(ktq_tile_type, SUBGROUP_SIZE,
         ugemm_ktq_c_type_block0, ugemm_ktq_c_type_block1,
         ugemm_ktq_c_type_nblock0, ugemm_ktq_c_type_nblock1, dq_tile_type_dst,
         SUBGROUP_SIZE, ugemm_ktq_sg_tile_m, 1, 1, ugemm_ktq_sg_tile_n,
-        CONVERT_DATA_T)
+        CONVERT_TILE_DATA_T)
 
 DECLARE_2D_TILE_COPY_REBLOCK(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
         ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
         ugemm_kq_c_type_nblock1, s_tile_type_reblock, SUBGROUP_SIZE,
-        ugemm_kq_sg_tile_m, 1, 1, ugemm_kq_sg_tile_n, CONVERT_DATA_T)
+        ugemm_kq_sg_tile_m, 1, 1, ugemm_kq_sg_tile_n, CONVERT_TILE_FMA_T)
 DECLARE_2D_TILE_COPY_REBLOCK(p_tile_type, SUBGROUP_SIZE,
         ugemm_vtdA_c_type_block0, ugemm_vtdA_c_type_block1,
         ugemm_vtdA_c_type_nblock0, ugemm_vtdA_c_type_nblock1,
         p_tile_type_reblock, SUBGROUP_SIZE, ugemm_vtdA_c_type_block0, 1,
         ugemm_vtdA_c_type_nblock0,
-        ugemm_vtdA_c_type_block1 *ugemm_vtdA_c_type_nblock1, CONVERT_DATA_T)
+        ugemm_vtdA_c_type_block1 *ugemm_vtdA_c_type_nblock1, CONVERT_TILE_FMA_T)
 DECLARE_2D_TILE_COPY_REBLOCK(p_tile_type_reblock, SUBGROUP_SIZE,
         ugemm_vtdA_c_type_block0, 1, ugemm_vtdA_c_type_nblock0,
         ugemm_vtdA_c_type_block1 *ugemm_vtdA_c_type_nblock1, p_tile_type,
         SUBGROUP_SIZE, ugemm_vtdA_c_type_block0, ugemm_vtdA_c_type_block1,
-        ugemm_vtdA_c_type_nblock0, ugemm_vtdA_c_type_nblock1, CONVERT_FLOAT_T)
+        ugemm_vtdA_c_type_nblock0, ugemm_vtdA_c_type_nblock1,
+        CONVERT_TILE_FLOAT_FMA_T)
 
 DECLARE_2D_TILE_VREDUCE(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
         ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
@@ -328,9 +386,10 @@ inline void tile_load_k(k_tile_type *K_tile, const global KEY_DATA_T *K,
     uint k0_copy = k_tile_t_sg_n * sg_ij;
     // Coalesced load from d×k column-major memory (d contiguous, k strided)
 #if BLOCK_K
-    tile_load_block(K_tile, K, ldk, 0, seq_off + k0_copy);
+    tile_load_block(K_tile, AS_KEY_TILE_PTR(K), ldk, 0, seq_off + k0_copy);
 #else
-    tile_load(K_tile, K, head_size, seq_len, ldk, 0, seq_off + k0_copy);
+    tile_load(K_tile, AS_KEY_TILE_PTR(K), head_size, seq_len, ldk, 0,
+            seq_off + k0_copy);
 #endif
 
 #else
@@ -338,9 +397,10 @@ inline void tile_load_k(k_tile_type *K_tile, const global KEY_DATA_T *K,
     uint k0_copy = dmax_tile_sg_n * sg_ij;
 #if BLOCK_K
     // can ignore load_rem due to d_full requirement
-    tile_load_block(K_tile, K, ldk, seq_off, k0_copy);
+    tile_load_block(K_tile, AS_KEY_TILE_PTR(K), ldk, seq_off, k0_copy);
 #else
-    tile_load(K_tile, K, seq_len, head_size, ldk, seq_off, k0_copy);
+    tile_load(K_tile, AS_KEY_TILE_PTR(K), seq_len, head_size, ldk, seq_off,
+            k0_copy);
 #endif
 
 #endif
@@ -353,22 +413,22 @@ inline void tile_store_k_slm(
     // Bc / n_sg -- tile is D*Bc, write transposed to SLM (Bc*D)
     uint k0_copy = k_tile_t_sg_n * sg_ij;
 #if USE_SYSTOLIC_UKERNEL
-    tile_store_t_sys_src11(*K_tile, K_slm, SUBGROUP_SIZE, D_MAX, D_MAX,
-            ugemm_kq_wg_tile_m, 0, k0_copy);
+    tile_store_t_sys_src11(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm), SUBGROUP_SIZE,
+            D_MAX, D_MAX, ugemm_kq_wg_tile_m, 0, k0_copy);
 #else
-    tile_store_t_packed_src1(
-            *K_tile, K_slm, ugemm_kq_sg_tile_m, D_MAX, k0_copy, 0);
+    tile_store_t_packed_src1(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm),
+            ugemm_kq_sg_tile_m, D_MAX, k0_copy, 0);
 #endif
 
 #else
 
     uint k0_copy = dmax_tile_sg_n * sg_ij;
 #if USE_SYSTOLIC_UKERNEL
-    tile_store_sys_src1(*K_tile, K_slm, SUBGROUP_SIZE, D_MAX,
-            ugemm_kq_wg_tile_m, D_MAX, 0, k0_copy);
+    tile_store_sys_src1(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm), SUBGROUP_SIZE,
+            D_MAX, ugemm_kq_wg_tile_m, D_MAX, 0, k0_copy);
 #else
-    tile_store_packed_src1(
-            *K_tile, K_slm, ugemm_kq_sg_tile_m, D_MAX, 0, k0_copy);
+    tile_store_packed_src1(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm),
+            ugemm_kq_sg_tile_m, D_MAX, 0, k0_copy);
 #endif
 
 #endif
@@ -409,9 +469,11 @@ inline void tile_store_dV(dv_tile_type *dV_tile_slm, global DST_DATA_T_DKDV *dV,
     dv_tile_type_dst dV_tile_dst; // convert to half
     tile_copy_reblock(*dV_tile_slm, &dV_tile_dst);
 #if BLOCK_DV
-    tile_store_block_rem_q(dV_tile_dst, dV, n, ld, offset_r, offset_c, rem)
+    tile_store_block_rem_q(dV_tile_dst, (global DST_TILE_DATA_T *)dV, n, ld,
+            offset_r, offset_c, rem)
 #else
-    tile_store(dV_tile_dst, dV, m, n, ld, offset_r, offset_c);
+    tile_store(dV_tile_dst, (global DST_TILE_DATA_T *)dV, m, n, ld, offset_r,
+            offset_c);
 #endif
 
 #endif
@@ -429,9 +491,11 @@ inline void tile_store_dK_t(dv_tile_type *dK_tile, global DST_DATA_T_DKDV *dK,
     dv_tile_type_dst dK_tile_dst;
     tile_copy_reblock(*dK_tile, &dK_tile_dst);
 #if BLOCK_DK
-    tile_store_block_rem_q(dK_tile_dst, dK, n, ld, offset_r, offset_c, rem)
+    tile_store_block_rem_q(dK_tile_dst, (global DST_TILE_DATA_T *)dK, n, ld,
+            offset_r, offset_c, rem)
 #else
-    tile_store(dK_tile_dst, dK, m, n, ld, offset_r, offset_c);
+    tile_store(dK_tile_dst, (global DST_TILE_DATA_T *)dK, m, n, ld, offset_r,
+            offset_c);
 #endif
 #endif
 }
@@ -450,9 +514,11 @@ inline void tile_store_dK(a_tile_type *dK_tile, global DST_DATA_T_DKDV *dK,
     a_tile_type_dst dK_tile_dst;
     tile_copy_reblock(*dK_tile, &dK_tile_dst);
 #if BLOCK_DK
-    tile_store_block(dK_tile_dst, dK, ld, offset_r, offset_c);
+    tile_store_block(
+            dK_tile_dst, (global DST_TILE_DATA_T *)dK, ld, offset_r, offset_c);
 #else
-    tile_store(dK_tile_dst, dK, m, n, ld, offset_r, offset_c);
+    tile_store(dK_tile_dst, (global DST_TILE_DATA_T *)dK, m, n, ld, offset_r,
+            offset_c);
 #endif
 
 #endif
@@ -652,7 +718,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     if (qdiag0 < q0end) {
         /* Load K tile, destined for SLM */
         k_tile_type K_tile;
-        tile_fill(K_tile, TO_DATA_T(0.f));
+        tile_fill(K_tile, CONVERT_TILE_FMA_T(0.f));
 
         tile_load_k(&K_tile, K, k, d, ldk, wg_i0, sg_ij, remainder_k);
 
@@ -724,9 +790,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         int q_nchunk = min(q0end - q0, ugemm_kq_wg_tile_n);
         /* Calculate S = (K^T) * Q */
 #if DO_MM
-        s_tile_type S_tile
-                = ugemm_kq(K_slm, D_MAX, Q + q0 * ldq, ldq, k_chunk, q_nchunk,
-                        d, 0, 0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
+        s_tile_type S_tile = ugemm_kq(AS_KEY_SLM_TILE_PTR(K_slm), D_MAX,
+                AS_QRY_TILE_PTR(Q + q0 * ldq), ldq, k_chunk, q_nchunk, d, 0, 0,
+                0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
 #else
         s_tile_type S_tile;
 #endif
@@ -738,12 +804,15 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         mask_tile_type mask_tile;
 #if BROADCAST_MASK_Q
         if (block_msk) {
-            tile_load_block(&mask_tile, msk, MSK_S2, 0, k0 + sg_i0_kq, 0);
+            tile_load_block(&mask_tile, (const global MSK_TILE_DATA_T *)msk,
+                    MSK_S2, 0, k0 + sg_i0_kq, 0);
         } else {
-            tile_load(&mask_tile, msk, k, 1, MSK_S2, k0 + sg_i0_kq, 0);
+            tile_load(&mask_tile, (const global MSK_TILE_DATA_T *)msk, k, 1,
+                    MSK_S2, k0 + sg_i0_kq, 0);
         }
 #else
-        tile_load(&mask_tile, msk, k, q, MSK_S2, k0 + sg_i0_kq, q0 + sg_j0_kq);
+        tile_load(&mask_tile, (const global MSK_TILE_DATA_T *)msk, k, q, MSK_S2,
+                k0 + sg_i0_kq, q0 + sg_j0_kq);
 #endif
 
 #define unscale(x) ((x) * iscale)
@@ -823,7 +892,8 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             // Store softmax for ugemm_vs B-operand
 #if USE_SYSTOLIC_UKERNEL
             s_tile_type_packed S_tile_packed;
-            tile_copy_to_vec2(S_tile, S_tile_packed, VEC_TYPE2);
+            tile_copy_to_vec2_cvt(
+                    S_tile, S_tile_packed, VEC_TYPE2, CONVERT_TILE_FMA_T);
             tile_store_t_sys_src2(S_tile_packed, (local uint *)S_slm,
                     ugemm_vs_sg_tile_n, ugemm_kq_wg_tile_n / 2, sg_j0_kq / 2,
                     sg_i0_kq);
@@ -839,9 +909,10 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         {
 #if DO_MM
             dv_tile_type dV_tile1;
-            dV_tile1 = ugemm_vs(dA + q0 * ldda, ldda, (local FMA_TYPE *)S_slm,
-                    ugemm_kq_wg_tile_n, d, k_chunk, q_nchunk, 0, 0, 0, sg_i_vs,
-                    sg_j_vs, (local char *)ugemm_slm);
+            dV_tile1 = ugemm_vs(AS_DST_TILE_PTR(dA + q0 * ldda), ldda,
+                    (local FMA_TYPE *)S_slm, ugemm_kq_wg_tile_n, d, k_chunk,
+                    q_nchunk, 0, 0, 0, sg_i_vs, sg_j_vs,
+                    (local char *)ugemm_slm);
 #else
             dv_tile_type dV_tile1;
 #endif
@@ -855,9 +926,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         }
 
 #if DO_MM
-        p_tile_type dP_tile = ugemm_vtdA(V + k0 * ldv, ldv, dA + q0 * ldda,
-                ldda, k_chunk, q_nchunk, d, 0, 0, 0, sg_i_kq, sg_j_kq,
-                (local char *)ugemm_slm);
+        p_tile_type dP_tile = ugemm_vtdA(AS_VAL_TILE_PTR(V + k0 * ldv), ldv,
+                AS_DST_TILE_PTR(dA + q0 * ldda), ldda, k_chunk, q_nchunk, d, 0,
+                0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
 #else
         p_tile_type dP_tile;
 #endif
@@ -922,7 +993,8 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             tile_store_sys_src22(P_tile_reblock, dSt_slm, ugemm_ktq_sg_tile_n,
                     ugemm_kq_wg_tile_m, ugemm_kq_wg_tile_n, sg_i0_kq, sg_j0_kq);
             p_tile_type_packed dP_tile_packed;
-            tile_copy_to_vec2(dP_tile, dP_tile_packed, VEC_TYPE2);
+            tile_copy_to_vec2_cvt(
+                    dP_tile, dP_tile_packed, VEC_TYPE2, CONVERT_TILE_FMA_T);
             tile_store_sys_src1(dP_tile_packed, (local uint *)S_slm,
                     SUBGROUP_SIZE, ugemm_kq_wg_tile_n / 2, ugemm_kq_wg_tile_m,
                     ugemm_kq_wg_tile_n / 2, sg_i0_kq, sg_j0_kq / 2);
@@ -937,8 +1009,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         {
 #if DO_MM
             a_tile_type dK_tile1;
-            dK_tile1 = ugemm_qdSt(S_slm, ugemm_kq_wg_tile_n, Q + q0 * ldq, ldq,
-                    k_chunk, d, q_nchunk, 0, 0, 0, sg_i_qdSt, sg_j_qdSt,
+            dK_tile1 = ugemm_qdSt(S_slm, ugemm_kq_wg_tile_n,
+                    AS_QRY_TILE_PTR(Q + q0 * ldq), ldq, k_chunk, d, q_nchunk, 0,
+                    0, 0, sg_i_qdSt, sg_j_qdSt,
                     (local char *)ugemm_slm); // dS^t * Q -> Bc x d
 #else
             a_tile_type dK_tile1;
@@ -977,9 +1050,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 
             dQ_tile = ugemm_ktq(
 #if TRANSPOSE_K
-                    K + k0 * ldk,
+                    AS_KEY_TILE_PTR(K + k0 * ldk),
 #else
-                    K + k0,
+                    AS_KEY_TILE_PTR(K + k0),
 #endif
                     ldk, dSt_slm, ugemm_kq_wg_tile_m, d, q_nchunk, k_chunk, 0,
                     0, 0, sg_i_ktq, sg_j_ktq, (local char *)ugemm_slm);
@@ -1092,8 +1165,8 @@ preprocess_Di(global float *Di, const global DST_DATA_T *A,
 #else
         dq_tile_type dA_tile, A_tile;
         q_tile_type dA_tile_reblock, A_tile_reblock; // load native type
-        tile_fill(A_tile_reblock, TO_DATA_T(0.f));
-        tile_fill(dA_tile_reblock, TO_DATA_T(0.f));
+        tile_fill(A_tile_reblock, CONVERT_TILE_FMA_T(0.f));
+        tile_fill(dA_tile_reblock, CONVERT_TILE_FMA_T(0.f));
 
         tile_load(&dA_tile_reblock, (global FMA_TYPE *)dA, d, q, ldda, 0,
                 wg_j0 + q0_copy);


### PR DESCRIPTION
In [MFDNN-14925](https://jira.devtools.intel.com/browse/MFDNN-14925), we found multiple primitive failure due to inconsistent use of WITH_PUNNING across buffers. This PR completely removes this knob so that this failure mode can no longer occur. This fixes  [MFDNN-14925](https://jira.devtools.intel.com/browse/MFDNN-14925) along with a few other existing issues I found during testing.