### PR TITLE
cpu: rv64: add JIT kernel for f32 binary primitive

### DIFF
--- a/src/cpu/rv64/jit_rvv_binary_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_binary_kernel.cpp
@@ -1,0 +1,212 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <assert.h>
+
+#include "cpu/rv64/jit_rvv_binary_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+namespace {
+
+template <alg_kind_t alg>
+void dispatch_jit_binary_f32(const jit_rvv_binary_kernel_t::call_params_t *p) {
+    static const jit_rvv_binary_kernel_t kernel(alg);
+    kernel(p);
+}
+
+} // namespace
+
+jit_rvv_binary_kernel_t::jit_rvv_binary_kernel_t(alg_kind_t alg)
+    : jit_generator_t("jit_rvv_binary_kernel"), alg_(alg) {
+    create_kernel();
+}
+
+bool jit_rvv_binary_f32_supported(alg_kind_t alg) {
+    switch (alg) {
+        case alg_kind::binary_add:
+        case alg_kind::binary_div:
+        case alg_kind::binary_eq:
+        case alg_kind::binary_ge:
+        case alg_kind::binary_gt:
+        case alg_kind::binary_le:
+        case alg_kind::binary_lt:
+        case alg_kind::binary_max:
+        case alg_kind::binary_min:
+        case alg_kind::binary_mul:
+        case alg_kind::binary_ne:
+        case alg_kind::binary_sub: return true;
+        default: return false;
+    }
+}
+
+void jit_rvv_binary_apply_f32(alg_kind_t alg, const float *src0,
+        const float *src1, float *dst, dim_t len) {
+    const jit_rvv_binary_kernel_t::call_params_t p {src0, src1, dst, len};
+    switch (alg) {
+        case alg_kind::binary_add:
+            dispatch_jit_binary_f32<alg_kind::binary_add>(&p);
+            break;
+        case alg_kind::binary_div:
+            dispatch_jit_binary_f32<alg_kind::binary_div>(&p);
+            break;
+        case alg_kind::binary_eq:
+            dispatch_jit_binary_f32<alg_kind::binary_eq>(&p);
+            break;
+        case alg_kind::binary_ge:
+            dispatch_jit_binary_f32<alg_kind::binary_ge>(&p);
+            break;
+        case alg_kind::binary_gt:
+            dispatch_jit_binary_f32<alg_kind::binary_gt>(&p);
+            break;
+        case alg_kind::binary_le:
+            dispatch_jit_binary_f32<alg_kind::binary_le>(&p);
+            break;
+        case alg_kind::binary_lt:
+            dispatch_jit_binary_f32<alg_kind::binary_lt>(&p);
+            break;
+        case alg_kind::binary_max:
+            dispatch_jit_binary_f32<alg_kind::binary_max>(&p);
+            break;
+        case alg_kind::binary_min:
+            dispatch_jit_binary_f32<alg_kind::binary_min>(&p);
+            break;
+        case alg_kind::binary_mul:
+            dispatch_jit_binary_f32<alg_kind::binary_mul>(&p);
+            break;
+        case alg_kind::binary_ne:
+            dispatch_jit_binary_f32<alg_kind::binary_ne>(&p);
+            break;
+        case alg_kind::binary_sub:
+            dispatch_jit_binary_f32<alg_kind::binary_sub>(&p);
+            break;
+        default: assert(!"unsupported f32 binary JIT alg");
+    }
+}
+
+void jit_rvv_binary_kernel_t::compute_vector(const VReg &v_dst,
+        const VReg &v_src0, const VReg &v_src1, const FReg &f_zero,
+        const FReg &f_one) {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const VReg v_mask(0);
+    switch (alg_) {
+        case alg_kind::binary_add: vfadd_vv(v_dst, v_src0, v_src1); break;
+        case alg_kind::binary_div: vfdiv_vv(v_dst, v_src0, v_src1); break;
+        case alg_kind::binary_max: vfmax_vv(v_dst, v_src0, v_src1); break;
+        case alg_kind::binary_min: vfmin_vv(v_dst, v_src0, v_src1); break;
+        case alg_kind::binary_mul: vfmul_vv(v_dst, v_src0, v_src1); break;
+        case alg_kind::binary_sub: vfsub_vv(v_dst, v_src0, v_src1); break;
+        case alg_kind::binary_eq:
+            vmfeq_vv(v_mask, v_src0, v_src1);
+            vfmv_v_f(v_dst, f_zero);
+            vfmerge_vfm(v_dst, v_dst, f_one);
+            break;
+        case alg_kind::binary_ne:
+            vmfne_vv(v_mask, v_src0, v_src1);
+            vfmv_v_f(v_dst, f_zero);
+            vfmerge_vfm(v_dst, v_dst, f_one);
+            break;
+        case alg_kind::binary_lt:
+            vmflt_vv(v_mask, v_src0, v_src1);
+            vfmv_v_f(v_dst, f_zero);
+            vfmerge_vfm(v_dst, v_dst, f_one);
+            break;
+        case alg_kind::binary_le:
+            vmfle_vv(v_mask, v_src0, v_src1);
+            vfmv_v_f(v_dst, f_zero);
+            vfmerge_vfm(v_dst, v_dst, f_one);
+            break;
+        case alg_kind::binary_gt:
+            vmfgt_vv(v_mask, v_src0, v_src1);
+            vfmv_v_f(v_dst, f_zero);
+            vfmerge_vfm(v_dst, v_dst, f_one);
+            break;
+        case alg_kind::binary_ge:
+            vmfge_vv(v_mask, v_src0, v_src1);
+            vfmv_v_f(v_dst, f_zero);
+            vfmerge_vfm(v_dst, v_dst, f_one);
+            break;
+        default: assert(!"unsupported f32 binary JIT alg");
+    }
+#else
+    UNUSED(v_dst, v_src0, v_src1, f_zero, f_one);
+#endif
+}
+
+void jit_rvv_binary_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src0 = a1;
+    const Reg reg_src1 = a2;
+    const Reg reg_dst = a3;
+    const Reg reg_len = a4;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+    const Reg reg_tmp = t2;
+
+    const FReg f_zero = fa0;
+    const FReg f_one = fa1;
+
+    const VReg v_mask(0);
+    const VReg v_src0(1);
+    const VReg v_src1(2);
+    const VReg v_dst(3);
+
+    // call_params_t layout:
+    //  0: src0, 8: src1, 16: dst, 24: len
+    ld(reg_src0, reg_param, 0);
+    ld(reg_src1, reg_param, 8);
+    ld(reg_dst, reg_param, 16);
+    ld(reg_len, reg_param, 24);
+
+    li(reg_tmp, 0);
+    fmv_w_x(f_zero, reg_tmp);
+    li(reg_tmp, 0x3f800000);
+    fmv_w_x(f_one, reg_tmp);
+
+    Label loop, done;
+    L(loop);
+    beqz(reg_len, done);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vle32_v(v_src0, reg_src0);
+    vle32_v(v_src1, reg_src1);
+    compute_vector(v_dst, v_src0, v_src1, f_zero, f_one);
+    vse32_v(v_dst, reg_dst);
+    slli(reg_bytes, reg_vl, 2);
+    add(reg_src0, reg_src0, reg_bytes);
+    add(reg_src1, reg_src1, reg_bytes);
+    add(reg_dst, reg_dst, reg_bytes);
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(done);
+    ret();
+
+    UNUSED(v_mask);
+#else
+    ret();
+#endif
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_rvv_binary_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_binary_kernel.cpp
@@ -53,14 +53,15 @@ bool jit_rvv_binary_f32_supported(alg_kind_t alg) {
         case alg_kind::binary_min:
         case alg_kind::binary_mul:
         case alg_kind::binary_ne:
+        case alg_kind::binary_select:
         case alg_kind::binary_sub: return true;
         default: return false;
     }
 }
 
 void jit_rvv_binary_apply_f32(alg_kind_t alg, const float *src0,
-        const float *src1, float *dst, dim_t len) {
-    const jit_rvv_binary_kernel_t::call_params_t p {src0, src1, dst, len};
+        const float *src1, const int8_t *src2, float *dst, dim_t len) {
+    const jit_rvv_binary_kernel_t::call_params_t p {src0, src1, src2, dst, len};
     switch (alg) {
         case alg_kind::binary_add:
             dispatch_jit_binary_f32<alg_kind::binary_add>(&p);
@@ -94,6 +95,9 @@ void jit_rvv_binary_apply_f32(alg_kind_t alg, const float *src0,
             break;
         case alg_kind::binary_ne:
             dispatch_jit_binary_f32<alg_kind::binary_ne>(&p);
+            break;
+        case alg_kind::binary_select:
+            dispatch_jit_binary_f32<alg_kind::binary_select>(&p);
             break;
         case alg_kind::binary_sub:
             dispatch_jit_binary_f32<alg_kind::binary_sub>(&p);
@@ -144,6 +148,9 @@ void jit_rvv_binary_kernel_t::compute_vector(const VReg &v_dst,
             vfmv_v_f(v_dst, f_zero);
             vfmerge_vfm(v_dst, v_dst, f_one);
             break;
+        case alg_kind::binary_select:
+            // Handled in generate() because it needs the src2 condition input.
+            break;
         default: assert(!"unsupported f32 binary JIT alg");
     }
 #else
@@ -156,8 +163,9 @@ void jit_rvv_binary_kernel_t::generate() {
     const Reg reg_param = a0;
     const Reg reg_src0 = a1;
     const Reg reg_src1 = a2;
-    const Reg reg_dst = a3;
-    const Reg reg_len = a4;
+    const Reg reg_src2 = a3;
+    const Reg reg_dst = a4;
+    const Reg reg_len = a5;
     const Reg reg_vl = t0;
     const Reg reg_bytes = t1;
     const Reg reg_tmp = t2;
@@ -169,13 +177,15 @@ void jit_rvv_binary_kernel_t::generate() {
     const VReg v_src0(1);
     const VReg v_src1(2);
     const VReg v_dst(3);
+    const VReg v_src2(4);
 
     // call_params_t layout:
-    //  0: src0, 8: src1, 16: dst, 24: len
+    //  0: src0, 8: src1, 16: src2, 24: dst, 32: len
     ld(reg_src0, reg_param, 0);
     ld(reg_src1, reg_param, 8);
-    ld(reg_dst, reg_param, 16);
-    ld(reg_len, reg_param, 24);
+    ld(reg_src2, reg_param, 16);
+    ld(reg_dst, reg_param, 24);
+    ld(reg_len, reg_param, 32);
 
     li(reg_tmp, 0);
     fmv_w_x(f_zero, reg_tmp);
@@ -188,11 +198,20 @@ void jit_rvv_binary_kernel_t::generate() {
     vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
     vle32_v(v_src0, reg_src0);
     vle32_v(v_src1, reg_src1);
-    compute_vector(v_dst, v_src0, v_src1, f_zero, f_one);
+    if (alg_ == alg_kind::binary_select) {
+        vsetvli(reg_vl, reg_vl, SEW::e8, LMUL::mf4);
+        vle8_v(v_src2, reg_src2);
+        vmsne_vi(v_mask, v_src2, 0);
+        vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m1);
+        vmerge_vvm(v_dst, v_src1, v_src0);
+    } else {
+        compute_vector(v_dst, v_src0, v_src1, f_zero, f_one);
+    }
     vse32_v(v_dst, reg_dst);
     slli(reg_bytes, reg_vl, 2);
     add(reg_src0, reg_src0, reg_bytes);
     add(reg_src1, reg_src1, reg_bytes);
+    if (alg_ == alg_kind::binary_select) add(reg_src2, reg_src2, reg_vl);
     add(reg_dst, reg_dst, reg_bytes);
     sub(reg_len, reg_len, reg_vl);
     j_(loop);

--- a/src/cpu/rv64/jit_rvv_binary_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_binary_kernel.cpp
@@ -174,10 +174,9 @@ void jit_rvv_binary_kernel_t::generate() {
     const FReg f_one = fa1;
 
     const VReg v_mask(0);
-    const VReg v_src0(1);
-    const VReg v_src1(2);
-    const VReg v_dst(3);
-    const VReg v_src2(4);
+    const VReg v_src0(4);
+    const VReg v_src1(8);
+    const VReg v_dst(12);
 
     // call_params_t layout:
     //  0: src0, 8: src1, 16: src2, 24: dst, 32: len
@@ -187,6 +186,40 @@ void jit_rvv_binary_kernel_t::generate() {
     ld(reg_dst, reg_param, 24);
     ld(reg_len, reg_param, 32);
 
+    if (alg_ == alg_kind::binary_select) {
+        const VReg v_src0_m1(1);
+        const VReg v_src1_m1(2);
+        const VReg v_dst_m1(3);
+        const VReg v_src2_mf4(4);
+
+        Label select_loop, select_done;
+        L(select_loop);
+        beqz(reg_len, select_done);
+
+        vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+        vle32_v(v_src0_m1, reg_src0);
+        vle32_v(v_src1_m1, reg_src1);
+
+        vsetvli(reg_vl, reg_vl, SEW::e8, LMUL::mf4);
+        vle8_v(v_src2_mf4, reg_src2);
+        vmsne_vi(v_mask, v_src2_mf4, 0);
+
+        vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m1);
+        vmerge_vvm(v_dst_m1, v_src1_m1, v_src0_m1);
+        vse32_v(v_dst_m1, reg_dst);
+
+        slli(reg_bytes, reg_vl, 2);
+        add(reg_src0, reg_src0, reg_bytes);
+        add(reg_src1, reg_src1, reg_bytes);
+        add(reg_src2, reg_src2, reg_vl);
+        add(reg_dst, reg_dst, reg_bytes);
+        sub(reg_len, reg_len, reg_vl);
+        j_(select_loop);
+
+        L(select_done);
+        ret();
+    }
+
     li(reg_tmp, 0);
     fmv_w_x(f_zero, reg_tmp);
     li(reg_tmp, 0x3f800000);
@@ -195,23 +228,14 @@ void jit_rvv_binary_kernel_t::generate() {
     Label loop, done;
     L(loop);
     beqz(reg_len, done);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
     vle32_v(v_src0, reg_src0);
     vle32_v(v_src1, reg_src1);
-    if (alg_ == alg_kind::binary_select) {
-        vsetvli(reg_vl, reg_vl, SEW::e8, LMUL::mf4);
-        vle8_v(v_src2, reg_src2);
-        vmsne_vi(v_mask, v_src2, 0);
-        vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m1);
-        vmerge_vvm(v_dst, v_src1, v_src0);
-    } else {
-        compute_vector(v_dst, v_src0, v_src1, f_zero, f_one);
-    }
+    compute_vector(v_dst, v_src0, v_src1, f_zero, f_one);
     vse32_v(v_dst, reg_dst);
     slli(reg_bytes, reg_vl, 2);
     add(reg_src0, reg_src0, reg_bytes);
     add(reg_src1, reg_src1, reg_bytes);
-    if (alg_ == alg_kind::binary_select) add(reg_src2, reg_src2, reg_vl);
     add(reg_dst, reg_dst, reg_bytes);
     sub(reg_len, reg_len, reg_vl);
     j_(loop);

--- a/src/cpu/rv64/jit_rvv_binary_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_binary_kernel.hpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_RVV_BINARY_KERNEL_HPP
+#define CPU_RV64_JIT_RVV_BINARY_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_rvv_binary_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const float *src0;
+        const float *src1;
+        float *dst;
+        dim_t len;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_binary_kernel_t)
+
+    explicit jit_rvv_binary_kernel_t(alg_kind_t alg);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    void compute_vector(const Xbyak_riscv::VReg &v_dst,
+            const Xbyak_riscv::VReg &v_src0, const Xbyak_riscv::VReg &v_src1,
+            const Xbyak_riscv::FReg &f_zero, const Xbyak_riscv::FReg &f_one);
+
+    alg_kind_t alg_;
+};
+
+bool jit_rvv_binary_f32_supported(alg_kind_t alg);
+
+void jit_rvv_binary_apply_f32(alg_kind_t alg, const float *src0,
+        const float *src1, float *dst, dim_t len);
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/jit_rvv_binary_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_binary_kernel.hpp
@@ -29,6 +29,7 @@ struct jit_rvv_binary_kernel_t : public jit_generator_t {
     struct call_params_t {
         const float *src0;
         const float *src1;
+        const int8_t *src2;
         float *dst;
         dim_t len;
     };
@@ -55,7 +56,7 @@ private:
 bool jit_rvv_binary_f32_supported(alg_kind_t alg);
 
 void jit_rvv_binary_apply_f32(alg_kind_t alg, const float *src0,
-        const float *src1, float *dst, dim_t len);
+        const float *src1, const int8_t *src2, float *dst, dim_t len);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/rvv_binary.cpp
+++ b/src/cpu/rv64/rvv_binary.cpp
@@ -39,14 +39,10 @@ static inline void compute_binary_rvv(const alg_kind_t alg, const void *x,
         const data_type_t dt) {
     switch (dt) {
         case data_type::f32:
-            if (jit_rvv_binary_f32_supported(alg)) {
-                jit_rvv_binary_apply_f32(alg,
-                        reinterpret_cast<const float *>(x),
-                        reinterpret_cast<const float *>(y),
-                        reinterpret_cast<float *>(dst), len);
-            } else {
-                rvv_binary_apply_f32(alg, x, y, dst, c, len, dt);
-            }
+            assert(jit_rvv_binary_f32_supported(alg));
+            jit_rvv_binary_apply_f32(alg, reinterpret_cast<const float *>(x),
+                    reinterpret_cast<const float *>(y), c,
+                    reinterpret_cast<float *>(dst), len);
             break;
         case data_type::s32:
             rvv_binary_apply_s32(alg, x, y, dst, c, len, dt);

--- a/src/cpu/rv64/rvv_binary.cpp
+++ b/src/cpu/rv64/rvv_binary.cpp
@@ -16,7 +16,6 @@
 
 #include <assert.h>
 #include <memory>
-#include <riscv_vector.h>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
@@ -24,6 +23,7 @@
 #include "common/type_helpers.hpp"
 
 #include "cpu/primitive_attr_postops.hpp"
+#include "cpu/rv64/jit_rvv_binary_kernel.hpp"
 #include "cpu/rv64/rvv_binary_kernels.hpp"
 
 #include "cpu/rv64/rvv_binary.hpp"
@@ -39,7 +39,14 @@ static inline void compute_binary_rvv(const alg_kind_t alg, const void *x,
         const data_type_t dt) {
     switch (dt) {
         case data_type::f32:
-            rvv_binary_apply_f32(alg, x, y, dst, c, len, dt);
+            if (jit_rvv_binary_f32_supported(alg)) {
+                jit_rvv_binary_apply_f32(alg,
+                        reinterpret_cast<const float *>(x),
+                        reinterpret_cast<const float *>(y),
+                        reinterpret_cast<float *>(dst), len);
+            } else {
+                rvv_binary_apply_f32(alg, x, y, dst, c, len, dt);
+            }
             break;
         case data_type::s32:
             rvv_binary_apply_s32(alg, x, y, dst, c, len, dt);

--- a/src/cpu/rv64/rvv_binary_kernels.hpp
+++ b/src/cpu/rv64/rvv_binary_kernels.hpp
@@ -36,26 +36,6 @@ using eval_s8m1_t = vint8m1_t (*)(vint8m1_t, vint8m1_t, size_t);
 using eval_u8m1_t = vuint8m1_t (*)(vuint8m1_t, vuint8m1_t, size_t);
 
 /*** Kernel methods ***/
-static inline void rvv_binary_kernel_f32(const void *x_base, const void *y_base,
-        void *dst_base, const int8_t * /*c*/, dim_t len, eval_f32m1_t eval,
-        const data_type_t dt) {
-    for (dim_t i = 0; i < len;) {
-        size_t vl = __riscv_vsetvl_e32m1(static_cast<size_t>(len - i));
-        const float *x = reinterpret_cast<const float *>(
-                static_cast<const char *>(x_base)
-                + i * types::data_type_size(dt));
-        const float *y = reinterpret_cast<const float *>(
-                static_cast<const char *>(y_base)
-                + i * types::data_type_size(dt));
-        float *dst = reinterpret_cast<float *>(
-                static_cast<char *>(dst_base) + i * types::data_type_size(dt));
-        vfloat32m1_t vx = __riscv_vle32_v_f32m1(x, vl);
-        vfloat32m1_t vy = __riscv_vle32_v_f32m1(y, vl);
-        vfloat32m1_t vd = eval(vx, vy, vl);
-        __riscv_vse32_v_f32m1(dst, vd, vl);
-        i += static_cast<dim_t>(vl);
-    }
-}
 static inline void rvv_binary_kernel_s32(const void *x_base, const void *y_base,
         void *dst_base, const int8_t * /*c*/, dim_t len, eval_s32m1_t eval,
         const data_type_t dt) {
@@ -163,10 +143,6 @@ inline vuint8m1_t rvv_convert_and_apply_f32_to_u8(
 
 /*** Operations (evaluate in f32 domain) ***/
 // Add
-inline vfloat32m1_t rvv_binary_add_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    return __riscv_vfadd_vv_f32m1(x, y, vl);
-}
 inline vint32m1_t rvv_binary_add_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     return __riscv_vadd_vv_i32m1(x, y, vl);
 }
@@ -195,10 +171,6 @@ inline vuint8m1_t rvv_binary_div_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return rvv_convert_and_apply_f32_to_u8(x, y, vl, rvv_binary_div_f32_m4);
 }
 // Max
-inline vfloat32m1_t rvv_binary_max_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    return __riscv_vfmax_vv_f32m1(x, y, vl);
-}
 inline vint32m1_t rvv_binary_max_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     return __riscv_vmax_vv_i32m1(x, y, vl);
 }
@@ -209,10 +181,6 @@ inline vuint8m1_t rvv_binary_max_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return __riscv_vmaxu_vv_u8m1(x, y, vl);
 }
 // Min
-inline vfloat32m1_t rvv_binary_min_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    return __riscv_vfmin_vv_f32m1(x, y, vl);
-}
 inline vint32m1_t rvv_binary_min_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     return __riscv_vmin_vv_i32m1(x, y, vl);
 }
@@ -241,10 +209,6 @@ inline vuint8m1_t rvv_binary_mul_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return rvv_convert_and_apply_f32_to_u8(x, y, vl, rvv_binary_mul_f32_m4);
 }
 // Sub
-inline vfloat32m1_t rvv_binary_sub_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    return __riscv_vfsub_vv_f32m1(x, y, vl);
-}
 inline vfloat32m4_t rvv_binary_sub_f32_m4(
         vfloat32m4_t x, vfloat32m4_t y, size_t vl) {
     return __riscv_vfsub_vv_f32m4(x, y, vl);
@@ -260,12 +224,6 @@ inline vuint8m1_t rvv_binary_sub_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return rvv_convert_and_apply_f32_to_u8(x, y, vl, rvv_binary_sub_f32_m4);
 }
 // Ge
