### PR TITLE
benchdnn: parser: fix str2bool

### DIFF
--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -246,7 +246,7 @@ class Converter(metaclass=ConverterMeta):
         else:
             result += ":0"
         if dropout.use_host_scalars:
-            result += f":{dropout.use_host_scalars}"
+            result += f":{dropout.use_host_scalars:d}"
         return f"--attr-dropout={result}"
 
     deterministic = attribute_flag("deterministic")

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -32,6 +32,7 @@
 
 #include "utils/fill.hpp"
 #include "utils/parallel.hpp"
+#include "utils/parser.hpp"
 
 /* result structure */
 const char *state2str(res_state_t state) {
@@ -619,8 +620,7 @@ std::string benchdnn_getenv_string(const char *name) {
     const int len = 128;
     char value_str[len];
     if (getenv(name, value_str, len) > 0) { value = value_str; }
-    std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-    return value;
+    return parser::utils::lowercase(value);
 }
 
 std::string smart_bytes(double bytes) {

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -173,9 +173,8 @@ const char *attr_t::policy2str(policy_t policy) {
 }
 
 dnnl_rounding_mode_t str2rounding_mode(const std::string &str) {
-    std::string s(str);
     // s.compare is lexicographical, case matters
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    auto s = parser::utils::lowercase(str);
 #define CASE(_rm) \
     if (s.compare(STRINGIFY(_rm)) == 0) return dnnl_rounding_mode_##_rm
     CASE(environment);
@@ -693,9 +692,8 @@ static po_table_entry_t kind_table[] = {
         {pk_t::KIND_TOTAL, {"kind_undef"}, dnnl_alg_kind_undef}};
 
 pk_t attr_t::post_ops_t::str2kind(const std::string &str) {
-    std::string s(str);
     // string::operator== is lexicographical, case matters
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    auto s = parser::utils::lowercase(str);
     for (const auto &e : kind_table) {
         for (const auto &name : e.kind_names) {
             if (s == name) return e.kind;

--- a/tests/benchdnn/reorder/reorder_aux.cpp
+++ b/tests/benchdnn/reorder/reorder_aux.cpp
@@ -30,8 +30,7 @@ flag_t str2flag(const char *str) {
 
     size_t start_pos = 0;
     // format of single entry is `flag_bit:mask`
-    auto sub = parser::get_substr(s, start_pos, ':');
-    std::transform(sub.begin(), sub.end(), sub.begin(), ::tolower);
+    auto sub = parser::utils::lowercase(parser::get_substr(s, start_pos, ':'));
 
     flag_bit_t flag = FLAG_NONE;
     if (sub.compare("s8s8_comp") == 0)

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -83,6 +83,12 @@ bool has_only_digits(const std::string &s) {
     });
 }
 
+std::string lowercase(const std::string &s) {
+    std::string s_low(s);
+    std::transform(s.begin(), s.end(), s_low.begin(), ::tolower);
+    return s_low;
+}
+
 // Covers all integer parsing routines: `atoi`, `atol, `atoll`, `stoi`, `stol`.
 int64_t stoll_safe(const std::string &s) {
     int64_t value = 0;

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -682,10 +682,11 @@ cold_cache_input_t str2cold_cache_input(const std::string &s) {
     return c;
 }
 
-bool str2bool(const std::string &s) {
-    if (s == "1" || s == "true" || s == "TRUE") {
+bool str2bool(const std::string &str) {
+    auto s = utils::lowercase(str);
+    if (s == "1" || s == "true") {
         return true;
-    } else if (s == "0" || s == "false" || s == "FALSE") {
+    } else if (s == "0" || s == "false") {
         return false;
     } else {
         BENCHDNN_PRINT(0,

--- a/tests/benchdnn/utils/parser.hpp
+++ b/tests/benchdnn/utils/parser.hpp
@@ -59,6 +59,8 @@ inline bool option_matched(const std::string &option_str, const char *str) {
             && option_str.find(str, 0, option_str.size()) != std::string::npos;
 }
 
+std::string lowercase(const std::string &s);
+
 } // namespace utils
 
 namespace parsers {


### PR DESCRIPTION
[MFDNN-15049](https://jira.devtools.intel.com/browse/MFDNN-15049)

Python backstabbed str2bool with its `True` value put into dropout entries.