### PR TITLE
add limited postops support (eltwise_swish, binary_mul) for grouped gemm in CPU ref and benchdnn

### DIFF
--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -383,6 +383,13 @@ Setting attributes for grouped GEMM follows the regular matmul attribute API.
 Below are some examples of common use cases for MoE workloads.
 For more details on how to set attributes, refer to the @ref dev_guide_attributes page.
 
+#### Scales and Zero Points
+
+Scales and zero points for grouped GEMM follow the same API as regular matmul.
+Tensors must use dense memory descriptors.
+The data in the scales/zero points tensor must follow the same flat concatenated
+order as the grouped source/weights.
+
 Per-token source scales:
 ~~~cpp
 attr.set_scales_mask(DNNL_ARG_SRC, (1 << 0));  // Varies along M dimension
@@ -410,6 +417,42 @@ Bias per expert:
 auto bias_md = memory::desc({num_groups, N},
     memory::data_type::f32, memory::format_tag::ab);
 // Layout: standard ab layout
+~~~
+
+#### Post-ops Support
+
+Post-ops for grouped GEMM follow the same API as regular matmul.
+Eltwise and binary multiplication post-ops are supported.
+
+Binary post-op tensors accept both dense and grouped memory descriptors.
+Note that when a grouped descriptor is provided, we use the binary tensor's
+own per-group offsets for addressing, but they must describe the same grouped
+partition as the grouped destination tensor.
+
+SiLU and element-wise matrix multiplication as post-op:
+~~~cpp
+// [total_tokens, N] tensor, that could be either grouped or dense with
+// memory::format_tag::ab
+auto binary_md = /*...*/;
+
+post_ops po;
+po.append_eltwise(algorithm::eltwise_swish, 1.0f, 0.f);  // SiLU first
+po.append_binary(algorithm::binary_mul, binary_md);      // then mul
+attr.set_post_ops(po);
+~~~
+
+Note that dense tensor must follow the same flat concatenated order as the grouped dst.
+
+Binary multiply with per-row broadcast:
+~~~cpp
+// [total_tokens, 1] tensor, that is one scalar per row
+// in the same flat concatenated order as the grouped destination
+auto routing_md = memory::desc({total_tokens, 1},
+    memory::data_type::f32, memory::format_tag::ab);
+
+post_ops po;
+po.append_binary(algorithm::binary_mul, routing_md);
+attr.set_post_ops(po);
 ~~~
 
 ### Execution Hints
@@ -455,10 +498,15 @@ The following are supported:
 - Zero points attribute for source and weights tensors:
   - The masks must match the scales mask
   - Source zero points data types include `u8`, `s8`
