### PR TITLE
graph: backend: dnnl: exec: make host scalar copy async

### DIFF
--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -54,22 +54,18 @@ void host_scalar_executable_t::execute(const stream &stream,
     const memory &src_mem = it_src->second;
     const memory &dst_mem = it_dst->second;
 
-    // Use queue.memcpy() to copy the host scalar value to device memory. We
-    // have to wait here as the val is on stack and will become invalid if
-    // queue.memcpy() is asynchronous. A better solution may be supporting
-    // host scalar memory to device memory reorder primitive.
-    auto sycl_queue = dnnl::sycl_interop::get_queue(stream);
+    // get_data_handle() is blocked for host scalar memories at the C API
+    // level, so we access the underlying storage pointer directly.
+    void *src_ptr = const_cast<memory_t *>(src_mem.get())
+                            ->memory_storage()
+                            ->data_handle();
+    void *dst_ptr = dst_mem.get_data_handle();
     const size_t size = src_mem.get_desc().get_size();
-    const auto dt = src_mem.get_desc().get_data_type();
-    assert(size == types::data_type_size(static_cast<impl::data_type_t>(dt)));
-    DNNL_HOST_SCALAR_TYPE_SWITCH(dt, DType, {
-        const DType val = src_mem.get_host_scalar_value<DType>();
-        sycl_queue
-                .memcpy(dst_mem.get_data_handle(),
-                        static_cast<const void *>(&val), size)
-                .wait();
+    auto sycl_queue = dnnl::sycl_interop::get_queue(stream);
+    return sycl_queue.submit([&](::sycl::handler &cgh) {
+        cgh.depends_on(deps);
+        cgh.memcpy(dst_ptr, src_ptr, size);
     });
-    return {};
 }
 #endif
 


### PR DESCRIPTION
For primitive based SDPA implementation, we need to copy the host scalar from host to device for primitive execution (eg., binary primitive or binary post-ops). Previously a queue.memcpy() +  wait() was called to ensure the lifetime of the local variable. It causes synchronization overhead and potential issue in sycl graph capture. Now, change it to copy from the internal memory stage of host scalar and make it async.