### PR TITLE
cpu: rv64: matmul: add brgemm matmul for rv64 platform

### DIFF
--- a/src/cpu/matmul/cpu_matmul_list.cpp
+++ b/src/cpu/matmul/cpu_matmul_list.cpp
@@ -46,6 +46,7 @@ using namespace dnnl::impl::cpu::aarch64::matmul;
 using namespace dnnl::impl::cpu::aarch64;
 #elif DNNL_RV64
 #ifdef DNNL_RISCV_USE_RVV_INTRINSICS
+#include "cpu/rv64/rvv_brgemm_matmul.hpp"
 #include "cpu/rv64/rvv_matmul.hpp"
 using namespace dnnl::impl::cpu::rv64::matmul;
 using namespace dnnl::impl::cpu::rv64;
@@ -83,6 +84,7 @@ constexpr impl_list_item_t impl_list[] = REG_MATMUL_P({
         CPU_INSTANCE_AVX2(brgemm_matmul_t<avx2_vnni_2>)
         CPU_INSTANCE_AVX2(brgemm_matmul_t<avx2_vnni>)
         CPU_INSTANCE_AVX2(brgemm_matmul_t<avx2>)
+        CPU_INSTANCE_RV64GCV(rvv_brgemm_matmul_t)
         CPU_INSTANCE_RV64GCV(rvv_matmul_t)
         CPU_INSTANCE(gemm_f32_matmul_t)
         CPU_INSTANCE(gemm_bf16_matmul_t<f32>)

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -150,13 +150,13 @@ protected:
 // ---------------------------------------------------------------------------
 struct jit_bias_postops_row_t : public jit_generator_t {
     // bias_type: 0=none, 1=scalar broadcast, 2=per-element vector
-    // postop: 0=none, 1=relu
     struct call_params_t {
         float *row_dst; // offset 0
         dim_t N; // offset 8
         const float *bias_ptr; // offset 16
         int32_t bias_type; // offset 24
         int32_t postop; // offset 28
+        float postop_alpha; // offset 32
     };
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_bias_postops_row_t)
@@ -185,9 +185,12 @@ protected:
         const Reg reg_postop = t4;
 
         const FReg f_bias_scalar = fa0;
-        const FReg f_zero = fa1;
-        const VReg v_acc(0);
-        const VReg v_bias(1);
+        const FReg f_alpha = fa1;
+        const FReg f_zero = fa2;
+        const VReg v_acc(1);
+        const VReg v_bias(2);
+        const VReg v_neg(3);
+        const VReg v_orig(4);
 
         // Load parameters
         ld(reg_dst, reg_param, 0);
@@ -196,7 +199,9 @@ protected:
         lw(reg_bias_type, reg_param, 24);
         lw(reg_postop, reg_param, 28);
 
-        // Prepare f_zero = 0.0 for ReLU
+        // Load alpha for Leaky ReLU
+        flw(f_alpha, reg_param, 32);
+
         xor_(reg_tmp, reg_tmp, reg_tmp);
         fmv_w_x(f_zero, reg_tmp);
 
@@ -235,10 +240,19 @@ protected:
 
         L(after_bias);
 
-        // Post-op: ReLU (max(acc, 0))
-        Label postop_done;
+        // Post-op: ReLU with negative slope alpha
+        Label postop_done, leaky_relu;
         beqz(reg_postop, postop_done);
+        vmv_v_v(v_orig, v_acc);
+        fmv_x_w(reg_tmp, f_alpha);
+        bnez(reg_tmp, leaky_relu);
         vfmax_vf(v_acc, v_acc, f_zero);
+        j_(postop_done);
+
+        L(leaky_relu);
+        vmfgt_vf(VReg(0), v_orig, f_zero);
+        vfmul_vf(v_neg, v_orig, f_alpha);
+        vmerge_vvm(v_acc, v_neg, v_orig);
         L(postop_done);
 
         // Store result
@@ -494,11 +508,13 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
     const dim_t *src_dims_ptr = src_d.dims();
     const dim_t dst_batch_stride = M * N;
 
-    // Determine postop type for JIT kernel
     int32_t postop = 0;
+    float postop_alpha = 0.f;
     if (post_ops.len() > 0 && post_ops.entry_[0].is_eltwise()
-            && post_ops.entry_[0].eltwise.alg == alg_kind::eltwise_relu)
+            && post_ops.entry_[0].eltwise.alg == alg_kind::eltwise_relu) {
         postop = 1;
+        postop_alpha = post_ops.entry_[0].eltwise.alpha;
+    }
 
     parallel_nd(batch, [&](dim_t b) {
         float *dst_base = dst + b * dst_batch_stride;
@@ -553,6 +569,7 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
             bp.bias_ptr = bias_ptr;
             bp.bias_type = bias_type;
             bp.postop = postop;
+            bp.postop_alpha = postop_alpha;
             (*bias_postops_kernel)(&bp);
         }
     });

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -1,0 +1,348 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_desc_wrapper.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "common/verbose.hpp"
+
+#include "cpu/platform.hpp"
+#include "cpu/rv64/rvv_brgemm_matmul.hpp"
+#include "cpu/rv64/rvv_postops.hpp"
+
+#include <riscv_vector.h>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace matmul {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::utils;
+using namespace data_type;
+
+// Pack bd rows × K_inner columns from col-major A (with LDA_orig) into
+// contiguous workspace with LDA=bd.
+static void pack_a_tile(float *ws, const float *A, dim_t LDA_orig, dim_t bd,
+        dim_t valid_rows, dim_t K_inner) {
+    for (dim_t k = 0; k < K_inner; k++) {
+        const float *A_col = A + k * LDA_orig;
+        float *ws_row = ws + k * bd;
+        dim_t i = 0;
+        while (i < valid_rows) {
+            size_t vl = __riscv_vsetvl_e32m1(valid_rows - i);
+            vfloat32m1_t v = __riscv_vle32_v_f32m1(A_col + i, vl);
+            __riscv_vse32_v_f32m1(ws_row + i, v, vl);
+            i += vl;
+        }
+    }
+}
+
+status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
+    using smask_t = primitive_attr_t::skip_mask_t;
+
+    VDISPATCH_MATMUL(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+
+    VDISPATCH_MATMUL(dnnl_get_max_threads() <= 1, VERBOSE_IMPL_HEURISTIC_FAIL,
+            "brgemm matmul is single-thread only");
+
+    VDISPATCH_MATMUL(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+
+    const memory_desc_wrapper src_mdw(src_md(0));
+    const memory_desc_wrapper wei_mdw(weights_md(0));
+    const memory_desc_wrapper dst_mdw(dst_md(0));
+    const memory_desc_wrapper bias_mdw = bias_md_;
+
+    VDISPATCH_MATMUL(!src_mdw.has_runtime_dims_or_strides()
+                    && !wei_mdw.has_runtime_dims_or_strides()
+                    && !dst_mdw.has_runtime_dims_or_strides()
+                    && !bias_mdw.has_runtime_dims_or_strides(),
+            VERBOSE_UNSUPPORTED_TAG);
+
+    const bool types_ok = src_mdw.data_type() == f32
+            && wei_mdw.data_type() == f32 && dst_mdw.data_type() == f32
+            && IMPLICATION(!bias_mdw.is_zero(), bias_mdw.data_type() == f32)
+            && desc()->accum_data_type == f32;
+    VDISPATCH_MATMUL(types_ok, VERBOSE_UNSUPPORTED_DT);
+
+    VDISPATCH_MATMUL(attr()->has_default_values(smask_t::post_ops, f32),
+            VERBOSE_UNSUPPORTED_ATTR);
+
+    VDISPATCH_MATMUL(rvv_postops_t::post_ops_ok(attr()->post_ops_),
+            VERBOSE_UNSUPPORTED_POSTOP);
+
+    VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
+
+    const int ndims = src_mdw.ndims();
+    const int wei_ndims = wei_mdw.ndims();
+
+    // Plain dense tensors
+    VDISPATCH_MATMUL(src_mdw.blocking_desc().inner_nblks == 0
+                    && wei_mdw.blocking_desc().inner_nblks == 0
+                    && dst_mdw.blocking_desc().inner_nblks == 0,
+            VERBOSE_UNSUPPORTED_TAG);
+
+    // All tensors must be dense row-major (full stride chain verified).
+    // Weights must be row-major; col-major would require transpose which
+    // is not yet supported with copy_A packing.
+    VDISPATCH_MATMUL(is_row_major(src_mdw), VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_MATMUL(is_row_major(dst_mdw), VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_MATMUL(is_row_major(wei_mdw), VERBOSE_UNSUPPORTED_TAG);
+
+    // Check bias
+    if (!bias_mdw.is_zero()) {
+        VDISPATCH_MATMUL(bias_mdw.data_type() == f32, VERBOSE_UNSUPPORTED_DT);
+        const int bias_ndims = bias_mdw.ndims();
+        const auto *bias_dims = bias_mdw.dims();
+        const auto *dst_dims = dst_mdw.dims();
+        const int dst_ndims = dst_mdw.ndims();
+        VDISPATCH_MATMUL(bias_ndims <= dst_ndims, VERBOSE_UNSUPPORTED_BIAS_CFG);
+        for (int d = 1; d <= bias_ndims; ++d) {
+            dim_t bias_dim = bias_dims[bias_ndims - d];
+            dim_t dst_dim = dst_dims[dst_ndims - d];
+            VDISPATCH_MATMUL(bias_dim == 1 || bias_dim == dst_dim,
+                    VERBOSE_UNSUPPORTED_BIAS_CFG);
+        }
+    }
+
+    // Check weight broadcast
+    {
+        bool bc_ok = true;
+        for (int i = 0; i < wei_ndims - 2; ++i) {
+            if (src_mdw.dims()[i] != wei_mdw.dims()[i]
+                    && wei_mdw.dims()[i] != 1) {
+                bc_ok = false;
+                break;
+            }
+        }
+        VDISPATCH_MATMUL(bc_ok, VERBOSE_UNSUPPORTED_TAG);
+    }
+
+    // Extract dimensions (same as rvv_matmul.cpp)
+    const dim_t *src_dims = src_mdw.dims();
+    const dim_t *wei_dims = wei_mdw.dims();
+
+    batch_ = 1;
+    for (int i = 0; i < ndims - 2; ++i)
+        batch_ *= src_dims[i];
+
+    M_ = src_dims[ndims - 2];
+    K_ = src_dims[ndims - 1];
+    N_ = wei_dims[wei_ndims - 1];
+
+    dim_t weights_batch_size = 1;
+    for (int i = 0; i < wei_ndims - 2; ++i)
+        weights_batch_size *= wei_dims[i];
+    weights_are_broadcast_ = (weights_batch_size == 1 && batch_ > 1);
+
+    // Shape guards
+    VDISPATCH_MATMUL(weights_are_broadcast_, VERBOSE_IMPL_HEURISTIC_FAIL,
+            "weights are not broadcast across batch");
+    VDISPATCH_MATMUL(
+            N_ >= 16, VERBOSE_IMPL_HEURISTIC_FAIL, "N too small for brgemm");
+
+    // BRGEMM's copy_A packing reads A sequentially (stride bd_block) while
+    // GEMM reads A with stride N. When A exceeds L2 cache, sequential reads
+    // from DRAM are ~2x faster than strided reads. Two conditions ensure
+    // BRGEMM is beneficial:
+    // 1. K >= 4096: K-blocking amortizes packing overhead
+    // 2. A exceeds L2: N * K * 4 > L2_size
+    // 3. batch * M >= 128: BRGEMM kernel's N-loop needs enough iterations
+    //    to pipeline efficiently; fewer causes regression (benchmarked).
+    const dim_t A_bytes = N_ * K_ * (dim_t)sizeof(float);
+    const auto L2_bytes = platform::get_per_core_cache_size(3);
+    VDISPATCH_MATMUL(K_ >= 4096 && A_bytes > L2_bytes && batch_ * M_ >= 128,
+            VERBOSE_IMPL_HEURISTIC_FAIL,
+            "shape not beneficial for brgemm matmul");
+
+    // Compute blocking parameters
+    const int vlen_f32 = get_platform_vlen() / 32;
+    const int bd_block = vlen_f32 * 4; // LMUL=m4
+    const dim_t M_brg = N_;
+    const dim_t K_brg = K_;
+    const dim_t LDA = bd_block; // packed stride (not N)
+    const dim_t LDB = K_;
+    const dim_t LDC = N_;
+    const dim_t N_brg = batch_ * M_;
+
+    brgemm_desc_t brg_desc;
+    CHECK(brgemm_desc_init(&brg_desc, v, brgemm_strd, f32, f32,
+            brgemm_col_major, 1.0f, 0.0f, LDA, LDB, LDC, M_brg, N_brg, K_brg));
+
+    brgemm_kernel_t *kernel = nullptr;
+    CHECK(brgemm_kernel_create(&kernel, brg_desc));
+    brg_kernel_.reset(kernel);
+
+    init_scratchpad();
+
+    return status::success;
+}
+
+void rvv_brgemm_matmul_t::pd_t::init_scratchpad() {
+    using namespace memory_tracking::names;
+    const auto &brg = brg_kernel_->get_brg();
+    auto scratchpad = scratchpad_registry().registrar();
+    scratchpad.template book<float>(
+            key_brgemm_primitive_buffer_a, brg.bd_block * K_);
+}
+
+status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
+    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const float *, DNNL_ARG_WEIGHTS);
+    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
+
+    const dim_t M = pd()->M_;
+    const dim_t N = pd()->N_;
+    const dim_t K = pd()->K_;
+    const dim_t batch = pd()->batch_;
+
+    const auto &brg = pd()->brg_kernel_->get_brg();
+    const int bd = brg.bd_block;
+    const int bdb = brg.bdb;
+    const int bdb_tail = brg.bdb_tail;
+    const dim_t total_N = batch * M;
+    const dim_t LDA_orig = N; // row-major weights: original col-major LDA = N
+
+    const auto *brg_kernel = pd()->brg_kernel_.get();
+
+    // Packing workspace from scratchpad.
+    // Size: bd × K × sizeof(float). For bd=32, K=4096: 512KB.
+    // Pack once per M-tile, then call kernel per K-block with offset.
+    const dim_t BK = BRGEMM_BK;
+    auto &grantor = ctx.get_scratchpad_grantor();
+    float *ws = grantor.template get<float>(
+            memory_tracking::names::key_brgemm_primitive_buffer_a);
+
+    // Manual M-tile × K-block loop with copy_A packing.
+    //
+    // For each M-tile:
+    // 1. Pack the tile's full A data from col-major (LDA=N) into contiguous
+    //    layout (LDA=bd).
+    // 2. For each K-block, call the JIT kernel with ptr_A pointing into the
+    //    packed buffer at the correct K-block offset.
+    const int num_tiles = bdb + (bdb_tail > 0 ? 1 : 0);
+    for (int t = 0; t < num_tiles; t++) {
+        const bool is_tail = (t == bdb);
+        const int rows = is_tail ? bdb_tail : bd;
+        const float *A_tile = weights + t * bd;
+        pack_a_tile(ws, A_tile, LDA_orig, bd, rows, K);
+
+        for (dim_t kb = 0; kb < K; kb += BK) {
+            const dim_t K_inner = nstl::min(BK, K - kb);
+            const float beta_kb = (kb == 0) ? 0.0f : 1.0f;
+
+            brgemm_kernel_params_t p;
+            p.ptr_A = ws + kb * bd;
+            p.ptr_B = src + kb;
+            p.ptr_C = dst + t * bd;
+            p.N = total_N;
+            p.M = rows;
+            p.K = K_inner;
+            p.beta = beta_kb;
+            p.ptr_bias = nullptr;
+            (*brg_kernel)(&p);
+        }
+    }
+
+    // Apply bias + post-ops (same as rvv_matmul.cpp)
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper bias_d(pd()->desc()->bias_desc);
+    const float *bias = CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
+    const post_ops_t &post_ops = pd()->attr()->post_ops_;
+    rvv_postops_t postops_handler(post_ops);
+
+    if (!bias && post_ops.len() == 0) return status::success;
+
+    const int dst_ndims = dst_d.ndims();
+    const int bias_ndims = bias_d.ndims();
+    const dim_t *bias_dims = bias_d.dims();
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const dim_t *src_dims_ptr = src_d.dims();
+    const dim_t dst_batch_stride = M * N;
+
+    parallel_nd(batch, [&](dim_t b) {
+        float *dst_base = dst + b * dst_batch_stride;
+
+        dim_t dst_idx_prefix[DNNL_MAX_NDIMS] = {};
+        size_t bias_strides[DNNL_MAX_NDIMS] = {};
+
+        if (bias && bias_ndims > 1) {
+            bias_strides[bias_ndims - 1] = 1;
+            for (int d = bias_ndims - 2; d >= 0; --d)
+                bias_strides[d]
+                        = bias_strides[d + 1] * (size_t)bias_dims[d + 1];
+        }
+
+        for (dim_t m = 0; m < M; ++m) {
+            if (dst_ndims > 2) {
+                utils::l_dims_by_l_offset(
+                        dst_idx_prefix, b, src_dims_ptr, dst_ndims - 2);
+            }
+            dst_idx_prefix[dst_ndims - 2] = m;
+
+            float *row_dst = dst_base + m * N;
+
+            for (dim_t n0 = 0; n0 < N;) {
+                size_t vl = __riscv_vsetvl_e32m1(N - n0);
+                vfloat32m1_t acc = __riscv_vle32_v_f32m1(row_dst + n0, vl);
+
+                if (bias) {
+                    if (bias_d.nelems() == 1) {
+                        acc = __riscv_vfadd_vf_f32m1(acc, bias[0], vl);
+                    } else {
+                        size_t base_bias_off = 0;
+                        if (bias_ndims > 1) {
+                            for (int d = 0; d < bias_ndims - 1; ++d) {
+                                int dst_dim_idx = d + (dst_ndims - bias_ndims);
+                                dim_t idx = (bias_dims[d] == 1)
+                                        ? 0
+                                        : dst_idx_prefix[dst_dim_idx];
+                                base_bias_off += idx * bias_strides[d];
+                            }
+                        }
+
+                        if (bias_dims[bias_ndims - 1] == 1) {
+                            acc = __riscv_vfadd_vf_f32m1(
+                                    acc, bias[base_bias_off], vl);
+                        } else {
+                            const float *bias_ptr = bias + base_bias_off + n0;
+                            vfloat32m1_t bias_vec
+                                    = __riscv_vle32_v_f32m1(bias_ptr, vl);
+                            acc = __riscv_vfadd_vv_f32m1(acc, bias_vec, vl);
+                        }
+                    }
+                }
+
+                acc = postops_handler.apply(acc, vl);
+                __riscv_vse32_v_f32m1(row_dst + n0, acc, vl);
+                n0 += vl;
+            }
+        }
+    });
+
+    return status::success;
+}
+
+} // namespace matmul
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -24,10 +24,9 @@
 #include "common/verbose.hpp"
 
 #include "cpu/platform.hpp"
