### PR TITLE
xe: gemm: fix stride interface

### DIFF
--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -173,10 +173,10 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
 
     if (pd()->batch_dims() >= 1) {
         for (int i = pd()->batch_dims() - 1; i >= 0; i--) {
-            auto stride_a = int32_t(pd()->stride(DNNL_ARG_A, i));
-            auto stride_b = int32_t(pd()->stride(DNNL_ARG_B, i));
+            auto stride_a = int64_t(pd()->stride(DNNL_ARG_A, i));
+            auto stride_b = int64_t(pd()->stride(DNNL_ARG_B, i));
             if (swap_ab) std::swap(stride_a, stride_b);
-            auto stride_c = int32_t(pd()->desc()->stride_c(i));
+            auto stride_c = int64_t(pd()->desc()->stride_c(i));
             if (jit::enable_generator_dsl()) {
                 auto hw = ngen::getCore(
                         ((ngen::Product *)&utils::downcast<intel::engine_t *>(
@@ -235,7 +235,7 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         for (int i = 0; i < po_count; i++) {
             if (problem->postOps.binaryBatch[i]) {
                 for (int b = pd()->batch_dims() - 1; b >= 0; b--) {
-                    arg_list.set(argn++, int32_t(pd()->stride_binary(i, b)));
+                    arg_list.set(argn++, int64_t(pd()->stride_binary(i, b)));
                 }
             }
         }

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -869,9 +869,9 @@ void gen_kernel_t::init_interface() {
     }
     if (problem.batch == BatchMode::Strided) {
         for (int i = 0; i < problem.batchDims; i++) {
-            interface_.newArgument("stride_A" + std::to_string(i), DataType::d);
-            interface_.newArgument("stride_B" + std::to_string(i), DataType::d);
-            interface_.newArgument("stride_C" + std::to_string(i), DataType::d);
+            interface_.newArgument("stride_A" + std::to_string(i), DataType::q);
+            interface_.newArgument("stride_B" + std::to_string(i), DataType::q);
+            interface_.newArgument("stride_C" + std::to_string(i), DataType::q);
             if (problem.hasAScalePtr()) {
                 interface_.newArgument(
                         "scale_stride_A" + std::to_string(i), DataType::d);
@@ -882,7 +882,7 @@ void gen_kernel_t::init_interface() {
             }
             if (problem.hasCMXScale()) {
                 interface_.newArgument(
-                        "scale_stride_C" + std::to_string(i), DataType::d);
+                        "scale_stride_C" + std::to_string(i), DataType::q);
             }
             if (problem.hasAOffsetPtr()) {
                 interface_.newArgument(
@@ -907,7 +907,7 @@ void gen_kernel_t::init_interface() {
                 for (int b = 0; b < problem.batchDims; b++) {
                     interface_.newArgument("stride" + std::to_string(b)
                                     + "binary" + std::to_string(i),
-                            DataType::d);
+                            DataType::q);
                 }
             }
         }


### PR DESCRIPTION
Avoids incorrect offset calculations for batched GEMM. Fixes the following issue reported in [MFDNN-14479](https://jira.devtools.intel.com/browse/MFDNN-14479)

```
$ ./tests/benchdnn/benchdnn --matmul --engine=gpu --dt=f32:f32:f32 --stag=acbd --wtag=adbc --dtag=abcd --attr-post-ops=binary_mul:f32:0 --attr-scratchpad=user 4x3x16413x16:4x3x16x16413
Segmentation fault from GPU at 0xff0000000000f000, ctx_id: 1 (CCS) type: 0 (NotPresent), level: 1 (PDE), access: 1 (Write), banned: 1, aborting.
Segmentation fault from GPU at 0xff0000000000f000, ctx_id: 1 (CCS) type: 0 (NotPresent), level: 1 (PDE), access: 1 (Write), banned: 1, aborting.
Abort was called at 306 line in file:
./shared/source/os_interface/linux/drm_neo.cpp
Aborted (core dumped) 

```