### PR TITLE
benchdnn: graph: enable sycl graph execution mode

### DIFF
--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -688,38 +688,48 @@ int doit(const prb_t *prb, res_t *res) {
 
         ref_partition_t ref_partition(dg, partitions[i], inputs, outputs);
 
-        // Construct memory for both perf & corr modes
-        SAFE(ref_partition.init_ref(graph_in_ports, res), WARN);
-        if (res->state == SKIPPED) return OK;
+        // Reference execution must use direct execution mode. Use RAII guard to
+        // ensure the original execution mode is restored.
+        // TODO: introduce exec_args_t for `execute_and_wait` to explicitly
+        // specify `execution_mode` value instead of updating the global value.
+        {
+            execution_mode_guard_t exec_mode_guard(execution_mode_t::direct);
 
-        if (has_bench_mode_bit(mode_bit_t::corr)) {
-            // correctness mode, run ref partition
-            if (res->state == UNTESTED || res->state == EXECUTED
-                    || res->state == DEFERRED) {
-                ref_partition.exec_ops(res);
-                if (res->state == FAILED) return FAIL;
-                if (res->state == SKIPPED || res->state == UNIMPLEMENTED)
-                    return OK;
-            } else {
-                // once a partition failed on init_ref, terminate whole graph execution
-                return FAIL;
+            // Construct memory for both perf & corr modes
+            SAFE(ref_partition.init_ref(graph_in_ports, res), WARN);
+            if (res->state == SKIPPED) return OK;
+
+            if (has_bench_mode_bit(mode_bit_t::corr)) {
+                // correctness mode, run ref partition
+                if (res->state == UNTESTED || res->state == EXECUTED
+                        || res->state == DEFERRED) {
+                    ref_partition.exec_ops(res);
+                    if (res->state == FAILED) return FAIL;
+                    if (res->state == SKIPPED || res->state == UNIMPLEMENTED)
+                        return OK;
+                } else {
+                    // once a partition failed on init_ref, terminate whole graph execution
+                    return FAIL;
+                }
             }
+
+            // To ensure data consistency between graph and reference paths,
+            // memory initialization and data displacement for reference
+            // primitives (performed in ref_partition.init_ref and
+            // ref_partition.exec_ops) must be completed before initializing
+            // graph memory.
+            SAFE(ref_partition.init_graph_mem(partition_mem_map_v[i], res),
+                    WARN);
+            if (res->state == SKIPPED) return OK;
+
+            // unmap memory from host to device
+            SAFE(map_unmap_partition_mem(
+                         partition_mem_map_v[i], inputs, UNMAP, res),
+                    WARN);
+            SAFE(map_unmap_partition_mem(
+                         partition_mem_map_v[i], outputs, UNMAP, res),
+                    WARN);
         }
-
-        // To ensure data consistency between graph and reference paths,
-        // memory initialization and data displacement for reference primitives
-        // (performed in ref_partition.init_ref and ref_partition.exec_ops)
-        // must be completed before initializing graph memory.
-        SAFE(ref_partition.init_graph_mem(partition_mem_map_v[i], res), WARN);
-        if (res->state == SKIPPED) return OK;
-
-        // unmap memory from host to device
-        SAFE(map_unmap_partition_mem(
-                     partition_mem_map_v[i], inputs, UNMAP, res),
-                WARN);
-        SAFE(map_unmap_partition_mem(
-                     partition_mem_map_v[i], outputs, UNMAP, res),
-                WARN);
 
         const op_ref_list_t &op_list = ref_partition.get_partition_ops();
         const auto &inplace_ports

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -751,15 +751,31 @@ int doit(const prb_t *prb, res_t *res) {
         graph_mem_mgr.start_graph_mem_check();
         BENCHDNN_PRINT(3, "[INFO]: Start execution of partition #%zd.\n", i);
 
-        stream_staller_t staller(strm);
-        // Need following clean-up steps as the memories have been mappped to
-        // device. Otherwise the deconstruction will fail.
-        DNN_GRAPH_SAFE(
-                c_partitions[i - idx_offset].execute(strm, input_ts, output_ts),
-                (WARN | NEED_CLEANUP), res);
-        staller.release();
+        // TODO: consolidate with primitives.
+        if (use_sycl_graph_exec()) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+            ::sycl::queue queue = dnnl::sycl_interop::get_queue(strm);
+            SAFE(sycl_graph_ctx::validate_backend(queue, res), FAIL);
 
-        DNN_GRAPH_SAFE(strm.wait(), WARN, res);
+            std::function<void()> record_fn = std::bind(
+                    compiled_partition_executor, c_partitions[i - idx_offset],
+                    std::ref(strm), input_ts, output_ts);
+            auto exec = sycl_graph_ctx::record_and_finalize(
+                    strm, queue, record_fn, res);
+            if (!exec) return FAIL;
+            SAFE(sycl_graph_ctx::replay(queue, *exec, res), FAIL);
+#endif
+        } else {
+            stream_staller_t staller(strm);
+            // Need following clean-up steps as the memories have been mappped
+            // to device. Otherwise the deconstruction will fail.
+            DNN_GRAPH_SAFE(c_partitions[i - idx_offset].execute(
+                                   strm, input_ts, output_ts),
+                    (WARN | NEED_CLEANUP), res);
+            staller.release();
+
+            DNN_GRAPH_SAFE(strm.wait(), WARN, res);
+        }
         graph_mem_mgr.stop_graph_mem_check();
 
         // map memory from device back to host

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -282,5 +282,86 @@ private:
     std::promise<void> prom_;
 };
 
+// Returns true if SYCL command graph execution mode is active.
+inline bool use_sycl_graph_exec() {
+    return is_sycl_engine() && execution_mode == execution_mode_t::graph;
+}
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+// TODO(xxx): Consolidate the SYCL graph utilities under a single umbrella and
+// reuse them across benchdnn (eg. dnnl_common.cpp).
+namespace sycl_graph_ctx {
+namespace syclex = ::sycl::ext::oneapi::experimental;
+using sycl_exec_graph_t
+        = syclex::command_graph<syclex::graph_state::executable>;
+
+// Validate that the queue supports SYCL command graph (Level Zero backend).
+// Returns OK on success, FAIL on error (with res->state set to FAILED).
+inline int validate_backend(const ::sycl::queue &queue, res_t *res) {
+    if (queue.get_device().get_backend()
+            != ::sycl::backend::ext_oneapi_level_zero) {
+        BENCHDNN_PRINT(0, "%s %s\n",
+                "[ERROR] SYCL graph execution is only available on Level "
+                "Zero backend; currently using:",
+                ::sycl::detail::get_backend_name_no_vendor(
+                        queue.get_device().get_backend())
+                        .data());
+        res->state = FAILED;
+        return FAIL;
+    }
+    return OK;
+}
+
+// Record operations into a SYCL command graph and return the finalized
+// executable. `record_func` is called while the queue is in recording state.
+// Returns nullptr on failure (with res->state set to FAILED).
+inline std::unique_ptr<sycl_exec_graph_t> record_and_finalize(
+        cpp_stream_t &stream, ::sycl::queue &queue,
+        std::function<void()> &record_func, res_t *res) {
+    BENCHDNN_PRINT(
+            2, "%s\n", "[INFO] Using experimental SYCL graph execution.");
+
+    // Drain the queue to clear any pending events before recording.
+    stream.wait();
+    queue.wait_and_throw();
+
+    syclex::command_graph sycl_graph {queue.get_context(), queue.get_device(),
+            {syclex::property::graph::assume_buffer_outlives_graph {}}};
+
+    try {
+        sycl_graph.begin_recording(queue);
+        record_func();
+        sycl_graph.end_recording(queue);
+        return std::unique_ptr<sycl_exec_graph_t>(
+                new sycl_exec_graph_t(sycl_graph.finalize()));
+    } catch (const std::exception &e) {
+        // Ensure recording is stopped.
+        try {
+            sycl_graph.end_recording(queue);
+        } catch (...) {}
+        BENCHDNN_PRINT(0, "%s %s\n",
+                "[ERROR] SYCL graph execution exception:", e.what());
+        res->state = FAILED;
+        return nullptr;
+    }
+}
+
+// Replay a finalized executable graph. Returns OK on success, FAIL on error.
+inline int replay(::sycl::queue &queue, const sycl_exec_graph_t &exec_graph,
+        res_t *res, bool wait = true) {
+    try {
+        auto event = queue.ext_oneapi_graph(exec_graph);
+        if (wait) event.wait();
+        return OK;
+    } catch (const std::exception &e) {
+        BENCHDNN_PRINT(
+                0, "%s %s\n", "[ERROR] SYCL graph replay exception:", e.what());
+        res->state = FAILED;
+        return FAIL;
+    }
+}
+
+} // namespace sycl_graph_ctx
+#endif // DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
 } // namespace graph
 #endif

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -282,6 +282,22 @@ private:
     std::promise<void> prom_;
 };
 
+// RAII guard that temporarily overrides `execution_mode` and restores the
+// original value when the guard goes out of scope.
+struct execution_mode_guard_t {
+    execution_mode_guard_t(execution_mode_t mode)
+        : saved_mode_(execution_mode) {
+        execution_mode = mode;
+    }
+    ~execution_mode_guard_t() { execution_mode = saved_mode_; }
+
+    execution_mode_guard_t(const execution_mode_guard_t &) = delete;
+    execution_mode_guard_t &operator=(const execution_mode_guard_t &) = delete;
+
+private:
+    execution_mode_t saved_mode_;
+};
+
 // Returns true if SYCL command graph execution mode is active.
 inline bool use_sycl_graph_exec() {
     return is_sycl_engine() && execution_mode == execution_mode_t::graph;


### PR DESCRIPTION
Add SYCL graph recording (--execution-mode=graph) support to benchdnn graph driver.