+#include "cpu/rv64/jit_generator.hpp"
 #include "cpu/rv64/rvv_brgemm_matmul.hpp"
 #include "cpu/rv64/rvv_postops.hpp"
-
-#include <riscv_vector.h>
 
 namespace dnnl {
 namespace impl {
@@ -39,22 +38,225 @@ using namespace dnnl::impl::status;
 using namespace dnnl::impl::utils;
 using namespace data_type;
 
-// Pack bd rows × K_inner columns from col-major A (with LDA_orig) into
-// contiguous workspace with LDA=bd.
-static void pack_a_tile(float *ws, const float *A, dim_t LDA_orig, dim_t bd,
-        dim_t valid_rows, dim_t K_inner) {
-    for (dim_t k = 0; k < K_inner; k++) {
-        const float *A_col = A + k * LDA_orig;
-        float *ws_row = ws + k * bd;
-        dim_t i = 0;
-        while (i < valid_rows) {
-            size_t vl = __riscv_vsetvl_e32m1(valid_rows - i);
-            vfloat32m1_t v = __riscv_vle32_v_f32m1(A_col + i, vl);
-            __riscv_vse32_v_f32m1(ws_row + i, v, vl);
-            i += vl;
-        }
+// ---------------------------------------------------------------------------
+// JIT kernel: pack_a_tile
+// Copies valid_rows floats per column from col-major A (stride LDA_orig)
+// into contiguous workspace (stride bd). Vectorized with LMUL=m4.
+// ---------------------------------------------------------------------------
+struct jit_pack_a_tile_t : public jit_generator_t {
+    struct call_params_t {
+        float *ws; // offset 0
+        const float *A; // offset 8
+        dim_t LDA_orig; // offset 16
+        dim_t bd; // offset 24
+        dim_t valid_rows; // offset 32
+        dim_t K_inner; // offset 40
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_pack_a_tile_t)
+
+    jit_pack_a_tile_t() : jit_generator_t("jit_pack_a_tile") {
+        create_kernel();
     }
-}
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+        using namespace Xbyak_riscv;
+
+        const Reg reg_param = a0;
+        const Reg reg_ws = a1;
+        const Reg reg_A = a2;
+        const Reg reg_LDA = t0;
+        const Reg reg_bd = t1;
+        const Reg reg_K = t2;
+        const Reg reg_k = t3; // outer loop counter
+        const Reg reg_src = t4;
+        const Reg reg_dst = t5;
+        const Reg reg_rows_remaining = t6;
+        const Reg reg_vl = a3;
+        const Reg reg_bytes = a4;
+        const Reg reg_tmp = a5;
+
+        const VReg v_tmp(0);
+
+        // Load parameters
+        ld(reg_ws, reg_param, 0);
+        ld(reg_A, reg_param, 8);
+        ld(reg_LDA, reg_param, 16);
+        ld(reg_bd, reg_param, 24);
+        ld(reg_rows_remaining, reg_param, 32); // reuse as valid_rows temp
+        ld(reg_K, reg_param, 40);
+
+        // Compute LDA_orig * sizeof(float) and bd * sizeof(float)
+        slli(reg_LDA, reg_LDA, 2);
+        slli(reg_bd, reg_bd, 2);
+
+        // Save valid_rows for reuse in each k iteration
+        const Reg reg_valid_rows = a6;
+        ld(reg_valid_rows, reg_param, 32);
+
+        xor_(reg_k, reg_k, reg_k); // k = 0
+
+        Label k_loop, k_done;
+        L(k_loop);
+        beq(reg_k, reg_K, k_done);
+
+        // src = A + k * LDA_bytes
+        mul(reg_tmp, reg_k, reg_LDA);
+        add(reg_src, reg_A, reg_tmp);
+
+        // dst = ws + k * bd_bytes
+        mul(reg_tmp, reg_k, reg_bd);
+        add(reg_dst, reg_ws, reg_tmp);
+
+        // Inner copy loop: copy valid_rows floats
+        mv(reg_rows_remaining, reg_valid_rows);
+        Label copy_loop, copy_done;
+        L(copy_loop);
+        beqz(reg_rows_remaining, copy_done);
+
+        vsetvli(reg_vl, reg_rows_remaining, SEW::e32, LMUL::m4);
+        vle32_v(v_tmp, reg_src);
+        vse32_v(v_tmp, reg_dst);
+
+        slli(reg_bytes, reg_vl, 2);
+        add(reg_src, reg_src, reg_bytes);
+        add(reg_dst, reg_dst, reg_bytes);
+        sub(reg_rows_remaining, reg_rows_remaining, reg_vl);
+        j_(copy_loop);
+
+        L(copy_done);
+
+        addi(reg_k, reg_k, 1);
+        j_(k_loop);
+
+        L(k_done);
+        ret();
+#else
+        ret();
+#endif
+    }
+};
+
+// ---------------------------------------------------------------------------
+// JIT kernel: bias + post-ops for one row
+// Processes N elements: load dst, add bias (vector/scalar/none),
+// apply post-op (none/relu), store dst. Vectorized with LMUL=m1.
+// ---------------------------------------------------------------------------
+struct jit_bias_postops_row_t : public jit_generator_t {
+    // bias_type: 0=none, 1=scalar broadcast, 2=per-element vector
+    // postop: 0=none, 1=relu
+    struct call_params_t {
+        float *row_dst; // offset 0
+        dim_t N; // offset 8
+        const float *bias_ptr; // offset 16
+        int32_t bias_type; // offset 24
+        int32_t postop; // offset 28
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_bias_postops_row_t)
+
+    jit_bias_postops_row_t() : jit_generator_t("jit_bias_postops_row") {
+        create_kernel();
+    }
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+        using namespace Xbyak_riscv;
+
+        const Reg reg_param = a0;
+        const Reg reg_dst = a1;
+        const Reg reg_N = a2;
+        const Reg reg_bias = a3;
+        const Reg reg_vl = t0;
+        const Reg reg_bytes = t1;
+        const Reg reg_tmp = t2;
+        const Reg reg_bias_type = t3;
+        const Reg reg_postop = t4;
+
+        const FReg f_bias_scalar = fa0;
+        const FReg f_zero = fa1;
+        const VReg v_acc(0);
+        const VReg v_bias(1);
+
+        // Load parameters
+        ld(reg_dst, reg_param, 0);
+        ld(reg_N, reg_param, 8);
+        ld(reg_bias, reg_param, 16);
+        lw(reg_bias_type, reg_param, 24);
+        lw(reg_postop, reg_param, 28);
+
+        // Prepare f_zero = 0.0 for ReLU
+        xor_(reg_tmp, reg_tmp, reg_tmp);
+        fmv_w_x(f_zero, reg_tmp);
+
+        Label loop, done;
+        L(loop);
+        beqz(reg_N, done);
+
+        vsetvli(reg_vl, reg_N, SEW::e32, LMUL::m1);
+        vle32_v(v_acc, reg_dst);
+
+        // Bias: 0=none, 1=scalar, 2=vector
+        Label bias_scalar, bias_vector, after_bias;
+        bnez(reg_bias_type, bias_scalar);
+
+        // bias_type == 0: no bias
+        j_(after_bias);
+
+        L(bias_scalar);
+        // Load bias[0] into float register
+        flw(f_bias_scalar, reg_bias, 0);
+        // Check if bias_type == 1 (scalar) or 2 (vector)
+        addi(reg_tmp, reg_bias_type, -1);
+        bnez(reg_tmp, bias_vector);
+
+        // Scalar bias: acc += broadcast
+        vfadd_vf(v_acc, v_acc, f_bias_scalar);
+        j_(after_bias);
+
+        L(bias_vector);
+        // Vector bias: acc += bias[n0..n0+vl)
+        vle32_v(v_bias, reg_bias);
+        vfadd_vv(v_acc, v_acc, v_bias);
+        // Advance bias pointer for next iteration
+        slli(reg_bytes, reg_vl, 2);
+        add(reg_bias, reg_bias, reg_bytes);
+
+        L(after_bias);
+
+        // Post-op: ReLU (max(acc, 0))
+        Label postop_done;
+        beqz(reg_postop, postop_done);
+        vfmax_vf(v_acc, v_acc, f_zero);
+        L(postop_done);
+
+        // Store result
+        vse32_v(v_acc, reg_dst);
+
+        // Advance dst pointer
+        slli(reg_bytes, reg_vl, 2);
+        add(reg_dst, reg_dst, reg_bytes);
+        sub(reg_N, reg_N, reg_vl);
+        j_(loop);
+
+        L(done);
+        ret();
+#else
+        ret();
+#endif
+    }
+};
 
 status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     using smask_t = primitive_attr_t::skip_mask_t;
@@ -191,6 +393,10 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     CHECK(brgemm_kernel_create(&kernel, brg_desc));
     brg_kernel_.reset(kernel);
 
+    // Create JIT kernels for pack_a_tile and bias+postops
+    pack_kernel_.reset(new jit_pack_a_tile_t());
+    bias_postops_kernel_.reset(new jit_bias_postops_row_t());
+
     init_scratchpad();
 
     return status::success;
@@ -222,6 +428,8 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
     const dim_t LDA_orig = N; // row-major weights: original col-major LDA = N
 
     const auto *brg_kernel = pd()->brg_kernel_.get();
+    const auto *pack_kernel = pd()->pack_kernel_.get();
+    const auto *bias_postops_kernel = pd()->bias_postops_kernel_.get();
 
     // Packing workspace from scratchpad.
     // Size: bd × K × sizeof(float). For bd=32, K=4096: 512KB.
@@ -243,7 +451,16 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
         const bool is_tail = (t == bdb);
         const int rows = is_tail ? bdb_tail : bd;
         const float *A_tile = weights + t * bd;
-        pack_a_tile(ws, A_tile, LDA_orig, bd, rows, K);
+
+        // JIT pack_a_tile
+        jit_pack_a_tile_t::call_params_t pack_p;
+        pack_p.ws = ws;
+        pack_p.A = A_tile;
+        pack_p.LDA_orig = LDA_orig;
+        pack_p.bd = bd;
+        pack_p.valid_rows = rows;
+        pack_p.K_inner = K;
+        (*pack_kernel)(&pack_p);
 
         for (dim_t kb = 0; kb < K; kb += BK) {
             const dim_t K_inner = nstl::min(BK, K - kb);
@@ -262,12 +479,11 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
         }
     }
 
