### PR TITLE
cpu: rv64: add JIT f32 support for ip, eltwise, bnorm and gnorm

### DIFF
--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -69,7 +69,6 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
             CPU_INSTANCE_RV64GCV(rvv_brgemm_inner_product_fwd_t)
             CPU_INSTANCE_RV64GCV(rvv_gemm_inner_product_fwd_t)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
             CPU_INSTANCE(gemm_inner_product_fwd_t<f32>)
             CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,

--- a/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/rv64/jit_rvv_batch_normalization_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+namespace {
+
+template <bool per_elem_params, bool with_relu>
+void dispatch_jit_batch_normalization_f32(
+        const jit_rvv_batch_normalization_fwd_kernel_t::call_params_t *p) {
+    static const jit_rvv_batch_normalization_fwd_kernel_t kernel(
+            per_elem_params, with_relu);
+    kernel(p);
+}
+
+} // namespace
+
+jit_rvv_batch_normalization_fwd_kernel_t::
+        jit_rvv_batch_normalization_fwd_kernel_t(
+                bool per_elem_params, bool with_relu)
+    : jit_generator_t("jit_rvv_batch_normalization_fwd_kernel")
+    , per_elem_params_(per_elem_params)
+    , with_relu_(with_relu) {
+    create_kernel();
+}
+
+void jit_rvv_batch_normalization_apply_f32(const float *src, float *dst,
+        dim_t len, const float *mean, const float *scale_mul,
+        const float *scale_add, bool per_elem_params, bool with_relu) {
+    const jit_rvv_batch_normalization_fwd_kernel_t::call_params_t p {
+            src, dst, len, mean, scale_mul, scale_add};
+    if (per_elem_params) {
+        if (with_relu)
+            dispatch_jit_batch_normalization_f32<true, true>(&p);
+        else
+            dispatch_jit_batch_normalization_f32<true, false>(&p);
+    } else {
+        if (with_relu)
+            dispatch_jit_batch_normalization_f32<false, true>(&p);
+        else
+            dispatch_jit_batch_normalization_f32<false, false>(&p);
+    }
+}
+
+void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_dst = a2;
+    const Reg reg_len = a3;
+    const Reg reg_mean = a4;
+    const Reg reg_sm = a5;
+    const Reg reg_sv = a6;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+
+    const FReg f_mean = fa0;
+    const FReg f_sm = fa1;
+    const FReg f_sv = fa2;
+    const FReg f_zero = fa3;
+
+    const VReg v_src(4);
+    const VReg v_mean(8);
+    const VReg v_sm(12);
+    const VReg v_sv(16);
+
+    ld(reg_src, reg_param, 0);
+    ld(reg_dst, reg_param, 8);
+    ld(reg_len, reg_param, 16);
+    ld(reg_mean, reg_param, 24);
+    ld(reg_sm, reg_param, 32);
+    ld(reg_sv, reg_param, 40);
+
+    if (!per_elem_params_) {
+        flw(f_mean, reg_mean, 0);
+        flw(f_sm, reg_sm, 0);
+        flw(f_sv, reg_sv, 0);
+    }
+    fmv_w_x(f_zero, x0);
+
+    Label loop, done;
+    L(loop);
+    beqz(reg_len, done);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vle32_v(v_src, reg_src);
+    if (per_elem_params_) {
+        vle32_v(v_mean, reg_mean);
+        vle32_v(v_sm, reg_sm);
+        vle32_v(v_sv, reg_sv);
+        vfsub_vv(v_src, v_src, v_mean);
+        vfmul_vv(v_src, v_src, v_sm);
+        vfadd_vv(v_src, v_src, v_sv);
+    } else {
+        vfsub_vf(v_src, v_src, f_mean);
+        vfmul_vf(v_src, v_src, f_sm);
+        vfadd_vf(v_src, v_src, f_sv);
+    }
+    if (with_relu_) vfmax_vf(v_src, v_src, f_zero);
+    vse32_v(v_src, reg_dst);
+
+    slli(reg_bytes, reg_vl, 2);
+    add(reg_src, reg_src, reg_bytes);
+    add(reg_dst, reg_dst, reg_bytes);
+    if (per_elem_params_) {
+        add(reg_mean, reg_mean, reg_bytes);
+        add(reg_sm, reg_sm, reg_bytes);
+        add(reg_sv, reg_sv, reg_bytes);
+    }
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(done);
+    ret();
+#else
+    ret();
+#endif
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_rvv_batch_normalization_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_batch_normalization_kernel.hpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_RVV_BATCH_NORMALIZATION_KERNEL_HPP
+#define CPU_RV64_JIT_RVV_BATCH_NORMALIZATION_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_rvv_batch_normalization_fwd_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const float *src;
+        float *dst;
+        dim_t len;
+        const float *mean;
+        const float *scale_mul;
+        const float *scale_add;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_batch_normalization_fwd_kernel_t)
+
+    jit_rvv_batch_normalization_fwd_kernel_t(
+            bool per_elem_params, bool with_relu);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    bool per_elem_params_;
+    bool with_relu_;
+};
+
+void jit_rvv_batch_normalization_apply_f32(const float *src, float *dst,
+        dim_t len, const float *mean, const float *scale_mul,
+        const float *scale_add, bool per_elem_params, bool with_relu);
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_JIT_RVV_BATCH_NORMALIZATION_KERNEL_HPP

