### PR TITLE
cpu: x64: xbyak: disable XBYAK_STRICT_CHECK_MEM_REG_SIZE

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -46,8 +46,13 @@
 #define XBYAK_NO_EXCEPTION
 #endif
 
+// Several JIT kernels intentionally or unintentionally use size-mismatched memory operands
+// (e.g. zword[]-annotated addresses with 64-bit GPR instructions, or dword[] fields loaded into
+// Reg64 registers). These are architecturally correct on x86-64 but trigger this check. Until all
+// call sites are updated to use properly-sized operands or stripped annotations, set this to 0 to
+// suppress the false-positive errors.
 #if !defined(XBYAK_STRICT_CHECK_MEM_REG_SIZE)
-#define XBYAK_STRICT_CHECK_MEM_REG_SIZE 1
+#define XBYAK_STRICT_CHECK_MEM_REG_SIZE 0
 #endif
 
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)


### PR DESCRIPTION
Fix for [MFDNN-15033](https://jira.devtools.intel.com/browse/MFDNN-15033)

I recently introduced a [PR#4907](https://github.com/uxlfoundation/oneDNN/pull/4907) that enabled the XBYAK_STRICT_CHECK_MEM_REG_SIZE unfortunately one or more locations were missed and resulted in multiple "bad mem size" failures.

This will once again disable the XBYAK_STRICT_CHECK_MEM_REG_SIZE feature. This will retain the fixes from [PR#4907](https://github.com/uxlfoundation/oneDNN/pull/4907) but will disable the check that was causing failures after the PR merged.