### PR TITLE
graph: backend: dnnl: kernels: fix vector assign

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -236,7 +236,7 @@ status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        deps.assign(1, returned_event);
     }
 
     scratchpad.set_deps(returned_event);


### PR DESCRIPTION
Fixes MFDNN-14964

Work around a warning about -Werror=stringop-overread with GCC12.

Related bugzilla:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824 
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111499