### PR TITLE
[GPU] Fixup GEMM pd init order

### DIFF
--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -54,7 +54,17 @@ struct gen_t : public primitive_t {
 
             assert(engine->kind() == engine_kind::gpu);
             auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+
+            CHECK(set_default_formats(false));
+
+            dev_info_ = intel_engine->device_info();
+            arch_ = dev_info_->gpu_arch();
+
+            CHECK(jit::pd_t::init(engine, arch_));
+
             const auto d = desc();
+            auto m = desc()->m();
+            auto n = desc()->n();
 
             // Basic implementation attr support:
             auto attr_skip_mask = smask_t::post_ops | smask_t::fpmath_mode
@@ -69,18 +79,6 @@ struct gen_t : public primitive_t {
                     !utils::one_of(DNNL_RUNTIME_DIM_VAL, d->m(), d->n(), d->k(),
                             d->lda(), d->ldb(), d->ldc(), d->batch()),
                     VERBOSE_RUNTIMEDIM_UNSUPPORTED);
-
-            auto &attr_zps = attr()->zero_points_;
-
-            dev_info_ = intel_engine->device_info();
-            arch_ = dev_info_->gpu_arch();
-            int stepping = dev_info_->stepping_id();
-
-            CHECK(set_default_formats(false));
-            CHECK(jit::pd_t::init(engine, arch_));
-
-            auto m = desc()->m();
-            auto n = desc()->n();
 
             // If m = 1, swap A/B to use more efficient n = 1 kernels if possible.
             bool check_lda = ((d->transa() == dnnl_notrans && d->lda() == 1)
@@ -169,10 +167,11 @@ struct gen_t : public primitive_t {
                     IMPLICATION(with_bias,
                             (d->c_type() != f64 || d->bias_type() == f64)),
                     VERBOSE_UNSUPPORTED_BIAS_CFG);
-            VDISPATCH_GEMM(IMPLICATION(with_sum_ab(),
-                                   !with_bias
-                                           && (attr_zps.has_default_values(
-                                                   DNNL_ARG_DST))),
+            VDISPATCH_GEMM(
+                    IMPLICATION(with_sum_ab(),
+                            !with_bias
+                                    && (attr()->zero_points_.has_default_values(
+                                            DNNL_ARG_DST))),
                     VERBOSE_UNSUPPORTED_ATTR);
 
             VDISPATCH_GEMM(attr()->post_ops_.check_sum_consistency(d->c_type(),
@@ -269,6 +268,7 @@ struct gen_t : public primitive_t {
             auto ldb = ld(DNNL_ARG_B);
             if (swap_ab_) std::swap(lda, ldb);
             auto product = intel_engine->device_info()->gpu_product();
+            int stepping = dev_info_->stepping_id();
             auto entries = kernel_desc_.select_kernel(product, stepping,
                     dev_info_->eu_count(), has_systolic, is_integrated, mode,
                     problem, alpha(), beta(), m, n, d->k(), lda, ldb, d->ldc(),


### PR DESCRIPTION
# Description

LD queries require default format initialization so prior commit moving up queries hits exception. 

Fixes # [MFDNN-15032](https://jira.devtools.intel.com/browse/MFDNN-15032)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?