### PR TITLE
aarch64: fixes for jit_binary and post_op injectors

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -22,6 +22,7 @@
 
 #include "common/primitive_attr.hpp"
 #include "common/utils.hpp"
+#include "common/verbose_msg.hpp"
 #include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
 
 namespace dnnl {
@@ -30,10 +31,14 @@ namespace cpu {
 namespace aarch64 {
 namespace binary_injector {
 
+#define VCHECK_BIN_INJ_BOOL(cond, msg) \
+    VCONDCHECK(primitive, create, check, binary_injector, cond, false, msg);
+
 static bcast_set_t get_all_strategies_supported_by_injector() {
     return bcast_set_t {broadcasting_strategy_t::scalar,
             broadcasting_strategy_t::per_oc,
             broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::per_mb_spatial,
             broadcasting_strategy_t::per_mb_w, broadcasting_strategy_t::per_w,
             broadcasting_strategy_t::no_broadcast};
 }
@@ -41,6 +46,22 @@ static bcast_set_t get_all_strategies_supported_by_injector() {
 bool is_data_supported(cpu_isa_t isa, data_type_t data_type) {
     UNUSED(isa);
     return !(data_type == data_type::bf16);
+}
+
+bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    // FIXME: address SVE correctness issues (failing convs and matmuls when
+    // used with binary post-ops)
+    VCHECK_BIN_INJ_BOOL(isa == asimd, VERBOSE_UNSUPPORTED_ISA);
+
+    VCHECK_BIN_INJ_BOOL(is_data_supported(isa, src1_desc.data_type),
+            VERBOSE_ISA_DT_MISMATCH);
+
+    VCHECK_BIN_INJ_BOOL(memory_desc_wrapper(src1_desc).is_dense(true),
+            VERBOSE_NONTRIVIAL_STRIDE);
+
+    return is_bcast_supported(src1_desc, dst_d, supported_strategy_set);
 }
 
 static bool src1_desc_layout_same_as_dst_d(
@@ -72,19 +93,12 @@ bool is_bcast_supported(const dnnl::impl::memory_desc_t &src1_desc,
     const auto bcast_type = get_rhs_arg_broadcasting_strategy(
             src1_desc, dst_d, supported_strategy_set);
 
-    if (bcast_type == broadcasting_strategy_t::no_broadcast) {
-        // in case of no broadcast data layout of dst and src1 have to be the same
-        if (!src1_desc_layout_same_as_dst_d(src1_desc, dst_d)) return false;
-    }
+    VCHECK_BIN_INJ_BOOL(
+            IMPLICATION(bcast_type == broadcasting_strategy_t::no_broadcast,
+                    src1_desc_layout_same_as_dst_d(src1_desc, dst_d)),
+            "src1 and dst must have the same layout if not broadcasting");
 
     return bcast_type != broadcasting_strategy_t::unsupported;
-}
-
-bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
-        const memory_desc_wrapper &dst_d,
-        const bcast_set_t &supported_strategy_set) {
-    return is_data_supported(isa, src1_desc.data_type)
-            && is_bcast_supported(src1_desc, dst_d, supported_strategy_set);
 }
 
 bool binary_args_broadcast_supported(const post_ops_t &post_ops,

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -15,12 +15,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 
-#include "common/primitive.hpp"
 #include "common/primitive_attr.hpp"
-#include "common/primitive_exec_types.hpp"
 #include "common/utils.hpp"
 #include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
 
@@ -1393,7 +1393,8 @@ void jit_uni_binary_injector_t<isa>::inject_binary(
             load_rhs(rhs_arg_data_type, tmp_vmm, rhs_addr, tail_load_mode,
                     with_tail);
 
-        if (rhs_arg_data_type != data_type::f32) cvt_to_f32(tmp_vmm);
+        if (rhs_arg_data_type != data_type::f32)
+            host_->uni_scvtf(tmp_vmm.s, tmp_vmm.s);
 
         execute_binary(alg, dst, host_->P_ALL_ONE, dst, tmp_vmm);
     } else {
@@ -1451,26 +1452,22 @@ rhs_address_t jit_uni_binary_injector_t<isa>::remove_bcast_bit(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_binary_injector_t<isa>::cvt_to_f32(const Vmm &tmp_vmm) const {
-    host_->uni_scvtf(tmp_vmm.s, tmp_vmm.s);
-}
-
-template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::execute_broadcast_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const rhs_address_t &rhs_addr) const {
     switch (data_type) {
         case data_type::f32:
-            host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_,
-                    rhs_addr.offt_, host_->X_TMP_0);
-            host_->uni_ldr(tmp_vmm, host_->X_DEFAULT_ADDR);
-            break;
         case data_type::s32:
             host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_,
                     rhs_addr.offt_, host_->X_TMP_0);
-            host_->ld1rw(Xbyak_aarch64::ZRegS(tmp_vmm.getIdx()),
-                    host_->P_ALL_ONE / Xbyak_aarch64::T_z,
-                    Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            if (is_superset(isa, sve)) {
+                host_->ld1rw(Xbyak_aarch64::ZRegS(tmp_vmm.getIdx()),
+                        host_->P_ALL_ONE / Xbyak_aarch64::T_z,
+                        Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            } else {
+                host_->ld1r(Xbyak_aarch64::VReg4S {tmp_vmm.getIdx()},
+                        Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            }
             break;
         case data_type::s8:
         case data_type::u8:

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,18 +19,14 @@
 #ifndef CPU_AARCH64_INJECTORS_JIT_UNI_BINARY_INJECTOR_HPP
 #define CPU_AARCH64_INJECTORS_JIT_UNI_BINARY_INJECTOR_HPP
 
-#include <array>
-#include <cassert>
 #include <functional>
 #include <map>
 #include <utility>
-#include <vector>
 #include <unordered_set>
 
 #include "common/broadcast_strategy.hpp"
 #include "common/c_types_map.hpp"
 #include "common/primitive_attr.hpp"
-#include "common/primitive_exec_types.hpp"
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/aarch64/injectors/injector_utils.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
@@ -594,7 +590,6 @@ private:
             const rhs_address_t &rhs_addr) const;
     void load_rhs_i8_no_tail(const data_type_t &data_type, const Vmm &tmp_reg,
             const rhs_address_t &rhs_addr) const;
-    void cvt_to_f32(const Vmm &tmp_reg) const;
     /*
      * Returns pair consisting of flag indication preservation is needed for vmm
      * index in second member that should be used as temporary vmm inside inject

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -24,28 +24,6 @@ namespace cpu {
 namespace aarch64 {
 namespace injector {
 
-bool is_supported(const post_ops_ok_args_t &post_ops_ok_args) {
-    const cpu_isa_t isa = post_ops_ok_args.isa;
-    const post_ops_t &post_ops = post_ops_ok_args.post_ops;
-    const memory_desc_wrapper *dst_d = post_ops_ok_args.dst_d;
-    const auto &enabled_bcast_strategy
-            = post_ops_ok_args.enabled_bcast_strategy;
-
-    for (const auto &post_op : post_ops.entry_) {
-        if (post_op.is_eltwise()) {
-            const auto res = eltwise_injector::is_supported(
-                    to_vla_sve(isa), post_op.eltwise.alg);
-            if (!res) return false;
-        } else if (post_op.is_binary()) {
-            const auto &src1_desc = post_op.binary.src1_desc;
-            const auto res = binary_injector::is_supported(
-                    isa, src1_desc, *dst_d, enabled_bcast_strategy);
-            if (!res) return false;
-        }
-    }
-    return true;
-}
-
 template <cpu_isa_t isa>
 jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
@@ -195,54 +173,58 @@ post_ops_ok_args_t::post_ops_ok_args_t(const cpu_isa_t isa,
     , enabled_bcast_strategy(enabled_bcast_strategy) {};
 
 bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
-    const cpu_isa_t isa = post_ops_ok_args.isa;
-    const std::vector<post_op_type> &accepted_post_op_types
-            = post_ops_ok_args.accepted_post_op_types;
-    const post_ops_t &post_ops = post_ops_ok_args.post_ops;
-    const bool sum_at_pos_0_only = post_ops_ok_args.sum_at_pos_0_only;
-    const bool sum_requires_scale_one = post_ops_ok_args.sum_requires_scale_one;
-    const bool sum_requires_zp_zero = post_ops_ok_args.sum_requires_zp_zero;
-    const bool sum_requires_same_params
-            = post_ops_ok_args.sum_requires_same_params;
+    const auto &args = post_ops_ok_args;
+
+    const post_ops_t &post_ops = args.post_ops;
 
     // Save scale and zero point of first sum postop in order to check that any
     // subsequent sum postops have the same values. This check is necessary
     // because there is only one lambda injector.
-    const auto sum_idx = post_ops.find(primitive_kind::sum);
-    const bool with_sum = sum_idx != -1;
-    const auto &entry
-            = with_sum ? post_ops.entry_[sum_idx] : dnnl_post_ops::entry_t();
-    const auto sum_scale = with_sum ? entry.sum.scale : 0;
-    const auto sum_zero_point = with_sum ? entry.sum.zero_point : 0;
+    const auto first_sum_idx = post_ops.find(primitive_kind::sum);
+    const bool with_sum = first_sum_idx != -1;
+    const auto &maybe_sum_entry = with_sum ? post_ops.entry_[first_sum_idx]
+                                           : dnnl_post_ops::entry_t();
+    const auto first_sum_scale = with_sum ? maybe_sum_entry.sum.scale : 0;
+    const auto first_sum_zero_point
+            = with_sum ? maybe_sum_entry.sum.zero_point : 0;
 
     const auto is_accepted_postop = [&](const int idx) {
-        for (const auto &post_op : accepted_post_op_types) {
+        for (const auto &post_op : args.accepted_post_op_types) {
             const auto &entry = post_ops.entry_[idx];
             switch (post_op) {
                 case sum:
                     if (entry.is_sum(false, false)) {
-                        if (sum_requires_same_params
-                                && entry.sum.scale != sum_scale)
+                        if (args.sum_requires_same_params
+                                && entry.sum.scale != first_sum_scale)
                             return false;
-                        if (sum_requires_same_params
-                                && entry.sum.zero_point != sum_zero_point)
+                        if (args.sum_requires_same_params
+                                && entry.sum.zero_point != first_sum_zero_point)
                             return false;
-                        if (sum_requires_scale_one && entry.sum.scale != 1)
+                        if (args.sum_requires_scale_one && entry.sum.scale != 1)
                             return false;
-                        if (sum_requires_zp_zero && entry.sum.zero_point != 0)
+                        if (args.sum_requires_zp_zero
+                                && entry.sum.zero_point != 0)
                             return false;
-                        return IMPLICATION(sum_at_pos_0_only, idx == 0);
+                        return IMPLICATION(args.sum_at_pos_0_only, idx == 0);
                     }
                     break;
                 case eltwise:
                     if (entry.is_eltwise()) {
                         const auto alg = entry.eltwise.alg;
                         return eltwise_injector::is_supported(
-                                to_vla_sve(isa), alg);
+                                to_vla_sve(args.isa), alg);
                     }
                     break;
                 case binary:
-                    if (entry.is_binary()) { return isa == asimd; }
+                    // TODO: support alg_kind::prelu with entry.is_like_binary()
+                    if (entry.is_binary()) {
+                        //TODO: support alg_kind::select
+                        if (entry.is_binary_with_ternary_op()) return false;
+
+                        return binary_injector::is_supported(
+                                to_vla_sve(args.isa), entry.binary.src1_desc,
+                                *args.dst_d, args.enabled_bcast_strategy);
+                    }
                     break;
                 default: assert(false && "Unhandled post_op type");
             }

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,14 +23,10 @@
 #include <memory>
 
 #include "common/c_types_map.hpp"
-#include "common/primitive_attr.hpp"
-#include "common/type_helpers.hpp"
-#include "common/utils.hpp"
 #include "cpu/aarch64/injectors/injector_utils.hpp"
 #include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
-#include <initializer_list>
 
 namespace dnnl {
 namespace impl {
@@ -52,7 +48,7 @@ struct post_ops_ok_args_t;
 /*
  * Checks if postops injection for given args is supported.
  */
-bool is_supported(const post_ops_ok_args_t &post_ops_ok_args);
+bool post_ops_ok(const post_ops_ok_args_t &args);
 
 /*
  * Main mechanism of handling various post-ops types. It utilizes internally
@@ -161,8 +157,6 @@ struct post_ops_ok_args_t {
     const bool sum_requires_same_params;
     const bcast_set_t enabled_bcast_strategy;
 };
-
-bool post_ops_ok(const post_ops_ok_args_t &args);
 
 } // namespace injector
 } // namespace aarch64

--- a/tests/benchdnn/inputs/binary/harness_binary_regression
+++ b/tests/benchdnn/inputs/binary/harness_binary_regression
@@ -10,3 +10,6 @@
 
 # Large-axis index stress
 --reset --allow-enum-tags-only=0 --alg=ADD --stag=abcd:abcd --dtag=abcd --sdt=f16:f16 --ddt=f16 1x1x512x65536:1x1x512x65536
+
+# Post-op with non-broadcast load
+--reset --alg=add --attr-post-ops=binary_div:f32:common 1x4:1x4


### PR DESCRIPTION
# Description

This change de-duplicates the functions used to check support for post-op injection.

Also fixes an issue where the wrong instruction is used for broadcast loads on `asimd`, causing crashes in nightly: https://github.com/uxlfoundation/oneDNN/actions/runs/26145272841/job/76901306317

Failing case:
```
$ DNNL_MAX_CPU_ISA='advanced_simd' ./build/tests/benchdnn/benchdnn --binary --alg=add --attr-post-ops=binary_div:f32:common 1x4:1x4
zsh: segmentation fault (core dumped)
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?