### PR TITLE
Fix labels for rfcs branch

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -24,11 +24,18 @@ governance:
 - changed-files:
   - any-glob-to-any-file:
     - '.github/CODEOWNERS'
+    - 'rfcs/template.md'
+    - 'README.md'
     - 'SECURITY.md'
     - 'MAINTAINERS.md'
     - 'CONTRIBUTING.md'
     - 'CODING_STANDARDS.md'
     - 'CODE_OF_CONDUCT.md'
+
+# RFC
+RFC:
+- changed-files:
+  - any-glob-to-any-file: 'rfcs/**'
 
 # Github automation
 devops:


### PR DESCRIPTION
Apparently labeler pick up configuration file from the main branch unless the code is checked out. As we don't check out the code in labeler workflow the RFC label does not get added to PRs.

This PR merges labeler config from rfcs to main. Besides labeler working correctly there's an extra benefit for managing label configuration in one place.
