### PR TITLE
ze: address testing issues

### DIFF
--- a/src/gpu/intel/ze/device_info.cpp
+++ b/src/gpu/intel/ze/device_info.cpp
@@ -132,6 +132,11 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
         }
     }
 
+    ze_device_module_properties_t device_module_props = {};
+    device_module_props.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
+    CHECK(xpu::ze::zeDeviceGetModuleProperties(device, &device_module_props));
+    max_kernel_param_size_ = device_module_props.maxArgumentsSize;
+
     ze_device_memory_access_properties_t device_memory_access_properties = {};
     device_memory_access_properties.stype
             = ZE_STRUCTURE_TYPE_DEVICE_MEMORY_ACCESS_PROPERTIES;

--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -81,6 +81,16 @@ function(register_benchdnn_test engine driver test_file)
         set(mode_modifier "--mode-modifier=P")
     endif()
 
+    # TODO: workaround a hang in Level Zero backend when during parallel
+    # creation several resources are initialized.
+    # Remove me once resolved.
+    if(${engine} MATCHES "gpu"
+       AND ${driver} MATCHES "rnn"
+       AND ${DNNL_GPU_VENDOR} MATCHES "INTEL"
+       AND ${DNNL_GPU_RUNTIME} MATCHES "ZE")
+        set(mode_modifier "")
+    endif()
+
     foreach(tm ${test_mode})
         string(REPLACE "test_" "test_benchdnn_mode${tm}_" target_name ${test_file})
         set(cmd "--mode=${tm} ${mode_modifier} -v1 --engine=${engine} --${driver} --batch=${test_file}")


### PR DESCRIPTION
Fixes [MFDNN-14976](https://jira.devtools.intel.com/browse/MFDNN-14976) - the current kernel arguments size limits is reached by concat cases but it turned out the default limit of 1024 is not relevant for ze runtime. Bumped it to 4k.

Workaround for [MFDNN-14974](https://jira.devtools.intel.com/browse/MFDNN-14974) - parallel primitive creation leads to a hang in "create_resource" function when synchronizing on data mapping from several threads. The reason for that is unknown yet. Until the problem is fixed, remove the parallel creation as machine hangs for 8 hours in every nightly cycle.