### PR TITLE
build, xpu: fix SYCL kernel compiler issues

### DIFF
--- a/cmake/SYCL.cmake
+++ b/cmake/SYCL.cmake
@@ -128,20 +128,18 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 
 if(DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER)
-    include(CheckCXXSourceRuns)
+    include(CheckCXXSourceCompiles)
     set(CHECK_SYCL_KERNEL_COMPILER_SOURCE
     "
         #include <sycl/sycl.hpp>
         namespace syclex = sycl::ext::oneapi::experimental;
         int main() {
-            for (auto platform : sycl::platform::get_platforms())
-                for (auto d : platform.get_devices())
-                    if (!d.ext_oneapi_can_build(syclex::source_language::opencl))
-                        return 1;
+            sycl::device d;
+            (void)d.ext_oneapi_can_build(syclex::source_language::opencl);
             return 0;
         }
     ")
-    CHECK_CXX_SOURCE_RUNS(
+    CHECK_CXX_SOURCE_COMPILES(
         "${CHECK_SYCL_KERNEL_COMPILER_SOURCE}"
         SYCL_KERNEL_COMPILER_DETECTED)
     if(NOT SYCL_KERNEL_COMPILER_DETECTED)

--- a/cmake/SYCL.cmake
+++ b/cmake/SYCL.cmake
@@ -136,7 +136,7 @@ if(DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER)
         int main() {
             for (auto platform : sycl::platform::get_platforms())
                 for (auto d : platform.get_devices())
-                    if (!d.ext_oneapi_can_compile(syclex::source_language::opencl))
+                    if (!d.ext_oneapi_can_build(syclex::source_language::opencl))
                         return 1;
             return 0;
         }

--- a/src/gpu/intel/sycl/engine.cpp
+++ b/src/gpu/intel/sycl/engine.cpp
@@ -105,8 +105,7 @@ status_t engine_t::create_kernels(
     auto device
             = utils::downcast<const impl::xpu::sycl::engine_impl_t *>(impl())
                       ->device();
-    VERROR_ENGINE(
-            device.ext_oneapi_can_compile(syclex::source_language::opencl),
+    VERROR_ENGINE(device.ext_oneapi_can_build(syclex::source_language::opencl),
             status::runtime_error,
             "SYCL implementation does not support OpenCL kernel compiler "
             "extension - make sure that SYCL and OCLOC are correctly "

--- a/src/gpu/intel/sycl/utils.cpp
+++ b/src/gpu/intel/sycl/utils.cpp
@@ -35,6 +35,8 @@ namespace intel {
 namespace sycl {
 
 namespace {
+
+#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 status_t create_ocl_engine(
         std::unique_ptr<gpu::intel::ocl::engine_t, engine_deleter_t>
                 *ocl_engine,
@@ -77,6 +79,7 @@ status_t create_ocl_engine(
             utils::downcast<gpu::intel::ocl::engine_t *>(ocl_engine_ptr));
     return status::success;
 }
+#endif
 
 status_t get_ze_kernel_binary(
         const ::sycl::kernel &kernel, xpu::binary_t &binary) {

--- a/src/xpu/ocl/utils.hpp
+++ b/src/xpu/ocl/utils.hpp
@@ -412,9 +412,7 @@ cl_platform_id get_platform(engine_t *engine);
 status_t create_program(ocl::wrapper_t<cl_program> &ocl_program,
         cl_device_id dev, cl_context ctx, const xpu::binary_t &binary);
 
-#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 status_t get_device_uuid(xpu::device_uuid_t &uuid, cl_device_id ocl_dev);
-#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 // Check for three conditions:
 // 1. Device and context are compatible, i.e. the device belongs to

--- a/src/xpu/ocl/utils_shared.cpp
+++ b/src/xpu/ocl/utils_shared.cpp
@@ -276,7 +276,6 @@ status_t get_extensions(cl_device_id dev, std::string &ext) {
     return status::success;
 }
 
-#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 status_t get_device_uuid(xpu::device_uuid_t &uuid, cl_device_id ocl_dev) {
     // This function is used only with SYCL that works with OpenCL 3.0
     // that supports `cl_khr_device_uuid` extension.
@@ -299,7 +298,6 @@ status_t get_device_uuid(xpu::device_uuid_t &uuid, cl_device_id ocl_dev) {
 #endif
     return status::runtime_error;
 }
-#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 } // namespace ocl
 } // namespace xpu


### PR DESCRIPTION
PR fixes build issues:

- To query feature support we need to use `ext_oneapi_can_build()` instead of `ext_oneapi_can_compile()`
    - `can_compile()` returns `false` in my tests + we use `syclex::build()` so the can-build check looks like the correct approach
- `get_device_uuid()` is used by recently added L0 runtime support - removed the guard
- `create_ocl_engine()` is unused with `DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER` - added the guard