### PR TITLE
examples: switch activations from nchw to nhwc

### DIFF
--- a/examples/cnn_inference_f32.c
+++ b/examples/cnn_inference_f32.c
@@ -80,11 +80,11 @@ static void init_net_data(float *data, uint32_t dim, const dnnl_dim_t *dims) {
         }
     } else if (dim == 4) {
         for (dnnl_dim_t in = 0; in < dims[0]; ++in)
-            for (dnnl_dim_t ic = 0; ic < dims[1]; ++ic)
-                for (dnnl_dim_t ih = 0; ih < dims[2]; ++ih)
-                    for (dnnl_dim_t iw = 0; iw < dims[3]; ++iw) {
-                        dnnl_dim_t indx = in * dims[1] * dims[2] * dims[3]
-                                + ic * dims[2] * dims[3] + ih * dims[3] + iw;
+            for (dnnl_dim_t ih = 0; ih < dims[2]; ++ih)
+                for (dnnl_dim_t iw = 0; iw < dims[3]; ++iw)
+                    for (dnnl_dim_t ic = 0; ic < dims[1]; ++ic) {
+                        dnnl_dim_t indx = in * dims[2] * dims[3] * dims[1]
+                                + ih * dims[3] * dims[1] + iw * dims[1] + ic;
                         data[indx] = (float)(indx % 1637);
                     }
     }
@@ -212,7 +212,7 @@ void simple_net(dnnl_engine_kind_t engine_kind) {
     // create memory for user data
     dnnl_memory_t conv_user_src_memory, conv_user_weights_memory,
             conv_user_bias_memory;
-    init_data_memory(ndims, conv_user_src_sizes, dnnl_nchw, engine, conv_src,
+    init_data_memory(ndims, conv_user_src_sizes, dnnl_nhwc, engine, conv_src,
             &conv_user_src_memory);
     init_data_memory(ndims, conv_user_weights_sizes, dnnl_oihw, engine,
             conv_weights, &conv_user_weights_memory);
@@ -375,7 +375,7 @@ void simple_net(dnnl_engine_kind_t engine_kind) {
 
     // create memory for user data
     dnnl_memory_t pool_user_dst_memory;
-    init_data_memory(ndims, pool_dst_sizes, dnnl_nchw, engine, net_dst,
+    init_data_memory(ndims, pool_dst_sizes, dnnl_nhwc, engine, net_dst,
             &pool_user_dst_memory);
 
     // create a pooling

--- a/examples/cnn_inference_f32.cpp
+++ b/examples/cnn_inference_f32.cpp
@@ -91,12 +91,12 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     //[Allocate buffers]
 
     /// Create memory that describes data layout in the buffers. This example
-    /// uses dnnl::memory::format_tag::nchw (batch-channels-height-width)
+    /// uses dnnl::memory::format_tag::nhwc (batch-height-width-channels)
     /// for input data and dnnl::memory::format_tag::oihw for weights.
     /// @snippet cnn_inference_f32.cpp Create user memory
     //[Create user memory]
     auto user_src_memory = memory(
-            {{conv1_src_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{conv1_src_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(user_src.data(), user_src_memory);
     auto user_weights_memory
@@ -114,7 +114,7 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     /// The `any` format enables the convolution primitive to choose the data
     /// format that will result in best performance based on its input
     /// parameters (convolution kernel sizes, strides, padding, and so on).
-    /// If the resulting format is different from `nchw`, the user data must be
+    /// If the resulting format is different from `nhwc`, the user data must be
     /// transformed to the format required for the convolution (as explained
     /// below).
     /// @snippet cnn_inference_f32.cpp Create convolution memory descriptors

--- a/examples/cnn_inference_int8.cpp
+++ b/examples/cnn_inference_int8.cpp
@@ -89,7 +89,7 @@ void simple_net_int8(engine::kind engine_kind) {
     /// @snippet cnn_inference_int8.cpp Allocate buffers
     //[Allocate buffers]
     auto user_src_memory = memory(
-            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(user_src.data(), user_src_memory);
     auto user_weights_memory
@@ -264,7 +264,7 @@ void simple_net_int8(engine::kind engine_kind) {
     /// @snippet cnn_inference_int8.cpp Dequantize the result
     ///[Dequantize the result]
     auto user_dst_memory = memory(
-            {{conv_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{conv_dst_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(user_dst.data(), user_dst_memory);
     primitive_attr dst_attr;

--- a/examples/cnn_training_bf16.cpp
+++ b/examples/cnn_training_bf16.cpp
@@ -77,7 +77,7 @@ void simple_net(engine::kind engine_kind) {
 
     // create memory for user data
     auto conv_user_src_memory = memory(
-            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(net_src.data(), conv_user_src_memory);
 
@@ -232,7 +232,7 @@ void simple_net(engine::kind engine_kind) {
 
     // create memory for pool dst data in user format
     auto pool_user_dst_memory = memory(
-            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
 
     // create pool dst memory descriptor in format any for bfloat16 data type
@@ -278,7 +278,7 @@ void simple_net(engine::kind engine_kind) {
 
     // create memory for user diff dst data stored in float data type
     auto pool_user_diff_dst_memory = memory(
-            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(net_diff_dst.data(), pool_user_diff_dst_memory);
 

--- a/examples/cnn_training_bf16.cpp
+++ b/examples/cnn_training_bf16.cpp
@@ -382,7 +382,7 @@ void simple_net(engine::kind engine_kind) {
 
     auto conv_user_diff_weights_memory
             = memory({{conv_weights_tz}, memory::data_type::f32,
-                             memory::format_tag::nchw},
+                             memory::format_tag::oihw},
                     eng);
     auto conv_diff_bias_memory = memory(
             {{conv_bias_tz}, memory::data_type::f32, memory::format_tag::x},

--- a/examples/cnn_training_f32.cpp
+++ b/examples/cnn_training_f32.cpp
@@ -349,7 +349,7 @@ void simple_net(engine::kind engine_kind) {
 
     auto conv_user_diff_weights_memory
             = memory({{conv_weights_tz}, memory::data_type::f32,
-                             memory::format_tag::nchw},
+                             memory::format_tag::oihw},
                     eng);
     write_to_dnnl_memory(conv_user_diff_weights_buffer.data(),
             conv_user_diff_weights_memory);

--- a/examples/cnn_training_f32.cpp
+++ b/examples/cnn_training_f32.cpp
@@ -74,7 +74,7 @@ void simple_net(engine::kind engine_kind) {
 
     // create memory for user data
     auto conv_user_src_memory = memory(
-            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(net_src.data(), conv_user_src_memory);
     auto conv_user_weights_memory
@@ -197,7 +197,7 @@ void simple_net(engine::kind engine_kind) {
 
     // create memory for pool dst data in user format
     auto pool_user_dst_memory = memory(
-            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(net_dst.data(), pool_user_dst_memory);
 
@@ -243,7 +243,7 @@ void simple_net(engine::kind engine_kind) {
 
     // create memory for user diff dst data
     auto pool_user_diff_dst_memory = memory(
-            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     write_to_dnnl_memory(net_diff_dst.data(), pool_user_diff_dst_memory);
 

--- a/examples/cpu_cnn_training_f32.c
+++ b/examples/cpu_cnn_training_f32.c
@@ -65,11 +65,11 @@ static void init_net_data(float *data, uint32_t dim, const dnnl_dim_t *dims) {
         }
     } else if (dim == 4) {
         for (dnnl_dim_t in = 0; in < dims[0]; ++in)
-            for (dnnl_dim_t ic = 0; ic < dims[1]; ++ic)
-                for (dnnl_dim_t ih = 0; ih < dims[2]; ++ih)
-                    for (dnnl_dim_t iw = 0; iw < dims[3]; ++iw) {
-                        dnnl_dim_t indx = in * dims[1] * dims[2] * dims[3]
-                                + ic * dims[2] * dims[3] + ih * dims[3] + iw;
+            for (dnnl_dim_t ih = 0; ih < dims[2]; ++ih)
+                for (dnnl_dim_t iw = 0; iw < dims[3]; ++iw)
+                    for (dnnl_dim_t ic = 0; ic < dims[1]; ++ic) {
+                        dnnl_dim_t indx = in * dims[2] * dims[3] * dims[1]
+                                + ih * dims[3] * dims[1] + iw * dims[1] + ic;
                         data[indx] = (float)(indx % 1637);
                     }
     }
@@ -199,7 +199,7 @@ void simple_net() {
     // create memory for user data
     dnnl_memory_t conv_user_src_memory, conv_user_weights_memory,
             conv_user_bias_memory;
-    init_data_memory(ndims, conv_user_src_sizes, dnnl_nchw, engine, conv_src,
+    init_data_memory(ndims, conv_user_src_sizes, dnnl_nhwc, engine, conv_src,
             &conv_user_src_memory);
     init_data_memory(ndims, conv_user_weights_sizes, dnnl_oihw, engine,
             conv_weights, &conv_user_weights_memory);
@@ -369,7 +369,7 @@ void simple_net() {
 
     // create memory for user dst data
     dnnl_memory_t pool_user_dst_memory;
-    init_data_memory(4, pool_dst_sizes, dnnl_nchw, engine, net_dst,
+    init_data_memory(4, pool_dst_sizes, dnnl_nhwc, engine, net_dst,
             &pool_user_dst_memory);
 
     // create a pooling primitive descriptor
@@ -440,7 +440,7 @@ void simple_net() {
 
     // create memory for user diff dst data
     dnnl_memory_t pool_user_diff_dst_memory;
-    init_data_memory(4, pool_dst_sizes, dnnl_nchw, engine, net_diff_dst,
+    init_data_memory(4, pool_dst_sizes, dnnl_nhwc, engine, net_diff_dst,
             &pool_user_diff_dst_memory);
 
     // Pooling Backward

--- a/examples/cross_engine_reorder.c
+++ b/examples/cross_engine_reorder.c
@@ -78,9 +78,9 @@ void cross_engine_reorder() {
 
     dnnl_memory_desc_t m_cpu_md, m_gpu_md;
     CHECK(dnnl_memory_desc_create_with_tag(
-            &m_cpu_md, 4, tz, dnnl_f32, dnnl_nchw));
+            &m_cpu_md, 4, tz, dnnl_f32, dnnl_nhwc));
     CHECK(dnnl_memory_desc_create_with_tag(
-            &m_gpu_md, 4, tz, dnnl_f32, dnnl_nchw));
+            &m_gpu_md, 4, tz, dnnl_f32, dnnl_nhwc));
 
     dnnl_memory_t m_cpu, m_gpu;
     CHECK(dnnl_memory_create(

--- a/examples/cross_engine_reorder.cpp
+++ b/examples/cross_engine_reorder.cpp
@@ -116,10 +116,10 @@ void cross_engine_reorder_tutorial() {
     //  [reorder cpu2gpu]
     const auto tz = memory::dims {2, 16, 1, 1};
     auto m_cpu
-            = memory({{tz}, memory::data_type::f32, memory::format_tag::nchw},
+            = memory({{tz}, memory::data_type::f32, memory::format_tag::nhwc},
                     cpu_engine);
     auto m_gpu
-            = memory({{tz}, memory::data_type::f32, memory::format_tag::nchw},
+            = memory({{tz}, memory::data_type::f32, memory::format_tag::nhwc},
                     gpu_engine);
     fill(m_cpu, tz);
     auto r1 = reorder(m_cpu, m_gpu);

--- a/examples/gpu_opencl_interop.cpp
+++ b/examples/gpu_opencl_interop.cpp
@@ -141,7 +141,7 @@ void gpu_opencl_interop_tutorial() {
     /// Next, we create a memory object. We need to specify dimensions of our
     /// memory by passing a memory::dims object. Then we create a memory
     /// descriptor with these dimensions, with the dnnl::memory::data_type::f32
-    /// data type, and with the dnnl::memory::format_tag::nchw memory format.
+    /// data type, and with the dnnl::memory::format_tag::nhwc memory format.
     /// Finally, we construct a memory object and pass the memory descriptor.
     /// The library allocates memory internally.
     /// @snippet  gpu_opencl_interop.cpp memory alloc
@@ -151,7 +151,7 @@ void gpu_opencl_interop_tutorial() {
             std::multiplies<size_t>());
 
     memory::desc mem_d(
-            tz_dims, memory::data_type::f32, memory::format_tag::nchw);
+            tz_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     memory mem(mem_d, eng);
     //  [memory alloc]

--- a/examples/memory_format_propagation.cpp
+++ b/examples/memory_format_propagation.cpp
@@ -84,7 +84,7 @@
 /// a pooling and consists of the following steps:
 /// 1. Create a pooling primitive descriptor based on the memory format chosen
 ///    by the convolution primitive.
-/// 2. Create memory descriptors for input and output data in the NCHW memory
+/// 2. Create memory descriptors for input and output data in the NHWC memory
 ///    format.
 /// 3. Determine if input and output data needs to be reordered from/to the
 ///    optimized memory format.
@@ -176,20 +176,20 @@ void memory_format_propagation_tutorial(engine::kind engine_kind) {
     /// @subsection memory_format_propagation_sub3 Create source and destination memory objects
     ///
     /// We assume that the 'user' source and destination memory format is
-    /// NCHW. Since there is no result validation in this tutorial, we do not
+    /// NHWC. Since there is no result validation in this tutorial, we do not
     /// bother with filling the data with some values and let oneDNN
     /// allocate the memory.
     ///
     /// @snippet memory_format_propagation.cpp Create source and destination memory objects
     // [Create source and destination memory objects]
     auto src_mem = memory(
-            {{N, IC, H, W}, memory::data_type::f32, memory::format_tag::nchw},
+            {{N, IC, H, W}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     auto weights_mem = memory({{OC, IC, KH, KW}, memory::data_type::f32,
                                       memory::format_tag::oihw},
             eng);
     auto dst_mem = memory(
-            {{N, OC, H, W}, memory::data_type::f32, memory::format_tag::nchw},
+            {{N, OC, H, W}, memory::data_type::f32, memory::format_tag::nhwc},
             eng);
     // [Create source and destination memory objects]
 
@@ -335,34 +335,37 @@ int main(int argc, char **argv) {
 ///
 /// ~~~sh
 /// $ ONEDNN_VERBOSE=1 ./memory-format-propagation-cpp
-/// onednn_verbose,v0,info,oneDNN <ver> (Git Hash <hash>)
-/// onednn_verbose,v0,info,cpu,runtime:OpenMP
-/// onednn_verbose,v0,info,cpu,isa:Intel AVX2
-/// onednn_verbose,v0,info,gpu,runtime:none
-/// onednn_verbose,v0,exec,cpu,reorder,jit:uni,undef,
-///     src_f32::blocked:abcd:f0 dst_f32::blocked:aBcd8b:f0,,,1x128x14x14,0.326904
-/// onednn_verbose,v0,exec,cpu,reorder,jit:uni,undef,
-///     src_f32::blocked:abcd:f0 dst_f32::blocked:ABcd8b8a:f0,,,256x128x3x3,0.244141
-/// onednn_verbose,v0,exec,cpu,convolution,jit:avx2,forward_inference,
-///     src_f32::blocked:aBcd8b:f0 wei_f32::blocked:ABcd8b8a:f0 bia_undef::undef::f0 dst_f32::blocked:aBcd8b:f0,,
-///     alg:convolution_direct,mb1_ic128oc256_ih14oh14kh3sh1dh0ph1_iw14ow14kw3sw1dw0pw1,1.20312
-/// onednn_verbose,v0,exec,cpu,pooling,jit:avx,forward_inference,
-///     src_f32::blocked:aBcd8b:f0 dst_f32::blocked:aBcd8b:f0 ws_undef::undef::f0,,
-///     alg:pooling_max,mb1ic256_ih14oh14kh3sh1ph1_iw14ow14kw3sw1pw1,0.187012
-/// onednn_verbose,v0,exec,cpu,reorder,jit:uni,undef,
-///     src_f32::blocked:aBcd8b:f0 dst_f32::blocked:abcd:f0,,,1x256x14x14,0.0419922
+/// onednn_verbose,v1,info,oneDNN <ver> (Git Hash <hash>)
+/// onednn_verbose,v1,info,cpu,runtime:OpenMP
+/// onednn_verbose,v1,info,cpu,isa:Intel AVX2
+/// onednn_verbose,v1,info,gpu,runtime:none
+/// onednn_verbose,v1,info,graph,backend,0:dnnl_backend
+/// onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
+/// onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
+/// onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,
+///     src:f32::blocked:abcd::f0 dst:f32::blocked:Acdb16a::f0,,,256x128x3x3,1.54907
+/// onednn_verbose,v1,primitive,exec,cpu,convolution,
+///     brg_conv_fwd:avx2,forward_inference,
+///     src:f32:a:blocked:acdb::f0 wei:f32:a:blocked:Acdb16a::f0 bia:undef::undef::: dst:f32:a:blocked:acdb::f0,,
+///     alg:convolution_direct,mb1_ic128oc256_ih14oh14kh3sh1dh0ph1_iw14ow14kw3sw1dw0pw1,1.35791
+/// onednn_verbose,v1,primitive,exec,cpu,pooling,jit:avx2,forward_inference,
+///     src:f32::blocked:acdb::f0 dst:f32:a:blocked:acdb::f0,,
+///     alg:pooling_max,mb1ic256_ih14oh14kh3sh1dh0ph1_iw14ow14kw3sw1dw0pw1,1.34204
 /// Example passed on CPU.
 /// ~~~
 ///
 /// From this output we can deduce that:
-/// * The convolution primitive picked up @ref
-///   dnnl::memory::format_tag::aBcd8b optimized memory format for
-///   activations. In this format the channels dimension (denoted by letter B
-///   since it is the second dimension; see also @ref dev_guide_conventions)
-///   is blocked by a factor of 8. Because of this memory format is different
-///   from the NCHW format the tutorial uses, the source and destination had
-///   to be reordered to and from this optimized memory layout.
-/// * The convolution primitive picked up @ref
-///   dnnl::memory::format_tag::ABcd8b8a optimized memory format (output (A)
-///   and input (B) channel dimensions blocked by 8) which we also had to
-///   reorder the initial weights to since they are in the OIHW memory format.
+/// * The convolution primitive picked up @ref dnnl::memory::format_tag::acdb
+///   (NHWC-like) memory format for activations. The input and output tensors
+///   are both in acdb format, which means that no reorders are needed for
+///   activations between convolution and subsequent operations. This
+///   demonstrates memory format propagation across convolution and subsequent
+///   operations.
+/// * The convolution primitive picked up @ref dnnl::memory::format_tag::Acdb16a
+///   optimized memory format for weights (channel dimension blocked by 16).
+///   Since the original weights are provided in the abcd (OIHW) format, they
+///   must be reordered once before execution.
+/// * The pooling primitive also operates on @ref dnnl::memory::format_tag::acdb
+///   layout for both source and destination tensors, reusing the same
+///   memory format selected by convolution. This confirms that the chosen
+///   layout is propagated through the pipeline without additional conversions.

--- a/examples/primitives/batch_normalization.cpp
+++ b/examples/primitives/batch_normalization.cpp
@@ -88,9 +88,9 @@ void batch_normalization_example(dnnl::engine::kind engine_kind) {
 
     // Create src and scale/shift memory descriptors and memory objects.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto scaleshift_md = memory::desc(
             scaleshift_dims, memory::data_type::f32, memory::format_tag::x);
 

--- a/examples/primitives/binary.cpp
+++ b/examples/primitives/binary.cpp
@@ -75,11 +75,11 @@ void binary_example(dnnl::engine::kind engine_kind) {
 
     // Create src and dst memory descriptors.
     auto src_0_md = memory::desc(
-            src_0_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_0_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto src_1_md = memory::desc(
-            src_1_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_1_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
-            src_0_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_0_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     // Create src memory objects.
     auto src_0_mem = memory(src_0_md, engine);

--- a/examples/primitives/concat.cpp
+++ b/examples/primitives/concat.cpp
@@ -82,7 +82,7 @@ void concat_example(dnnl::engine::kind engine_kind) {
 
     for (int n = 0; n < num_src; ++n) {
         src_mds.emplace_back(
-                src_dims, memory::data_type::f32, memory::format_tag::nchw);
+                src_dims, memory::data_type::f32, memory::format_tag::nhwc);
         src_mems.emplace_back(src_mds.back(), engine);
 
         // Write data to memory object's handle.

--- a/examples/primitives/convolution.cpp
+++ b/examples/primitives/convolution.cpp
@@ -101,15 +101,15 @@ void convolution_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory objects for tensor data (src, weights, dst). In this
-    // example, NCHW layout is assumed for src and dst, and OIHW for weights.
+    // example, NHWC layout is assumed for src and dst, and OIHW for weights.
     auto user_src_mem = memory(
-            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {src_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
     auto user_weights_mem = memory(
             {weights_dims, memory::data_type::f32, memory::format_tag::oihw},
             engine);
     auto user_dst_mem = memory(
-            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {dst_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
 
     // Create memory descriptors with format_tag::any for the primitive. This
@@ -263,15 +263,15 @@ void depthwise_convolution_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory objects for tensor data (src, weights, dst). In this
-    // example, NCHW layout is assumed for src and dst, and OIHW for weights.
+    // example, NHWC layout is assumed for src and dst, and OIHW for weights.
     auto user_src_mem = memory(
-            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {src_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
     auto user_weights_mem = memory(
             {weights_dims, memory::data_type::f32, memory::format_tag::goihw},
             engine);
     auto user_dst_mem = memory(
-            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {dst_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
 
     // Create memory descriptors with format_tag::any for the primitive. This

--- a/examples/primitives/deconvolution.cpp
+++ b/examples/primitives/deconvolution.cpp
@@ -106,15 +106,15 @@ void deconvolution_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory objects for tensor data (src, weights, dst). In this
-    // example, NCHW layout is assumed for src and dst, and OIHW for weights.
+    // example, NHWC layout is assumed for src and dst, and OIHW for weights.
     auto user_src_mem = memory(
-            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {src_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
     auto user_weights_mem = memory(
             {weights_dims, memory::data_type::f32, memory::format_tag::oihw},
             engine);
     auto user_dst_mem = memory(
-            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {dst_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
 
     // Create memory descriptors with format_tag::any for the primitive. This

--- a/examples/primitives/eltwise.cpp
+++ b/examples/primitives/eltwise.cpp
@@ -70,9 +70,9 @@ void eltwise_example(dnnl::engine::kind engine_kind) {
 
     // Create src and dst memory descriptors and memory objects.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
-            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
+            dst_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);

--- a/examples/primitives/inner_product.cpp
+++ b/examples/primitives/inner_product.cpp
@@ -84,9 +84,9 @@ void inner_product_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src and dst. In this
-    // example, NCHW layout is assumed.
+    // example, NHWC layout is assumed.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto bias_md = memory::desc(
             bias_dims, memory::data_type::f32, memory::format_tag::a);
     auto dst_md = memory::desc(

--- a/examples/primitives/lrn.cpp
+++ b/examples/primitives/lrn.cpp
@@ -66,9 +66,9 @@ void lrn_example(dnnl::engine::kind engine_kind) {
 
     // Create src and dst memory descriptors and memory objects.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(src_md, engine);
 

--- a/examples/primitives/lrn.cpp
+++ b/examples/primitives/lrn.cpp
@@ -70,7 +70,7 @@ void lrn_example(dnnl::engine::kind engine_kind) {
     auto dst_md = memory::desc(
             src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto src_mem = memory(src_md, engine);
-    auto dst_mem = memory(src_md, engine);
+    auto dst_mem = memory(dst_md, engine);
 
     // Write data to memory object's handle.
     write_to_dnnl_memory(src_data.data(), src_mem);

--- a/examples/primitives/pooling.cpp
+++ b/examples/primitives/pooling.cpp
@@ -99,11 +99,11 @@ void pooling_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors and memory objects for src and dst.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto src_mem = memory(src_md, engine);
 
     auto dst_md = memory::desc(
-            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
+            dst_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_mem = memory(dst_md, engine);
 
     // Write data to memory object's handle.

--- a/examples/primitives/prelu.cpp
+++ b/examples/primitives/prelu.cpp
@@ -72,15 +72,15 @@ void prelu_example(dnnl::engine::kind engine_kind) {
     std::fill(weights_data.begin(), weights_data.end(), 0.3f);
 
     // Create memory objects for tensor data (src, weights, dst). In this
-    // example, NCHW layout is assumed for src, weights and dst.
+    // example, NHWC layout is assumed for src, weights and dst.
     auto user_src_mem = memory(
-            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {src_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
     auto user_weights_mem = memory(
-            {weights_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {weights_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
     auto user_dst_mem = memory(
-            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            {dst_dims, memory::data_type::f32, memory::format_tag::nhwc},
             engine);
 
     // Create memory descriptors for the primitive. Src tag is set
@@ -89,7 +89,7 @@ void prelu_example(dnnl::engine::kind engine_kind) {
     // primitive implementation, and that layout may differ from the one
     // provided by the user.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto weights_md = memory::desc(
             weights_dims, memory::data_type::f32, memory::format_tag::any);
     auto dst_md = memory::desc(

--- a/examples/primitives/reduction.cpp
+++ b/examples/primitives/reduction.cpp
@@ -62,9 +62,9 @@ void reduction_example(dnnl::engine::kind engine_kind) {
 
     // Create src and dst memory descriptors and memory objects.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
-            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
+            dst_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);

--- a/examples/primitives/reorder.cpp
+++ b/examples/primitives/reorder.cpp
@@ -69,7 +69,7 @@ void reorder_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors and memory objects for src and dst.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
             src_dims, memory::data_type::s8, memory::format_tag::nhwc);
 

--- a/examples/primitives/resampling.cpp
+++ b/examples/primitives/resampling.cpp
@@ -69,9 +69,9 @@ void resampling_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors and memory objects for src and dst.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
-            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
+            dst_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);

--- a/examples/primitives/shuffle.cpp
+++ b/examples/primitives/shuffle.cpp
@@ -73,9 +73,9 @@ void shuffle_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptor and memory objects for src and dst.
     auto src_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto dst_md = memory::desc(
-            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+            src_dims, memory::data_type::f32, memory::format_tag::nhwc);
     auto src_mem = memory(src_md, engine);
 
     auto dst_mem = memory(

--- a/examples/primitives/sum.cpp
+++ b/examples/primitives/sum.cpp
@@ -81,7 +81,7 @@ void sum_example(dnnl::engine::kind engine_kind) {
 
     for (int n = 0; n < num_src; ++n) {
         src_md.emplace_back(
-                src_dims, memory::data_type::f32, memory::format_tag::nchw);
+                src_dims, memory::data_type::f32, memory::format_tag::nhwc);
         src_mem.emplace_back(src_md.back(), engine);
 
         // Write data to memory object's handle.

--- a/examples/sycl_interop_buffer.cpp
+++ b/examples/sycl_interop_buffer.cpp
@@ -121,7 +121,7 @@ void sycl_interop_buffer_tutorial(engine::kind engine_kind) {
     /// Next, we create a memory object. We need to specify dimensions of our
     /// memory by passing a memory::dims object. Then we create a memory
     /// descriptor with these dimensions, with the dnnl::memory::data_type::f32
-    /// data type, and with the dnnl::memory::format_tag::nchw memory format.
+    /// data type, and with the dnnl::memory::format_tag::nhwc memory format.
     /// Finally, we construct a memory object and pass the memory descriptor.
     /// The library allocates memory internally.
     /// @snippet  sycl_interop_buffer.cpp memory alloc
@@ -131,7 +131,7 @@ void sycl_interop_buffer_tutorial(engine::kind engine_kind) {
             std::multiplies<size_t>());
 
     memory::desc mem_d(
-            tz_dims, memory::data_type::f32, memory::format_tag::nchw);
+            tz_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     memory mem = sycl_interop::make_memory(
             mem_d, eng, sycl_interop::memory_kind::buffer);

--- a/examples/sycl_interop_usm.cpp
+++ b/examples/sycl_interop_usm.cpp
@@ -73,7 +73,7 @@ void sycl_usm_tutorial(engine::kind engine_kind) {
             sycl_interop::get_device(eng), sycl_interop::get_context(eng));
 
     memory::desc mem_d(
-            tz_dims, memory::data_type::f32, memory::format_tag::nchw);
+            tz_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     memory mem = sycl_interop::make_memory(
             mem_d, eng, sycl_interop::memory_kind::usm, usm_buffer);


### PR DESCRIPTION
# Description

General change - switch examples to NHWC activations format [MFDNN-2712].
Also fixed couple other observations:
- examples/cnn_training_bf16.cpp, examples/cnn_training_f32.cpp - change weights layout to OIHW instead NCHW
- examples/primitives/lrn.cpp - adjust initialization of `dst_mem`

[MFDNN-2712]: https://jira.devtools.intel.com/browse/MFDNN-2712