### PR TITLE
common, cpu: random fixes and updates

### DIFF
--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -508,20 +508,40 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
                     pr_dt == data_type::s32, VERBOSE_UNSUPPORTED_PR_CFG);
 
             if (!pr.get(DNNL_ARG_SRC).has_default_groups()) {
+                const auto &sc = attr->scales_;
                 const dim_t src_pr_group_k = pr.get_group(DNNL_ARG_SRC, 1);
 
+                // Pre-computed reductions can only be used when the PR group
+                // size is the minimal amongst all group sizes along the K
+                // dimension from a mathematical point of view.
+                dim_t minimal_group = INT64_MAX;
                 dim_t wei_zp_group_k = 1;
                 if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
-                    const int mask_wei = zp.get_mask(DNNL_ARG_WEIGHTS);
-                    if (mask_wei & wei_qmask_K)
-                        wei_zp_group_k = zp.get_group(DNNL_ARG_WEIGHTS, 0);
+                    wei_zp_group_k = zp.get_group(DNNL_ARG_WEIGHTS, -2);
+                    minimal_group = std::min(minimal_group, wei_zp_group_k);
+                }
+                if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
+                    auto src_zp_group_k = zp.get_group(DNNL_ARG_SRC, -1);
+                    minimal_group = std::min(minimal_group, src_zp_group_k);
+                }
+                if (!sc.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
+                    auto wei_sc_group_k = sc.get_group(DNNL_ARG_WEIGHTS, -2);
+                    minimal_group = std::min(minimal_group, wei_sc_group_k);
+                }
+                if (!sc.get(DNNL_ARG_SRC).has_default_groups()) {
+                    auto src_sc_group_k = sc.get_group(DNNL_ARG_SRC, -1);
+                    minimal_group = std::min(minimal_group, src_sc_group_k);
                 }
 
                 const bool groups_are_divisible = quant_groups_are_divisible(
                         src_pr_group_k, wei_zp_group_k);
