### PR TITLE
cpu: rv64: gemm: add bias fusion for gemm kernel

### DIFF
--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
@@ -26,11 +26,12 @@ namespace gemm_utils {
 using namespace Xbyak_riscv;
 
 jit_rvv_gemm_kernel_t::jit_rvv_gemm_kernel_t(
-        dim_t n_cols, bool isTransA, bool isTransB)
+        dim_t n_cols, bool isTransA, bool isTransB, bool has_bias)
     : jit_generator_t("rv64_gemm_kernel_f32_jit")
     , n_cols_(n_cols)
     , isTransA_(isTransA)
-    , isTransB_(isTransB) {
+    , isTransB_(isTransB)
+    , has_bias_(has_bias) {
     create_kernel();
 }
 
@@ -47,6 +48,7 @@ void jit_rvv_gemm_kernel_t::generate() {
     const Reg reg_ldc_bytes = t2;
     const Reg reg_K = t3;
     const Reg reg_alpha_bits = t4;
+    const Reg reg_bias_ptr = t4; // reuse after alpha bits moved to freg
     const Reg reg_beta_bits = t5;
 
     const Reg reg_k = a4; // current k counter
@@ -72,6 +74,7 @@ void jit_rvv_gemm_kernel_t::generate() {
     //   56 : dim_t m
     //   64 : float alpha
     //   68 : float beta
+    //   72 : const float *bias  (only used when has_bias_)
     ld(reg_A_ptr, reg_param, 0);
     ld(reg_B0_ptr, reg_param, 8);
     ld(reg_C_base, reg_param, 16);
@@ -85,6 +88,8 @@ void jit_rvv_gemm_kernel_t::generate() {
     fmv_w_x(freg_alpha, reg_alpha_bits);
     lw(reg_beta_bits, reg_param, 68);
     fmv_w_x(freg_beta, reg_beta_bits);
+
+    if (has_bias_) { ld(reg_bias_ptr, reg_param, 72); }
 
     slli(reg_lda_bytes, reg_lda_bytes, 2);
     slli(reg_ldb_bytes, reg_ldb_bytes, 2);
@@ -169,35 +174,82 @@ void jit_rvv_gemm_kernel_t::generate() {
 
     L(label_k_tail_end);
 
-    auto emit_c_update = [&](dim_t col_idx) {
-        Label label_beta_zero, label_done;
+    if (has_bias_) {
+        // C-update with fused bias: result = alpha*acc + beta*C + bias
+        auto emit_c_update = [&](dim_t col_idx) {
+            Label label_beta_zero, label_done;
+            Label label_skip_bias, label_c_store;
 
-        if (col_idx == 0) {
-            mv(reg_tmp3, reg_C_base);
-        } else {
-            li(reg_tmp0, col_idx);
-            mul(reg_tmp3, reg_ldc_bytes, reg_tmp0);
-            add(reg_tmp3, reg_C_base, reg_tmp3);
-        }
+            if (col_idx == 0) {
+                mv(reg_tmp3, reg_C_base);
+            } else {
+                li(reg_tmp0, col_idx);
+                mul(reg_tmp3, reg_ldc_bytes, reg_tmp0);
+                add(reg_tmp3, reg_C_base, reg_tmp3);
+            }
 
-        beq(reg_beta_bits, x0, label_beta_zero);
+            beq(reg_beta_bits, x0, label_beta_zero);
 
-        vle32_v(v_a, reg_tmp3);
-        vfmul_vf(v_a, v_a, freg_beta);
-        vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
-        vfadd_vv(v_a, v_a, v_c[col_idx]);
-        vse32_v(v_a, reg_tmp3);
-        j_(label_done);
+            vle32_v(v_a, reg_tmp3);
+            vfmul_vf(v_a, v_a, freg_beta);
+            vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
+            vfadd_vv(v_a, v_a, v_c[col_idx]);
 
-        L(label_beta_zero);
-        vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
-        vse32_v(v_c[col_idx], reg_tmp3);
+            beq(reg_bias_ptr, x0, label_skip_bias);
+            vle32_v(v_c[col_idx], reg_bias_ptr);
+            vfadd_vv(v_a, v_a, v_c[col_idx]);
+            L(label_skip_bias);
 
-        L(label_done);
-    };
+            vse32_v(v_a, reg_tmp3);
+            j_(label_done);
 
-    for (dim_t c = 0; c < n_cols_; c++)
-        emit_c_update(c);
+            L(label_beta_zero);
+            vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
+
+            beq(reg_bias_ptr, x0, label_c_store);
+            vle32_v(v_a, reg_bias_ptr);
+            vfadd_vv(v_c[col_idx], v_c[col_idx], v_a);
+
+            L(label_c_store);
+            vse32_v(v_c[col_idx], reg_tmp3);
+
+            L(label_done);
+        };
+
+        for (dim_t c = 0; c < n_cols_; c++)
+            emit_c_update(c);
+    } else {
+        // C-update without bias: result = alpha*acc + beta*C
+        auto emit_c_update = [&](dim_t col_idx) {
+            Label label_beta_zero, label_done;
+
+            if (col_idx == 0) {
+                mv(reg_tmp3, reg_C_base);
+            } else {
+                li(reg_tmp0, col_idx);
+                mul(reg_tmp3, reg_ldc_bytes, reg_tmp0);
+                add(reg_tmp3, reg_C_base, reg_tmp3);
+            }
+
+            beq(reg_beta_bits, x0, label_beta_zero);
+
+            vle32_v(v_a, reg_tmp3);
+            vfmul_vf(v_a, v_a, freg_beta);
+            vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
+            vfadd_vv(v_a, v_a, v_c[col_idx]);
+            vse32_v(v_a, reg_tmp3);
+            j_(label_done);
+
+            L(label_beta_zero);
+            vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
+            vse32_v(v_c[col_idx], reg_tmp3);
+
+            L(label_done);
+        };
+
+        for (dim_t c = 0; c < n_cols_; c++)
+            emit_c_update(c);
+    }
 
     ret();
 #else
@@ -210,17 +262,30 @@ namespace {
 template <bool isTransA, bool isTransB>
 void jit_rvv_gemm_kernel_dispatch(const float *A, const float *B, float *C,
         dim_t lda, dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta,
-        dim_t m, dim_t n_cols) {
-    static jit_rvv_gemm_kernel_t k1(1, isTransA, isTransB);
-    static jit_rvv_gemm_kernel_t k2(2, isTransA, isTransB);
-    static jit_rvv_gemm_kernel_t k3(3, isTransA, isTransB);
-    static jit_rvv_gemm_kernel_t k4(4, isTransA, isTransB);
-    static jit_rvv_gemm_kernel_t k5(5, isTransA, isTransB);
-    static jit_rvv_gemm_kernel_t k6(6, isTransA, isTransB);
-    static jit_rvv_gemm_kernel_t k7(7, isTransA, isTransB);
+        dim_t m, dim_t n_cols, const float *bias) {
+    // Kernels without fused bias (same code size as upstream)
+    static jit_rvv_gemm_kernel_t nb1(1, isTransA, isTransB, false);
+    static jit_rvv_gemm_kernel_t nb2(2, isTransA, isTransB, false);
+    static jit_rvv_gemm_kernel_t nb3(3, isTransA, isTransB, false);
+    static jit_rvv_gemm_kernel_t nb4(4, isTransA, isTransB, false);
+    static jit_rvv_gemm_kernel_t nb5(5, isTransA, isTransB, false);
+    static jit_rvv_gemm_kernel_t nb6(6, isTransA, isTransB, false);
+    static jit_rvv_gemm_kernel_t nb7(7, isTransA, isTransB, false);
 
-    static jit_rvv_gemm_kernel_t *arr[]
-            = {nullptr, &k1, &k2, &k3, &k4, &k5, &k6, &k7};
+    static jit_rvv_gemm_kernel_t *arr_nb[]
+            = {nullptr, &nb1, &nb2, &nb3, &nb4, &nb5, &nb6, &nb7};
+
+    // Kernels with fused bias
+    static jit_rvv_gemm_kernel_t b1(1, isTransA, isTransB, true);
+    static jit_rvv_gemm_kernel_t b2(2, isTransA, isTransB, true);
+    static jit_rvv_gemm_kernel_t b3(3, isTransA, isTransB, true);
+    static jit_rvv_gemm_kernel_t b4(4, isTransA, isTransB, true);
+    static jit_rvv_gemm_kernel_t b5(5, isTransA, isTransB, true);
+    static jit_rvv_gemm_kernel_t b6(6, isTransA, isTransB, true);
+    static jit_rvv_gemm_kernel_t b7(7, isTransA, isTransB, true);
+
+    static jit_rvv_gemm_kernel_t *arr_b[]
+            = {nullptr, &b1, &b2, &b3, &b4, &b5, &b6, &b7};
 
     static bool verbose_printed = false;
     if (!verbose_printed) {
@@ -240,7 +305,9 @@ void jit_rvv_gemm_kernel_dispatch(const float *A, const float *B, float *C,
     p.m = m;
     p.alpha = alpha;
     p.beta = beta;
+    p.bias = bias;
 
+    jit_rvv_gemm_kernel_t **arr = bias ? arr_b : arr_nb;
     (*arr[n_cols])(&p);
 }
 
@@ -248,19 +315,19 @@ void jit_rvv_gemm_kernel_dispatch(const float *A, const float *B, float *C,
 
 void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
         dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m,
-        dim_t n_cols, bool isTransA, bool isTransB) {
+        dim_t n_cols, bool isTransA, bool isTransB, const float *bias) {
     if (!isTransA && !isTransB) {
         jit_rvv_gemm_kernel_dispatch<false, false>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
     } else if (isTransA && !isTransB) {
         jit_rvv_gemm_kernel_dispatch<true, false>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
     } else if (!isTransA && isTransB) {
         jit_rvv_gemm_kernel_dispatch<false, true>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
     } else {
         jit_rvv_gemm_kernel_dispatch<true, true>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
     }
 }
 

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
@@ -62,12 +62,15 @@ struct jit_rvv_gemm_kernel_t : public jit_generator_t {
         dim_t m;
         float alpha;
         float beta;
+        const float *bias;
     };
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_kernel_t)
 
-    // Construct a JIT kernel for a specific n_cols (1..7) and transpose modes
-    jit_rvv_gemm_kernel_t(dim_t n_cols, bool isTransA, bool isTransB);
+    // Construct a JIT kernel for a specific n_cols (1..7), transpose modes,
+    // and optional fused-bias support.
+    jit_rvv_gemm_kernel_t(
+            dim_t n_cols, bool isTransA, bool isTransB, bool has_bias);
 
     void operator()(const call_params_t *p) const {
         jit_generator_t::operator()(p);
@@ -80,6 +83,7 @@ private:
     dim_t n_cols_;
     bool isTransA_;
     bool isTransB_;
+    bool has_bias_;
 };
 
 } // namespace gemm_utils

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
@@ -59,7 +59,7 @@ template <bool isTransA, bool isTransB>
 void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
         const dim_t lda, const float *B, const dim_t ldb, float *C,
         const dim_t ldc, const float alpha, const float beta, float *ws,
-        bool do_copy, int ithr = -1) {
+        bool do_copy, int ithr, const float *bias) {
     MAYBE_UNUSED(ithr);
 
     const dim_t n_unroll = gemm_f32_traits::get_n_unroll_factor();
@@ -70,8 +70,9 @@ void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
     const dim_t n_tail = N - Nu;
     const dim_t m_tail = M - Mu;
 
-    auto invoke_kernel = [&](const float *a_orig, const float *b, float *c,
-                                 dim_t tile_m, dim_t tile_n, dim_t j_col) {
+    auto invoke_kernel
+            = [&](const float *a_orig, const float *b, float *c, dim_t tile_m,
+                      dim_t tile_n, dim_t j_col, const float *bias_tile) {
         const float *a_eff;
         dim_t lda_eff;
         bool trans_a_eff;
@@ -88,35 +89,40 @@ void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
         }
 
         jit_rvv_gemm_kernel(a_eff, b, c, lda_eff, ldb, ldc, K, alpha, beta,
-                tile_m, tile_n, trans_a_eff, isTransB);
+                tile_m, tile_n, trans_a_eff, isTransB, bias_tile);
     };
 
     for (dim_t i = 0; i < Mu; i += m_unroll) {
         const float *a = isTransA ? &A[i * lda] : &A[i];
+        const float *bias_tile = bias ? bias + i : nullptr;
         for (dim_t j = 0; j < Nu; j += n_unroll) {
             const float *b = isTransB ? &B[j] : &B[j * ldb];
-            invoke_kernel(a, b, &C[i + j * ldc], m_unroll, n_unroll, j);
+            invoke_kernel(
+                    a, b, &C[i + j * ldc], m_unroll, n_unroll, j, bias_tile);
         }
 
         if (n_tail > 0) {
             const float *b = isTransB ? &B[Nu] : &B[Nu * ldb];
-            invoke_kernel(a, b, &C[i + Nu * ldc], m_unroll, n_tail, Nu);
+            invoke_kernel(
+                    a, b, &C[i + Nu * ldc], m_unroll, n_tail, Nu, bias_tile);
         }
     }
 
     if (m_tail > 0) {
         const float *a_tail = isTransA ? &A[Mu * lda] : &A[Mu];
+        const float *bias_tile = bias ? bias + Mu : nullptr;
 
         for (dim_t j = 0; j < Nu; j += n_unroll) {
             const float *b = isTransB ? &B[j] : &B[j * ldb];
             jit_rvv_gemm_kernel(a_tail, b, &C[Mu + j * ldc], lda, ldb, ldc, K,
-                    alpha, beta, m_tail, n_unroll, isTransA, isTransB);
+                    alpha, beta, m_tail, n_unroll, isTransA, isTransB,
+                    bias_tile);
         }
 
         if (n_tail > 0) {
             const float *b = isTransB ? &B[Nu] : &B[Nu * ldb];
             jit_rvv_gemm_kernel(a_tail, b, &C[Mu + Nu * ldc], lda, ldb, ldc, K,
-                    alpha, beta, m_tail, n_tail, isTransA, isTransB);
+                    alpha, beta, m_tail, n_tail, isTransA, isTransB, bias_tile);
         }
     }
 }
@@ -125,7 +131,7 @@ template <bool isTransA, bool isTransB>
 void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
         const float *A, const dim_t lda, const float *B, const dim_t ldb,
         const float beta, float *C, const dim_t ldc, bool do_copy, float *ws,
-        int ithr = -1) {
+        int ithr, const float *bias) {
 
     constexpr dim_t BM = gemm_traits_t<float, isTransA, isTransB>::BM;
     constexpr dim_t BN = gemm_traits_t<float, isTransA, isTransB>::BN;
@@ -146,6 +152,11 @@ void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
             for (dim_t j = 0; j < MN; j++)
                 C[j] *= beta;
         }
+        if (bias) {
+            for (dim_t j = 0; j < M; j++)
+                for (dim_t i = 0; i < N; i++)
+                    C[i * ldc + j] += bias[j];
+        }
         return;
     }
 
