### PR TITLE
cpu: rv64: enable batch-parallel RVV Winograd convolution

### DIFF
--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -533,6 +533,7 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
 
     const dim_t mb = src_d.dims()[0];
     conf.mb = mb;
+    conf.nthr = nstl::min(static_cast<int>(mb), dnnl_get_max_threads());
 
     conf.ih = src_d.dims()[2];
     conf.iw = src_d.dims()[3];
@@ -600,8 +601,8 @@ status_t rvv_winograd_init_conf(rvv_winograd_conf_t &conf,
     using namespace memory_tracking::names;
 
     scratchpad.book<float>(key_wino_U, conf.wspec.weight_matrix_size);
-    scratchpad.book<float>(key_wino_V, conf.wspec.V_buffer_size);
-    scratchpad.book<float>(key_wino_M, conf.wspec.M_buffer_size);
+    scratchpad.book<float>(key_wino_V, conf.nthr * conf.wspec.V_buffer_size);
+    scratchpad.book<float>(key_wino_M, conf.nthr * conf.wspec.M_buffer_size);
 
     return status::success;
 }
@@ -626,14 +627,13 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
             transformed_weights, conf.wspec.N, conf.wspec.K,
             conf.wspec.weight_ic_rounded, conf.wspec.weight_oc_rounded);
 
-    float *V = scratchpad.template get<float>(key_wino_V);
-    float *M = scratchpad.template get<float>(key_wino_M);
+    float *V_base = scratchpad.template get<float>(key_wino_V);
+    float *M_base = scratchpad.template get<float>(key_wino_M);
 
     auto *input_xform = input_xform_.get();
     auto *output_xform = output_xform_.get();
 
-    // Sequential batch processing: input transform -> GEMM -> output transform
-    // per batch, keeping working set in L2 cache.
+    // Batch-parallel processing: each worker owns one V/M scratchpad slice.
     const dim_t nb_oh = (conf.oh + 1) / 2;
     const dim_t nb_ow = (conf.ow + 1) / 2;
     const dim_t total_tiles = nb_oh * nb_ow;
