### PR TITLE
[GPU] gemm xe3p fixups

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -237,8 +237,8 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     //                         64-bit emulation > r0 header storage.
     if (AccumulatorRegister::count(hw, GRFs, problem.Tc.real().ngen()) == 0)
         kChain = 1;
-    // Using acc and mad not working on xe3p
-    if (!systolic && !dotVL && hw == HW::Xe3p)
+    // Fwd modifier not supported in below case
+    if (hw == HW::Xe3p && systolic && problem.product.family < ProductFamily::CRI)
         kChain = 1;
     cAccumulators &= (kChain == 1);
 

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -101,7 +101,7 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
     if (dt_int_ok) attr_skip_mask |= smask_t::zero_points;
 
     bool arch_ok = utils::one_of(arch, arch_t::xe_hp, arch_t::xe_hpg,
-            arch_t::xe_hpc, arch_t::xe2, arch_t::xe3, arch_t::xe3p);
+            arch_t::xe_hpc, arch_t::xe2, arch_t::xe3);
 
     VDISPATCH_GEMM(limits_ok, VERBOSE_RUNTIMEDIM_UNSUPPORTED);
     VDISPATCH_GEMM((dt_float_ok || dt_int_ok), VERBOSE_UNSUPPORTED_DT_CFG);


### PR DESCRIPTION
fixups for #4981 , addresses MFDNN-14989, MFDNN-14994, MFDNN-14995.
1)jit  xehp systolic implementation was not enabled properly for xe3p; revert change.
2) allowing grf 512 kernels for nvl-p  uncovered issue with strategy where kChain was incorrectly enabled; Fwd modifier is not supported on nvl-p. 