-  - Weights zero points data types include `u8`, `s8`, `u4`, `s4‘
-- Post-ops: binary post-ops are supported (e.g., binary `mul` with a scalar
-  `f32` tensor can be used to apply a global scale factor, as needed for NVFP4
-  two-level scaling).
+  - Weights zero points data types include `u8`, `s8`, `u4`, `s4`
+- Post-ops: eltwise and binary multiplication post-ops are supported. Binary post-op
+  tensors accept both dense and grouped memory descriptors.
+  Common patterns include `eltwise_swish` for SiLU activation,
+  `binary_mul` with a `[total_tokens, N]` grouped or dense tensor,
+  `binary_mul` with a `[total_tokens, 1]` dense tensor,
+  and `[1, 1]` that could be used to apply a global scale for NVFP4.
+  For grouped binary tensors, the per-group offsets must match the grouped dst
+  partition.
 - Bias supports per-expert shape.
 - Supported on CPU and GPU engines.
 

--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -371,6 +371,8 @@ class StridesMixin(TagTripletMixin):
         strides = []
 
         def add_strides_or_tag(arg, md):
+            if md.tag == "grouped":
+                return
             tag = maybe_make_any_tag(md)
             if arg == "wei" and str(md.flags.value) != "f0":
                 tag = "any"

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -174,7 +174,38 @@ status_t grouped_matmul_attr_check(
             attr->has_default_values(allowed_mask, desc.dst_desc.data_type),
             VERBOSE_UNSUPPORTED_ATTR);
 
-    // Specific checks are happening in impls for now
+    // Post-ops: only eltwise and binary_mul are supported
+    const memory_desc_wrapper dst_d(&desc.dst_desc);
+    const auto &po = attr->post_ops_;
+    for (int i = 0; i < po.len(); ++i) {
+        const auto &e = po.entry_[i];
+        VCHECK_MATMUL_UNIMPL(
+                e.is_eltwise() || e.is_binary(), VERBOSE_UNSUPPORTED_POSTOP);
+
+        if (e.is_binary()) {
+            VCHECK_MATMUL_UNIMPL(e.binary.alg == alg_kind::binary_mul,
+                    VERBOSE_UNSUPPORTED_POSTOP);
+            const memory_desc_wrapper src1_d(e.binary.src1_desc);
+
+            if (src1_d.is_grouped_desc()) {
+                // Validate grouped binary post-op descriptor:
+                // group_count and variable_dim_idx must match dst
+                const auto &bin_g = src1_d.sparse_desc().grouped_desc;
+                const auto &dst_g = dst_d.sparse_desc().grouped_desc;
+                VCHECK_MATMUL_UNIMPL(bin_g.group_count == dst_g.group_count
+                                && bin_g.variable_dim_idx
+                                        == dst_g.variable_dim_idx,
+                        VERBOSE_INCONSISTENT_MDS, "binary post-op", "dst");
+            } else if (!src1_d.format_any()) {
+                // Dense binary post-op:
+                // only support N == 1 (scalar/per-row) or ab layout
+                const dim_t bin_N = src1_d.dims()[src1_d.ndims() - 1];
+                VCHECK_MATMUL_UNIMPL(
+                        bin_N == 1 || src1_d.matches_one_of_tag(format_tag::ab),
+                        VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "binary post-op");
+            }
+        }
+    }
 
     return status::success;
 }

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -809,6 +809,13 @@ std::ostream &operator<<(std::ostream &ss, const primitive_attr_t *attr) {
                                     ss << ":" << strides_str;
                             }
                             break;
+                        case format_kind::sparse:
+                            if (mdw.is_grouped_desc()) {
+                                ss << ":grouped";
+                                break;
+                            }
+                            assert(!"unsupported sparse encoding");
+                            break;
                         case format_kind::any: ss << ":any"; break;
                         default: assert(!"unsupported format_kind");
                     }

--- a/src/cpu/matmul/ref_grouped_gemm.cpp
+++ b/src/cpu/matmul/ref_grouped_gemm.cpp
@@ -118,7 +118,8 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
                     data_type::s4, data_type::u4)
             && pd()->attr()->fpmath_.apply_to_int_;
 
-    const bool with_post_ops = !pd()->attr()->post_ops_.has_default_values();
+    const auto &po = pd()->attr()->post_ops_;
+    const bool with_post_ops = !po.has_default_values();
 
     // Parallelize over groups (experts in MoE)
     // Expectation is to see 128-256+ groups, with varying M per group
@@ -286,14 +287,58 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
 
             const dim_t dst_idx = dst_base_idx + m * N + n;
 
-            // Apply post-ops (binary mul for NVFP4 global scale)
+            // Post-Ops support: binary mul with grouped or dense
+            // (incl. NVFP4 recipe with global scale) tensor, eltwise
+            //
+            // Note: ref_post_ops_t won't allow using grouped tensor (with their
+            // own per-group offsets) in binary po
             if (with_post_ops) {
-                ref_post_ops_t::args_t args;
-                args.dst_val = io::load_float_value(dst_dt, dst_data, dst_idx);
-                args.ctx = &ctx;
-                args.l_offset = dst_idx;
-                args.dst_md = pd()->dst_md();
-                ref_post_ops->execute(result, args);
+                int eltwise_idx = 0, binary_idx = 0;
+                for (int po_idx = 0; po_idx < po.len(); ++po_idx) {
+                    const auto &entry = po.entry_[po_idx];
+                    if (entry.is_eltwise()) {
+                        result = eltwise_po_[eltwise_idx++].compute_scalar(
+                                result);
+                    } else if (entry.is_binary()) {
+                        const int po_arg
+                                = DNNL_ARG_ATTR_MULTIPLE_POST_OP(po_idx)
+                                | DNNL_ARG_SRC_1;
+                        const auto bin_data = CTX_IN_MEM(const void *, po_arg);
+                        const memory_desc_wrapper bin_d(entry.binary.src1_desc);
+
+                        // For grouped binary tensors, use their own offsets
+                        // For dense tensor, use dst offsets
+                        dim_t row_base = dst_offset_start;
+                        if (bin_d.is_grouped_desc()) {
+                            const auto bin_offsets
+                                    = CTX_IN_MEM(const int32_t *, po_arg, 1);
+                            const dim_t bin_offset_start = group_id > 0
+                                    ? bin_offsets[group_id - 1]
+                                    : 0;
+                            const dim_t bin_offset_end = bin_offsets[group_id];
+                            const dim_t bin_total_m = bin_d.dims()[0];
+
+                            if (bin_offset_start < 0
+                                    || bin_offset_end > bin_total_m
+                                    || bin_offset_end < bin_offset_start
+                                    || bin_offset_start != dst_offset_start
+                                    || bin_offset_end != dst_offset_end) {
+                                st = status::invalid_arguments;
+                                return;
+                            }
+                            row_base = bin_offset_start;
+                        }
+                        const dim_t bin_M = bin_d.dims()[0];
+                        const dim_t bin_N = bin_d.dims()[1];
+                        const dim_t eff_m = bin_M > 1 ? (row_base + m) : 0;
+                        const dim_t eff_n = bin_N > 1 ? n : 0;
+                        const float val
+                                = io::load_float_value(bin_d.data_type(),
+                                        bin_data, eff_m * bin_N + eff_n);
+                        result = binary_po_[binary_idx++].compute_scalar(
+                                result, val, false);
+                    }
+                }
             }
 
             io::store_float_value(dst_dt, result, dst_data, dst_idx);

--- a/src/cpu/matmul/ref_grouped_gemm.hpp
+++ b/src/cpu/matmul/ref_grouped_gemm.hpp
@@ -216,18 +216,49 @@ struct ref_grouped_t : public primitive_t {
                         (int)zp_gK);
             }
 
-            // Post-ops: only binary mul is supported (for NVFP4 global scale)
+            // Post-ops: only eltwise and binary_mul are supported
             const auto &po = attr()->post_ops_;
-            bool po_ok = true;
             for (int i = 0; i < po.len(); ++i) {
-                const auto &e = po.entry_[i];
-                po_ok = po_ok && e.is_binary()
-                        && e.binary.alg == alg_kind::binary_mul;
+                auto &e = attr_.post_ops_.entry_[i];
+                VDISPATCH_MATMUL(e.is_eltwise() || e.is_binary(),
+                        VERBOSE_UNSUPPORTED_POSTOP);
+
+                if (e.is_binary()) {
+                    VDISPATCH_MATMUL(e.binary.alg == alg_kind::binary_mul,
+                            VERBOSE_UNSUPPORTED_POSTOP);
+                    const memory_desc_wrapper src1_d(e.binary.src1_desc);
+
+                    if (src1_d.is_grouped_desc()) {
+                        // Validate grouped binary post-op descriptor:
+                        // group_count and variable_dim_idx must match dst
+                        const auto &bin_g = src1_d.sparse_desc().grouped_desc;
+                        const auto &dst_g = dst_d.sparse_desc().grouped_desc;
+                        VDISPATCH_MATMUL(bin_g.group_count == dst_g.group_count
+                                        && bin_g.variable_dim_idx
+                                                == dst_g.variable_dim_idx,
+                                VERBOSE_UNSUPPORTED_POSTOP);
+                    } else if (!src1_d.format_any()) {
+                        // Dense binary post-op:
+                        // only support N == 1 (scalar/per-row) or ab layout
+                        const dim_t bin_N = src1_d.dims()[src1_d.ndims() - 1];
+                        VDISPATCH_MATMUL(bin_N == 1
+                                        || src1_d.matches_one_of_tag(
+                                                format_tag::ab),
+                                VERBOSE_UNSUPPORTED_POSTOP);
+                    }
+
+                    // Only scalar [1, 1] is allowed to have format_any
+                    // (i.e. NVFP4 global scale support)
+                    // All other binary post-ops are expected to have
+                    // explicit format
+                    if (src1_d.format_any()) {
+                        VDISPATCH_MATMUL(src1_d.count_non_unit_dims(0),
+                                VERBOSE_UNSUPPORTED_POSTOP);
+                        CHECK(memory_desc_init_by_strides(
+                                e.binary.src1_desc, nullptr));
+                    }
+                }
             }
-            VDISPATCH_MATMUL(po_ok, VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_MATMUL(attr_.post_ops_.set_default_formats(dst_md(0))
-                            == status::success,
-                    VERBOSE_UNSUPPORTED_POSTOP);
 
             return status::success;
         }
@@ -236,10 +267,14 @@ struct ref_grouped_t : public primitive_t {
     ref_grouped_t(const pd_t *apd) : primitive_t(apd) {}
 
     status_t init(engine_t *engine) override {
-        ref_post_ops
-                = utils::make_unique<ref_post_ops_t>(pd()->attr()->post_ops_);
-        if (!ref_post_ops) return status::out_of_memory;
-        CHECK(ref_post_ops->init(pd()->dst_md()));
+        const auto &po = pd()->attr()->post_ops_;
+        for (int i = 0; i < po.len(); ++i) {
+            const auto &e = po.entry_[i];
+            if (e.is_eltwise())
+                eltwise_po_.emplace_back(e.eltwise);
+            else if (e.is_binary())
+                binary_po_.emplace_back(e.binary);
+        }
         return status::success;
     }
 
@@ -247,7 +282,8 @@ struct ref_grouped_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<ref_post_ops_t> ref_post_ops;
+    std::vector<ref_eltwise_scalar_fwd_t> eltwise_po_;
+    std::vector<ref_binary_scalar_t> binary_po_;
 };
 
 } // namespace matmul

--- a/src/cpu/matmul/ref_grouped_gemm.hpp
+++ b/src/cpu/matmul/ref_grouped_gemm.hpp
@@ -216,41 +216,13 @@ struct ref_grouped_t : public primitive_t {
                         (int)zp_gK);
             }
 
-            // Post-ops: only eltwise and binary_mul are supported
+            // Below is to allow using format_any for scalar [1, 1] as binary
+            // post-ops for NVFP4 global scale support
             const auto &po = attr()->post_ops_;
             for (int i = 0; i < po.len(); ++i) {
                 auto &e = attr_.post_ops_.entry_[i];
-                VDISPATCH_MATMUL(e.is_eltwise() || e.is_binary(),
-                        VERBOSE_UNSUPPORTED_POSTOP);
-
                 if (e.is_binary()) {
-                    VDISPATCH_MATMUL(e.binary.alg == alg_kind::binary_mul,
-                            VERBOSE_UNSUPPORTED_POSTOP);
                     const memory_desc_wrapper src1_d(e.binary.src1_desc);
-
-                    if (src1_d.is_grouped_desc()) {
-                        // Validate grouped binary post-op descriptor:
-                        // group_count and variable_dim_idx must match dst
-                        const auto &bin_g = src1_d.sparse_desc().grouped_desc;
-                        const auto &dst_g = dst_d.sparse_desc().grouped_desc;
-                        VDISPATCH_MATMUL(bin_g.group_count == dst_g.group_count
-                                        && bin_g.variable_dim_idx
-                                                == dst_g.variable_dim_idx,
-                                VERBOSE_UNSUPPORTED_POSTOP);
-                    } else if (!src1_d.format_any()) {
-                        // Dense binary post-op:
-                        // only support N == 1 (scalar/per-row) or ab layout
-                        const dim_t bin_N = src1_d.dims()[src1_d.ndims() - 1];
-                        VDISPATCH_MATMUL(bin_N == 1
-                                        || src1_d.matches_one_of_tag(
-                                                format_tag::ab),
-                                VERBOSE_UNSUPPORTED_POSTOP);
-                    }
-
-                    // Only scalar [1, 1] is allowed to have format_any
-                    // (i.e. NVFP4 global scale support)
-                    // All other binary post-ops are expected to have
-                    // explicit format
                     if (src1_d.format_any()) {
                         VDISPATCH_MATMUL(src1_d.count_non_unit_dims(0),
                                 VERBOSE_UNSUPPORTED_POSTOP);

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -965,6 +965,7 @@ std::ostream &operator<<(std::ostream &s, const attr_t::post_ops_t &post_ops) {
             if (e.binary.tag != tag::any) s << src_delim << e.binary.tag;
             if (!e.binary.strides.empty())
                 s << src_delim << dims2str(e.binary.strides);
+            if (e.binary.grouped) s << src_delim << "grouped";
 
             if (e.is_binary_kind_with_ternary_op()) {
                 bool delim_added = false;
@@ -1330,11 +1331,23 @@ post_ops_rhs_tensor_entry_t get_po_rhs_tensor_entry(
 } // namespace
 
 int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
-        const dnnl_dims_t prb_dims, dnnl_primitive_kind_t prim_kind) {
+        const dnnl_dims_t prb_dims, dnnl_primitive_kind_t prim_kind,
+        const sparse_options_t *sparse_options) {
     const auto &po = attr.post_ops;
     dnnl_dims_t dims;
     for (int d = 0; d < ndims; ++d)
         dims[d] = prb_dims[d];
+
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+    int grouped_var_dim_idx = -1;
+    dnnl_dim_t grouped_count = 0;
+    if (sparse_options) {
+        grouped_var_dim_idx
+                = sparse_options->get_variable_dim_idx(DNNL_ARG_SRC);
+        grouped_count = sparse_options->get_group_count();
+    }
+#endif
+
     // iterate over all post ops and prepare md for each binary
     for (int idx = 0; idx < po.len(); ++idx) {
         const auto &e = po.entry[idx];
@@ -1351,6 +1364,13 @@ int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
             auto rhs_tensor_desc = dnn_mem_t::init_md(ndims, rhs_tensor_dims,
                     po_rhs_tensor_entry.dt, po_rhs_tensor_entry.tag,
                     po_rhs_tensor_entry.strides);
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+            if (e.binary.grouped) {
+                rhs_tensor_desc = dnn_mem_t::init_grouped_md(ndims,
+                        rhs_tensor_dims, po_rhs_tensor_entry.dt,
+                        grouped_var_dim_idx, grouped_count);
+            }
+#endif
             mds.emplace((DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx)
                                 | po_rhs_tensor_entry.arg_attr_mask),
                     std::move(rhs_tensor_desc));

--- a/tests/benchdnn/dnn_types.hpp
+++ b/tests/benchdnn/dnn_types.hpp
@@ -418,6 +418,7 @@ struct attr_t {
                 mask_input_t mask_input = mask_input_t::none;
                 std::string tag = tag::any;
                 dims_t strides;
+                bool grouped = false;
 
                 // For the src2 tensor when the algorithm takes ternary inputs
                 dnnl_data_type_t src2_dt = dnnl_data_type_undef;
@@ -755,7 +756,8 @@ struct attr_args_t {
 
     int prepare_post_ops_mds(const attr_t &attr, int ndims,
             const dnnl_dims_t prb_dims,
-            dnnl_primitive_kind_t prim_kind = dnnl_undefined_primitive);
+            dnnl_primitive_kind_t prim_kind = dnnl_undefined_primitive,
+            const sparse_options_t *sparse_options = nullptr);
 
     void prepare_dw_post_op(const attr_t &attr, dnnl_data_type_t wei_dt,
             dnnl_data_type_t bia_dt);

--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
@@ -25,6 +25,8 @@
 # - MXFP4: f4_e2m1 dtypes, e8m0 block scales, block size 32
 # - NVFP4: f4_e2m1 dtypes, f8_e4m3 block scales (block size 16) + global f32 scale via
 #           binary mul post-op (--attr-post-ops=mul:f32:0)
+# - Post-ops: eltwise_swish, binary_mul (per-row, dense, grouped encoding),
+#             chained eltwise_swish+binary_mul(grouped), post-ops with bias/scales
 
 --reset
 
@@ -198,3 +200,41 @@
 --wtag=abc
 --grouped=0:4:10+20+30+40:40
 100x64:4x64x32
+
+# Post-ops:
+# eltwise_swish
+# binary_mul with per-row mask (e.g., routing weight for Down)
+# binary_mul with grouped tensor (e.g., Gate * Up, grouped encoding)
+--reset
+--dt=f16:f16:f16
+--wtag=abc
+--grouped=0:4:8+8+8+8
+--attr-post-ops=eltwise_swish:1.0,mul:f32:1:ab,mul:f32:3:grouped
+32x64:4x64x32
+
+# Post-ops: eltwise_swish + binary_mul (grouped)
+--reset
+--dt=f16:f16:f16
+--wtag=abc,acb
+--grouped=0:4:8+8+8+8,0:4:8+0+16+8
+--attr-post-ops=eltwise_swish:1.0+mul:f32:3:grouped
+32x64:4x64x32
+
+# Post-ops + bias: binary_mul per-row and grouped with bias
+--reset
+--dt=f32:f32:f32
+--wtag=abc
+--grouped=0:4:8+8+8+8
+--bia-dt=f32 --bia_mask=2
+--attr-post-ops=mul:f32:1:ab,mul:f32:3:grouped
+32x64:4x64x32
+
+# Post-ops + quantization: binary_mul per-row and grouped with WOQ scales
+--reset
+--dt=f16:s4:f16
+--wtag=abc
+--grouped=0:4:8+8+8+8
+--attr-fpmath=f16:true
+--attr-scales=wei:7:f16:32x1
+--attr-post-ops=mul:f32:1:ab,mul:f32:3:grouped
+32x128:4x128x64

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -205,7 +205,8 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
     }
 
     attr_args_t attr_args;
-    attr_args.prepare_post_ops_mds(prb->attr, prb->ndims, prb->dst_dims.data());
+    attr_args.prepare_post_ops_mds(prb->attr, prb->ndims, prb->dst_dims.data(),
+            dnnl_undefined_primitive, &prb->sparse_options);
 
     const auto overload_quant_mask = [&](policy_t policy, int arg) {
         // Overload PER_OC/PER_OCIC mask definition for batched cases.
@@ -497,10 +498,12 @@ static void fill_dense_fp_values(data_kind_t kind, const prb_t *prb,
 }
 
 #if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+
 // Fill offsets buffer for grouped memory with cumulative sums
-static int fill_grouped_offsets(dnn_mem_t &mem, const prb_t *prb) {
-    const int64_t group_count = prb->sparse_options.get_group_count();
-    const auto &group_sizes = prb->sparse_options.get_group_sizes();
+static int fill_grouped_offsets(
+        dnn_mem_t &mem, const sparse_options_t &sparse_options) {
+    const int64_t group_count = sparse_options.get_group_count();
+    const auto &group_sizes = sparse_options.get_group_sizes();
 
     int64_t cumulative = 0;
     for (int64_t g = 0; g < group_count; g++) {
@@ -537,7 +540,7 @@ static int fill_grouped_data(data_kind_t kind, const prb_t *prb,
     }
 
     // Fill offsets buffer
-    SAFE(fill_grouped_offsets(mem_dt, prb), WARN);
+    SAFE(fill_grouped_offsets(mem_dt, prb->sparse_options), WARN);
 
     if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) return OK;
 
@@ -1202,7 +1205,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 if (is_grouped) {
                     // Only offsets need to be filled
                     // as values are computed by the library
-                    SAFE(fill_grouped_offsets(mem, prb), WARN);
+                    SAFE(fill_grouped_offsets(mem, prb->sparse_options), WARN);
                 }
 #endif
                 const auto &po = prb->attr.post_ops;
@@ -1231,11 +1234,30 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 // TODO: introduce an order of processing arguments to avoid
                 // post filling manipulations.
                 break;
-            default:
+            default: {
                 SAFE(init_ref_memory_args_default_case(
                              exec_arg, mem, ref_mem, prb->attr, res),
                         WARN);
-                break;
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+                // Fill offsets for grouped binary post-op tensors
+                // Note that values are already filled by the default case above
+                if (is_grouped) {
+                    const auto &po = prb->attr.post_ops;
+                    // DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) = BASE * (idx + 1)
+                    const int po_idx
+                            = exec_arg / DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE
+                            - 1;
+                    const bool is_grouped_bin_po = po_idx >= 0
+                            && po_idx < po.len()
+                            && po.entry[po_idx].is_binary_kind()
+                            && po.entry[po_idx].binary.grouped;
+                    if (is_grouped_bin_po) {
+                        SAFE(fill_grouped_offsets(mem, prb->sparse_options),
+                                WARN);
+                    }
+                }
+#endif
+            } break;
         }
 
         update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -390,14 +390,22 @@ attr_t::post_ops_t str2attr_post_ops(const std::string &s) {
                 if (src_subpos == std::string::npos) return;
 
                 // parse tag input - processed for both src1/2 tensors.
+                //
+                // WARNING: "grouped" in the tag position means post-op tensor
+                // follows dst layout (e.g., offsets, layout, strides),
+                // in this case tag is left as default (any)
                 const auto tag_str = get_substr(s, src_subpos, delim);
-                if (check_tag(tag_str) != OK) {
-                    BENCHDNN_PRINT(0, "%s \'%s\' %s\n",
-                            "Error: binary post-op tag", tag_str.c_str(),
-                            "is not recognized.");
-                    SAFE_V(FAIL);
+                if (tag_str == "grouped") {
+                    e.binary.grouped = true;
+                } else {
+                    if (check_tag(tag_str) != OK) {
+                        BENCHDNN_PRINT(0, "%s \'%s\' %s\n",
+                                "Error: binary post-op tag", tag_str.c_str(),
+                                "is not recognized.");
+                        SAFE_V(FAIL);
+                    }
+                    e.binary.tag = tag_str;
                 }
-                e.binary.tag = tag_str;
 
                 if (src_subpos == std::string::npos) return;
 

--- a/tests/gtests/test_iface_grouped.cpp
+++ b/tests/gtests/test_iface_grouped.cpp
@@ -487,6 +487,136 @@ HANDLE_EXCEPTIONS_FOR_TEST(iface_grouped_test_t, TestMaxGroupMHint) {
     }
 }
 
+HANDLE_EXCEPTIONS_FOR_TEST(iface_grouped_test_t, TestBinaryPostOpPDCreation) {
+    engine eng = get_test_engine();
+
+    SKIP_IF(eng.get_kind() == engine::kind::gpu
+                    || DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL,
+            "Test requires host-allocated memory.");
+
+    const int ngroups = 2;
+    auto src_md = memory::desc::grouped({6, 4}, dt::f32, 0, ngroups);
+    auto wei_md
+            = memory::desc({ngroups, 4, 4}, dt::f32, memory::format_tag::abc);
+    auto dst_md = memory::desc::grouped({6, 4}, dt::f32, 0, ngroups);
+    auto bin_md = memory::desc::grouped({6, 4}, dt::f32, 0, ngroups);
+
+    post_ops po;
+    po.append_binary(algorithm::binary_mul, bin_md);
+    primitive_attr attr;
+    attr.set_post_ops(po);
+
+    ASSERT_NO_THROW(matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr));
+
+    // Mismatched: 3 groups vs 2
+    auto mismatched_bin_md = memory::desc::grouped({6, 4}, dt::f32, 0, 3);
+
+    post_ops mismatched_po;
+    mismatched_po.append_binary(algorithm::binary_mul, mismatched_bin_md);
+    primitive_attr mismatched_attr;
+    mismatched_attr.set_post_ops(mismatched_po);
+
+    EXPECT_THROW(matmul::primitive_desc(
+                         eng, src_md, wei_md, dst_md, mismatched_attr),
+            dnnl::error);
+}
+
+TEST(iface_grouped_test_t, TestUnsupportedPostOps) {
+    engine eng = get_test_engine();
+
+    SKIP_IF(eng.get_kind() == engine::kind::gpu
+                    || DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL,
+            "Test requires host-allocated memory.");
+
+    const int ngroups = 2;
+    auto src_md = memory::desc::grouped({6, 4}, dt::f32, 0, ngroups);
+    auto wei_md
+            = memory::desc({ngroups, 4, 4}, dt::f32, memory::format_tag::abc);
+    auto dst_md = memory::desc::grouped({6, 4}, dt::f32, 0, ngroups);
+    auto bin_md = memory::desc({6, 4}, dt::f32, memory::format_tag::ab);
+
+    // eltwise_swish + binary_mul is accepted
+    {
+        post_ops po;
+        po.append_eltwise(algorithm::eltwise_swish, 1.f, 0.f);
+        po.append_binary(algorithm::binary_mul, bin_md);
+        primitive_attr attr;
+        attr.set_post_ops(po);
+        EXPECT_NO_THROW(
+                matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr));
+    }
+
+    // binary_add is not supported for grouped matmul
+    {
+        post_ops po;
+        po.append_binary(algorithm::binary_add, bin_md);
+        primitive_attr attr;
+        attr.set_post_ops(po);
+        EXPECT_THROW(matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr),
+                dnnl::error);
+    }
+
+    // sum is not supported
+    {
+        post_ops po;
+        po.append_sum(1.0f);
+        primitive_attr attr;
+        attr.set_post_ops(po);
+        EXPECT_THROW(matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr),
+                dnnl::error);
+    }
+}
+
+HANDLE_EXCEPTIONS_FOR_TEST(
+        iface_grouped_test_t, TestBinaryPostOpRejectsMismatchedOffsets) {
+    engine eng = get_test_engine();
+
+    SKIP_IF(eng.get_kind() == engine::kind::gpu
+                    || DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL,
+            "Test requires host-allocated memory.");
+
+    const int ngroups = 2;
+    const int total_m = 6;
+    const int K = 4;
+    const int N = 4;
+
+    auto src_md = memory::desc::grouped({total_m, K}, dt::f32, 0, ngroups);
+    auto wei_md
+            = memory::desc({ngroups, K, N}, dt::f32, memory::format_tag::abc);
+    auto dst_md = memory::desc::grouped({total_m, N}, dt::f32, 0, ngroups);
+    auto bin_md = memory::desc::grouped({total_m, N}, dt::f32, 0, ngroups);
+
+    post_ops po;
+    po.append_binary(algorithm::binary_mul, bin_md);
+    primitive_attr attr;
+    attr.set_post_ops(po);
+
+    matmul::primitive_desc pd(eng, src_md, wei_md, dst_md, attr);
+    matmul prim(pd);
+    stream strm(eng);
+
+    std::vector<float> src_data(total_m * K, 1.f);
+    std::vector<float> wei_data(ngroups * K * N, 1.f);
+    std::vector<float> dst_data(total_m * N, 0.f);
+    std::vector<float> bin_data(total_m * N, 1.f);
+    std::vector<int32_t> src_offsets = {3, 6};
+    std::vector<int32_t> dst_offsets = {3, 6};
+    std::vector<int32_t> bin_offsets = {2, 6};
+
+    memory src_mem(src_md, eng, {src_data.data(), src_offsets.data()});
+    memory wei_mem(wei_md, eng, wei_data.data());
+    memory dst_mem(dst_md, eng, {dst_data.data(), dst_offsets.data()});
+    memory bin_mem(bin_md, eng, {bin_data.data(), bin_offsets.data()});
+
+    EXPECT_THROW(
+            prim.execute(strm,
+                    {{DNNL_ARG_SRC, src_mem}, {DNNL_ARG_WEIGHTS, wei_mem},
+                            {DNNL_ARG_DST, dst_mem},
+                            {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
+                                    bin_mem}}),
+            dnnl::error);
+}
+
 } // namespace dnnl
 
 #endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY


### PR DESCRIPTION
Implements [MFDNN-15013](https://jira.devtools.intel.com/browse/MFDNN-15013):
- eltwise_swish, binary_mul for `[total_M, 1]` dense tensor and `[total_M, N]` tensor 

Biggest change is to allow grouped tensor for binary_mul: for CPU ref we're making sure to validate offsets against `dst` offsets, and for benchdnn it is required to create a grouped memory instead of dense and be able to recognize `:grouped` as a new "tag"