### PR TITLE
benchdnn: graph: support dropout shape rewrite

### DIFF
--- a/tests/benchdnn/graph/flex_rewrite.cpp
+++ b/tests/benchdnn/graph/flex_rewrite.cpp
@@ -1620,6 +1620,7 @@ int flex_rewrite_t::update_output_info(deserialized_op_t &aop,
         case dnnl::graph::op::kind::ConvTransposeBackwardWeights:
         case dnnl::graph::op::kind::Dequantize:
         case dnnl::graph::op::kind::Divide:
+        case dnnl::graph::op::kind::Dropout:
         case dnnl::graph::op::kind::DynamicDequantize:
         case dnnl::graph::op::kind::DynamicQuantize:
         case dnnl::graph::op::kind::Elu:


### PR DESCRIPTION
Before this change, cannot rewrite the in-shapes of a graph containing dropout op.

```
$ ONEDNN_VERBOSE=all ./tests/benchdnn/benchdnn --graph --engine=gpu --in-shapes=1:2x4x256x64+2:2x4x256x64+5:2x4x256x1+0:2x4x256x64+3:2x4x256x64+4:2x4x256x64 --case=1.json
Dropout is not supported
Error: Function 'update_output_info' at (/nfs/pdx/disks/ipl_users/lvtao/oneDNN/tests/benchdnn/graph/flex_rewrite.cpp:1741) returned '1'
Dropout is not supported
Error: Function 'update_output_info' at (/nfs/pdx/disks/ipl_users/lvtao/oneDNN/tests/benchdnn/graph/flex_rewrite.cpp:1741) returned '1'
0:SKIPPED (Invalid case) (110 ms) __REPRO: --graph --engine=gpu --in-shapes=0:2x4x256x64+1:2x4x256x64+2:2x4x256x64+3:2x4x256x64+4:2x4x256x64+5:2x4x256x1 --case=1.json
tests:1 passed:0 skipped:1 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.11s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.00s (0%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```