### PR TITLE
xe: ocl, sycl, l0: unify to use EU count query

### DIFF
--- a/src/gpu/intel/gemm/jit/dsl/runtime.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/runtime.cpp
@@ -172,13 +172,16 @@ dsl::hw_t get_hardware(ze_device_handle_t device, ze_context_handle_t context) {
     ze_result_t status;
     size_t eu_count = 0;
     {
+        auto euCountExt = ze_eu_count_ext_t();
+        euCountExt.stype = ZE_STRUCTURE_TYPE_EU_COUNT_EXT;
+
         auto deviceProps = ze_device_properties_t();
         deviceProps.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+        deviceProps.pNext = &euCountExt;
 
         status = ngen::dynamic::zeDeviceGetProperties(device, &deviceProps);
         if (status != ZE_RESULT_SUCCESS) return {};
-        eu_count = deviceProps.numEUsPerSubslice
-                * deviceProps.numSubslicesPerSlice * deviceProps.numSlices;
+        eu_count = euCountExt.numTotalEUs;
     }
 
     size_t max_wg_size;

--- a/src/gpu/intel/ocl/device_info.cpp
+++ b/src/gpu/intel/ocl/device_info.cpp
@@ -119,7 +119,7 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
     cl_int err = CL_SUCCESS;
     auto device = utils::downcast<const engine_t *>(engine)->device();
 
-    CHECK(get_ocl_device_eu_count(device, gpu_arch_, &eu_count_));
+    CHECK(get_ocl_device_eu_count(device, &eu_count_));
 
     size_t max_wg_size = 0;
     err = xpu::ocl::clGetDeviceInfo(device, CL_DEVICE_MAX_WORK_GROUP_SIZE,

--- a/src/gpu/intel/ocl/utils.cpp
+++ b/src/gpu/intel/ocl/utils.cpp
@@ -30,18 +30,6 @@
 #define CL_KERNEL_BINARY_PROGRAM_INTEL 0x407D
 #endif
 
-#ifndef CL_DEVICE_NUM_SLICES_INTEL
-#define CL_DEVICE_NUM_SLICES_INTEL 0x4252
-#endif
-
-#ifndef CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL
-#define CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL 0x4253
-#endif
-
-#ifndef CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL
-#define CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL 0x4254
-#endif
-
 #ifndef CL_DEVICE_FEATURE_CAPABILITIES_INTEL
 #define CL_DEVICE_FEATURE_CAPABILITIES_INTEL 0x4256
 #endif
@@ -311,47 +299,11 @@ status_t get_ocl_device_enabled_native_float_atomics(
     return status::success;
 }
 
-status_t get_ocl_device_eu_count(cl_device_id device,
-        gpu::intel::compute::gpu_arch_t arch, int32_t *eu_count) {
-    // Start with standard OpenCL query.
+status_t get_ocl_device_eu_count(cl_device_id device, int32_t *eu_count) {
     cl_uint max_compute_units = 0;
     OCL_CHECK(xpu::ocl::clGetDeviceInfo(device, CL_DEVICE_MAX_COMPUTE_UNITS,
             sizeof(max_compute_units), &max_compute_units, nullptr));
-
-    // Try to use Intel-specific slice/sub-slice queries to correct EU count
-    //   for certain buggy drivers.
-    bool ok = true;
-
-#ifdef _WIN32
-    // But don't try this on Windows Xe2 to avoid undercounting EUs.
-    ok &= (arch != gpu::intel::compute::gpu_arch_t::xe2);
-#endif
-
-    auto do_query = [&](cl_uint query) -> cl_uint {
-        cl_uint val = 0;
-        ok = ok
-                && (xpu::ocl::clGetDeviceInfo(
-                            device, query, sizeof(val), &val, nullptr)
-                        == CL_SUCCESS);
-        return val;
-    };
-
-    cl_uint num_slices = do_query(CL_DEVICE_NUM_SLICES_INTEL);
-    cl_uint num_sub_slices_per_slice
-            = do_query(CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL);
-    cl_uint num_eus_per_sub_slice
-            = do_query(CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL);
-
-    if (ok) {
-        /* Some drivers report incorrect values on Xe2 */
-        if (arch == gpu::intel::compute::gpu_arch_t::xe2)
-            num_eus_per_sub_slice = 8;
-        max_compute_units = std::min(max_compute_units,
-                num_slices * num_sub_slices_per_slice * num_eus_per_sub_slice);
-    }
-
     *eu_count = (int32_t)max_compute_units;
-
     return status::success;
 }
 

--- a/src/gpu/intel/ocl/utils.hpp
+++ b/src/gpu/intel/ocl/utils.hpp
@@ -58,8 +58,7 @@ status_t get_ocl_program_binary_size(
 status_t get_kernel_arg_types(cl_kernel ocl_kernel,
         std::vector<gpu::intel::compute::scalar_type_t> *arg_types);
 
-status_t get_ocl_device_eu_count(cl_device_id device,
-        gpu::intel::compute::gpu_arch_t arch, int32_t *eu_count);
+status_t get_ocl_device_eu_count(cl_device_id device, int32_t *eu_count);
 
 status_t get_ocl_device_enabled_systolic_intel(
         cl_device_id device, bool &systolic_enabled);

--- a/src/gpu/intel/sycl/device_info.cpp
+++ b/src/gpu/intel/sycl/device_info.cpp
@@ -19,7 +19,6 @@
 #include "gpu/intel/sycl/engine.hpp"
 
 #include "gpu/intel/ocl/hw_info.hpp"
-#include "gpu/intel/ocl/utils.hpp"
 
 #include "gpu/intel/ze/utils.hpp"
 
@@ -119,22 +118,7 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
     auto &device
             = utils::downcast<const xpu::sycl::engine_impl_t *>(engine->impl())
                       ->device();
-    if (device.is_gpu() && xpu::sycl::is_intel_device(device)) {
-        xpu::sycl::backend_t be = xpu::sycl::get_backend(device);
-        if (be == xpu::sycl::backend_t::opencl) {
-            // XXX: OpenCL backend get_info() queries below are not yet
-            // supported so query OpenCL directly.
-            cl_device_id ocl_dev
-                    = xpu::sycl::compat::get_native<cl_device_id>(device);
-            CHECK(gpu::intel::ocl::get_ocl_device_eu_count(
-                    ocl_dev, gpu_arch_, &eu_count_));
-        } else {
-            eu_count_ = device.get_info<
-                    ::sycl::info::device::max_compute_units>();
-        }
-    } else {
-        eu_count_ = device.get_info<::sycl::info::device::max_compute_units>();
-    }
+    eu_count_ = device.get_info<::sycl::info::device::max_compute_units>();
     max_wg_size_ = device.get_info<::sycl::info::device::max_work_group_size>();
     memory_size_ = device.get_info<::sycl::info::device::global_mem_size>();
     l3_cache_size_

--- a/src/gpu/intel/ze/device_info.cpp
+++ b/src/gpu/intel/ze/device_info.cpp
@@ -94,15 +94,16 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
     auto *ze_engine = utils::downcast<const gpu::intel::ze::engine_t *>(engine);
     auto device = ze_engine->device();
 
+    ze_eu_count_ext_t eu_count_ext = {};
+    eu_count_ext.stype = ZE_STRUCTURE_TYPE_EU_COUNT_EXT;
+
     ze_device_properties_t device_properties = {};
     device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+    device_properties.pNext = &eu_count_ext;
 
     CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
 
-    // Note: for some reason `numTotalEUs` query is not used.
-    eu_count_ = device_properties.numSlices
-            * device_properties.numSubslicesPerSlice
-            * device_properties.numEUsPerSubslice;
+    eu_count_ = eu_count_ext.numTotalEUs;
 
     ze_device_compute_properties_t device_compute_properties = {};
     device_compute_properties.stype


### PR DESCRIPTION
See background in [MFDNN-15042](https://jira.devtools.intel.com/browse/MFDNN-15042).

The existing code relies on calculation using the number of slices and sub-slices. However these queries return the max value by [spec](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/api.html#_CPPv4N22ze_device_properties_t20numSubslicesPerSliceE) and not the real value so it's not a reliable way to compute the EU count.

~Opening as a draft now - need to test a 56-EU Xe2 (as the old code mentions issues with this SKU) to confirm if the new queries work as expected with newer drivers.~ Checked the previous PRs and Jiras - the related issues with driver queries were resolved ~1.5 years ago. It should be sufficient time for users to update their drivers.