### PR TITLE
[backport][rls-v3.12] common: norm: differentiate scale and shift tensors

### DIFF
--- a/src/common/batch_normalization_pd.hpp
+++ b/src/common/batch_normalization_pd.hpp
@@ -191,8 +191,8 @@ struct batch_normalization_fwd_pd_t : public batch_normalization_pd_t {
             case DNNL_ARG_MEAN: return stats_is_src() ? src_md(1) : dst_md(1);
             case DNNL_ARG_VARIANCE:
                 return stats_is_src() ? src_md(2) : dst_md(2);
-            case DNNL_ARG_SCALE:
-            case DNNL_ARG_SHIFT: return weights_md(0);
+            case DNNL_ARG_SCALE: return weights_md(0);
+            case DNNL_ARG_SHIFT: return weights_md(1);
             default: return batch_normalization_pd_t::arg_md(arg);
         }
     }
@@ -215,7 +215,7 @@ struct batch_normalization_fwd_pd_t : public batch_normalization_pd_t {
 
     const memory_desc_t *weights_md(
             int index = 0, bool user_input = false) const override {
-        return index == 0 ? &scaleshift_md_ : &glob_zero_md;
+        return (index == 0 || index == 1) ? &scaleshift_md_ : &glob_zero_md;
     }
 
     const memory_desc_t *workspace_md(int index = 0) const override {
@@ -269,8 +269,6 @@ struct batch_normalization_bwd_pd_t : public batch_normalization_pd_t {
 
         if (arg == DNNL_ARG_SCALE)
             return use_scale() ? arg_usage_t::input : arg_usage_t::unused;
-        if (arg == DNNL_ARG_SHIFT)
-            return use_shift() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_WORKSPACE)
             return !types::is_zero_md(workspace_md()) ? arg_usage_t::input
@@ -294,13 +292,12 @@ struct batch_normalization_bwd_pd_t : public batch_normalization_pd_t {
             case DNNL_ARG_SRC: return src_md(0);
             case DNNL_ARG_MEAN: return src_md(1);
             case DNNL_ARG_VARIANCE: return src_md(2);
-            case DNNL_ARG_SCALE:
-            case DNNL_ARG_SHIFT: return weights_md(0);
+            case DNNL_ARG_SCALE: return weights_md(0);
             case DNNL_ARG_DIFF_SRC_1: return diff_dst_md(1);
             case DNNL_ARG_DIFF_SRC: return diff_src_md(0);
             case DNNL_ARG_DIFF_DST: return diff_dst_md(0, user_input);
-            case DNNL_ARG_DIFF_SCALE:
-            case DNNL_ARG_DIFF_SHIFT: return diff_weights_md(0);
+            case DNNL_ARG_DIFF_SCALE: return diff_weights_md(0);
+            case DNNL_ARG_DIFF_SHIFT: return diff_weights_md(1);
             default: return batch_normalization_pd_t::arg_md(arg);
         }
     }
@@ -332,7 +329,8 @@ struct batch_normalization_bwd_pd_t : public batch_normalization_pd_t {
     }
     const memory_desc_t *diff_weights_md(
             int index = 0, bool user_input = false) const override {
-        return index == 0 ? &diff_scaleshift_md_ : &glob_zero_md;
+        return (index == 0 || index == 1) ? &diff_scaleshift_md_
+                                          : &glob_zero_md;
     }
 
     const memory_desc_t *workspace_md(int index = 0) const override {

--- a/src/common/group_normalization_pd.hpp
+++ b/src/common/group_normalization_pd.hpp
@@ -141,8 +141,8 @@ struct group_normalization_fwd_pd_t : public group_normalization_pd_t {
             case DNNL_ARG_MEAN: return stats_is_src() ? src_md(1) : dst_md(1);
             case DNNL_ARG_VARIANCE:
                 return stats_is_src() ? src_md(2) : dst_md(2);
-            case DNNL_ARG_SCALE:
-            case DNNL_ARG_SHIFT: return weights_md(0);
+            case DNNL_ARG_SCALE: return weights_md(0);
+            case DNNL_ARG_SHIFT: return weights_md(1);
             default: return group_normalization_pd_t::arg_md(arg);
         }
     }
@@ -164,7 +164,7 @@ struct group_normalization_fwd_pd_t : public group_normalization_pd_t {
 
     const memory_desc_t *weights_md(
             int index = 0, bool user_input = false) const override {
-        return index == 0 ? &scaleshift_md_ : &glob_zero_md;
+        return (index == 0 || index == 1) ? &scaleshift_md_ : &glob_zero_md;
     }
 
     int n_inputs() const override {
@@ -243,8 +243,8 @@ struct group_normalization_bwd_pd_t : public group_normalization_pd_t {
             case DNNL_ARG_SCALE: return weights_md(0);
             case DNNL_ARG_DIFF_SRC: return diff_src_md(0);
             case DNNL_ARG_DIFF_DST: return diff_dst_md(0, user_input);
-            case DNNL_ARG_DIFF_SCALE:
-            case DNNL_ARG_DIFF_SHIFT: return diff_weights_md(0);
+            case DNNL_ARG_DIFF_SCALE: return diff_weights_md(0);
+            case DNNL_ARG_DIFF_SHIFT: return diff_weights_md(1);
             default: return group_normalization_pd_t::arg_md(arg);
         }
     }
@@ -274,7 +274,8 @@ struct group_normalization_bwd_pd_t : public group_normalization_pd_t {
     }
     const memory_desc_t *diff_weights_md(
             int index = 0, bool user_input = false) const override {
-        return index == 0 ? &diff_scaleshift_md_ : &glob_zero_md;
+        return (index == 0 || index == 1) ? &diff_scaleshift_md_
+                                          : &glob_zero_md;
     }
 
     int n_inputs() const override { return 4 + use_scale(); }

--- a/src/common/layer_normalization_pd.hpp
+++ b/src/common/layer_normalization_pd.hpp
@@ -195,8 +195,8 @@ struct layer_normalization_fwd_pd_t : public layer_normalization_pd_t {
             case DNNL_ARG_MEAN: return stats_are_src() ? src_md(1) : dst_md(1);
             case DNNL_ARG_VARIANCE:
                 return stats_are_src() ? src_md(2) : dst_md(2);
-            case DNNL_ARG_SCALE:
-            case DNNL_ARG_SHIFT: return weights_md(0);
+            case DNNL_ARG_SCALE: return weights_md(0);
+            case DNNL_ARG_SHIFT: return weights_md(1);
             default: return layer_normalization_pd_t::arg_md(arg);
         }
     }
@@ -218,7 +218,7 @@ struct layer_normalization_fwd_pd_t : public layer_normalization_pd_t {
 
     const memory_desc_t *weights_md(
             int index = 0, bool user_input = false) const override {
-        return index == 0 ? &scaleshift_md_ : &glob_zero_md;
+        return (index == 0 || index == 1) ? &scaleshift_md_ : &glob_zero_md;
     }
 
     int n_inputs() const override {
@@ -310,12 +310,11 @@ struct layer_normalization_bwd_pd_t : public layer_normalization_pd_t {
             case DNNL_ARG_SRC: return src_md(0);
             case DNNL_ARG_MEAN: return src_md(1);
             case DNNL_ARG_VARIANCE: return src_md(2);
-            case DNNL_ARG_SCALE:
-            case DNNL_ARG_SHIFT: return weights_md(0);
+            case DNNL_ARG_SCALE: return weights_md(0);
             case DNNL_ARG_DIFF_SRC: return diff_src_md(0);
             case DNNL_ARG_DIFF_DST: return diff_dst_md(0, user_input);
-            case DNNL_ARG_DIFF_SCALE:
-            case DNNL_ARG_DIFF_SHIFT: return diff_weights_md(0);
+            case DNNL_ARG_DIFF_SCALE: return diff_weights_md(0);
+            case DNNL_ARG_DIFF_SHIFT: return diff_weights_md(1);
             default: return layer_normalization_pd_t::arg_md(arg);
         }
     }
@@ -345,7 +344,8 @@ struct layer_normalization_bwd_pd_t : public layer_normalization_pd_t {
     }
     const memory_desc_t *diff_weights_md(
             int index = 0, bool user_input = false) const override {
-        return index == 0 ? &diff_scaleshift_md_ : &glob_zero_md;
+        return (index == 0 || index == 1) ? &diff_scaleshift_md_
+                                          : &glob_zero_md;
     }
 
     int n_inputs() const override { return 4 - skip_mean() + use_scale(); }

--- a/tests/benchdnn/graph/graph_memory.cpp
+++ b/tests/benchdnn/graph/graph_memory.cpp
@@ -133,6 +133,9 @@ dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
 
 int dnn_graph_mem_t::fill_mem_with_data(
         const dnn_mem_t &mem, const dnnl::engine &eng) {
+    // If `mem` comes empty, don't update the underlying `mem_` then.
+    if (!mem) return OK;
+
     const auto &src_eng = mem.engine();
     const auto &dst_eng = eng.get();
 


### PR DESCRIPTION
Backport of #5095 and #5117