### PR TITLE
x64: matmul: add acdb/adbc dst support to brgemm matmul

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -514,6 +514,9 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
         CHECK(sparse_decompress_kernel_->create_kernel());
     }
 
+    if (bgmmc.dst_is_acdb || bgmmc.dst_is_adbc)
+        CHECK(create_brgemm_matmul_copy_c(copy_C_kernel_, &bgmmc));
+
     return status::success;
 }
 
@@ -601,7 +604,12 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
         int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
         int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
         int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
-        if (brgmm_ctx.is_chunks_horizontal_process_order())
+
+        if (bgmmc.dst_is_acdb)
+            nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
+                    bgmmc.nthr_n, mc_per_t, m_chunks_per_thread, nc_per_t,
+                    n_chunks_per_thread, b_per_t, batch_per_thread);
+        else if (brgmm_ctx.is_chunks_horizontal_process_order())
             nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                     bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
                     m_chunks_per_thread, nc_per_t, n_chunks_per_thread);
@@ -615,7 +623,12 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
 
         auto advance_func = [&]() {
             ++start;
-            if (brgmm_ctx.is_chunks_horizontal_process_order())
+            if (bgmmc.dst_is_acdb)
+                nd_iterator_step(bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
+                        bgmmc.nthr_n, mc_per_t, m_chunks_per_thread,
+                        nc_per_t, n_chunks_per_thread, b_per_t,
+                        batch_per_thread);
+            else if (brgmm_ctx.is_chunks_horizontal_process_order())
                 nd_iterator_step(bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                         bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
                         m_chunks_per_thread, nc_per_t, n_chunks_per_thread);
@@ -708,6 +721,40 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
     maybe_reduce_and_convert_partial_results_A(brgmm_ctx_ptr);
     maybe_reduce_partial_results_and_apply_postops(brgmm_ctx_ptr);
 
+    // Phase 2: copy scratch buffer to acdb dst.
+    if (pd()->get_brgemm_matmul_conf().dst_is_acdb) {
+        const auto &bgmmc = pd()->get_brgemm_matmul_conf();
+        const auto &brgmm_ctx = *brgmm_ctx_ptr;
+        const int M = bgmmc.M;
+        const int N = bgmmc.N;
+        const int inner_batch = bgmmc.acdb_inner_batch;
+        const int outer_batch = bgmmc.batch / inner_batch;
+        const dim_t buf_row_stride = N * bgmmc.c_dt_sz;
+        const dim_t dst_m_stride = bgmmc.C_strides[1];
+        const dim_t dst_n_stride = bgmmc.C_strides[0];
+        const int dt_sz = bgmmc.c_dt_sz;
+
+        const int N_tile = 64;
+        const int n_tiles = utils::div_up(N, N_tile);
+
+        parallel_nd(outer_batch, n_tiles, M, [&](int ob, int nt, int m) {
+            const int n_start = nt * N_tile;
+            const int n_len = nstl::min(N_tile, N - n_start);
+            const int b_start = ob * inner_batch;
+            const char *buf_base
+                    = brgmm_ctx.get_buf_D_acdb_ptr(b_start);
+            char *dst_base = brgmm_ctx.get_data_C_ptr(b_start, 0, 0);
+            jit_brgemm_matmul_copy_c_t::ctx_t copy_c_ctx;
+            copy_c_ctx.src = buf_base + m * buf_row_stride
+                    + n_start * dt_sz;
+            copy_c_ctx.dst = dst_base + m * dst_m_stride
+                    + n_start * dst_n_stride;
+            copy_c_ctx.current_M_blk = 1;
+            copy_c_ctx.current_N_blk = n_len;
+            (*copy_C_kernel_)(&copy_c_ctx);
+        });
+    }
+
     return status::success;
 }
 
