### PR TITLE
[backport][rls-v3.12] tests: gtests: disable test_concurrency for ze backend

### DIFF
--- a/tests/gtests/test_concurrency.cpp
+++ b/tests/gtests/test_concurrency.cpp
@@ -287,6 +287,12 @@ protected:
         if (get_test_engine_kind() == engine::kind::gpu)
             set_primitive_cache_capacity(0);
 #endif
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
+        // Note: necessary abstractions to support concurrent kernel generation
+        // are not introduced for Level Zero backend.
+        SKIP_IF(true,
+                "Concurrent execution is not supported by Level Zero backend.");
+#endif
         // This test doesn't work properly under SDE.
         const int len = 1024;
         char value_str[len];


### PR DESCRIPTION
This is a backport of a single commit from #4959 from main, required post update for verbose.

[MFDNN-15010](https://jira.devtools.intel.com/browse/MFDNN-15010)
