### PR TITLE
cpu: rv64: pool: improve nhwc pooling with jit implementation

### DIFF
--- a/src/cpu/rv64/jit_rvv_pooling_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_pooling_kernel.cpp
@@ -1,0 +1,201 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstddef>
+
+#include "cpu/rv64/jit_rvv_pooling_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+jit_rvv_pooling_fwd_kernel_t::jit_rvv_pooling_fwd_kernel_t(alg_t alg)
+    : jit_generator_t(alg == alg_t::max_pool ? "jit_rvv_pooling_fwd_max"
+                      : alg == alg_t::avg_include
+                      ? "jit_rvv_pooling_fwd_avg_inc"
+                      : "jit_rvv_pooling_fwd_avg_exc")
+    , alg_(alg) {
+    create_kernel();
+}
+
+void jit_rvv_pooling_fwd_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const VReg v_mask(0), v_acc(4), v_tmp(8);
+
+    // Save callee-saved regs (s0-s7) to hold loop invariants across the
+    // nested id/ih/iw/channel loops (src/dst ptrs, strides, range bounds)
+    const int stack_size = 8 * 8;
+    addi(sp, sp, -stack_size);
+    sd(s0, sp, 0);
+    sd(s1, sp, 8);
+    sd(s2, sp, 16);
+    sd(s3, sp, 24);
+    sd(s4, sp, 32);
+    sd(s5, sp, 40);
+    sd(s6, sp, 48);
+    sd(s7, sp, 56);
+
+    // Load params from call_params_t
+    using p_t = call_params_t;
+    ld(s0, reg_param, static_cast<int>(offsetof(p_t, src)));
+    ld(s1, reg_param, static_cast<int>(offsetof(p_t, dst)));
+    ld(s2, reg_param, static_cast<int>(offsetof(p_t, channels)));
+    ld(s6, reg_param, static_cast<int>(offsetof(p_t, id_start)));
+    ld(s7, reg_param, static_cast<int>(offsetof(p_t, ih_start)));
+    ld(a1, reg_param, static_cast<int>(offsetof(p_t, iw_start)));
+    ld(t5, reg_param, static_cast<int>(offsetof(p_t, id_end)));
+    ld(t6, reg_param, static_cast<int>(offsetof(p_t, ih_end)));
+    ld(a2, reg_param, static_cast<int>(offsetof(p_t, iw_end)));
+    ld(t2, reg_param, static_cast<int>(offsetof(p_t, inW_stride)));
+    ld(t3, reg_param, static_cast<int>(offsetof(p_t, inD_stride)));
+    flw(fa0, reg_param, static_cast<int>(offsetof(p_t, init_val)));
+    flw(ft1, reg_param, static_cast<int>(offsetof(p_t, scale_val)));
+    flw(fa2, reg_param, static_cast<int>(offsetof(p_t, relu_alpha)));
+
+    fmv_w_x(fa1, x0); // f_zero = 0.0
+
+    // Compute byte strides
+    slli(s4, t2, 2); // inW_stride_bytes = inW_stride * 4
+    slli(s5, t3, 2); // inD_stride_bytes = inD_stride * 4
+
+    // Byte stride to advance one pixel in W: channels * sizeof(float)
+    slli(s3, s2, 2); // W_spatial_byte_stride = channels * 4
+
+    // Load with_relu flag (t3 is free after inD_stride consumed into s5)
+    lbu(t3, reg_param, static_cast<int>(offsetof(p_t, with_relu)));
+
+    // Channel loop: process channels in vector chunks
+    Label ch_loop, ch_done;
+    L(ch_loop);
+    beqz(s2, ch_done);
+
+    // Set vector length for remaining channels
+    vsetvli(t0, s2, SEW::e32, LMUL::m1);
+
+    // Initialize accumulator
+    if (alg_ == alg_t::max_pool) {
+        // init_val = -FLT_MAX for max pool
+        vfmv_v_f(v_acc, fa0);
+    } else {
+        vfmv_v_f(v_acc, fa1); // zero
+    }
+
+    // Depth (id) loop
+    mv(a3, s6); // reg_id = id_start
+    mul(t1, a3, s5);
+    add(t1, s0, t1); // t1 = depth_ptr = src + id * inD_stride_bytes
+
+    Label id_loop, id_done;
+    L(id_loop);
+    bge(a3, t5, id_done); // if id >= id_end, done
+
+    // Height (ih) loop
+    mv(a4, s7); // reg_ih = ih_start
+    mul(t2, a4, s4);
+    add(a6, t1, t2); // a6 = row_ptr
+
+    Label ih_loop, ih_done;
+    L(ih_loop);
+    bge(a4, t6, ih_done); // if ih >= ih_end, done
+
+    // Width (iw) loop
+    mv(a5, a1); // reg_iw = iw_start
+    mul(t2, a5, s3);
+    add(a7, a6, t2); // a7 = src_ptr
+
+    Label iw_loop, iw_done;
+    L(iw_loop);
+    bge(a5, a2, iw_done); // if iw >= iw_end, done
+
+    // Load and accumulate
+    vle32_v(v_tmp, a7);
+    if (alg_ == alg_t::max_pool) {
+        vfmax_vv(v_acc, v_acc, v_tmp);
+    } else {
+        vfadd_vv(v_acc, v_acc, v_tmp);
+    }
+
+    addi(a5, a5, 1); // iw++
+    add(a7, a7, s3); // advance src_ptr by channels * 4
+    j_(iw_loop);
+    L(iw_done);
+
+    addi(a4, a4, 1); // ih++
+    add(a6, a6, s4); // advance row_ptr by inW_stride_bytes
+    j_(ih_loop);
+    L(ih_done);
+
+    addi(a3, a3, 1); // id++
+    add(t1, t1, s5); // advance depth_ptr by inD_stride_bytes
+    j_(id_loop);
+    L(id_done);
+
+    // Apply avg pooling divide
+    if (alg_ != alg_t::max_pool) { vfmul_vf(v_acc, v_acc, ft1); }
+
+    // Apply ReLU post-op (t3 = with_relu, loaded before channel loop)
+    Label relu_done, relu_alpha_zero;
+    beqz(t3, relu_done);
+
+    // Check if alpha == 0
+    fmv_w_x(ft0, x0);
+    feq_s(t2, fa2, ft0);
+    bnez(t2, relu_alpha_zero);
+    // Alpha != 0: mask = v > 0; neg = v * alpha; merge
+    vmfgt_vf(v_mask, v_acc, fa1);
+    vfmul_vf(v_tmp, v_acc, fa2);
+    vmerge_vvm(v_acc, v_tmp, v_acc);
+    j_(relu_done);
+    L(relu_alpha_zero);
+    vfmax_vf(v_acc, v_acc, fa1);
+    L(relu_done);
+    // Store result
+    vse32_v(v_acc, s1);
+
+    // Advance src/dst pointers by vl * 4 bytes
+    slli(t1, t0, 2);
+    add(s0, s0, t1);
+    add(s1, s1, t1);
+    sub(s2, s2, t0); // channels -= vl
+
+    j_(ch_loop);
+    L(ch_done);
+
+    // Restore callee-saved regs
+    ld(s0, sp, 0);
+    ld(s1, sp, 8);
+    ld(s2, sp, 16);
+    ld(s3, sp, 24);
+    ld(s4, sp, 32);
+    ld(s5, sp, 40);
+    ld(s6, sp, 48);
+    ld(s7, sp, 56);
+    addi(sp, sp, stack_size);
+
+    ret();
+#else
+    ret();
+#endif
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_rvv_pooling_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_pooling_kernel.hpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_RVV_POOLING_KERNEL_HPP
+#define CPU_RV64_JIT_RVV_POOLING_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_rvv_pooling_fwd_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const float *src;
+        float *dst;
+        dim_t channels;
+        dim_t id_start, ih_start, iw_start;
+        dim_t id_end, ih_end, iw_end;
+        dim_t inW_stride; // IW * C (elements)
+        dim_t inD_stride; // IH * IW * C (elements)
+        float init_val; // -FLT_MAX for max, 0.0 for avg
+        float scale_val; // 1.0/count for avg, unused for max
+        float relu_alpha;
+        bool with_relu;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_pooling_fwd_kernel_t)
+
+    enum class alg_t : int { max_pool, avg_include, avg_exclude };
+
+    jit_rvv_pooling_fwd_kernel_t(alg_t alg);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    alg_t alg_;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_JIT_RVV_POOLING_KERNEL_HPP

