### PR TITLE
[rls-v3.12] x64: conv: fixed reduced lowering copy routine for VNNI cases

### DIFF
--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -757,7 +757,14 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
     // number of zero-padded columns before src buffer to copy
     mov(reg_rov, ptr[param1 + GET_OFF(back_overflow)]);
 
-    vpxord(zmm_zero, zmm_zero, zmm_zero);
+    if (jcp.signed_input) {
+        // Apply -128 shift to zero padded area when using VPDPBUSD instruction
+        // to work with s8 inputs.
+        assert(jcp.src_dt == data_type::s8);
+        mov(reg_tmp, -128);
+        vpbroadcastb(zmm_zero, reg_tmp.cvt8());
+    } else
+        vpxord(zmm_zero, zmm_zero, zmm_zero);
 
     { // Handle Left Overflow
         Label label_lov, label_lov_skip;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -959,6 +959,9 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         ajcp.oc_block = jcp.oc_block;
         ajcp.ic_block = 16;
         ajcp.nb_oc = jcp.nb_oc;
+        // let copy routine know that zero padding needs special handling
+        // for legacy ISA without native s8s8 instructions
+        ajcp.signed_input = jcp.s8s8_compensation_required;
 
         CHECK(safe_ptr_assign(copy_to_relo_pbuffer_,
                 new jit_avx512_core_amx_copy_to_pbuffer_t(ajcp)));

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -437,3 +437,8 @@ mb64_ic3oc192_ih224oh14kh16sh16dh0ph0_iw224ow14kw16sw16dw0pw0n"rpad0_bf16_accura
 # Case with vpad != 0 in brgconv:sve_128 which triggered tmp register reuse issue
 --reset
 --dt=f32 --dir=FWD_B --impl=brgconv mb1ic342iw7oc10000ow7kw7pw3
+
+# accuracy issue in reduced lowering approach for s8s8 case on VNNI code path
+--reset
+--dt=s8:s8:s32 --dir=FWD_I
+mb1_ic1oc1_ih32oh16kh2sh2dh0ph0_iw64ow64kw4sw1dw0pw1


### PR DESCRIPTION
Backport of #5115.