### PR TITLE
tests: add matmul CI case for ReLU alpha post-op

### DIFF
--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -19,12 +19,12 @@
 --batch=shapes_2d_ci
 
 --attr-post-ops=sum:0.5,\
-                linear:2:1,\
+                relu:0.5,\
                 add:f32,\
                 add:u8:per_oc,\
                 prelu:per_tensor,\
                 prelu:per_oc,\
-                sum+relu:0.5+add:f32
+                sum+linear:2:1+add:f32
 --batch=shapes_2d
 --batch=shapes_3d
 


### PR DESCRIPTION
This PR adds a matmul CI case for a single ReLU post-op with non-zero alpha:

```bash
--attr-post-ops=relu:2
128x1x8192:1x8192x64_n"post_ops_relu_alpha"
````

The issue is in the RV64 post-ops path, `rvv_postops.cpp`, where ReLU alpha was not handled correctly. It is fixed by #5174.

Existing CI did not catch this because the nearby post-op coverage uses a multi-op chain such as `sum+relu:0.5+add:f32`, which does not exercise the affected single-ReLU RV64 path.

Before #5174 is merged, this PR is expected to cause a `ctest` failure. That is expected behavior. After #5174 lands, the new case should pass.

### The ctest -R test_benchdnn_modeC_matmul_ci_cpu results before and after this PR:
#### Before
[test_benchdnn_modeC_matmul_ci_cpu_raw.log](https://github.com/user-attachments/files/28195007/test_benchdnn_modeC_matmul_ci_cpu_raw.log)

#### After
[test_benchdnn_modeC_matmul_ci_cpu_5194.log](https://github.com/user-attachments/files/28195013/test_benchdnn_modeC_matmul_ci_cpu_5194.log)

We have confirmed that before #5174 was merged, `ctest` passes completely without the changes from this PR, while with the changes from this PR, it introduces only one new failure: `215 - test_benchdnn_modeC_matmul_ci_cpu (Failed)`.

At the same time, #5174 has been merged, and `ctest` now passes again, so this PR is ready for review.
```
[xiazz@openeuler-riscv64-143 benchdnn]$ ./benchdnn --matmul --stag=abc --wtag=abc --dtag=abc --attr-post-ops=relu:2 128x1x8192:1x8192x64_n"post_ops_relu_alpha"
0:PASSED (124 ms) __REPRO: --matmul --stag=abc --wtag=abc --dtag=abc --attr-post-ops=relu:2 128x1x8192:1x8192x64_npost_ops_relu_alpha
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| RISCV64GCV : 1 (100%)                                    |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.13s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.10s (78%); execute: 0.01s (6%); compute_ref: 0.00s (3%); compare: 0.00s (2%);
```

However, I suspect the issue is related to post-op handling in general, and its impact may be broader. Would it be appropriate to attribute it solely to matmul?

This is my first PR related to test cases, so any feedback or suggestions would be appreciated.