### PR TITLE
x64: sse41 conv: enable grayscale flat path and add regression test

### DIFF
--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -477,7 +477,7 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
                                     post_ops, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    const bool flat = jcp.ic == 3;
+    const bool flat = jcp.ic == 3 || jcp.ic == 1;
     const bool mimo = !flat;
 
     const bool tag_ok = true

--- a/src/cpu/x64/jit_sse41_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_convolution.hpp
@@ -87,7 +87,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
                     && IMPLICATION(curr_dst_tag != dat_tag_nxc,
                             dst_d.format_kind() == format_kind::any)
                     && utils::one_of(dat_tag_nxc, curr_src_tag, curr_dst_tag);
-            const bool flat = IC() == 3;
+            const bool flat = IC() == 3 || IC() == 1;
             auto src_tag = is_data_layout_nxc ? dat_tag_nxc
                     : flat                    ? dat_tag_ncx
                                               : dat_tag_nCx8c;

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -129,6 +129,10 @@ mb1_g16ic16oc16_ih5oh2kh2sh3ph0
 # AVX JIT incorrectly calculates output when nb_oc_block results in a prime number
 --reset --dir=FWD_I mb1ic3ih320oc51oh160kh7sh2ph3n"regression_oc-channel"
 
+# Grayscale (IC=1) plain-layout forward convolution regression coverage
+--reset --dt=f32 --dir=FWD_D --stag=axb --dtag=axb --skip-impl=ref
+mb1_ic1oc16_ih5oh5kh3ph1_iw5ow5kw3pw1n"regression_grayscale_ic1_plain"
+
 # Dilated convolution with ih<=dh when there is _no_ compute work.
 --reset --dt=u8:s8:u8 mb1ic16ih1iw1oc16oh2ow1kh3kw1dh1ph1n"regression_dh_equals_ih"
 


### PR DESCRIPTION
## Summary
This PR enables the SSE4.1 f32 NxN convolution path to treat `IC=1` as a flat input case, in addition to `IC=3`, and adds a benchdnn regression entry to ensure this behavior remains covered.

## Background
Previously, the SSE4.1 flat-path condition only handled `IC=3`.  
For grayscale inputs (`IC=1`), this could cause the intended optimized dispatch path to be skipped.

## Changes
- Update SSE4.1 flat-path checks from `IC == 3` to `IC == 1 || IC == 3`.
- Keep kernel-side and descriptor-side conditions consistent.
- Add one benchdnn regression case for f32 forward direct convolution with:
  - Plain layout
  - `IC=1`, `OC=16`
  - `3x3` kernel
  - Padding = `1`

## Validation
- Incremental benchdnn build succeeded.
- Targeted `IC=1` case passed under SSE4.1 capability.
- oneDNN verbose output confirms `jit:sse41` convolution implementation is selected.
- `IC=3` control case also passed.

## Impact
- Improves coverage for grayscale convolution dispatch on SSE4.1.
- Minimal, low-risk change with regression protection included.