### PR TITLE
clarifying on inconsistencies in quantization guide

### DIFF
--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -251,13 +251,8 @@ The following masks are supported by the primitive:
 - 2, which applies a zero point value per each element in a `IC` or `OC`
   dimension for `DNNL_ARG_SRC` or `DNNL_ARG_DST` arguments respectively.
 
-When scales and/or zero-points masks are specified, the user must
-provide the corresponding scales and/or zero-points as additional
-input memory objects with argument `DNNL_ARG_ATTR_SCALES |
-DNNL_ARG_${MEMORY_INDEX}` or `DNNL_ARG_ATTR_ZERO_POINTS |
-DNNL_ARG_${MEMORY_INDEX}` during the execution stage.  For instance, a
-source tensor zero points memory argument would be passed with index
-(`DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC`).
+Scales and zero-points require additional memory arguments at execution time.
+See the [quantization guide](@ref dgaq_execution) for details.
 
 
 @note The library does not prevent using post-ops in training, but note that

--- a/doc/primitives/inner_product.md
+++ b/doc/primitives/inner_product.md
@@ -140,10 +140,8 @@ The following masks are supported by the primitive:
 - 1, which applies a scale value per output channel for
   `DNNL_ARG_WEIGHTS` argument.
 
-When scales masks are specified, the user must provide the
-corresponding scales as additional input memory objects with argument
-`DNNL_ARG_ATTR_SCALES | DNNL_ARG_${MEMORY_INDEX}` during the execution
-stage.
+Scales require additional memory arguments at execution time. See the
+[quantization guide](@ref dgaq_execution) for details.
 
 
 ## Implementation Limitations

--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -411,6 +411,15 @@ attr.set_scales_mask(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 2));
 // Layout: standard ab layout
 ~~~
 
+K-grouped weight scales (e.g., MXFP8 with block size 32):
+~~~cpp
+attr.set_scales(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 1) | (1 << 2),
+    {32, 1}, memory::data_type::e8m0);
+// Groups are 2D {gK, gN} and are applied to two last dimensions of the tensor
+// Scale tensor: [num_groups, K/32, N] - dense 3D tensor
+// Layout: standard abc layout
+~~~
+
 Bias per expert:
 ~~~cpp
 // Bias: [num_groups, N] - dense 2D tensor

--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -163,19 +163,10 @@ The `mask` and `groups` parameters for scales and zero-points follow the
 conventions described in the
 [quantization guide](@ref dgaq_constructing_mask_and_groups).
 
