### PR TITLE
governance: @xiazhuozhao as code owner for rv64 component

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -179,6 +179,7 @@ Team: @uxlfoundation/onednn-cpu-rv64
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Fei Zhang          | @zhangfeiv0           | ISCAS             | Code Owner |
 | Jian Zhang         | @zhangjian29          | ZTE Corporation   | Code Owner |
+| Xia Zhuozhao       | @xiazhuozhao          | ISCAS             | Code Owner |
 
 ### Loongarch64
 


### PR DESCRIPTION
I would like to nominate Xia Zhuozhao @xiazhuozhao for the role of code owner for RISC-V component. Xia has a solid track record of [contributions](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+author%3Axiazhuozhao) over the last 6 months.