@@ -742,12 +789,6 @@ void brgemm_matmul_t<isa>::compute_kernel(
     const int brg_ker_idx = pd()->get_brg_kernel_idx(
             is_bs_tail, do_init, m_ker_idx, n_ker_idx, false, prefetch);
     const auto ptr_bias = brgmm_ctx.get_bias_ptr(n);
-    auto ptr_D = brgmm_ctx.get_data_C_ptr(
-            b_idx, brgmm_ctx.get_M_idx(m_blk_idx, true), n);
-    auto ptr_C = (bgmmc.use_buffer_c)
-            ? brgmm_ctx.get_buf_C_ptr(ithr, m_blk_idx, n_blk_idx)
-            : ptr_D;
-
     const auto zp_comp_a
             = brgmm_ctx.get_zp_a_compensation_ptr(ithr, b_idx, n_blk_idx);
     const auto zp_comp_b
@@ -756,6 +797,17 @@ void brgemm_matmul_t<isa>::compute_kernel(
             = brgmm_ctx.get_post_ops_binary_rhs_arg_vec();
     const bool post_ops_applicable = bgmmc.post_ops_applicable
             && (brgmm_ctx.get_num_threads_for_k() <= 1 || bgmmc.K_chunks == 1);
+
+    // For acdb dst: ptr_D points into shared buf_D at the correct (m,n) offset.
+    auto ptr_D = bgmmc.dst_is_acdb
+            ? (brgmm_ctx.get_buf_D_acdb_ptr(b_idx)
+                    + (brgmm_ctx.get_M_idx(m_blk_idx, true) * bgmmc.N + n)
+                            * bgmmc.c_dt_sz)
+            : brgmm_ctx.get_data_C_ptr(
+                      b_idx, brgmm_ctx.get_M_idx(m_blk_idx, true), n);
+    auto ptr_C = (bgmmc.use_buffer_c)
+            ? brgmm_ctx.get_buf_C_ptr(ithr, m_blk_idx, n_blk_idx)
+            : ptr_D;
 
     brgemm_dynamic_values_t leading_dimensions(
             bgmmc.LDA, bgmmc.LDB, brgmm_ctx.get_LDC(), brgmm_ctx.get_LDD());
@@ -873,6 +925,38 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
     brgmm_ctx.maybe_restore_dst_values_from_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
+
+    // For acdb dst: copy from buf_C to shared buf_D.
+    // The actual transpose to dst happens in Phase 2 after the parallel section.
+    if (bgmmc.dst_is_acdb && is_last_K_blk
+            && !post_ops_applicable && bgmmc.use_buffer_c) {
+        const int curr_M_blk = brgmm_ctx.get_M_kernel_size(m_blk_idx);
+        const int curr_N_blk = brgmm_ctx.get_N_kernel_size(n_blk_idx);
+        char *dst_buf = const_cast<char *>(ptr_D);
+        const char *src_buf = static_cast<const char *>(ptr_C);
+        for (int m = 0; m < curr_M_blk; m++) {
+            std::memcpy(dst_buf + m * bgmmc.N * bgmmc.c_dt_sz,
+                    src_buf + m * brgmm_ctx.get_LDC() * bgmmc.acc_dt_sz,
+                    curr_N_blk * bgmmc.c_dt_sz);
+        }
+    }
+
+    // For adbc dst: transpose from buf_C [M_blk, N_blk] to dst where M is
+    // contiguous. Uses JIT 16×16 in-register transpose for efficiency.
+    if (bgmmc.dst_is_adbc && is_last_K_blk
+            && !post_ops_applicable && bgmmc.use_buffer_c) {
+        const int curr_M_blk = brgmm_ctx.get_M_kernel_size(m_blk_idx);
+        const int curr_N_blk = brgmm_ctx.get_N_kernel_size(n_blk_idx);
+        char *dst_ptr = brgmm_ctx.get_data_C_ptr(
+                b_idx, brgmm_ctx.get_M_idx(m_blk_idx, true), n);
+
+        jit_brgemm_matmul_copy_c_t::ctx_t copy_c_ctx;
+        copy_c_ctx.src = ptr_C;
+        copy_c_ctx.dst = dst_ptr;
+        copy_c_ctx.current_M_blk = curr_M_blk;
+        copy_c_ctx.current_N_blk = curr_N_blk;
+        (*copy_C_kernel_)(&copy_c_ctx);
+    }
 }
 
 template <cpu_isa_t isa>
@@ -1467,7 +1551,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 ? scratchpad.template get<char>(key_brgemm_primitive_buffer)
                 : nullptr;
 
-        buf_D_ptr_ = (bgmmc.is_runtime_M || bgmmc.is_runtime_N)
+        buf_D_ptr_ = (bgmmc.is_runtime_M || bgmmc.is_runtime_N
+                             || bgmmc.dst_is_acdb)
                 ? scratchpad.template get<char>(key_brgemm_primitive_buffer_d)
                 : nullptr;
 
@@ -2055,7 +2140,6 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     dim_t get_data_C_off(int b, dim_t m, dim_t n) const {
         using namespace format_tag;
-        assert(bgmmc_.dst_tag != adbc);
         dim_t off = 0;
         if (bgmmc_.dst_tag == acbd
                 || (one_of(bgmmc_.dst_tag, abcd, abdc)
@@ -2463,6 +2547,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     dim_t copy_B_wei_stride() const { return copy_B_wei_stride_; }
 
     bool packed_sparse_weights() const { return bgmmc_.packed_sparse_weights; }
+
+    char *get_buf_D_acdb_ptr(int b_idx) const {
+        return buf_D_ptr_ + bgmmc_.acdb_buf_per_batch_sz * b_idx;
+    }
 
     int get_current_K_pad(int current_K_iters) const {
         if (bgmmc_.is_wei_zp_per_k || bgmmc_.is_wei_scale_per_k) return 0;

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -122,6 +122,7 @@ private:
     std::unique_ptr<cpu_accumulator_1d_t<data_type::s32>> acc_ker_s32_;
     std::unique_ptr<jit_avx512_sparse_decompress_kernel_t>
             sparse_decompress_kernel_;
+    std::unique_ptr<jit_brgemm_matmul_copy_c_t> copy_C_kernel_;
 
     using reducer_t = x64::jit_brgemm_kernel_diff_bias_t<
             typename cpu_isa_traits_t<isa>::Vmm>;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -6069,6 +6069,440 @@ status_t create_brgemm_matmul_copy_a(
     return copy_ker->create_kernel();
 }
 
+// Copy-C kernel for acdb dst: 16×16 transpose from scratch buffer to dst.
+struct jit_brgemm_matmul_copy_c_avx512_t : public jit_brgemm_matmul_copy_c_t,
+                                           public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_c_avx512_t)
+
+    jit_brgemm_matmul_copy_c_avx512_t(const brgemm_matmul_conf_t *conf)
+        : jit_brgemm_matmul_copy_c_t(conf)
+        , jit_generator_t(jit_name())
+        , dt_sz_(conf->c_dt_sz)
+        , batch_(conf->acdb_inner_batch)
+        , buf_batch_stride_(conf->acdb_buf_per_batch_sz)
+        , buf_row_stride_(conf->N * dt_sz_)
+        , dst_n_stride_(conf->C_strides[0])
+        , dst_m_stride_(conf->C_strides[1])
+        , batch_tail_(conf->acdb_inner_batch % 16)
+        , tail_mask_val_(batch_tail_ ? (uint16_t)((1 << batch_tail_) - 1)
+                                     : (uint16_t)0xFFFF) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
+
+private:
+    const int dt_sz_;
+    const int batch_;
+    const dim_t buf_batch_stride_;
+    const dim_t buf_row_stride_;
+    const dim_t dst_n_stride_;
+    const dim_t dst_m_stride_;
+    const int batch_tail_;  // batch_ % 16
+    const uint16_t tail_mask_val_;
+
+    using reg64_t = const Reg64;
+
+    reg64_t reg_src = r12;
+    reg64_t reg_dst = rbx;
+    reg64_t reg_M = rcx;
+    reg64_t reg_N = rdx;
+    reg64_t reg_src_row = r8;
+    reg64_t reg_dst_row = r9;
+    reg64_t reg_n_iter = r10;
+    reg64_t reg_tmp = r11;
+    reg64_t reg_tmp2 = r13;
+
+    Opmask k_tail_mask = k1;
+
+    // zmm0-zmm15: 16 data registers for transpose
+    // zmm16-zmm31: temporaries for transpose
+    Zmm zmm_src(int i) { return Zmm(i); }
+    Zmm zmm_tmp(int i) { return Zmm(16 + i); }
+
+    void emit_16x16_transpose();
+    void generate() override;
+};
+
+void jit_brgemm_matmul_copy_c_avx512_t::emit_16x16_transpose() {
+    // In-register 16x16 f32 transpose.
+    // Input: zmm0..zmm15 (rows), Output: zmm0..zmm15 (columns)
+
+    // Phase 1: interleave pairs
+    for (int i = 0; i < 16; i += 2) {
+        vunpcklps(zmm_tmp(i), zmm_src(i), zmm_src(i + 1));
+        vunpckhps(zmm_tmp(i + 1), zmm_src(i), zmm_src(i + 1));
+    }
+
+    // Phase 2: shuffle 64-bit pairs
+    for (int i = 0; i < 16; i += 4) {
+        vshufps(zmm_src(i + 0), zmm_tmp(i), zmm_tmp(i + 2), 0x44);
+        vshufps(zmm_src(i + 1), zmm_tmp(i), zmm_tmp(i + 2), 0xEE);
+        vshufps(zmm_src(i + 2), zmm_tmp(i + 1), zmm_tmp(i + 3), 0x44);
+        vshufps(zmm_src(i + 3), zmm_tmp(i + 1), zmm_tmp(i + 3), 0xEE);
+    }
+
+    // Phase 3: shuffle 128-bit lanes
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_tmp(i), zmm_src(i), zmm_src(i + 4), 0x88);
+        vshuff64x2(zmm_tmp(i + 4), zmm_src(i), zmm_src(i + 4), 0xDD);
+    }
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_tmp(i + 8), zmm_src(i + 8), zmm_src(i + 12), 0x88);
+        vshuff64x2(zmm_tmp(i + 12), zmm_src(i + 8), zmm_src(i + 12), 0xDD);
+    }
+
+    // Phase 4: final 256-bit shuffle
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_src(i), zmm_tmp(i), zmm_tmp(i + 8), 0x88);
+        vshuff64x2(zmm_src(i + 8), zmm_tmp(i), zmm_tmp(i + 8), 0xDD);
+    }
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_src(i + 4), zmm_tmp(i + 4), zmm_tmp(i + 12), 0x88);
+        vshuff64x2(zmm_src(i + 12), zmm_tmp(i + 4), zmm_tmp(i + 12), 0xDD);
+    }
+}
+
+void jit_brgemm_matmul_copy_c_avx512_t::generate() {
+    preamble();
+
+    mov(reg_src, ptr[abi_param1 + GET_OFF(src)]);
+    mov(reg_dst, ptr[abi_param1 + GET_OFF(dst)]);
+    mov(reg_M, ptr[abi_param1 + GET_OFF(current_M_blk)]);
+    mov(reg_N, ptr[abi_param1 + GET_OFF(current_N_blk)]);
+
+    // Setup tail mask for last batch chunk if batch % 16 != 0
+    if (batch_tail_) {
+        mov(reg_tmp, (uint64_t)tail_mask_val_);
+        kmovw(k_tail_mask, Reg32(reg_tmp.getIdx()));
+    }
+
+    mov(reg_src_row, reg_src);
+    mov(reg_dst_row, reg_dst);
+
+    Label m_loop_label, done_label;
+    L(m_loop_label);
+    cmp(reg_M, 0);
+    jle(done_label, T_NEAR);
+
+    xor_(reg_n_iter, reg_n_iter);
+
+    Label n_loop_16, n_tail_label, n_done_label;
+    L(n_loop_16);
+    {
+        mov(reg_tmp, reg_N);
+        sub(reg_tmp, reg_n_iter);
+        cmp(reg_tmp, 16);
+        jl(n_tail_label, T_NEAR);
+
+        // Process batch in chunks of 16 for the 16x16 transpose.
+        for (int b_chunk = 0; b_chunk < batch_; b_chunk += 16) {
+            const int chunk_len = nstl::min(16, batch_ - b_chunk);
+            const bool is_tail_chunk = (chunk_len < 16);
+
+            // Load chunk_len ZMMs from batch buffers, zero-pad rest
+            mov(reg_tmp, reg_n_iter);
+            imul(reg_tmp, reg_tmp, dt_sz_);
+            add(reg_tmp, reg_src_row);
+            for (int b = 0; b < 16; b++) {
+                if (b < chunk_len)
+                    vmovups(zmm_src(b),
+                            ptr[reg_tmp
+                                    + (b_chunk + b) * buf_batch_stride_]);
+                else
+                    vpxorq(zmm_src(b), zmm_src(b), zmm_src(b));
+            }
+
+            // 16x16 in-register transpose
+            emit_16x16_transpose();
+
+            // Store transposed values to dst at batch offset
+            const dim_t dst_b_offset = b_chunk * dt_sz_;
+            for (int n = 0; n < 16; n++) {
+                auto dst_addr = ptr[reg_dst_row + n * dst_n_stride_
+                        + dst_b_offset];
+                if (!is_tail_chunk)
+                    vmovups(dst_addr, zmm_src(n));
+                else
+                    vmovups(dst_addr | k_tail_mask, zmm_src(n));
+            }
+        }
+
+        add(reg_n_iter, 16);
+        add(reg_dst_row, 16 * dst_n_stride_);
+        jmp(n_loop_16, T_NEAR);
+    }
+
+    L(n_tail_label);
+    {
+        cmp(reg_n_iter, reg_N);
+        jge(n_done_label, T_NEAR);
+
+        // Scalar tail: one element at a time
+        Label tail_loop;
+        L(tail_loop);
+        cmp(reg_n_iter, reg_N);
+        jge(n_done_label, T_NEAR);
+
+        mov(reg_tmp, reg_n_iter);
+        imul(reg_tmp, reg_tmp, dt_sz_);
+        add(reg_tmp, reg_src_row);
+        for (int b = 0; b < batch_; b++) {
+            vmovss(Xmm(0), ptr[reg_tmp + b * buf_batch_stride_]);
+            vmovss(ptr[reg_dst_row + b * dt_sz_], Xmm(0));
+        }
+
+        add(reg_dst_row, dst_n_stride_);
+        inc(reg_n_iter);
+        jmp(tail_loop, T_NEAR);
+    }
+
+    L(n_done_label);
+    add(reg_src_row, buf_row_stride_);
+    mov(reg_dst_row, reg_dst);
+    dec(reg_M);
+    add(reg_dst, dst_m_stride_);
+    mov(reg_dst_row, reg_dst);
+    jmp(m_loop_label, T_NEAR);
+
+    L(done_label);
+    postamble();
+}
+
+// Copy-C kernel for adbc dst: 16×16 transpose from scratch buffer to dst.
+struct jit_brgemm_matmul_copy_c_adbc_avx512_t
+    : public jit_brgemm_matmul_copy_c_t,
+      public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_c_adbc_avx512_t)
+
+    jit_brgemm_matmul_copy_c_adbc_avx512_t(const brgemm_matmul_conf_t *conf)
+        : jit_brgemm_matmul_copy_c_t(conf)
+        , jit_generator_t(jit_name())
+        , dt_sz_(conf->c_dt_sz)
+        , src_row_stride_(conf->LDC * conf->c_dt_sz)
+        , dst_n_stride_(conf->C_strides[0]) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
+
+private:
+    const int dt_sz_;
+    const dim_t src_row_stride_; // LDC * dt_sz between rows in buf_C
+    const dim_t dst_n_stride_; // stride between N positions in dst
+
+    using reg64_t = const Reg64;
+
+    reg64_t reg_src = r12;
+    reg64_t reg_dst = rbx;
+    reg64_t reg_M = rcx;
+    reg64_t reg_N = rdx;
+    reg64_t reg_m_iter = r8;
+    reg64_t reg_n_iter = r9;
+    reg64_t reg_tmp = r10;
+    reg64_t reg_src_row = r11;
+    reg64_t reg_dst_col = r13;
+
+    Zmm zmm_src(int i) { return Zmm(i); }
+    Zmm zmm_tmp(int i) { return Zmm(16 + i); }
+
+    void emit_16x16_transpose();
+    void generate() override;
+};
+
+void jit_brgemm_matmul_copy_c_adbc_avx512_t::emit_16x16_transpose() {
+    // In-register 16×16 f32 transpose.
+    // Input: zmm0..zmm15 (rows from buf_C), Output: zmm0..zmm15 (columns)
+
+    // Phase 1: interleave pairs
+    for (int i = 0; i < 16; i += 2) {
+        vunpcklps(zmm_tmp(i), zmm_src(i), zmm_src(i + 1));
+        vunpckhps(zmm_tmp(i + 1), zmm_src(i), zmm_src(i + 1));
+    }
+
+    // Phase 2: shuffle 64-bit pairs
+    for (int i = 0; i < 16; i += 4) {
+        vshufps(zmm_src(i + 0), zmm_tmp(i), zmm_tmp(i + 2), 0x44);
+        vshufps(zmm_src(i + 1), zmm_tmp(i), zmm_tmp(i + 2), 0xEE);
+        vshufps(zmm_src(i + 2), zmm_tmp(i + 1), zmm_tmp(i + 3), 0x44);
+        vshufps(zmm_src(i + 3), zmm_tmp(i + 1), zmm_tmp(i + 3), 0xEE);
+    }
+
+    // Phase 3: shuffle 128-bit lanes
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_tmp(i), zmm_src(i), zmm_src(i + 4), 0x88);
+        vshuff64x2(zmm_tmp(i + 4), zmm_src(i), zmm_src(i + 4), 0xDD);
+    }
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_tmp(i + 8), zmm_src(i + 8), zmm_src(i + 12), 0x88);
+        vshuff64x2(zmm_tmp(i + 12), zmm_src(i + 8), zmm_src(i + 12), 0xDD);
+    }
+
+    // Phase 4: final 256-bit shuffle
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_src(i), zmm_tmp(i), zmm_tmp(i + 8), 0x88);
+        vshuff64x2(zmm_src(i + 8), zmm_tmp(i), zmm_tmp(i + 8), 0xDD);
+    }
+    for (int i = 0; i < 4; i++) {
+        vshuff64x2(zmm_src(i + 4), zmm_tmp(i + 4), zmm_tmp(i + 12), 0x88);
+        vshuff64x2(zmm_src(i + 12), zmm_tmp(i + 4), zmm_tmp(i + 12), 0xDD);
+    }
+}
+
+void jit_brgemm_matmul_copy_c_adbc_avx512_t::generate() {
+    preamble();
+
+    mov(reg_src, ptr[abi_param1 + GET_OFF(src)]);
+    mov(reg_dst, ptr[abi_param1 + GET_OFF(dst)]);
+    mov(reg_M, ptr[abi_param1 + GET_OFF(current_M_blk)]);
+    mov(reg_N, ptr[abi_param1 + GET_OFF(current_N_blk)]);
+
+    // Outer loop over M in chunks of 16
+    xor_(reg_m_iter, reg_m_iter);
+    Label m_loop_16, m_tail_label, done_label;
+
+    L(m_loop_16);
+    {
+        mov(reg_tmp, reg_M);
+        sub(reg_tmp, reg_m_iter);
+        cmp(reg_tmp, 16);
+        jl(m_tail_label, T_NEAR);
+
+        // reg_src_row = reg_src + m_iter * src_row_stride
+        mov(reg_src_row, reg_m_iter);
+        imul(reg_src_row, reg_src_row, src_row_stride_);
+        add(reg_src_row, reg_src);
+
+        // reg_dst_col = reg_dst + m_iter * dt_sz (M is contiguous)
+        mov(reg_dst_col, reg_m_iter);
+        imul(reg_dst_col, reg_dst_col, dt_sz_);
+        add(reg_dst_col, reg_dst);
+
+        // Inner loop over N in chunks of 16
+        xor_(reg_n_iter, reg_n_iter);
+        Label n_loop_16, n_tail_label, n_done_label;
+
+        L(n_loop_16);
+        {
+            mov(reg_tmp, reg_N);
+            sub(reg_tmp, reg_n_iter);
+            cmp(reg_tmp, 16);
+            jl(n_tail_label, T_NEAR);
+
+            // Load 16 rows of 16 N elements each
+            for (int i = 0; i < 16; i++) {
+                vmovups(zmm_src(i),
+                        ptr[reg_src_row + i * src_row_stride_
+                                + reg_n_iter * dt_sz_]);
+            }
+
+            emit_16x16_transpose();
+
+            // Store 16 transposed rows: each goes to dst at n_stride offset
+            for (int i = 0; i < 16; i++) {
+                // dst_col + (n_iter + i) * dst_n_stride
+                mov(reg_tmp, reg_n_iter);
+                add(reg_tmp, i);
+                imul(reg_tmp, reg_tmp, dst_n_stride_);
+                vmovups(ptr[reg_dst_col + reg_tmp], zmm_src(i));
+            }
+
+            add(reg_n_iter, 16);
+            jmp(n_loop_16, T_NEAR);
+        }
+
+        L(n_tail_label);
+        {
+            // Scalar tail for remaining N elements
+            cmp(reg_n_iter, reg_N);
+            jge(n_done_label, T_NEAR);
+
+            Label n_scalar_loop;
+            L(n_scalar_loop);
+            cmp(reg_n_iter, reg_N);
+            jge(n_done_label, T_NEAR);
+
+            // For this N position, copy 16 M values one-by-one
+            mov(reg_tmp, reg_n_iter);
+            imul(reg_tmp, reg_tmp, dst_n_stride_);
+            // reg_tmp = dst offset for this N column
+
+            for (int i = 0; i < 16; i++) {
+                Xmm xmm_val = Xmm(0);
+                vmovss(xmm_val,
+                        ptr[reg_src_row + i * src_row_stride_
+                                + reg_n_iter * dt_sz_]);
+                vmovss(ptr[reg_dst_col + reg_tmp + i * dt_sz_], xmm_val);
+            }
+
+            inc(reg_n_iter);
+            jmp(n_scalar_loop, T_NEAR);
+        }
+
+        L(n_done_label);
+        add(reg_m_iter, 16);
+        jmp(m_loop_16, T_NEAR);
+    }
+
+    L(m_tail_label);
+    {
+        // M tail: process remaining rows one-by-one
+        cmp(reg_m_iter, reg_M);
+        jge(done_label, T_NEAR);
+
+        Label m_scalar_loop, m_tail_n_done;
+        L(m_scalar_loop);
+        cmp(reg_m_iter, reg_M);
+        jge(done_label, T_NEAR);
+
+        // reg_src_row = reg_src + m_iter * src_row_stride
+        mov(reg_src_row, reg_m_iter);
+        imul(reg_src_row, reg_src_row, src_row_stride_);
+        add(reg_src_row, reg_src);
+
+        // dst offset for this M position
+        mov(reg_dst_col, reg_m_iter);
+        imul(reg_dst_col, reg_dst_col, dt_sz_);
+        add(reg_dst_col, reg_dst);
+
+        xor_(reg_n_iter, reg_n_iter);
+        Label m_tail_n_loop;
+        L(m_tail_n_loop);
+        cmp(reg_n_iter, reg_N);
+        jge(m_tail_n_done, T_NEAR);
+
+        // Load one element, store to dst
+        Xmm xmm_val = Xmm(0);
+        vmovss(xmm_val, ptr[reg_src_row + reg_n_iter * dt_sz_]);
+        mov(reg_tmp, reg_n_iter);
+        imul(reg_tmp, reg_tmp, dst_n_stride_);
+        vmovss(ptr[reg_dst_col + reg_tmp], xmm_val);
+
+        inc(reg_n_iter);
+        jmp(m_tail_n_loop, T_NEAR);
+
+        L(m_tail_n_done);
+        inc(reg_m_iter);
+        jmp(m_scalar_loop, T_NEAR);
+    }
+
+    L(done_label);
+    postamble();
+}
+
+status_t create_brgemm_matmul_copy_c(
+        std::unique_ptr<jit_brgemm_matmul_copy_c_t> &copy_ker,
+        const brgemm_matmul_conf_t *conf) {
+    if (conf->dst_is_adbc)
+        copy_ker = utils::make_unique<jit_brgemm_matmul_copy_c_adbc_avx512_t>(
+                conf);
+    else
+        copy_ker = utils::make_unique<jit_brgemm_matmul_copy_c_avx512_t>(conf);
+    return copy_ker->create_kernel();
+}
+
 } // namespace matmul
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
@@ -78,12 +78,34 @@ struct jit_brgemm_matmul_copy_a_t {
     const brgemm_matmul_conf_t *conf_;
 };
 