-When scales and/or zero-points masks are specified, the user must
-provide the corresponding scales and/or zero-points as additional
-input memory objects with argument `DNNL_ARG_ATTR_SCALES |
-DNNL_ARG_${MEMORY_INDEX}` or `DNNL_ARG_ATTR_ZERO_POINTS |
-DNNL_ARG_${MEMORY_INDEX}` during the execution stage. For instance, a
-source tensor zero points memory argument would be passed with index
-(`DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC`).
-
-When Dropout is specified, at the execution stage the user must provide 2 input
-memory objects with #DNNL_ARG_ATTR_DROPOUT_PROBABILITY (1x1x...x1 f32 value
-from 0.f to 1.f) and #DNNL_ARG_ATTR_DROPOUT_SEED (1x1x...x1 s32 value from INT_MIN
-to INT_MAX), and 1 output memory object with #DNNL_ARG_ATTR_DROPOUT_MASK (u8
-memory buffer that shares its shape with the destination buffer).
+Scales, zero-points, and dropout require additional memory arguments at
+execution time. See the
+[quantization guide](@ref dgaq_execution) and the
+[dropout guide](@ref dev_guide_attributes_dropout) for details.
 
 @note Check the [list of examples and tutorials](#examples) below to see
 run-time attributes in use.

--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -159,14 +159,9 @@ The following attributes and post-ops are supported:
 | Post-op   | [Binary](@ref dnnl::post_ops::append_binary)                   | Applies a @ref dnnl_api_binary operation to the result                        | General binary post-op restrictions |
 | Post-op   | [Prelu](@ref dnnl::post_ops::append_prelu)                     | Applies an @ref dnnl_api_prelu operation to the result                        |                                     |
 
-The following masks are supported by the primitive:
-- 0, which applies one scale / zero point value to an entire tensor
-- 1, which applies a scale / zero point values along `k`-dimension
-  for #DNNL_ARG_WEIGHTS. Values could be grouped along this dimension
-  via specifying scales / zero points shapes for the attribute
-  (see the code example @ref matmul_with_weight_only_quantization_cpp).
-- 2, which applies a scale / zero point values per column along the
-  `n`-dimension for #DNNL_ARG_WEIGHTS.
+The `mask` and `groups` parameters for scales and zero-points follow the
+conventions described in the
+[quantization guide](@ref dgaq_constructing_mask_and_groups).
 
 When scales and/or zero-points masks are specified, the user must
 provide the corresponding scales and/or zero-points as additional

--- a/doc/programming_model/attributes_quantization.md
+++ b/doc/programming_model/attributes_quantization.md
@@ -180,7 +180,7 @@ Key parameters of the scaling API methods are summarized below:
 |:----------|:--------|:------------|
 | `arg` | `DNNL_ARG_SRC`, `DNNL_ARG_WEIGHTS`, `DNNL_ARG_DST`, `DNNL_ARG_BIAS` | Tensor to scale |
 | `mask` | `0`, `1<<dim`, `(1<<d1)+(1<<d2)` | Scaling granularity: global, per-dimension, multi-dimensional |
-| `groups` | `{}`, `{G}`, `{G1,G2,...}` | Block quantization: none, single-size, multi-dimensional blocks |
+| `groups` | `{}`, `{G0, G1}` | Block quantization: none, or two group sizes for the last two tensor dimensions |
 | `data_type` | `f32`, `bf16`, `f16`, `f8_e5m2`, `f8_e4m3`, `e8m0` | Scaling factor data type |
 | `is_on_host` | `true`/`false` | Host vs device memory location of scaling factor |
 | `qmode` | `static_sazp`, `dynamic_mx`, `dynamic_fp` | Quantization mode: static with scales and zero-points, dynamic (MXFP8 compatible), dynamic (NVFP4 compatible) |
@@ -360,7 +360,7 @@ Key parameters of the zero-point API methods are summarized below:
 |:----------|:--------|:------------|
 | `arg` | `DNNL_ARG_SRC`, `DNNL_ARG_WEIGHTS`, `DNNL_ARG_DST` | Tensor to apply zero-point |
 | `mask` | `0`, `1<<dim`, `(1<<d1)+(1<<d2)` | Zero-point granularity: global, per-dimension, multi-dimensional |
-| `groups` | `{}`, `{G}`, `{G1,G2,...}` | Block quantization: none, single-size, multi-dimensional blocks |
+| `groups` | `{}`, `{G0, G1}` | Block quantization: none, or two group sizes for the last two tensor dimensions |
 | `data_type` | `s32`, `s8`, `u8`, `s4`, `u4` | Zero-point data type |
 | `is_on_host` | `true`/`false` | Host vs device memory location of zero-point |
 
@@ -461,7 +461,7 @@ Key parameters of the precomputed reductions API method are summarized below:
 |:----------|:--------|:------------|
 | `arg` | `DNNL_ARG_SRC` | Tensor to apply precomputed reductions |
 | `mask` | `0`, `1<<dim`, `(1<<d1)+(1<<d2)` | Reduction granularity: global, per-dimension, multi-dimensional |
-| `groups` | `{}`, `{G}`, `{G1,G2,...}` | Block quantization: none, single-size, multi-dimensional blocks |
+| `groups` | `{}`, `{G0, G1}` | Block quantization: none, or two group sizes for the last two tensor dimensions |
 | `data_type` | `s32` | Reduction data type |
 
 @note

--- a/doc/programming_model/attributes_quantization.md
+++ b/doc/programming_model/attributes_quantization.md
@@ -197,11 +197,28 @@ consecutive elements share one value.
 | Per-B and per-N (shared across K) | (1<<0) + (1<<2) (or 5) | {} | [8, 1, 512] |
 | Per-B, K-grouped by 64, per-N | (1<<0) + (1<<1) + (1<<2) (or 7) | {64, 1} | [8, 16, 512] |
 
-Note, then when groups are `{}`, no sub-blocking is applied and the parameter
+Note that when groups are `{}`, no sub-blocking is applied and the parameter
 (e.g., scales) shape is determined by the mask alone.
 
 In the tables above, "shared across" means the same value is broadcast to
 all positions along that unmasked dimension.
+
+@anchor dgaq_execution
+### Providing Quantization Parameters at Execution
+
+When scales and/or zero-points are specified via primitive attributes, the user
+must provide the corresponding values as additional input memory objects during
+primitive execution. The argument index is formed by combining the attribute
+tag with the tensor argument:
+
+- Scales: `DNNL_ARG_ATTR_SCALES | DNNL_ARG_<tensor>` (e.g.,
+  `DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC`).
+- Zero-points: `DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_<tensor>` (e.g.,
+  `DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC`).
+
+The memory descriptor for each quantization parameter is determined by the
+mask and groups that were set in the primitive attributes (see
+@ref dgaq_constructing_mask_and_groups).
 
 @anchor dgaq_scaling
 ### Argument Scaling
@@ -309,7 +326,7 @@ each with its own scaling factor.
 ~~~cpp
 // Weight shape: [K, N] = [1024, 512] with groups [32, 1]
 // Creates 32 groups along K dimension, each with its own scaling factor per N value
-std::vector<dnnl::memory::dim_t> groups = {32, 1};
+std::vector<dnnl::memory::dim> groups = {32, 1};
 attr.set_scales(DNNL_ARG_WEIGHTS, (1 << 0) + (1 << 1), groups,
                 dnnl::memory::data_type::f32);
 
@@ -424,7 +441,7 @@ attr.set_zero_points(DNNL_ARG_SRC, 0, {}, dnnl::memory::data_type::s32);
 attr.set_zero_points(DNNL_ARG_WEIGHTS, 1 << 0, {}, dnnl::memory::data_type::s8);
 
 // Block zero-points
-std::vector<dnnl::memory::dim_t> groups = {64, 1};
+std::vector<dnnl::memory::dim> groups = {64, 1};
 attr.set_zero_points(DNNL_ARG_WEIGHTS, (1 << 0) + (1 << 1), groups,
                      dnnl::memory::data_type::s32);
 ~~~
@@ -444,7 +461,7 @@ quantization that varies per batch element:
 // dim 0 = B, dim 1 = K, dim 2 = N -- vary along all three
 int mask = (1 << 0) | (1 << 1) | (1 << 2); // = 7
 // groups: 32 along K (dim ndims-2), 1 along N (dim ndims-1)
-std::vector<dnnl::memory::dim_t> groups = {32, 1};
+std::vector<dnnl::memory::dim> groups = {32, 1};
 
 // Resulting param shape: [4, 1024/32, 512] = [4, 32, 512]
 // Total values: 4 * 32 * 512 = 65,536

--- a/doc/programming_model/attributes_quantization.md
+++ b/doc/programming_model/attributes_quantization.md
@@ -145,6 +145,64 @@ parameter of the appropriate post-operation.
 oneDNN provides APIs to set scales, zero-points, and precomputed reductions
 for different quantization levels from global (per-tensor) to fine-grained block-wise.
 
+@anchor dgaq_constructing_mask_and_groups
+### Mask and Groups
+
+Scales and zero-points share the same `mask` and `groups` concepts.
+
+@note
+Below, "dimension" refers to the tensor's logical shape as specified in the
+memory descriptor, not the physical memory layout.
+
+#### Mask
+
+`mask` is a bitmask where bit `d` being set means the quantization parameter
+varies along dimension `d`, unset means one value is shared across that
+dimension.
+
+`mask =` \f$\sum_{d_i} 2^{d_i}\f$ for each varying dimension \f$d_i\f$.
+
+#### Groups
+
+Groups subdivide dimensions into blocks that share a single quantization
+parameter value. The parameter `{G0, G1}` applies to the last two tensor
+dimensions:
+- `G0` is a block size for dimension `ndims - 2`
+- `G1` is a block size for dimension `ndims - 1`
+
+A value of `1` means no sub-blocking, and a value of `G > 1` means every `G`
+consecutive elements share one value.
+
+- Groups require `mask > 0`.
+- The mask bits for the last two dimensions must be set when groups are used.
+- Each group size must evenly divide the corresponding dimension.
+
+#### Common Masks and Groups Examples
+
+2D matmul weights `[K=1024, N=512]`:
+
+| Quantization pattern | `mask` | `groups` | Quantization parameter shape |
+|:---------------------|:-------|:---------|:-----------------------------|
+| Per-tensor | 0 | {} | scalar (1 value) |
+| Per-N | 1 << 1 (or 2) | {} | [1, 512] |
+| Per-K | 1 << 0 (or 1) | {} | [1024, 1] |
+| K-grouped by 64 | (1<<0) + (1<<1) (or 3) | {64, 1} | [16, 512] |
+
+3D batched matmul weights `[B=8, K=1024, N=512]`:
+
+| Quantization pattern | `mask` | `groups` | Quantization parameter shape |
+|:---------------------|:-------|:---------|:-----------------------------|
+| Per-tensor | 0 | {} | scalar (1 value) |
+| Per-N (shared across B and K) | 1 << 2 (or 4) | {} | [1, 1, 512] |
+| Per-B and per-N (shared across K) | (1<<0) + (1<<2) (or 5) | {} | [8, 1, 512] |
+| Per-B, K-grouped by 64, per-N | (1<<0) + (1<<1) + (1<<2) (or 7) | {64, 1} | [8, 16, 512] |
+
+Note, then when groups are `{}`, no sub-blocking is applied and the parameter
+(e.g., scales) shape is determined by the mask alone.
+
+In the tables above, "shared across" means the same value is broadcast to
+all positions along that unmasked dimension.
+
 @anchor dgaq_scaling
 ### Argument Scaling
 
@@ -188,23 +246,7 @@ Key parameters of the scaling API methods are summarized below:
 (*) Support for quantization options varies based on individual primitive and
 target hardware. Refer to primitives documentation for the details.
 
-#### Supported Scaling Granularity Levels
-
-oneDNN supports the following scaling granularity levels to support different quantization
-schemes:
-
-- [Per-tensor scaling](#per-tensor-scaling) (`mask=0`) uses a single scaling factor for the entire
-  tensor, making it the simplest approach.
-- [Per-channel scaling](#per-channel-scaling) (`mask=1<<dim`) applies different scaling factors
-  along a specific dimension, for instance commonly used for CNN weights.
-- [Block scaling](#block-scaling) subdivides tensor dimensions into smaller
-  blocks with individual scaling factors, important for large transformer
-  models and advanced quantization techniques.
-- [Multi-dimensional scaling](#multi-dimensional-scaling) (`mask=(1<<dim1)+(1<<dim2)`) provides
-  independent scaling factors along multiple tensor dimensions, useful for complex
-  activations where both batch and channel dimensions need separate scaling.
-
-##### Per-tensor Scaling
+#### Per-tensor Scaling
 
 In the simplest case, when there is only one common scaling factor the attribute changes
 the op behavior from
@@ -239,7 +281,7 @@ host, use @ref host-side-scalars-and-zero-points "host-side scalar scaling"
 See examples:
 - [Convolution with Per-output-channel Quantization](#convolution-with-per-output-channel-quantization)
 
-##### Per-Channel Scaling
+#### Per-Channel Scaling
 
 Per-channel scaling applies different scaling factors along specific tensor
 dimensions. For instance, it is commonly used for CNN weights where each
@@ -259,11 +301,10 @@ See examples:
 - [Convolution with Per-output-channel Quantization](#convolution-with-per-output-channel-quantization)
 - @ref inference_int8_matmul_cpp
 
-##### Block Scaling
+#### Block Scaling
 
-Groups enable block-wise quantization by subdividing tensor dimensions into
-smaller blocks, each with its own scaling factor. This might help balance accuracy
-and efficiency by providing more granular quantization than per-tensor scaling.
+Groups enable block-wise quantization by subdividing dimensions into blocks,
+each with its own scaling factor.
 
 ~~~cpp
 // Weight shape: [K, N] = [1024, 512] with groups [32, 1]
@@ -273,7 +314,7 @@ attr.set_scales(DNNL_ARG_WEIGHTS, (1 << 0) + (1 << 1), groups,
                 dnnl::memory::data_type::f32);
 
 // Tensor: [K, N] = [1024, 512]
-// Scaling factors: 32 × 512 = 16,384 values (one per group)
+// Scaling factors: 32 * 512 = 16,384 values (one per group)
 // Usage: Each (group_k, n) combination gets its own scaling factor
 ~~~
 
@@ -282,31 +323,28 @@ See examples:
 - [Matmul with Precomputed Reductions and Advanced Quantization](#matmul-with-precomputed-reductions-and-advanced-quantization)
 - @ref matmul_with_weight_only_quantization_cpp
 
-###### Special Case: MX-compatible Block Scaling (or Dynamic Quantization)
+##### Special Case: MX-compatible Block Scaling (or Dynamic Quantization)
 
-MX-compatible block scaling uses `e8m0` data type for scaling factors
-and `dynamic_mx` quantization mode to align with the [OCP MX Formats Specification][mx-spec].
+MX-compatible block scaling uses `e8m0` scaling factors and `dynamic_mx`
+quantization mode per the [OCP MX Formats Specification][mx-spec].
 
 ~~~cpp
-// Set MX-compatible block scaling for weights
-attr.set_scales(DNNL_ARG_WEIGHTS, 1 << 0, {32}, dnnl::memory::data_type::e8m0,
+// Weights [K, N] = [1024, 512], K-grouped by 32
+attr.set_scales(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 1), {32, 1},
+                dnnl::memory::data_type::e8m0,
                 false /*on device*/, dnnl::quantization_mode::dynamic_mx);
-
-// Tensor: [K, N] = [1024, 512]
-// Scaling factors: 32 values (one per group of 32 in K dimension)
-// Usage: Each group of 32 in K dimension gets its own scaling factor
+// Scaling factors: (1024 / 32) * 512 = 16,384 values
 ~~~
 See example @ref mxfp_matmul_cpp.
 
-##### Multi-Dimensional Scaling
+#### Multi-Dimensional Scaling
 
-Multi-dimensional scaling applies scaling factors across multiple tensor dimensions
-simultaneously.
+Multi-dimensional scaling applies scaling factors across multiple dimensions
+simultaneously by setting multiple bits in `mask`.
 
-For scaling factors per dimensions \f$d_i\f$, set `mask = `\f$\sum_{d_i} 2^{d_i}\f$.
-
-Resulting scaling factor count without groups: \f$\prod_{d_i} D_{d_i}\f$, with groups:
-\f$\prod_{d_i} G_{d_i}\f$.
+Scaling factor count without groups: \f$\prod_{d_i} D_{d_i}\f$.
+With groups (the last two dimensions must be included in the mask):
+\f$\left(\prod_{d_i \notin \{ndims{-}2,\, ndims{-}1\}} D_{d_i}\right) \cdot \frac{D_{ndims-2}}{G_0} \cdot \frac{D_{ndims-1}}{G_1}\f$.
 
 ~~~cpp
 // Scaling factors vary along batch and channel dimensions
@@ -369,15 +407,14 @@ target hardware. Refer to primitives documentation for the details.
 
 #### Supported Zero-Point Granularity Levels
 
-Zero-point granularity mirrors the scaling factor granularity described above.
-The same mask and groups concepts apply:
+Zero-point granularity mirrors scaling factor granularity. The same mask and
+groups concepts apply (see @ref dgaq_constructing_mask_and_groups), for instance:
 
-- **Per-tensor zero-point** (`mask=0`): Single zero-point for entire tensor
-- **Per-channel zero-points** (`mask=1<<dim`): Different zero-points per
-  channel
-- **Block zero-points** (`mask` with `groups`): Block-wise zero-points
-- **Multi-dimensional zero-points** (`mask=(1<<dim1)+(1<<dim2)`):
-  Independent zero-points across multiple dimensions
+- **Per-tensor** (`mask=0`): single zero-point for the entire tensor
+- **Per-channel** (`mask=1<<dim`): one zero-point per channel
+- **Block** (`mask` with `groups`): block-wise zero-points
+- **Multi-dimensional** (`mask=(1<<dim1)+(1<<dim2)`): independent zero-points
+  across multiple dimensions
 
 ~~~cpp
 // Per-tensor zero-point
@@ -397,6 +434,24 @@ See examples:
 - [Matmul with Precomputed Reductions and Advanced Quantization](#matmul-with-precomputed-reductions-and-advanced-quantization)
 - @ref inference_int8_matmul_cpp
 - @ref matmul_with_weight_only_quantization_cpp
+
+#### Example: 3D Batched Matmul Weights
+
+For 3D weights `[B=4, K=1024, N=512]` with K-grouped (group size 32)
+quantization that varies per batch element:
+
+~~~cpp
+// dim 0 = B, dim 1 = K, dim 2 = N -- vary along all three
+int mask = (1 << 0) | (1 << 1) | (1 << 2); // = 7
+// groups: 32 along K (dim ndims-2), 1 along N (dim ndims-1)
+std::vector<dnnl::memory::dim_t> groups = {32, 1};
+
+// Resulting param shape: [4, 1024/32, 512] = [4, 32, 512]
+// Total values: 4 * 32 * 512 = 65,536
+
+attr.set_scales(DNNL_ARG_WEIGHTS, mask, groups, dnnl::memory::data_type::f16);
+attr.set_zero_points(DNNL_ARG_WEIGHTS, mask, groups, dnnl::memory::data_type::s8);
+~~~
 
 @anchor host-side-scalars-and-zero-points
 ### Special Case: Host-side Scalar Scaling Factor and Zero-point

--- a/include/oneapi/dnnl/dnnl.h
+++ b/include/oneapi/dnnl/dnnl.h
@@ -473,11 +473,12 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_set_scales_mask(
 ///     The set i-th bit indicates that a dedicated scaling factor is used for
 ///     each index along that dimension. Set the mask to 0 to use a common
 ///     scaling factor for the whole output tensor.
-/// @param group_ndims Number of group dimensions.
-/// @param group_dims Scaling factors correspondence groups that define the
-///     correspondence between the tensor dimensions and the scales array.
-///     The group dimensions should only be provided for each logical dimension
-///     that has correspondence mask @p mask set.
+/// @param group_ndims Number of group dimensions. Must be 0 or 2.
+/// @param group_dims Block sizes for the last two tensor dimensions:
+///     `{G0, G1}` where `G0` subdivides the second-to-last tensor dimension
+///     and `G1` subdivides the last. The corresponding mask bits must
+///     be set. Use `1` for no sub-blocking.
+///     NULL when @p group_ndims is 0.
 /// @param data_type Scaling factors data_type.
 /// @returns #dnnl_success on success and a status describing the error
 ///     otherwise.
@@ -504,13 +505,14 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_set_scales(
 ///     The set i-th bit indicates that a dedicated scaling factor is used for
 ///     each index along that dimension. Set the mask to 0 to use a common
 ///     scaling factor for the whole output tensor.
-/// @param ndims Number of group dimensions.
-/// @param group_dims Scaling factors correspondence groups that define the
-///     correspondence between the tensor dimensions and the scales array.
-///     The group dimensions should only be provided for each logical dimension
-///     that has correspondence mask @p mask set.
+/// @param ndims Number of group dimensions. Must be 0 or 2.
+/// @param group_dims Block sizes for the last two tensor dimensions:
+///     `{G0, G1}` where `G0` subdivides the second-to-last tensor dimension
+///     and `G1` subdivides the last. The corresponding mask bits must
+///     be set. Use `1` for no sub-blocking.
+///     NULL when @p ndims is 0.
 /// @param data_type Scaling factors data_type.
-/// @param is_on_host Indicates whether the zero point is a host-side scalar.
+/// @param is_on_host Indicates whether the scaling factor is a host-side scalar.
 /// @returns #dnnl_success on success and a status describing the error
 ///     otherwise.
 dnnl_status_t DNNL_API dnnl_primitive_attr_set_scales_v2(
@@ -531,11 +533,12 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_set_scales_v2(
 ///     The set i-th bit indicates that a dedicated scaling factor is used for
 ///     each index along that dimension. Set the mask to 0 to use a common
 ///     scaling factor for the whole tensor.
-/// @param ndims Number of group dimensions.
-/// @param group_dims Scaling factors correspondence groups that define the
-///     correspondence between the tensor dimensions and the scales array.
-///     The group dimensions should only be provided for each logical dimension
-///     that has correspondence mask @p mask set.
+/// @param ndims Number of group dimensions. Must be 0 or 2.
+/// @param group_dims Block sizes for the last two tensor dimensions:
+///     `{G0, G1}` where `G0` subdivides the second-to-last tensor dimension
+///     and `G1` subdivides the last. The corresponding mask bits must
+///     be set. Use `1` for no sub-blocking.
+///     NULL when @p ndims is 0.
 /// @param data_type Scaling factors data_type.
 /// @param is_on_host Indicates whether the scale is a host-side scalar.
 /// @param qmode Quantization mode, can be #dnnl_quantization_mode_static_sazp
@@ -579,11 +582,12 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_set_zero_points_mask(
 ///     zero points array. The set i-th bit indicates that a dedicated
 ///     zero point is used for each index along that dimension. Set the
 ///     mask to 0 to use a common zero point for the whole output tensor.
-/// @param group_ndims Number of group dimensions.
-/// @param group_dims Zero point factors correspondence groups that define the
-///     correspondence between the tensor dimensions and the zero points array.
-///     The group dimensions should be only provided for each logical dimension
-///     that has the bit set correspondence mask @p mask set.
+/// @param group_ndims Number of group dimensions. Must be 0 or 2.
+/// @param group_dims Block sizes for the last two tensor dimensions:
+///     `{G0, G1}` where `G0` subdivides the second-to-last tensor dimension
+///     and `G1` subdivides the last. The corresponding mask bits must
+///     be set. Use `1` for no sub-blocking.
+///     NULL when @p group_ndims is 0.
 /// @param data_type Zero points factors data_type.
 /// @returns #dnnl_success on success and a status describing the error
 ///     otherwise.
@@ -606,12 +610,12 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_set_zero_points(
 ///     correspondence between the tensor dimensions and the precomputed
 ///     reductions array. The set i-th bit indicates that a dedicated
 ///     precomputed reductions is used for each index along that dimension.
-/// @param group_ndims Number of group dimensions.
-/// @param group_dims Precomputed reduction factors correspondence groups that
-///     define the correspondence between the tensor dimensions and the
-///     precomputed reductions array.
-///     The group dimensions should be only provided for each logical dimension
-///     that has the bit set correspondence mask @p mask set.
+/// @param group_ndims Number of group dimensions. Must be 0 or 2.
+/// @param group_dims Block sizes for the last two tensor dimensions:
+///     `{G0, G1}` where `G0` subdivides the second-to-last tensor dimension
+///     and `G1` subdivides the last. The corresponding mask bits must
+///     be set. Use `1` for no sub-blocking.
+///     NULL when @p group_ndims is 0.
 /// @param data_type Precomputed reduction factors data_type.
 /// @returns #dnnl_success on success and a status describing the error
 ///     otherwise.
@@ -637,11 +641,12 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_set_precomputed_reductions(
 ///     zero_points array. The set i-th bit indicates that a dedicated
 ///     zero point is used for each index along that dimension. Set the
 ///     mask to 0 to use a common zero point for the whole output tensor.
-/// @param ndims Number of group dimensions.
-/// @param group_dims Zero point factors correspondence groups that define the
-///     correspondence between the tensor dimensions and the zero_points array.
-///     The group dimensions should be only provided for each logical dimension
-///     that has the bit set correspondence mask @p mask set.
+/// @param ndims Number of group dimensions. Must be 0 or 2.
+/// @param group_dims Block sizes for the last two tensor dimensions:
+///     `{G0, G1}` where `G0` subdivides the second-to-last tensor dimension
+///     and `G1` subdivides the last. The corresponding mask bits must
+///     be set. Use `1` for no sub-blocking.
+///     NULL when @p ndims is 0.
 /// @param data_type Zero points factors data_type.
 /// @param is_on_host Indicates whether the zero point is a host-side scalar.
 /// @returns #dnnl_success on success and a status describing the error

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -4354,12 +4354,12 @@ struct primitive_attr : public handle<dnnl_primitive_attr_t> {
     /// @param mask Scaling factors correspondence mask that defines the
     ///     correspondence between the tensor dimensions and the @p scales array.
     ///     The set i-th bit indicates that a dedicated scaling factor is used for
-    ///     each index along that dimension. Set the mask to 0 to use a common
+    ///     each index along that dimension. Set the mask to `0` to use a common
     ///     scaling factor for the whole tensor.
-    /// @param groups Scaling factors correspondence groups that define the
-    ///     correspondence between the tensor dimensions and the scales array.
-    ///     The group dimensions should only be provided for each logical dimension
-    ///     that has correspondence mask @p mask set.
+    /// @param groups Block sizes for the last two tensor dimensions: `{G0, G1}`
+    ///     where `G0` subdivides the second-to-last tensor dimension
+    ///     and `G1` subdivides the last. The corresponding mask bits must be set.
+    ///     Use `1` for no sub-blocking. `{}` indicates no grouping.
     /// @param data_type Scaling factors data_type.
     /// @param is_on_host Indicates whether the scaling factor is a host-side scalar.
     /// @param qmode Quantization mode, can be #quantization_mode::static_sazp
@@ -4433,12 +4433,10 @@ struct primitive_attr : public handle<dnnl_primitive_attr_t> {
     ///     vector. The set i-th bit indicates that a dedicated zero point is
     ///     used for each index along that dimension. Set the mask to 0 to use
     ///     a common zero point for the whole output tensor.
-    /// @param groups Zero point factors correspondence groups that define the
-    ///     correspondence between the tensor dimensions and the zero points
-    ///     array.
-    ///     The set i-th dimension indicates a number of groups of zero point
-    ///     factors used for that logical dimension in a memory indicated by
-    ///     @p arg.
+    /// @param groups Block sizes for the last two tensor dimensions: `{G0, G1}`
+    ///     where `G0` subdivides the second-to-last tensor dimension
+    ///     and `G1` subdivides the last. The corresponding mask bits must be set.
+    ///     Use `1` for no sub-blocking. `{}` indicates no grouping.
     /// @param data_type Zero point factors data_type.
     /// @param is_on_host Indicates whether the zero point is a host-side scalar.
     void set_zero_points(int arg, int mask, const memory::dims &groups,
@@ -4483,12 +4481,10 @@ struct primitive_attr : public handle<dnnl_primitive_attr_t> {
     ///     reductions vector. The set i-th bit indicates that a dedicated
     ///     precomputed reduction point is used for each index along that
     ///     dimension.
-    /// @param groups Precomputed reduction factors correspondence groups that
-    ///     define the correspondence between the tensor dimensions and the
-    ///     precomputed reductions array.
-    ///     The set i-th dimension indicates a number of groups of precomputed
-    ///     reduction factors used for that logical dimension in a memory
-    ///     indicated by @p arg.
+    /// @param groups Block sizes for the last two tensor dimensions: `{G0, G1}`
+    ///     where `G0` subdivides the second-to-last tensor dimension
+    ///     and `G1` subdivides the last. The corresponding mask bits must be set.
+    ///     Use `1` for no sub-blocking. `{}` indicates no grouping.
     /// @param data_type Precomputed reduction factors data_type.
     void set_precomputed_reductions(int arg, int mask,
             const memory::dims &groups,

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -709,6 +709,8 @@ status_t dnnl_primitive_attr_set_zero_points_v2(dnnl_primitive_attr_t attr,
     } else {
         VCHECK_ATTR(mask >= 0, VERBOSE_BAD_PARAM, "mask");
         VCHECK_ATTR(group_ndims >= 0, VERBOSE_BAD_PARAM, "group_ndims");
+        VCHECK_ATTR(IMPLICATION(group_ndims > 0, mask > 0), VERBOSE_BAD_PARAM,
+                "mask incompatible with group_dims");
         return attr->zero_points_.set(
                 arg, mask, data_type, group_ndims, group_dims);
     }
@@ -730,6 +732,8 @@ status_t dnnl_primitive_attr_set_precomputed_reductions(
             VERBOSE_BAD_PARAM, "group_dims");
     VCHECK_ATTR(utils::one_of(group_ndims, 0, 2), VERBOSE_BAD_PARAM,
             "group_ndims must be 0 or 2");
+    VCHECK_ATTR(IMPLICATION(group_ndims > 0, mask > 0), VERBOSE_BAD_PARAM,
+            "mask incompatible with group_dims");
 
     return attr->precomputed_reductions_.set(
             arg, mask, data_type, group_ndims, group_dims);

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -652,6 +652,8 @@ status_t dnnl_primitive_attr_set_scales_v3(primitive_attr_t *attr, int arg,
     VCHECK_ATTR(
             IMPLICATION(group_ndims, validate_dims(group_ndims, group_dims)),
             VERBOSE_BAD_PARAM, "group_dims");
+    VCHECK_ATTR(utils::one_of(group_ndims, 0, 2), VERBOSE_BAD_PARAM,
+            "group_ndims must be 0 or 2");
     if (is_on_host) { // only single value host-side scale is supported
         VCHECK_ATTR(mask == 0, VERBOSE_BAD_PARAM, "mask");
         VCHECK_ATTR(group_ndims == 0, VERBOSE_BAD_PARAM, "group_ndims");
@@ -697,6 +699,8 @@ status_t dnnl_primitive_attr_set_zero_points_v2(dnnl_primitive_attr_t attr,
     VCHECK_ATTR(
             IMPLICATION(group_ndims, validate_dims(group_ndims, group_dims)),
             VERBOSE_BAD_PARAM, "group_dims");
+    VCHECK_ATTR(utils::one_of(group_ndims, 0, 2), VERBOSE_BAD_PARAM,
+            "group_ndims must be 0 or 2");
 
     if (is_on_host) { // host-side zero point is only supported as single scalar value
         VCHECK_ATTR(mask == 0, VERBOSE_BAD_PARAM, "mask");
@@ -724,6 +728,8 @@ status_t dnnl_primitive_attr_set_precomputed_reductions(
     VCHECK_ATTR(
             IMPLICATION(group_ndims, validate_dims(group_ndims, group_dims)),
             VERBOSE_BAD_PARAM, "group_dims");
+    VCHECK_ATTR(utils::one_of(group_ndims, 0, 2), VERBOSE_BAD_PARAM,
+            "group_ndims must be 0 or 2");
 
     return attr->precomputed_reductions_.set(
             arg, mask, data_type, group_ndims, group_dims);

--- a/tests/gtests/test_iface_attr.cpp
+++ b/tests/gtests/test_iface_attr.cpp
@@ -185,14 +185,19 @@ TEST_F(attr_test_t, TestZeroPointsWithGroups) {
         // single zero_point for supported arg with data type specified
         attr.set_zero_points(arg, 0, {}, data_type::s8);
         // multiple zero_points for supported arg with data type specified
-        attr.set_zero_points(arg, 1 << 0, {4}, data_type::s8);
+        attr.set_zero_points(arg, 1 << 0, {4, 1}, data_type::s8);
         // single host zero_point for supported arg with data type specified
         attr.set_zero_points(arg, 0, {}, data_type::s8, true);
+        // single-element groups should be rejected
+        EXPECT_ANY_THROW(attr.set_zero_points(arg, 1 << 0, {4}, data_type::s8));
+        // three-element groups should be rejected
+        EXPECT_ANY_THROW(
+                attr.set_zero_points(arg, 1 << 0, {1, 4, 1}, data_type::s8));
     }
 
     for (auto arg : unsupported_args) {
-        // multiple zero_points for unsupported arg with data type specified
-        EXPECT_ANY_THROW(attr.set_zero_points(arg, 1 << 0, {4}));
+        // multiple zero_points for unsupported arg with groups specified
+        EXPECT_ANY_THROW(attr.set_zero_points(arg, 1 << 0, {4, 1}));
         // single zero_point for unsupported arg with data type specified
         EXPECT_ANY_THROW(attr.set_zero_points(arg, 0, {}, data_type::s8));
         // single host zero_point for unsupported arg with data type specified
@@ -202,7 +207,7 @@ TEST_F(attr_test_t, TestZeroPointsWithGroups) {
     // multiple zero_points that are not supported for host zero_point
     int any_support_arg = DNNL_ARG_SRC;
     EXPECT_ANY_THROW(attr.set_zero_points(
-            any_support_arg, 1 << 0, {4}, data_type::s8, true));
+            any_support_arg, 1 << 0, {4, 1}, data_type::s8, true));
 }
 
 TEST_F(attr_test_t, TestZeroPointsDataTypes) {
@@ -268,16 +273,21 @@ TEST_F(attr_test_t, TestPrecomputedReductionsWithGroups) {
         // single precomputed_reductions (not supported, but valid).
         attr.set_precomputed_reductions(arg, 0, {});
         // multiple precomputed_reductions for supported arg.
-        attr.set_precomputed_reductions(arg, 1 << 0, {4});
+        attr.set_precomputed_reductions(arg, 1 << 0, {4, 1});
         // multiple precomputed_reductions for supported arg with data type
         // specified. Anything but s32 is unsupported so far.
         EXPECT_ANY_THROW(attr.set_precomputed_reductions(
-                arg, 1 << 0, {4}, data_type::s8));
+                arg, 1 << 0, {4, 1}, data_type::s8));
+        // single-element groups should be rejected
+        EXPECT_ANY_THROW(attr.set_precomputed_reductions(arg, 1 << 0, {4}));
+        // three-element groups should be rejected
+        EXPECT_ANY_THROW(
+                attr.set_precomputed_reductions(arg, 1 << 0, {1, 4, 1}));
     }
 
     for (auto arg : unsupported_args) {
-        // multiple zero_points for supported arg with data type specified
-        EXPECT_ANY_THROW(attr.set_precomputed_reductions(arg, 1 << 0, {4}));
+        // precomputed_reductions for unsupported arg
+        EXPECT_ANY_THROW(attr.set_precomputed_reductions(arg, 1 << 0, {4, 1}));
     }
 }
 
@@ -306,10 +316,12 @@ HANDLE_EXCEPTIONS_FOR_TEST_F(attr_test_t, TestScalesWithGroups) {
     for (auto arg : supported_args) {
         // single non-default scales for supported arg
         attr.set_scales(arg, 0, {});
-        // multiple scales with a single group dim
-        attr.set_scales(arg, 1 << 0, {4});
-        // multiple scales with multiple group dims
+        // multiple scales with group dims
         attr.set_scales(arg, 1 << 0, {4, 1});
+        // single-element groups should be rejected
+        EXPECT_ANY_THROW(attr.set_scales(arg, 1 << 0, {4}));
+        // three-element groups should be rejected
+        EXPECT_ANY_THROW(attr.set_scales(arg, 1 << 0, {1, 4, 1}));
         // scales with groups and a data type
         attr.set_scales(arg, 1 << 0, {4, 1}, data_type::f32);
         // single host scale for supported arg with data type specified

--- a/tests/gtests/test_iface_attr.cpp
+++ b/tests/gtests/test_iface_attr.cpp
@@ -193,6 +193,8 @@ TEST_F(attr_test_t, TestZeroPointsWithGroups) {
         // three-element groups should be rejected
         EXPECT_ANY_THROW(
                 attr.set_zero_points(arg, 1 << 0, {1, 4, 1}, data_type::s8));
+        // groups with mask=0 should be rejected
+        EXPECT_ANY_THROW(attr.set_zero_points(arg, 0, {4, 1}, data_type::s8));
     }
 
     for (auto arg : unsupported_args) {
@@ -283,6 +285,8 @@ TEST_F(attr_test_t, TestPrecomputedReductionsWithGroups) {
         // three-element groups should be rejected
         EXPECT_ANY_THROW(
                 attr.set_precomputed_reductions(arg, 1 << 0, {1, 4, 1}));
+        // groups with mask=0 should be rejected
+        EXPECT_ANY_THROW(attr.set_precomputed_reductions(arg, 0, {4, 1}));
     }
 
     for (auto arg : unsupported_args) {
@@ -322,6 +326,8 @@ HANDLE_EXCEPTIONS_FOR_TEST_F(attr_test_t, TestScalesWithGroups) {
         EXPECT_ANY_THROW(attr.set_scales(arg, 1 << 0, {4}));
         // three-element groups should be rejected
         EXPECT_ANY_THROW(attr.set_scales(arg, 1 << 0, {1, 4, 1}));
+        // groups with mask=0 should be rejected
+        EXPECT_ANY_THROW(attr.set_scales(arg, 0, {4, 1}));
         // scales with groups and a data type
         attr.set_scales(arg, 1 << 0, {4, 1}, data_type::f32);
         // single host scale for supported arg with data type specified


### PR DESCRIPTION
This PR is to clear some inconsistencies on supported quantization as well as an attempt to clarify on group sizes and mask used for setting scales and zero-points (incl. api notes, gtests, quantization guide); Specifically, there were questions on 3D and grouped gemm, therefore adding extra snippets into the doc.

Should address concerns in [MFDNN-15068](https://jira.devtools.intel.com/browse/MFDNN-15068).

// easier to review by commits