@@ -160,11 +171,14 @@ void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
                 curC = C + Bm + Bn * ldc;
 
                 if (Bk == 0) {
+                    const float *bias_block = bias ? bias + Bm : nullptr;
                     block_ker<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
-                            ldb, curC, ldc, alpha, beta, ws, do_copy, ithr);
+                            ldb, curC, ldc, alpha, beta, ws, do_copy, ithr,
+                            bias_block);
                 } else {
                     block_ker<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
-                            ldb, curC, ldc, alpha, 1.0f, ws, do_copy, ithr);
+                            ldb, curC, ldc, alpha, 1.0f, ws, do_copy, ithr,
+                            nullptr);
                 }
             }
         }
@@ -269,21 +283,24 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
             const float *myB = isTransB ? &(B[n_from + k_from * ldb])
                                         : &(B[k_from + n_from * ldb]);
 
+            const float *myBias
+                    = (ithr_k == 0 && bias) ? bias + m_from : nullptr;
+
             if (!isTransA) {
                 if (!isTransB) {
                     gemm_ithr<false, false>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
                 } else {
                     gemm_ithr<false, true>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
                 }
             } else {
                 if (!isTransB) {
                     gemm_ithr<true, false>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
                 } else {
                     gemm_ithr<true, true>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
                 }
             }
         }