-inline vfloat32m1_t rvv_binary_ge_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    vbool32_t mask = __riscv_vmfge_vv_f32m1_b32(x, y, vl);
-    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
-    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
-}
 inline vint32m1_t rvv_binary_ge_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     vbool32_t mask = __riscv_vmsge_vv_i32m1_b32(x, y, vl);
     vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
@@ -282,12 +240,6 @@ inline vuint8m1_t rvv_binary_ge_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
 }
 // Gt
-inline vfloat32m1_t rvv_binary_gt_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    vbool32_t mask = __riscv_vmfgt_vv_f32m1_b32(x, y, vl);
-    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
-    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
-}
 inline vint32m1_t rvv_binary_gt_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     vbool32_t mask = __riscv_vmsgt_vv_i32m1_b32(x, y, vl);
     vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
@@ -304,12 +256,6 @@ inline vuint8m1_t rvv_binary_gt_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
 }
 // Le
-inline vfloat32m1_t rvv_binary_le_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    vbool32_t mask = __riscv_vmfle_vv_f32m1_b32(x, y, vl);
-    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
-    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
-}
 inline vint32m1_t rvv_binary_le_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     vbool32_t mask = __riscv_vmsle_vv_i32m1_b32(x, y, vl);
     vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
@@ -326,12 +272,6 @@ inline vuint8m1_t rvv_binary_le_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
 }
 // Lt
