### PR TITLE
tests: benchdnn: Fix repro arg order

### DIFF
--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1149,6 +1149,11 @@ std::ostream &operator<<(std::ostream &s, memory_kind_ext_t memory_kind) {
 }
 
 std::ostream &dump_global_params(std::ostream &s) {
+    if (canonical || engine_tgt_kind != dnnl_cpu) {
+        s << "--engine=" << engine_tgt_kind;
+        if (engine_index != 0) s << ":" << engine_index;
+        s << " ";
+    }
     // Need to dump mode and modifiers in front of the driver name to make all
     // updated default values take effect before parsing a state of a problem.
     if (canonical || bench_mode != default_bench_mode)
@@ -1168,11 +1173,6 @@ std::ostream &dump_global_params(std::ostream &s) {
 
     s << "--" << driver_name << " ";
     if (canonical) s << "--canonical=" << bool2str(canonical) << " ";
-    if (canonical || engine_tgt_kind != dnnl_cpu) {
-        s << "--engine=" << engine_tgt_kind;
-        if (engine_index != 0) s << ":" << engine_index;
-        s << " ";
-    }
     if (canonical || fast_ref != default_fast_ref)
         s << "--fast-ref=" << bool2str(fast_ref) << " ";
     if (!skip_impl.empty()) s << "--skip-impl=" << skip_impl << " ";


### PR DESCRIPTION
# Description

Currently repro args are emitted with engine following mode args: 

```
~/dnn-mod/build$ ./tests/benchdnn/benchdnn --engine=gpu --mode=p --matmul --dt=s8:u8:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=src:7:f16:1x3072+wei:4:f16 --attr-zero-points=wei:4:u8 584x1x3072:1x3072x5120
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,gpu,jit:gemm:any,,--mode=P --mode-modifier=M --matmul --engine=gpu --dt=s8:u8:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=src:7:f16:1x3072+wei:4:f16 --attr-zero-points=wei:4:u8 584x1x3072:1x3072x5120,18.3711,98.9854,0.0688,267021,0.0813049,225953
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:gemm:any : 1 (100%)                                  |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):0.0688 avg(ms):0.0813049
total: 4.01s; create_pd: 0.10s (2%); create_prim: 0.00s (0%); fill: 0.00s (0%); execute: 0.00s (0%);
```

if they are executed directly it can cause the engine flag to be overriden: 

```
:~/dnn-mod/build$ ./tests/benchdnn/benchdnn --mode=P --mode-modifier=M --matmul --engine=gpu --dt=s8:u8:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=src:7:f16:1x3072+wei:4:f16 --attr-zero-points=wei:4:u8 584x1x3072:1x3072x5120
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,gpu,ref_int8:any,,--mode=P --mode-modifier=M --matmul --engine=gpu --dt=s8:u8:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=src:7:f16:1x3072+wei:4:f16 --attr-zero-points=wei:4:u8 584x1x3072:1x3072x5120,18.3711,1.52393,55961.9,0.328278,56900.7,0.322862
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| ref_int8:any : 1 (100%)                                  |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):55961.9 avg(ms):56900.7
total: 341.24s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.00s (0%); execute: 0.00s (0%);
```

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?