### PR TITLE
cpu: rv64: fix relu alpha handling in default post-ops

### DIFF
--- a/src/cpu/rv64/rvv_postops.hpp
+++ b/src/cpu/rv64/rvv_postops.hpp
@@ -36,6 +36,7 @@ struct rvv_postops_t {
         if (po.len() > 0) {
             if (po.entry_[0].is_eltwise()) {
                 alg_ = po.entry_[0].eltwise.alg;
+                alpha_ = po.entry_[0].eltwise.alpha;
             } else if (po.entry_[0].is_binary()) {
                 alg_ = po.entry_[0].binary.alg;
             }
@@ -112,7 +113,8 @@ struct rvv_postops_t {
         return status::success;
     }
 
-    explicit rvv_postops_t(alg_kind_t alg) : alg_(alg) {}
+    explicit rvv_postops_t(alg_kind_t alg, float alpha = 0.f)
+        : alg_(alg), alpha_(alpha) {}
 
     static bool post_ops_ok(const post_ops_t &po) {
         if (po.len() == 0) return true;
@@ -135,8 +137,14 @@ struct rvv_postops_t {
     inline vfloat32m1_t apply(vfloat32m1_t v, size_t vl) const {
         switch (alg_) {
             case alg_kind::eltwise_relu: {
-                vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
-                return __riscv_vfmax_vv_f32m1(v, zero, vl);
+                if (alpha_ == 0.f) {
+                    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
+                    return __riscv_vfmax_vv_f32m1(v, zero, vl);
+                }
+
+                vbool32_t p = __riscv_vmfgt_vf_f32m1_b32(v, 0.f, vl);
+                vfloat32m1_t vneg = __riscv_vfmul_vf_f32m1(v, alpha_, vl);
+                return __riscv_vmerge_vvm_f32m1(vneg, v, p, vl);
             }
             default: return v;
         }
@@ -147,6 +155,7 @@ struct rvv_postops_t {
 
 private:
     alg_kind_t alg_ = alg_kind::undef;
+    float alpha_ = 0.f;
     post_ops_t po_;
     int post_op_start_index_ = 0;
     data_type_t dst_data_type_ = data_type::undef;


### PR DESCRIPTION
This PR fixes incorrect `eltwise_relu` alpha handling in the default RV64 post-ops path.

Previously, `src/cpu/rv64/rvv_postops.hpp` ignored the configured alpha and effectively implemented ReLU as `max(x, 0)`. As a result, RV64 primitives using the default post-ops helper could produce incorrect results for cases such as `relu:0.1` or `relu:2`.

This change stores the eltwise alpha in `rvv_postops_t` and applies ReLU with oneDNN semantics:

```cpp
x > 0 ? x : alpha * x
````

while preserving the existing fast path for `alpha == 0`.

## Repro command

```bash
DNNL_VERBOSE=1 ./benchdnn \
  --matmul --mode=C \
  --dt=f32 --stag=abc --wtag=abc --dtag=abc \
  --attr-post-ops=relu:2 \
  128x1x8192:1x8192x64
```

## Logs

* Before fix: 
```
% DNNL_VERBOSE=1 ./benchdnn   --matmul --mode=C   --dt=f32 --stag=abc --wtag=abc --dtag=abc   --attr-post-ops=relu:2   128x1x8192:1x8192x64
onednn_verbose,v1,info,oneDNN v3.13.0 (commit 7f0a3e02c55c1ad505c51db1897286b2053a21dd)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:8
onednn_verbose,v1,info,cpu,isa:Generic
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:acb::f0 dst:f32::blocked:abc::f0,,,1x8192x64,35.3188
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:abc::f0 dst:f32::blocked:abc::f0,,,128x1x8192,47.98
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:101
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:101
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:101
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:101
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:101
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:101
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:101
onednn_verbose,v1,primitive,exec,cpu,matmul,RISCV64GCV,undef,src:f32::blocked:abc::f0 wei:f32::blocked:abc::f0 dst:f32::blocked:abc::f0,attr-post-ops:eltwise_relu:2,,128x1x8192:1x8192x64,14.9668
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:abc::f0 dst:f32::blocked:abc::f0,,,128x1x64,0.462158
[   0][DST][0:0:0] exp_f32:      -57366 exp:      -57366 got:           0 diff:   57366 rdiff:       1
[   2][DST][0:0:2] exp_f32:      -31110 exp:      -31110 got:           0 diff:   31110 rdiff:       1
[   3][DST][0:0:3] exp_f32:      -53778 exp:      -53778 got:           0 diff:   53778 rdiff:       1
[   5][DST][0:0:5] exp_f32:     -455180 exp:     -455180 got:           0 diff:  455180 rdiff:       1
[   6][DST][0:0:6] exp_f32:     -257752 exp:     -257752 got:           0 diff:  257752 rdiff:       1
[   7][DST][0:0:7] exp_f32:     -573058 exp:     -573058 got:           0 diff:  573058 rdiff:       1
[   9][DST][0:0:9] exp_f32:     -130502 exp:     -130502 got:           0 diff:  130502 rdiff:       1
[  10][DST][0:0:10] exp_f32:     -158078 exp:     -158078 got:           0 diff:  158078 rdiff:       1
[  12][DST][0:0:12] exp_f32:      -87322 exp:      -87322 got:           0 diff:   87322 rdiff:       1
[  13][DST][0:0:13] exp_f32:     -226712 exp:     -226712 got:           0 diff:  226712 rdiff:       1
[COMPARE_STATS][DST]: trh=0 err_max_diff:  957192 err_max_rdiff:       1 all_max_diff:  957192 all_max_rdiff:       1
0:FAILED (errors:4016 total:8192) (817 ms) __REPRO: --matmul --stag=abc --wtag=abc --dtag=abc --attr-post-ops=relu:2 128x1x8192:1x8192x64
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| RISCV64GCV : 1 (100%)                                    |
============================================================
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:FAILED (errors:4016 total:8192) (817 ms) __REPRO: --matmul --stag=abc --wtag=abc --dtag=abc --attr-post-ops=relu:2 128x1x8192:1x8192x64
============================
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 0.82s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.75s (91%); execute: 0.02s (2%); compute_ref: 0.04s (4%); compare: 0.00s (1%);
```

* After fix: 
```
% DNNL_VERBOSE=1 ./benchdnn   --matmul --mode=C   --dt=f32 --stag=abc --wtag=abc --dtag=abc   --attr-post-ops=relu:2   128x1x8192:1x8192x64
onednn_verbose,v1,info,oneDNN v3.13.0 (commit 70cb813c8f825a1350ed4905f83f46dc08af0f88)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:8
onednn_verbose,v1,info,cpu,isa:Generic
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:acb::f0 dst:f32::blocked:abc::f0,,,1x8192x64,26.251
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:abc::f0 dst:f32::blocked:abc::f0,,,128x1x8192,1.53906
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,warning,jit_profiling,VTune Profiler integration is not supported,src/cpu/jit_utils/jit_utils.cpp:100
onednn_verbose,v1,primitive,exec,cpu,matmul,RISCV64GCV,undef,src:f32::blocked:abc::f0 wei:f32::blocked:abc::f0 dst:f32::blocked:abc::f0,attr-post-ops:eltwise_relu:2,,128x1x8192:1x8192x64,18.54
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:abc::f0 dst:f32::blocked:abc::f0,,,128x1x64,0.0429688
0:PASSED (200 ms) __REPRO: --matmul --stag=abc --wtag=abc --dtag=abc --attr-post-ops=relu:2 128x1x8192:1x8192x64
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| RISCV64GCV : 1 (100%)                                    |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.20s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.05s (26%); execute: 0.02s (9%); compute_ref: 0.11s (56%); compare: 0.00s (1%);
```