@@ -319,10 +336,6 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
                         &C[m_from + (n_from + offset) * ldc], ldc);
             }
         });
-    }
-
-    if (bias) {
-        parallel_nd(N, M, [&](dim_t i, dim_t j) { C[i * ldc + j] += bias[j]; });
     }
 
     free(ws_buffers);

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -84,7 +84,7 @@ void partition_unit_diff(
 // n_cols must be 1..7, m can be any value (handled by vsetvl).
 void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
         dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m,
-        dim_t n_cols, bool isTransA, bool isTransB);
+        dim_t n_cols, bool isTransA, bool isTransB, const float *bias);
 
 } // namespace gemm_utils
 } // namespace rv64


### PR DESCRIPTION
# Description

This PR introduces fused bias addition into the RVV JIT GEMM micro-kernel for RISC-V architectures, eliminating the separate bias post-processing loop from the inner-product and matmul driver code.

This version provides:

1. Fused bias computation inside the GEMM C-update phase: `C = alpha*A*B + beta*C + bias`
2. Dual-variant JIT kernel generation: separate code paths for with-bias and without-bias to avoid I-cache pressure
3. Correct bias handling across M-blocking, K-blocking and multi-threaded (K-split) execution

## Key Features

- **Fused Bias in GEMM Kernel**: Bias is added during the C-update phase of the GEMM micro-kernel, saving one pass over the output matrix
- **Dual-Variant JIT Kernel**: Two sets of JIT-compiled kernels are generated at static initialization — one with fused bias instructions and one without. The no-bias variant generates identical code to upstream, ensuring zero regression for workloads that do not use bias (matmul, convolution)
- **Data Types**: `f32`
- **Memory Layouts**: All transpose combinations (`NN`, `TN`, `NT`, `TT`)
- **Post-Ops**: Bias is applied as a post-operation fused into the GEMM kernel