+struct jit_brgemm_matmul_copy_c_t {
+    struct ctx_t {
+        const void *src = nullptr; // buf_row base (batch 0, row m)
+        void *dst = nullptr; // dst_row base
+        dim_t current_M_blk = 0;
+        dim_t current_N_blk = 0;
+    };
+
+    virtual void operator()(ctx_t *ctx) = 0;
+    virtual status_t create_kernel() = 0;
+
+    jit_brgemm_matmul_copy_c_t(const brgemm_matmul_conf_t *conf)
+        : conf_(conf) {}
+    virtual ~jit_brgemm_matmul_copy_c_t() = default;
+
+    const brgemm_matmul_conf_t *conf_;
+};
+
 status_t create_brgemm_matmul_copy_b(
         std::unique_ptr<jit_brgemm_matmul_copy_b_t> &copy_ker,
         const brgemm_matmul_conf_t *conf);
 
 status_t create_brgemm_matmul_copy_a(
         std::unique_ptr<jit_brgemm_matmul_copy_a_t> &copy_ker,
+        const brgemm_matmul_conf_t *conf);
+
+status_t create_brgemm_matmul_copy_c(
+        std::unique_ptr<jit_brgemm_matmul_copy_c_t> &copy_ker,
         const brgemm_matmul_conf_t *conf);
 
 } // namespace matmul

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -667,7 +667,8 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_tags(memory_desc_t &A_md,
                 : plain_tensor_layout_tag;
         bgmmc.dst_tag
                 = memory_desc_matches_one_of_tag(C_md, plain_tensor_layout_tag,
-                        allowed_transposed_tensor_layout_tag, acbd);
+                        allowed_transposed_tensor_layout_tag, acbd, acdb,
+                        adbc);
         if (bgmmc.dst_tag == format_tag::undef) {
             if (gemm_based::check_gemm_output_format(C_md)) {
                 // Note: Here we batch layout may not be accurately represented
@@ -1631,6 +1632,38 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     VCHECK_BG(bm_conf_utils.set_or_check_tags(src_md, dst_md, bias_md, helper),
             VERBOSE_UNSUPPORTED_TAG);
+    // Detect dst layouts where N (ndims-1) is not innermost, requiring a
+    // copy C kernel. Use stride-based checks for generality: layouts with
+    // unit batch may degenerate to plain strides and skip the copy path.
+    bgmmc.dst_is_acdb = false;
+    bgmmc.dst_is_adbc = false;
+    if (bgmmc.ndims >= 4) {
+        const auto &dst_strides = dst_d.blocking_desc().strides;
+        const bool dst_N_not_innermost
+                = dst_strides[bgmmc.ndims - 1] != 1;
+        const bool dst_M_innermost
+                = dst_strides[bgmmc.ndims - 2] == 1;
+        bgmmc.dst_is_adbc = dst_N_not_innermost && dst_M_innermost;
+        bgmmc.dst_is_acdb = dst_N_not_innermost && !dst_M_innermost;
+    }
+    // acdb/adbc dst is only supported for f32 dst.
+    VCONDCHECK_BG(!((bgmmc.dst_is_acdb || bgmmc.dst_is_adbc)
+                          && bgmmc.dst_dt != data_type::f32),
+            VERBOSE_UNSUPPORTED_DT);
+    // acdb/adbc dst with sum post-op is not yet supported (sum reads from D
+    // buffer which would not contain prior dst values).
+    VCONDCHECK_BG(!((bgmmc.dst_is_acdb || bgmmc.dst_is_adbc)
+                          && bgmmc.with_sum),
+            VERBOSE_UNSUPPORTED_POSTOP);
+    // acdb/adbc dst is not supported for gemv: brgemv handles strided writes
+    // directly via INCY and does not need the copy C kernel.
+    VCONDCHECK_BG(
+            !((bgmmc.dst_is_acdb || bgmmc.dst_is_adbc) && bgmmc.is_gemv),
+            VERBOSE_UNSUPPORTED_TAG);
+    // Parallel K reduction with acdb/adbc dst is not yet supported.
+    VCONDCHECK_BG(
+            !((bgmmc.dst_is_acdb || bgmmc.dst_is_adbc) && bgmmc.nthr_k > 1),
+            VERBOSE_UNSUPPORTED_TAG)
     VCHECK_BG(attr.set_default_formats(&dst_md), VERBOSE_UNSUPPORTED_TAG);
     VCONDCHECK_BG(post_ops_ok(bgmmc, attr, dst_d), VERBOSE_UNSUPPORTED_POSTOP);
 
@@ -1717,13 +1750,14 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     // We cannot change M at this point as all gemv related parameters have
     // already been set up.
-    // For 4D tensors with acbd layout, avoid merging batches to prevent stride issues
+    // For 4D tensors with acbd/acdb layout, avoid merging batches to prevent stride issues
     const bool merge_batch_dims_into_M = !(bgmmc.is_gemv && bgmmc.gemv_swap_a_b)
             && bgmmc.batch > 1 && bgmmc.bcast_B_desc.bcast_across_all_batch_dims
             && plain_A_layout && helper.is_src_dst_layout_batch_fusable()
             && post_ops_ok(
                     bgmmc, attr, dst_d, true /* limit_bcast_strategies_set */)
-            && !(bgmmc.ndims == 4 && src_d.matches_tag(format_tag::acbd));
+            && !(bgmmc.ndims == 4 && src_d.matches_tag(format_tag::acbd))
+            && !bgmmc.dst_is_acdb && !bgmmc.dst_is_adbc;
     if (merge_batch_dims_into_M) {
         bgmmc.M *= bgmmc.batch;
         bgmmc.batch = 1;
@@ -1902,6 +1936,28 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                                 : bgmmc.N_blk)
                         * (bgmmc.is_runtime_N ? bgmmc.N_chunk_size : 1)
                 : bgmmc.LDD;
+    }
+
+    // acdb dst: N stride != 1, use scratch buffer + copy-out.
+    if (bgmmc.dst_is_acdb) {
+        bgmmc.LDD = bgmmc.N;
+        bgmmc.acdb_buf_per_batch_sz = bgmmc.M * bgmmc.N * bgmmc.c_dt_sz;
+        // For 4D (axbxMxN) only the inner batch dim b is contiguous.
+        bgmmc.acdb_inner_batch = bgmmc.batch_ndims > 1
+                ? dst_d.dims()[1]
+                : bgmmc.batch;
+        bgmmc.use_buffer_c = true;
+        bgmmc.LDC = (bgmmc.is_amx ? nstl::min((dim_t)32, bgmmc.N_blk)
+                                  : bgmmc.N_blk)
+                * (bgmmc.is_runtime_N ? bgmmc.N_chunk_size : 1);
+    }
+
+    // adbc dst: N stride != 1, use scratch buffer + per-tile scatter.
+    if (bgmmc.dst_is_adbc) {
+        bgmmc.use_buffer_c = true;
+        bgmmc.LDC = (bgmmc.is_amx ? nstl::min((dim_t)32, bgmmc.N_blk)
+                                  : bgmmc.N_blk)
+                * (bgmmc.is_runtime_N ? bgmmc.N_chunk_size : 1);
     }
 
     bgmmc.is_src_batch_layout_trivial
@@ -2364,7 +2420,11 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
         scratchpad.book(key_conv_amx_tile_buffer,
                 static_cast<size_t>(bgmmc.nthr) * bgmmc.wsp_tile_per_thr_bytes,
                 default_data_align);
-    if (bgmmc.is_runtime_M || bgmmc.is_runtime_N)
+    if (bgmmc.dst_is_acdb)
+        scratchpad.book(key_brgemm_primitive_buffer_d,
+                bgmmc.acdb_buf_per_batch_sz * bgmmc.batch,
+                default_data_align);
+    else if (bgmmc.is_runtime_M || bgmmc.is_runtime_N)
         scratchpad.book(key_brgemm_primitive_buffer_d,
                 bgmmc.M_blk * bgmmc.N_blk * bgmmc.c_dt_sz * bgmmc.nthr,
                 default_data_align);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -229,6 +229,13 @@ struct brgemm_matmul_conf_t {
     // were changed.
     bool adjust_a_strides = false;
 
+    // acdb/adbc dst: brgemm writes to scratch buffer, copy-out after.
+    bool dst_is_acdb = false;
+    dim_t acdb_buf_per_batch_sz = 0;
+    int acdb_inner_batch = 0;
+
+    bool dst_is_adbc = false;
+
     int wsp_tile_per_thr_bytes;
     int brgemm_batch_element_per_thr_sz;
     bool is_amx;


### PR DESCRIPTION
Issue converted to draft, as JAX team confirmed their MHA lowering approach has changed and they no longer encounter the original case. Ticket closed by requester. MFDNN-11647. Keeping this version here in case ticket reopens.

## Description

brgemm matmul cannot write to acdb or adbc dst layouts directly.
Before this patch such cases fell back to ref matmul.

This patch adds support for both layouts by computing into a scratch
buffer and transposing out with a JIT AVX-512 16×16 kernel.

Not supported yet: sum post-op, parallel K reduction.

## Performance

56-core Intel AVX10.1/AMX, f32.

**Ref** = ref matmul (only path before this change).
**abcd+reorder** = brgemm to abcd dst + separate reorder (best a framework could do manually).

### adbc dst

| M | Shape | vs Ref | vs abcd+reorder |
|--:|:------|-------:|----------------:|
| 64  | $\color{goldenrod}{\textrm{1×16×64×384 : 1×16×384×384}}$ | $\color{green}{\textrm{1609x}}$ | $\color{green}{\textrm{1.24x}}$ |
| 64  | 1×16×64×384 : 1×16×384×64   | $\color{green}{\textrm{741x}}$ | $\color{green}{\textrm{1.64x}}$ |
| 64  | 1×12×64×64  : 1×12×64×64    | $\color{green}{\textrm{145x}}$ | $\color{green}{\textrm{1.93x}}$ |
| 64  | 1×32×64×64  : 1×32×64×64    | $\color{green}{\textrm{304x}}$ | $\color{green}{\textrm{1.71x}}$ |
| 128 | 1×16×128×384 : 1×16×384×128 | $\color{green}{\textrm{1120x}}$ | $\color{gray}{\textrm{0.97x}}$ |
| 256 | 1×8×256×256  : 1×8×256×256  | $\color{green}{\textrm{963x}}$ | $\color{red}{\textrm{0.75x}}$ |

### acdb dst

| M | Shape | vs Ref | vs abcd+reorder |
|--:|:------|-------:|----------------:|
| 64  | $\color{goldenrod}{\textrm{1×16×64×384 : 1×16×384×384}}$ | $\color{green}{\textrm{857x}}$ | $\color{red}{\textrm{0.72x}}$ |
| 64  | 1×16×64×384 : 1×16×384×64   | $\color{green}{\textrm{362x}}$ | $\color{red}{\textrm{0.81x}}$ |
| 64  | 1×12×64×64  : 1×12×64×64    | $\color{green}{\textrm{67x}}$  | $\color{red}{\textrm{0.90x}}$ |
| 64  | 1×32×64×64  : 1×32×64×64    | $\color{green}{\textrm{132x}}$ | $\color{red}{\textrm{0.74x}}$ |
| 128 | 1×16×128×384 : 1×16×384×128 | $\color{green}{\textrm{803x}}$ | $\color{red}{\textrm{0.66x}}$ |
| 256 | 1×8×256×256  : 1×8×256×256  | $\color{green}{\textrm{749x}}$ | $\color{red}{\textrm{0.56x}}$ |

$\color{goldenrod}{\textrm{Highlighted}}$ = JAX MHA model shape.

### Summary

- **67–1609×** faster than ref for both layouts.
- **adbc** beats abcd+reorder by **1.24–1.93×** at M≤64 (typical MHA shapes).
- **acdb** is 0.56–0.90× vs abcd+reorder but removes the need for the framework to manage a separate reorder.