### PR TITLE
[rls-v3.12] graph: backend: dnnl: passes: fused_sdpa supports reorder

### DIFF
--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -4637,6 +4637,10 @@ status_t fuse_sdpa(std::shared_ptr<subgraph_t> &sg) {
                     has_dropout = true;
                     break;
                 }
+                case op_kind::_reorder: {
+                    // allow reorder for typecast in xf16-f32 mixed pattern.
+                    break;
+                }
                 default: valid_pattern = false;
             }
 


### PR DESCRIPTION
- Backports #5143 