### PR TITLE
build: graph: enable msvc c4244 and fix warnings

### DIFF
--- a/src/graph/CMakeLists.txt
+++ b/src/graph/CMakeLists.txt
@@ -14,14 +14,6 @@
 # limitations under the License.
 #===============================================================================
 
-if (MSVC)
-    if(${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
-        # int64_t -> int (tent)
-        append(CMAKE_C_FLAGS "/wd4244")
-        append(CMAKE_CXX_FLAGS "/wd4244")
-    endif()
-endif()
-
 if (ONEDNN_BUILD_GRAPH)
     add_subdirectory(interface)
     add_subdirectory(backend)

--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -334,8 +334,11 @@ std::vector<int64_t> get_permutation(int ndims, const std::string &from_format,
     return axes;
 }
 
-memory::desc transpose(const memory::desc &adesc, dim dim0, dim dim1) {
-    std::vector<int> axes(static_cast<std::size_t>(adesc.get_ndims()));
+memory::desc transpose(const memory::desc &adesc, int dim0, int dim1) {
+    size_t ndims = static_cast<std::size_t>(adesc.get_ndims());
+    assert(dim0 >= 0 && dim0 < static_cast<int>(ndims) && dim1 >= 0
+            && dim1 < static_cast<int>(ndims));
+    std::vector<int> axes(ndims);
     std::iota(axes.begin(), axes.end(), 0);
     axes[static_cast<std::size_t>(dim0)] = dim1;
     axes[static_cast<std::size_t>(dim1)] = dim0;
@@ -369,8 +372,8 @@ dims get_ncx_strides(const dims &shape) {
     }
     dims strides(_shape.size());
     for (auto it = _shape.begin(); it < _shape.end(); ++it) {
-        const auto val = std::accumulate(
-                std::next(it), _shape.end(), 1, std::multiplies<dim_t>());
+        const auto val = std::accumulate(std::next(it), _shape.end(), (dim_t)1,
+                std::multiplies<dim_t>());
         const auto dist = std::distance(_shape.begin(), it);
         strides[static_cast<size_t>(dist)] = val;
     }
@@ -463,22 +466,6 @@ bool is_4c_blocked(const memory::desc &adesc) {
 bool is_plain(const memory::desc &adesc) {
     if (adesc.get_format_kind() != format_kind::blocked) return false;
     return adesc.get_inner_nblks() == 0;
-}
-
-// get the dense strides of a given shape
-// eg. (3, 4, 5) -> (20, 5, 1)
-dims get_dense_strides(const dims &shape) {
-    dims strides(shape.size());
-    for (auto it = shape.begin(); it < shape.end(); ++it) {
-        const auto val = std::accumulate(
-                std::next(it), shape.end(), 1, [](dim_t x, dim_t y) {
-            // replace 0 in shape to 1 when computing the strides
-            return std::max<dim_t>(x, 1) * std::max<dim_t>(y, 1);
-        });
-        const auto dist = std::distance(shape.begin(), it);
-        strides[static_cast<size_t>(dist)] = val;
-    }
-    return strides;
 }
 
 memory::desc to_ncx_format(const memory::desc &adesc) {

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -99,7 +99,7 @@ std::vector<int64_t> get_permutation(int ndims, const std::string &from_format,
 
 std::vector<int64_t> get_last_two_dims_permutation(int ndims);
 
-memory::desc transpose(const memory::desc &adesc, dim dim0, dim dim1);
+memory::desc transpose(const memory::desc &adesc, int dim0, int dim1);
 
 memory::desc to_grouped(const memory::desc &adesc, dim groups);
 
@@ -110,8 +110,6 @@ memory::desc to_format_any(const memory::desc &adesc);
 dims get_ncx_strides(const dims &shape);
 
 dims get_nxc_strides(const dims &shape);
-
-dims get_dense_strides(const dims &shape);
 
 memory::desc to_nxc_format(const memory::desc &adesc);
 

--- a/src/graph/backend/dnnl/executables/const_memory_filler.hpp
+++ b/src/graph/backend/dnnl/executables/const_memory_filler.hpp
@@ -114,7 +114,11 @@ private:
     }
     std::vector<target_dt> get_attr_data(
             const std::vector<attr_dt> &orig_data, std::false_type) {
-        return std::vector<target_dt>(orig_data.begin(), orig_data.end());
+        std::vector<target_dt> result;
+        result.reserve(orig_data.size());
+        for (const auto &v : orig_data)
+            result.push_back(static_cast<target_dt>(v));
+        return result;
     }
 
     const engine::kind dflt_eng_kind = engine::kind::cpu;

--- a/src/graph/backend/dnnl/executables/gen_index.cpp
+++ b/src/graph/backend/dnnl/executables/gen_index.cpp
@@ -80,7 +80,7 @@ void genindex_executable_t::execute_impl(const stream &stream,
                 input_dims, i, output_dims_, ndims_);
         auto offset
                 = utils::offset_compute(output_strides_, input_dims, ndims_);
-        output_ptr[offset] = input_dims[axis_];
+        output_ptr[offset] = static_cast<int32_t>(input_dims[axis_]);
     });
     stream.get()->after_exec_hook();
 }
@@ -129,7 +129,7 @@ void genindex_executable_t::execute(const stream &stream,
     compute::kernel_arg_list_t arg_list;
     const auto &dst = *(args.at(DNNL_ARG_DST).get()->memory_storage());
     arg_list.set(0, dst);
-    arg_list.set(1, axis_);
+    arg_list.set(1, static_cast<int>(axis_));
     auto *sycl_stream
             = dnnl::impl::utils::downcast<sycl::stream_t *>(compute_stream);
     sycl_stream->before_exec_hook();
@@ -183,7 +183,7 @@ cl_event genindex_executable_t::execute_ocl_impl(const stream &stream,
     compute::kernel_arg_list_t arg_list;
     const auto &dst = *(args.at(DNNL_ARG_DST).get()->memory_storage());
     arg_list.set(0, dst);
-    arg_list.set(1, axis_);
+    arg_list.set(1, static_cast<int>(axis_));
     auto *ocl_stream = dnnl::impl::utils::downcast<gpu::intel::ocl::stream_t *>(
             compute_stream);
 

--- a/src/graph/backend/dnnl/executables/gen_index.hpp
+++ b/src/graph/backend/dnnl/executables/gen_index.hpp
@@ -69,7 +69,9 @@ struct genindex_executable_t : public op_executable_t {
     }
 
 private:
-    int axis_, nelems_, ndims_;
+    dim_t axis_;
+    dim_t nelems_;
+    int32_t ndims_;
     dims_t output_dims_, output_strides_;
     dnnl::engine::kind ekind_;
     std::string info_;

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -175,10 +175,10 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
     mqa_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    int MBO = mqa_cfg_.batch_size, MBI = mqa_cfg_.num_head,
-        M1 = mqa_cfg_.seq_len, K1 = mqa_cfg_.size_per_head,
-        N1 = mqa_cfg_.seq_len, M2 = mqa_cfg_.size_per_head,
-        K2 = mqa_cfg_.seq_len, N2 = mqa_cfg_.seq_len;
+    dim_t MBO = mqa_cfg_.batch_size, MBI = mqa_cfg_.num_head,
+          M1 = mqa_cfg_.seq_len, K1 = mqa_cfg_.size_per_head,
+          N1 = mqa_cfg_.seq_len, M2 = mqa_cfg_.size_per_head,
+          K2 = mqa_cfg_.seq_len, N2 = mqa_cfg_.seq_len;
 
     char *src1_user_pointer = static_cast<char *>(
             inputs[mqa_cfg_.graph_inport[0]].get_data_handle());

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -180,7 +180,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
     sdp_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    int MBO = sdp_cfg_.batch_size, MBI = sdp_cfg_.num_head_q;
+    dim_t MBO = sdp_cfg_.batch_size, MBI = sdp_cfg_.num_head_q;
 
     char *src1_user_pointer = static_cast<char *>(
             inputs[sdp_cfg_.graph_inport[sdp_decomp_config_t::mm1_src]]

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -123,7 +123,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
 
     // Record the ops inside of SDP pattern for later usage
     CHECK(record_sdp_ops(sg, quantized));
-    const int last_dim = ndims - 1, second_last_dim = ndims - 2;
+    const dim_t last_dim = ndims - 1, second_last_dim = ndims - 2;
 
     // Update SDPA input params. Sequence length for query and key/value are
     // NOT always same.
@@ -200,9 +200,9 @@ impl::status_t sdp_decomp_config_t::construct_params(
     sub_mm1_dst_md = memory::desc(sub_mm1_dst_dims, dt_inter, format_tag::ab);
     dnnl::post_ops dnnl_pops;
     auto mm1_ori_dnnl_pops = sub_matmul1_attr.get_post_ops();
-    auto make_sub_md
-            = [&](const dnnl::impl::memory_desc_t &ori_desc,
-                      int second_last_dim, int last_dim) -> dnnl::memory::desc {
+    auto make_sub_md = [&](const dnnl::impl::memory_desc_t &ori_desc,
+                               dim_t second_last_dim,
+                               dim_t last_dim) -> dnnl::memory::desc {
         auto post_shape = ori_desc.dims;
         auto post_stride = ori_desc.format_desc.blocking.strides;
         auto post_dt = static_cast<dnnl::memory::data_type>(ori_desc.data_type);

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -2790,8 +2790,9 @@ status_t fuse_adjacent_reorders(std::shared_ptr<subgraph_t> &sg) {
             fused_dst_zps.reserve(max_num);
             for (size_t i = 0; i < max_num; i++) {
                 fused_scales.emplace_back(scales1[i] * scales2[i]);
-                fused_dst_zps.emplace_back(
-                        scales2[i] * (dst_zps1[i] - src_zps2[i]) + dst_zps2[i]);
+                fused_dst_zps.emplace_back(static_cast<int64_t>(
+                        scales2[i] * (dst_zps1[i] - src_zps2[i])
+                        + dst_zps2[i]));
             }
 
             int64_t axis = -1;

--- a/src/graph/interface/op_def_constraint.cpp
+++ b/src/graph/interface/op_def_constraint.cpp
@@ -31,7 +31,7 @@ namespace graph {
 bool check_pads(const op_t *n) {
     auto hasNegative = [](const dims &pads) {
         return std::any_of(pads.begin(), pads.end(),
-                [](int element) { return element < 0; });
+                [](dim_t element) { return element < 0; });
     };
     const dims pads_begin = n->get_attr<dims>(op_attr::pads_begin);
     VCHECK_SHAPE_INFER(!hasNegative(pads_begin),

--- a/src/graph/interface/shape_infer.cpp
+++ b/src/graph/interface/shape_infer.cpp
@@ -150,11 +150,14 @@ bool validate(const dims &inferred, const dims &expected) {
 
 /// get the dense strides of a given shape
 /// eg. (3, 4, 5) -> (20, 5, 1)
-inline dims get_dense_strides(const dims &shape) {
+dims get_dense_strides(const dims &shape) {
     dims strides(shape.size());
     for (auto it = shape.begin(); it < shape.end(); ++it) {
         const auto val = std::accumulate(
-                std::next(it), shape.end(), 1, std::multiplies<dim_t>());
+                std::next(it), shape.end(), (dim_t)1, [](dim_t x, dim_t y) {
+            // replace 0 in shape to 1 when computing the strides
+            return std::max<dim_t>(x, 1) * std::max<dim_t>(y, 1);
+        });
         const auto dist = std::distance(shape.begin(), it);
         strides[static_cast<size_t>(dist)] = val;
     }
@@ -805,9 +808,9 @@ status_t infer_pool_output_shape(op_t *n,
         dim_t dilated = dilations[i] * (kernel[i] - 1) + 1;
         dim_t out_value;
         if (rounding_type == "ceil") {
-            out_value = utils::div_and_ceil(padded - dilated, strides[i]) + 1;
+            out_value = utils::div_up(padded - dilated, strides[i]) + 1;
         } else {
-            out_value = utils::div_and_floor(padded - dilated, strides[i]) + 1;
+            out_value = (padded - dilated) / strides[i] + 1;
         }
         output_sp.push_back(out_value);
     }
@@ -1572,12 +1575,12 @@ status_t infer_static_reshape_output_shape(op_t *n,
         }
     }
 
-    int in_size = 1;
-    int out_size = 1;
-    for (size_t i = 0; i < static_cast<size_t>(in0.ndims()); i++) {
+    dim_t in_size = 1;
+    dim_t out_size = 1;
+    for (size_t i = 0; i < in_dims.size(); i++) {
         if (in_dims[i] >= 0) in_size *= in_dims[i];
     }
-    for (size_t i = 0; i < static_cast<size_t>(out_dims.size()); i++) {
+    for (size_t i = 0; i < out_dims.size(); i++) {
         if (out_dims[i] >= 0) out_size *= out_dims[i];
     }
     // handle -1 in output shape: the value is inferred from the size of the
@@ -1585,7 +1588,7 @@ status_t infer_static_reshape_output_shape(op_t *n,
     if (find_uncertain_dim) {
         VCHECK_INVALID_SHAPE((out_size != 0),
                 "%s, output size is not allowed to be 0 for uncertain dims, "
-                "output size: %d  ",
+                "output size: %" PRId64 " ",
                 op_t::kind2str(n->get_kind()).c_str(), out_size);
         out_dims[uncertain_axis] = in_size / out_size;
     }
@@ -1593,14 +1596,17 @@ status_t infer_static_reshape_output_shape(op_t *n,
     // size of input should be same as output
     if (find_uncertain_dim == false) {
         VCHECK_INVALID_SHAPE((out_size == in_size),
-                "%s, size of input should be same as output. input size: %d, "
-                "output size: %d  ",
+                "%s, size of input should be same as output. input size: "
+                "%" PRId64
+                ", "
+                "output size: %" PRId64 " ",
                 op_t::kind2str(n->get_kind()).c_str(), in_size, out_size);
     } else {
         VCHECK_INVALID_SHAPE((out_size * out_dims[uncertain_axis] == in_size),
                 "%s, the product of output size and output dim at uncertain "
-                "axis should be equal to the input size. input size: %d, "
-                "output size: %d, output dim at uncertain axis: %d  ",
+                "axis should be equal to the input size. input size: %" PRId64
+                ", "
+                "output size: %" PRId64 ", output dim at uncertain axis: %d  ",
                 op_t::kind2str(n->get_kind()).c_str(), in_size, out_size,
                 static_cast<int>(out_dims[uncertain_axis]));
     }
@@ -1725,7 +1731,10 @@ status_t infer_interpolate_output_shape(op_t *n,
 
         // spatial_ndim
         for (size_t i = 0; i < static_cast<size_t>(spatial_ndim); i++) {
-            in_dims[i + spatial_dim_start_axis] *= scales[i];
+            const float d
+                    = static_cast<float>(in_dims[i + spatial_dim_start_axis]);
+            in_dims[i + spatial_dim_start_axis]
+                    = static_cast<dim_t>(d * scales[i]);
         }
     }
     if (!sizes.empty()) {

--- a/src/graph/interface/shape_infer.hpp
+++ b/src/graph/interface/shape_infer.hpp
@@ -51,7 +51,7 @@ bool validate(const dims &inferred, const dims &expected);
 
 /// get the dense strides of a given shape
 /// eg. (3, 4, 5) -> (20, 5, 1)
-inline dims get_dense_strides(const dims &shape);
+dims get_dense_strides(const dims &shape);
 
 /// shapes of the logical tensors in the vector are known
 inline bool every_shape_is_known(const std::vector<logical_tensor_t *> &lts);

--- a/src/graph/utils/utils.hpp
+++ b/src/graph/utils/utils.hpp
@@ -116,14 +116,6 @@ inline std::string thread_id_to_str(std::thread::id id) {
     return ss.str();
 }
 
-inline int div_and_ceil(float x, float y) {
-    return static_cast<int>(std::ceil(x / y));
-}
-
-inline int div_and_floor(float x, float y) {
-    return static_cast<int>(std::floor(x / y));
-}
-
 template <typename T, typename... Args>
 inline std::string set2str(const std::set<T, Args...> &obj) {
     ostringstream_t oss;


### PR DESCRIPTION
- Follow-up work of #5069 
- Enable the MSVC C4244 flag in graph component. See src/graph/CMakeLists.txt.
- Fix all the type conversion warnings by C4244 in graph component.