--- a/src/cpu/rv64/jit_rvv_eltwise_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_eltwise_kernel.cpp
@@ -1,0 +1,184 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <assert.h>
+
+#include "cpu/rv64/jit_rvv_eltwise_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+namespace {
+
+template <alg_kind_t alg>
+void dispatch_jit_eltwise_f32(
+        const jit_rvv_eltwise_fwd_kernel_t::call_params_t *p) {
+    static const jit_rvv_eltwise_fwd_kernel_t kernel(alg);
+    kernel(p);
+}
+
+} // namespace
+
+jit_rvv_eltwise_fwd_kernel_t::jit_rvv_eltwise_fwd_kernel_t(alg_kind_t alg)
+    : jit_generator_t("jit_rvv_eltwise_fwd_kernel"), alg_(alg) {
+    create_kernel();
+}
+
+bool jit_rvv_eltwise_f32_supported(alg_kind_t alg) {
+    switch (alg) {
+        case alg_kind::eltwise_abs:
+        case alg_kind::eltwise_clip:
+        case alg_kind::eltwise_hardsigmoid:
+        case alg_kind::eltwise_hardswish:
+        case alg_kind::eltwise_linear:
+        case alg_kind::eltwise_relu:
+        case alg_kind::eltwise_sqrt:
+        case alg_kind::eltwise_square: return true;
+        default: return false;
+    }
+}
+
+void jit_rvv_eltwise_apply_f32(alg_kind_t alg, const float *src, float *dst,
+        dim_t len, float alpha, float beta) {
+    const jit_rvv_eltwise_fwd_kernel_t::call_params_t p {
+            src, dst, len, alpha, beta};
+    switch (alg) {
+        case alg_kind::eltwise_abs:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_abs>(&p);
+            break;
+        case alg_kind::eltwise_clip:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_clip>(&p);
+            break;
+        case alg_kind::eltwise_hardsigmoid:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_hardsigmoid>(&p);
+            break;
+        case alg_kind::eltwise_hardswish:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_hardswish>(&p);
+            break;
+        case alg_kind::eltwise_linear:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_linear>(&p);
+            break;
+        case alg_kind::eltwise_relu:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_relu>(&p);
+            break;
+        case alg_kind::eltwise_sqrt:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_sqrt>(&p);
+            break;
+        case alg_kind::eltwise_square:
+            dispatch_jit_eltwise_f32<alg_kind::eltwise_square>(&p);
+            break;
+        default: assert(!"unsupported f32 eltwise JIT alg");
+    }
+}
+
+void jit_rvv_eltwise_fwd_kernel_t::compute_vector(const VReg &v_dst,
+        const VReg &v_src, const VReg &v_tmp, const FReg &f_alpha,
+        const FReg &f_beta, const FReg &f_zero, const FReg &f_one) {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const VReg v_mask(0);
+    switch (alg_) {
+        case alg_kind::eltwise_abs: vfabs_v(v_dst, v_src); break;
+        case alg_kind::eltwise_clip:
+            vfmax_vf(v_dst, v_src, f_alpha);
+            vfmin_vf(v_dst, v_dst, f_beta);
+            break;
+        case alg_kind::eltwise_hardsigmoid:
+            vfmul_vf(v_dst, v_src, f_alpha);
+            vfadd_vf(v_dst, v_dst, f_beta);
+            vfmax_vf(v_dst, v_dst, f_zero);
+            vfmin_vf(v_dst, v_dst, f_one);
+            break;
+        case alg_kind::eltwise_hardswish:
+            vfmul_vf(v_tmp, v_src, f_alpha);
+            vfadd_vf(v_tmp, v_tmp, f_beta);
+            vfmax_vf(v_tmp, v_tmp, f_zero);
+            vfmin_vf(v_tmp, v_tmp, f_one);
+            vfmul_vv(v_dst, v_src, v_tmp);
+            break;
+        case alg_kind::eltwise_linear:
+            vfmul_vf(v_dst, v_src, f_alpha);
+            vfadd_vf(v_dst, v_dst, f_beta);
+            break;
+        case alg_kind::eltwise_relu:
+            vmfgt_vf(v_mask, v_src, f_zero);
+            vfmul_vf(v_tmp, v_src, f_alpha);
+            vmerge_vvm(v_dst, v_tmp, v_src);
+            break;
+        case alg_kind::eltwise_sqrt: vfsqrt_v(v_dst, v_src); break;
+        case alg_kind::eltwise_square: vfmul_vv(v_dst, v_src, v_src); break;
+        default: assert(!"unsupported f32 eltwise JIT alg");
+    }
+#else
+    UNUSED(v_dst, v_src, v_tmp, f_alpha, f_beta, f_zero, f_one);
+#endif
+}
+
+void jit_rvv_eltwise_fwd_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_dst = a2;
+    const Reg reg_len = a3;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+    const Reg reg_tmp = t2;
+
+    const FReg f_alpha = fa0;
+    const FReg f_beta = fa1;
+    const FReg f_zero = fa2;
+    const FReg f_one = fa3;
+
+    const VReg v_src(4);
+    const VReg v_tmp(8);
+    const VReg v_dst(12);
+
+    ld(reg_src, reg_param, 0);
+    ld(reg_dst, reg_param, 8);
+    ld(reg_len, reg_param, 16);
+    flw(f_alpha, reg_param, 24);
+    flw(f_beta, reg_param, 28);
+    fmv_w_x(f_zero, x0);
+    li(reg_tmp, 0x3f800000);
+    fmv_w_x(f_one, reg_tmp);
+
+    Label loop, done;
+    L(loop);
+    beqz(reg_len, done);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
+    vle32_v(v_src, reg_src);
+    compute_vector(v_dst, v_src, v_tmp, f_alpha, f_beta, f_zero, f_one);
+    vse32_v(v_dst, reg_dst);
+    slli(reg_bytes, reg_vl, 2);
+    add(reg_src, reg_src, reg_bytes);
+    add(reg_dst, reg_dst, reg_bytes);
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(done);
+    ret();
+#else
+    ret();
+#endif
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_rvv_eltwise_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_eltwise_kernel.hpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_RVV_ELTWISE_KERNEL_HPP
+#define CPU_RV64_JIT_RVV_ELTWISE_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_rvv_eltwise_fwd_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const float *src;
+        float *dst;
+        dim_t len;
+        float alpha;
+        float beta;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_eltwise_fwd_kernel_t)
+
+    explicit jit_rvv_eltwise_fwd_kernel_t(alg_kind_t alg);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    void compute_vector(const Xbyak_riscv::VReg &v_dst,
+            const Xbyak_riscv::VReg &v_src, const Xbyak_riscv::VReg &v_tmp,
+            const Xbyak_riscv::FReg &f_alpha, const Xbyak_riscv::FReg &f_beta,
+            const Xbyak_riscv::FReg &f_zero, const Xbyak_riscv::FReg &f_one);
+
+    alg_kind_t alg_;
+};
+
+bool jit_rvv_eltwise_f32_supported(alg_kind_t alg);
+
+void jit_rvv_eltwise_apply_f32(alg_kind_t alg, const float *src, float *dst,
+        dim_t len, float alpha, float beta);
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_JIT_RVV_ELTWISE_KERNEL_HPP