## Implementation Details

The GEMM micro-kernel (`jit_rvv_gemm_kernel_t`) is parameterized at JIT compile time with `has_bias_`. When `has_bias_` is true, the generated code loads bias values from the bias pointer and adds them to the accumulator before storing to C. When `has_bias_` is false, the generated code is identical to upstream — no bias-related instructions are emitted.

Bias pointer handling in the driver (`rvv_gemm_f32.cpp`):

- **K-blocking**: Bias is only added in the first K-block (`Bk == 0`). Subsequent K-blocks use `alpha=1.0` and `bias=nullptr` to accumulate partial products
- **M-blocking**: Bias is offset by the M-block start (`bias + Bm`) to apply the correct bias values for each row tile
- **K-split threading**: Only the `ithr_k == 0` thread applies bias. Other threads write partial sums to temporary buffers that are later reduced
- **Early exit**: When `K <= 0` or `alpha == 0`, bias is applied in a scalar fallback loop

# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Correctness Evaluation

Test command:
```bash
./benchdnn --ip --dir=FWD_B --batch=tests/benchdnn/inputs/ip/shapes_alexnet
./benchdnn --matmul --batch=tests/benchdnn/inputs/matmul/shapes_converted_ip_inf_lb_alexnet
./benchdnn --conv --batch=tests/benchdnn/inputs/conv/shapes_resnet_50
```