--- a/src/cpu/rv64/rvv_nhwc_pooling.cpp
+++ b/src/cpu/rv64/rvv_nhwc_pooling.cpp
@@ -17,13 +17,17 @@
 
 #include <algorithm>
 #include <float.h>
-#include <riscv_vector.h>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
+#include "cpu/rv64/jit_rvv_pooling_kernel.hpp"
 #include "cpu/rv64/rvv_nhwc_pooling.hpp"
+
+#if defined(DNNL_RISCV_USE_ZVFH_INTRINSICS)
+#include <riscv_vector.h>
+#endif
 
 namespace dnnl {
 namespace impl {
@@ -32,74 +36,67 @@ namespace rv64 {
 
 namespace {
 
-static void MaxPooling_f32(const void *src_raw, void *dst_raw,
-        const dim_t batch, const dim_t channels, const dim_t outD,
-        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
-        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
-        const dim_t strideD, const dim_t strideH, const dim_t strideW,
-        const dim_t padFront, const dim_t padTop, const dim_t padLeft,
-        const rvv_postops_t &postops_handler) {
+using kernel_t = jit_rvv_pooling_fwd_kernel_t;
 
-    const float *src = static_cast<const float *>(src_raw);
-    float *dst = static_cast<float *>(dst_raw);
+// Compute per-output-pixel JIT kernel parameters (spatial window, init/scale).
+kernel_t::call_params_t make_pooling_params(kernel_t::alg_t alg,
+        const float *src_mb_base, float *dst, dim_t mb, dim_t channels,
+        dim_t od, dim_t oh, dim_t ow, dim_t outD, dim_t outH, dim_t outW,
+        dim_t inD, dim_t inH, dim_t inW, dim_t kerD, dim_t kerH, dim_t kerW,
+        dim_t strideD, dim_t strideH, dim_t strideW, dim_t padFront,
+        dim_t padTop, dim_t padLeft, dim_t inW_stride, dim_t inD_stride,
+        bool with_relu, float relu_alpha) {
 
-    parallel_nd(batch, outD, outH, outW,
-            [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
-        const size_t dst_spatial_base
-                = ((((size_t)mb * outD + od) * outH + oh) * outW + ow)
-                * channels;
+    const size_t dst_spatial_base
+            = ((((size_t)mb * outD + od) * outH + oh) * outW + ow) * channels;
 
-        // Compute valid kernel ranges per spatial dim
-        const int od_offset = (int)(od * strideD - padFront);
-        const int oh_offset = (int)(oh * strideH - padTop);
-        const int ow_offset = (int)(ow * strideW - padLeft);
-        const int id_start = std::max(od_offset, 0);
-        const int ih_start = std::max(oh_offset, 0);
-        const int iw_start = std::max(ow_offset, 0);
-        const int id_end = std::min(od_offset + (int)kerD, (int)inD);
-        const int ih_end = std::min(oh_offset + (int)kerH, (int)inH);
-        const int iw_end = std::min(ow_offset + (int)kerW, (int)inW);
+    const int od_offset = (int)(od * strideD - padFront);
+    const int oh_offset = (int)(oh * strideH - padTop);
+    const int ow_offset = (int)(ow * strideW - padLeft);
 
-        // If no overlap in width, early out (no overlap implies whole kernel outside)
-        if (id_start >= id_end || ih_start >= ih_end || iw_start >= iw_end) {
-            size_t oc = 0;
-            while (oc < (size_t)channels) {
-                size_t vl = __riscv_vsetvl_e32m1((size_t)channels - oc);
-                vfloat32m1_t vfill = __riscv_vfmv_v_f_f32m1(-__FLT_MAX__, vl);
-                vfill = postops_handler.apply(vfill, vl);
-                __riscv_vse32_v_f32m1(&dst[dst_spatial_base + oc], vfill, vl);
-                oc += vl;
-            }
-            return;
-        }
+    int id_start = std::max(od_offset, 0);
+    int ih_start = std::max(oh_offset, 0);
+    int iw_start = std::max(ow_offset, 0);
+    int id_end = std::min(od_offset + (int)kerD, (int)inD);
+    int ih_end = std::min(oh_offset + (int)kerH, (int)inH);
+    int iw_end = std::min(ow_offset + (int)kerW, (int)inW);
 
-        size_t oc = 0;
-        while (oc < (size_t)channels) {
-            size_t vl = __riscv_vsetvl_e32m1((size_t)channels - oc);
-            vfloat32m1_t vmax = __riscv_vfmv_v_f_f32m1(-__FLT_MAX__, vl);
+    float init_val, scale_val;
+    if (alg == kernel_t::alg_t::max_pool) {
+        init_val = -FLT_MAX;
+        scale_val = 0.0f; /* unused for max pool */
+    } else if (alg == kernel_t::alg_t::avg_include) {
+        init_val = 0.0f;
+        scale_val = 1.0f / (float)(kerD * kerH * kerW);
+    } else { // avg_exclude
+        init_val = 0.0f;
+        const int count = std::max(0, id_end - id_start)
+                * std::max(0, ih_end - ih_start)
+                * std::max(0, iw_end - iw_start);
+        scale_val = (count > 0) ? 1.0f / (float)count : 0.0f;
+    }
 
-            for (int id = id_start; id < id_end; ++id) {
-                for (int ih = ih_start; ih < ih_end; ++ih) {
-                    for (int iw = iw_start; iw < iw_end; ++iw) {
-                        const size_t src_spatial_base
-                                = ((((size_t)mb * inD + id) * inH + ih) * inW
-                                          + iw)
-                                * channels;
-                        const float *src_ptr = &src[src_spatial_base + oc];
-                        vfloat32m1_t vsrc = __riscv_vle32_v_f32m1(src_ptr, vl);
-                        vmax = __riscv_vfmax_vv_f32m1(vmax, vsrc, vl);
-                    }
-                }
-            }
-
-            vmax = postops_handler.apply(vmax, vl);
-            __riscv_vse32_v_f32m1(&dst[dst_spatial_base + oc], vmax, vl);
-            oc += vl;
-        }
-    });
+    kernel_t::call_params_t p;
+    p.src = src_mb_base;
+    p.dst = &dst[dst_spatial_base];
+    p.channels = channels;
+    p.id_start = id_start;
+    p.ih_start = ih_start;
+    p.iw_start = iw_start;
+    p.id_end = id_end;
+    p.ih_end = ih_end;
+    p.iw_end = iw_end;
+    p.inW_stride = inW_stride;
+    p.inD_stride = inD_stride;
+    p.init_val = init_val;
+    p.scale_val = scale_val;
+    p.relu_alpha = relu_alpha;
+    p.with_relu = with_relu;
+    return p;
 }
 
-static void AvgPoolingIncludePadding_f32(const void *src_raw, void *dst_raw,
+template <kernel_t::alg_t alg>
+static void Pooling_f32_jit(const void *src_raw, void *dst_raw,
         const dim_t batch, const dim_t channels, const dim_t outD,
         const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
         const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
@@ -107,122 +104,28 @@ static void AvgPoolingIncludePadding_f32(const void *src_raw, void *dst_raw,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft,
         const rvv_postops_t &postops_handler) {
 
-    const float *src = static_cast<const float *>(src_raw);
-    float *dst = static_cast<float *>(dst_raw);
-    const float kernel_volume = (float)(kerD * kerH * kerW);
-
-    parallel_nd(batch, outD, outH, outW,
-            [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
-        const size_t dst_spatial_base
-                = ((((size_t)mb * outD + od) * outH + oh) * outW + ow)
-                * channels;
-
-        const int od_offset = (int)(od * strideD - padFront);
-        const int oh_offset = (int)(oh * strideH - padTop);
-        const int ow_offset = (int)(ow * strideW - padLeft);
-        const int id_start = std::max(od_offset, 0);
-        const int ih_start = std::max(oh_offset, 0);
-        const int iw_start = std::max(ow_offset, 0);
-        const int id_end = std::min(od_offset + (int)kerD, (int)inD);
-        const int ih_end = std::min(oh_offset + (int)kerH, (int)inH);
-        const int iw_end = std::min(ow_offset + (int)kerW, (int)inW);
-
-        size_t oc = 0;
-        while (oc < (size_t)channels) {
-            size_t vl = __riscv_vsetvl_e32m1((size_t)channels - oc);
-            vfloat32m1_t vsum = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-
-            if (id_start < id_end && ih_start < ih_end && iw_start < iw_end) {
-                for (int id = id_start; id < id_end; ++id) {
-                    for (int ih = ih_start; ih < ih_end; ++ih) {
-                        for (int iw = iw_start; iw < iw_end; ++iw) {
-                            const size_t src_spatial_base
-                                    = ((((size_t)mb * inD + id) * inH + ih)
-                                                      * inW
-                                              + iw)
-                                    * channels;
-                            const float *src_ptr = &src[src_spatial_base + oc];
-                            vfloat32m1_t vsrc
-                                    = __riscv_vle32_v_f32m1(src_ptr, vl);
-                            vsum = __riscv_vfadd_vv_f32m1(vsum, vsrc, vl);
-                        }
-                    }
-                }
-            }
-
-            // divide by kernel volume
-            vfloat32m1_t vscale
-                    = __riscv_vfmv_v_f_f32m1(1.0f / kernel_volume, vl);
-            vfloat32m1_t vout = __riscv_vfmul_vv_f32m1(vsum, vscale, vl);
-            vout = postops_handler.apply(vout, vl);
-            __riscv_vse32_v_f32m1(&dst[dst_spatial_base + oc], vout, vl);
-            oc += vl;
-        }
-    });
-}
-
-static void AvgPoolingExcludePadding_f32(const void *src_raw, void *dst_raw,
-        const dim_t batch, const dim_t channels, const dim_t outD,
-        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
-        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
-        const dim_t strideD, const dim_t strideH, const dim_t strideW,
-        const dim_t padFront, const dim_t padTop, const dim_t padLeft,
-        const rvv_postops_t &postops_handler) {
+    static const kernel_t kernel(alg);
 
     const float *src = static_cast<const float *>(src_raw);
     float *dst = static_cast<float *>(dst_raw);
 
+    const bool with_relu = postops_handler.is_relu_postop();
+    const float relu_alpha = postops_handler.relu_alpha();
+
+    const dim_t inW_stride = inW * channels;
+    const dim_t inD_stride = inH * inW * channels;
+
     parallel_nd(batch, outD, outH, outW,
             [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
-        const size_t dst_spatial_base
-                = ((((size_t)mb * outD + od) * outH + oh) * outW + ow)
-                * channels;
+        const size_t mb_offset = (size_t)mb * (size_t)inD * inD_stride;
+        const float *src_mb_base = &src[mb_offset];
 
-        const int od_offset = (int)(od * strideD - padFront);
-        const int oh_offset = (int)(oh * strideH - padTop);
-        const int ow_offset = (int)(ow * strideW - padLeft);
+        auto p = make_pooling_params(alg, src_mb_base, dst, mb, channels, od,
+                oh, ow, outD, outH, outW, inD, inH, inW, kerD, kerH, kerW,
+                strideD, strideH, strideW, padFront, padTop, padLeft,
+                inW_stride, inD_stride, with_relu, relu_alpha);
 
-        size_t oc = 0;
-        while (oc < (size_t)channels) {
-            size_t vl = __riscv_vsetvl_e32m1((size_t)channels - oc);
-            vfloat32m1_t vsum = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            float count_scalar = 0.0f;
-
-            for (int id = od_offset; id < od_offset + (int)kerD; ++id) {
-                if (id < 0 || id >= (int)inD) continue;
-                for (int ih = oh_offset; ih < oh_offset + (int)kerH; ++ih) {
-                    if (ih < 0 || ih >= (int)inH) continue;
-
-                    int iw_start = std::max(ow_offset, 0);
-                    int iw_end = std::min(ow_offset + (int)kerW, (int)inW);
-                    if (iw_start >= iw_end) continue;
-
-                    for (int iw = iw_start; iw < iw_end; ++iw) {
-                        const size_t src_spatial_base
-                                = ((((size_t)mb * inD + id) * inH + ih) * inW
-                                          + iw)
-                                * channels;
-                        const float *src_ptr = &src[src_spatial_base + oc];
-                        vfloat32m1_t vsrc = __riscv_vle32_v_f32m1(src_ptr, vl);
-                        vsum = __riscv_vfadd_vv_f32m1(vsum, vsrc, vl);
-                        count_scalar += 1.0f;
-                    }
-                }
-            }
-
-            if (count_scalar == 0.0f) {
-                vfloat32m1_t vzero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-                vzero = postops_handler.apply(vzero, vl);
-                __riscv_vse32_v_f32m1(&dst[dst_spatial_base + oc], vzero, vl);
-            } else {
-                vfloat32m1_t vscale
-                        = __riscv_vfmv_v_f_f32m1(1.0f / count_scalar, vl);
-                vfloat32m1_t vout = __riscv_vfmul_vv_f32m1(vsum, vscale, vl);
-                vout = postops_handler.apply(vout, vl);
-                __riscv_vse32_v_f32m1(&dst[dst_spatial_base + oc], vout, vl);
-            }
-            oc += vl;
-        }
+        kernel(&p);
     });
 }
 
@@ -233,7 +136,7 @@ static void MaxPooling_f16(const void *src_raw, void *dst_raw,
         const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
         const dim_t strideD, const dim_t strideH, const dim_t strideW,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft,
-        const rvv_postops_t &postops_handler) {
+        const rvv_postops_t &) {
 
     const dnnl::impl::float16_t *src
             = static_cast<const dnnl::impl::float16_t *>(src_raw);
@@ -264,7 +167,6 @@ static void MaxPooling_f16(const void *src_raw, void *dst_raw,
                 size_t vl = __riscv_vsetvl_e16m1((size_t)channels - oc);
                 vfloat16m1_t vfill
                         = __riscv_vfmv_v_f_f16m1((_Float16)f16_lowest, vl);
-                // vfill = postops_handler.apply(vfill, vl); // TODO: f16 postops
                 __riscv_vse16_v_f16m1(
                         (_Float16 *)&dst[dst_spatial_base + oc], vfill, vl);
                 oc += vl;
@@ -294,7 +196,6 @@ static void MaxPooling_f16(const void *src_raw, void *dst_raw,
                 }
             }
 
-            // vmax = postops_handler.apply(vmax, vl); // TODO: f16 postops
             __riscv_vse16_v_f16m1(
                     (_Float16 *)&dst[dst_spatial_base + oc], vmax, vl);
             oc += vl;
@@ -308,7 +209,7 @@ static void AvgPoolingIncludePadding_f16(const void *src_raw, void *dst_raw,
         const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
         const dim_t strideD, const dim_t strideH, const dim_t strideW,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft,
-        const rvv_postops_t &postops_handler) {
+        const rvv_postops_t &) {
 
     const dnnl::impl::float16_t *src
             = static_cast<const dnnl::impl::float16_t *>(src_raw);
@@ -363,8 +264,6 @@ static void AvgPoolingIncludePadding_f16(const void *src_raw, void *dst_raw,
             vfloat32m2_t vout_f32
                     = __riscv_vfmul_vv_f32m2(vsum_f32, vscale_f32, vl);
 
-            // vout_f32 = postops_handler.apply(vout_f32, vl); // TODO: f16 postops
-
             vfloat16m1_t vout_f16 = __riscv_vfncvt_f_f_w_f16m1(vout_f32, vl);
 
             __riscv_vse16_v_f16m1(
@@ -380,7 +279,7 @@ static void AvgPoolingExcludePadding_f16(const void *src_raw, void *dst_raw,
         const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
         const dim_t strideD, const dim_t strideH, const dim_t strideW,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft,
-        const rvv_postops_t &postops_handler) {
+        const rvv_postops_t &) {
 
     const dnnl::impl::float16_t *src
             = static_cast<const dnnl::impl::float16_t *>(src_raw);
@@ -431,7 +330,6 @@ static void AvgPoolingExcludePadding_f16(const void *src_raw, void *dst_raw,
 
             if (count_scalar == 0.0f) {
                 vfloat32m2_t vzero_f32 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-                // vzero_f32 = postops_handler.apply(vzero_f32, vl); // TODO: f16 postops
                 vfloat16m1_t vout_f16
                         = __riscv_vfncvt_f_f_w_f16m1(vzero_f32, vl);
                 __riscv_vse16_v_f16m1(
@@ -441,8 +339,6 @@ static void AvgPoolingExcludePadding_f16(const void *src_raw, void *dst_raw,
                         = __riscv_vfmv_v_f_f32m2(1.0f / count_scalar, vl);
                 vfloat32m2_t vout_f32
                         = __riscv_vfmul_vv_f32m2(vsum_f32, vscale_f32, vl);
-
-                // vout_f32 = postops_handler.apply(vout_f32, vl); // TODO: f16 postops
 
                 vfloat16m1_t vout_f16
                         = __riscv_vfncvt_f_f_w_f16m1(vout_f32, vl);
@@ -502,22 +398,26 @@ status_t riscv_nhwc_pooling_fwd_t::execute_forward(
             = alg == alg_kind::pooling_avg_exclude_padding;
 
     if (dt == data_type::f32) {
+        using kalg = kernel_t::alg_t;
         if (is_max_pool) {
-            MaxPooling_f32(src_raw, dst_raw, MB, C, OD, OH, OW, ID, IH, IW, KD,
-                    KH, KW, SD, SH, SW, padF, padT, padL, postops_handler);
-        } else if (is_avg_pool_exclude) {
-            AvgPoolingExcludePadding_f32(src_raw, dst_raw, MB, C, OD, OH, OW,
+            Pooling_f32_jit<kalg::max_pool>(src_raw, dst_raw, MB, C, OD, OH, OW,
                     ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
                     postops_handler);
+        } else if (is_avg_pool_exclude) {
+            Pooling_f32_jit<kalg::avg_exclude>(src_raw, dst_raw, MB, C, OD, OH,
+                    OW, ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
+                    postops_handler);
         } else if (is_avg_pool_include) {
-            AvgPoolingIncludePadding_f32(src_raw, dst_raw, MB, C, OD, OH, OW,
-                    ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
+            Pooling_f32_jit<kalg::avg_include>(src_raw, dst_raw, MB, C, OD, OH,
+                    OW, ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
                     postops_handler);
         } else {
             return status::unimplemented;
         }
     }
 #if defined(DNNL_RISCV_USE_ZVFH_INTRINSICS)
+    // TODO: f16 post-ops not yet supported — postops_handler is accepted but
+    // ignored by the f16 intrinsics path (enforced by post_ops_ok check in pd).
     else if (dt == data_type::f16) {
         if (is_max_pool) {
             MaxPooling_f16(src_raw, dst_raw, MB, C, OD, OH, OW, ID, IH, IW, KD,

--- a/src/cpu/rv64/rvv_postops.hpp
+++ b/src/cpu/rv64/rvv_postops.hpp
@@ -153,6 +153,12 @@ struct rvv_postops_t {
     status_t execute(
             const exec_ctx_t &ctx, void *src, void *dst = nullptr) const;
 
+    // Only valid when constructed from post_ops_t (narrow constructor).
+    // Callers enforce via post_ops_ok() that only ReLU is accepted,
+    // so these always return well-defined values in supported paths.
+    bool is_relu_postop() const { return alg_ == alg_kind::eltwise_relu; }
+    float relu_alpha() const { return alpha_; }
+
 private:
     alg_kind_t alg_ = alg_kind::undef;
     float alpha_ = 0.f;


### PR DESCRIPTION
# Summary

Replace RVV intrinsics-based f32 pooling kernels with JIT-generated code using
Xbyak_riscv, following the established pattern of `jit_rvv_eltwise_kernel`,
`jit_rvv_batch_normalization_kernel`, etc. The f16 path remains unchanged
(guarded by `DNNL_RISCV_USE_ZVFH_INTRINSICS`).

# Motivation

- **Instruction scheduling**: RVV intrinsics prevent the compiler from
  reordering/scheduling vector instructions optimally. JIT gives full control.
- **Consistency**: Aligns pooling with other rv64 primitives that already use
  JIT (eltwise, batch norm, layer norm, layernorm).
- **Foundation for further optimization**: Enables LMUL tuning and spatial
  batching (Phases 2 & 3 from the optimization roadmap).

# Changes

## New files
- `src/cpu/rv64/jit_rvv_pooling_kernel.hpp` — JIT kernel declaration
- `src/cpu/rv64/jit_rvv_pooling_kernel.cpp` — JIT kernel implementation

## Modified files
- `src/cpu/rv64/rvv_nhwc_pooling.cpp` — Call JIT kernel instead of intrinsics
  for f32; keep f16 intrinsics path under `DNNL_RISCV_USE_ZVFH_INTRINSICS`
- `src/cpu/rv64/rvv_postops.hpp` — Add `has_relu()` and `relu_alpha()` accessors

# Design

A single `jit_rvv_pooling_fwd_kernel_t` struct handles all three pooling
algorithms (`max`, `avg_include`, `avg_exclude`) via a template parameter.
The JIT kernel is instantiated once per algorithm (3 static kernels total).

**Kernel structure:**
```
channel_loop:
  vsetvli(vl, remaining_channels, e32, m1)
  init accumulator (-FLT_MAX for max, 0 for avg)
  for id in [id_start, id_end):
    for ih in [ih_start, ih_end):
      for iw in [iw_start, iw_end):
        vle32.v  v_src, (src_ptr)
        vfmax.vv / vfadd.vv  v_acc, v_acc, v_src
  vfmul.vf  v_acc, v_acc, inv_count  // avg only
  apply ReLU if needed
  vse32.v  v_acc, (dst)
  advance src/dst by vl*4, decrement remaining
```

**`avg_exclude_padding`** requires per-position count of valid elements
(dependent on padding), which is computed in C++ before calling the JIT kernel.
The clamped spatial ranges and `1/count` are passed as parameters.

# Test Plan

- [x] Correctness: `benchdnn --pool --dir=FWD_I --tag=axb --batch=shapes_alexnet
      --batch=shapes_resnet_50 --batch=shapes_googlenet_v1 --batch=shapes_googlenet_v3`
      — all 27 cases PASSED
- [x] Performance: 1-core and 8-core benchmarks on SG2044

# Performance Results

## 1-Core (taskset -c 32, SG2044, VLEN=128)

| Test Case | Baseline (ms) | JIT (ms) | Change |
|-----------|-------------|---------|--------|
| alexnet:max_pool1 | 430.8 | 304.3 | **+29.4%** |
| alexnet:max_pool2 | 274.5 | 205.1 | **+25.2%** |
| alexnet:max_pool5 | 45.8 | 42.9 | +6.2% |
| resnet_50:max_pool1 | 267.6 | 180.2 | **+32.7%** |
| resnet_50:ave_pool5 | 40.5 | 39.6 | +2.1% |
| googlenet_v1:max_pool1/3x3_s2 | 542.6 | 359.5 | **+33.7%** |
| googlenet_v1:max_pool2/3x3_s2 | 396.9 | 268.9 | **+32.2%** |
| googlenet_v1:inception_3a/max_pool | 304.6 | 102.0 | **+66.5%** |
| googlenet_v1:inception_3b/max_pool | 421.9 | 191.1 | **+54.7%** |
| googlenet_v1:max_pool3/3x3_s2 | 257.4 | 177.1 | **+31.2%** |
| googlenet_v1:inception_4a/max_pool | 176.3 | 84.1 | **+52.3%** |
| googlenet_v1:inception_4b/max_pool*3 | 184.4 | 83.6 | **+54.7%** |
| googlenet_v1:inception_4e/max_pool | 169.8 | 75.8 | **+55.4%** |
| googlenet_v1:max_pool4/3x3_s2 | 113.7 | 77.3 | **+32.0%** |
| googlenet_v1:inception_5a/max_pool*2 | 67.8 | 38.0 | **+44.0%** |
| googlenet_v1:avg_pool5/7x7_s1 | 28.0 | 21.6 | **+22.9%** |
| googlenet_v3:max_pool | 791.8 | 602.3 | **+23.9%** |
| googlenet_v3:max_pool1 | 676.4 | 422.2 | **+37.6%** |
| googlenet_v3:ave_pool_mixed_pool | 485.9 | 155.8 | **+67.9%** |
| googlenet_v3:ave_pool_mixed_1_pool | 688.8 | 440.7 | **+36.0%** |
| googlenet_v3:ave_pool_mixed_2_pool | 765.3 | 476.0 | **+37.8%** |
| googlenet_v3:max_pool_mixed_3_pool | 216.3 | 154.6 | **+28.5%** |
| googlenet_v3:ave_pool_mixed_4_pool*4 | 434.1 | 309.4 | **+28.7%** |
| googlenet_v3:max_pool_mixed_8_pool | 163.3 | 134.4 | **+17.7%** |
| googlenet_v3:ave_pool_mixed_9_pool | 154.9 | 114.8 | **+25.9%** |
| googlenet_v3:max_pool_mixed_10_pool | 362.9 | 264.2 | **+27.2%** |
| googlenet_v3:ave_global_pool | 101.5 | 94.3 | +7.1% |
| **Total** | **8,816.6** | **5,611.9** | **+36.3%** |

## 8-Core (taskset -c 0-7, SG2044)

| Test Case | Baseline (ms) | JIT (ms) | Change |
|-----------|-------------|---------|--------|
| alexnet:max_pool1 | 64.8 | 57.3 | +11.5% |
| alexnet:max_pool2 | 37.9 | 29.5 | **+22.1%** |
| alexnet:max_pool5 | 6.8 | 6.3 | +7.3% |
| resnet_50:max_pool1 | 38.5 | 26.8 | **+30.3%** |
| resnet_50:ave_pool5 | 19.3 | 19.4 | -0.5% |
| googlenet_v1:max_pool1/3x3_s2 | 78.4 | 52.9 | **+32.6%** |
| googlenet_v1:max_pool2/3x3_s2 | 57.5 | 40.2 | **+30.1%** |
| googlenet_v1:inception_3a/max_pool | 39.4 | 14.8 | **+62.5%** |
| googlenet_v1:inception_3b/max_pool | 51.6 | 28.5 | **+44.8%** |
| googlenet_v1:max_pool3/3x3_s2 | 34.7 | 24.4 | **+29.6%** |
| googlenet_v1:inception_4a/max_pool | 23.2 | 10.8 | **+53.5%** |
| googlenet_v1:inception_4b/max_pool*3 | 23.6 | 11.6 | **+50.7%** |
| googlenet_v1:inception_4e/max_pool | 20.8 | 10.0 | **+51.7%** |
| googlenet_v1:max_pool4/3x3_s2 | 15.1 | 10.4 | **+31.3%** |
| googlenet_v1:inception_5a/max_pool*2 | 9.0 | 4.8 | **+46.6%** |
| googlenet_v1:avg_pool5/7x7_s1 | 9.7 | 10.0 | -2.8% |
| googlenet_v3:max_pool | 126.6 | 91.2 | **+28.0%** |
| googlenet_v3:max_pool1 | 91.1 | 63.1 | **+30.7%** |
| googlenet_v3:ave_pool_mixed_pool | 62.1 | 23.7 | **+61.8%** |
| googlenet_v3:ave_pool_mixed_1_pool | 89.1 | 63.8 | **+28.4%** |
| googlenet_v3:ave_pool_mixed_2_pool | 97.8 | 69.4 | **+29.1%** |
| googlenet_v3:max_pool_mixed_3_pool | 30.3 | 22.4 | **+26.1%** |
| googlenet_v3:ave_pool_mixed_4_pool*4 | 56.6 | 41.6 | **+26.5%** |
| googlenet_v3:max_pool_mixed_8_pool | 21.3 | 18.7 | +12.4% |
| googlenet_v3:ave_pool_mixed_9_pool | 19.5 | 15.8 | **+19.0%** |
| googlenet_v3:max_pool_mixed_10_pool | 65.9 | 48.7 | **+26.2%** |
| googlenet_v3:ave_global_pool | 62.0 | 69.6 | -12.3% |
| **Total** | **1,263.7** | **942.5** | **+25.4%** |