-                VCHECK_MATMUL_UNIMPL(
-                        IMPLICATION(src_pr_group_k > 1,
-                                src_is_int8 && groups_are_divisible),
+                VCHECK_MATMUL(IMPLICATION(src_pr_group_k > 1, src_is_int8),
+                        VERBOSE_UNSUPPORTED_PR_CFG);
+                VCHECK_MATMUL(
+                        IMPLICATION(src_pr_group_k > 1, groups_are_divisible),
+                        VERBOSE_UNSUPPORTED_PR_CFG);
+                VCHECK_MATMUL(IMPLICATION(src_pr_group_k > 1,
+                                      src_pr_group_k <= minimal_group),
                         VERBOSE_UNSUPPORTED_PR_CFG);
             }
         }

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -400,7 +400,7 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
     if (!attr->zero_points_.has_default_values()) {
         const auto &zp = attr->zero_points_;
 
-        dim_t src_zero_point_group_k = 1;
+        dim_t src_zp_group_k = 1;
         if (!zp.has_default_values(DNNL_ARG_SRC)) {
             const int mask_src = zp.get_mask(DNNL_ARG_SRC);
 
@@ -410,19 +410,19 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
 
             if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
                 if (mask_src & src_qmask_K)
-                    src_zero_point_group_k = zp.get_group(DNNL_ARG_SRC, 1);
+                    src_zp_group_k = zp.get_group(DNNL_ARG_SRC, 1);
             }
 
             // Due to hardware specifics, groups, when more than 1, should be
             // multiple of 32.
-            VCHECK_MATMUL_UNIMPL(IMPLICATION(src_zero_point_group_k > 1
-                                                 && src_zero_point_group_k < K,
-                                         src_zero_point_group_k % 32 == 0),
+            VCHECK_MATMUL_UNIMPL(
+                    IMPLICATION(src_zp_group_k > 1 && src_zp_group_k < K,
+                            src_zp_group_k % 32 == 0),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         }
 
-        dim_t wei_zero_point_group_k = 1;
-        dim_t wei_zero_point_group_n = 1;
+        dim_t wei_zp_group_k = 1;
+        dim_t wei_zp_group_n = 1;
         if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
             const int mask_wei = zp.get_mask(DNNL_ARG_WEIGHTS);
 
@@ -430,38 +430,36 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
 
             if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
                 if (mask_wei & wei_qmask_K)
-                    wei_zero_point_group_k = zp.get_group(DNNL_ARG_WEIGHTS, 0);
+                    wei_zp_group_k = zp.get_group(DNNL_ARG_WEIGHTS, 0);
                 if (mask_wei & wei_qmask_N)
-                    wei_zero_point_group_n = zp.get_group(DNNL_ARG_WEIGHTS, 1);
+                    wei_zp_group_n = zp.get_group(DNNL_ARG_WEIGHTS, 1);
             }
 
             // Groups per N are solely for weights decompression as it's
             // impossible to get performant kernel for a single `k` element in
             // chain for regular quantized case.
-            VCHECK_MATMUL_UNIMPL(IMPLICATION(wei_zero_point_group_n > 1,
+            VCHECK_MATMUL_UNIMPL(IMPLICATION(wei_zp_group_n > 1,
                                          attr->fpmath_.apply_to_int_),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
 
             // Due to hardware specifics, groups, when more than 1, should be
             // multiple of 16.
-            VCHECK_MATMUL_UNIMPL(IMPLICATION(wei_zero_point_group_k > 1
-                                                 && wei_zero_point_group_k < K,
-                                         wei_zero_point_group_k % 16 == 0),
+            VCHECK_MATMUL_UNIMPL(
+                    IMPLICATION(wei_zp_group_k > 1 && wei_zp_group_k < K,
+                            wei_zp_group_k % 16 == 0),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
-            VCHECK_MATMUL_UNIMPL(IMPLICATION(wei_zero_point_group_n > 1
-                                                 && wei_zero_point_group_n < N,
-                                         wei_zero_point_group_n % 16 == 0),
+            VCHECK_MATMUL_UNIMPL(
+                    IMPLICATION(wei_zp_group_n > 1 && wei_zp_group_n < N,
+                            wei_zp_group_n % 16 == 0),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
 
             if (utils::one_of(zp.get_data_type(DNNL_ARG_WEIGHTS), data_type::s4,
                         data_type::u4)) {
-                dim_t k = desc.weights_desc.dims[ndims_wei - 2];
-                dim_t n = desc.weights_desc.dims[ndims_wei - 1];
                 VCHECK_MATMUL_UNIMPL(
-                        IMPLICATION(mask_wei & wei_qmask_K, k % 2 == 0),
+                        IMPLICATION(mask_wei & wei_qmask_K, K % 2 == 0),
                         VERBOSE_UNSUPPORTED_ZP_CFG);
                 VCHECK_MATMUL_UNIMPL(
-                        IMPLICATION(mask_wei & wei_qmask_N, n % 2 == 0),
+                        IMPLICATION(mask_wei & wei_qmask_N, N % 2 == 0),
                         VERBOSE_UNSUPPORTED_ZP_CFG);
             }
         }
@@ -477,9 +475,9 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
         // Check dependency between zero_points.
         // Source zero_points groups are supported for int8 source and must
         // divide or be divided by weights groups when both are greater than 1.
-        const bool groups_are_divisible = quant_groups_are_divisible(
-                src_zero_point_group_k, wei_zero_point_group_k);
-        VCHECK_MATMUL_UNIMPL(IMPLICATION(src_zero_point_group_k > 1,
+        const bool groups_are_divisible
+                = quant_groups_are_divisible(src_zp_group_k, wei_zp_group_k);
+        VCHECK_MATMUL_UNIMPL(IMPLICATION(src_zp_group_k > 1,
                                      src_is_int8 && groups_are_divisible),
                 VERBOSE_UNSUPPORTED_ZP_CFG);
     }
@@ -512,16 +510,15 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
             if (!pr.get(DNNL_ARG_SRC).has_default_groups()) {
                 const dim_t src_pr_group_k = pr.get_group(DNNL_ARG_SRC, 1);
 
-                dim_t wei_zero_point_group_k = 1;
+                dim_t wei_zp_group_k = 1;
                 if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
                     const int mask_wei = zp.get_mask(DNNL_ARG_WEIGHTS);
                     if (mask_wei & wei_qmask_K)
-                        wei_zero_point_group_k
-                                = zp.get_group(DNNL_ARG_WEIGHTS, 0);
+                        wei_zp_group_k = zp.get_group(DNNL_ARG_WEIGHTS, 0);
                 }
 
                 const bool groups_are_divisible = quant_groups_are_divisible(
-                        src_pr_group_k, wei_zero_point_group_k);
+                        src_pr_group_k, wei_zp_group_k);
                 VCHECK_MATMUL_UNIMPL(
                         IMPLICATION(src_pr_group_k > 1,
                                 src_is_int8 && groups_are_divisible),

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -644,8 +644,10 @@ status_t dnnl_primitive_attr_set_scales_v3(primitive_attr_t *attr, int arg,
                         quantization_mode::dynamic_mx,
                         quantization_mode::dynamic_fp),
             VERBOSE_BAD_PARAM, "qmode");
-    VCHECK_ATTR(
-            utils::one_of(data_type, f32, bf16, f16, e8m0, f8_e5m2, f8_e4m3),
+    VCHECK_ATTR(utils::one_of(data_type, f32, bf16, f16, e8m0, f8_e4m3),
+            VERBOSE_INVALID_DATATYPE, "scales");
+    // A single low-precision scale is not expected as they work per group.
+    VCHECK_ATTR(IMPLICATION(utils::one_of(data_type, e8m0, f8_e4m3), mask > 0),
             VERBOSE_INVALID_DATATYPE, "scales");
     VCHECK_ATTR(
             IMPLICATION(group_ndims, validate_dims(group_ndims, group_dims)),

--- a/src/cpu/matmul/ref_matmul_int8.cpp
+++ b/src/cpu/matmul/ref_matmul_int8.cpp
@@ -222,6 +222,17 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
                 const auto wei_zp = io::load_int_value(
                         wei_zp_dt, wei_zero_points, wei_zp_offset);
                 acc -= src_pr * wei_zp;
+
+                // If both zero-points are defined, need to append cross-zp
+                // compensation times the reduction chain.
+                if (with_src_zero_points) {
+                    const dim_t src_zp_offset = matmul_helper_t::get_quant_off(
+                            src_dims_idx, ndims, src_zp_mask, 1, src_zp_group_k,
+                            src_zp_md);
+                    const auto src_zp = io::load_int_value(
+                            src_zp_dt, src_zero_points, src_zp_offset);
+                    acc += group_k * wei_zp * src_zp;
+                }
             }
 
             // Apply scaling after computing a group.

--- a/src/cpu/matmul/ref_matmul_int8.hpp
+++ b/src/cpu/matmul/ref_matmul_int8.hpp
@@ -76,7 +76,7 @@ struct ref_matmul_int8_t : public primitive_t {
             VDISPATCH_MATMUL(ref_post_ops_t::post_ops_ok(attr()->post_ops_),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_MATMUL(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
-            VDISPATCH_MATMUL(attr_zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok(engine));
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_MATMUL(
                     attr_.set_default_formats(dst_md(0)) == status::success,
@@ -86,46 +86,45 @@ struct ref_matmul_int8_t : public primitive_t {
         }
 
     private:
-        bool attr_zero_points_ok() const {
+        status_t attr_zero_points_ok(engine_t *engine) const {
             const auto &zp = attr()->zero_points_;
             if (!zp.has_default_values(DNNL_ARG_SRC)) {
                 int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                bool ok = utils::one_of(mask_src, 0, src_qmask_K(),
-                        src_qmask_M() + src_qmask_K());
-                if (!ok) return false;
+                VDISPATCH_MATMUL(utils::one_of(mask_src, 0, src_qmask_K(),
+                                         src_qmask_M() + src_qmask_K()),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
 
                 if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
                     const auto gM = zp.get_group(DNNL_ARG_SRC, 0);
-                    ok = gM == 1;
-                    if (!ok) return false;
+                    VDISPATCH_MATMUL(gM == 1, VERBOSE_UNSUPPORTED_ZP_CFG);
 
                     const auto gK = zp.get_group(DNNL_ARG_SRC, 1);
-                    ok = IMPLICATION(gK > 1, K() % gK == 0);
-                    if (!ok) return false;
+                    VDISPATCH_MATMUL(IMPLICATION(gK > 1, K() % gK == 0),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
                 }
             }
             /* weights decompression requires zero points support */
             if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
                 if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
                     const auto gK = zp.get_group(DNNL_ARG_WEIGHTS, 0);
-                    bool ok = IMPLICATION(gK > 1, K() % gK == 0);
-                    if (!ok) return false;
+                    VDISPATCH_MATMUL(IMPLICATION(gK > 1, K() % gK == 0),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
 
                     const auto gN = zp.get_group(DNNL_ARG_WEIGHTS, 1);
-                    ok = IMPLICATION(gN > 1, N() % gN == 0);
-                    if (!ok) return false;
+                    VDISPATCH_MATMUL(IMPLICATION(gN > 1, N() % gN == 0),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
 
                     // Only one non-unit group is supported.
-                    ok = utils::one_of(1, gK, gN);
-                    if (!ok) return false;
+                    VDISPATCH_MATMUL(utils::one_of(1, gK, gN),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
                 }
             }
             if (!zp.has_default_values(DNNL_ARG_DST)) {
                 int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                bool ok = utils::one_of(mask_dst, 0, wei_qmask_N());
-                if (!ok) return false;
+                VDISPATCH_MATMUL(utils::one_of(mask_dst, 0, wei_qmask_N()),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
             }
-            return true;
+            return status::success;
         }
     };
 

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -468,10 +468,9 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
 
     const auto &src_scales = attr->scales_.get(DNNL_ARG_SRC);
     const auto &wei_scales = attr->scales_.get(DNNL_ARG_WEIGHTS);
-    brg->with_src_scales
-            = !brg->skip_scales && !src_scales.has_default_values();
+    brg->with_src_scales = !src_scales.has_default_values();
     brg->with_wei_scales
-            = !brg->skip_scales && !wei_scales.has_default_values();
+            = !brg->skip_wei_scales && !wei_scales.has_default_values();
     if (brg->with_wei_scales) {
         // Note. the current version supports only two different wei scales
         // types:
@@ -811,7 +810,7 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(zp_type_b);
     CMP_BRGEMM_FIELD(zp_type_c);
 
-    CMP_BRGEMM_FIELD(skip_scales);
+    CMP_BRGEMM_FIELD(skip_wei_scales);
     CMP_BRGEMM_FIELD(is_oc_scale);
     CMP_BRGEMM_FIELD(with_src_scales);
     CMP_BRGEMM_FIELD(with_wei_scales);

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -303,8 +303,9 @@ struct brgemm_desc_t {
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_c = brgemm_broadcast_t::none;
 
-    // `skip_scales` is controlled by the implementation and not by kernel API.
-    bool skip_scales = false;
+    // `skip_wei_scales` is controlled by the implementation and not by kernel
+    // API.
+    bool skip_wei_scales = false;
     int is_oc_scale = 0;
     bool with_src_scales = false;
     bool with_wei_scales = false;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -392,7 +392,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         auto LDD = bgmmc_.LDD;
         if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
             brg.skip_zp_b_compensation = true;
-        if (bgmmc_.apply_scales_in_buffer_b) brg.skip_scales = true;
+        if (bgmmc_.apply_scales_in_buffer_b) brg.skip_wei_scales = true;
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2292,8 +2292,8 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.has_zero_point_b = bgmmc.wei_zp_type != brgemm_broadcast_t::none;
     bgmmc.has_zero_point_c = bgmmc.dst_zp_type != brgemm_broadcast_t::none;
     bgmmc.post_ops_applicable = one_of(true, bgmmc.with_sum, bgmmc.with_bias,
-            (bgmmc.with_src_scales || bgmmc.with_wei_scales)
-                    && !bgmmc.apply_scales_in_buffer_b,
+            bgmmc.with_src_scales,
+            bgmmc.with_wei_scales && !bgmmc.apply_scales_in_buffer_b,
             bgmmc.with_eltwise, bgmmc.with_binary, bgmmc.acc_dt != bgmmc.dst_dt,
             bgmmc.s8s8_compensation_required, bgmmc.has_zero_point_a,
             bgmmc.has_zero_point_b && !bgmmc.with_wei_decompression,

--- a/tests/benchdnn/inputs/matmul/option_set_fp8_mixed
+++ b/tests/benchdnn/inputs/matmul/option_set_fp8_mixed
@@ -123,5 +123,5 @@
 --reset
 --stag=abx --wtag=abx,any --dtag=abx
 --dt=f8_e4m3:f8_e4m3:f32,f8_e4m3:f8_e4m3:bf16
---attr-scales=src:per_tensor:f8_e5m2:1x128+wei:per_tensor:f8_e5m2:128x128,src:per_tensor:f16:32x32+wei:per_tensor:f8_e5m2:32x32
+--attr-scales=src:per_tensor:f8_e4m3:1x128+wei:per_tensor:f8_e4m3:128x128,src:per_tensor:f16:32x32+wei:per_tensor:f8_e4m3:32x32
 --batch=shapes_2d_attr

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -111,14 +111,6 @@
 # Decompression flavors
 --batch=harness_matmul_decompression
 
-### dst scaling with e8m0
---reset
---dt=bf16,f16
---attr-scales=dst:common:2:e8m0,dst:common:0.25:e8m0
-4x256:256x64
-6x256:256x100
-
-
 # Test bf32, tf32 data type configuration
 --reset
 --skip-impl=ref,x64:gemm

--- a/tests/benchdnn/inputs/matmul/test_matmul_fp4
+++ b/tests/benchdnn/inputs/matmul/test_matmul_fp4
@@ -37,5 +37,5 @@
 --reset
 --stag=abx --wtag=abx,any --dtag=abx
 --dt=f4_e2m1:f4_e2m1:f32,f4_e2m1:f4_e2m1:bf16,f8_e5m2:f4_e2m1:bf16
---attr-scales=src:per_tensor:f8_e5m2:1x128+wei:per_tensor:f8_e5m2:128x128,src:per_tensor:f16:32x32+wei:per_tensor:f8_e5m2:32x32
+--attr-scales=src:per_tensor:f8_e4m3:1x128+wei:per_tensor:f8_e4m3:128x128,src:per_tensor:f16:32x32+wei:per_tensor:f8_e4m3:32x32
 --batch=shapes_2d_attr


### PR DESCRIPTION
Fixes and updates for random spots found during generated coverage testing.

* Restricting e8m0 and e4m3 scales data types to be used with multiple values only as they are part of scaling policies that assume grouping.
* Fixing brgemm kernel and brg_matmul for WoQ cases with a common src_scale.
* Fixing API and ref impl to work properly with precomputed reductions.