### PR TITLE
xe: gated_mlp: enable gmlp primitive descriptor serialization

### DIFF
--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -35,6 +35,7 @@ status_t serialize_desc(
         CASE(convolution)
         CASE(deconvolution)
         CASE(eltwise)
+        CASE(gated_mlp)
         CASE(gemm)
         CASE(group_normalization)
         CASE(inner_product)


### PR DESCRIPTION
This fix allows GMLP primitives to correctly serialize their PDs.
PD serialization enables proper kernel caching in benchdnn.

This is a prerequisite of #4951.