--- a/src/cpu/rv64/jit_rvv_group_normalization_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_group_normalization_kernel.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/rv64/jit_rvv_group_normalization_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+namespace {
+
+template <bool use_scale, bool use_shift>
+void dispatch_jit_group_normalization_f32(
+        const jit_rvv_group_normalization_fwd_kernel_t::call_params_t *p) {
+    static const jit_rvv_group_normalization_fwd_kernel_t kernel(
+            use_scale, use_shift);
+    kernel(p);
+}
+
+} // namespace
+
+jit_rvv_group_normalization_fwd_kernel_t::
+        jit_rvv_group_normalization_fwd_kernel_t(bool use_scale, bool use_shift)
+    : jit_generator_t("jit_rvv_group_normalization_fwd_kernel")
+    , use_scale_(use_scale)
+    , use_shift_(use_shift) {
+    create_kernel();
+}
+
+void jit_rvv_group_normalization_apply_f32(const float *src, float *dst,
+        dim_t len, float mean, float inv_std, float gamma, float beta,
+        bool use_scale, bool use_shift) {
+    const jit_rvv_group_normalization_fwd_kernel_t::call_params_t p {
+            src, dst, len, mean, inv_std, gamma, beta};
+    if (use_scale) {
+        if (use_shift)
+            dispatch_jit_group_normalization_f32<true, true>(&p);
+        else
+            dispatch_jit_group_normalization_f32<true, false>(&p);
+    } else {
+        if (use_shift)
+            dispatch_jit_group_normalization_f32<false, true>(&p);
+        else
+            dispatch_jit_group_normalization_f32<false, false>(&p);
+    }
+}
+
+void jit_rvv_group_normalization_fwd_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_dst = a2;
+    const Reg reg_len = a3;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+
+    const FReg f_mean = fa0;
+    const FReg f_inv_std = fa1;
+    const FReg f_gamma = fa2;
+    const FReg f_beta = fa3;
+
+    const VReg v_src(4);
+
+    ld(reg_src, reg_param, 0);
+    ld(reg_dst, reg_param, 8);
+    ld(reg_len, reg_param, 16);
+    flw(f_mean, reg_param, 24);
+    flw(f_inv_std, reg_param, 28);
+    flw(f_gamma, reg_param, 32);
+    flw(f_beta, reg_param, 36);
+
+    Label loop, done;
+    L(loop);
+    beqz(reg_len, done);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vle32_v(v_src, reg_src);
+    vfsub_vf(v_src, v_src, f_mean);
+    vfmul_vf(v_src, v_src, f_inv_std);
+    if (use_scale_) vfmul_vf(v_src, v_src, f_gamma);
+    if (use_shift_) vfadd_vf(v_src, v_src, f_beta);
+    vse32_v(v_src, reg_dst);
+
+    slli(reg_bytes, reg_vl, 2);
+    add(reg_src, reg_src, reg_bytes);
+    add(reg_dst, reg_dst, reg_bytes);
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(done);
+    ret();
+#else
+    ret();
+#endif
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_rvv_group_normalization_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_group_normalization_kernel.hpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_RVV_GROUP_NORMALIZATION_KERNEL_HPP
+#define CPU_RV64_JIT_RVV_GROUP_NORMALIZATION_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_rvv_group_normalization_fwd_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const float *src;
+        float *dst;
+        dim_t len;
+        float mean;
+        float inv_std;
+        float gamma;
+        float beta;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_group_normalization_fwd_kernel_t)
+
+    jit_rvv_group_normalization_fwd_kernel_t(bool use_scale, bool use_shift);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    bool use_scale_;
+    bool use_shift_;
+};
+
+void jit_rvv_group_normalization_apply_f32(const float *src, float *dst,
+        dim_t len, float mean, float inv_std, float gamma, float beta,
+        bool use_scale, bool use_shift);
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_JIT_RVV_GROUP_NORMALIZATION_KERNEL_HPP

