### PR TITLE
cpu: x64: matmul: use T0 load for A when L1 budget allows

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1008,6 +1008,30 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
             is_a_nt_ = true;
         }
 
+        // Re-check A's L1 residency after the "give up on L1" branch above
+        // shrinks k_blk_h. That branch unconditionally sets is_a_nt_ = true,
+        // but the smaller k_blk_h often leaves A's per-iter panel
+        // (k_blk_h * m_decomposition * gemm_dt_sz) fitting in L1 alongside
+        // C/D. In that case prefer caching A in L1 (T0): the same A panel
+        // is reused by every AMX N-tile within one k_blk iteration and
+        // avoiding the NT hint also prevents needless eviction of B/C from
+        // L1/L2.
+        //
+        // The original L1-residency predicate (l1_set_issues) over-estimated
+        // A's footprint by scaling it with l1_eff_factor = div_up(K, k_blk_h),
+        // i.e. counting all K-blocks as co-resident, which forced that branch
+        // to trigger more often than warranted.
+        const size_t a_l1_final
+                = (size_t)k_blk_h * m_decomposition * gemm_dt_sz;
+        // Per-iter L1 budget mirrors the original predicate above.
+        const bool a_fits_l1 = a_l1_final + 2 * c_l1 + d_post <= L1_threshold();
+        // Skip the override for write-bound layers (small K). On such layers
+        // the bottleneck is C writes. Pulling A into L1 evicts the C
+        // accumulator and hurts performance even when A nominally fits.
+        const bool is_write_bound_layer = nthr_k_ == 1
+                && k_per_thread < k_threshold_write_bound_layer_elem;
+        if (a_fits_l1 && !is_write_bound_layer) is_a_nt_ = false;
+
         k_blk_ = k_blk_h;
         k_chunk_size_ = best_k_h;
         n_blk_ = nstl::min(best_n_h * n_decomposition, N);


### PR DESCRIPTION
Addresses MFDNN-14892 and MFDNN-14891.

This pull request improves performance for some batch matmul cases via adjusting the heuristics for AMX.

The AMX horizontal blocking heuristic falls back to L2-sized blocking when the L1-residency check (`l1_set_issues`) fails and as part of that fall-back unconditionally sets `is_a_nt_ = true`. The L1-residency check itself scales A's footprint by `l1_eff_factor = div_up(K, k_blk_h)` i.e. counts all K-blocks as co-resident, which over-estimates A and forces the fall-back more often than it should.

After the fall-back shrinks `k_blk_h`, A's per-iteration panel (`k_blk_h * m_decomposition * gemm_dt_sz`) frequently fits in L1. In that case the NT hint on A is needless cache pollution as it streams A past L1/L2 and evicts B lines that the next N-tile within the same `k_blk` iteration is about to reuse.

Re-check A's actual L1 footprint after the fall-back (without the `l1_eff_factor` inflation) and revert to a cached (`T0`) load when it fits. The override is gated by a write-bound check (`nthr_k == 1 and k_per_thread < k_threshold_write_bound_layer_elem`) so it's not triggered for small-K layers where the bottleneck is C writes and pulling A into L1 would evict the accumulator. Non-AMX dispatch paths and the small-dims early-return (M <= 32) are unaffected.

For the reported shape from MFDNN-14892 I got ~9% performance improvement.
`./tests/benchdnn/benchdnn --matmul --mode=P --dt=u8:s8:s32 --stag=abc --dtag=abc 8x144x7168:8x7168x4096`

SPR (bf16, int8)
<img width="627" height="522" alt="image" src="https://github.com/user-attachments/assets/f337e511-97b6-4480-942e-2cf7c26da92b" />
GNR (bf16, f16, int8)
<img width="643" height="506" alt="image" src="https://github.com/user-attachments/assets/ee47e2a1-c524-47db-9ea0-ea80953eb57b" />

**NOTE**: I re-measured Transformer LT Inference RT on a GNR and got 102%. Also confirmed that the degradation is not manually reproduced.