-inline vfloat32m1_t rvv_binary_lt_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    vbool32_t mask = __riscv_vmflt_vv_f32m1_b32(x, y, vl);
-    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
-    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
-}
 inline vint32m1_t rvv_binary_lt_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     vbool32_t mask = __riscv_vmslt_vv_i32m1_b32(x, y, vl);
     vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
@@ -348,12 +288,6 @@ inline vuint8m1_t rvv_binary_lt_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
 }
 // Eq
-inline vfloat32m1_t rvv_binary_eq_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    vbool32_t mask = __riscv_vmfeq_vv_f32m1_b32(x, y, vl);
-    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
-    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
-}
 inline vint32m1_t rvv_binary_eq_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     vbool32_t mask = __riscv_vmseq_vv_i32m1_b32(x, y, vl);
     vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
@@ -370,12 +304,6 @@ inline vuint8m1_t rvv_binary_eq_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
     return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
 }
 // Ne
-inline vfloat32m1_t rvv_binary_ne_f32(
-        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
-    vbool32_t mask = __riscv_vmfne_vv_f32m1_b32(x, y, vl);
-    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
-    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
-}
 inline vint32m1_t rvv_binary_ne_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
     vbool32_t mask = __riscv_vmsne_vv_i32m1_b32(x, y, vl);
     vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