--- a/src/cpu/rv64/rvv_batch_normalization.cpp
+++ b/src/cpu/rv64/rvv_batch_normalization.cpp
@@ -17,12 +17,12 @@
 #include <assert.h>
 #include <math.h>
 #include <vector>
-#include <riscv_vector.h>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/type_helpers.hpp"
 
+#include "cpu/rv64/jit_rvv_batch_normalization_kernel.hpp"
 #include "cpu/rv64/rvv_batch_normalization.hpp"
 
 namespace dnnl {
@@ -32,43 +32,12 @@ namespace rv64 {
 
 namespace {
 
-// If per_elem_params is false, uses broadcast scalars mean/sm/sv (mean[0], sm[0], sv[0]).
-// If true, loads per-element mean/sm/sv from the provided arrays.
 static inline void bn_fwd_kernel_f32(const void *s_base, void *d_base,
         size_t len, const float *mean, const float *sm, const float *sv,
-        bool per_elem_params, const rv64::rvv_postops_t &po) {
-    const size_t data_size = types::data_type_size(data_type::f32);
-    for (size_t i = 0; i < len;) {
-        size_t vl = __riscv_vsetvl_e32m1(len - i);
-
-        const float *s_ptr = reinterpret_cast<const float *>(
-                reinterpret_cast<const char *>(s_base) + i * data_size);
-        float *d_ptr = reinterpret_cast<float *>(
-                reinterpret_cast<char *>(d_base) + i * data_size);
-
-        vfloat32m1_t vx = __riscv_vle32_v_f32m1(s_ptr, vl);
-
-        vfloat32m1_t vmean_v;
-        vfloat32m1_t vsm_v;
-        vfloat32m1_t vsv_v;
-        if (per_elem_params) {
-            vmean_v = __riscv_vle32_v_f32m1(mean + i, vl);
-            vsm_v = __riscv_vle32_v_f32m1(sm + i, vl);
-            vsv_v = __riscv_vle32_v_f32m1(sv + i, vl);
-        } else {
-            vmean_v = __riscv_vfmv_v_f_f32m1(mean[0], vl);
-            vsm_v = __riscv_vfmv_v_f_f32m1(sm[0], vl);
-            vsv_v = __riscv_vfmv_v_f_f32m1(sv[0], vl);
-        }
-
-        vfloat32m1_t vtmp = __riscv_vfsub_vv_f32m1(vx, vmean_v, vl);
-        vfloat32m1_t vout = __riscv_vfmul_vv_f32m1(vtmp, vsm_v, vl);
-        vout = __riscv_vfadd_vv_f32m1(vout, vsv_v, vl);
-        vout = po.apply(vout, vl);
-
-        __riscv_vse32_v_f32m1(d_ptr, vout, vl);
-        i += vl;
-    }
+        bool per_elem_params, bool with_relu) {
+    jit_rvv_batch_normalization_apply_f32(static_cast<const float *>(s_base),
+            static_cast<float *>(d_base), static_cast<dim_t>(len), mean, sm, sv,
+            per_elem_params, with_relu);
 }
 
 } // namespace
@@ -98,9 +67,8 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
             ? CTX_IN_MEM(const float *, DNNL_ARG_SHIFT)
             : nullptr;
 
-    rv64::rvv_postops_t po = pd()->fused_relu_in_kernel()
-            ? rv64::rvv_postops_t(alg_kind::eltwise_relu)
-            : rv64::rvv_postops_t(pd()->attr()->post_ops_);
+    const bool with_relu = pd()->fused_relu_in_kernel()
+            || pd()->attr()->post_ops_.find(primitive_kind::eltwise) != -1;
 
     auto off = [&](dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) -> size_t {
         switch (ndims) {
@@ -138,7 +106,8 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
                     const float sm_b[1] = {sm};
                     const float sv_b[1] = {sv};
                     bn_fwd_kernel_f32(s_ptr, d_ptr, static_cast<size_t>(W),
-                            mean_b, sm_b, sv_b, /*per_elem_params=*/false, po);
+                            mean_b, sm_b, sv_b, /*per_elem_params=*/false,
+                            with_relu);
                     break;
                 }
                 default:
@@ -176,7 +145,7 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
 
                     bn_fwd_kernel_f32(s_ptr, d_ptr, static_cast<size_t>(C),
                             mean, sm_arr, sv_arr,
-                            /*per_elem_params=*/true, po);
+                            /*per_elem_params=*/true, with_relu);
                     break;
                 }
                 default:

