### PR TITLE
xpu: ze: stream_profiler: fix cast warning

### DIFF
--- a/src/xpu/ze/stream_profiler.hpp
+++ b/src/xpu/ze/stream_profiler.hpp
@@ -41,7 +41,9 @@ public:
 
         uint64_t get_cycles() const { return context_; }
 
-        uint64_t get_nsec() const { return get_cycles() * freq_; }
+        uint64_t get_nsec() const {
+            return static_cast<uint64_t>(freq_ * get_cycles());
+        }
 
     private:
         uint64_t get_timestamp(


### PR DESCRIPTION
Seems to be a product of stricter warning policies.

[Failure log](https://ecmd.jf.intel.com/commander/link/workspaceFile/workspaces/JF-COMMON-CI?jobStepId=f144635b-662d-f19b-9f58-a4bf010d0e2d&fileName=intel-ze-release.f144635b-662d-f19b-9f58-a4bf010d0e2d.log&jobName=Nightly_oneDNN_2026-04-30-07%3A03%3A49-main-f5fcce3&jobId=f14462bd-4e39-f152-942f-a4bf010d0e2d&diagCharEncoding=&resourceName=jfdnn9248&completed=1).