### PR TITLE
gpu: refactor gpu_primitive_attr_t to grf per thread

### DIFF
--- a/src/common/c_types_map.hpp
+++ b/src/common/c_types_map.hpp
@@ -2115,7 +2115,7 @@ const query_t num_handles_s32 = dnnl_query_num_handles_s32;
 // Internal only query kinds.
 const query_t internal_only_start = (query_t)(1 << 12);
 const query_t zero_pad_d = internal_only_start;
-const query_t preferred_gpu_threads_per_eu = (query_t)(internal_only_start + 1);
+const query_t preferred_gpu_grf_per_thread = (query_t)(internal_only_start + 1);
 } // namespace query
 
 // There are no external values to map to because this is an internal feature

--- a/src/gpu/intel/bnorm/xe.cpp
+++ b/src/gpu/intel/bnorm/xe.cpp
@@ -279,7 +279,7 @@ static status_t init_conf_common(lookup_table::params_t &conf, offsets_t &off,
     if (conf.use_fused_atomics_reduction()) {
         auto *gpu_attr
                 = downcast<gpu_primitive_attr_t *>(pd->attr()->gpu_attr_.get());
-        bool large_grf_mode = gpu_attr && gpu_attr->threads_per_eu() == 4;
+        bool large_grf_mode = gpu_attr && gpu_attr->grf_per_thread() > 128;
         adjust_lws_calc_kernel(
                 conf, dispatch_calc_stat, intel_engine, large_grf_mode);
 

--- a/src/gpu/intel/compute/dispatch_reusable.hpp
+++ b/src/gpu/intel/compute/dispatch_reusable.hpp
@@ -327,7 +327,7 @@ struct lws_strategy_t {
     virtual bool is_included(const mapped_block_t &blocks) const = 0;
 
     size_t get_max_wg_size() const {
-        bool large_grf_mode = gpu_attr && gpu_attr->threads_per_eu() == 4;
+        bool large_grf_mode = gpu_attr && gpu_attr->grf_per_thread() > 128;
         return engine->device_info()->max_wg_size(large_grf_mode);
     }
 

--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -179,7 +179,7 @@ private:
         if (attr && attr->gpu_attr_) {
             auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
                     attr->gpu_attr_.get());
-            if (gpu_attr->threads_per_eu() == 4) {
+            if (gpu_attr->grf_per_thread() > 128) {
                 add_option("-cl-intel-256-GRF-per-thread");
             }
         }

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -372,9 +372,8 @@ struct gen_t : public primitive_t {
 
         status_t query(query_t what, int idx, void *result) const override {
             switch ((int)what) {
-                case (int)query::preferred_gpu_threads_per_eu: {
-                    int grfs = kernel_desc_.driver_info()->grfCount;
-                    *(int *)result = (grfs > 128) ? 4 : 8;
+                case (int)query::preferred_gpu_grf_per_thread: {
+                    *(int *)result = kernel_desc_.driver_info()->grfCount;
                     break;
                 }
                 default: return gemm::pd_t::query(what, idx, result);

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
@@ -146,8 +146,8 @@ struct xe_hp_systolic_t : public gemm::primitive_t {
 
         status_t query(query_t what, int idx, void *result) const override {
             switch ((int)what) {
-                case (int)query::preferred_gpu_threads_per_eu: {
-                    *(int *)result = 4;
+                case (int)query::preferred_gpu_grf_per_thread: {
+                    *(int *)result = 256;
                     break;
                 }
                 default: return gemm::pd_t::query(what, idx, result);

--- a/src/gpu/intel/gemm/with_post_ops.hpp
+++ b/src/gpu/intel/gemm/with_post_ops.hpp
@@ -66,11 +66,11 @@ struct with_post_ops_t : public primitive_t {
         auto ret_status = create_nested_primitive(prim_, pd()->pd_, engine);
         CHECK(ret_status);
         primitive_attr_t attr;
-        int threads_per_eu = 0;
+        int grf_per_thread = 0;
         if (status::success
-                == pd()->pd_->query(query::preferred_gpu_threads_per_eu, 0,
-                        &threads_per_eu)) {
-            CHECK(attr.set_gpu_attr(gpu_primitive_attr_t(threads_per_eu)));
+                == pd()->pd_->query(query::preferred_gpu_grf_per_thread, 0,
+                        &grf_per_thread)) {
+            CHECK(attr.set_gpu_attr(gpu_primitive_attr_t(grf_per_thread)));
         }
         compute::kernel_ctx_t kernel_ctx(&attr);
         CHECK(pd()->init_kernel_ctx(kernel_ctx));

--- a/src/gpu/intel/ip/gemm.hpp
+++ b/src/gpu/intel/ip/gemm.hpp
@@ -341,14 +341,14 @@ struct gemm_bwd_weights_t : public primitive_t {
                                 0.0f),
                         VERBOSE_UNSUPPORTED_TAG);
                 primitive_attr_t reduction_attr = *attr();
-                int threads_per_eu;
+                int grf_per_thread;
                 auto status
-                        = gemm_pd_->query(query::preferred_gpu_threads_per_eu,
-                                0, &threads_per_eu);
+                        = gemm_pd_->query(query::preferred_gpu_grf_per_thread,
+                                0, &grf_per_thread);
                 if (status == status::success) {
                     VDISPATCH_INNER_PRODUCT_SC(
                             reduction_attr.set_gpu_attr(
-                                    gpu_primitive_attr_t(threads_per_eu)),
+                                    gpu_primitive_attr_t(grf_per_thread)),
                             VERBOSE_UNSUPPORTED_ATTR);
                 }
                 primitive_desc_iterator_t it(engine, (op_desc_t *)&reduction_d,

--- a/src/gpu/intel/jit/ir/hw.hpp
+++ b/src/gpu/intel/jit/ir/hw.hpp
@@ -56,7 +56,7 @@ inline dsl::hw_t make_ir_hw(const impl::engine_t *engine) {
 inline bool prefer_large_grf(
         const dsl::hw_t &hw, const gpu_primitive_attr_t *gpu_attr) {
     if (!gpu_attr || !hw.large_grf_support()) return false;
-    return gpu_attr->threads_per_eu() * 2 == hw.threads_per_eu();
+    return gpu_attr->grf_per_thread() > 128;
 }
 
 } // namespace jit

--- a/src/gpu/intel/lnorm/vectorized.cpp
+++ b/src/gpu/intel/lnorm/vectorized.cpp
@@ -244,7 +244,7 @@ static status_t init_conf_common(
 
     auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
             pd->attr()->gpu_attr_.get());
-    bool large_grf_mode = gpu_attr && gpu_attr->threads_per_eu() == 4;
+    bool large_grf_mode = gpu_attr && gpu_attr->grf_per_thread() > 128;
     auto eu_count = intel_engine->device_info()->eu_count();
     auto threads_per_eu
             = device_info_t::threads_per_eu(gpu_arch, large_grf_mode);

--- a/src/gpu/intel/primitive_attr.hpp
+++ b/src/gpu/intel/primitive_attr.hpp
@@ -26,30 +26,30 @@ namespace gpu {
 namespace intel {
 
 struct gpu_primitive_attr_t : public primitive_attr_item_t {
-    gpu_primitive_attr_t(int threads_per_eu = 0)
-        : threads_per_eu_(threads_per_eu) {}
+    gpu_primitive_attr_t(int grf_per_thread = 0)
+        : grf_per_thread_(grf_per_thread) {}
 
     std::unique_ptr<primitive_attr_item_t> clone() const override {
-        return utils::make_unique<gpu_primitive_attr_t>(threads_per_eu_);
+        return utils::make_unique<gpu_primitive_attr_t>(grf_per_thread_);
     }
 
-    bool has_default_values() const override { return threads_per_eu_ == 0; }
+    bool has_default_values() const override { return grf_per_thread_ == 0; }
 
     bool is_equal(const primitive_attr_item_t &other) const override {
         auto *other_ptr = utils::downcast<const gpu_primitive_attr_t *>(&other);
-        return threads_per_eu_ == other_ptr->threads_per_eu_;
+        return grf_per_thread_ == other_ptr->grf_per_thread_;
     }
 
-    size_t get_hash() const override { return threads_per_eu_; }
+    size_t get_hash() const override { return grf_per_thread_; }
 
     void serialize(serialization_stream_t &stream) const override {
-        stream.append(threads_per_eu_);
+        stream.append(grf_per_thread_);
     }
 
-    int threads_per_eu() const { return threads_per_eu_; }
+    int grf_per_thread() const { return grf_per_thread_; }
 
 private:
-    int threads_per_eu_;
+    int grf_per_thread_;
 };
 
 } // namespace intel

--- a/src/gpu/intel/reduction/atomic.cpp
+++ b/src/gpu/intel/reduction/atomic.cpp
@@ -104,18 +104,17 @@ atomic_conf_t::atomic_conf_t(const subproblem_t &subprb, alg_kind_t alg,
     if (outer_block.block == 0 || inner_block.block == 0) return;
 
     auto arch = device_info.gpu_arch();
-    const int base_threads_per_eu
-            = compute::device_info_t::threads_per_eu(arch);
-    conf.threads_per_eu
-            = gpu_attr ? gpu_attr->threads_per_eu() : base_threads_per_eu;
+    conf.grf_per_thread = gpu_attr ? gpu_attr->grf_per_thread() : 128;
 
-    const bool large_grf_mode = conf.threads_per_eu == 4;
+    const bool large_grf_mode = conf.grf_per_thread > 128;
     const size_t max_wg_size = device_info.max_wg_size(large_grf_mode);
     const int eu_count = device_info.eu_count();
     const size_t max_sg_per_wg = utils::div_up(max_wg_size, conf.subgroup_size);
 
     // number of subgroups (threads) to saturate the GPU
-    const int target_subgroups = eu_count * conf.threads_per_eu;
+    const int threads_per_eu
+            = compute::device_info_t::threads_per_eu(arch, large_grf_mode);
+    const int target_subgroups = eu_count * threads_per_eu;
 
     const dim_t max_local_size
             = std::min(into<dim_t>(max_sg_per_wg), reduction_block.block);
@@ -487,7 +486,7 @@ static void init_kernel_ctx_common(
 status_t atomic_key_params_t::get_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
     primitive_attr_t ocl_attr;
-    CHECK(ocl_attr.set_gpu_attr(gpu_primitive_attr_t(threads_per_eu)));
+    CHECK(ocl_attr.set_gpu_attr(gpu_primitive_attr_t(grf_per_thread)));
     kernel_ctx = compute::kernel_ctx_t(&ocl_attr);
 
     init_kernel_ctx_common(kernel_ctx, *this);

--- a/src/gpu/intel/reduction/atomic.hpp
+++ b/src/gpu/intel/reduction/atomic.hpp
@@ -54,7 +54,7 @@ struct atomic_key_params_t : trivially_serializable_t<atomic_key_params_t> {
     data_type_t src_type, dst_type;
 
     // Implementation-specific parameters
-    int32_t threads_per_eu;
+    int32_t grf_per_thread;
     int32_t subgroup_size;
     int32_t vect_size;
     int32_t full_unroll_factor;

--- a/src/gpu/intel/reduction/combined.cpp
+++ b/src/gpu/intel/reduction/combined.cpp
@@ -298,7 +298,7 @@ status_t combined_t::pd_t::init_conf(impl::engine_t *engine) {
 
     auto *gpu_attr
             = utils::downcast<gpu_primitive_attr_t *>(attr()->gpu_attr_.get());
-    bool large_grf_mode = gpu_attr && gpu_attr->threads_per_eu() == 4;
+    bool large_grf_mode = gpu_attr && gpu_attr->grf_per_thread() > 128;
     // Further break up phases if needed, for parallelism
     data_type_t accum_data_type = types::default_accum_data_type(
             src_mdw.data_type(), data_type::undef);

--- a/src/gpu/intel/reduction/jit.cpp
+++ b/src/gpu/intel/reduction/jit.cpp
@@ -85,9 +85,10 @@ status_t gen_t::pd_t::init_conf(impl::engine_t *engine) {
         const compute::gpu_arch_t arch = device_info.gpu_arch();
         auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
                 attr()->gpu_attr_.get());
-        const int threads_per_eu = gpu_attr
-                ? gpu_attr->threads_per_eu()
-                : compute::device_info_t::threads_per_eu(arch);
+        const bool large_grf_mode
+                = gpu_attr && gpu_attr->grf_per_thread() > 128;
+        const int threads_per_eu
+                = compute::device_info_t::threads_per_eu(arch, large_grf_mode);
         int tg_size = utils::rnd_down_pow2(
                 device_info.max_eus_per_wg() * threads_per_eu);
         while (nthreads % tg_size != 0) {

--- a/src/gpu/intel/reduction/reusable_ref.cpp
+++ b/src/gpu/intel/reduction/reusable_ref.cpp
@@ -58,11 +58,7 @@ ref_conf_t::ref_conf_t(const subproblem_t &subprb, alg_kind_t alg,
     conf.alg = alg;
     conf.src_dt = src_dt;
     conf.dst_dt = dst_dt;
-    auto arch = device_info.gpu_arch();
-    const int base_threads_per_eu
-            = compute::device_info_t::threads_per_eu(arch);
-    conf.threads_per_eu
-            = gpu_attr ? gpu_attr->threads_per_eu() : base_threads_per_eu;
+    conf.grf_per_thread = gpu_attr ? gpu_attr->grf_per_thread() : 128;
 }
 
 status_t ref_conf_t::init_dispatcher(const subproblem_t &subprb,
@@ -218,7 +214,7 @@ static void init_kernel_ctx_common(
 status_t ref_key_params_t::get_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
     primitive_attr_t ocl_attr;
-    CHECK(ocl_attr.set_gpu_attr(gpu_primitive_attr_t(threads_per_eu)));
+    CHECK(ocl_attr.set_gpu_attr(gpu_primitive_attr_t(grf_per_thread)));
     kernel_ctx = compute::kernel_ctx_t(&ocl_attr);
 
     init_kernel_ctx_common(kernel_ctx, *this);

--- a/src/gpu/intel/reduction/reusable_ref.hpp
+++ b/src/gpu/intel/reduction/reusable_ref.hpp
@@ -52,7 +52,7 @@ struct ref_key_params_t : trivially_serializable_t<ref_key_params_t> {
 
     alg_kind_t alg;
     data_type_t src_dt, dst_dt;
-    int32_t threads_per_eu;
+    int32_t grf_per_thread;
 
     compute::dispatch_compile_params_t params;
 };

--- a/src/gpu/intel/rnn/config.hpp
+++ b/src/gpu/intel/rnn/config.hpp
@@ -116,7 +116,7 @@ struct ocl_conf_t {
 
     status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
-    int threads_per_eu = 0;
+    int grf_per_thread = 0;
     int subgroup_size = 0;
     int cell_kind = 0;
     int activation_kind = 0;

--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -151,7 +151,7 @@ static status_t init_layouts_data(offsets_t &off,
 }
 
 static status_t init_ocl_conf(ocl_conf_t &ocl_conf, const pd_t *pd,
-        const conf_t &conf, int threads_per_eu,
+        const conf_t &conf, int grf_per_thread,
         const compute::device_info_t &device_info, offsets_t &off) {
 
     const memory_desc_wrapper &src_iter_c_d = pd->src_md(2);
@@ -205,7 +205,7 @@ static status_t init_ocl_conf(ocl_conf_t &ocl_conf, const pd_t *pd,
     ocl_conf.wei_qparam_mask = pd->attr()->rnn_weights_qparams_.mask_;
     ocl_conf.is_testmode = conf.is_testmode;
 
-    ocl_conf.threads_per_eu = threads_per_eu;
+    ocl_conf.grf_per_thread = grf_per_thread;
     ocl_conf.subgroup_size = dev_getenv(
             "subgroup_size", device_info.max_subgroup_size(ocl_conf.acc_dt));
     auto max_elemwise_threads
@@ -256,7 +256,7 @@ static status_t init_ocl_conf(ocl_conf_t &ocl_conf, const pd_t *pd,
                 dim_t mb_tg = b_thread;
                 dim_t mb_block = mb_thr * mb_tg;
                 if (size_t(dhc_tg * mb_tg) > device_info.max_wg_size(
-                            threads_per_eu == 4, ocl_conf.subgroup_size))
+                            grf_per_thread > 128, ocl_conf.subgroup_size))
                     break;
 
                 double score = [&]() {
@@ -345,7 +345,7 @@ status_t ocl_conf_t::init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const {
     // Fwd operations are not well optimized for larger grf mode
     primitive_attr_t ocl_attr;
     if (!is_fwd)
-        CHECK(ocl_attr.set_gpu_attr(gpu_primitive_attr_t(threads_per_eu)));
+        CHECK(ocl_attr.set_gpu_attr(gpu_primitive_attr_t(grf_per_thread)));
     ocl_attr.deterministic_ = deterministic;
     kernel_ctx = compute::kernel_ctx_t(&ocl_attr);
 
@@ -745,7 +745,7 @@ status_t simple_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
     dim_t dhc = conf.dhc;
 
     auto fpmath_mode = this->attr()->fpmath_.mode_;
-    int threads_per_eu = 0;
+    int grf_per_thread = 0;
 
     // The inputs of create_gemm_pd describe a gemm in column major.
     // Below, we have to transpose the a and b descriptor to describe
@@ -772,12 +772,12 @@ status_t simple_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
         CHECK(dnnl::impl::create_gemm_pd(gemm_pd, engine, &a_md, &b_md, &c_md,
                 &glob_zero_md, c_dt, &attr));
         bool verbose = get_verbose_dev_mode(verbose_t::debuginfo) > 1;
-        if (threads_per_eu == 0 || verbose) {
+        if (grf_per_thread == 0 || verbose) {
             auto t = 0;
-            auto s = gemm_pd->query(query::preferred_gpu_threads_per_eu, 0, &t);
-            if (threads_per_eu == 0)
-                threads_per_eu = (status::success != s) ? t : 128;
-            if (verbose && t != threads_per_eu)
+            auto s = gemm_pd->query(query::preferred_gpu_grf_per_thread, 0, &t);
+            if (grf_per_thread == 0)
+                grf_per_thread = (status::success == s) ? t : 128;
+            if (verbose && t != grf_per_thread)
                 verbose_printf("[WARNING] GEMM grf modes are inconsistent\n");
         }
         return status::success;
@@ -936,7 +936,7 @@ status_t simple_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
         }
     }
 
-    VDISPATCH_RNN_SC(init_ocl_conf(ocl_conf, this, conf, threads_per_eu,
+    VDISPATCH_RNN_SC(init_ocl_conf(ocl_conf, this, conf, grf_per_thread,
                              device_info, this->off),
             "init_ocl_conf()");
 

--- a/src/gpu/intel/softmax/reusable.hpp
+++ b/src/gpu/intel/softmax/reusable.hpp
@@ -236,7 +236,7 @@ struct reusable_fwd_t : public primitive_t {
                 auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
                         attr()->gpu_attr_.get());
                 return intel_engine->device_info()->max_wg_size(
-                        gpu_attr && gpu_attr->threads_per_eu() == 4);
+                        gpu_attr && gpu_attr->grf_per_thread() > 128);
             }();
 
             const size_t num_workers_per_workgroup = dnnl::impl::utils::div_up(

--- a/src/gpu/intel/zeropad/simple.cpp
+++ b/src/gpu/intel/zeropad/simple.cpp
@@ -308,7 +308,7 @@ status_t simple_t::execute_subg_16_mask_and_clear_dt_1B(const exec_ctx_t &ctx,
 
     auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
             pd()->attr()->gpu_attr_.get());
-    bool large_grf_mode = gpu_attr && gpu_attr->threads_per_eu() == 4;
+    bool large_grf_mode = gpu_attr && gpu_attr->grf_per_thread() > 128;
     const size_t max_local_ws = device->max_wg_size(large_grf_mode, 16);
 
     const auto &dims = mdw.dims();


### PR DESCRIPTION
The `gpu_primitive_attr_t` was created a time when there were only two modes (both limited physically by 1024 GRF/EU):
- 4 threads/EU -- 256 GRF/thread
- 8 threads/EU -- 128 GRF/thread

At the time this feature was originally developed, it was not clear whether threads/EU or GRF/thread would be better. Nowadays it's clear that GRF/thread is more uniformly used in the library (likely because it separates software requirements from hardware capabilities), so it doesn't make sense to switch to threads/EU for this object then back to GRF/thread where it's used.

This PR simplifies the feature by sticking to GRF/thread everywhere. This is the first step in fixing a few features related to Variable Registers per Thread (VRT) on Xe3p.