-    // Apply bias + post-ops (same as rvv_matmul.cpp)
+    // Apply bias + post-ops using JIT kernel
     const memory_desc_wrapper dst_d(pd()->dst_md());
     const memory_desc_wrapper bias_d(pd()->desc()->bias_desc);
     const float *bias = CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
     const post_ops_t &post_ops = pd()->attr()->post_ops_;
-    rvv_postops_t postops_handler(post_ops);
 
     if (!bias && post_ops.len() == 0) return status::success;
 
@@ -277,6 +493,12 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper src_d(pd()->src_md());
     const dim_t *src_dims_ptr = src_d.dims();
     const dim_t dst_batch_stride = M * N;
+
+    // Determine postop type for JIT kernel
+    int32_t postop = 0;
+    if (post_ops.len() > 0 && post_ops.entry_[0].is_eltwise()
+            && post_ops.entry_[0].eltwise.alg == alg_kind::eltwise_relu)
+        postop = 1;
 
     parallel_nd(batch, [&](dim_t b) {
         float *dst_base = dst + b * dst_batch_stride;
@@ -300,41 +522,38 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
 
             float *row_dst = dst_base + m * N;
 
-            for (dim_t n0 = 0; n0 < N;) {
-                size_t vl = __riscv_vsetvl_e32m1(N - n0);
-                vfloat32m1_t acc = __riscv_vle32_v_f32m1(row_dst + n0, vl);
-
-                if (bias) {
-                    if (bias_d.nelems() == 1) {
-                        acc = __riscv_vfadd_vf_f32m1(acc, bias[0], vl);
-                    } else {
-                        size_t base_bias_off = 0;
-                        if (bias_ndims > 1) {
-                            for (int d = 0; d < bias_ndims - 1; ++d) {
-                                int dst_dim_idx = d + (dst_ndims - bias_ndims);
-                                dim_t idx = (bias_dims[d] == 1)
-                                        ? 0
-                                        : dst_idx_prefix[dst_dim_idx];
-                                base_bias_off += idx * bias_strides[d];
-                            }
-                        }
-
-                        if (bias_dims[bias_ndims - 1] == 1) {
-                            acc = __riscv_vfadd_vf_f32m1(
-                                    acc, bias[base_bias_off], vl);
-                        } else {
-                            const float *bias_ptr = bias + base_bias_off + n0;
-                            vfloat32m1_t bias_vec
-                                    = __riscv_vle32_v_f32m1(bias_ptr, vl);
-                            acc = __riscv_vfadd_vv_f32m1(acc, bias_vec, vl);
+            int32_t bias_type = 0; // 0=none
+            const float *bias_ptr = nullptr;
+            if (bias) {
+                if (bias_d.nelems() == 1) {
+                    bias_type = 1; // scalar broadcast
+                    bias_ptr = bias;
+                } else {
+                    size_t base_bias_off = 0;
+                    if (bias_ndims > 1) {
+                        for (int d = 0; d < bias_ndims - 1; ++d) {
+                            int dst_dim_idx = d + (dst_ndims - bias_ndims);
+                            dim_t idx = (bias_dims[d] == 1)
+                                    ? 0
+                                    : dst_idx_prefix[dst_dim_idx];
+                            base_bias_off += idx * bias_strides[d];
                         }
                     }
+                    bias_ptr = bias + base_bias_off;
+                    if (bias_dims[bias_ndims - 1] == 1)
+                        bias_type = 1; // scalar
+                    else
+                        bias_type = 2; // vector
                 }
-
-                acc = postops_handler.apply(acc, vl);
-                __riscv_vse32_v_f32m1(row_dst + n0, acc, vl);
-                n0 += vl;
             }
+
+            jit_bias_postops_row_t::call_params_t bp;
+            bp.row_dst = row_dst;
+            bp.N = N;
+            bp.bias_ptr = bias_ptr;
+            bp.bias_type = bias_type;
+            bp.postop = postop;
+            (*bias_postops_kernel)(&bp);
         }
     });
 

--- a/src/cpu/rv64/rvv_brgemm_matmul.hpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.hpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_RVV_BRGEMM_MATMUL_HPP
+#define CPU_RV64_RVV_BRGEMM_MATMUL_HPP
+
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/matmul/cpu_matmul_pd.hpp"
+
+#include "cpu/rv64/brgemm/brgemm.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace matmul {
+
+struct rvv_brgemm_matmul_t : public primitive_t {
+    struct pd_t : public ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
+        using ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t::cpu_matmul_pd_t;
+
+        DECLARE_COMMON_PD_T("brgemm:rvv", rvv_brgemm_matmul_t);
+
+        status_t init(engine_t *engine);
+
+        std::shared_ptr<brgemm_kernel_t> brg_kernel_;
+
+        dim_t M_ = 0;
+        dim_t N_ = 0;
+        dim_t K_ = 0;
+        dim_t batch_ = 0;
+        bool weights_are_broadcast_ = false;
+
+    private:
+        void init_scratchpad();
+
+        static bool is_row_major(const memory_desc_wrapper &mdw) {
+            const int ndims = mdw.ndims();
+            if (ndims < 2) return false;
+            const auto &strides = mdw.blocking_desc().strides;
+            if (strides[ndims - 1] != 1) return false;
+            dim_t expected_stride = mdw.dims()[ndims - 1];
+            for (int d = ndims - 2; d >= 0; --d) {
+                if (strides[d] != expected_stride) return false;
+                expected_stride *= mdw.dims()[d];
+            }
+            return true;
+        }
+    };
+
+    rvv_brgemm_matmul_t(const pd_t *apd) : primitive_t(apd) {}
+
+    ~rvv_brgemm_matmul_t() override = default;
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+protected:
+    status_t init(engine_t *engine) override { return status::success; }
+
+private:
+    const pd_t *pd() const {
+        return static_cast<const pd_t *>(primitive_t::pd().get());
+    }
+};
+
+} // namespace matmul
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_RVV_BRGEMM_MATMUL_HPP

--- a/src/cpu/rv64/rvv_brgemm_matmul.hpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.hpp
@@ -35,6 +35,9 @@ namespace cpu {
 namespace rv64 {
 namespace matmul {
 
+struct jit_pack_a_tile_t;
+struct jit_bias_postops_row_t;
+
 struct rvv_brgemm_matmul_t : public primitive_t {
     struct pd_t : public ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
         using ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t::cpu_matmul_pd_t;
@@ -44,6 +47,8 @@ struct rvv_brgemm_matmul_t : public primitive_t {
         status_t init(engine_t *engine);
 
         std::shared_ptr<brgemm_kernel_t> brg_kernel_;
+        std::shared_ptr<jit_pack_a_tile_t> pack_kernel_;
+        std::shared_ptr<jit_bias_postops_row_t> bias_postops_kernel_;
 
         dim_t M_ = 0;
         dim_t N_ = 0;


### PR DESCRIPTION
# Description

This PR introduces a BRGEMM-based matmul primitive for RISC-V RV64 using the existing JIT BRGEMM micro-kernel with copy_A packing.

This version provides:

1. BRGEMM matmul for broadcast weight inference (batch > 1, weights shared across batch)
2. copy_A packing that reads A matrix sequentially (stride bd_block=32) instead of strided (stride N), achieving ~2x DRAM throughput when A exceeds L2 cache compared to gemm kernel
3. Strict three-guard dispatch: K >= 4096, A exceeds L2 cache, batch * M >= 128

## Key Features

- **copy_A packing**: Transforms the weight matrix A from col-major stride N to contiguous stride bd_block per M-tile, enabling sequential DRAM reads. Packed once per M-tile for all K-blocks, amortizing packing cost.
- **K-blocking**: Uses BRGEMM_BK=256 K-blocking tiles, calling the JIT kernel per K-block with offset into the packed buffer.
- **Bias + post-ops**: Applied after BRGEMM computation via the existing rvv_postops infrastructure, supporting broadcast bias with arbitrary dimension matching.
- **Safe tail handling**: The pack_a_tile function uses a separate valid_rows parameter to avoid out-of-bounds reads on the tail M-tile.

## Implementation Details

### Dimension Mapping

Broadcast matmul `Y = X @ W` with X=[batch,M,K], W=[1,K,N] is mapped to BRGEMM as:

```
C(N x batch*M) = W^T(N x K) * X^T(K x batch*M)
  M_brg = N, K_brg = K, N_brg = batch * M
```

### Dispatch Conditions

Three guards ensure BRGEMM only fires when beneficial:

1. **K >= 4096**: K-blocking amortizes the per-tile packing overhead. Below this threshold, GEMM's existing copy_A is sufficient.
2. **N * K * 4 > L2 cache size**: When the A matrix (weights) exceeds L2 cache, GEMM's copy_A reads with stride N cause every access to miss cache and reload from DRAM. BRGEMM's sequential packing reads (stride bd_block=32) achieve ~2x higher throughput from main memory.
3. **batch * M >= 128**: The BRGEMM kernel's N-loop needs sufficient iterations (>= 32 at n_step=4) to pipeline efficiently. Tested: batch*M=32 causes -4% regression; batch*M=128 provides consistent improvement.

### Why BRGEMM Wins

When A exceeds L2 cache, GEMM reads A with stride N (e.g., 4096 floats) per K column. Two such rows fill the entire 32KB L1D cache, causing constant eviction. GEMM throughput drops to ~3-5 Gflops.

BRGEMM packs A into contiguous blocks with stride bd_block=32 per K element. Sequential reads from DRAM achieve ~7-9 Gflops, yielding 1.4-2.0x speedup.

For broadcast matmul specifically, the advantage is even larger: GEMM processes each batch element separately, re-loading the entire weight matrix from DRAM for each element. BRGEMM loads weights once and shares across all batch elements via the strided B panel, achieving **2.45x speedup** on GPT-J prefill shapes.

---

# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on Spacemit X60 (VLEN=256, L1D=32KB, L2=1MB) with single core (`taskset -c 32`). We draw comparisons between:

1. **RISCV64GCV** (upstream main - GEMM-based matmul using rvv intrinsics)
2. **brgemm:rvv** (this PR - BRGEMM-based matmul with copy_A packing)

### GPT-J Prefill Phase (3D Broadcast - Real LLM Workload)

The benchdnn GPT-J harness (`harness_matmul_gpt-j_2016-32_inf_lb_f32`) expresses LLM inference as 2D matmul (M flattened to batch*seq_len). In real LLM frameworks (PyTorch, TensorFlow), the same computation uses **3D broadcast matmul** where weights are shared across the batch dimension.

We reshape the GPT-J prefill shapes as 3D broadcast to match how real frameworks call oneDNN:

| GPT-J Operation | 2D Shape (original) | 3D Broadcast Shape | brgemm:rvv (ms) | RISCV64GCV (ms) | Speedup |
|-----------------|---------------------|--------------------|-----------------|-----------------|---------|
| gemm0: hidden FC | 48384x4096:4096x4096 | 128x32x4096:1x4096x4096 | 36,869 | 90,206 | **2.45x** |

**Why GEMM is 2.45x slower for broadcast matmul:**
- GEMM processes each of 128 batch elements as a separate M=32 GEMM call
- Each call re-loads the entire 64MB weight matrix from DRAM
- Total weight reads: 128 × 64MB = 8GB of redundant DRAM traffic
- BRGEMM loads weights once and shares across all 128 × 32 = 4096 output columns

### Synthesized LLM Inference Shapes

Additional shapes representing typical BERT/GPT-2/LLaMA broadcast matmul workloads:

| Shape | K | N | batch*M | brgemm:rvv (ms) | RISCV64GCV (ms) | Speedup |
|-------|---|---|---------|-----------------|-----------------|---------|
| gpt2_attn (16x40x4096:1x4096x4096) | 4096 | 4096 | 640 | 3,009 | 6,069 | **2.02x** |
| bert_output (128x1x4096:1x4096x3072) | 4096 | 3072 | 128 | 357 | 683 | **1.91x** |
| bert_intermediate (128x1x4096:1x4096x768) | 4096 | 768 | 128 | 104 | 153 | **1.47x** |
| gpt2_fc_up (128x1x4096:1x4096x4096) | 4096 | 4096 | 128 | 661 | 946 | **1.43x** |

**Summary for BRGEMM-dispatched shapes:**
- Average speedup: **1.71x** (synthesized), **2.45x** (GPT-J prefill)
- All BRGEMM shapes show significant improvement (43-145%)