### PR TITLE
benchdnn: styling and minor changes

### DIFF
--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1094,10 +1094,9 @@ std::ostream &operator<<(
         const std::vector<int> args
                 = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
         bool has_grouped = false;
         for (const int arg : args) {
-            if (sparse_options.get_encoding(arg) == dnnl_grouped) {
+            if (sparse_options.is_grouped(arg)) {
                 has_grouped = true;
                 // Output format: --grouped=0:8:32+64+...
                 int var_idx = sparse_options.get_variable_dim_idx(arg);
@@ -1114,9 +1113,7 @@ std::ostream &operator<<(
                 break;
             }
         }
-        if (!has_grouped)
-#endif
-        {
+        if (!has_grouped) {
             // Rest of sparse options use different format: --encoding=...
             s << "--encoding=";
             for (int i = 0; i < (int)args.size(); i++) {
@@ -1336,7 +1333,6 @@ int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
     for (int d = 0; d < ndims; ++d)
         dims[d] = prb_dims[d];
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
     int grouped_var_dim_idx = -1;
     dnnl_dim_t grouped_count = 0;
     if (sparse_options) {
@@ -1344,7 +1340,6 @@ int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
                 = sparse_options->get_variable_dim_idx(DNNL_ARG_SRC);
         grouped_count = sparse_options->get_group_count();
     }
-#endif
 
     // iterate over all post ops and prepare md for each binary
     for (int idx = 0; idx < po.len(); ++idx) {
@@ -1362,13 +1357,11 @@ int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
             auto rhs_tensor_desc = dnn_mem_t::init_md(ndims, rhs_tensor_dims,
                     po_rhs_tensor_entry.dt, po_rhs_tensor_entry.tag,
                     po_rhs_tensor_entry.strides);
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
             if (e.binary.grouped) {
                 rhs_tensor_desc = dnn_mem_t::init_grouped_md(ndims,
                         rhs_tensor_dims, po_rhs_tensor_entry.dt,
                         grouped_var_dim_idx, grouped_count);
             }
-#endif
             mds.emplace((DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx)
                                 | po_rhs_tensor_entry.arg_attr_mask),
                     std::move(rhs_tensor_desc));

--- a/tests/benchdnn/dnn_types.hpp
+++ b/tests/benchdnn/dnn_types.hpp
@@ -606,25 +606,25 @@ struct sparse_options_t {
             = dnnl_sparse_encoding_undef;
     static constexpr float def_sparsity = 0.9f;
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-    // Buffer indices for multi-handle grouped memory
-    static constexpr int grouped_values_idx = 0;
-    static constexpr int grouped_offsets_idx = 1;
-
     struct grouped_data_t {
-        int variable_dim_idx
-                = -1; // index of the dimension with variable size (0 for M)
-        dnnl_dim_t group_count = 0; // total number of grouped blocks
-        std::vector<dnnl_dim_t>
-                group_sizes; // sizes for each group along the variable dimension
-        dnnl_dim_t max_variable_dim = 0; // optional dispatch hint (0 = unused)
+        // Buffer indices for multi-handle grouped memory
+        static constexpr int grouped_values_idx = 0;
+        static constexpr int grouped_offsets_idx = 1;
+
+        // index of the dimension with variable size (0 for M)
+        int variable_dim_idx = -1;
+        // total number of grouped blocks
+        dnnl_dim_t group_count = 0;
+        // sizes for each group along the variable dimension
+        std::vector<dnnl_dim_t> group_sizes;
+        // optional dispatch hint (0 = unused)
+        dnnl_dim_t max_variable_dim = 0;
 
         bool is_def() const {
             return variable_dim_idx == -1 && group_count == 0
                     && group_sizes.empty();
         }
     };
-#endif
 
     sparse_options_t() = default;
     sparse_options_t(int arg, dnnl_sparse_encoding_t encoding, float sparsity) {
@@ -634,10 +634,12 @@ struct sparse_options_t {
     void add(int arg, dnnl_sparse_encoding_t encoding, float sparsity) {
         options_.insert({arg, {encoding, sparsity}});
     }
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+
     void set_grouped(int arg, int var_dim_idx, dnnl_dim_t count,
             const std::vector<dnnl_dim_t> &sizes, dnnl_dim_t max_var_dim = 0) {
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
         add(arg, dnnl_grouped, 0.0f);
+#endif
         grouped_data_t gd;
         gd.variable_dim_idx = var_dim_idx;
         gd.group_count = count;
@@ -650,22 +652,24 @@ struct sparse_options_t {
         const auto it = grouped_data_.find(arg);
         return it == grouped_data_.end() ? -1 : it->second.variable_dim_idx;
     }
+
     // Get group count - the count is the same across all grouped arguments
     dnnl_dim_t get_group_count() const {
         if (grouped_data_.empty()) return 0;
         return grouped_data_.begin()->second.group_count;
     }
+
     const std::vector<dnnl_dim_t> &get_group_sizes(
             int arg = DNNL_ARG_SRC) const {
         static const std::vector<dnnl_dim_t> empty;
         const auto it = grouped_data_.find(arg);
         return it == grouped_data_.end() ? empty : it->second.group_sizes;
     }
+
     dnnl_dim_t get_max_variable_dim() const {
         if (grouped_data_.empty()) return 0;
         return grouped_data_.begin()->second.max_variable_dim;
     }
-#endif
 
     dnnl_sparse_encoding_t get_encoding(int arg) const {
         if (options_.count(arg) == 0) return dnnl_sparse_encoding_undef;
@@ -679,6 +683,7 @@ struct sparse_options_t {
         switch (kind) {
             case SRC: return get_encoding(DNNL_ARG_SRC);
             case WEI: return get_encoding(DNNL_ARG_WEIGHTS);
+            case DST: return get_encoding(DNNL_ARG_DST);
             default: return def_encoding;
         }
     }
@@ -690,6 +695,14 @@ struct sparse_options_t {
 
     bool is_encoding_def(int arg) const {
         return get_encoding(arg) == def_encoding;
+    }
+
+    bool is_grouped(int arg) const {
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+        return get_encoding(arg) == dnnl_grouped;
+#else
+        return false;
+#endif
     }
 
     bool is_sparsity_def(int arg) const {
@@ -718,9 +731,7 @@ struct sparse_options_t {
 
 private:
     std::unordered_map<int, std::pair<dnnl_sparse_encoding_t, float>> options_;
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
     std::unordered_map<int, grouped_data_t> grouped_data_;
-#endif
 };
 
 std::ostream &operator<<(

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -956,8 +956,7 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
 #if DNNL_EXPERIMENTAL_GROUPED_MEMORY
     // Grouped max variable dim hint
     // Optional host scalar, created when src is a grouped descriptor
-    if (query_md_sparse_encoding(query_md(const_pd, DNNL_ARG_SRC))
-            == dnnl_grouped) {
+    if (has_grouped_encoding(query_md(const_pd, DNNL_ARG_SRC))) {
         auto hint_md = dnn_mem_t::init_host_scalar_md(dnnl_s32);
         mem_map.emplace(DNNL_ARG_HINT_MAX_GROUP_SIZE, dnn_mem_t(hint_md));
     }

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -172,13 +172,10 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
         //   values reside in buffer 0 only.
         const bool can_plain_copy = dnnl_memory_desc_equal(src.md_, dst.md_)
                 || dst.format_kind() == dnnl_format_kind_host_scalar
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-                || (query_md_sparse_encoding(src.md_) == dnnl_grouped
+                || (has_grouped_encoding(src.md_)
                         && query_md_num_handles(dst.md_) == 1)
-                || (query_md_sparse_encoding(dst.md_) == dnnl_grouped
-                        && query_md_num_handles(src.md_) == 1)
-#endif
-                ;
+                || (has_grouped_encoding(dst.md_)
+                        && query_md_num_handles(src.md_) == 1);
         if (can_plain_copy) {
             BENCHDNN_PRINT(2, "%s\n", "[REORDER] Fallback to plain copy.");
             const int64_t chunk_size = 64;
@@ -777,17 +774,17 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> dnn_mem_t::init_host_scalar_md(
     return md;
 }
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> dnn_mem_t::init_grouped_md(
         int ndims, const dnnl_dims_t dims, dnnl_data_type_t data_type,
         int variable_dim_idx, dnnl_dim_t group_count,
         dnnl_data_type_t offsets_dt) {
     dnnl_memory_desc_t md {};
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
     DNN_SAFE_V(dnnl_memory_desc_create_with_grouped_encoding(&md, ndims, dims,
             data_type, variable_dim_idx, group_count, offsets_dt));
+#endif
     return md;
 }
-#endif
 
 int dnn_mem_t::initialize_memory_create_sycl(const handle_info_t &handle_info) {
 #ifdef DNNL_WITH_SYCL
@@ -1464,6 +1461,14 @@ bool has_sparse_md(const dnn_mem_map_t &dnn_mem_map) {
         if (m.is_sparse_md()) return true;
     }
     return false;
+}
+
+bool has_grouped_encoding(const_dnnl_memory_desc_t md) {
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+    return query_md_sparse_encoding(md) == dnnl_grouped;
+#else
+    return false;
+#endif
 }
 
 dnnl_memory_desc_t clone_md(const_dnnl_memory_desc_t md) {

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -1016,12 +1016,13 @@ int dnn_mem_t::initialize_memory_create(const handle_info_t &handle_info) {
         SAFE(is_cpu(engine_) ? OK : FAIL, CRIT);
     }
 
+    const int nhandles = query_md_num_handles(md_);
+
     if (is_cpu(engine_) && handle_info.is_allocate() && !is_sycl) {
         // Allocate memory for native runtime directly.
         is_data_owner_ = true;
         const size_t alignment = 2 * 1024 * 1024;
 
-        const int nhandles = query_md_num_handles(md_);
         for (int i = 0; i < nhandles; i++) {
             size_t sz = dnnl_memory_desc_get_size_v2(md_, i);
             data_.push_back(zmalloc(sz, alignment));
@@ -1044,7 +1045,6 @@ int dnn_mem_t::initialize_memory_create(const handle_info_t &handle_info) {
         SAFE(initialize_memory_create_ze(handle_info), CRIT);
     } else {
         is_data_owner_ = false;
-        const int nhandles = query_md_num_handles(md_);
         std::vector<void *> handles(nhandles, handle_info.ptr);
         DNN_SAFE(dnnl_memory_create_v2(&m_, md_, engine_, (int)handles.size(),
                          handles.data()),
@@ -1061,54 +1061,55 @@ int dnn_mem_t::initialize(
 
     SAFE(initialize_memory_create(handle_info), CRIT);
 
-    if (handle_info.is_allocate()) {
-        // Memory objects consisting of several buffers can rely on indirect
-        // data access through metadata (e.g., sparse memory objects).
-        // Filling metadata buffers with random values can lead to accessing an
-        // address location not controlled by the process. Thus, such metadata
-        // buffers must be always properly filled according to the driver rules.
-        // Filling buffers requires them to be mapped.
-        // To save code on updating every case separately, update the logic in
-        // this common place.
-        // ANCHOR: FILL_SPARSE_METADATA.
-        const bool mem_has_indirect_access = is_sparse_md();
-        if (!has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
-                || mem_has_indirect_access)
-            map();
+    // If the memory object doesn't own its buffers, nothing to do.
+    if (!handle_info.is_allocate()) return OK;
 
-        const int nhandles = query_md_num_handles(md_);
-        for (int i = 0; i < nhandles; i++) {
-            size_t sz = dnnl_memory_desc_get_size_v2(md_, i);
-            if (is_canary_protected_) sz = pad_memory_size(sz, engine_kind_);
+    // Memory objects consisting of several buffers can rely on indirect
+    // data access through metadata (e.g., sparse memory objects).
+    // Filling metadata buffers with random values can lead to accessing an
+    // address location not controlled by the process. Thus, such metadata
+    // buffers must be always properly filled according to the driver rules.
+    // Filling buffers requires them to be mapped.
+    // To save code on updating every case separately, update the logic in
+    // this common place.
+    // ANCHOR: FILL_SPARSE_METADATA.
+    const bool mem_has_indirect_access = is_sparse_md();
+    if (!has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
+            || mem_has_indirect_access)
+        map();
 
-            // Do not fill a memory if its size is zero. Moreover, memset
-            // expects defined pointer, nullptr is not allowed.
-            if (sz == 0 || !prefill) continue;
+    const int nhandles = query_md_num_handles(md_);
+    for (int i = 0; i < nhandles; i++) {
+        size_t sz = dnnl_memory_desc_get_size_v2(md_, i);
+        if (is_canary_protected_) sz = pad_memory_size(sz, engine_kind_);
 
-            // Avoid costy data reorders for cold cache mode when
-            // initializing cold cache buffers.
-            // TODO: consider enabling broadly for perf mode.
-            if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
-                    || cold_cache_input.cold_cache_mode_
-                            != default_cold_cache_input().cold_cache_mode_) {
+        // Do not fill a memory if its size is zero. Moreover, memset
+        // expects defined pointer, nullptr is not allowed.
+        if (sz == 0 || !prefill) continue;
+
+        // Avoid costy data reorders for cold cache mode when
+        // initializing cold cache buffers.
+        // TODO: consider enabling broadly for perf mode.
+        if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
+                || cold_cache_input.cold_cache_mode_
+                        != default_cold_cache_input().cold_cache_mode_) {
 #if (DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
         && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL)
-                if (!is_cpu(engine_))
-                    // Fill memory with pseudo-random data directly on device
-                    // to avoid data compression.
-                    SAFE(this->gpu_fill_random(sz, i), WARN);
-                else
-                    // Fill memory directly with 0x3F3F3F3F (0.747059f).
-                    this->memset(dnnl_mem_default_perf_test_value, sz, i);
-#else
+            if (!is_cpu(engine_))
+                // Fill memory with pseudo-random data directly on device
+                // to avoid data compression.
+                SAFE(this->gpu_fill_random(sz, i), WARN);
+            else
                 // Fill memory directly with 0x3F3F3F3F (0.747059f).
                 this->memset(dnnl_mem_default_perf_test_value, sz, i);
+#else
+            // Fill memory directly with 0x3F3F3F3F (0.747059f).
+            this->memset(dnnl_mem_default_perf_test_value, sz, i);
 #endif
-            } else {
-                // Fill memory with a magic number (NAN for fp data types)
-                // to catch possible uninitialized access.
-                ::memset(mapped_ptrs_[i], dnnl_mem_default_value, sz);
-            }
+        } else {
+            // Fill memory with a magic number (NAN for fp data types)
+            // to catch possible uninitialized access.
+            ::memset(mapped_ptrs_[i], dnnl_mem_default_value, sz);
         }
     }
 

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -171,6 +171,7 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
         // - For grouped to plain and plain to grouped,
         //   values reside in buffer 0 only.
         const bool can_plain_copy = dnnl_memory_desc_equal(src.md_, dst.md_)
+                || dst.format_kind() == dnnl_format_kind_host_scalar
 #if DNNL_EXPERIMENTAL_GROUPED_MEMORY
                 || (query_md_sparse_encoding(src.md_) == dnnl_grouped
                         && query_md_num_handles(dst.md_) == 1)

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -210,13 +210,11 @@ struct dnn_mem_t {
     // Initializes memory descriptor for host scalar memory.
     static benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> init_host_scalar_md(
             dnnl_data_type_t data_type);
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
     // Initializes memory descriptor for grouped encoding.
     static benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> init_grouped_md(
             int ndims, const dnnl_dims_t dims, dnnl_data_type_t data_type,
             int variable_dim_idx, dnnl_dim_t group_count,
             dnnl_data_type_t offsets_dt = dnnl_s32);
-#endif
 
     /* fields */
     dnnl_memory_desc_t md_ {};
@@ -266,6 +264,8 @@ private:
 using dnn_mem_map_t = std::unordered_map<int, dnn_mem_t>;
 
 bool has_sparse_md(const dnn_mem_map_t &dnn_mem_map);
+
+bool has_grouped_encoding(const_dnnl_memory_desc_t md);
 
 dnnl_memory_desc_t clone_md(const_dnnl_memory_desc_t md);
 

--- a/tests/benchdnn/matmul/bench_matmul.cpp
+++ b/tests/benchdnn/matmul/bench_matmul.cpp
@@ -127,7 +127,6 @@ int verify_input(const settings_t &s, const settings_t &def) {
     return OK;
 }
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 // Validate input consistency for grouped encoding
 //
 // Notes:
@@ -135,7 +134,7 @@ int verify_input(const settings_t &s, const settings_t &def) {
 //   DST, so we only validate SRC parameters
 // - Currently only M dimension grouping is supported
 int verify_grouped_input(const settings_t &s) {
-    if (s.sparse_options[0].get_encoding(DNNL_ARG_SRC) == dnnl_grouped) {
+    if (s.sparse_options[0].is_grouped(DNNL_ARG_SRC)) {
 
         const int variable_dim_idx
                 = s.sparse_options[0].get_variable_dim_idx(DNNL_ARG_SRC);
@@ -179,7 +178,6 @@ int verify_grouped_input(const settings_t &s) {
     }
     return OK;
 }
-#endif
 
 static const std::string help_bia_mask
         = "UINT    (Default: `2`)\n    Specifies a bit-mask that indicates "
@@ -221,9 +219,7 @@ int bench(int argc, char **argv) {
                 || parse_tag(s.wtag, def.wtag, argv[0], "wtag")
                 || parse_tag(s.dtag, def.dtag, argv[0], "dtag")
                 || parse_encoding(s.sparse_options, argv[0], "encoding")
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
                 || parse_grouped(s.sparse_options, argv[0], "grouped")
-#endif
                 || parse_strides(s.strides, def.strides, argv[0], "strides")
                 || parse_dt(s.bia_dt, def.bia_dt, argv[0], "bia-dt")
                 // TODO: remove this later
@@ -240,9 +236,7 @@ int bench(int argc, char **argv) {
             parse_prb_vdims(s.prb_vdims, argv[0]);
 
             SAFE(verify_input(s, def), WARN);
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
             SAFE(verify_grouped_input(s), WARN);
-#endif
 
             s.finalize();
             check_correctness(s, task_executor);

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -34,7 +34,6 @@
 
 namespace matmul {
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 // Helper to create grouped memory descriptor
 //
 // Current input format for grouped matmul is:
@@ -54,7 +53,7 @@ static benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> create_grouped_md(
             : (kind == DST) ? DNNL_ARG_DST
                             : DNNL_ARG_UNDEF;
     if (arg == DNNL_ARG_UNDEF) return md;
-    if (prb->sparse_options.get_encoding(arg) != dnnl_grouped) return md;
+    if (!prb->sparse_options.is_grouped(arg)) return md;
     if (prb->sparse_options.get_variable_dim_idx(arg) != 0) return md;
 
     const int64_t group_count = prb->sparse_options.get_group_count();
@@ -70,7 +69,6 @@ static benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> create_grouped_md(
     return dnn_mem_t::init_grouped_md(
             2, dims_2d, dt, /* variable_dim_idx = */ 0, group_count, dnnl_s32);
 }
-#endif
 
 dims_t get_runtime_dims(const dims_t &dims, const dims_mask_t &mask) {
     if (mask.none() || dims.empty()) return dims;
@@ -94,11 +92,9 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> create_md(const prb_t *prb,
         auto src_encoding = prb->sparse_options.get_encoding(DNNL_ARG_SRC);
         auto src_sparsity = prb->sparse_options.get_sparsity(DNNL_ARG_SRC);
         if (src_encoding != dnnl_sparse_encoding_undef) {
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-            if (src_encoding == dnnl_grouped) {
+            if (prb->sparse_options.is_grouped(DNNL_ARG_SRC)) {
                 return create_grouped_md(prb, SRC, dt);
             }
-#endif
             const dnnl_dim_t nnz
                     = std::max(prb->m * prb->k * (1.0f - src_sparsity), 1.0f);
             switch (src_encoding) {
@@ -155,12 +151,10 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> create_md(const prb_t *prb,
         const auto &dst_rt_dims
                 = get_runtime_dims(prb->dst_dims, prb->dst_runtime_dim_mask());
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-        auto dst_encoding = prb->sparse_options.get_encoding(DNNL_ARG_DST);
-        if (dst_encoding == dnnl_grouped) {
+        if (prb->sparse_options.is_grouped(DNNL_ARG_DST)) {
             return create_grouped_md(prb, DST, dt);
         }
-#endif
+
         return dnn_mem_t::init_md(prb->ndims, dst_rt_dims.data(), dt, prb->dtag,
                 prb->strides[STRIDES_DST]);
     }
@@ -184,20 +178,14 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
         auto bia_dims = get_runtime_dims(
                 prb->bia_dims(), prb->bias_runtime_dim_mask());
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-        const auto src_encoding
-                = prb->sparse_options.get_encoding(DNNL_ARG_SRC);
-        const auto dst_encoding
-                = prb->sparse_options.get_encoding(DNNL_ARG_DST);
-        if (src_encoding == dnnl_grouped && dst_encoding == dnnl_grouped) {
+        if (prb->sparse_options.is_grouped(DNNL_ARG_SRC)
+                && prb->sparse_options.is_grouped(DNNL_ARG_DST)) {
             // verify_grouped_input() enforces bia_mask=2 (N-only)
             const int64_t group_count = prb->sparse_options.get_group_count();
             const dnnl_dim_t grouped_bias_dims[2] = {group_count, prb->n};
             bia_d = dnn_mem_t::init_md(2, grouped_bias_dims,
                     force_f32_dt ? dnnl_f32 : prb->bia_dt, tag::abx);
-        } else
-#endif
-        {
+        } else {
             bia_d = dnn_mem_t::init_md(prb->ndims, bia_dims.data(),
                     force_f32_dt ? dnnl_f32 : prb->bia_dt,
                     prb->dst_runtime_dim_mask() != 0 ? tag::abx : tag::any);
@@ -252,10 +240,8 @@ int init_prim_ref(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &prim_ref,
     if (is_cpu() && (prb->src_dt() == dnnl_f32 && prb->wei_dt() == dnnl_f32))
         return OK;
 
-    if (prb->sparse_options.get_encoding(DNNL_ARG_SRC)
-                    != dnnl_sparse_encoding_undef
-            || prb->sparse_options.get_encoding(DNNL_ARG_WEIGHTS)
-                    != dnnl_sparse_encoding_undef)
+    if (!prb->sparse_options.is_encoding_def(DNNL_ARG_SRC)
+            || !prb->sparse_options.is_encoding_def(DNNL_ARG_WEIGHTS))
         return OK;
 
     std::vector<std::vector<dnnl_data_type_t>> prim_ref_dt {
@@ -497,8 +483,6 @@ static void fill_dense_fp_values(data_kind_t kind, const prb_t *prb,
     });
 }
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-
 // Fill offsets buffer for grouped memory with cumulative sums
 static int fill_grouped_offsets(
         dnn_mem_t &mem, const sparse_options_t &sparse_options) {
@@ -516,7 +500,7 @@ static int fill_grouped_offsets(
         }
         cumulative += group_sizes[g];
         mem.set_elem(g, static_cast<int32_t>(cumulative),
-                sparse_options_t::grouped_offsets_idx);
+                sparse_options_t::grouped_data_t::grouped_offsets_idx);
     }
     return OK;
 }
@@ -553,7 +537,6 @@ static int fill_grouped_data(data_kind_t kind, const prb_t *prb,
 
     return OK;
 }
-#endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY
 
 int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
@@ -569,10 +552,6 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
     const bool is_sparse_csr_coo
             = sparse_encoding == dnnl_csr || sparse_encoding == dnnl_coo;
     is_sparse_packed = sparse_encoding == dnnl_packed;
-    bool is_grouped_dt = false;
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-    is_grouped_dt = (sparse_encoding == dnnl_grouped);
-#endif
     is_any_sparse = sparse_encoding != sparse_options_t::def_encoding;
 
     if (is_sparse_csr_coo) {
@@ -580,13 +559,9 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
                 kind, prb, mem_dt, mem_fp, res, sparse_encoding);
     }
 
-    if (is_grouped_dt) {
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+    if (prb->sparse_options.is_grouped(exec_arg)) {
         SAFE(fill_grouped_data(kind, prb, mem_dt, mem_fp), WARN);
         return OK;
-#else
-        return FAIL;
-#endif
     }
 
     if (is_sparse_packed) {
@@ -677,20 +652,13 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
 
     if (!prb->sparse_options.is_def() && is_cpu() && is_wei_dense
             && prb->wtag != "any" && prb->wtag != "ab") {
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
         // Check if this is grouped encoding which requires 3D weight tags
-        const auto src_encoding
-                = prb->sparse_options.get_encoding(DNNL_ARG_SRC);
-        const auto dst_encoding
-                = prb->sparse_options.get_encoding(DNNL_ARG_DST);
-        bool is_grouped = (src_encoding == dnnl_grouped
-                || dst_encoding == dnnl_grouped);
+        bool is_grouped = prb->sparse_options.is_grouped(DNNL_ARG_SRC)
+                && prb->sparse_options.is_grouped(DNNL_ARG_DST);
 
         if (is_grouped && (prb->wtag == "abc" || prb->wtag == "acb")) {
             // Allow 3D tags for grouped encoding
-        } else
-#endif
-        {
+        } else {
             BENCHDNN_PRINT(2,
                     "[SKIP][%s:%d]: Only `any` and `ab` tags are supported for "
                     "dense weights on CPU.\n",
@@ -730,14 +698,9 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
         // Grouped matmul supports weight-only quantization (fp src + int wei)
         // when fpmath apply_to_int is set. For regular matmul, and for grouped
         // without apply_to_int, mixed int/fp src+wei is not supported on CPU.
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-        const bool is_grouped_woq
-                = prb->sparse_options.get_encoding(DNNL_ARG_SRC) == dnnl_grouped
+        const bool is_grouped_woq = prb->sparse_options.is_grouped(DNNL_ARG_SRC)
                 && !is_int(prb->src_dt()) && is_int(prb->wei_dt())
                 && prb->attr.fpmath_mode.apply_to_int;
-#else
-        const bool is_grouped_woq = false;
-#endif
         if (!is_grouped_woq && is_int(prb->src_dt()) != is_int(prb->wei_dt())) {
             BENCHDNN_PRINT(2,
                     "[SKIP][%s:%d]: CPU doesn't support mixed integer and "
@@ -961,16 +924,11 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
     // Move cfg out of filling since its creation is not free.
     cfg_t cfg(prb, {SRC, WEI, BIA, DST});
 
-    const auto src_encoding = prb->sparse_options.get_encoding(DNNL_ARG_SRC);
     const auto wei_encoding
             = prb->sparse_options.get_encoding(DNNL_ARG_WEIGHTS);
-    const auto dst_encoding = prb->sparse_options.get_encoding(DNNL_ARG_DST);
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-    // The only supported configuration of grouped matmul
-    const bool is_grouped
-            = src_encoding == dnnl_grouped && dst_encoding == dnnl_grouped;
-#endif
+    const bool is_grouped = prb->sparse_options.is_grouped(DNNL_ARG_SRC)
+            && prb->sparse_options.is_grouped(DNNL_ARG_DST);
 
     for (auto &entry : mem_map) {
         const int exec_arg = entry.first;
@@ -981,27 +939,21 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         auto &mem = entry.second; // `mem` is modified by filler (reorder).
 
+        // Route grouped to the generic else branch below
         const bool is_sparse_src = exec_arg == DNNL_ARG_SRC
-                && src_encoding != dnnl_sparse_encoding_undef
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-                && !is_grouped // Route grouped to the generic else branch below
-#endif
-                ;
+                && !prb->sparse_options.is_encoding_def(DNNL_ARG_SRC)
+                && !is_grouped;
         const bool is_sparse_wei = exec_arg == DNNL_ARG_WEIGHTS
                 && wei_encoding != dnnl_sparse_encoding_undef;
         const bool is_sparse_dst = exec_arg == DNNL_ARG_DST
-                && dst_encoding != dnnl_sparse_encoding_undef
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-                && !is_grouped
-#endif
-                ;
+                && !prb->sparse_options.is_encoding_def(DNNL_ARG_DST)
+                && !is_grouped;
         const bool is_sparse = is_sparse_src || is_sparse_wei || is_sparse_dst;
         const bool is_sparse_wei_packed
                 = is_sparse_wei && wei_encoding == dnnl_packed;
 
         // See the comment at the beginning of the function.
         if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
                 // Grouped SRC/DST are excluded from `is_sparse` to keep the
                 // sparse and grouped paths separate below, so exclude them here
                 // to allow `no_ref_memory` to work for grouped cases.
@@ -1009,8 +961,10 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 // reference memory, so it must always be filled.
                 && !(is_grouped
                         && (exec_arg == DNNL_ARG_SRC || exec_arg == DNNL_ARG_DST
-                                || exec_arg == DNNL_ARG_HINT_MAX_GROUP_SIZE))
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+                                || exec_arg == DNNL_ARG_HINT_MAX_GROUP_SIZE
 #endif
+                                ))
                 && !is_sparse)
             continue;
 
@@ -1079,13 +1033,11 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                         WARN);
                 break;
             case DNNL_ARG_DST: {
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
                 if (is_grouped) {
                     // Only offsets need to be filled
                     // as values are computed by the library
                     SAFE(fill_grouped_offsets(mem, prb->sparse_options), WARN);
                 }
-#endif
                 const auto &po = prb->attr.post_ops;
                 const int sum_idx = po.find(attr_t::post_ops_t::SUM);
                 if (sum_idx >= 0) {
@@ -1116,7 +1068,6 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 SAFE(init_ref_memory_args_default_case(
                              exec_arg, mem, ref_mem, prb->attr, res),
                         WARN);
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
                 // Fill offsets for grouped binary post-op tensors
                 // Note that values are already filled by the default case above
                 if (is_grouped) {
@@ -1134,7 +1085,6 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                                 WARN);
                     }
                 }
-#endif
             } break;
         }
 

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -1036,21 +1036,19 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             if (exec_arg == DNNL_ARG_WEIGHTS) {
                 const auto ndims = mem.ndims();
                 const auto &dims = mem.dims();
-                {
-                    // Switch the format tag from "ab" to "ba" but to handle batched
-                    // cases, use strides instead.
-                    dnnl_dims_t strides {};
-                    dnnl_dim_t stride = 1;
-                    for (int d = ndims - 2; d >= 0; d--) {
-                        strides[d] = stride * dims[d + 1];
-                        stride = strides[d];
-                    }
-                    strides[ndims - 2] = 1;
-                    strides[ndims - 1] = dims[ndims - 2];
-                    ref_mem_map.emplace(exec_arg,
-                            dnn_mem_t(mem.md_, dnnl_f32, strides, ref_engine,
-                                    /* prefill = */ false));
+                // Switch the format tag from "ab" to "ba" but to handle batched
+                // cases, use strides instead.
+                dnnl_dims_t strides {};
+                dnnl_dim_t stride = 1;
+                for (int d = ndims - 2; d >= 0; d--) {
+                    strides[d] = stride * dims[d + 1];
+                    stride = strides[d];
                 }
+                strides[ndims - 2] = 1;
+                strides[ndims - 1] = dims[ndims - 2];
+                ref_mem_map.emplace(exec_arg,
+                        dnn_mem_t(mem.md_, dnnl_f32, strides, ref_engine,
+                                /* prefill = */ false));
             } else if (exec_arg != DNNL_ARG_SCRATCHPAD) {
                 // Scratchpad memory relates to a primitive. If reference needs
                 // it, use switch below to define a memory desc for it.

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -320,7 +320,6 @@ static void compute_ref_matmul_chunk(const chunk_params_t &p, int64_t M,
     }
 }
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 // Reference implementation for grouped matmul
 // Computes per-group matmuls: for each group g, dst[g] = src[g] * wei[g]
 //
@@ -384,7 +383,6 @@ void compute_ref_grouped_matmul(const prb_t *prb, const args_t &args) {
                 args);
     });
 }
-#endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY
 
 void compute_ref_matmul(const prb_t *prb, const args_t &args) {
     // Fast return if any dim is zero. Common logic doesn't apply because of
@@ -568,15 +566,11 @@ void compute_ref(const prb_t *prb, dir_t dir, const args_t &args,
     const auto wei_encoding
             = prb->sparse_options.get_encoding(DNNL_ARG_WEIGHTS);
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
-    const auto dst_encoding = prb->sparse_options.get_encoding(DNNL_ARG_DST);
-
-    if (src_encoding == dnnl_grouped && dst_encoding == dnnl_grouped) {
+    if (prb->sparse_options.is_grouped(DNNL_ARG_SRC)
+            && prb->sparse_options.is_grouped(DNNL_ARG_DST)) {
         compute_ref_grouped_matmul(prb, args);
-    } else
-#endif
-            if (src_encoding == dnnl_csr || wei_encoding == dnnl_csr
-                    || src_encoding == dnnl_coo || wei_encoding == dnnl_coo) {
+    } else if (src_encoding == dnnl_csr || wei_encoding == dnnl_csr
+            || src_encoding == dnnl_coo || wei_encoding == dnnl_coo) {
         compute_ref_sparse_matmul(prb, args);
     } else {
         compute_ref_matmul(prb, args);

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -149,7 +149,8 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
     if (e.has_single_element()) {
         assert(nelems == 1);
         mem_fp.set_f32_elem(0, e.scale);
-        if (mem_dt) mem_dt.set_elem(0, e.scale);
+        // TODO: replace reorder with `fill` that takes any pattern unlike
+        // memset.
     } else {
         /* Do fixed partitioning to have same filling for any number of threads */
         static constexpr int64_t chunk_size = 64;
@@ -173,10 +174,11 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
                         = pow2 < 0 ? (1.f / pow2_shift) : pow2_shift;
                 const float val = gen_val;
                 mem_fp.set_f32_elem(idx, val);
-                if (mem_dt) mem_dt.set_elem(idx, val);
             }
         });
     }
+
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
 
     return OK;
 }
@@ -192,7 +194,8 @@ int fill_zero_points(
     if (e.has_single_element()) {
         assert(nelems == 1);
         mem_fp.set_f32_elem(0, e.value);
-        if (mem_dt) mem_dt.set_elem(0, e.value);
+        // TODO: replace reorder with `fill` that takes any pattern unlike
+        // memset.
     } else {
         /* Do fixed partitioning to have same filling for any number of threads */
         static constexpr int64_t chunk_size = 64;
@@ -213,10 +216,11 @@ int fill_zero_points(
             for (int64_t idx = idx_start; idx < idx_end; ++idx) {
                 const float zp_val = gen(int_seed);
                 mem_fp.set_f32_elem(idx, zp_val);
-                if (mem_dt) mem_dt.set_elem(idx, zp_val);
             }
         });
     }
+
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
 
     return OK;
 }

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -791,7 +791,6 @@ bool parse_encoding(std::vector<sparse_options_t> &sparse_options,
             str, option_name, help);
 }
 
-#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 // Format: DIM_IDX:NUM_GROUPS:size0+size1+...+sizeN[:max_size][,config2,...]
 // - DIM_IDX is the dimension index, where src MxK * weights KxN = dst MxN
 //   0 = M,  1 = K, 2 = N
@@ -823,6 +822,13 @@ bool parse_grouped(std::vector<sparse_options_t> &sparse_options,
     utils::add_option_to_help(option_name, help);
     const std::string pattern = utils::get_pattern(option_name);
     if (!utils::option_matched(pattern, str)) return false;
+
+#if !DNNL_EXPERIMENTAL_GROUPED_MEMORY
+    BENCHDNN_PRINT(0, "%s\n",
+            "\'--grouped\' option requires DNNL_EXPERIMENTAL_GROUPED_MEMORY "
+            "build option set to ON.");
+    SAFE_V(FAIL);
+#endif
 
     str = str + pattern.size();
     std::string full_str(str);
@@ -931,7 +937,6 @@ bool parse_grouped(std::vector<sparse_options_t> &sparse_options,
 
     return true;
 }
-#endif
 
 bool parse_multi_tag(std::vector<std::vector<std::string>> &tag,
         const std::vector<std::vector<std::string>> &def_tag, const char *str,


### PR DESCRIPTION
This PR mostly updates stylistic part.

One notice is that continuation of #5118 which should improve data filling for mode=F requires careful handling of mapping as regular approach is to keep all memories mapped by default but no_ref_memory modifier changes that default. It means that to update the library memory objects, they must be either:
1. directly filled with a dedicated GPU-side kernel (as it's done now with `gpu_fill_random`), or
2. explicitly mapped if `dnn_mem_t::sel_elem(...)` interface is used, or
3. filled through reorder.

The global idea is to get rid of approach 2 in benchdnn (as it creates a lot of extra code to explicitly map and unmap an access spot), use approach 1 in cases when it doesn't lead to perf issues (read, data compression on GPU by its driver), which wouldn't do any mapping, and use approach 3 when the data must be controlled, with mapping happening in the common for benchdnn spot - execute_reorder function which is the essense of filling for all library memory objects.

There will be PRs that update approach 2 with approach 3. The first commit is presented here.