### PR TITLE
[GPU] Fix issues found when testing without JIT kernels

### DIFF
--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -113,6 +113,12 @@ static inline int format_type_checker(const char *, ...) {
                     __LINE__); \
     } while (0)
 
+// Per-primitive VDISPATCH_<PRIM>{,_SC,_IC} wrappers (in <primitive>_pd.hpp) are
+// built on VCONDCHECK/VCHECK below. Suffixes:
+//   (none) - boolean check; returns unimplemented, prefixes msg with info(engine).
+//   _SC    - status check; propagates the returned status_t on failure.
+//   _IC    - init check; like the boolean variant but without the info(engine)
+//            prefix, for use outside a pd_t context (e.g. init_conf()).
 // Macro for boolean checks
 #define VCONDCHECK( \
         apitype, logtype, logsubtype, component, condition, status, msg, ...) \

--- a/src/gpu/intel/ip/ref.cl
+++ b/src/gpu/intel/ip/ref.cl
@@ -41,8 +41,8 @@ __kernel void ref_inner_product_fwd(__global SRC_DATA_T *src,
                     const off_t wei_off = WEI_OFF(0, oc, ic, kd, kh, kw);
 #else
     for (off_t ic = 0; ic < IC_TOTAL; ++ic) {
-        const off_t src_off = mb * IC_TOTAL + ic;
-        const off_t wei_off = oc * IC_TOTAL + ic;
+        const off_t src_off = SRC_OFF(mb, ic, 0, 0, 0);
+        const off_t wei_off = WEI_OFF(0, oc, ic, 0, 0, 0);
 #endif
                     d += SRC_TO_REF(src[src_off]) * WEI_TO_REF(wei[wei_off]);
                 }

--- a/src/gpu/intel/matmul/ref.cl
+++ b/src/gpu/intel/matmul/ref.cl
@@ -130,7 +130,7 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
     int mb = get_global_id(2);
 
 #if WITH_DST_ZPOINTS
-    int dst_zp = c0[0];
+    int dst_zp = c0[WITH_DST_ZPOINTS_PER_OC ? n : 0];
 #else
     int dst_zp = 0;
 #endif

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -194,7 +194,7 @@ struct ref_t : public primitive_t {
             }
             if (!zp.has_default_values(DNNL_ARG_DST)) {
                 int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                bool ok = mask_dst == 0;
+                bool ok = utils::one_of(mask_dst, 0, dst_qmask_N());
                 if (!ok) return false;
             }
             return true;

--- a/src/gpu/intel/pool/jit.cpp
+++ b/src/gpu/intel/pool/jit.cpp
@@ -43,6 +43,8 @@ status_t gen_fwd_t::pd_t::init(impl::engine_t *engine) {
     auto acc_data_t = desc()->accum_data_type;
 
     // TODO: add training(?), add bwd
+    VDISPATCH_POOLING_IC(
+            intel_engine->mayiuse_ngen_kernels(), VERBOSE_BAD_ENGINE_KIND);
     VDISPATCH_POOLING_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
     VDISPATCH_POOLING(utils::one_of(desc()->prop_kind,
                               /*forward_training,*/ forward_inference),

--- a/src/gpu/intel/reorder/ref.cpp
+++ b/src/gpu/intel/reorder/ref.cpp
@@ -131,11 +131,15 @@ void ref_t::pd_t::init_scratchpad() {
 status_t ref_t::execute(const exec_ctx_t &ctx) const {
     auto &src = CTX_IN_STORAGE(DNNL_ARG_FROM);
     auto &dst = CTX_OUT_STORAGE(DNNL_ARG_TO);
-    auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
-            memory_tracking::names::key_reorder_space);
 
     const auto &conf = pd()->conf;
     if (conf.nelems == 0) return status::success;
+
+    std::unique_ptr<memory_storage_t> tmp;
+    if (conf.subbyte_pack) {
+        tmp = ctx.get_scratchpad_grantor().get_memory_storage(
+                memory_tracking::names::key_reorder_space);
+    }
 
     compute::kernel_arg_list_t arg_list;
     arg_list.append(src);

--- a/tests/gtests/ocl/api/test_engine.cpp
+++ b/tests/gtests/ocl/api/test_engine.cpp
@@ -23,8 +23,6 @@
 #include <string>
 #include <CL/cl.h>
 
-extern "C" bool dnnl_impl_gpu_intel_mayiuse_ngen_kernels(dnnl_engine_t engine);
-
 namespace dnnl {
 namespace {
 
@@ -278,13 +276,6 @@ TEST_P(ocl_engine_test_t, BinaryKernels) {
     dnnl_status_t s = dnnl_ocl_interop_engine_create(&eng, ocl_dev, ocl_ctx);
 
     ASSERT_EQ(s, p.expected_status);
-
-//DNNL_ENABLE_MEM_DEBUG forces allocation fail, causing mayiuse to fail
-#ifndef DNNL_ENABLE_MEM_DEBUG
-    if (s == dnnl_success) {
-        ASSERT_EQ(dnnl_impl_gpu_intel_mayiuse_ngen_kernels(eng), true);
-    }
-#endif
 
     if (s == dnnl_success) { DNNL_CHECK(dnnl_engine_destroy(eng)); }
 }

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -43,6 +43,10 @@ class convolution_any_fmt_test_t
     : public ::testing::TestWithParam<conv_any_fmt_test_params_t> {
 protected:
     void SetUp() override {
+        // Blocked-vs-plain format check is not reliable on GPU, optimized
+        // implementation can use plain format with "any".
+        SKIP_IF(get_test_engine_kind() == engine::kind::gpu,
+                "blocked format check is not reliable on GPU");
 #if DNNL_X64
         // Skip this test if the library cannot select blocked format a priori.
         // Currently blocking is supported only for sse41 and later CPUs.
@@ -131,8 +135,6 @@ using tf32 = conv_any_fmt_test_params_t;
 TEST_P(conv_any_fmt_test_float, TestsConvolutionAnyFmt) {}
 
 CPU_INSTANTIATE_TEST_SUITE_P(TestConvolutionAlexnetAnyFmtForward,
-        conv_any_fmt_test_float, ::testing::Values(ALEXNET_SUITE(BLK)));
-GPU_INSTANTIATE_TEST_SUITE_P(TestConvolutionAlexnetAnyFmtForward,
         conv_any_fmt_test_float, ::testing::Values(ALEXNET_SUITE(BLK)));
 #endif
 } // namespace dnnl

--- a/tests/gtests/ze/api/test_engine.cpp
+++ b/tests/gtests/ze/api/test_engine.cpp
@@ -19,8 +19,6 @@
 
 #include "oneapi/dnnl/dnnl_ze.hpp"
 
-extern "C" bool dnnl_impl_gpu_intel_mayiuse_ngen_kernels(dnnl_engine_t engine);
-
 namespace dnnl {
 namespace {
 
@@ -122,13 +120,6 @@ TEST_P(ze_engine_test_t, BinaryKernels) {
             = dnnl_ze_interop_engine_create(&eng, ze_driver, ze_dev, ze_ctx);
 
     ASSERT_EQ(s, p.expected_status);
-
-//DNNL_ENABLE_MEM_DEBUG forces allocation fail, causing mayiuse to fail
-#ifndef DNNL_ENABLE_MEM_DEBUG
-    if (s == dnnl_success) {
-        ASSERT_EQ(dnnl_impl_gpu_intel_mayiuse_ngen_kernels(eng), true);
-    }
-#endif
 
     if (s == dnnl_success) { DNNL_CHECK(dnnl_engine_destroy(eng)); }
 }


### PR DESCRIPTION
While working on https://github.com/uxlfoundation/oneDNN/pull/5105, I found and fixed several issues:

- Correctness issues in reference implementations
- Missing `mayiuse_ngen_kernels` check in JIT pooling
- Invalid or incorrect tests, e.g. `mayiuse_ngen_kernels` check doesn't work when JIT kernels for the current architecture are disabled via `ONEDNN_ENABLE_PRIMITIVE_GPU_ISA`