### PR TITLE
[GPU][NVL-P] Fix JIT HW detection

### DIFF
--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -88,7 +88,7 @@ status_t device_info_t::init(
     return status::success;
 }
 
-const ngen::Product &device_info_t::ngen_product(gpu_product_t &product) {
+const ngen::Product &device_info_t::ngen_product(const gpu_product_t &product) {
     static_assert(sizeof(ngen::Product) == sizeof(compute::gpu_product_t),
             "Can't cast gpu_product_t to ngen::Product");
     return reinterpret_cast<const ngen::Product &>(product);

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -190,7 +190,7 @@ public:
     }
     gpu_arch_t gpu_arch() const { return gpu_arch_; }
     const gpu_product_t &gpu_product() const { return gpu_product_; }
-    static const ngen::Product &ngen_product(gpu_product_t &product);
+    static const ngen::Product &ngen_product(const gpu_product_t &product);
     ngen::HW ngen_hw() const;
     int stepping_id() const;
     uint64_t native_extensions() const { return native_extensions_; }

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -269,7 +269,8 @@ struct gen_t : public primitive_t {
             auto lda = ld(DNNL_ARG_A);
             auto ldb = ld(DNNL_ARG_B);
             if (swap_ab_) std::swap(lda, ldb);
-            auto entries = kernel_desc_.select_kernel(arch_, stepping,
+            auto product = intel_engine->device_info()->gpu_product();
+            auto entries = kernel_desc_.select_kernel(product, stepping,
                     dev_info_->eu_count(), has_systolic, is_integrated, mode,
                     problem, alpha(), beta(), m, n, d->k(), lda, ldb, d->ldc(),
                     d->batch());

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -385,16 +385,18 @@ void gen_desc_t::update_driver_info() {
 }
 
 std::vector<const gemmstone::kcatalog::Entry *>
-gen_nocopy_desc_t::select_kernel(compute::gpu_arch_t arch, int stepping,
+gen_nocopy_desc_t::select_kernel(compute::gpu_product_t product, int stepping,
         int eu_count, bool has_systolic, bool is_integrated, compute_mode mode,
         const gemmstone::GEMMProblem &problem, float alpha, float beta, dim_t m,
         dim_t n, dim_t k, dim_t lda, dim_t ldb, dim_t ldc, dim_t batch) {
     using namespace ngen;
     using namespace kcatalog;
 
-    arch_ = arch;
-    hw_ = convert_dnnl_arch_to_ngen(arch);
+    product_ = compute::device_info_t::ngen_product(product);
+    hw_ = getCore(product_.family);
+    arch_ = convert_ngen_arch_to_dnnl(hw_);
     stepping_ = stepping;
+    problem_.product = product_;
     m_ = into<int>(m);
     n_ = into<int>(n);
     k_ = into<int>(k);
@@ -425,7 +427,8 @@ gen_nocopy_desc_t::select_kernel(compute::gpu_arch_t arch, int stepping,
     bool can_2d_c = (ldc * problem.Tc_ext <= 16777216);
 
     // Xe2 requires stronger alignment for block 2D.
-    if (arch == compute::gpu_arch_t::xe2 || arch == compute::gpu_arch_t::xe3) {
+    if (arch_ == compute::gpu_arch_t::xe2
+            || arch_ == compute::gpu_arch_t::xe3) {
         can_2d_a &= (problem.A.alignment % 16 == 0);
         can_2d_b &= (problem.B.alignment % 16 == 0);
         can_2d_c &= (problem.C.alignment % 16 == 0);
@@ -610,11 +613,11 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     using namespace ngen;
     using namespace kcatalog;
 
-    auto ngen_product = compute::device_info_t::ngen_product(product);
-    hw_ = getCore(ngen_product.family);
+    product_ = compute::device_info_t::ngen_product(product);
+    hw_ = getCore(product_.family);
     arch_ = convert_ngen_arch_to_dnnl(hw_);
     stepping_ = stepping;
-    problem_.product = ngen_product;
+    problem_.product = product_;
     m_ = into<int>(m);
     n_ = into<int>(n);
     k_ = into<int>(k);
@@ -1000,7 +1003,7 @@ status_t gen_kernel_t::get_kernel(
 
 #define ARCH_DISPATCH(arch) \
     case ngen::HW::arch: { \
-        gemm_kernel_generator_t<ngen::HW::arch> generator; \
+        gemm_kernel_generator_t<ngen::HW::arch> generator(desc()->product_); \
         generator.setStepping(desc()->stepping_); \
         generator.gemm(*desc()->problem(), *desc()->strategy(), interface_); \
         return generator.get_kernel(kernel, engine); \

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -103,6 +103,7 @@ struct gen_desc_t {
 protected:
     compute::gpu_arch_t arch_;
     ngen::HW hw_ = ngen::HW::Unknown;
+    ngen::Product product_ = {};
     int stepping_ = 0;
     gemmstone::GEMMProblem problem_ = {};
     gemmstone::GEMMStrategy strategy_;
@@ -139,7 +140,7 @@ struct gen_nocopy_desc_t : public gen_desc_t {
     }
 
     std::vector<const gemmstone::kcatalog::Entry *> select_kernel(
-            compute::gpu_arch_t arch, int stepping, int eu_count,
+            compute::gpu_product_t product, int stepping, int eu_count,
             bool has_systolic, bool is_integrated, compute_mode mode,
             const gemmstone::GEMMProblem &problem, float alpha, float beta,
             dim_t m, dim_t n, dim_t k, dim_t lda, dim_t ldb, dim_t ldc,

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -367,7 +367,7 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
             /* Generate microkernel */
             #define ARCH_DISPATCH(arch)                                                         \
                 case HW::arch: {                                                                \
-                    Generator<HW::arch> generator;                                              \
+                    Generator<HW::arch> generator(product);                                     \
                     generator.setStepping(stepping);                                            \
                     return generator.gemmMicrokernelPackage(problem, strategy, interface,       \
                                                             makeProtocol(options), hwInfo.gmdid,\

--- a/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
@@ -65,7 +65,7 @@ template <ngen::HW hw> class Generator : public GENERATOR_BASE(hw) {
 public:
     using super = GENERATOR_SUPER(hw);
 
-    Generator() : GENERATOR_BASE(hw)(GENERATOR_DEBUGINFO) {}
+    Generator(ngen::Product product) : GENERATOR_BASE(hw)(product, GENERATOR_DEBUGINFO) {}
 
     FORWARD(hw)
 

--- a/src/gpu/intel/jit/binary_format.cpp
+++ b/src/gpu/intel/jit/binary_format.cpp
@@ -62,8 +62,9 @@ class binary_format_kernel_t : public generator_t<hw> {
     FORWARD(hw);
 
 public:
-    binary_format_kernel_t(const engine_t *engine)
-        : generator_t<hw>(debug_config_t {GENERATOR_NAME, GENERATOR_LINE}) {
+    binary_format_kernel_t(const engine_t *engine, const ngen::Product &product)
+        : generator_t<hw>(
+                  product, debug_config_t {GENERATOR_NAME, GENERATOR_LINE}) {
 
         auto low_half = [](uint64_t q) -> uint32_t { return q & 0xFFFFFFFF; };
         auto high_half = [](uint64_t q) -> uint32_t { return q >> 32; };
@@ -173,10 +174,10 @@ public:
         *skip_check = false;
 
         if (hw != HW::Unknown) {
-            binary_format_kernel_t<hw> binary_format_kernel(engine);
-
+            auto product = engine->device_info()->gpu_product();
+            binary_format_kernel_t<hw> binary_format_kernel(
+                    engine, compute::device_info_t::ngen_product(product));
             auto status = engine->create_kernel(&kernel, &binary_format_kernel);
-
             if (status != status::success) return nullptr;
             *skip_check = binary_format_kernel.binaryIsZebin();
         } else {

--- a/src/gpu/intel/jit/emulated_generator.hpp
+++ b/src/gpu/intel/jit/emulated_generator.hpp
@@ -22,6 +22,7 @@
 
 #include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/jit/generator.hpp"
+#include "gpu/intel/jit/utils/type_bridge.hpp"
 #include "ngen_core.hpp"
 #include "ngen_emulation.hpp"
 #include "ngen_register_allocator.hpp"
@@ -42,7 +43,7 @@ protected:
 public:
     emulated_generator_t(const compute::device_info_t &device_info,
             const debug_config_t &debug_config)
-        : generator_t<hw>(debug_config)
+        : generator_t<hw>(get_ngen_product(device_info), debug_config)
         , ra_(hw)
         , emu_strategy(hw, device_info.stepping_id()) {}
 

--- a/src/gpu/intel/jit/generator.hpp
+++ b/src/gpu/intel/jit/generator.hpp
@@ -108,9 +108,6 @@ void check_kernel_size(const std::string &kernel_name, size_t kernel_size,
 template <gpu_gen_t hw>
 class generator_t : public ngen_code_generator_t<hw>, public generator_base_t {
 public:
-    generator_t(const ngen::DebugConfig &debug_config)
-        : ngen_code_generator_t<hw>(0, debug_config) {}
-
     generator_t(
             const ngen::Product &product, const ngen::DebugConfig &debug_config)
         : ngen_code_generator_t<hw>(product, debug_config) {}

--- a/third_party/ngen/ngen.hpp
+++ b/third_party/ngen/ngen.hpp
@@ -89,6 +89,12 @@ public:
 #include "ngen_registers.hpp"
 #endif
 
+#if __cplusplus >= 201402L
+#define DEPRECATED [[deprecated]]
+#else
+#define DEPRECATED
+#endif
+
 template <HW hw>
 class BinaryCodeGenerator
 {
@@ -337,7 +343,7 @@ public:
         pushStream(rootStream);
     }
 
-    explicit BinaryCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : BinaryCodeGenerator({genericProductFamily(hw), stepping_, PlatformType::Unknown}, debugConfig) {}
+    DEPRECATED explicit BinaryCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : BinaryCodeGenerator({genericProductFamily(hw), stepping_, PlatformType::Unknown}, debugConfig) {}
 
     BinaryCodeGenerator(BinaryCodeGenerator &&) = default;
 

--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -356,7 +356,7 @@ static inline constexpr14 ProductFamily genericProductFamily(HW hw)
 
 static inline constexpr14 Core getCore(ProductFamily family)
 {
-    if (family >= ProductFamily::GenericXe3p) return Core::Xe3p;
+    if (family >= ProductFamily::GenericXe3p)  return Core::Xe3p;
     if (family >= ProductFamily::GenericXe3)   return Core::Xe3;
     if (family >= ProductFamily::GenericXe2)   return Core::Xe2;
     if (family >= ProductFamily::GenericXeHPC) return Core::XeHPC;

--- a/third_party/ngen/ngen_elf.hpp
+++ b/third_party/ngen/ngen_elf.hpp
@@ -34,7 +34,7 @@ public:
     static inline Product getBinaryHWInfo(const std::vector<uint8_t> &binary);
 
     explicit ELFCodeGenerator(Product product_, DebugConfig debugConfig = {})  : BinaryCodeGenerator<hw>(product_, debugConfig) {}
-    explicit ELFCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : BinaryCodeGenerator<hw>(stepping_, debugConfig) {}
+    DEPRECATED explicit ELFCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : BinaryCodeGenerator<hw>(stepping_, debugConfig) {}
     explicit ELFCodeGenerator(DebugConfig debugConfig) : ELFCodeGenerator(0, debugConfig) {}
     ELFCodeGenerator(ELFCodeGenerator &&) = default;
 
@@ -345,7 +345,7 @@ private:
             return (sz + 0xF) & ~0xF;
         }
 
-        ZebinELF(size_t szKernelName, size_t szMetadata, size_t szKernel, InterfaceHandler &interface_,
+        ZebinELF(size_t szKernelName, size_t szMetadata, size_t szKernel, InterfaceHandler &interface_, const Product &product,
                  size_t szDebugLine, size_t szDebugLineStr, uint32_t file1, uint32_t subProgramLine) {
             fileHeader.size = sizeof(fileHeader);
             fileHeader.sectionHeaderSize = sizeof(SectionHeader);
@@ -418,7 +418,7 @@ private:
             symTable[3].value = 0;
             symTable[3].size = 0;
 
-            noteGfxCore.payload = static_cast<uint32_t>(npack::encodeGfxCoreFamily(hw));
+            noteGfxCore.payload = static_cast<uint32_t>(npack::encodeGfxCoreFamily(product));
 
             sectionHeaders[6].name = offsetof(StringTable, snDebugInfo) + 5;
             sectionHeaders[6].type = SectionHeader::Type::Program;
@@ -637,7 +637,7 @@ std::vector<uint8_t> ELFCodeGenerator<hw>::getBinary(const std::vector<uint8_t> 
 
     binary.resize(paddedSzELF + paddedSzMetadata + paddedSzKernel + paddedSzDebugLine + paddedSzDebugLineStr + paddedSzRelDebugLine + paddedSzRelDebugInfo);
 
-    (void) new(binary.data()) ZebinELF(paddedSzKernelName, metadata.size(), kernel.size(), interface_,
+    (void) new(binary.data()) ZebinELF(paddedSzKernelName, metadata.size(), kernel.size(), interface_, super::getProduct(),
                                        debugLine.size(), debugLineStr.size(), file1, super::debugLine.programLine);
     utils::copy_into(binary, ZebinELF::kernelNameOffset(), interface_.getExternalName());
     size_t offset = paddedSzELF;

--- a/third_party/ngen/ngen_level_zero.hpp
+++ b/third_party/ngen/ngen_level_zero.hpp
@@ -98,7 +98,7 @@ public:
         this->interface_.setInlineGRFCount(0);
     }
 
-    explicit LevelZeroCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : LevelZeroCodeGenerator({genericProductFamily(hw), stepping_, PlatformType::Unknown}, debugConfig) {}
+    DEPRECATED explicit LevelZeroCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : LevelZeroCodeGenerator({genericProductFamily(hw), stepping_, PlatformType::Unknown}, debugConfig) {}
 
     explicit LevelZeroCodeGenerator(DebugConfig debugConfig) : LevelZeroCodeGenerator({genericProductFamily(hw), 0}, debugConfig) {}
     LevelZeroCodeGenerator(LevelZeroCodeGenerator&&) = default;

--- a/third_party/ngen/ngen_opencl.hpp
+++ b/third_party/ngen/ngen_opencl.hpp
@@ -107,7 +107,7 @@ class OpenCLCodeGenerator : public ELFCodeGenerator<hw>
 {
 public:
     explicit OpenCLCodeGenerator(Product product_, DebugConfig debugConfig = {})  : ELFCodeGenerator<hw>(product_, debugConfig) {}
-    explicit OpenCLCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : ELFCodeGenerator<hw>(stepping_, debugConfig) {}
+    DEPRECATED explicit OpenCLCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : ELFCodeGenerator<hw>(stepping_, debugConfig) {}
     explicit OpenCLCodeGenerator(DebugConfig debugConfig) : ELFCodeGenerator<hw>(debugConfig) {}
     OpenCLCodeGenerator(OpenCLCodeGenerator &&) = default;
 

--- a/third_party/ngen/npack/neo_packager.hpp
+++ b/third_party/ngen/npack/neo_packager.hpp
@@ -199,20 +199,30 @@ inline HW decodeGfxCoreFamily(GfxCoreFamily family)
     }
 }
 
-inline GfxCoreFamily encodeGfxCoreFamily(HW hw)
+inline GfxCoreFamily encodeGfxCoreFamily(const ngen::Product &product)
 {
-    switch (hw) {
-        case HW::Gen9:         return GfxCoreFamily::Gen9;
-        case HW::Gen10:        return GfxCoreFamily::Gen10;
-        case HW::Gen11:        return GfxCoreFamily::Gen11LP;
-        case HW::Gen12LP:      return GfxCoreFamily::Gen12LP;
-        case HW::XeHP:         return GfxCoreFamily::XeHP;
-        case HW::XeHPG:        return GfxCoreFamily::XeHPG;
-        case HW::XeHPC:        return GfxCoreFamily::XeHPC;
-        case HW::Xe2:          return GfxCoreFamily::Xe2;
-        case HW::Xe3:          return GfxCoreFamily::Xe3;
-        case HW::Xe3p:         return GfxCoreFamily::Xe3p;
-        default:               return GfxCoreFamily::Unknown;
+    switch (product.family) {
+        case NGEN_NAMESPACE::ProductFamily::Unknown:        return GfxCoreFamily::Unknown;
+        case NGEN_NAMESPACE::ProductFamily::GenericGen9:    return GfxCoreFamily::Gen9;
+        case NGEN_NAMESPACE::ProductFamily::GenericGen10:   return GfxCoreFamily::Gen10;
+        case NGEN_NAMESPACE::ProductFamily::GenericGen11:   return GfxCoreFamily::Gen11LP;
+        case NGEN_NAMESPACE::ProductFamily::GenericGen12LP: return GfxCoreFamily::Gen12LP;
+        case NGEN_NAMESPACE::ProductFamily::GenericXeHP:    return GfxCoreFamily::XeHP;
+        case NGEN_NAMESPACE::ProductFamily::GenericXeHPG:
+        case NGEN_NAMESPACE::ProductFamily::DG2:
+        case NGEN_NAMESPACE::ProductFamily::MTL:
+        case NGEN_NAMESPACE::ProductFamily::ARL:            return GfxCoreFamily::XeHPG;
+        case NGEN_NAMESPACE::ProductFamily::GenericXeHPC:
+        case NGEN_NAMESPACE::ProductFamily::PVC:
+        case NGEN_NAMESPACE::ProductFamily::PVCVG:          return GfxCoreFamily::XeHPC;
+        case NGEN_NAMESPACE::ProductFamily::GenericXe2:
+        case NGEN_NAMESPACE::ProductFamily::BMG:
+        case NGEN_NAMESPACE::ProductFamily::LNL:            return GfxCoreFamily::Xe2;
+        case NGEN_NAMESPACE::ProductFamily::GenericXe3:     return GfxCoreFamily::Xe3;
+        case NGEN_NAMESPACE::ProductFamily::GenericXe3p:
+        case NGEN_NAMESPACE::ProductFamily::NVLP:
+        case NGEN_NAMESPACE::ProductFamily::CRI:            return GfxCoreFamily::Xe3p;
+        default:                                            return GfxCoreFamily::Unknown;
     }
 }
 


### PR DESCRIPTION
# Description

Fix hardware detection in main by forcing generators to be initialized with product family, obtaining GfxCoreFamily from Product. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