@@ -642,43 +642,51 @@ status_t rvv_wino_convolution_fwd_t::execute_forward(
     const dim_t ic_spatial_stride = conf.ih * conf.iw;
     const dim_t oc_spatial_stride = conf.oh * conf.ow;
 
-    for (dim_t mb_idx = 0; mb_idx < conf.mb; mb_idx++) {
-        const float *src_batch = src + mb_idx * conf.ic * ic_spatial_stride;
+    parallel(conf.nthr, [&](const int ithr, const int nthr) {
+        dim_t mb_start = 0, mb_end = 0;
+        balance211(conf.mb, nthr, ithr, mb_start, mb_end);
 
-        // Step 1: Input transform via JIT kernel (tile loop is inside JIT)
-        {
-            jit_wino_input_transform_t::call_params_t params;
-            params.src_batch = src_batch;
-            params.V = V;
-            params.ic_spatial_stride = ic_spatial_stride;
-            params.nb_oh = nb_oh;
-            params.nb_ow = nb_ow;
-            (*input_xform)(&params);
+        float *V = V_base + ithr * conf.wspec.V_buffer_size;
+        float *M = M_base + ithr * conf.wspec.M_buffer_size;
+
+        for (dim_t mb_idx = mb_start; mb_idx < mb_end; mb_idx++) {
+            const float *src_batch = src + mb_idx * conf.ic * ic_spatial_stride;
+
+            // Step 1: Input transform via JIT kernel (tile loop is inside JIT)
+            {
+                jit_wino_input_transform_t::call_params_t params;
+                params.src_batch = src_batch;
+                params.V = V;
+                params.ic_spatial_stride = ic_spatial_stride;
+                params.nb_oh = nb_oh;
+                params.nb_ow = nb_ow;
+                (*input_xform)(&params);
+            }
+
+            // Step 2: GEMM using brgemm kernel (16 elements)
+            for (int elem = 0; elem < 16; elem++) {
+                const float *A_weights = transformed_weights
+                        + elem * conf.wspec.weight_ld_matrix;
+                const float *B_input = V + elem * V_elem_stride;
+                float *C_output = M + elem * M_elem_stride;
+
+                brgemm_kernel_execute(brg_kernel, A_weights, B_input, C_output,
+                        total_tiles, 0.0f);
+            }
+
+            // Step 3: Output transform via JIT kernel (tile loop is inside JIT)
+            {
+                data_t *dst_batch = dst + mb_idx * conf.oc * oc_spatial_stride;
+                jit_wino_output_transform_t::call_params_t params;
+                params.M = M;
+                params.bias = bias;
+                params.dst_batch = dst_batch;
+                params.nb_oh = nb_oh;
+                params.nb_ow = nb_ow;
+                (*output_xform)(&params);
+            }
         }
-
-        // Step 2: GEMM using brgemm kernel (16 elements)
-        for (int elem = 0; elem < 16; elem++) {
-            const float *A_weights
-                    = transformed_weights + elem * conf.wspec.weight_ld_matrix;
-            const float *B_input = V + elem * V_elem_stride;
-            float *C_output = M + elem * M_elem_stride;
-
-            brgemm_kernel_execute(brg_kernel, A_weights, B_input, C_output,
-                    total_tiles, 0.0f);
-        }
-
-        // Step 3: Output transform via JIT kernel (tile loop is inside JIT)
-        {
-            data_t *dst_batch = dst + mb_idx * conf.oc * oc_spatial_stride;
-            jit_wino_output_transform_t::call_params_t params;
-            params.M = M;
-            params.bias = bias;
-            params.dst_batch = dst_batch;
-            params.nb_oh = nb_oh;
-            params.nb_ow = nb_ow;
-            (*output_xform)(&params);
-        }
-    }
+    });
 
     return status::success;
 }

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -40,8 +40,8 @@ namespace cpu {
 namespace rv64 {
 
 // Winograd domain specification for GEMM-based Winograd convolution.
-// Single-core execution: processes batches sequentially with
-// local input/output buffers to keep working set in cache.
+// Batch-parallel execution: workers process disjoint batch ranges and use
+// private input/output scratchpad slices to preserve cache locality.
 struct WinogradDomainSpec_t {
     // Matrix dimensions for brgemm: C[OC×tiles] = A[OC×IC] × B[IC×tiles]
     dim_t M; // Total tiles per batch = ceil(oh/2) * ceil(ow/2)

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -86,6 +86,7 @@ struct rvv_winograd_conf_t {
 
     // Winograd transform parameters
     dim_t mb; // Batch size
+    int nthr; // Number of batch-parallel threads
 
     // Winograd domain specification for GEMM-based execution
     WinogradDomainSpec_t wspec;
@@ -149,6 +150,8 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
 
             VDISPATCH_CONV(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
+            VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_winograd),
+                    VERBOSE_BAD_ALGORITHM);
 
             // Check data types: f32 only
             VDISPATCH_CONV(with_bias()
@@ -207,11 +210,15 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "ic and oc must be >= 96 for winograd");
 
-            // Winograd dispatch is restricted to single-core execution.
-            // On multi-core, brgemm's spatial parallelism is superior.
-            VDISPATCH_CONV(dnnl_get_max_threads() <= 1,
+            const dim_t nb_wino_tiles
+                    = ((dst_d.dims()[2] + 1) / 2) * ((dst_d.dims()[3] + 1) / 2);
+            VDISPATCH_CONV(nb_wino_tiles >= 100, VERBOSE_UNSUPPORTED_FEATURE,
+                    "too few winograd tiles");
+
+            const int nthr = dnnl_get_max_threads();
+            VDISPATCH_CONV(nthr <= 1 || src_d.dims()[0] >= nstl::min(nthr, 8),
                     VERBOSE_UNSUPPORTED_FEATURE,
-                    "winograd only beneficial for single-thread execution");
+                    "minibatch is too small for multi-thread winograd");
 
             // Minimum output spatial dimensions for Winograd benefit
             VDISPATCH_CONV(dst_d.dims()[2] >= 7 && dst_d.dims()[3] >= 7,
@@ -233,10 +240,6 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
                 brgemm_kernel_t *kernel = nullptr;
                 CHECK(brgemm_kernel_create(&kernel, brg_desc));
                 brg_kernel_.reset(kernel);
-            }
-
-            if (desc()->alg_kind == alg_kind::convolution_auto) {
-                set_default_alg_kind(alg_kind::convolution_winograd);
             }
 
             return status::success;

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -220,18 +220,23 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
                     = ((dst_d.dims()[2] + 1) / 2) * ((dst_d.dims()[3] + 1) / 2);
             VDISPATCH_CONV(!is_auto || nb_wino_tiles >= 100,
                     VERBOSE_UNSUPPORTED_FEATURE, "too few winograd tiles");
+            const int nthr = dnnl_get_max_threads();
+            const bool is_auto_wino_profitable_small_nthr = nthr <= 8
+                    && dst_d.dims()[2] >= 28 && dst_d.dims()[3] >= 28
+                    && ((src_d.dims()[0] >= 50)
+                            || (src_d.dims()[0] >= 32 && dst_d.dims()[1] >= 256)
+                            || (src_d.dims()[0] >= 32 && dst_d.dims()[2] >= 56
+                                    && dst_d.dims()[3] >= 56));
+            const bool is_auto_wino_profitable_many_nthr = nthr > 8
+                    && src_d.dims()[0] >= 50 && src_d.dims()[1] == 128
+                    && dst_d.dims()[1] == 128 && dst_d.dims()[2] == 28
+                    && dst_d.dims()[3] == 28;
             const bool is_auto_wino_profitable = !is_auto
-                    || (dst_d.dims()[2] >= 28 && dst_d.dims()[3] >= 28
-                            && ((src_d.dims()[0] >= 50)
-                                    || (src_d.dims()[0] >= 32
-                                            && dst_d.dims()[1] >= 256)
-                                    || (src_d.dims()[0] >= 32
-                                            && dst_d.dims()[2] >= 56
-                                            && dst_d.dims()[3] >= 56)));
+                    || is_auto_wino_profitable_small_nthr
+                    || is_auto_wino_profitable_many_nthr;
             VDISPATCH_CONV(is_auto_wino_profitable, VERBOSE_UNSUPPORTED_FEATURE,
                     "shape is not profitable for auto winograd");
 
-            const int nthr = dnnl_get_max_threads();
             VDISPATCH_CONV(nthr <= 1 || src_d.dims()[0] >= nstl::min(nthr, 8),
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "minibatch is too small for multi-thread winograd");

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -150,6 +150,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
 
             VDISPATCH_CONV(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
+            const bool is_auto = desc()->alg_kind == alg_kind::convolution_auto;
             VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_winograd),
                     VERBOSE_BAD_ALGORITHM);
 
@@ -209,11 +210,16 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
             VDISPATCH_CONV(src_d.dims()[1] >= 96 && dst_d.dims()[1] >= 96,
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "ic and oc must be >= 96 for winograd");
+            VDISPATCH_CONV(!is_auto
+                            || (src_d.dims()[1] >= 128
+                                    && dst_d.dims()[1] >= 128),
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "ic and oc must be >= 128 for auto winograd");
 
             const dim_t nb_wino_tiles
                     = ((dst_d.dims()[2] + 1) / 2) * ((dst_d.dims()[3] + 1) / 2);
-            VDISPATCH_CONV(nb_wino_tiles >= 100, VERBOSE_UNSUPPORTED_FEATURE,
-                    "too few winograd tiles");
+            VDISPATCH_CONV(!is_auto || nb_wino_tiles >= 100,
+                    VERBOSE_UNSUPPORTED_FEATURE, "too few winograd tiles");
 
             const int nthr = dnnl_get_max_threads();
             VDISPATCH_CONV(nthr <= 1 || src_d.dims()[0] >= nstl::min(nthr, 8),

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -220,6 +220,16 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
                     = ((dst_d.dims()[2] + 1) / 2) * ((dst_d.dims()[3] + 1) / 2);
             VDISPATCH_CONV(!is_auto || nb_wino_tiles >= 100,
                     VERBOSE_UNSUPPORTED_FEATURE, "too few winograd tiles");
+            const bool is_auto_wino_profitable = !is_auto
+                    || (dst_d.dims()[2] >= 28 && dst_d.dims()[3] >= 28
+                            && ((src_d.dims()[0] >= 50)
+                                    || (src_d.dims()[0] >= 32
+                                            && dst_d.dims()[1] >= 256)
+                                    || (src_d.dims()[0] >= 32
+                                            && dst_d.dims()[2] >= 56
+                                            && dst_d.dims()[3] >= 56)));
+            VDISPATCH_CONV(is_auto_wino_profitable, VERBOSE_UNSUPPORTED_FEATURE,
+                    "shape is not profitable for auto winograd");
 
             const int nthr = dnnl_get_max_threads();
             VDISPATCH_CONV(nthr <= 1 || src_d.dims()[0] >= nstl::min(nthr, 8),


### PR DESCRIPTION
# Description

This PR enables RV64 RVV Winograd convolution to be selected by the AUTO convolution path for suitable f32 forward convolution cases, and removes the previous single-thread-only restriction by adding batch-level parallel execution.

The original RVV Winograd implementation had two practical limitations:

1. `convolution_auto` did not reliably select `wino:rvv`, so Winograd had to be forced explicitly and could not be evaluated as a normal AUTO dispatch candidate.
2. The implementation was restricted to single-thread execution because the input/output Winograd-domain scratchpad buffers (`V` and `M`) were shared. Removing the single-thread guard directly would introduce data races between workers.

This PR addresses both issues by:

- accepting `convolution_auto` and setting the default algorithm to `convolution_winograd`;
- introducing `conf.nthr` for batch-level parallel execution;
- allocating per-thread `V` and `M` scratchpad slices;
- using `parallel(conf.nthr, ...)` and `balance211()` to split minibatch work across workers;
- keeping transformed weights shared, since they are read-only during execution;
- tightening AUTO dispatch with a conservative, thread-aware heuristic to avoid selecting Winograd for marginal or regressive shapes.

# Implementation details

The execution flow remains the same for each minibatch:

1. input transform: `src -> V`
2. 16 Winograd-domain GEMMs: `U * V -> M`
3. output transform: `M -> dst`

The difference is that minibatches are now processed in parallel. Each worker owns a private `V/M` scratchpad slice:

```cpp
float *V = V_base + ithr * conf.wspec.V_buffer_size;
float *M = M_base + ithr * conf.wspec.M_buffer_size;
```

This avoids cross-thread overwrites while still allowing the transformed weights buffer to be shared.

The number of workers is capped by both minibatch size and the maximum runtime thread count:

```cpp
conf.nthr = nstl::min(static_cast<int>(mb), dnnl_get_max_threads());
```

For dispatch, this PR keeps explicit `WINO` less restrictive than AUTO:

- explicit `--alg=WINO` still supports `ic >= 96 && oc >= 96`;
- AUTO Winograd requires `ic >= 128 && oc >= 128`;
- the minimum Winograd tile threshold is used as an AUTO heuristic;
- explicit WINO remains available for manual testing outside the AUTO region.

For AUTO, this PR uses a conservative profiled region. On hosts with `nthr <= 8`, AUTO Winograd is allowed only for 28x28-or-larger output shapes that also satisfy one of the profitable-region conditions, such as sufficiently large minibatch, sufficiently large output channels, or larger spatial size.

For `nthr > 8`, AUTO is more restrictive. The current SG2044-tested guard limits AUTO Winograd to the region that was profitable under 64-thread testing:

```text
mb >= 50 && ic == 128 && oc == 128 && oh == 28 && ow == 28
```

The stricter AUTO conditions are intentional. Broader testing showed that Winograd is beneficial for selected ResNet-like and profiled synthetic shapes, but 96-channel VGG boundary cases, 25x25 cases, small-batch 28x28 cases, and some high-thread-count shapes are marginal or regressive. Keeping AUTO conservative avoids selecting Winograd where BRGEMM/GEMM is still preferable.

# Performance

Current performance numbers were collected on two RV64 platforms:

- MUSE Pi Pro / Spacemit(R) X60, using up to 8 logical cores;
- SG2044, using 64 cores.

The metric is benchdnn `avg ms`; lower is better.

Note: Current benchdnn defaults convolution `--alg` to `DIRECT`, so AUTO dispatch is tested explicitly with `--alg=AUTO`.

## MUSE Pi Pro / Spacemit(R) X60 results

### Single-thread `--alg=AUTO`

Command shape:

```sh
OMP_NUM_THREADS=1 LD_LIBRARY_PATH=./src taskset -c 0 \
  ./tests/benchdnn/benchdnn -v2 --mode=P --conv --alg=AUTO <shape>
```

| Case | Baseline impl | Baseline avg ms | Optimized impl | Optimized avg ms | Speedup |
| --- | --- | ---: | --- | ---: | ---: |
| resnet_50:res3a_branch2b*4 | brgemm:rvv | 1553.89 | wino:rvv | 1432.82 | +8.45% |
| resnet_50:res4a_branch2b*6 | gemm:rvv | 2915.59 | gemm:rvv | 2890.40 | +0.87% |
| resnet_50:res5a_branch2b*3 | gemm:rvv | 3471.93 | gemm:rvv | 3442.58 | +0.85% |
| vgg_11:conv3_1 | brgemm:rvv | 840.69 | brgemm:rvv | 834.20 | +0.78% |
| vgg_11:conv3_2 | brgemm:rvv | 1409.57 | brgemm:rvv | 1443.65 | -2.36% |
| vgg_11:conv4_1 | gemm:rvv | 1087.31 | gemm:rvv | 1100.96 | -1.24% |
| vgg_11:conv4_2 | gemm:rvv | 1566.46 | gemm:rvv | 1576.21 | -0.62% |
| vgg_11:conv5_1 | gemm:rvv | 573.19 | gemm:rvv | 589.53 | -2.77% |
| vgg_11:conv5_2 | gemm:rvv | 737.47 | gemm:rvv | 758.64 | -2.79% |

The main AUTO Winograd win in this set is `resnet_50:res3a_branch2b*4`, where AUTO switches from `brgemm:rvv` to `wino:rvv` and improves `avg ms` by 8.45%.

The other cases keep their original GEMM/BRGEMM implementations. Their small positive or negative deltas should be treated as run-to-run noise or fallback-path variation, not as Winograd performance claims.

### 8-thread `--alg=AUTO`

Command shape:

```sh
OMP_NUM_THREADS=8 LD_LIBRARY_PATH=./src taskset -c 0-7 \
  ./tests/benchdnn/benchdnn -v2 --mode=P --conv --alg=AUTO <shape>
```

| Case | Baseline impl | Baseline avg ms | Optimized impl | Optimized avg ms | Speedup |
| --- | --- | ---: | --- | ---: | ---: |
| resnet_50:res3a_branch2b*4 | brgemm:rvv | 345.38 | wino:rvv | 301.44 | +14.58% |
| vgg_11:conv3_1 | brgemm:rvv | 129.11 | brgemm:rvv | 143.65 | -10.12% |
| vgg_11:conv3_2 | brgemm:rvv | 231.73 | brgemm:rvv | 234.35 | -1.12% |
| resnet_50:res3a_branch2b*4 | brgemm:rvv | 342.66 | wino:rvv | 287.91 | +19.02% |
| mb8_c128_h28 | brgemm:rvv | 54.39 | brgemm:rvv | 53.17 | +2.28% |
| mb16_c128_h28 | brgemm:rvv | 107.68 | brgemm:rvv | 109.51 | -1.67% |
| mb32_c128_h28 | brgemm:rvv | 202.86 | brgemm:rvv | 215.11 | -5.69% |
| mb64_c128_h28 | brgemm:rvv | 417.99 | wino:rvv | 338.11 | +23.62% |
| mb32_c128_h25 | brgemm:rvv | 151.98 | brgemm:rvv | 171.69 | -11.48% |
| mb64_c128_h25 | brgemm:rvv | 311.12 | brgemm:rvv | 306.19 | +1.61% |
| mb16_c128_h56 | brgemm:rvv | 411.91 | brgemm:rvv | 415.84 | -0.94% |
| mb32_c128_h56 | brgemm:rvv | 815.31 | wino:rvv | 738.23 | +10.44% |
| mb32_c256_h28 | brgemm:rvv | 955.68 | wino:rvv | 804.76 | +18.75% |
| mb32_c128_256_h28 | brgemm:rvv | 441.73 | wino:rvv | 400.46 | +10.31% |
| mb32_c256_128_h28 | brgemm:rvv | 396.31 | brgemm:rvv | 387.41 | +2.30% |

## SG2044 64-thread results

Additional testing was done on SG2044 with 64 cores.

- Command shape:

```sh
OMP_NUM_THREADS=64 LD_LIBRARY_PATH=./src taskset -c 0-63 \
  ./tests/benchdnn/benchdnn -v2 --mode=P --conv --alg=AUTO <shape>
```

### 64-thread `--alg=AUTO`

| Case | Baseline impl | Baseline avg ms | Optimized impl | Optimized avg ms | Speedup |
| --- | --- | ---: | --- | ---: | ---: |
| resnet_50:res3a_branch2b*4 | brgemm:rvv | 38.65 | wino:rvv | 27.13 | +42.45% |
| resnet_50:res4a_branch2b*6 | gemm:rvv | 24.13 | gemm:rvv | 24.30 | -0.73% |
| resnet_50:res5a_branch2b*3 | gemm:rvv | 36.90 | gemm:rvv | 33.42 | +10.41% |
| vgg_11:conv3_1 | brgemm:rvv | 11.79 | brgemm:rvv | 13.01 | -9.34% |
| vgg_11:conv3_2 | brgemm:rvv | 36.63 | brgemm:rvv | 23.46 | +56.18% |
| vgg_11:conv4_1 | gemm:rvv | 11.47 | gemm:rvv | 9.98 | +14.90% |
| vgg_11:conv4_2 | gemm:rvv | 13.30 | gemm:rvv | 14.56 | -8.67% |
| vgg_11:conv5_1 | gemm:rvv | 6.45 | gemm:rvv | 6.43 | +0.36% |
| vgg_11:conv5_2 | gemm:rvv | 7.08 | gemm:rvv | 6.69 | +5.96% |
| resnet_50:res3a_branch2b*4 | brgemm:rvv | 43.08 | wino:rvv | 26.44 | +62.95% |
| mb8_c128_h28 | brgemm:rvv | 7.43 | brgemm:rvv | 6.71 | +10.84% |
| mb16_c128_h28 | brgemm:rvv | 14.26 | brgemm:rvv | 15.89 | -10.23% |
| mb32_c128_h28 | brgemm:rvv | 27.31 | brgemm:rvv | 31.94 | -14.50% |
| mb64_c128_h28 | brgemm:rvv | 50.04 | wino:rvv | 38.51 | +29.94% |
| mb32_c128_h25 | brgemm:rvv | 20.75 | brgemm:rvv | 19.23 | +7.92% |
| mb64_c128_h25 | brgemm:rvv | 38.49 | brgemm:rvv | 38.09 | +1.04% |
| mb16_c128_h56 | brgemm:rvv | 50.23 | brgemm:rvv | 45.00 | +11.62% |
| mb32_c128_h56 | brgemm:rvv | 91.99 | brgemm:rvv | 81.48 | +12.90% |
| mb32_c256_h28 | brgemm:rvv | 143.37 | brgemm:rvv | 164.82 | -13.02% |
| mb32_c128_256_h28 | brgemm:rvv | 73.41 | brgemm:rvv | 63.87 | +14.95% |
| mb32_c256_128_h28 | brgemm:rvv | 68.52 | brgemm:rvv | 66.90 | +2.43% |

SG2044 showed higher-than-usual noise when using 64 cores, possibly because some scattered tasks were running at the same time. I’ll try to find another idle window to update these numbers.