### PR TITLE
grouped matmul: support per-group global NVFP4 scale 

### DIFF
--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -450,6 +450,17 @@ po.append_binary(algorithm::binary_mul, routing_md);
 attr.set_post_ops(po);
 ~~~
 
+Binary multiply with per-group broadcast (one value per expert):
+~~~cpp
+// [num_groups, 1] tensor, one scalar per expert
+auto scale_md = memory::desc({num_groups, 1},
+    memory::data_type::f32, memory::format_tag::ab);
+
+post_ops po;
+po.append_binary(algorithm::binary_mul, scale_md);
+attr.set_post_ops(po);
+~~~
+
 ### Execution Hints
 
 An optional execution-time hint `DNNL_ARG_HINT_MAX_GROUP_SIZE` can be provided to
@@ -504,15 +515,16 @@ The following are supported:
   Common patterns include `eltwise_swish` for SiLU activation,
   `binary_mul` with a `[total_tokens, N]` grouped or dense tensor,
   `binary_mul` with a `[total_tokens, 1]` dense tensor,
-  and `[1, 1]` that could be used to apply a global scale for NVFP4.
+  and `[num_groups, 1]` for a per-group global scale (e.g. NVFP4).
+  Scalar `[1, 1]` binary post-ops are not supported for grouped matmul.
   For grouped binary tensors, the per-group offsets must match the grouped dst
   partition.
- 
+
  @attention The GPU implementation supports at most one dense binary multiplication
   post-op and at most one grouped binary multiplication post-op. Providing more
   than one of either kind is not supported on GPU.
 
-- Bias supports per-expert shape.
+- Bias supports per-group shape.
 - Supported on CPU and GPU engines.
 
 #### Supported Data Types

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -212,13 +212,20 @@ status_t grouped_matmul_attr_check(
                                 && bin_g.variable_dim_idx
                                         == dst_g.variable_dim_idx,
                         VERBOSE_INCONSISTENT_MDS, "binary post-op", "dst");
-            } else if (!src1_d.format_any()) {
-                // Dense binary post-op:
-                // only support N == 1 (scalar/per-row) or ab layout
+            } else {
+                // Validate dense binary post-op descriptor:
+                // only per-group (e.g., NVFP4 with [G, 1])
+                // or per-row shapes are allowed
+                const dim_t bin_M = src1_d.dims()[0];
                 const dim_t bin_N = src1_d.dims()[src1_d.ndims() - 1];
+                const dim_t total_M = dst_d.dims()[0];
+                const dim_t gc = dst_d.sparse_desc().grouped_desc.group_count;
                 VCHECK_MATMUL_UNIMPL(
                         bin_N == 1 || src1_d.matches_one_of_tag(format_tag::ab),
                         VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "binary post-op");
+                VCHECK_MATMUL_UNIMPL(utils::one_of(bin_M, gc, total_M)
+                                && IMPLICATION(bin_M == gc, bin_N == 1),
+                        VERBOSE_INCONSISTENT_MDS, "binary post-op", "dst");
             }
         }
     }

--- a/src/cpu/matmul/ref_grouped_gemm.cpp
+++ b/src/cpu/matmul/ref_grouped_gemm.cpp
@@ -330,7 +330,12 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
                         }
                         const dim_t bin_M = bin_d.dims()[0];
                         const dim_t bin_N = bin_d.dims()[1];
-                        const dim_t eff_m = bin_M > 1 ? (row_base + m) : 0;
+                        // Per-group [G, 1]: index is group_id
+                        // Per-row [total_M, *]: index is row_base + m
+                        const bool per_group
+                                = (bin_M == group_count && bin_N == 1);
+                        const dim_t eff_m
+                                = per_group ? group_id : (row_base + m);
                         const dim_t eff_n = bin_N > 1 ? n : 0;
                         const float val
                                 = io::load_float_value(bin_d.data_type(),

--- a/src/cpu/matmul/ref_grouped_gemm.hpp
+++ b/src/cpu/matmul/ref_grouped_gemm.hpp
@@ -213,16 +213,13 @@ struct ref_grouped_t : public primitive_t {
                         (int)zp_gK);
             }
 
