### PR TITLE
cpu: x64: matmul: Disable small-shapes heuristic fallback to AVX‑512 for s8s8 matmul

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2001,35 +2001,44 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     const bool runtime_dims
             = bgmmc.is_runtime_M || bgmmc.is_runtime_N || bgmmc.is_runtime_K;
 
-    bool is_small_shapes = bgmmc.is_amx && !runtime_dims;
+    bool allow_small_shape_fallback = bgmmc.is_amx && !runtime_dims;
 
     // Disable 'small_shape' heuristic for amx_fp16 until it is validated with
     // performance measurements.
-    is_small_shapes = is_small_shapes && (bgmmc.isa != avx512_core_amx_fp16);
-
-    if (bm_conf_utils.is_bf16() || bm_conf_utils.is_f16()
-            || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
-            || bm_conf_utils.is_bf16_with_int_wei()
-            || bm_conf_utils.is_f16_with_int_wei()
-            || bm_conf_utils.is_f32_with_int_wei()) {
-        // empirical observation for performance breakpoint between amx and vnni
-        // bf16/f16
-        const dim_t buffer_a_chunk_sz_limit = 126;
-        is_small_shapes = is_small_shapes
-                && bgmmc.buffer_a_gb_stride <= buffer_a_chunk_sz_limit;
-    } else if (bm_conf_utils.is_f8() || bm_conf_utils.is_bf8()) {
-        is_small_shapes = false;
-    } else {
-        is_small_shapes = is_small_shapes && bgmmc.ndims < 3
-                && ((bgmmc.M == 1 && bgmmc.K == 256)
-                        || (bgmmc.M <= 32 && bgmmc.M * bgmmc.N <= 256)
-                        || bgmmc.K <= 16);
-    }
+    allow_small_shape_fallback
+            = allow_small_shape_fallback && !bgmmc.packed_sparse_weights;
     // This is the only implementation that support the packed_sparse_weights
     // case therefore there is no fallback for it.
-    is_small_shapes = is_small_shapes && !bgmmc.packed_sparse_weights;
-    VCONDCHECK_BG(!is_small_shapes, VERBOSE_SMALL_SHAPES);
+    allow_small_shape_fallback
+            = allow_small_shape_fallback && !bgmmc.packed_sparse_weights;
 
+    // avx512 doesn’t support native s8s8, but amx does so falling back to avx512 is not supported.
+    bool is_s8s8_matmul = bgmmc.src_dt == s8 && bgmmc.wei_dt == s8;
+    allow_small_shape_fallback = allow_small_shape_fallback && !is_s8s8_matmul;
+
+    if (allow_small_shape_fallback) {
+        bool is_small_shapes = false;
+        if (bm_conf_utils.is_bf16() || bm_conf_utils.is_f16()
+                || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
+                || bm_conf_utils.is_bf16_with_int_wei()
+                || bm_conf_utils.is_f16_with_int_wei()
+                || bm_conf_utils.is_f32_with_int_wei()) {
+            // empirical observation for performance breakpoint between amx and vnni
+            // bf16/f16
+            const dim_t buffer_a_chunk_sz_limit = 126;
+            is_small_shapes = is_small_shapes
+                    && bgmmc.buffer_a_gb_stride <= buffer_a_chunk_sz_limit;
+        } else if (bm_conf_utils.is_f8() || bm_conf_utils.is_bf8()) {
+            is_small_shapes = false;
+        } else {
+            is_small_shapes = is_small_shapes && bgmmc.ndims < 3
+                    && ((bgmmc.M == 1 && bgmmc.K == 256)
+                            || (bgmmc.M <= 32 && bgmmc.M * bgmmc.N <= 256)
+                            || bgmmc.K <= 16);
+        }
+
+        VCONDCHECK_BG(!is_small_shapes, VERBOSE_SMALL_SHAPES);
+    }
     if (bgmmc.use_buffer_b) {
         // If B is copied to a temporary buffer then the layout of B is
         //      [n = n_blk / LDB][k = k_blk / wei_k_blk][k = wei_k_blk / vnni][n = LDB][k = vnni]


### PR DESCRIPTION

## Description
This PR fixes an incorrect execution path for **s8s8 matmul** caused by the small-shapes heuristic.

The current heuristic avoids executing very small dimensions on AMX when there is insufficient work available and instead falls back to **AVX‑512**. However, **AVX‑512 does not support s8s8 matmul**, which causes execution to fall back further to the **reference implementation**.

To prevent this unintended behavior, the small-shapes heuristic fallback is **disabled for the s8s8 case**, avoiding selection of unsupported AVX‑512 paths.

## Root Cause
- Small-shapes heuristic redirects very small workloads away from AMX
- Fallback target is AVX‑512
- AVX‑512 does **not** support s8s8 matmul
- Execution incorrectly falls back to the reference implementation

## Fix
- Disable the small-shapes heuristic fallback to AVX‑512 **only for s8s8**
- Preserve existing heuristic behavior for other data types

## Bug
- https://jira.devtools.intel.com/browse/MFDNN-14921
