### PR TITLE
gpu: intel: fill_random: clear exponent MSB to bound |val| < 2

### DIFF
--- a/src/gpu/intel/fill_random.cl
+++ b/src/gpu/intel/fill_random.cl
@@ -18,7 +18,7 @@
 
 // Fills a buffer with pseudo-random data using Philox RNG.
 // Each work-item generates 4 × uint32 (16 bytes) via vstore4.
-// The mask clears exponent LSBs to prevent NaN/Inf for FP types.
+// The mask clears exponent MSBs to prevent NaN/Inf for FP types.
 __kernel void fill_random(
         __global uint *buf, uint seed, ulong byte_count, uint mask) {
     const ulong start = (ulong)get_global_id(0) * 16;

--- a/src/gpu/intel/fill_random.cpp
+++ b/src/gpu/intel/fill_random.cpp
@@ -49,15 +49,18 @@ static status_t get_cached_kernel(
     return status::success;
 }
 
+// The mask clears the MSB of the exponent for FP types. This both rules out
+// NaN/Inf in the buffer (exp != all-ones) and bounds |val| < 2 (except e8m0)
+// so that reductions cannot overflow the accumulator.
 static uint32_t nan_safe_mask(data_type_t dt) {
     switch (dt) {
-        case data_type::f32: return 0xFF7FFFFFu;
-        case data_type::f16: return 0xFBFFFBFFu;
-        case data_type::bf16: return 0xFF7FFF7Fu;
-        case data_type::f8_e5m2: return 0xFBFBFBFBu;
-        case data_type::f8_e4m3: return 0xF7F7F7F7u;
-        case data_type::e8m0: return 0xFEFEFEFEu;
-        case data_type::f64: return 0xFFEFFFFFu;
+        case data_type::f32: return 0xBFFFFFFFu;
+        case data_type::f16: return 0xBFFFBFFFu;
+        case data_type::bf16: return 0xBFFFBFFFu;
+        case data_type::f8_e5m2: return 0xBFBFBFBFu;
+        case data_type::f8_e4m3: return 0xBFBFBFBFu;
+        case data_type::e8m0: return 0x7F7F7F7Fu;
+        case data_type::f64: return 0xBFFFFFFFu;
         default: return 0xFFFFFFFFu;
     }
 }


### PR DESCRIPTION
Found with @dzarukin while testing https://github.com/uxlfoundation/oneDNN/pull/5118.

The current mask in `fill_random` avoids Inf/NaN in data itself but when this data is fed into a reduction, we can still hit overflows (large x large). This results in NaN (`-infinity + infinity`) or plain Inf values in the output.

The PR adjusts the filling logic to zero out the MSB instead of the LSB. This approach solves both issues:

- Avoids Inf/NaN in data filling
- Virtually eliminates the possibility of overflow during reduction

Validated via a Python script (see below).

**Before**:

`f32`, `f64` and `bf16` are affected.

```
$ python3 fill_random_test.py --K 2048
# n_chains=10000, K=[2048]
# accumulator: f32 for all dtypes except f64 (which uses f64)
# in_H, out_H = Shannon byte entropy in bits/byte (8 = uncompressible)

dtype      mask          in_H      K     %inf     %nan    max|fin|    out_std  out_H
------------------------------------------------------------------------------------------
f32        0xFF7FFFFF    7.95   2048    0.00%  100.00%   0.000e+00  0.000e+00   1.50

f64        0xFFEFFFFF    7.95   2048    0.00%  100.00%   0.000e+00  0.000e+00   1.06

f16        0xFBFFFBFF    7.81   2048    0.00%    0.00%   3.025e+10  7.555e+09   7.35

bf16       0xFF7FFF7F    7.81   2048    0.00%  100.00%   0.000e+00  0.000e+00   1.50

f8_e5m2    0xFBFBFBFB    7.00   2048    0.00%    0.00%   3.012e+10  6.411e+09   7.35

f8_e4m3    0xF7F7F7F7    7.00   2048    0.00%    0.00%   9.112e+05  2.109e+05   7.32

e8m0       0xFEFEFEFE    7.00   2048  100.00%    0.00%   0.000e+00  0.000e+00   1.50
```

**After**:

No Inf/Nan in the reduction output.

```
$ python3 fill_random_test.py --mask-f32 0xBFFFFFFF --mask-f64 0xBFFFFFFF --mask-f16 0xBFFFBFFF --mask-bf16 0xBFFFBFFF --mask-f8_e5m2 0xBFBFBFBF --mask-f8_e4m3 0xBFBFBFBF --mask-e8m0 0x7F7F7F7F --K 2048
# n_chains=10000, K=[2048]
# accumulator: f32 for all dtypes except f64 (which uses f64)
# in_H, out_H = Shannon byte entropy in bits/byte (8 = uncompressible)

dtype      mask          in_H      K     %inf     %nan    max|fin|    out_std  out_H
------------------------------------------------------------------------------------------
f32        0xBFFFFFFF    7.95   2048    0.00%    0.00%   6.328e+00  1.086e+00   7.45

f64        0xBFFFFFFF    7.95   2048    0.00%    0.00%   3.568e+00  1.470e-01   7.80

f16        0xBFFFBFFF    7.81   2048    0.00%    0.00%   3.478e+01  8.781e+00   7.34

bf16       0xBFFFBFFF    7.81   2048    0.00%    0.00%   7.762e+00  1.090e+00   7.45

f8_e5m2    0xBFBFBFBF    7.00   2048    0.00%    0.00%   2.882e+01  7.482e+00   7.35

f8_e4m3    0xBFBFBFBF    7.00   2048    0.00%    0.00%   6.186e+01  1.626e+01   7.19

e8m0       0x7F7F7F7F    7.00   2048    0.00%    0.00%   4.238e+00  4.762e-01   7.17
```

<details>
<summary>fill_random_test.py</summary>

```python
#!/usr/bin/env python3
"""
Test fill_random masks for matmul-style reduction overflow.

Mirrors the masking scheme of src/gpu/intel/fill_random.cl:
  1. Generate uint32 words from a PRNG.
  2. AND each word with a per-dtype mask.
  3. Reinterpret bytes as the target FP type.

Then for each chain length K, compute n_chains independent dot
products  sum_{i=0}^{K-1} a[i] * b[i]  and report the percentage
of results that are +/-inf or NaN.

Accumulator is f32 for every dtype except f64 (which uses f64),
matching how matmul typically accumulates.
"""

import argparse
import numpy as np

# Default masks copied from src/gpu/intel/fill_random.cpp:nan_safe_mask
DEFAULT_MASKS = {
    "f32": 0xFF7FFFFF,
    "f64": 0xFFEFFFFF,
    "f16": 0xFBFFFBFF,
    "bf16": 0xFF7FFF7F,
    "f8_e5m2": 0xFBFBFBFB,
    "f8_e4m3": 0xF7F7F7F7,
    "e8m0": 0xFEFEFEFE,
}
DTYPES = list(DEFAULT_MASKS.keys())


def gen_words(n_words, mask, seed):
    rng = np.random.default_rng(seed)
    raw = rng.integers(0, 1 << 32, size=n_words, dtype=np.int64).astype(
        np.uint32
    )
    return raw & np.uint32(mask)


def words_per_n(dtype, n):
    if dtype == "f64":
        return 2 * n
    if dtype == "f32":
        return n
    if dtype in ("f16", "bf16"):
        return (n + 1) // 2
    if dtype in ("f8_e5m2", "f8_e4m3", "e8m0"):
        return (n + 3) // 4
    raise ValueError(dtype)


def to_native(dtype, words, n):
    """Decode masked uint32 words into f32 (or f64 for dt=f64)."""
    if dtype == "f32":
        return words[:n].view(np.float32).copy()

    if dtype == "f64":
        return words[: 2 * n].view(np.float64).copy()

    if dtype == "f16":
        u16 = words.view(np.uint16)[:n]
        return u16.view(np.float16).astype(np.float32)

    if dtype == "bf16":
        u16 = words.view(np.uint16)[:n].astype(np.uint32)
        return (u16 << 16).view(np.float32).copy()

    if dtype == "f8_e5m2":
        return _e5m2_to_f32(words.view(np.uint8)[:n])
    if dtype == "f8_e4m3":
        return _e4m3_to_f32(words.view(np.uint8)[:n])
    if dtype == "e8m0":
        return _e8m0_to_f32(words.view(np.uint8)[:n])

    raise ValueError(dtype)


def _e5m2_to_f32(u8):
    """OCP f8_e5m2: 1 sign + 5 exp (bias 15) + 2 mantissa, IEEE-style (has inf)."""
    u = u8.astype(np.uint32)
    s = (u >> 7) & 1
    e = (u >> 2) & 0x1F
    m = u & 0x3
    out = np.zeros_like(u, dtype=np.uint32)

    nrm = (e >= 1) & (e <= 30)
    out = np.where(nrm, (s << 31) | ((e + 112) << 23) | (m << 21), out)

    inf = (e == 31) & (m == 0)
    out = np.where(inf, (s << 31) | (0xFF << 23), out)

    nan = (e == 31) & (m != 0)
    out = np.where(nan, (s << 31) | (0xFF << 23) | (1 << 22), out)

    f = out.view(np.float32).copy()

    sub = (e == 0) & (m != 0)
    if np.any(sub):
        idx = np.where(sub)[0]
        v = (m[idx].astype(np.float32) / 4.0) * np.float32(2.0**-14)
        f[idx] = np.where(s[idx] != 0, -v, v)
    return f


def _e4m3_to_f32(u8):
    """OCP f8_e4m3 (FN): 1 sign + 4 exp (bias 7) + 3 mantissa. NaN = S.1111.111, no inf."""
    u = u8.astype(np.uint32)
    s = (u >> 7) & 1
    e = (u >> 3) & 0xF
    m = u & 0x7
    out = np.zeros_like(u, dtype=np.uint32)

    is_nan = (e == 15) & (m == 7)
    nrm = (e >= 1) & ~is_nan
    out = np.where(nrm, (s << 31) | ((e + 120) << 23) | (m << 20), out)
    out = np.where(is_nan, (s << 31) | (0xFF << 23) | (1 << 22), out)

    f = out.view(np.float32).copy()

    sub = (e == 0) & (m != 0)
    if np.any(sub):
        idx = np.where(sub)[0]
        v = (m[idx].astype(np.float32) / 8.0) * np.float32(2.0**-6)
        f[idx] = np.where(s[idx] != 0, -v, v)
    return f


def _e8m0_to_f32(u8):
    """e8m0: 8-bit exponent only (no sign, no mantissa). value = 2^(e - 127). 0xFF = NaN."""
    e = u8.astype(np.int32)
    v = np.exp2(e.astype(np.float64) - 127.0).astype(np.float32)
    return np.where(u8 == 0xFF, np.float32("nan"), v).astype(np.float32)


def byte_entropy(arr):
    """Shannon entropy of the byte stream, in bits/byte (0..8).
    8.0 = uncompressible (uniform); 0 = constant. A tight proxy for how
    much GPU memory compression can squeeze the buffer."""
    if arr.size == 0:
        return 0.0
    b = np.ascontiguousarray(arr).view(np.uint8).reshape(-1)
    counts = np.bincount(b, minlength=256).astype(np.float64)
    p = counts / counts.sum()
    p = p[p > 0]
    return float(-np.sum(p * np.log2(p)))


def measure(dtype, mask, K, n_chains, seed_a=1, seed_b=2):
    n_total = K * n_chains
    words_a = gen_words(words_per_n(dtype, n_total), mask, seed_a)
    words_b = gen_words(words_per_n(dtype, n_total), mask, seed_b)
    a = to_native(dtype, words_a, n_total)
    b = to_native(dtype, words_b, n_total)

    # Input randomness: byte entropy of the *raw* masked words as they sit
    # in memory (what HW compression actually sees).
    in_H = 0.5 * (byte_entropy(words_a) + byte_entropy(words_b))

    a = a.reshape(n_chains, K)
    b = b.reshape(n_chains, K)

    # Suppress numpy warnings; we explicitly count overflows.
    with np.errstate(over="ignore", invalid="ignore"):
        accum = (a * b).sum(axis=1)

    n_inf = int(np.sum(np.isinf(accum)))
    n_nan = int(np.sum(np.isnan(accum)))
    finite = accum[np.isfinite(accum)]

    out_H = byte_entropy(accum)
    with np.errstate(over="ignore", invalid="ignore"):
        # Cast to f64 to widen the range; values near f64 max may still overflow to inf.
        out_std = (
            float(np.std(finite.astype(np.float64))) if finite.size else 0.0
        )

    return {
        "K": K,
        "pct_inf": 100.0 * n_inf / n_chains,
        "pct_nan": 100.0 * n_nan / n_chains,
        "max_abs_finite": float(np.max(np.abs(finite))) if finite.size else 0.0,
        "in_H": in_H,
        "out_H": out_H,
        "out_std": out_std,
    }


def parse_mask(s):
    return int(s, 0)


def main():
    p = argparse.ArgumentParser(
        description=__doc__,
        formatter_class=argparse.RawDescriptionHelpFormatter,
    )
    p.add_argument(
        "--K",
        type=int,
        nargs="+",
        default=[64, 512, 1024, 2048],
        help="reduction chain lengths (default: 64 512 1024 2048)",
    )
    p.add_argument(
        "--n-chains",
        type=int,
        default=10000,
        help="independent chains per K (default: 10000)",
    )
    p.add_argument(
        "--dtype",
        default="all",
        choices=["all"] + DTYPES,
        help="restrict to a single dtype",
    )
    for dt in DTYPES:
        p.add_argument(
            f"--mask-{dt}",
            type=parse_mask,
            default=None,
            metavar="HEX",
            help=f"override mask for {dt} (e.g. 0xBFFFFFFF)",
        )
    args = p.parse_args()

    dtypes = DTYPES if args.dtype == "all" else [args.dtype]

    print(f"# n_chains={args.n_chains}, K={args.K}")
    print("# accumulator: f32 for all dtypes except f64 (which uses f64)")
    print(
        "# in_H, out_H = Shannon byte entropy in bits/byte (8 = uncompressible)"
    )
    print()
    print(
        f"{'dtype':<10} {'mask':<12} {'in_H':>5} {'K':>6} "
        f"{'%inf':>8} {'%nan':>8} {'max|fin|':>11} "
        f"{'out_std':>10} {'out_H':>6}"
    )
    print("-" * 90)

    for dt in dtypes:
        mask = getattr(args, f"mask_{dt}")
        if mask is None:
            mask = DEFAULT_MASKS[dt]
        for i, K in enumerate(args.K):
            r = measure(dt, mask, K, args.n_chains)
            in_H_str = f"{r['in_H']:5.2f}" if i == 0 else "     "
            mask_str = f"0x{mask:08X}" if i == 0 else " " * 10
            dt_str = dt if i == 0 else ""
            print(
                f"{dt_str:<10} {mask_str:<12} {in_H_str:>5} {r['K']:>6d} "
                f"{r['pct_inf']:>7.2f}% {r['pct_nan']:>7.2f}% "
                f"{r['max_abs_finite']:>11.3e} "
                f"{r['out_std']:>10.3e} {r['out_H']:>6.2f}"
            )
        print()


if __name__ == "__main__":
    main()
```