All correctness tests pass with zero errors.

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on the SG2044 platform with VLEN=256 using RISC-V GNU toolchain 14.2. We draw comparisons among:

1. **baseline**: upstream `main` branch (`gemm:rvv` / `RISCV64GCV:gemm` / `brgemm:rvv` / `jit_1x1:rvv`)
2. **this PR**: dual-variant JIT kernel with fused bias support

### Inner Product (Single-Core, 1 Thread)

IP layers exercise the fused bias path. The GEMM kernel adds bias during C-update, eliminating the separate bias loop.

| Layer | Impl | Baseline (ms) | This PR (ms) | Change |
|-------|------|---------------|--------------|--------|
| Alexnet:ip1 | RISCV64GCV:gemm | 844.04 | 839.08 | +0.6% |
| Alexnet:ip2 | RISCV64GCV:gemm | 304.66 | 304.65 | +0.0% |
| VGG16:ip2 | RISCV64GCV:gemm | 283.55 | 269.65 | **+4.9%** |
| BERT:3 | RISCV64GCV:gemm | 7.37 | 7.36 | +0.1% |
| resnet:ip1 | brgemm:rvv | 2.52 | 2.44 | +3.2% |
| VGG16:ip4 | brgemm:rvv | 1.63 | 1.55 | +4.9% |
| **Total** | | **1443.77** | **1424.73** | **+1.3%** |

### Inner Product (8-Core, 8 Threads)

| Layer | Impl | Baseline (ms) | This PR (ms) | Change |
|-------|------|---------------|--------------|--------|
| Alexnet:ip1 | RISCV64GCV:gemm | 96.50 | 93.29 | +3.3% |
| Alexnet:ip2 | RISCV64GCV:gemm | 37.04 | 25.61 | **+30.9%** |
| VGG16:ip2 | RISCV64GCV:gemm | 37.33 | 30.24 | **+19.0%** |
| BERT:3 | RISCV64GCV:gemm | 2.47 | 1.90 | **+23.1%** |
| BERT:4 | brgemm:rvv | 4.18 | 3.33 | **+20.3%** |
| **Total** | | **177.52** | **154.37** | **+13.0%** |

