### PR TITLE
benchdnn: improve perf time reporting for mode=F on GPU

### DIFF
--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1486,7 +1486,12 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
 
 void add_md_size(const_dnnl_memory_desc_t md,
         check_mem_size_args_t &check_mem_size_args) {
-    const auto mem_size = dnnl_memory_desc_get_size(md);
+    size_t mem_size = SIZE_MAX;
+    if (check_mem_size_args.use_logical_size) {
+        mem_size = get_logical_size(md);
+    } else {
+        mem_size = dnnl_memory_desc_get_size(md);
+    }
     // Runtime mem size is not defined.
     if (mem_size == 0 || mem_size == DNNL_RUNTIME_SIZE_VAL) return;
 
@@ -1671,15 +1676,18 @@ int collect_mem_size(check_mem_size_args_t &mem_size_args,
 }
 
 int get_memory_footprint(const_dnnl_primitive_desc_t const_pd, res_t *res) {
-    check_mem_size_args_t check_mem_in_size_args(
-            const_pd, /* want_input = */ true, DIR_UNDEF);
+    check_mem_size_args_t check_mem_in_size_args(const_pd,
+            /* want_input = */ true, DIR_UNDEF,
+            /* use_logical_size */ true);
     get_memory_bytes(check_mem_in_size_args); // Get input bytes.
-    check_mem_size_args_t check_mem_out_size_args(
-            const_pd, /* want_input = */ false, DIR_UNDEF);
+    check_mem_size_args_t check_mem_out_size_args(const_pd,
+            /* want_input = */ false, DIR_UNDEF,
+            /* use_logical_size */ true);
     get_memory_bytes(check_mem_out_size_args); // Get output bytes.
 
-    // Sum post-ops include dst bytes as an input. Not included in get_memory_bytes
-    // since it would cause `collect_mem_size` to double-count dst bytes.
+    // Sum post-ops include dst bytes as an input. Not included in
+    // `get_memory_bytes` since it would cause `collect_mem_size` to
+    // double-count dst bytes.
     auto const_attr_po = query_post_ops(const_pd);
     auto po_len = dnnl_post_ops_len(const_attr_po);
     for (int idx = 0; idx < po_len; ++idx) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -667,6 +667,37 @@ void finalize() {
 #endif
 }
 
+int update_timer_with_profiling_info(timer::timer_t &t, bool use_profiling,
+        const std::vector<stream_t> &v_stream, int execute_count) {
+    if (!use_profiling) {
+        t.stamp(execute_count * num_streams);
+        return OK;
+    }
+
+    std::vector<std::vector<uint64_t>> v_nsecs(num_streams);
+    std::vector<std::vector<uint64_t>> v_cycles(num_streams);
+    for (size_t j = 0; j < v_stream.size(); j++) {
+        SAFE(get_gpu_profiling_info(
+                     v_stream[j], v_nsecs[j], v_cycles[j], execute_count),
+                CRIT);
+        reset_gpu_profiling(v_stream[j]);
+
+        // Profiling should have information to report, otherwise, stop.
+        if (v_nsecs[j].empty()) {
+            BENCHDNN_PRINT(0, "%s\n",
+                    "WARNING: no counters were found during profiling.");
+            return FAIL;
+        }
+    }
+
+    for_(size_t j = 0; j < v_stream.size(); j++)
+    for (size_t i = 0; i < v_nsecs[j].size(); i++) {
+        t.stop(1, (int64_t)v_cycles[j][i], v_nsecs[j][i] / 1e6);
+    }
+
+    return OK;
+}
+
 inline int measure_perf_individual(timer::timer_t &t, dnnl_stream_t stream,
         perf_function_t &perf_func, std::vector<dnnl_exec_arg_t> &dnnl_args) {
     // Warm-up run.
@@ -689,91 +720,62 @@ inline int measure_perf_individual(timer::timer_t &t, dnnl_stream_t stream,
 inline int measure_perf_aggregate(timer::timer_t &t,
         const std::vector<stream_t> &v_stream, perf_function_t &perf_func,
         std::vector<std::vector<dnnl_exec_arg_t>> &dnnl_args) {
-    // There seems to be some limit to how many kernels can be queued in OCL
-    // builds and 4096 seems to be a nice number under that limit.
-    // Otherwise, hangs in perf validation are observed due to many kernels
-    // being queued at once.
-    static constexpr int max_batch_times = 4096;
-
     std::vector<cold_cache_t> cold_cache(num_streams);
 
     // Nvidia/AMD don't support profiling.
     const bool use_profiling = is_gpu() && !is_nvidia_gpu() && !is_amd_gpu();
 
+    // Warm-up run, this is not measured due to possibility the associated
+    // kernel has not been built and skews the results.
     for (size_t j = 0; j < v_stream.size(); j++) {
-        // Warm-up run, this is not measured due to possibility the associated
-        // kernel has not been built and skews the results.
         DNN_SAFE(perf_func(v_stream[j], dnnl_args[j]), WARN);
         DNN_SAFE(dnnl_stream_wait(v_stream[j]), CRIT);
         cold_cache[j] = cold_cache_t(dnnl_args[j], v_stream[j]);
         if (use_profiling) reset_gpu_profiling(v_stream[j]);
     }
 
-    bool is_first_loop = true;
-    int cur_batch_times
-            = fix_times_per_prb ? fix_times_per_prb : min_times_per_prb;
+    int num_submissions = 0;
+    if (fix_times_per_prb) {
+        // If user specified the number of runs, just use it.
+        num_submissions = fix_times_per_prb;
+    } else {
+        // Otherwise, use an estimate run, which is not a part of final time
+        // collection. It's used to calculate the number of submissions to run
+        // before synchronization. Done on a single stream.
+        t.reset();
+        DNN_SAFE(perf_func(v_stream[0], dnnl_args[0]), WARN);
+        DNN_SAFE(dnnl_stream_wait(v_stream[0]), CRIT);
+        SAFE(update_timer_with_profiling_info(t, use_profiling, v_stream, 1),
+                WARN);
 
-    t.reset();
-    while (true) {
-        // Keep separate var due to a `break` inside the loop.
-        int execute_count = 0;
-        // Keep inner loop over streams for better submission overlapping.
-        for_(int i = 0; i < cur_batch_times; i++)
-        for (size_t j = 0; j < v_stream.size(); j++) {
-            if (!cold_cache[j].update_dnnl_args(dnnl_args[j])) break;
-            DNN_SAFE(perf_func(v_stream[j], dnnl_args[j]), WARN);
-            execute_count++;
-        }
-
-        for (size_t j = 0; j < v_stream.size(); j++) {
-            DNN_SAFE(dnnl_stream_wait(v_stream[j]), CRIT);
-        }
-
-        if (use_profiling) {
-            std::vector<std::vector<uint64_t>> v_nsecs(num_streams);
-            std::vector<std::vector<uint64_t>> v_cycles(num_streams);
-            bool nsecs_is_empty = false;
-            for (size_t j = 0; j < v_stream.size(); j++) {
-                SAFE(get_gpu_profiling_info(v_stream[j], v_nsecs[j],
-                             v_cycles[j], execute_count),
-                        CRIT);
-                reset_gpu_profiling(v_stream[j]);
-
-                // Profiling should have information to report, otherwise, stop.
-                if (v_nsecs[j].empty()) {
-                    nsecs_is_empty = true;
-                    BENCHDNN_PRINT(0, "%s\n",
-                            "WARNING: no counters were found during "
-                            "profiling.");
-                    break;
-                }
-            }
-            if (nsecs_is_empty) break;
-
-            for_(size_t j = 0; j < v_stream.size(); j++)
-            for (size_t i = 0; i < v_nsecs[j].size(); i++) {
-                t.stop(1, (int64_t)v_cycles[j][i], v_nsecs[j][i] / 1e6);
-            }
-        } else {
-            t.stamp(cur_batch_times * num_streams);
-        }
-
-        // Assumption that for each stream cold_cache acts same.
-        if (should_stop(t) || cold_cache[0].should_stop()) break;
-
-        // Adjust cur_batch_times after the first batch run
-        if (is_first_loop) {
-            double ms_min = t.ms(timer::timer_t::min);
-            // Heuristic: try to use ~5 batch runs for the whole benchmark
-            int batch_times_heuristic = (ms_min == 0.0)
-                    ? INT_MAX
-                    : MAX2(1,
-                              (int)((max_ms_per_prb - t.total_ms()) / ms_min
-                                      / 5));
-            cur_batch_times = MIN2(max_batch_times, batch_times_heuristic);
-            is_first_loop = false;
-        }
+        double ms_min = t.total_ms();
+        if (ms_min == 0.0) SAFE_V(FAIL);
+        num_submissions
+                = MAX2(min_times_per_prb, (int)(max_ms_per_prb / ms_min));
     }
+
+    BENCHDNN_PRINT(
+            4, "%s%d%s\n", "[PERF]: submissions: ", num_submissions, ";");
+    // Measuring loop. A single synchronization point, called once, the number
+    // of submissions determined above based on n_times or plain time criterion.
+    t.reset();
+    // Keep a separate variable due to a `break` inside the loop.
+    int execute_count = 0;
+    // Keep inner loop over streams for better submission overlapping.
+    for_(int i = 0; i < num_submissions; i++)
+    for (size_t j = 0; j < v_stream.size(); j++) {
+        if (!cold_cache[j].update_dnnl_args(dnnl_args[j])) break;
+        DNN_SAFE(perf_func(v_stream[j], dnnl_args[j]), WARN);
+        execute_count++;
+    }
+
+    for (size_t j = 0; j < v_stream.size(); j++) {
+        DNN_SAFE(dnnl_stream_wait(v_stream[j]), CRIT);
+    }
+
+    SAFE(update_timer_with_profiling_info(
+                 t, use_profiling, v_stream, execute_count),
+            WARN);
 
     if (use_profiling) {
         for (size_t j = 0; j < v_stream.size(); j++) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1729,6 +1729,50 @@ int get_memory_footprint(const_dnnl_primitive_desc_t const_pd, res_t *res) {
         check_mem_in_size_args.total_size_device += fixed_src_size - src_size;
     }
 
+    const auto &adjust_src_bytes_for_stride
+            = [&check_mem_in_size_args](const_dnnl_memory_desc_t src_md,
+                      int spatial_dims, const dnnl_dims_t strides,
+                      const dnnl_dims_t kernels) {
+        double kernel_ratio = 1;
+        for (int d = 0; d < spatial_dims; d++) {
+            auto stride = strides[d];
+            auto kernel = kernels[d];
+            if (stride > kernel) {
+                kernel_ratio *= static_cast<double>(stride) / kernel;
+            }
+        }
+        const auto src_size = dnnl_memory_desc_get_size(src_md);
+        const auto fixed_src_size = static_cast<size_t>(
+                static_cast<double>(src_size) / kernel_ratio);
+        check_mem_in_size_args.total_size_device += fixed_src_size - src_size;
+    };
+
+    // When a dimensional stride is bigger than kernel window, it means there
+    // are less reads from source by stride/kernel times.
+    if (is_fwd_prop_kind(prop) && kind == dnnl_convolution) {
+        auto src_md = query_md(const_pd, DNNL_ARG_SRC);
+        auto wei_md = query_md(const_pd, DNNL_ARG_WEIGHTS);
+        auto src_ndims = query_md_ndims(src_md);
+        auto wei_ndims = query_md_ndims(wei_md);
+        auto with_groups = src_ndims < wei_ndims;
+        auto wei_dims = query_md_dims(wei_md);
+
+        auto strides = query_strides(const_pd);
+        adjust_src_bytes_for_stride(
+                src_md, src_ndims - 2, strides, &wei_dims[with_groups + 2]);
+    }
+
+    // When a dimensional stride is bigger than kernel window, it means there
+    // are less reads from source by stride/kernel times.
+    if (is_fwd_prop_kind(prop) && kind == dnnl_pooling) {
+        auto src_md = query_md(const_pd, DNNL_ARG_SRC);
+        auto ndims = query_md_ndims(src_md);
+
+        auto strides = query_strides(const_pd);
+        auto kernels = query_kernels(const_pd);
+        adjust_src_bytes_for_stride(src_md, ndims - 2, strides, kernels);
+    }
+
     res->ibytes = check_mem_in_size_args.total_size_device;
     res->obytes = check_mem_out_size_args.total_size_device;
 

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -781,6 +781,8 @@ inline int measure_perf_aggregate(timer::timer_t &t,
         for (size_t j = 0; j < v_stream.size(); j++) {
             notify_gpu_profiling_complete(v_stream[j]);
         }
+
+        t.filter_collection();
     }
 
     return OK;

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -269,9 +269,10 @@ int collect_mem_size(check_mem_size_args_t &mem_size_args,
 
 inline bool should_stop(const timer::timer_t &t) {
     const bool stop = false
-            || (fix_times_per_prb && t.times() >= fix_times_per_prb)
+            || (fix_times_per_prb
+                    && t.times() >= static_cast<size_t>(fix_times_per_prb))
             || (!fix_times_per_prb && t.total_ms() >= max_ms_per_prb
-                    && t.times() >= min_times_per_prb);
+                    && t.times() >= static_cast<size_t>(min_times_per_prb));
     return stop;
 }
 

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -1470,3 +1470,19 @@ dnnl_memory_desc_t clone_md(const_dnnl_memory_desc_t md) {
     if (status != dnnl_success) return nullptr;
     return cloned_md;
 }
+
+size_t get_logical_size(const_dnnl_memory_desc_t md) {
+    const auto ndims = query_md_ndims(md);
+    if (ndims == 0) return 0;
+
+    const auto dims = query_md_dims(md);
+    int64_t nelems = 1;
+    for (int i = 0; i < ndims; ++i)
+        nelems *= dims[i];
+
+    const auto dt = query_md_data_type(md);
+    const size_t dt_size = dnnl_data_type_size(dt);
+    const size_t dt_bits = bits_dt(dt);
+    const size_t elems_in_byte = div_up(size_t(8), dt_bits);
+    return div_up(static_cast<size_t>(nelems) * dt_size, elems_in_byte);
+}

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -269,6 +269,10 @@ bool has_sparse_md(const dnn_mem_map_t &dnn_mem_map);
 
 dnnl_memory_desc_t clone_md(const_dnnl_memory_desc_t md);
 
+// Returns the logical size of a memory descriptor, which is a product of nelems
+// by data_type_size.
+size_t get_logical_size(const_dnnl_memory_desc_t md);
+
 // Checks that zero padding is preserved.
 int check_zero_padding(const dnn_mem_t &mem, int arg, res_t *res = nullptr,
         int *error_count = nullptr);

--- a/tests/benchdnn/self/self.cpp
+++ b/tests/benchdnn/self/self.cpp
@@ -39,6 +39,7 @@ int bench(int argc, char **argv) {
     graph();
     norm();
     compare();
+    timer();
 
     return bs.tests == bs.passed ? OK : FAIL;
 }

--- a/tests/benchdnn/self/self.hpp
+++ b/tests/benchdnn/self/self.hpp
@@ -87,6 +87,7 @@ void memory();
 void graph();
 void norm();
 void compare();
+void timer();
 
 int bench(int argc, char **argv);
 

--- a/tests/benchdnn/self/timer.cpp
+++ b/tests/benchdnn/self/timer.cpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "utils/timer.hpp"
+
+#include "self/self.hpp"
+
+namespace self {
+
+static int check_timer_filter() {
+    {
+        timer::timer_t t;
+        constexpr int sample_size = 20;
+        for (int i = 0; i < sample_size / 2; i++) {
+            t.stop(1, 0, 0);
+        }
+        for (int i = 0; i < sample_size - sample_size / 2; i++) {
+            t.stop(1, 0, 1000);
+        }
+        t.filter_collection();
+        SELF_CHECK_EQ(t.ms(timer::timer_t::mode_t::min), 1000);
+        SELF_CHECK_EQ(t.times(), sample_size - sample_size / 2);
+    }
+    {
+        timer::timer_t t;
+        constexpr int sample_size = 20;
+        for (int i = 0; i < sample_size / 2; i++) {
+            t.stop(1, 0, 0);
+        }
+        t.stop(1, 0, 500);
+        for (int i = 1; i < sample_size - sample_size / 2; i++) {
+            t.stop(1, 0, 1000);
+        }
+        t.filter_collection();
+        SELF_CHECK_EQ(t.ms(timer::timer_t::mode_t::min), 1000);
+        // 500us must be dropped.
+        SELF_CHECK_EQ(t.times(), sample_size - sample_size / 2 - 1);
+    }
+    {
+        timer::timer_t t;
+        constexpr int sample_size = 21;
+        for (int i = 0; i < sample_size / 2; i++) {
+            t.stop(1, 0, 0);
+        }
+        t.stop(1, 0, 1000);
+        t.stop(1, 0, 1039);
+        for (int i = 2; i < sample_size - sample_size / 2; i++) {
+            t.stop(1, 0, 2000);
+        }
+        t.filter_collection();
+        SELF_CHECK_EQ(t.ms(timer::timer_t::mode_t::min), 1000);
+        // 1000us mustn't be dropped.
+        SELF_CHECK_EQ(t.times(), sample_size - sample_size / 2);
+    }
+    {
+        timer::timer_t t;
+        constexpr int sample_size = 21;
+        for (int i = 0; i < sample_size / 2; i++) {
+            t.stop(1, 0, 0);
+        }
+        t.stop(1, 0, 1000);
+        t.stop(1, 0, 1040);
+        for (int i = 2; i < sample_size - sample_size / 2; i++) {
+            t.stop(1, 0, 2000);
+        }
+        t.filter_collection();
+        SELF_CHECK_EQ(t.ms(timer::timer_t::mode_t::min), 1040);
+        // 1000us must be dropped.
+        SELF_CHECK_EQ(t.times(), sample_size - sample_size / 2 - 1);
+    }
+    {
+        timer::timer_t t;
+        constexpr int sample_size = 40;
+        for (int i = 0; i < sample_size / 2; i++) {
+            t.stop(1, 0, 0);
+        }
+        t.stop(1, 0, 1000);
+        t.stop(1, 0, 1000);
+        for (int i = 2; i < sample_size - sample_size / 2; i++) {
+            t.stop(1, 0, 2000);
+        }
+        t.filter_collection();
+        SELF_CHECK_EQ(t.ms(timer::timer_t::mode_t::min), 2000);
+        // Both 1000us must be dropped.
+        SELF_CHECK_EQ(t.times(), sample_size - sample_size / 2 - 2);
+    }
+    {
+        timer::timer_t t;
+        constexpr int sample_size = 1000;
+        for (int i = 0; i < sample_size / 2; i++) {
+            t.stop(1, 0, 0);
+        }
+        const int n_special_fill = (sample_size - sample_size / 2) / 100 - 1;
+        for (int i = 0; i < n_special_fill; i++) {
+            t.stop(1, 0, 1000);
+        }
+        for (int i = n_special_fill; i < sample_size - sample_size / 2; i++) {
+            t.stop(1, 0, 1001);
+        }
+        t.filter_collection();
+        SELF_CHECK_EQ(t.ms(timer::timer_t::mode_t::min), 1001);
+        // Both 1000us must be dropped.
+        SELF_CHECK_EQ(
+                t.times(), sample_size - sample_size / 2 - n_special_fill);
+    }
+    return OK;
+}
+
+void timer() {
+    RUN(check_timer_filter());
+}
+
+} // namespace self

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -62,7 +62,7 @@ cold_cache_t::cold_cache_t(
 
     static size_t gpu_cache_capacity = 0;
     SAFE_V(get_gpu_cache_size(gpu_cache_capacity));
-    static const size_t gpu_cache_size_upper_bound = gpu_cache_capacity * 2;
+    static const size_t gpu_cache_size_upper_bound = gpu_cache_capacity * 4;
 
     const auto cache_capacity
             = is_gpu() ? gpu_cache_capacity : cpu_cache_capacity;

--- a/tests/benchdnn/utils/dnnl_query.cpp
+++ b/tests/benchdnn/utils/dnnl_query.cpp
@@ -36,6 +36,18 @@ dnnl_alg_kind_t query_alg_kind(const_dnnl_primitive_desc_t pd) {
     return alg_kind;
 }
 
+const dnnl_dims_t &query_strides(const_dnnl_primitive_desc_t pd) {
+    dnnl_dims_t *strides;
+    dnnl_primitive_desc_query(pd, dnnl_query_strides, 0, &strides);
+    return *strides;
+}
+
+const dnnl_dims_t &query_kernels(const_dnnl_primitive_desc_t pd) {
+    dnnl_dims_t *kernels;
+    dnnl_primitive_desc_query(pd, dnnl_query_kernel, 0, &kernels);
+    return *kernels;
+}
+
 std::string query_impl_info(const_dnnl_primitive_desc_t pd) {
     const char *str = nullptr;
     dnnl_primitive_desc_query(pd, dnnl_query_impl_info_str, 0, &str);

--- a/tests/benchdnn/utils/dnnl_query.hpp
+++ b/tests/benchdnn/utils/dnnl_query.hpp
@@ -25,6 +25,8 @@
 dnnl_prop_kind_t query_prop_kind(const_dnnl_primitive_desc_t pd);
 dnnl_primitive_kind_t query_prim_kind(const_dnnl_primitive_desc_t pd);
 dnnl_alg_kind_t query_alg_kind(const_dnnl_primitive_desc_t pd);
+const dnnl_dims_t &query_strides(const_dnnl_primitive_desc_t pd);
+const dnnl_dims_t &query_kernels(const_dnnl_primitive_desc_t pd);
 
 std::string query_impl_info(const_dnnl_primitive_desc_t pd);
 

--- a/tests/benchdnn/utils/numeric.cpp
+++ b/tests/benchdnn/utils/numeric.cpp
@@ -220,6 +220,29 @@ float round_to_nearest_representable(dnnl_data_type_t dt, float value) {
 
 #undef CASE_ALL
 
-bool is_subbyte_type(const dnnl_data_type_t &type) {
+bool is_subbyte_type(dnnl_data_type_t type) {
     return type == dnnl_f4_e2m1 || type == dnnl_u4 || type == dnnl_s4;
+}
+
+size_t bits_dt(dnnl_data_type_t dt) {
+    switch (dt) {
+        case dnnl_s64:
+        case dnnl_f64: return 64;
+        case dnnl_s32:
+        case dnnl_f32: return 32;
+        case dnnl_bf16:
+        case dnnl_f16: return 16;
+        case dnnl_e8m0:
+        case dnnl_f8_e5m2:
+        case dnnl_f8_e4m3:
+        case dnnl_s8:
+        case dnnl_u8: return 8;
+        case dnnl_f4_e2m1:
+        case dnnl_s4:
+        case dnnl_u4: return 4;
+        case dnnl_boolean: return 1;
+        default: assert(!"unsupported data type"); SAFE_V(FAIL);
+    }
+
+    return 0;
 }

--- a/tests/benchdnn/utils/numeric.hpp
+++ b/tests/benchdnn/utils/numeric.hpp
@@ -35,7 +35,8 @@ float max_dt(dnnl_data_type_t dt);
 bool is_integral_dt(dnnl_data_type_t dt);
 float maybe_saturate(dnnl_data_type_t dt, float value);
 float round_to_nearest_representable(dnnl_data_type_t dt, float value);
-bool is_subbyte_type(const dnnl_data_type_t &type);
+bool is_subbyte_type(dnnl_data_type_t type);
+size_t bits_dt(dnnl_data_type_t dt);
 template <class T>
 T gcd(std::initializer_list<T> ilist) {
     auto gcd = [](T a, T b) {

--- a/tests/benchdnn/utils/res.hpp
+++ b/tests/benchdnn/utils/res.hpp
@@ -58,14 +58,20 @@ enum dir_t {
 
 struct check_mem_size_args_t {
     check_mem_size_args_t() = default;
-    check_mem_size_args_t(
-            const_dnnl_primitive_desc_t pd, bool want_input, dir_t dir)
-        : pd(pd), want_input(want_input), dir(dir) {}
+    check_mem_size_args_t(const_dnnl_primitive_desc_t pd, bool want_input,
+            dir_t dir, bool use_logical_size = false)
+        : pd(pd)
+        , want_input(want_input)
+        , dir(dir)
+        , use_logical_size(use_logical_size) {}
 
     // Input args: get their values only at construction.
     const_dnnl_primitive_desc_t pd = nullptr;
     bool want_input = false;
     dir_t dir = DIR_UNDEF; // See ANCHOR: MEM_CHECK_ARGS_DIR;
+    // Logical size is used to properly return iobytes for bandwidth
+    // calculation. Padded or strided area mustn't be included.
+    bool use_logical_size = false;
 
     // Manually input args: must be set by the user to handle additional logic.
     //

--- a/tests/benchdnn/utils/timer.cpp
+++ b/tests/benchdnn/utils/timer.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 
 #include "common.hpp"
 #include "utils/timer.hpp"
@@ -51,6 +52,7 @@ void timer_t::reset() {
     for (int i = 0; i < n_modes; ++i)
         ms_[i] = 0;
     ms_start_ = 0;
+    ms_vec_.clear();
 
     start();
 }
@@ -77,6 +79,8 @@ void timer_t::stop(int add_times, int64_t add_ticks, double add_ms) {
     d_ticks /= add_times;
     d_ms /= add_times;
 
+    ms_vec_.insert(ms_vec_.end(), add_times, d_ms);
+
     ms_[mode_t::min] = times_ ? std::min(ms_[mode_t::min], d_ms) : d_ms;
     ms_[mode_t::max] = times_ ? std::max(ms_[mode_t::max], d_ms) : d_ms;
 
@@ -90,6 +94,111 @@ void timer_t::stop(int add_times, int64_t add_ticks, double add_ms) {
 
 void timer_t::stamp(int add_times) {
     stop(add_times, ticks_now() - ticks_start_, ms_now() - ms_start_);
+}
+
+void timer_t::filter_collection() {
+    if (times_ <= 1) return;
+
+    assert(ms_vec_.size() == times_);
+
+    // First, drop the first half of all measurements. The motivation is second
+    // half operates with stabilized frequency.
+    size_t midpoint = ms_vec_.size() / 2;
+    auto it_mid = ms_vec_.begin() + midpoint;
+    ms_vec_.erase(ms_vec_.begin(), it_mid);
+    if (ms_vec_.size() <= 1) return;
+
+    // Then filter out "single-point" outliers that could appear even in a
+    // second half of the run by pushing the bottom line of the peak time based
+    // on bandwidth measurements in cold-cache mode.
+    std::sort(ms_vec_.begin(), ms_vec_.end());
+
+    // Remove up to 10% of fastest times.
+    constexpr double outlier_percent = 0.10;
+
+    // The idea is to measure the magnitude between values and if up to several
+    // values are of bigger magnitude, drop them from the collection.
+    //
+    // The number of magnitudes is `outlier_percent` of the population round
+    // down but, at least, one.
+    //
+    // For example, 25 samples will check two delta values between [0th, 1st]
+    // and [1st, 2nd]. In case both delta will be outliers, e.g., 1.0, 1.1,
+    // 1.21, [1.22...], both first values will be dropped.
+    const size_t deltas_size = std::max(size_t(1),
+            static_cast<size_t>(std::floor(outlier_percent * ms_vec_.size())));
+
+    std::string msg;
+
+    // The major magnitude is when `x_i = x_{i+1} * 1.04`.
+    constexpr double magnitude_threshold = 1.04;
+    size_t cut_point = SIZE_MAX;
+    // For large collections demand that the minimal time has at least 1% of
+    // representatives.
+    size_t n_same_samples = 1;
+    const size_t min_n_samples = std::max(
+            size_t(1), static_cast<size_t>(std::floor(ms_vec_.size() * 0.01)));
+    for (size_t i = 0; i < deltas_size; i++) {
+        // It may happen there are more major magnitude jumps within
+        // `outlier_percent` number of elements, drop as much values as allowed.
+        if (ms_vec_[i + 1] >= ms_vec_[i] * magnitude_threshold) {
+            cut_point = i;
+            if (verbose >= 4) {
+                msg += std::to_string(i) + ":" + std::to_string(ms_vec_[i + 1])
+                        + "/" + std::to_string(ms_vec_[i]) + "="
+                        + std::to_string(ms_vec_[i + 1] / ms_vec_[i]) + "; ";
+            }
+        }
+
+        // Get to another metric - number of samples. If minimum is one,
+        // nothing to do.
+        if (min_n_samples == 1) continue;
+
+        if (ms_vec_[i + 1] == ms_vec_[i]) {
+            n_same_samples++;
+            continue;
+        }
+
+        // If we just cut off by major value diff, it means there's no point
+        // of cutting it by the number of samples. Restart the counter.
+        if (cut_point == i) {
+            n_same_samples = 1;
+            continue;
+        }
+
+        // Values are not same, and diff val criterion didn't apply.
+        // If number of samples is less then desired, drop them and restart the
+        // counter.
+        if (n_same_samples < min_n_samples) {
+            cut_point = i;
+            if (verbose >= 4) {
+                msg += std::to_string(i) + ":" + std::to_string(ms_vec_[i])
+                        + "(" + std::to_string(n_same_samples) + "); ";
+            }
+            n_same_samples = 1;
+        }
+    }
+
+    if (cut_point < deltas_size) {
+        ms_vec_.erase(ms_vec_.begin(), ms_vec_.begin() + cut_point + 1);
+    }
+
+    // After all undesired values discarded, re-compute stats.
+    ms_[mode_t::sum] = 0;
+    ms_[mode_t::min] = *ms_vec_.begin();
+    ms_[mode_t::max] = *ms_vec_.rbegin();
+    for (size_t i = 0; i < ms_vec_.size(); i++) {
+        ms_[mode_t::sum] += ms_vec_[i];
+    }
+    ms_[mode_t::avg] = ms_[mode_t::sum];
+    times_ = ms_vec_.size();
+    // Frequency is not supported for filtering, explicitly zeroing it to avoid
+    // potential misuse.
+    for (int i = 0; i < n_modes; i++)
+        ticks_[i] = 0;
+
+    BENCHDNN_PRINT(4, "[TIMER]: MinSamples: %zu; Outliers: %zu; %s\n",
+            min_n_samples, deltas_size, msg.c_str());
 }
 
 timer_t &timer_t::operator=(const timer_t &rhs) {

--- a/tests/benchdnn/utils/timer.hpp
+++ b/tests/benchdnn/utils/timer.hpp
@@ -17,7 +17,11 @@
 #ifndef UTILS_TIMER_HPP
 #define UTILS_TIMER_HPP
 
+#include "utils/bench_mode.hpp"
+
+#include <cstdint>
 #include <string>
+#include <vector>
 #include <unordered_map>
 
 #define TIME_FUNC(func, res, name) \
@@ -63,7 +67,7 @@ struct timer_t {
         stop(add_times, add_ticks, add_ms);
     }
 
-    int times() const { return times_; }
+    size_t times() const { return times_; }
 
     double total_ms() const { return ms_[avg]; }
 
@@ -79,13 +83,18 @@ struct timer_t {
         return ticks_[mode] / (mode == avg ? times() : 1);
     }
 
+    // Discards measurements from the collection based on heuristic. See details
+    // inside the definition.
+    void filter_collection();
+
     timer_t(const timer_t &rhs) = default;
     timer_t &operator=(const timer_t &rhs);
     timer_t &operator=(timer_t &&rhs) = default;
 
-    int times_;
+    size_t times_;
     uint64_t ticks_[n_modes], ticks_start_;
     double ms_[n_modes], ms_start_;
+    std::vector<double> ms_vec_; // Collects all measurements.
 };
 
 // Designated timers to support benchdnn performance reporting and general time


### PR DESCRIPTION
[MFDNN-13816](https://jira.devtools.intel.com/browse/MFDNN-13816)

This PR seems to settle a part of the problem when it comes to reporting BW perf numbers more than the GPU HW can achieve. It comes from several factors:
* GPU driver tends to compress the similar data that it meets. Thus, a single output value will be stored times faster that it should be. This effect is referred as "data compression". It affects both inputs and outputs. Output suffers more as during reduction in Conv or MM, infinities, NaNs, zeros can be obtained, esp. due to randomness of data filling.
* Cache is flushed after queue synchronization. After cache is flushed, the next run doesn't need to clean before writing in it, saving a lot of bandwidth and leading to faster times. Additionally, there's some GPU driver heuristic when it decided to flush the cache without clear external reason, in that case such submission would be way faster than others.

This PR rather targets the second scenario issues with two main changes:
* Change the way submission happens for measure_perf_aggregate - instead of a batch of 6 times (one first loop and 5 consecutive), it does a single warm-up loop which doesn't go towards time collection, and then a single submission loop with roughly same number of runs which was before. It relies on the warm-up time (for time criterion) and time budget (max_ms_per_prb) to estimate the number of runs.
* Filters the times it gets. The first half of collection will be dropped. This is motivated by that empty cache effect described earlier, plus by the time of second half the frequency should be stabilized. Secondly, the rest of collection will be inspected for spikes between times (4% diff) and number of times for large collections (usually, small problems are affected) which expects to find at least 1% of all collection to have the same time value (granularity of profiling allows to rely on this).

There are some other minor fixes - increase the amount of memory for cold-cache on GPU for better stability; adjusted iobytes to report more realistic amount of bytes processed by the kernel.

The part about data compression will be handled separately as it requires some benchdnn infrastructure change as random filling must become semi-random - certain tensors can use random values, otherwise, they got hit by compression for the reasons explained above.