-            // Below is to allow using format_any for scalar [1, 1] as binary
-            // post-ops for NVFP4 global scale support
+            // Resolve format_any for dense binary post-ops
             const auto &po = attr()->post_ops_;
             for (int i = 0; i < po.len(); ++i) {
                 auto &e = attr_.post_ops_.entry_[i];
                 if (e.is_binary()) {
                     const memory_desc_wrapper src1_d(e.binary.src1_desc);
                     if (src1_d.format_any()) {
-                        VDISPATCH_MATMUL(src1_d.count_non_unit_dims(0),
-                                VERBOSE_UNSUPPORTED_POSTOP);
                         CHECK(memory_desc_init_by_strides(
                                 e.binary.src1_desc, nullptr));
                     }

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -327,7 +327,7 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
     with_post_op_ = !attr()->post_ops_.has_default_values();
     if (with_post_op_) {
         CHECK(check_post_op_chain(
-                *attr(), dst_d, po_chain_, binary_scale_dts_));
+                *attr(), dst_d, ngroups_, po_chain_, binary_scale_dts_));
     }
 
     // only supported dt for now

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -39,7 +39,7 @@ int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind) {
 }
 
 status_t check_post_op_chain(const primitive_attr_t &attr,
-        const memory_desc_wrapper &dst_desc, po_kind_t *po_chain,
+        const memory_desc_wrapper &dst_desc, dim_t ngroups, po_kind_t *po_chain,
         data_type_t *scale_arr) {
     auto &po = attr.post_ops_;
     scale_arr[0] = data_type::undef;
@@ -58,8 +58,11 @@ status_t check_post_op_chain(const primitive_attr_t &attr,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             const memory_desc_wrapper po_mdw(po.entry_[i].binary.src1_desc);
-            if (po_mdw.nelems() == 1 && po_mdw.data_type() == data_type::f32
+            if (po_mdw.nelems() == ngroups
+                    && po_mdw.data_type() == data_type::f32
                     && !po_mdw.is_host_scalar_desc()) {
+                // [G, 1] operand: one scale per group (expert), e.g. nvfp4
+                // per-expert global scale.
                 po_chain[i] = po_kind_t::binary_nvfp4_scale;
             } else {
                 if (po_mdw.is_grouped_desc()) {
@@ -192,7 +195,7 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
             } else if (po_chain[i] == po_kind_t::binary_nvfp4_scale) {
                 s += utils::format(
                         R"(
-    float gs_%d = *nvfp4_scale;
+    float gs_%d = nvfp4_scale[batch];
 #define binary_mul_%d(v) ((v) * gs_%d)
     tile_elementwise((*c_tile), binary_mul_%d);
 #undef binary_mul_%d
@@ -263,7 +266,7 @@ inline ACC_DATA_T apply_post_ops_chain(
     }
 )";
             } else if (po_chain[i] == po_kind_t::binary_nvfp4_scale) {
-                s += "    dst *= *nvfp4_scale;\n";
+                s += "    dst *= nvfp4_scale[group_id];\n";
             }
         }
     }

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.hpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.hpp
@@ -44,7 +44,7 @@ enum class po_kind_t {
 int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind);
 
 status_t check_post_op_chain(const primitive_attr_t &attr,
-        const memory_desc_wrapper &dst_desc, po_kind_t *po_chain,
+        const memory_desc_wrapper &dst_desc, dim_t ngroups, po_kind_t *po_chain,
         data_type_t *scale_arr);
 
 void set_binary_scales_dt(const primitive_attr_t &attr,

--- a/src/gpu/intel/matmul/ref_grouped_gemm.hpp
+++ b/src/gpu/intel/matmul/ref_grouped_gemm.hpp
@@ -113,8 +113,8 @@ struct ref_grouped_t : public primitive_t {
 
             with_post_op_ = !attr()->post_ops_.has_default_values();
             if (with_post_op_) {
-                CHECK(check_post_op_chain(
-                        *attr(), dst_d, po_chain_, binary_scale_dts_));
+                CHECK(check_post_op_chain(*attr(), dst_d, group_count_,
+                        po_chain_, binary_scale_dts_));
             }
 
             return status::success;

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1355,8 +1355,19 @@ int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
 
             // deduce binary, prelu dims based on input policy
             dnnl_dims_t rhs_tensor_dims = {};
-            for (auto d = 0; d < ndims; ++d)
-                rhs_tensor_dims[d] = (!(mask & (1 << d))) ? 1 : dims[d];
+            // Overload mask 0 meaning for when binary post-op is applied
+            // to grouped memory, changing it to be per-group (i.e. one value
+            // per concatenated tensor, for instance for NVFP4 global scale).
+            // The grouped dst has no explicit num_groups in dims,
+            // so form a [group_count, 1, ...] descriptor manually
+            if (grouped_count > 0 && mask == 0) {
+                for (auto d = 0; d < ndims; ++d)
+                    rhs_tensor_dims[d]
+                            = (d == grouped_var_dim_idx) ? grouped_count : 1;
+            } else {
+                for (auto d = 0; d < ndims; ++d)
+                    rhs_tensor_dims[d] = (!(mask & (1 << d))) ? 1 : dims[d];
+            }
 
             auto rhs_tensor_desc = dnn_mem_t::init_md(ndims, rhs_tensor_dims,
                     po_rhs_tensor_entry.dt, po_rhs_tensor_entry.tag,

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -857,13 +857,19 @@ int measure_perf(
 
 std::vector<float> prepare_po_vals(const dnn_mem_t &dst_m, const args_t &args,
         const std::vector<std::pair<int, int>> &v_po_masks,
-        const size_t dst_off) {
+        const size_t dst_off, int64_t group_id) {
     if (v_po_masks.empty()) return std::vector<float>();
 
     std::vector<float> v_vals(v_po_masks.size());
 
     for (size_t d = 0; d < v_po_masks.size(); ++d) {
-        const auto po_offset = dst_m.get_idx(dst_off, v_po_masks[d].second);
+        // For grouped memory, mask == 0 is overloaded to mean per-group:
+        // a single value per concatenated group, indexed by group_id
+        //
+        // Note, that group_id is 0 for non-grouped use
+        const auto po_offset = v_po_masks[d].second == 0
+                ? group_id
+                : dst_m.get_idx(dst_off, v_po_masks[d].second);
         const float val
                 = args.find(v_po_masks[d].first).get_f32_elem(po_offset);
         v_vals[d] = val;

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -715,7 +715,7 @@ int measure_perf(
 
 std::vector<float> prepare_po_vals(const dnn_mem_t &dst_m, const args_t &args,
         const std::vector<std::pair<int, int>> &v_po_masks,
-        const size_t dst_off);
+        const size_t dst_off, int64_t group_id = 0);
 
 bool check_md_consistency_with_tag(
         const_dnnl_memory_desc_t md, const std::string &tag);

--- a/tests/benchdnn/doc/driver_matmul.md
+++ b/tests/benchdnn/doc/driver_matmul.md
@@ -53,6 +53,9 @@ where *matmul-knobs* are:
             are sizes of each group with total `32+0+32+96 = 160`.
             Example: `--grouped=0:4:8+8+8+8:8` specifies max group size of `8`.
             Example: `--grouped=0:4:8+8+8+8,0:3:2+6+8` iterates over two configs.
+            Note: a binary post-op with `mask = 0` (e.g.
+            `--attr-post-ops=mul:f32:0`) is applied per group (`[G, 1]`,
+            e.g. NVFP4 global scale), not a whole-tensor.
  - `--match=REGEX` -- skip problems not matching the regular expression in
             `REGEX`. By default no pattern is applied (run everything).
             Note: Windows may interpret only string arguments surrounded by

--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
@@ -23,8 +23,8 @@
 # - FP8 row-wise: f8_e5m2/f8_e4m3 dtypes with row-wise src + column-wise wei f32 scales
 # - MXFP8: f8_e4m3 dtypes, e8m0 block scales, block size 32
 # - MXFP4: f4_e2m1 dtypes, e8m0 block scales, block size 32
-# - NVFP4: f4_e2m1 dtypes, f8_e4m3 block scales (block size 16) + global f32 scale via
-#           binary mul post-op (--attr-post-ops=mul:f32:0)
+# - NVFP4: f4_e2m1 dtypes, f8_e4m3 block scales (block size 16) + per-group global
+#           f32 scale via binary mul post-op (--attr-post-ops=mul:f32:0)
 # - Post-ops: eltwise_swish, binary_mul (per-row, dense, grouped encoding),
 #             chained eltwise_swish+binary_mul(grouped), post-ops with bias/scales
 
@@ -165,7 +165,8 @@
 --attr-scales=src:3:e8m0:1x32+wei:7:e8m0:32x1
 32x128:4x128x64
 
-# NVFP4: f4_e2m1 dt with f8_e4m3 block scales + global f32 scale via binary mul
+# NVFP4: f4_e2m1 dt with f8_e4m3 block scales + per-group global f32 scale
+# via binary mul
 --reset
 --dt=f4_e2m1:f4_e2m1:bf16
 --wtag=abc,acb
@@ -232,3 +233,12 @@
 --grouped=0:4:8+8+8+8
 --attr-post-ops=mul:f16:3:grouped+mul:f32:1:ab,eltwise_swish:1.0+mul:f16:3:grouped+mul:f32:1:ab
 32x64:4x64x32
+
+# Per-group binary_mul (mask 0) with variable group sizes
+--reset
+--dt=f16:f16:f16
+--wtag=abc
+--grouped=0:4:10+0+50+40
+--attr-post-ops=mul:f32:0
+100x64:4x64x32
+

--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_gpu
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_gpu
@@ -9,7 +9,7 @@
 --reset
 
 ########################################
-# grouped_mm: BF16/FP16               #
+# grouped_mm: BF16/FP16                #
 ########################################
 
 # mat2 row-major
@@ -70,7 +70,7 @@
 # scaled_grouped_mm: NvFP4             #
 # scale_a: f8_e4m3 block (M, K/16)     #
 # scale_b: f8_e4m3 block (E, K/16, N)  #
-# + global f32 scale via binary mul    #
+# + per-group global f32 scale         #
 ########################################
 
 --reset

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -186,7 +186,8 @@ static void compute_ref_matmul_chunk(const chunk_params_t &p, int64_t M,
         int64_t N, int64_t K, int64_t mc, int64_t nc, int64_t src_row_base,
         int64_t wei_base, int64_t wei_k_stride, int64_t wei_n_stride,
         int64_t dst_row_base, int64_t bia_base, int64_t bia_m_stride,
-        int64_t bia_n_stride, const attr_t &attr, const args_t &args) {
+        int64_t bia_n_stride, const attr_t &attr, const args_t &args,
+        int64_t group_id = 0) {
     // Mutable per-element quant params; initialised to the single value when
     // applicable and overwritten per K-group otherwise.
     int src_zp = p.src_zp_single;
@@ -247,8 +248,8 @@ static void compute_ref_matmul_chunk(const chunk_params_t &p, int64_t M,
             dst += p.bia_m->get_f32_elem(bia_idx);
         }
 
-        const auto v_po_vals
-                = prepare_po_vals(*p.dst_m, args, p.v_po_masks, dst_off);
+        auto v_po_vals = prepare_po_vals(
+                *p.dst_m, args, p.v_po_masks, dst_off, group_id);
         maybe_dropout(attr, dst, dst_off, *p.dropout_mask);
         const auto sum_val = p.dst_m->get_f32_elem(dst_off);
         maybe_post_ops(attr, dst, sum_val, v_po_vals);
@@ -380,7 +381,7 @@ void compute_ref_grouped_matmul(const prb_t *prb, const args_t &args) {
         compute_ref_matmul_chunk(params, M_g, prb->n, prb->k, mc, nc,
                 src_row_base, wei_base, wei_k_stride, wei_n_stride,
                 dst_row_base, bia_base, bia_m_stride, bia_n_stride, prb->attr,
-                args);
+                args, g);
     });
 }
 

--- a/tests/gtests/test_iface_grouped.cpp
+++ b/tests/gtests/test_iface_grouped.cpp
@@ -617,6 +617,55 @@ HANDLE_EXCEPTIONS_FOR_TEST(
             dnnl::error);
 }
 
+TEST(iface_grouped_test_t, TestBinaryPostOpDenseShapes) {
+    engine eng = get_test_engine();
+
+    const int ngroups = 4;
+    const int total_m = 32;
+    const int K = 64;
+    const int N = 32;
+
+    auto src_md = memory::desc::grouped({total_m, K}, dt::f32, 0, ngroups);
+    auto wei_md
+            = memory::desc({ngroups, K, N}, dt::f32, memory::format_tag::abc);
+    auto dst_md = memory::desc::grouped({total_m, N}, dt::f32, 0, ngroups);
+
+    // Scalar [1, 1] binary post-op should be rejected
+    {
+        auto scalar_md = memory::desc({1, 1}, dt::f32, memory::format_tag::ab);
+        post_ops po;
+        po.append_binary(algorithm::binary_mul, scalar_md);
+        primitive_attr attr;
+        attr.set_post_ops(po);
+        EXPECT_THROW(matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr),
+                dnnl::error);
+    }
+
+    // Per-group [G, 1] binary post-op is supported
+    {
+        auto per_group_md
+                = memory::desc({ngroups, 1}, dt::f32, memory::format_tag::ab);
+        post_ops po;
+        po.append_binary(algorithm::binary_mul, per_group_md);
+        primitive_attr attr;
+        attr.set_post_ops(po);
+        EXPECT_NO_THROW(
+                matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr));
+    }
+
+    // Per-row [total_M, 1] binary post-op is supported
+    {
+        auto per_row_md
+                = memory::desc({total_m, 1}, dt::f32, memory::format_tag::ab);
+        post_ops po;
+        po.append_binary(algorithm::binary_mul, per_row_md);
+        primitive_attr attr;
+        attr.set_post_ops(po);
+        EXPECT_NO_THROW(
+                matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr));
+    }
+}
+
 } // namespace dnnl
 
 #endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY


### PR DESCRIPTION
PR is to address [MFDNN-15180](https://jira.devtools.intel.com/browse/MFDNN-15180).
Essentially, for NVFP4 (that requires two-levels of scaling: grouped + global one), we need to change support to allow global value per-group and not per tensor. 