### PR TITLE
benchdnn: graph: memory: don't update from an empty object

### DIFF
--- a/tests/benchdnn/graph/graph_memory.cpp
+++ b/tests/benchdnn/graph/graph_memory.cpp
@@ -133,6 +133,9 @@ dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
 
 int dnn_graph_mem_t::fill_mem_with_data(
         const dnn_mem_t &mem, const dnnl::engine &eng) {
+    // If `mem` comes empty, don't update the underlying `mem_` then.
+    if (!mem) return OK;
+
     const auto &src_eng = mem.engine();
     const auto &dst_eng = eng.get();
 


### PR DESCRIPTION
[MFDNN-15009](https://jira.devtools.intel.com/browse/MFDNN-15009)

When trying to update from empty object, an assert pops up. Seems like it was handled by the library before through special patterns or something though it shouldn't be limited by pattern definition.