### Matmul (Single-Core, 1 Thread)

| Layer | Impl | Baseline (ms) | This PR (ms) | Change |
|-------|------|---------------|--------------|--------|
| Alexnet:ip1*1 | RISCV64GCV | 6637.30 | 6485.25 | +2.3% |
| VGG16:ip1*1 | RISCV64GCV | 1942.38 | 1957.93 | -0.8% |
| VGG16:ip2*1 | RISCV64GCV | 357.23 | 372.54 | -4.3% |
| inceptionv3:ip1*1 | RISCV64GCV | 71.93 | 57.30 | **+20.3%** |
| GNMT:1*1 | RISCV64GCV | 7.26 | 7.29 | -0.4% |
| **Total** | | **9016.10** | **8880.31** | +1.5% |

### Matmul (8-Core, 8 Threads)

| Layer | Impl | Baseline (ms) | This PR (ms) | Change |
|-------|------|---------------|--------------|--------|
| Alexnet:ip1*1 | RISCV64GCV | 2010.15 | 1905.43 | +5.2% |
| VGG16:ip1*1 | RISCV64GCV | 551.77 | 450.77 | **+18.3%** |
| VGG16:ip2*1 | RISCV64GCV | 72.09 | 72.02 | +0.1% |
| GNMT:0*1 | RISCV64GCV | 0.36 | 0.31 | +13.9% |
| **Total** | | **2634.37** | **2428.53** | +7.8% |

### Convolution (Single-Core, 1 Thread)

**ResNet-50**

| Layer | Impl | Baseline (ms) | This PR (ms) | Change |
|-------|------|---------------|--------------|--------|
| resnet_50:conv1 | gemm:rvv | 899.34 | 870.34 | +3.2% |
| resnet_50:res4a_branch2a | gemm:rvv | 255.93 | 220.81 | **+13.7%** |
| resnet_50:res4a_branch2b*6 | gemm:rvv | 913.72 | 822.50 | **+10.0%** |
| resnet_50:res5a_branch2a | gemm:rvv | 347.04 | 286.06 | **+17.6%** |
| resnet_50:res5a_branch2b*3 | gemm:rvv | 1123.50 | 1021.52 | **+9.1%** |
| resnet_50:res5a_branch1 | gemm:rvv | 3595.55 | 3511.88 | +2.3% |
| **gemm:rvv total** | | **8413.67** | **8008.94** | **+4.8%** |
| **All layers total** | | **14724.71** | **14366.69** | **+2.4%** |

**VGG-11**

| Layer | Impl | Baseline (ms) | This PR (ms) | Change |
|-------|------|---------------|--------------|--------|
| vgg_11:conv4_1 | gemm:rvv | 473.96 | 456.40 | +3.7% |
| vgg_11:conv4_2 | gemm:rvv | 575.38 | 547.63 | +4.8% |
| vgg_11:conv5_1 | gemm:rvv | 287.71 | 242.46 | **+15.7%** |
| vgg_11:conv5_2 | gemm:rvv | 297.10 | 275.80 | +7.2% |
| **gemm:rvv total** | | **1819.97** | **1722.58** | **+5.4%** |
| **All layers total** | | **6594.17** | **6509.52** | **+1.3%** |

**Dispatch Coverage:**
- ResNet-50: 7/20 layers (35%) use `gemm:rvv`, 6/20 (30%) use `brgemm:rvv`, 7/20 (35%) use `jit_1x1:rvv`
- VGG-11: 5/10 layers (50%) use `gemm:rvv`, 5/10 (50%) use `brgemm:rvv`

## No-Bias Workload Verification

To verify the PR does not regress workloads that do not use bias, we ran matmul benchmarks (which use the no-bias kernel variant) on a fresh build. The no-bias JIT kernel generates identical machine code to upstream — this experiment confirms zero regression from the dual-variant kernel approach.

- **Total regression is -2.0% (1-core) and -0.1% (8-core)** — well within test noise range
- Individual layer variations are within ±2-3% for all layers with runtime > 10ms, confirming the no-bias kernel is code-identical to upstream

# Future Plans

1. Extend fused bias to `brgemm:rvv` kernel for inner-product workloads that use the BRGEMM path
2. Fuse bias with element-wise post-ops (e.g., ReLU) in a single pass over the output matrix