--- a/src/cpu/rv64/rvv_eltwise.cpp
+++ b/src/cpu/rv64/rvv_eltwise.cpp
@@ -22,6 +22,7 @@
 #include "common/math_utils.hpp"
 #include "common/type_helpers.hpp"
 
+#include "cpu/rv64/jit_rvv_eltwise_kernel.hpp"
 #include "cpu/rv64/rvv_eltwise.hpp"
 #include "cpu/rv64/rvv_eltwise_kernels.hpp"
 
@@ -38,7 +39,8 @@ void compute_eltwise_rvv_fwd(const alg_kind_t alg, const void *src, void *dst,
         const data_type_t dt) {
     switch (dt) {
         case data_type::f32:
-            rvv_eltwise_apply_fwd_f32(alg, src, dst, len, alpha, beta, dt);
+            jit_rvv_eltwise_apply_f32(alg, static_cast<const float *>(src),
+                    static_cast<float *>(dst), len, alpha, beta);
             break;
         case data_type::s32:
             rvv_eltwise_apply_fwd_s32(alg, src, dst, len, alpha, beta, dt);

--- a/src/cpu/rv64/rvv_group_normalization.cpp
+++ b/src/cpu/rv64/rvv_group_normalization.cpp
@@ -20,6 +20,7 @@
 #include "common/dnnl_thread.hpp"
 #include "common/memory_desc_wrapper.hpp"
 
+#include "cpu/rv64/jit_rvv_group_normalization_kernel.hpp"
 #include "cpu/rv64/rvv_group_normalization.hpp"
 
 namespace dnnl {
@@ -90,63 +91,8 @@ inline void stats_reduction(
 inline void norm_spatial_loop(const float *src, float *dst, size_t len,
         float mean_val, float inv_std_val, float gamma_val, float beta_val,
         bool use_scale, bool use_shift) {
-
-    size_t vl_max = __riscv_vsetvlmax_e32m1();
-    size_t idx = 0;
-
-    vfloat32m1_t v_mean = __riscv_vfmv_v_f_f32m1(mean_val, vl_max);
-    vfloat32m1_t v_inv_std = __riscv_vfmv_v_f_f32m1(inv_std_val, vl_max);
-    vfloat32m1_t v_gamma = __riscv_vfmv_v_f_f32m1(gamma_val, vl_max);
-    vfloat32m1_t v_beta = __riscv_vfmv_v_f_f32m1(beta_val, vl_max);
-
-    for (; idx + 4 * vl_max <= len; idx += 4 * vl_max) {
-        vfloat32m1_t v0 = __riscv_vle32_v_f32m1(src + idx + 0 * vl_max, vl_max);
-        vfloat32m1_t v1 = __riscv_vle32_v_f32m1(src + idx + 1 * vl_max, vl_max);
-        vfloat32m1_t v2 = __riscv_vle32_v_f32m1(src + idx + 2 * vl_max, vl_max);
-        vfloat32m1_t v3 = __riscv_vle32_v_f32m1(src + idx + 3 * vl_max, vl_max);
-
-        v0 = __riscv_vfsub_vv_f32m1(v0, v_mean, vl_max);
-        v1 = __riscv_vfsub_vv_f32m1(v1, v_mean, vl_max);
-        v2 = __riscv_vfsub_vv_f32m1(v2, v_mean, vl_max);
-        v3 = __riscv_vfsub_vv_f32m1(v3, v_mean, vl_max);
-
-        v0 = __riscv_vfmul_vv_f32m1(v0, v_inv_std, vl_max);
-        v1 = __riscv_vfmul_vv_f32m1(v1, v_inv_std, vl_max);
-        v2 = __riscv_vfmul_vv_f32m1(v2, v_inv_std, vl_max);
-        v3 = __riscv_vfmul_vv_f32m1(v3, v_inv_std, vl_max);
-
-        if (use_scale) {
-            v0 = __riscv_vfmul_vv_f32m1(v0, v_gamma, vl_max);
-            v1 = __riscv_vfmul_vv_f32m1(v1, v_gamma, vl_max);
-            v2 = __riscv_vfmul_vv_f32m1(v2, v_gamma, vl_max);
-            v3 = __riscv_vfmul_vv_f32m1(v3, v_gamma, vl_max);
-        }
-        if (use_shift) {
-            v0 = __riscv_vfadd_vv_f32m1(v0, v_beta, vl_max);
-            v1 = __riscv_vfadd_vv_f32m1(v1, v_beta, vl_max);
-            v2 = __riscv_vfadd_vv_f32m1(v2, v_beta, vl_max);
-            v3 = __riscv_vfadd_vv_f32m1(v3, v_beta, vl_max);
-        }
-
-        __riscv_vse32_v_f32m1(dst + idx + 0 * vl_max, v0, vl_max);
-        __riscv_vse32_v_f32m1(dst + idx + 1 * vl_max, v1, vl_max);
-        __riscv_vse32_v_f32m1(dst + idx + 2 * vl_max, v2, vl_max);
-        __riscv_vse32_v_f32m1(dst + idx + 3 * vl_max, v3, vl_max);
-    }
-
-    while (idx < len) {
-        size_t vl = __riscv_vsetvl_e32m1(len - idx);
-        vfloat32m1_t v_x = __riscv_vle32_v_f32m1(src + idx, vl);
-
-        v_x = __riscv_vfsub_vf_f32m1(v_x, mean_val, vl);
-        v_x = __riscv_vfmul_vf_f32m1(v_x, inv_std_val, vl);
-
-        if (use_scale) v_x = __riscv_vfmul_vf_f32m1(v_x, gamma_val, vl);
-        if (use_shift) v_x = __riscv_vfadd_vf_f32m1(v_x, beta_val, vl);
-
-        __riscv_vse32_v_f32m1(dst + idx, v_x, vl);
-        idx += vl;
-    }
+    jit_rvv_group_normalization_apply_f32(src, dst, static_cast<dim_t>(len),
+            mean_val, inv_std_val, gamma_val, beta_val, use_scale, use_shift);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

This PR adds RV64 f32 JIT coverage for the following CPU primitives:

- inner product
- eltwise
- batch normalization
- group normalization

Main changes:

- Prefer the RV64GCV JIT inner product path for f32 by removing the older `rvv_inner_product_fwd_t` entry from the f32 inner product implementation list.
- Add a new RVV JIT f32 eltwise kernel for the currently supported RV64 eltwise algorithms:
  - `abs`
  - `clip`
  - `hardsigmoid`
  - `hardswish`
  - `linear`
  - `relu`
  - `sqrt`
  - `square`
- Replace the f32 RVV intrinsic batch normalization forward compute loop with a generated RVV JIT kernel.
- Replace the f32 RVV intrinsic group normalization forward normalization loop with a generated RVV JIT kernel.

## Performance

All numbers below are from `benchdnn` `avg(ms)`.

### Summary

| commit | primitive | batch | raw avg(ms) | opt avg(ms) | speedup |
|---|---|---|---:|---:|---:|
| `59d962857d104eb95ff189964b0335b990e46ded` | `bnorm` | `tests/benchdnn/inputs/bnorm/shapes_resnet_50` | 494.215000 | 493.560000 | 1.001x |
| `178bf9c46e6416549b4e95bbd8df7f2e936c45e0` | `gnorm` | `tests/benchdnn/inputs/gnorm/shapes_all` | 92.344700 | 91.739900 | 1.007x |
| `6d67c69d8e3b527c0ec7891f3f519608ef6b5aed` | `eltwise` | `tests/benchdnn/inputs/eltwise/shapes_eltwise` | 0.484517 | 0.472902 | 1.025x |
| `62c7fce4ccacc3a2fc0d2fb3fee3dd3202ced391` | `ip` | `tests/benchdnn/inputs/ip/shapes_regression` | 1373.510000 | 1370.850000 | 1.002x |

<details>
<summary>59d962857d104eb95ff189964b0335b990e46ded: bnorm detailed performance</summary>

- Primitive: `bnorm`
- Batch: `tests/benchdnn/inputs/bnorm/shapes_resnet_50`
- Overall speedup: `1.001x`

| case | shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---|---:|---:|---:|
| `resnet_50:bn_conv1` | `mb50ic64ih112n"resnet_50:bn_conv1"` | 124.365000 | 119.772000 | 1.038x |
| `resnet_50:bn2a_branch1*4` | `mb50ic256ih56n"resnet_50:bn2a_branch1*4"` | 117.937000 | 128.914000 | 0.915x |
| `resnet_50:bn2a_branch2a*6` | `mb50ic64ih56n"resnet_50:bn2a_branch2a*6"` | 29.184600 | 26.512100 | 1.101x |
| `resnet_50:bn3a_branch1*5` | `mb50ic512ih28n"resnet_50:bn3a_branch1*5"` | 82.683800 | 76.547000 | 1.080x |
| `resnet_50:bn3a_branch2a*8` | `mb50ic128ih28n"resnet_50:bn3a_branch2a*8"` | 20.888600 | 18.655100 | 1.120x |
| `resnet_50:bn4a_branch1*7` | `mb50ic1024ih14n"resnet_50:bn4a_branch1*7"` | 59.654100 | 62.762600 | 0.950x |
| `resnet_50:bn4a_branch2a*12` | `mb50ic256ih14n"resnet_50:bn4a_branch2a*12"` | 13.329600 | 13.999600 | 0.952x |
| `resnet_50:bn5a_branch1*4` | `mb50ic2048ih7n"resnet_50:bn5a_branch1*4"` | 36.227000 | 36.999500 | 0.979x |
| `resnet_50:bn5a_branch2a*6` | `mb50ic512ih7n"resnet_50:bn5a_branch2a*6"` | 9.945390 | 9.397790 | 1.058x |

</details>

<details>
<summary>178bf9c46e6416549b4e95bbd8df7f2e936c45e0: gnorm detailed performance</summary>

- Primitive: `gnorm`
- Batch: `tests/benchdnn/inputs/gnorm/shapes_all`
- Overall speedup: `1.007x`

| case | shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---|---:|---:|---:|
| `g32ic32id16ih224iw224` | `g32ic32id16ih224iw224` | 87.486800 | 86.786900 | 1.008x |
| `mb6g256ic256id2ih28iw28` | `mb6g256ic256id2ih28iw28` | 3.151960 | 3.236260 | 0.974x |
| `g320ic320id10ih14iw14` | `g320ic320id10ih14iw14` | 1.597370 | 1.594090 | 1.002x |
| `g128ic128id6ih7iw7` | `g128ic128id6ih7iw7` | 0.050218 | 0.055340 | 0.907x |
| `g1ic2iw40` | `g1ic2iw40` | 0.012198 | 0.011565 | 1.055x |
| `g2ic8ih30iw40` | `g2ic8ih30iw40` | 0.025238 | 0.029622 | 0.852x |
| `g5ic10id9ih10iw10` | `g5ic10id9ih10iw10` | 0.020884 | 0.026088 | 0.801x |

</details>

<details>
<summary>6d67c69d8e3b527c0ec7891f3f519608ef6b5aed: eltwise detailed performance</summary>

- Primitive: `eltwise`
- Batch: `tests/benchdnn/inputs/eltwise/shapes_eltwise`
- Overall speedup: `1.025x`

### Algorithm-level summary

| alg | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `abs` | 0.059809 | 0.056837 | 1.052x |
| `relu` | 0.061777 | 0.057708 | 1.070x |
| `sqrt` | 0.061845 | 0.060312 | 1.025x |
| `square` | 0.060408 | 0.059818 | 1.010x |
| `clip` | 0.060518 | 0.059153 | 1.023x |
| `linear` | 0.058997 | 0.058623 | 1.006x |
| `hardsigmoid` | 0.061348 | 0.061168 | 1.003x |
| `hardswish` | 0.059815 | 0.059283 | 1.009x |

### `abs`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.008363 | 0.008017 | 1.043x |
| `16x64x1x1` | 0.008200 | 0.008029 | 1.021x |
| `3x7x3x2` | 0.008325 | 0.008149 | 1.022x |
| `2x32x3x2` | 0.008401 | 0.007884 | 1.066x |
| `32x5x2x3` | 0.008739 | 0.008098 | 1.079x |
| `2x16x5x2x3` | 0.008738 | 0.008066 | 1.083x |
| `3x17x2x5x3` | 0.009043 | 0.008596 | 1.052x |

### `relu`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.008027 | 0.008113 | 0.989x |
| `16x64x1x1` | 0.008711 | 0.008109 | 1.074x |
| `3x7x3x2` | 0.008197 | 0.008369 | 0.979x |
| `2x32x3x2` | 0.008742 | 0.008032 | 1.088x |
| `32x5x2x3` | 0.008621 | 0.008421 | 1.024x |
| `2x16x5x2x3` | 0.010544 | 0.008181 | 1.289x |
| `3x17x2x5x3` | 0.008935 | 0.008485 | 1.053x |

### `sqrt`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.008372 | 0.008181 | 1.023x |
| `16x64x1x1` | 0.008842 | 0.008838 | 1.000x |
| `3x7x3x2` | 0.008476 | 0.008349 | 1.015x |
| `2x32x3x2` | 0.008624 | 0.008721 | 0.989x |
| `32x5x2x3` | 0.009232 | 0.008631 | 1.070x |
| `2x16x5x2x3` | 0.009008 | 0.008672 | 1.039x |
| `3x17x2x5x3` | 0.009291 | 0.008920 | 1.042x |

### `square`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.008267 | 0.008373 | 0.987x |
| `16x64x1x1` | 0.008482 | 0.008775 | 0.967x |
| `3x7x3x2` | 0.008306 | 0.007977 | 1.041x |
| `2x32x3x2` | 0.008649 | 0.008684 | 0.996x |
| `32x5x2x3` | 0.008719 | 0.008449 | 1.032x |
| `2x16x5x2x3` | 0.009039 | 0.009047 | 0.999x |
| `3x17x2x5x3` | 0.008948 | 0.008512 | 1.051x |

### `clip`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.008630 | 0.008223 | 1.049x |
| `16x64x1x1` | 0.008775 | 0.008436 | 1.040x |
| `3x7x3x2` | 0.008180 | 0.008533 | 0.959x |
| `2x32x3x2` | 0.008870 | 0.008304 | 1.068x |
| `32x5x2x3` | 0.008275 | 0.008456 | 0.979x |
| `2x16x5x2x3` | 0.009144 | 0.008414 | 1.087x |
| `3x17x2x5x3` | 0.008645 | 0.008787 | 0.984x |

### `linear`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.008065 | 0.008083 | 0.998x |
| `16x64x1x1` | 0.008684 | 0.008415 | 1.032x |
| `3x7x3x2` | 0.008142 | 0.008410 | 0.968x |
| `2x32x3x2` | 0.008280 | 0.008401 | 0.986x |
| `32x5x2x3` | 0.008550 | 0.008344 | 1.025x |
| `2x16x5x2x3` | 0.008580 | 0.008427 | 1.018x |
| `3x17x2x5x3` | 0.008696 | 0.008542 | 1.018x |

### `hardsigmoid`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.008289 | 0.008040 | 1.031x |
| `16x64x1x1` | 0.009374 | 0.008483 | 1.105x |
| `3x7x3x2` | 0.008469 | 0.008244 | 1.027x |
| `2x32x3x2` | 0.008714 | 0.008210 | 1.061x |
| `32x5x2x3` | 0.008776 | 0.008523 | 1.030x |
| `2x16x5x2x3` | 0.008867 | 0.008785 | 1.009x |
| `3x17x2x5x3` | 0.008861 | 0.010882 | 0.814x |

### `hardswish`

| shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---:|---:|---:|
| `5x16x3` | 0.007936 | 0.008259 | 0.961x |
| `16x64x1x1` | 0.008841 | 0.008354 | 1.058x |
| `3x7x3x2` | 0.008137 | 0.008573 | 0.949x |
| `2x32x3x2` | 0.008414 | 0.008479 | 0.992x |
| `32x5x2x3` | 0.008440 | 0.008516 | 0.991x |
| `2x16x5x2x3` | 0.009339 | 0.008256 | 1.131x |
| `3x17x2x5x3` | 0.008708 | 0.008845 | 0.984x |

</details>

<details>
<summary>62c7fce4ccacc3a2fc0d2fb3fee3dd3202ced391: inner product detailed performance</summary>

- Primitive: `ip`
- Batch: `tests/benchdnn/inputs/ip/shapes_regression`
- Overall speedup: `1.002x`

| case | shape | raw avg(ms) | opt avg(ms) | speedup |
|---|---|---:|---:|---:|
| `small_oc_block` | `mb1ic16oc26n"small_oc_block"` | 0.005109 | 0.004945 | 1.033x |
| `mb128ic2200oc2200` | `mb128ic2200oc2200` | 87.984200 | 95.088100 | 0.925x |
| `mb128ic1500oc1500` | `mb128ic1500oc1500` | 81.456600 | 81.426600 | 1.000x |
| `mb1120ic1024oc2046` | `mb1120ic1024oc2046` | 851.462000 | 840.295000 | 1.013x |
| `mb1000ic1000oc1111` | `mb1000ic1000oc1111` | 347.937000 | 347.625000 | 1.001x |
| `mb1ic16001oc101` | `mb1ic16001oc101` | 4.660060 | 6.411770 | 0.727x |

Implementation distribution:

| build | implementation distribution |
|---|---|
| raw | `brgemm:rvv 4 (67%)`, `RISCV64GCV:gemm 2 (33%)` |
| opt | `brgemm:rvv 4 (67%)`, `RISCV64GCV:gemm 2 (33%)` |

</details>

## Testing

- `ctest`: passed