### PR TITLE
tests: benchdnn: extend tested cases for grouped pos

### DIFF
--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
@@ -209,7 +209,7 @@
 --dt=f16:f16:f16
 --wtag=abc
 --grouped=0:4:8+8+8+8
---attr-post-ops=eltwise_swish:1.0,mul:f32:1:ab,mul:f32:3:grouped
+--attr-post-ops=eltwise_swish:1.0,mul:f32:1:ab,mul:f16:1:ab,mul:bf16:1:ab,mul:f32:3:grouped,mul:f16:3:grouped,mul:bf16:3:grouped
 32x64:4x64x32
 
 # Post-ops: eltwise_swish + binary_mul (grouped)
@@ -217,7 +217,7 @@
 --dt=f16:f16:f16
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8,0:4:8+0+16+8
---attr-post-ops=eltwise_swish:1.0+mul:f32:3:grouped
+--attr-post-ops=eltwise_swish:1.0+mul:f32:3:grouped,eltwise_swish:1.0+mul:f16:3:grouped,eltwise_swish:1.0+mul:bf16:3:grouped
 32x64:4x64x32
 
 # Post-ops + bias: binary_mul per-row and grouped with bias
@@ -226,7 +226,7 @@
 --wtag=abc
 --grouped=0:4:8+8+8+8
 --bia-dt=f32 --bia_mask=2
---attr-post-ops=mul:f32:1:ab,mul:f32:3:grouped
+--attr-post-ops=mul:f32:1:ab,mul:f32:3:grouped,mul:bf16:3:grouped,mul:f16:3:grouped
 32x64:4x64x32
 
 # Post-ops + quantization: binary_mul per-row and grouped with WOQ scales
@@ -236,5 +236,5 @@
 --grouped=0:4:8+8+8+8
 --attr-fpmath=f16:true
 --attr-scales=wei:7:f16:32x1
---attr-post-ops=mul:f32:1:ab,mul:f32:3:grouped
+--attr-post-ops=mul:f32:1:ab,mul:f16:1:ab,mul:f32:3:grouped,mul:f16:3:grouped
 32x128:4x128x64


### PR DESCRIPTION
Follow up for [MFDNN-14920](https://jira.devtools.intel.com/browse/MFDNN-14920):
- Binary mul post-op for grouped gemm supports grouped tensor as input, so ensuring we're testing all f32/bf16/f16 data types for it (i.e., all the data types that grouped gemm could produce)