### PR TITLE
cpu: aarch64: bnorm: improve SVE128 threading

### DIFF
--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -151,33 +151,46 @@ struct jit_bnorm_conf_t {
     bool thread_partition(bool spatial_thr_allowed, int nthr, dim_t N,
             dim_t C_blks, dim_t SP, int &C_nthr, int &N_nthr,
             int &S_nthr) const {
-        if (((nthr <= C_blks) && IMPLICATION(is_nspc_, N == 1))
-                || !dnnl_thr_syncable()) {
+        // For SVE128 NSPC with MB=1 and SP >= 225, force spatial threading
+        // instead of channel threading (currently yields better performance
+        // on certain bnorm shapes)
+        const bool force_sve128_spatial
+                = is_nspc_ && simd_w_ < 8 && N == 1 && SP >= 225;
+
+        if ((((nthr <= C_blks) && IMPLICATION(is_nspc_, N == 1)
+                     && !force_sve128_spatial)
+                    || !dnnl_thr_syncable())) {
             C_nthr = nthr;
             N_nthr = 1;
             S_nthr = 1;
         } else {
             if (is_nspc_) {
                 const int min_c_blks_per_thr = nstl::max(1, 16 / simd_w_);
-                if (C_blks <= 8)
+                if (C_blks <= 8) {
                     C_nthr = 1;
-                else if (simd_w_ < 16 && C_blks % min_c_blks_per_thr == 0) {
+                } else if (simd_w_ < 16 && C_blks % min_c_blks_per_thr == 0) {
                     // Keep each channel thread on a 16-channel boundary.
                     const dim_t C_chunks = C_blks / min_c_blks_per_thr;
                     C_nthr = (int)nstl::min<dim_t>(
                             nstl::min<dim_t>(8, nthr), C_chunks);
                     while (C_nthr > 1 && C_chunks % C_nthr != 0)
                         --C_nthr;
-                } else if (nthr >= 8 && C_blks <= 32)
+                } else if (nthr >= 8 && C_blks <= 32) {
                     C_nthr = 8;
-                else {
+                } else if (simd_w_ < 8) {
+                    // For SVE128 FP32 (simd_w_=4), keep channel threading disabled.
+                    // The plain-layout path still assumes 16-channel grouping:
+                    // plain layouts require padded C % 16 == 0, and channel partitioning
+                    // still assigns work on 16-channel boundaries rather than 4-channel SVE128 lanes.
+                    // This has caused some performance regressions (in cases like mb1ic160ih29iw29)
+                    C_nthr = 1;
+                } else {
                     C_nthr = (int)math::gcd((dim_t)nthr, C_blks);
                     // Unroll by channels in JIT kernel
                     if ((C_nthr == C_blks) || (C_nthr == nthr)) C_nthr = 1;
                 }
+                if (force_sve128_spatial) C_nthr = 1;
                 N_nthr = (int)nstl::min<dim_t>(N, nthr / C_nthr);
-                // heuristic for training on sve512_core_amx
-                // TODO: test heuristic when global stats flag is set
                 S_nthr = (int)nstl::min<dim_t>(SP, nthr / (C_nthr * N_nthr));
             } else {
                 if (do_blocking_) {
@@ -540,7 +553,11 @@ struct jit_bnorm_t : public jit_generator_t {
 
     void uni_store_spat_data(
             const XReg &x, const ZReg &z, bool is_nt_store = false) {
-        stnt1w(z.s, P_ALL_ONE / T_z, ptr(x));
+        if (is_nt_store) {
+            stnt1w(z.s, P_ALL_ONE / T_z, ptr(x));
+        } else {
+            st1w(z.s, P_ALL_ONE / T_z, ptr(x));
+        }
     }
 
     void jump_check(const Label &l_no_mask) {
@@ -1947,14 +1964,7 @@ struct jit_bnorm_t : public jit_generator_t {
     void generate() override {
         preamble();
 
-        size_t simd_w = simd_elems(data_type::f32, isa);
-        if (is_superset(isa, sve)) {
-            if (simd_w != cpu_sveLen / sizeof(float)) {
-                set_preg(P_ALL_ONE.s, simd_w, X_TMP_0, X_TMP_1);
-            }
-
-            prepare_tail_mask();
-        }
+        if (is_superset(isa, sve)) { prepare_tail_mask(); }
 
         compute_static_strides();
 


### PR DESCRIPTION
# Description

This PR builds on @Sqvid's patch #5124 to make bnorm VLA-agnostic. By forcing spatial threading for SVE128 NSPC inference (simd_w<8, N==1, SP>=225) and disabling channel threading by setting C_nthr=1 for simd_w<8 (instead of just narrowing that to MB=1, SP>=225), we observe a 1.332x geometric mean speedup across the entire bnorm benchdnn test suite compared with upstream. This holds true while plain-layout cases still use 16-input-channel grouping.

<img width="1560" height="1280" alt="abba_4var_5x_pr_vs_upstream_chart" src="https://github.com/user-attachments/assets/29941336-a541-499d-8439-7b795f2117e8" />

Overall, mine and Sid's changes have basically delivered a 2x geomean speedup on the benchdnn bnorm cases compared to upstream previously.
<img width="2900" height="1639" alt="abba_4var_5x_summary_chart" src="https://github.com/user-attachments/assets/418b5da4-e4e2-4eac-a330-74ce21f88e69" />

This patch also delivers some other minor improvements:
1. Gates ZReg non-temporal stores on the is_nt_store flag instead of unconditionally emitting stnt1w (because SVE128 NSPC stores are immediately reused and benefit from cacheable st1w) - should deliver a small speedup ~5-10% by taking advantage of cache

~~2. Always initialises P_ALL_ONE in the kernel prologue for SVE ISAs instead of skipping when ISA VL matches HW VL - not related to performance specifically, but this at least avoids the use of an uninitialized predicate register.~~

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?