@@ -393,22 +321,6 @@ inline vuint8m1_t rvv_binary_ne_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
 }
 
 /*** Select op needs three oprands: x, y, c mask. Do it specially without op dispatching ***/
-inline void rvv_binary_select_kernel_f32(const float *x, const float *y,
-        float *dst, const int8_t *c, dim_t len) {
-    for (dim_t i = 0; i < len;) {
-        // Set VL for f32m4 ops and compute vector length in elements
-        size_t vl = __riscv_vsetvl_e32m4(static_cast<size_t>(len - i));
-        vfloat32m4_t vx = __riscv_vle32_v_f32m4(x + i, vl);
-        vfloat32m4_t vy = __riscv_vle32_v_f32m4(y + i, vl);
-        // Mask
-        vint8m1_t vc8 = __riscv_vle8_v_i8m1(c + i, vl);
-        vbool8_t mask
-                = __riscv_vmsne_vx_i8m1_b8(vc8, static_cast<int8_t>(0), vl);
-        vfloat32m4_t vsel = __riscv_vmerge_vvm_f32m4(vy, vx, mask, vl);
-        __riscv_vse32_v_f32m4(dst + i, vsel, vl);
-        i += static_cast<dim_t>(vl);
-    }
-}
 inline void rvv_binary_select_kernel_s32(const int32_t *x, const int32_t *y,
         int32_t *dst, const int8_t *c, dim_t len) {
     for (dim_t i = 0; i < len;) {
@@ -494,23 +406,6 @@ inline void rvv_binary_select_kernel_u8(const uint8_t *x, const uint8_t *y,
 }
 
 /*** Dispatch getters for different data types ***/
-inline eval_f32m1_t get_eval_f32(const alg_kind_t alg) {
-    switch (alg) {
-        case alg_kind::binary_add: return rvv_binary_add_f32;
-        case alg_kind::binary_div: return rvv_binary_div_f32;
-        case alg_kind::binary_max: return rvv_binary_max_f32;
-        case alg_kind::binary_min: return rvv_binary_min_f32;
-        case alg_kind::binary_mul: return rvv_binary_mul_f32;
-        case alg_kind::binary_sub: return rvv_binary_sub_f32;
-        case alg_kind::binary_ge: return rvv_binary_ge_f32;
-        case alg_kind::binary_gt: return rvv_binary_gt_f32;
-        case alg_kind::binary_le: return rvv_binary_le_f32;
-        case alg_kind::binary_lt: return rvv_binary_lt_f32;
-        case alg_kind::binary_eq: return rvv_binary_eq_f32;
-        case alg_kind::binary_ne: return rvv_binary_ne_f32;
-        default: return nullptr;
-    }
-}
 inline eval_s32m1_t get_eval_s32(const alg_kind_t alg) {
     switch (alg) {
         case alg_kind::binary_add: return rvv_binary_add_s32;
@@ -564,22 +459,6 @@ inline eval_u8m1_t get_eval_u8(const alg_kind_t alg) {
 }
 
 /*** Apply methods ***/
-static inline void rvv_binary_apply_f32(const alg_kind_t alg, const void *x,
-        const void *y, void *dst, const int8_t *c, const dim_t len,
-        const data_type_t dt) {
-    if (alg == alg_kind::binary_select) {
-        rvv_binary_select_kernel_f32(reinterpret_cast<const float *>(x),
-                reinterpret_cast<const float *>(y),
-                reinterpret_cast<float *>(dst), c, len);
-        return;
-    }
-    auto eval = get_eval_f32(alg);
-    if (!eval) {
-        assert(!"[rvv_binary_apply_f32] unknown binary alg_kind");
-        return;
-    }
-    rvv_binary_kernel_f32(x, y, dst, c, len, eval, dt);
-}
 static inline void rvv_binary_apply_s32(const alg_kind_t alg, const void *x,
         const void *y, void *dst, const int8_t *c, const dim_t len,
         const data_type_t dt) {


### PR DESCRIPTION
# Summary

This PR adds a RISC-V RVV JIT kernel for the RV64 f32 binary primitive.

The new JIT path covers dense, same-shape f32 binary operations that are already accepted by the existing RV64 binary primitive descriptor. It does not expand the primitive coverage: broadcast, non-plain layouts, attributes, integer data types, and `SELECT` continue to use the existing paths or other implementations.

Covered f32 algorithms:

- `ADD`
- `SUB`
- `MUL`
- `DIV`
- `MAX`
- `MIN`
- `EQ`
- `NE`
- `LT`
- `LE`
- `GT`
- `GE`
- `SELECT`

# Changes

- Added `jit_rvv_binary_kernel_t`, a new RV64 RVV JIT kernel for f32 binary operations.
- Routed supported dense same-shape f32 binary operations through the new JIT kernel.
- Added JIT support for `SELECT`, including its third input.
- Kept the existing RVV intrinsic implementation for `s32`, `s8`, and `u8`.
- Removed the direct `riscv_vector.h` dependency from `rvv_binary.cpp`; remaining intrinsic code stays isolated in the existing kernel header.

# Test Batch

The performance and correctness batch used for this PR is derived from existing oneDNN benchdnn binary input files. The shapes were selected from:

- `tests/benchdnn/inputs/binary/shapes_ci`
- `tests/benchdnn/inputs/binary/option_set_bcast4d`
- `tests/benchdnn/inputs/binary/test_binary_gpu`

Selected shapes:

```text
3x5x6x9:3x5x6x9
1x15x8x8:1x15x8x8
1x17x7x5:1x17x7x5
1x16x8x8:1x16x8x8
1x16x16x16:1x16x16x16
16x384x20x20:16x384x20x20
8x128x64x64:8x128x64x64
16x64x16x16:16x64x16x16
```

These are all dense same-shape cases, which match the current RV64 binary primitive support. Broadcast cases were not used for this JIT performance comparison because the existing RV64 binary implementation does not support broadcast either.

# Correctness

Command:

```sh
build/tests/benchdnn/benchdnn --binary --mode=C \
    --sdt=f32:f32 --ddt=f32 \
    --stag=abcd:abcd --dtag=abcd \
    --alg=ADD,SUB,MUL,DIV,MAX,MIN,EQ,NE,LT,LE,GT,GE,SELECT \
    --batch=../runlogs/binary_dense_f32_from_inputs.batch
```

Result:

```text
tests:104 passed:104 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
Implementation statistics:
RISCV64GCV : 104 (100%)
```

# Performance

Command:

```sh
build/tests/benchdnn/benchdnn --binary --mode=P \
    --max-ms-per-prb=300 --fix-times-per-prb=20 \
    --sdt=f32:f32 --ddt=f32 \
    --stag=abcd:abcd --dtag=abcd \
    --alg=<ALG> \
    --batch=../runlogs/binary_dense_f32_from_inputs.batch
```

Benchmarks were run on MUSE Pi Pro (Spacemit(R) X60).

Performance testing has been completed for all f32 algorithms covered by this PR:

```text
ADD, SUB, MUL, DIV, MAX, MIN, EQ, NE, LT, LE, GT, GE, SELECT
```

Results below use benchdnn `%0time` in milliseconds.

| Shape | Alg | Baseline ms | JIT ms | Speedup |
|---|---:|---:|---:|---:|
| `16x384x20x20:16x384x20x20` | ADD | 7.50515 | 4.50470 | 1.67x |
| `8x128x64x64:8x128x64x64` | ADD | 11.8181 | 7.44634 | 1.59x |
| `16x64x16x16:16x64x16x16` | ADD | 0.808142 | 0.536096 | 1.51x |
| `16x384x20x20:16x384x20x20` | SUB | 7.00569 | 4.42795 | 1.58x |
| `8x128x64x64:8x128x64x64` | SUB | 11.9349 | 7.41588 | 1.61x |
| `16x64x16x16:16x64x16x16` | SUB | 0.816833 | 0.540479 | 1.51x |
| `16x384x20x20:16x384x20x20` | MUL | 7.12115 | 4.50148 | 1.58x |
| `8x128x64x64:8x128x64x64` | MUL | 11.8586 | 7.42002 | 1.60x |
| `16x64x16x16:16x64x16x16` | MUL | 0.815881 | 0.537781 | 1.52x |
| `16x384x20x20:16x384x20x20` | DIV | 7.09200 | 4.49491 | 1.58x |
| `8x128x64x64:8x128x64x64` | DIV | 12.2672 | 7.56066 | 1.62x |
| `16x64x16x16:16x64x16x16` | DIV | 0.821411 | 0.540271 | 1.52x |
| `16x384x20x20:16x384x20x20` | MAX | 6.97384 | 4.37750 | 1.59x |
| `8x128x64x64:8x128x64x64` | MAX | 12.0800 | 7.46368 | 1.62x |
| `16x64x16x16:16x64x16x16` | MAX | 0.824402 | 0.537244 | 1.53x |
| `16x384x20x20:16x384x20x20` | MIN | 7.00521 | 4.43513 | 1.58x |
| `8x128x64x64:8x128x64x64` | MIN | 12.1193 | 7.44341 | 1.63x |
| `16x64x16x16:16x64x16x16` | MIN | 0.895361 | 0.571680 | 1.57x |
| `16x384x20x20:16x384x20x20` | EQ | 7.27450 | 4.44902 | 1.64x |
| `8x128x64x64:8x128x64x64` | EQ | 11.9229 | 7.47892 | 1.59x |
| `16x64x16x16:16x64x16x16` | EQ | 0.905212 | 0.541016 | 1.67x |
| `16x384x20x20:16x384x20x20` | NE | 6.99880 | 4.43883 | 1.58x |
| `8x128x64x64:8x128x64x64` | NE | 12.1821 | 7.46724 | 1.63x |
| `16x64x16x16:16x64x16x16` | NE | 0.823682 | 0.543298 | 1.52x |
| `16x384x20x20:16x384x20x20` | LT | 7.24965 | 4.45317 | 1.63x |
| `8x128x64x64:8x128x64x64` | LT | 12.1199 | 7.60471 | 1.59x |
| `16x64x16x16:16x64x16x16` | LT | 0.818286 | 0.545715 | 1.50x |
| `16x384x20x20:16x384x20x20` | LE | 7.06379 | 4.44554 | 1.59x |
| `8x128x64x64:8x128x64x64` | LE | 12.0935 | 7.49332 | 1.61x |
| `16x64x16x16:16x64x16x16` | LE | 0.820532 | 0.535620 | 1.53x |
| `16x384x20x20:16x384x20x20` | GT | 7.02644 | 4.38422 | 1.60x |
| `8x128x64x64:8x128x64x64` | GT | 11.8948 | 7.88663 | 1.51x |
| `16x64x16x16:16x64x16x16` | GT | 0.817102 | 0.544666 | 1.50x |
| `16x384x20x20:16x384x20x20` | GE | 7.00369 | 4.85857 | 1.44x |
| `8x128x64x64:8x128x64x64` | GE | 11.8549 | 7.58335 | 1.56x |
| `16x64x16x16:16x64x16x16` | GE | 0.825232 | 0.539185 | 1.53x |
| `3x5x6x9:3x5x6x9` | SELECT | 0.0161621 | 0.0163086 | 0.99x |
| `1x15x8x8:1x15x8x8` | SELECT | 0.0241821 | 0.0162109 | 1.49x |
| `1x17x7x5:1x17x7x5` | SELECT | 0.0166260 | 0.0149658 | 1.11x |
| `1x16x8x8:1x16x8x8` | SELECT | 0.0185303 | 0.0150146 | 1.23x |
| `1x16x16x16:1x16x16x16` | SELECT | 0.0179565 | 0.0180664 | 0.99x |
| `16x384x20x20:16x384x20x20` | SELECT | 4.88973 | 5.39487 | 0.91x |
| `8x128x64x64:8x128x64x64` | SELECT | 8.59805 | 8.81656 | 0.98x |
| `16x64x16x16:16x64x16x16` | SELECT | 0.593604 | 0.586951 | 1.01x |

For small shapes, results are close to timer noise and can show minor regressions. For example, `1x15x8x8` and `1x16x8x8` are around `0.015-0.024 ms`, and several algorithms fluctuate below or above baseline.

For the regular two-input binary algorithms, the total `avg_time` over all selected shapes is `240.4573 ms` for baseline and `151.5530 ms` for the JIT version, a `1.59x` overall speedup. For medium and large dense same-shape f32 workloads, these algorithms generally show about `1.5x-1.6x` speedup.

`SELECT` is now JIT-enabled and passes the same correctness coverage. Its current performance is roughly on par with the existing path on MUSE Pi Pro.