### PR TITLE
graph: expose scratchpad api

### DIFF
--- a/doc/graph/scratchpad.md
+++ b/doc/graph/scratchpad.md
@@ -1,0 +1,95 @@
+Scratchpad Management {#dev_guide_graph_scratchpad}
+===================================================
+
+## Introduction
+
+Some compiled partitions require temporary memory (scratchpad) during execution
+to store the intermediate results. The amount of space required for the
+scratchpad depends on the compiled partition and its actual implementation.
+oneDNN Graph API supports two different scratchpad management modes:
+
+1. **User-managed scratchpad**: The user queries the required scratchpad size,
+   allocates the buffer, and passes it to the execution call. This mode gives
+   the user full control over scratchpad memory lifecycle, enabling buffer reuse
+   across multiple executions and reducing allocation overhead.
+
+2. **Library-managed scratchpad**: The library internally allocates and frees
+   the scratchpad buffer during each execution call. This mode is simple to use
+   but with its own limitations.
+
+## User-Managed Scratchpad
+
+To use user-managed scratchpad, follow these steps:
+
+1. Query the scratchpad logical tensor from the compiled partition.
+2. Check if a scratchpad is required (memory size > 0).
+3. Allocate a tensor with the queried logical tensor descriptor.
+4. Pass the scratchpad tensor to the execution call.
+
+~~~cpp
+// Compile the partition
+dnnl::graph::compiled_partition cp = partition.compile(inputs, outputs, engine);
+
+// Step 1: Query scratchpad requirements
+dnnl::graph::logical_tensor scratchpad_lt = cp.get_scratchpad_logical_tensor();
+
+// Step 2: Check if scratchpad is needed
+dnnl::graph::tensor scratchpad_ts;
+if (scratchpad_lt.get_mem_size() > 0) {
+    // Step 3: Allocate scratchpad tensor
+    void * user_scratchpad = user_allocate_method(scratchpad_lt.get_mem_size());
+    scratchpad_ts = dnnl::graph::tensor(scratchpad_lt, engine, user_scratchpad);
+}
+
+// Step 4: Execute with user-managed scratchpad
+cp.execute(stream, input_tensors, output_tensors, scratchpad_ts);
+~~~
+
+The user-managed scratchpad tensor follows the same rules and limitations as
+input and output tensors. It must be created using the same engine as partition
+compilation unless specified otherwise. If the same compiled partition is
+executed in multiple threads concurrently, a separate scratchpad buffer must be
+used per thread to ensure the thread safety. A user-managed scratchpad buffer
+can be reused across multiple executions of the same or different compiled
+partitions where the size fits.
+
+## Library-Managed Scratchpad
+
+By default, when no scratchpad tensor is provided to the execution call, the
+library allocates the required scratchpad memory internally and frees it after
+execution completes, through the allocator interfaces associated with engine
+object. This mode requires no additional user action.
+
+~~~cpp
+// Compile the partition
+dnnl::graph::compiled_partition cp = partition.compile(inputs, outputs, engine);
+
+// Execute without scratchpad - library manages it internally
+cp.execute(stream, input_tensors, output_tensors);
+~~~
+
+## Work with SYCL Graph Recording Mode
+
+User-managed scratchpad is required when working with SYCL graph recording mode.
+
+SYCL graph recording captures a sequence of kernel submissions into a graph
+object that can be replayed multiple times. During recording, all memory buffers
+accessed by the recorded kernels are bound to the graph. These buffers must
+remain valid across all subsequent replays.
+
+When library-managed scratchpad is used, the library allocates a temporary
+buffer at execution time and frees it immediately after execution completes.
+This is incompatible with SYCL graph recording.
+
+To work correctly with SYCL graph recording mode, users must pass the
+pre-allocated scratchpad tensor to the execute call during recording and keep
+the scratchpad buffer alive across all replay iterations.
+
+## API Reference
+
+| API                                                                 | Description                                                   |
+| :---                                                                | :-----------                                                  |
+| @ref dnnl::graph::compiled_partition::get_scratchpad_logical_tensor | Returns the logical tensor describing the required scratchpad |
+| @ref dnnl::graph::compiled_partition::execute                       | Executes with optional user-managed scratchpad                |
+| @ref dnnl::graph::sycl_interop::execute                             | SYCL interop execute with user-managed scratchpad             |
+| @ref dnnl::graph::ocl_interop::execute                              | OpenCL interop execute with user-managed scratchpad           |

--- a/doc/rst/graph_extension.rst
+++ b/doc/rst/graph_extension.rst
@@ -7,5 +7,6 @@ Graph Extension
    graph_programming_model
    graph_supported_operations
    graph_fusion_patterns
+   dev_guide_graph_scratchpad
    dev_guide_graph_dump
    dev_guide_constant_tensor_cache

--- a/examples/graph/gqa.cpp
+++ b/examples/graph/gqa.cpp
@@ -192,6 +192,21 @@ void bench_gqa(engine::kind ekind, logical_tensor::data_type dt,
     compiled_partition cp = partitions[0].compile(
             {query, key, scale, mask, value}, {output}, eng);
 
+    // Query scratchpad logical tensor and allocate scratchpad buffer. Here we
+    // leverage the tensor API to allocate the scratchpad buffer for
+    // convenience. In real applications, users can also manage the scratchpad
+    // buffer by:
+    // 1) query the scratchpad logical tensor from a compiled partition.
+    // 2) query the scratchpad size from the scratchpad logical tensor.
+    // 3) allocate a buffer with the required size.
+    // 4) create a tensor object with the scratchpad logical tensor, the buffer,
+    //    and the engine where the buffer is associated.
+    auto scratchpad_lt = cp.get_scratchpad_logical_tensor();
+    tensor scratchpad_ts;
+    if (scratchpad_lt.get_mem_size() > 0) {
+        scratchpad_ts = tensor(scratchpad_lt, eng);
+    }
+
     // Allocate user data.
     std::vector<float> query_data(product(q_sz));
     std::vector<float> key_data(product(kv_sz));
@@ -221,17 +236,17 @@ void bench_gqa(engine::kind ekind, logical_tensor::data_type dt,
     write_to_dnnl_tensor(value_data.data(), ts_value);
 
     // Warmup run.
-    // Execute the compiled partition of mqa.
-    cp.execute(
-            strm, {ts_query, ts_key, ts_scale, ts_mask, ts_value}, {ts_output});
+    // Execute the compiled partition of gqa with user-managed scratchpad.
+    cp.execute(strm, {ts_query, ts_key, ts_scale, ts_mask, ts_value},
+            {ts_output}, scratchpad_ts);
 
     // Wait for the computation to finish.
     strm.wait();
 
     // First run.
     auto start_first = std::chrono::steady_clock::now();
-    cp.execute(
-            strm, {ts_query, ts_key, ts_scale, ts_mask, ts_value}, {ts_output});
+    cp.execute(strm, {ts_query, ts_key, ts_scale, ts_mask, ts_value},
+            {ts_output}, scratchpad_ts);
     strm.wait();
     auto end_first = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> dur_first
@@ -244,7 +259,7 @@ void bench_gqa(engine::kind ekind, logical_tensor::data_type dt,
     auto start = std::chrono::steady_clock::now();
     for (int i = 0; i <= runs; i++)
         cp.execute(strm, {ts_query, ts_key, ts_scale, ts_mask, ts_value},
-                {ts_output});
+                {ts_output}, scratchpad_ts);
     strm.wait();
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> duration = end - start;

--- a/include/oneapi/dnnl/dnnl_graph.h
+++ b/include/oneapi/dnnl/dnnl_graph.h
@@ -524,6 +524,31 @@ dnnl_status_t DNNL_API dnnl_graph_compiled_partition_execute(
         const_dnnl_graph_tensor_t *inputs, size_t num_outputs,
         const_dnnl_graph_tensor_t *outputs);
 
+/// Executes a compiled partition.
+///
+/// @note The user can provide a scratchpad buffer for execution. If not
+/// provided, the library will allocate an internal scratchpad buffer for the
+/// execution. For user-provided scratchpad buffer, it should have a size no
+/// less than the value provided by
+/// #dnnl_graph_compiled_partition_get_scratchpad_logical_tensor API. The user
+/// is responsible for the memory management of the user-provided scratchpad
+/// buffer, including allocation, deallocation, and thread-safety.
+///
+/// @param compiled_partition The handle of target compiled partition.
+/// @param stream The stream used for execution.
+/// @param num_inputs The number of input tensors.
+/// @param inputs A list of input tensors.
+/// @param num_outputs The number of output tensors.
+/// @param outputs A non-empty list of output tensors.
+/// @param scratchpad User-provided scratchpad tensor.
+/// @returns #dnnl_success on success or a status describing the error otherwise.
+dnnl_status_t DNNL_API dnnl_graph_compiled_partition_execute_v2(
+        const_dnnl_graph_compiled_partition_t compiled_partition,
+        dnnl_stream_t stream, size_t num_inputs,
+        const_dnnl_graph_tensor_t *inputs, size_t num_outputs,
+        const_dnnl_graph_tensor_t *outputs,
+        const_dnnl_graph_tensor_t scratchpad);
+
 /// Destroys a compiled partition.
 ///
 /// @param compiled_partition The compiled partition to be destroyed.
@@ -564,6 +589,21 @@ dnnl_status_t DNNL_API dnnl_graph_compiled_partition_get_inplace_ports(
         const_dnnl_graph_compiled_partition_t compiled_partition,
         size_t *num_inplace_pairs,
         const dnnl_graph_inplace_pair_t **inplace_pairs);
+
+/// Queries the scratchpad logical tensor from a compiled partition. The
+/// scratchpad logical tensor describes the required scratchpad buffer for
+/// execution. The data type is u8 and the layout is strided with a single
+/// dimension equal to the scratchpad size in bytes. If no scratchpad is needed,
+/// the logical tensor will have a zero size dimension.
+///
+/// @param compiled_partition The handle of target compiled_partition.
+/// @param lt The output logical tensor describing the scratchpad.
+/// @returns #dnnl_success on success or a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API
+dnnl_graph_compiled_partition_get_scratchpad_logical_tensor(
+        const_dnnl_graph_compiled_partition_t compiled_partition,
+        dnnl_graph_logical_tensor_t *lt);
 
 /// @} dnnl_graph_api_compiled_partition
 

--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -734,13 +734,38 @@ public:
         return inplace_options;
     }
 
+    /// Returns the scratchpad logical tensor describing the required scratchpad
+    /// buffer for execution. The logical tensor has data type u8 and strided
+    /// layout with a single dimension equal to the scratchpad size in bytes.
+    ///
+    /// @returns A logical tensor describing the scratchpad.
+    logical_tensor get_scratchpad_logical_tensor() const {
+        dnnl_graph_logical_tensor_t lt;
+        error::wrap_c_api(
+                dnnl_graph_compiled_partition_get_scratchpad_logical_tensor(
+                        get(), &lt),
+                "could not get scratchpad logical tensor from "
+                "compiled_partition");
+        return logical_tensor {lt};
+    }
+
     /// Execute a compiled partition.
+    ///
+    /// @note The user can provide a scratchpad tensor for execution. If not
+    /// provided, the library will allocate an internal scratchpad buffer for
+    /// the execution. For user-provided scratchpad tensor, the size is
+    /// determined by the logical tensor returned by the
+    /// #get_scratchpad_logical_tensor API. The user is responsible for the
+    /// memory management of the user-provided scratchpad tensor, including
+    /// allocation, deallocation, and thread-safety.
     ///
     /// @param astream Stream object to run over.
     /// @param inputs A list of input tensors.
     /// @param outputs A list of output tensors.
+    /// @param scratchpad User-provided scratchpad tensor.
     void execute(stream &astream, const std::vector<tensor> &inputs,
-            const std::vector<tensor> &outputs) const {
+            const std::vector<tensor> &outputs,
+            const tensor &scratchpad = tensor()) const {
         std::vector<const_dnnl_graph_tensor_t> c_inputs;
         c_inputs.reserve(inputs.size());
         for (auto &in : inputs) {
@@ -753,10 +778,10 @@ public:
         }
 
         error::wrap_c_api(
-                dnnl_graph_compiled_partition_execute(get(), astream.get(),
+                dnnl_graph_compiled_partition_execute_v2(get(), astream.get(),
                         c_inputs.size(), c_inputs.data(), c_outputs.size(),
-                        c_outputs.data()),
-                "could not execute the compiled_partition");
+                        c_outputs.data(), scratchpad.get(true)),
+                "could not execute the compiled_partition with scratchpad");
     }
 };
 

--- a/include/oneapi/dnnl/dnnl_graph_ocl.h
+++ b/include/oneapi/dnnl/dnnl_graph_ocl.h
@@ -129,6 +129,29 @@ dnnl_status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute(
         const_dnnl_graph_tensor_t *outputs, const cl_event *deps, int ndeps,
         cl_event *return_event);
 
+/// Execute a compiled partition with OpenCL runtime.
+///
+/// @param compiled_partition The handle of target compiled_partition.
+/// @param stream The stream used for execution
+/// @param num_inputs The number of input tensors
+/// @param inputs A list of input tensors
+/// @param num_outputs The number of output tensors
+/// @param outputs A non-empty list of output tensors
+/// @param scratchpad User-provided scratchpad tensor. If not provided, the
+///     implementation will allocate scratchpad internally.
+/// @param deps Optional handle of list with `cl_event` dependencies.
+/// @param ndeps Number of dependencies.
+/// @param return_event The handle of cl_event.
+/// @returns #dnnl_success on success and a status describing the
+///     error otherwise.
+dnnl_status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute_v2(
+        const_dnnl_graph_compiled_partition_t compiled_partition,
+        dnnl_stream_t stream, size_t num_inputs,
+        const_dnnl_graph_tensor_t *inputs, size_t num_outputs,
+        const_dnnl_graph_tensor_t *outputs,
+        const_dnnl_graph_tensor_t scratchpad, const cl_event *deps, int ndeps,
+        cl_event *return_event);
+
 /// @} dnnl_graph_api_ocl_interop
 
 /// @} dnnl_graph_api_interop

--- a/include/oneapi/dnnl/dnnl_graph_ocl.hpp
+++ b/include/oneapi/dnnl/dnnl_graph_ocl.hpp
@@ -139,6 +139,44 @@ inline cl_event execute(compiled_partition &c_partition, stream &astream,
     return ocl_event;
 }
 
+/// Executes a compiled partition in a specified stream and returns a OpenCL
+/// event.
+///
+/// @param c_partition Compiled partition to execute.
+/// @param astream Stream object to run over
+/// @param inputs Arguments map.
+/// @param outputs Arguments map.
+/// @param scratchpad User-provided scratchpad tensor. If not provided, the
+///     implementation will allocate scratchpad internally.
+/// @param deps Optional vector with `cl_event` dependencies.
+/// @returns Output event.
+inline cl_event execute(compiled_partition &c_partition, stream &astream,
+        const std::vector<tensor> &inputs, std::vector<tensor> &outputs,
+        const tensor &scratchpad, const std::vector<cl_event> &deps = {}) {
+    std::vector<const_dnnl_graph_tensor_t> c_inputs;
+    c_inputs.reserve(inputs.size());
+    for (auto &in : inputs) {
+        c_inputs.push_back(in.get());
+    }
+    std::vector<const_dnnl_graph_tensor_t> c_outputs;
+    c_outputs.reserve(outputs.size());
+    for (auto &out : outputs) {
+        c_outputs.push_back(out.get());
+    }
+
+    const cl_event *c_deps = deps.empty() ? nullptr : deps.data();
+
+    cl_event ocl_event;
+    error::wrap_c_api(
+            dnnl_graph_ocl_interop_compiled_partition_execute_v2(
+                    c_partition.get(), astream.get(), c_inputs.size(),
+                    c_inputs.data(), c_outputs.size(), c_outputs.data(),
+                    scratchpad.get(true), c_deps, (int)deps.size(), &ocl_event),
+            "could not execute the compiled_partition with scratchpad on a "
+            "specified opencl stream");
+    return ocl_event;
+}
+
 } // namespace ocl_interop
 
 /// @} dnnl_graph_api_ocl_interop

--- a/include/oneapi/dnnl/dnnl_graph_sycl.h
+++ b/include/oneapi/dnnl/dnnl_graph_sycl.h
@@ -84,6 +84,28 @@ dnnl_status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute(
         const_dnnl_graph_tensor_t *inputs, size_t num_outputs,
         const_dnnl_graph_tensor_t *outputs, const void *deps, void *sycl_event);
 
+/// Execute a compiled partition with sycl runtime.
+///
+/// @param compiled_partition The handle of target compiled_partition.
+/// @param stream The stream used for execution
+/// @param num_inputs The number of input tensors
+/// @param inputs A list of input tensors
+/// @param num_outputs The number of output tensors
+/// @param outputs A non-empty list of output tensors
+/// @param scratchpad User-provided scratchpad tensor. If not provided, the
+///     implementation will allocate scratchpad internally.
+/// @param deps Optional handle of list with `sycl::event` dependencies
+/// @param sycl_event The handle of sycl event
+/// @returns #dnnl_success on success and a status describing the
+///     error otherwise.
+dnnl_status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
+        const_dnnl_graph_compiled_partition_t compiled_partition,
+        dnnl_stream_t stream, size_t num_inputs,
+        const_dnnl_graph_tensor_t *inputs, size_t num_outputs,
+        const_dnnl_graph_tensor_t *outputs,
+        const_dnnl_graph_tensor_t scratchpad, const void *deps,
+        void *sycl_event);
+
 /// @} dnnl_graph_api_sycl_interop
 
 /// @} dnnl_graph_api_interop

--- a/include/oneapi/dnnl/dnnl_graph_sycl.hpp
+++ b/include/oneapi/dnnl/dnnl_graph_sycl.hpp
@@ -114,6 +114,41 @@ inline sycl::event execute(compiled_partition &c_partition, stream &astream,
     return sycl_event;
 }
 
+/// Executes a compiled partition with a user-managed scratchpad in a specified
+/// stream and returns a SYCL event.
+///
+/// @param c_partition Compiled partition to execute.
+/// @param astream Stream object to run over
+/// @param inputs Arguments map.
+/// @param outputs Arguments map.
+/// @param scratchpad User-provided scratchpad buffer pointer.
+/// @param deps Optional vector with `sycl::event` dependencies.
+/// @returns Output event.
+inline sycl::event execute(compiled_partition &c_partition, stream &astream,
+        const std::vector<tensor> &inputs, std::vector<tensor> &outputs,
+        const tensor &scratchpad, const std::vector<sycl::event> &deps = {}) {
+    std::vector<const_dnnl_graph_tensor_t> c_inputs;
+    c_inputs.reserve(inputs.size());
+    for (auto &in : inputs) {
+        c_inputs.push_back(in.get());
+    }
+    std::vector<const_dnnl_graph_tensor_t> c_outputs;
+    c_outputs.reserve(outputs.size());
+    for (auto &out : outputs) {
+        c_outputs.push_back(out.get());
+    }
+
+    sycl::event sycl_event;
+    error::wrap_c_api(
+            dnnl_graph_sycl_interop_compiled_partition_execute_v2(
+                    c_partition.get(), astream.get(), c_inputs.size(),
+                    c_inputs.data(), c_outputs.size(), c_outputs.data(),
+                    scratchpad.get(true), &deps, &sycl_event),
+            "could not execute the compiled_partition with scratchpad on a "
+            "specified sycl stream");
+    return sycl_event;
+}
+
 } // namespace sycl_interop
 
 /// @} dnnl_graph_api_sycl_interop

--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -640,20 +640,6 @@ dnnl::accumulation_mode str2accumulation_mode(
     }
 }
 
-void prolong_temporary_scratchpad_lifetime(const stream_t *g_stream,
-        const std::shared_ptr<temporary_scratchpad_t> &scratchpad) {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    auto *tp_stream
-            = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
-                    const_cast<stream_t *>(g_stream));
-    tp_stream->before_exec_hook();
-
-    parallel(1, [=](int, int) { UNUSED(scratchpad); });
-
-    tp_stream->after_exec_hook();
-#endif
-}
-
 status_t dnnl_primitive_execute_without_tp_hook(const primitive &prim,
         const stream &astream,
         const std::unordered_map<int, memory> &exec_args) {

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -142,15 +142,6 @@ dnnl::accumulation_mode str2accumulation_mode(
 size_t generate_constant_md_hash(
         size_t part_id, const std::vector<dnnl::memory::desc> &const_mds);
 
-// This function artificially extends the `temporary_scratchpad_t` object's
-// lifetime to keep alive the handle this scratchpad object manages.
-// An alternative approach is to manage its handles through a system of caches
-// the same way it's done for memory objects before they are passed into a
-// primitive execute call.
-class temporary_scratchpad_t;
-void prolong_temporary_scratchpad_lifetime(const stream_t *g_stream,
-        const std::shared_ptr<temporary_scratchpad_t> &scratchpad);
-
 // This function is mostly a copy-paste of public `dnnl_primitive_execute` but
 // doesn't have calls for hooks since this API is intended to be used in nested
 // parallelism scenario in sdp-decomposed kernels, and double

--- a/src/graph/backend/dnnl/dnnl_partition_impl.hpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.hpp
@@ -49,20 +49,20 @@ public:
 
     status_t execute(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override {
-        // We don't need to resort the inputs and outputs
-        return kernel_->execute(g_stream, inputs, outputs);
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override {
+        return kernel_->execute(g_stream, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
     status_t execute_sycl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        // We don't need to resort the inputs and outputs
-        return kernel_->execute_sycl(
-                g_stream, inputs, outputs, sycl_deps, sycl_event);
+        return kernel_->execute_sycl(g_stream, inputs, outputs, scratchpad_buf,
+                sycl_deps, sycl_event);
     }
 #endif
 
@@ -72,12 +72,17 @@ public:
     status_t execute_ocl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps,
             cl_event *ocl_event) override {
         return kernel_->execute_ocl(
-                g_stream, inputs, outputs, ocl_deps, ocl_event);
+                g_stream, inputs, outputs, scratchpad_buf, ocl_deps, ocl_event);
     }
 #endif
+
+    size_t get_scratchpad_size() const override {
+        return kernel_->get_scratchpad_size();
+    }
 
     std::string str() const override { return kernel_->str(); }
 

--- a/src/graph/backend/dnnl/executables/batch_norm.cpp
+++ b/src/graph/backend/dnnl/executables/batch_norm.cpp
@@ -792,11 +792,12 @@ batchnorm_bwd_executable_t::desc_t batchnorm_bwd_executable_t::create_desc(
     }
 
     auto forward_hints = dnnl::batch_normalization_forward::primitive_desc(
-            p_engine, prop_kind::forward_training, src, src, epsilon, flags);
+            p_engine, prop_kind::forward_training, src, src, epsilon, flags,
+            prm_attr);
 
     dnnl::batch_normalization_backward::primitive_desc pd(p_engine,
             prop_kind::backward, src, forward_hints.dst_desc(), src, epsilon,
-            flags, forward_hints);
+            flags, forward_hints, prm_attr);
 
     pd_cache.insert({op.get(), pd});
     return {pd, false};

--- a/src/graph/backend/dnnl/executables/conv.cpp
+++ b/src/graph/backend/dnnl/executables/conv.cpp
@@ -337,11 +337,11 @@ conv_bwd_data_executable_t::desc_t conv_bwd_data_executable_t::create_desc(
     auto fwd_hints = dnnl::convolution_forward::primitive_desc(p_engine,
             dnnl::prop_kind::forward_training,
             dnnl::algorithm::convolution_direct, diff_src, weight, diff_dst,
-            strides, dilates, pads_begin, pads_end);
+            strides, dilates, pads_begin, pads_end, prm_attr);
 
     dnnl::convolution_backward_data::primitive_desc pd(p_engine,
             dnnl::algorithm::convolution_direct, diff_src, weight, diff_dst,
-            strides, dilates, pads_begin, pads_end, fwd_hints);
+            strides, dilates, pads_begin, pads_end, fwd_hints, prm_attr);
 
     pd_cache.insert({op.get(), pd});
 
@@ -409,11 +409,11 @@ conv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
     auto fwd_hints = dnnl::convolution_forward::primitive_desc(p_engine,
             dnnl::prop_kind::forward_training,
             dnnl::algorithm::convolution_direct, src, diff_weight, diff_dst,
-            strides, dilates, pads_begin, pads_end);
+            strides, dilates, pads_begin, pads_end, prm_attr);
 
     dnnl::convolution_backward_weights::primitive_desc pd(p_engine,
             dnnl::algorithm::convolution_direct, src, diff_weight, diff_dst,
-            strides, dilates, pads_begin, pads_end, fwd_hints);
+            strides, dilates, pads_begin, pads_end, fwd_hints, prm_attr);
 
     pd_cache.insert({op.get(), pd});
 

--- a/src/graph/backend/dnnl/executables/deconv.cpp
+++ b/src/graph/backend/dnnl/executables/deconv.cpp
@@ -187,7 +187,7 @@ deconv_bwd_data_executable_t::desc_t deconv_bwd_data_executable_t::create_desc(
 
     dnnl::deconvolution_backward_data::primitive_desc pd(p_engine,
             dnnl::algorithm::deconvolution_direct, diff_src, weight, diff_dst,
-            strides, pads_begin, pads_end, fwd_hints);
+            strides, pads_begin, pads_end, fwd_hints, prm_attr);
 
     pd_cache.insert({op.get(), pd});
 
@@ -237,11 +237,11 @@ deconv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
     auto fwd_hints = dnnl::deconvolution_forward::primitive_desc(p_engine,
             dnnl::prop_kind::forward_training,
             dnnl::algorithm::deconvolution_direct, src, diff_weight, diff_dst,
-            strides, dilates, pads_begin, pads_end);
+            strides, dilates, pads_begin, pads_end, prm_attr);
 
     dnnl::deconvolution_backward_weights::primitive_desc pd(p_engine,
             dnnl::algorithm::deconvolution_direct, src, diff_weight, diff_dst,
-            strides, dilates, pads_begin, pads_end, fwd_hints);
+            strides, dilates, pads_begin, pads_end, fwd_hints, prm_attr);
 
     pd_cache.insert({op.get(), pd});
 

--- a/src/graph/backend/dnnl/executables/layer_norm.cpp
+++ b/src/graph/backend/dnnl/executables/layer_norm.cpp
@@ -115,7 +115,8 @@ layernorm_bwd_executable_t::desc_t layernorm_bwd_executable_t::create_desc(
     auto diff_dst = make_dnnl_memory_desc(op->get_input_logical_tensor(1));
     auto diff_src = make_dnnl_memory_desc(op->get_output_logical_tensor(0));
     dnnl::layer_normalization_forward::primitive_desc fwd_hints(p_engine,
-            prop_kind::forward_training, src, diff_dst, epsilon, flags);
+            prop_kind::forward_training, src, diff_dst, epsilon, flags,
+            prm_attr);
 
     dnnl::layer_normalization_backward::primitive_desc pd(p_engine,
             prop_kind::backward, diff_src, diff_dst, src, epsilon, flags,

--- a/src/graph/backend/dnnl/executables/pool.cpp
+++ b/src/graph/backend/dnnl/executables/pool.cpp
@@ -183,11 +183,11 @@ pool_bwd_executable_t::desc_t pool_bwd_executable_t::create_desc(
     dnnl::pooling_forward::primitive_desc forward_hints
             = dnnl::pooling_forward::primitive_desc(p_engine,
                     prop_kind::forward_training, algo, src, diff_dst, strides,
-                    kernel, dilations, pads_begin, pads_end);
+                    kernel, dilations, pads_begin, pads_end, prm_attr);
 
     dnnl::pooling_backward::primitive_desc pd(p_engine, algo, diff_src,
             diff_dst, strides, kernel, dilations, pads_begin, pads_end,
-            forward_hints);
+            forward_hints, prm_attr);
 
     pd_cache.insert({op.get(), pd});
 

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -117,7 +117,7 @@ status_t batch_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
 
 status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -125,12 +125,9 @@ status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -177,7 +174,7 @@ status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -185,7 +182,7 @@ status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -198,13 +195,10 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -253,7 +247,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -264,7 +258,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t batch_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -276,13 +270,10 @@ status_t batch_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -331,7 +322,7 @@ status_t batch_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -408,7 +399,7 @@ void batch_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t batch_norm_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -416,19 +407,16 @@ status_t batch_norm_bwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -436,7 +424,7 @@ status_t batch_norm_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -449,13 +437,10 @@ status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -463,7 +448,7 @@ status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -474,7 +459,7 @@ status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t batch_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -486,13 +471,10 @@ status_t batch_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -501,7 +483,7 @@ status_t batch_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/batch_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.hpp
@@ -72,12 +72,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -86,10 +88,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(batch_norm_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(batch_norm_fwd_t)
 };
 
@@ -127,12 +131,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -141,10 +147,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(batch_norm_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(batch_norm_bwd_t)
 };
 #endif // BUILD_TRAINING

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -104,7 +104,7 @@ status_t binary_t::compile_impl(const dnnl_partition_impl_t *part,
 
 status_t binary_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -121,19 +121,16 @@ status_t binary_t::execute_impl(const stream_t *g_stream,
                 outputs[mem_idx.second].get_data_handle());
     }
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -141,7 +138,7 @@ status_t binary_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -154,13 +151,10 @@ status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -168,7 +162,7 @@ status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -179,7 +173,7 @@ status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t binary_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
 
     auto deps = ocl_deps;
@@ -191,13 +185,10 @@ status_t binary_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -206,7 +197,7 @@ status_t binary_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ocl_event) *ocl_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/binary.hpp
+++ b/src/graph/backend/dnnl/kernels/binary.hpp
@@ -83,12 +83,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -97,11 +99,13 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps,
             cl_event *ocl_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(binary_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(binary_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -108,26 +108,23 @@ void concat_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 template <bool quantized>
 status_t concat_t<quantized>::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -136,7 +133,7 @@ status_t concat_t<quantized>::execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -148,13 +145,10 @@ status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -162,7 +156,7 @@ status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -174,7 +168,7 @@ status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t concat_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -185,13 +179,10 @@ status_t concat_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -199,7 +190,7 @@ status_t concat_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/concat.hpp
+++ b/src/graph/backend/dnnl/kernels/concat.hpp
@@ -72,12 +72,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -86,10 +88,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(concat_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(concat_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/conv.hpp
+++ b/src/graph/backend/dnnl/kernels/conv.hpp
@@ -35,6 +35,7 @@ public:
     status_t prepare_inplace_pairs_impl() override;
 
     DEF_KERNEL_METHOD_STR(conv_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
 };
 
 using float_conv_fwd = conv_fwd_t</* quantized */ false>;
@@ -49,6 +50,7 @@ public:
             const std::vector<logical_tensor_t> &outputs) override;
 
     DEF_KERNEL_METHOD_STR(conv_bwd_data_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
 };
 
 struct conv_bwd_weights_t : public conv_base_t {
@@ -59,6 +61,7 @@ public:
             const std::vector<logical_tensor_t> &outputs) override;
 
     DEF_KERNEL_METHOD_STR(conv_bwd_weights_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
 };
 #endif
 

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -45,7 +45,7 @@ void conv_base_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t conv_base_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -53,12 +53,9 @@ status_t conv_base_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -105,7 +102,7 @@ status_t conv_base_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -113,7 +110,7 @@ status_t conv_base_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -126,13 +123,10 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -181,7 +175,7 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -192,7 +186,7 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t conv_base_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
 
     auto deps = ocl_deps;
@@ -204,13 +198,10 @@ status_t conv_base_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -259,7 +250,7 @@ status_t conv_base_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ocl_event) *ocl_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/conv_base.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.hpp
@@ -68,12 +68,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -82,6 +84,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps,
             cl_event *ocl_event) override;
 #endif

--- a/src/graph/backend/dnnl/kernels/conv_transpose.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_transpose.hpp
@@ -49,6 +49,7 @@ public:
     status_t prepare_inplace_pairs_impl() override;
 
     DEF_KERNEL_METHOD_STR(conv_transpose_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
 };
 
 using float_convtranspose_fwd = conv_transpose_fwd_t</* quantized */ false>;
@@ -63,6 +64,7 @@ public:
             const std::vector<logical_tensor_t> &outputs) override;
 
     DEF_KERNEL_METHOD_STR(conv_transpose_bwd_data_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
 };
 
 struct conv_transpose_bwd_weights_t : public conv_base_t {
@@ -73,6 +75,7 @@ public:
             const std::vector<logical_tensor_t> &outputs) override;
 
     DEF_KERNEL_METHOD_STR(conv_transpose_bwd_weights_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
 };
 #endif
 

--- a/src/graph/backend/dnnl/kernels/dummy.cpp
+++ b/src/graph/backend/dnnl/kernels/dummy.cpp
@@ -57,14 +57,14 @@ status_t dummy_kernel_t::compile_impl(const dnnl_partition_impl_t *part,
 
 status_t dummy_kernel_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 status_t dummy_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -93,7 +93,7 @@ status_t dummy_kernel_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t dummy_kernel_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);

--- a/src/graph/backend/dnnl/kernels/dummy.hpp
+++ b/src/graph/backend/dnnl/kernels/dummy.hpp
@@ -49,12 +49,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -63,8 +65,11 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
+
+    size_t get_scratchpad_size() const override { return 0; }
 
     DEF_KERNEL_METHOD_STR(dummy_kernel_t)
     DNNL_DISALLOW_COPY_AND_ASSIGN(dummy_kernel_t)

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -133,7 +133,7 @@ void eltwise_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 template <bool quantized>
 status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -141,12 +141,9 @@ status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -193,7 +190,7 @@ status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -202,7 +199,7 @@ status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -215,13 +212,10 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -270,7 +264,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -282,7 +276,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t eltwise_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -294,13 +288,10 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -349,7 +340,7 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -422,26 +413,23 @@ void eltwise_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t eltwise_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -449,7 +437,7 @@ status_t eltwise_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -461,13 +449,10 @@ status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -475,7 +460,7 @@ status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -486,7 +471,7 @@ status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t eltwise_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -497,13 +482,10 @@ status_t eltwise_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -511,7 +493,7 @@ status_t eltwise_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/eltwise.hpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.hpp
@@ -82,12 +82,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -96,10 +98,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(eltwise_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(eltwise_fwd_t)
 };
 
@@ -140,12 +144,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -154,10 +160,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(eltwise_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(eltwise_bwd_t)
 };
 #endif

--- a/src/graph/backend/dnnl/kernels/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp.hpp
@@ -81,17 +81,20 @@ public:
 
     status_t execute_impl(const stream_t *stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override {
-        return kernel->execute_impl(stream, inputs, outputs);
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override {
+        return kernel->execute_impl(stream, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &deps,
             ::sycl::event *event) override {
-        return kernel->sycl_execute_impl(stream, inputs, outputs, deps, event);
+        return kernel->sycl_execute_impl(
+                stream, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 
@@ -99,12 +102,17 @@ public:
     status_t ocl_execute_impl(const stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const std::vector<cl_event> &deps, cl_event *event) override {
-        return kernel->ocl_execute_impl(stream, inputs, outputs, deps, event);
+            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
+            cl_event *event) override {
+        return kernel->ocl_execute_impl(
+                stream, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 
     std::string str() const override { return kernel->str(); }
+    size_t get_scratchpad_size() const override {
+        return kernel->get_scratchpad_size();
+    }
 };
 } // namespace dnnl_impl
 } // namespace graph

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
@@ -144,17 +144,17 @@ void gated_mlp_primitive_kernel_t<quantized>::prepare_args_set(
 template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::execute_impl(
         const stream_t *stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
@@ -167,7 +167,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::execute_impl(
 template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
         const stream_t *stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps, ::sycl::event *ret_event) {
 // gated_mlp_primitive_kernel_t only supports Intel GPU.
 #if DNNL_GPU_VENDOR != DNNL_VENDOR_INTEL
@@ -182,10 +182,10 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -194,7 +194,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (ret_event)
         *ret_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -206,7 +206,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
 template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
         const stream_t *stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ret_event) {
     auto deps = ocl_deps;
     cl_event returned_event {};
@@ -217,10 +217,10 @@ status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -229,7 +229,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
@@ -70,12 +70,14 @@ public:
 
     status_t execute_impl(const stream_t *stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &deps,
             ::sycl::event *ret_event) override;
 #endif
@@ -84,10 +86,12 @@ public:
     status_t ocl_execute_impl(const stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const std::vector<cl_event> &deps, cl_event *ret_event) override;
+            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
+            cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(gated_mlp_primitive_kernel_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(gated_mlp_primitive_kernel_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -115,7 +115,7 @@ void genindex_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t genindex_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -136,7 +136,7 @@ status_t genindex_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t genindex_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
     if (p_engine_.get_kind() == engine::kind::gpu) {
@@ -160,13 +160,13 @@ status_t genindex_t::sycl_execute_impl(const stream_t *g_stream,
 
         return status::success;
     }
-    return execute_impl(g_stream, inputs, outputs);
+    return execute_impl(g_stream, inputs, outputs, scratchpad_buf);
 }
 #endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t genindex_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
     auto deps = ocl_deps;
     cl_event returned_event {};

--- a/src/graph/backend/dnnl/kernels/gen_index.hpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.hpp
@@ -64,11 +64,13 @@ public:
             const std::vector<logical_tensor_t> &outputs) override;
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -76,10 +78,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps,
             cl_event *ocl_event) override;
 #endif
     DEF_KERNEL_METHOD_STR(genindex_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(genindex_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -125,7 +125,7 @@ void group_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -133,12 +133,9 @@ status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -185,7 +182,7 @@ status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -193,7 +190,7 @@ status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -206,13 +203,10 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -261,7 +255,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -272,7 +266,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t group_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -284,13 +278,10 @@ status_t group_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -339,7 +330,7 @@ status_t group_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/group_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.hpp
@@ -74,12 +74,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -88,10 +90,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(group_norm_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(group_norm_fwd_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/kernel_base.cpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.cpp
@@ -32,8 +32,8 @@ status_t kernel_base_t::compile(const dnnl_partition_impl_t *part,
 
 status_t kernel_base_t::execute(const stream_t *astream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
-    return execute_impl(astream, inputs, outputs);
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
+    return execute_impl(astream, inputs, outputs, scratchpad_buf);
 }
 
 bool kernel_base_t::enabled_constant_cache() const {

--- a/src/graph/backend/dnnl/kernels/kernel_base.hpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.hpp
@@ -54,27 +54,31 @@ struct kernel_base_t {
 
     status_t execute(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs);
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf = nullptr);
 
     // each subclass should implement execute_impl()
     virtual status_t execute_impl(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs)
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf)
             = 0;
 
 #ifdef DNNL_WITH_SYCL
     status_t execute_sycl(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) {
-        return sycl_execute_impl(
-                astream, inputs, outputs, sycl_deps, sycl_event);
+        return sycl_execute_impl(astream, inputs, outputs, scratchpad_buf,
+                sycl_deps, sycl_event);
     }
 
     virtual status_t sycl_execute_impl(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event)
             = 0;
@@ -84,18 +88,24 @@ struct kernel_base_t {
     status_t execute_ocl(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
-        return ocl_execute_impl(astream, inputs, outputs, ocl_deps, ocl_event);
+        return ocl_execute_impl(
+                astream, inputs, outputs, scratchpad_buf, ocl_deps, ocl_event);
     }
 
     virtual status_t ocl_execute_impl(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps, cl_event *ocl_event)
             = 0;
 #endif
 
     virtual status_t prepare_inplace_pairs_impl() { return status::success; }
+
+    /// Returns the scratchpad size in bytes required for execution.
+    virtual size_t get_scratchpad_size() const = 0;
 
     // A string identity used in verbose indicating which kernels is dispatched
     // for a compiled partition.
@@ -119,6 +129,11 @@ using FCreateKernel = std::function<kernel_ptr(void)>;
 #define DEF_KERNEL_METHOD_STR(name) \
     std::string str() const override { \
         return #name; \
+    }
+
+#define DEF_KERNEL_METHOD_SCRATCHPAD_SIZE() \
+    size_t get_scratchpad_size() const override { \
+        return memory_planner_.total_internal_temporary_size(); \
     }
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -252,7 +252,7 @@ status_t larger_partition_kernel_t::compile_impl(
 
 status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -260,12 +260,9 @@ status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -312,7 +309,7 @@ status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -320,7 +317,7 @@ status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -332,13 +329,10 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -387,7 +381,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -398,7 +392,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t larger_partition_kernel_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *event) {
     auto deps = ocl_deps;
     cl_event returned_event {};
@@ -408,13 +402,10 @@ status_t larger_partition_kernel_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -463,7 +454,7 @@ status_t larger_partition_kernel_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (event) *event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/large_partition.hpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.hpp
@@ -89,12 +89,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -103,10 +105,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps, cl_event *event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(larger_partition_kernel_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(larger_partition_kernel_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -122,7 +122,7 @@ void layer_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -130,12 +130,9 @@ status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -182,7 +179,7 @@ status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -190,7 +187,7 @@ status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -203,13 +200,10 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -258,7 +252,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -269,7 +263,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t layer_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -281,13 +275,10 @@ status_t layer_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -336,7 +327,7 @@ status_t layer_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -408,26 +399,23 @@ void layer_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t layer_norm_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -435,7 +423,7 @@ status_t layer_norm_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -447,13 +435,10 @@ status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -461,7 +446,7 @@ status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -472,7 +457,7 @@ status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t layer_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -483,13 +468,10 @@ status_t layer_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -497,7 +479,7 @@ status_t layer_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/layer_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.hpp
@@ -73,12 +73,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -87,10 +89,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(layer_norm_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(layer_norm_fwd_t)
 };
 
@@ -128,12 +132,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -142,6 +148,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
@@ -151,6 +158,7 @@ public:
     }
 
     DEF_KERNEL_METHOD_STR(layer_norm_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(layer_norm_bwd_t)
 };
 #endif

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -95,7 +95,7 @@ void logsoftmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t logsoftmax_fwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -103,19 +103,16 @@ status_t logsoftmax_fwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -123,7 +120,7 @@ status_t logsoftmax_fwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -136,13 +133,10 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -150,7 +144,7 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -161,7 +155,7 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t logsoftmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -173,13 +167,10 @@ status_t logsoftmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -187,7 +178,7 @@ status_t logsoftmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -262,7 +253,7 @@ void logsoftmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t logsoftmax_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -270,19 +261,16 @@ status_t logsoftmax_bwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -290,7 +278,7 @@ status_t logsoftmax_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -303,13 +291,10 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -317,7 +302,7 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -328,7 +313,7 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t logsoftmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -340,13 +325,10 @@ status_t logsoftmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -354,7 +336,7 @@ status_t logsoftmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/log_softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.hpp
@@ -75,12 +75,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -89,10 +91,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(logsoftmax_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(logsoftmax_fwd_t)
 };
 
@@ -130,12 +134,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -144,6 +150,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
@@ -153,6 +160,7 @@ public:
     }
 
     DEF_KERNEL_METHOD_STR(logsoftmax_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(logsoftmax_bwd_t)
 };
 #endif

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -193,7 +193,7 @@ void matmul_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 template <bool quantized>
 status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -201,12 +201,9 @@ status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -253,7 +250,7 @@ status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -262,7 +259,7 @@ status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -275,13 +272,10 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -330,7 +324,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -342,7 +336,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t matmul_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -354,13 +348,10 @@ status_t matmul_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -409,7 +400,7 @@ status_t matmul_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/matmul.hpp
+++ b/src/graph/backend/dnnl/kernels/matmul.hpp
@@ -75,12 +75,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -89,6 +91,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
@@ -98,6 +101,7 @@ public:
     }
 
     DEF_KERNEL_METHOD_STR(matmul_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(matmul_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/mqa.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa.hpp
@@ -79,18 +79,20 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override {
-        return kernel->execute_impl(g_stream, inputs, outputs);
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override {
+        return kernel->execute_impl(g_stream, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        return kernel->sycl_execute_impl(
-                g_stream, inputs, outputs, sycl_deps, sycl_event);
+        return kernel->sycl_execute_impl(g_stream, inputs, outputs,
+                scratchpad_buf, sycl_deps, sycl_event);
     }
 #endif
 
@@ -98,12 +100,17 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const std::vector<cl_event> &deps, cl_event *event) override {
-        return kernel->ocl_execute_impl(g_stream, inputs, outputs, deps, event);
+            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
+            cl_event *event) override {
+        return kernel->ocl_execute_impl(
+                g_stream, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 
     std::string str() const override { return kernel->str(); }
+    size_t get_scratchpad_size() const override {
+        return kernel->get_scratchpad_size();
+    }
 };
 } // namespace dnnl_impl
 } // namespace graph

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -157,7 +157,7 @@ void mqa_decomp_kernel_t<quantized, dt>::prepare_sub_args(
 template <bool quantized, memory::data_type dt>
 status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
         const stream_t *g_stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream strm = make_dnnl_stream(p_engine_, *g_stream);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
@@ -192,10 +192,8 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
 
     // allocate the internal memory
     size_t block_size = mqa_registry_.size();
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
-            block_size * mqa_cfg_.nthr, p_engine_, *g_alloc_);
-    assertm(scratchpad->size() >= mqa_registry_.size(),
-            "no enough scratchpad memory");
+    auto scratchpad = std::make_shared<scratchpad_t>(
+            scratchpad_buf, block_size * mqa_cfg_.nthr, p_engine_, *g_alloc_);
     grantor_t var_grantor = mqa_registry_.grantor(scratchpad->get_buffer());
 
     const auto get_mem_dt_size = [](const memory &m) -> size_t {
@@ -288,7 +286,7 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
     tp_stream->after_exec_hook();
 #endif
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
@@ -78,7 +78,8 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
     class mqa_args_set_t {
     public:
@@ -138,6 +139,7 @@ public:
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
         UNUSED(g_stream);
@@ -153,6 +155,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps,
             cl_event *ret_event) override {
         UNUSED(g_stream);
@@ -165,6 +168,9 @@ public:
 #endif
 
     DEF_KERNEL_METHOD_STR(mqa_decomp_kernel_t)
+    size_t get_scratchpad_size() const override {
+        return mqa_registry_.size() * mqa_cfg_.nthr;
+    }
     DNNL_DISALLOW_COPY_AND_ASSIGN(mqa_decomp_kernel_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -152,7 +152,7 @@ void pooling_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 template <bool quantized>
 status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -160,12 +160,9 @@ status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -212,7 +209,7 @@ status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -221,7 +218,7 @@ status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -234,13 +231,10 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -289,7 +283,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -301,7 +295,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t pooling_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -313,13 +307,10 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -368,7 +359,7 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -453,7 +444,7 @@ void pooling_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t pooling_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -461,12 +452,9 @@ status_t pooling_bwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -474,7 +462,7 @@ status_t pooling_bwd_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -482,7 +470,7 @@ status_t pooling_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -495,13 +483,10 @@ status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -510,7 +495,7 @@ status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -521,7 +506,7 @@ status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t pooling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -533,13 +518,10 @@ status_t pooling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -548,7 +530,7 @@ status_t pooling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/pool.hpp
+++ b/src/graph/backend/dnnl/kernels/pool.hpp
@@ -75,12 +75,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -89,10 +91,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(pooling_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(pooling_fwd_t)
 };
 
@@ -133,12 +137,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -147,10 +153,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(pooling_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(pooling_bwd_t)
 };
 #endif

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -111,7 +111,7 @@ void prelu_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 template <bool quantized>
 status_t prelu_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -119,19 +119,16 @@ status_t prelu_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -140,7 +137,7 @@ status_t prelu_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -153,13 +150,10 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -167,7 +161,7 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -179,7 +173,7 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t prelu_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -191,13 +185,10 @@ status_t prelu_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -205,7 +196,7 @@ status_t prelu_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -282,7 +273,7 @@ void prelu_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t prelu_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -290,19 +281,16 @@ status_t prelu_bwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -310,7 +298,7 @@ status_t prelu_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -323,13 +311,10 @@ status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -337,7 +322,7 @@ status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -348,7 +333,7 @@ status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t prelu_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -360,13 +345,10 @@ status_t prelu_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -374,7 +356,7 @@ status_t prelu_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/prelu.hpp
+++ b/src/graph/backend/dnnl/kernels/prelu.hpp
@@ -73,12 +73,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -87,10 +89,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(prelu_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(prelu_fwd_t)
 };
 
@@ -130,12 +134,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -144,10 +150,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(prelu_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(prelu_bwd_t)
 };
 #endif

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -116,7 +116,7 @@ void quantize_dequantize_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t quantize_dequantize_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -124,12 +124,9 @@ status_t quantize_dequantize_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -176,7 +173,7 @@ status_t quantize_dequantize_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -189,7 +186,7 @@ status_t quantize_dequantize_t::prepare_inplace_pairs_impl() {
 #ifdef DNNL_WITH_SYCL
 status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -202,13 +199,10 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -257,7 +251,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -268,7 +262,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t quantize_dequantize_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -280,13 +274,10 @@ status_t quantize_dequantize_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -335,7 +326,7 @@ status_t quantize_dequantize_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/quantize.hpp
+++ b/src/graph/backend/dnnl/kernels/quantize.hpp
@@ -72,7 +72,8 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
     status_t prepare_inplace_pairs_impl() override;
 
@@ -80,6 +81,7 @@ public:
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -88,10 +90,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(quantize_dequantize_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(quantize_dequantize_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -111,26 +111,23 @@ void reduction_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 template <bool quantized>
 status_t reduction_t<quantized>::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -139,7 +136,7 @@ status_t reduction_t<quantized>::execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -151,13 +148,10 @@ status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -165,7 +159,7 @@ status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -177,7 +171,7 @@ status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t reduction_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -188,13 +182,10 @@ status_t reduction_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -202,7 +193,7 @@ status_t reduction_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/reduction.hpp
+++ b/src/graph/backend/dnnl/kernels/reduction.hpp
@@ -73,12 +73,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -87,6 +89,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
@@ -96,6 +99,7 @@ public:
     }
 
     DEF_KERNEL_METHOD_STR(reduction_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(reduction_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -135,7 +135,7 @@ void reorder_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 template <bool quantized>
 status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -143,12 +143,9 @@ status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -195,7 +192,7 @@ status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -204,7 +201,7 @@ status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -217,13 +214,10 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -272,7 +266,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -284,7 +278,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 template <bool quantized>
 status_t reorder_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -296,13 +290,10 @@ status_t reorder_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -351,7 +342,7 @@ status_t reorder_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/reorder.hpp
+++ b/src/graph/backend/dnnl/kernels/reorder.hpp
@@ -75,12 +75,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -89,6 +91,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
@@ -98,6 +101,7 @@ public:
     }
 
     DEF_KERNEL_METHOD_STR(reorder_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(reorder_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -114,26 +114,23 @@ void resampling_fwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t resampling_fwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -141,7 +138,7 @@ status_t resampling_fwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -153,13 +150,10 @@ status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -167,7 +161,7 @@ status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -178,7 +172,7 @@ status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t resampling_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -189,13 +183,10 @@ status_t resampling_fwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -203,7 +194,7 @@ status_t resampling_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -277,26 +268,23 @@ void resampling_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t resampling_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -304,7 +292,7 @@ status_t resampling_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -316,13 +304,10 @@ status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -330,7 +315,7 @@ status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -341,7 +326,7 @@ status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t resampling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -352,13 +337,10 @@ status_t resampling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -366,7 +348,7 @@ status_t resampling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/resampling.hpp
+++ b/src/graph/backend/dnnl/kernels/resampling.hpp
@@ -77,12 +77,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -91,10 +93,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(resampling_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(resampling_fwd_t)
 };
 
@@ -132,12 +136,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -146,10 +152,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(resampling_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(resampling_bwd_t)
 };
 #endif

--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -113,18 +113,20 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override {
-        return kernel->execute_impl(g_stream, inputs, outputs);
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override {
+        return kernel->execute_impl(g_stream, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        return kernel->sycl_execute_impl(
-                g_stream, inputs, outputs, sycl_deps, sycl_event);
+        return kernel->sycl_execute_impl(g_stream, inputs, outputs,
+                scratchpad_buf, sycl_deps, sycl_event);
     }
 #endif
 
@@ -132,12 +134,17 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const std::vector<cl_event> &deps, cl_event *event) override {
-        return kernel->ocl_execute_impl(g_stream, inputs, outputs, deps, event);
+            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
+            cl_event *event) override {
+        return kernel->ocl_execute_impl(
+                g_stream, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 
     std::string str() const override { return kernel->str(); }
+    size_t get_scratchpad_size() const override {
+        return kernel->get_scratchpad_size();
+    }
 };
 } // namespace dnnl_impl
 } // namespace graph

--- a/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
@@ -86,18 +86,20 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override {
-        return kernel->execute_impl(g_stream, inputs, outputs);
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override {
+        return kernel->execute_impl(g_stream, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        return kernel->sycl_execute_impl(
-                g_stream, inputs, outputs, sycl_deps, sycl_event);
+        return kernel->sycl_execute_impl(g_stream, inputs, outputs,
+                scratchpad_buf, sycl_deps, sycl_event);
     }
 #endif
 
@@ -105,12 +107,17 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const std::vector<cl_event> &deps, cl_event *event) override {
-        return kernel->ocl_execute_impl(g_stream, inputs, outputs, deps, event);
+            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
+            cl_event *event) override {
+        return kernel->ocl_execute_impl(
+                g_stream, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 
     std::string str() const override { return kernel->str(); }
+    size_t get_scratchpad_size() const override {
+        return kernel->get_scratchpad_size();
+    }
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -156,17 +156,17 @@ void sdp_bwd_primitive_kernel_t::prepare_args_set(
 
 status_t sdp_bwd_primitive_kernel_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
@@ -178,7 +178,7 @@ status_t sdp_bwd_primitive_kernel_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 // sdp_bwd_primitive_kernel_t only supports Intel GPU.
@@ -193,10 +193,10 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -205,7 +205,7 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -216,7 +216,7 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
     auto deps = cl_deps;
     cl_event returned_event {};
@@ -227,10 +227,10 @@ status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -239,7 +239,7 @@ status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
@@ -70,12 +70,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -84,6 +86,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
@@ -92,6 +95,7 @@ public:
             const std::vector<logical_tensor_t> &outputs);
 
     DEF_KERNEL_METHOD_STR(sdp_bwd_primitive_kernel_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(sdp_bwd_primitive_kernel_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -162,7 +162,7 @@ void sdp_decomp_kernel_t<quantized, dt>::prepare_sub_args(
 template <bool quantized, memory::data_type dt>
 status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
         const stream_t *g_stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream strm = make_dnnl_stream(p_engine_, *g_stream);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
@@ -194,10 +194,8 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
     char *dst2_user_pointer = static_cast<char *>(outputs[0].get_data_handle());
 
     size_t block_size = sdp_registry_.size();
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
-            block_size * sdp_cfg_.nthr, p_engine_, *g_alloc_);
-    assertm(scratchpad->size() >= sdp_registry_.size(),
-            "no enough scratchpad memory");
+    auto scratchpad = std::make_shared<scratchpad_t>(
+            scratchpad_buf, block_size * sdp_cfg_.nthr, p_engine_, *g_alloc_);
     grantor_t var_grantor = sdp_registry_.grantor(scratchpad->get_buffer());
 
     const auto get_mem_dt_size = [](const memory &m) -> size_t {
@@ -413,7 +411,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
     tp_stream->after_exec_hook();
 #endif
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -82,7 +82,8 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
     class sdp_args_set_t {
     public:
@@ -145,6 +146,7 @@ public:
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
         UNUSED(g_stream);
@@ -160,6 +162,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps,
             cl_event *ret_event) override {
         UNUSED(g_stream);
@@ -172,6 +175,9 @@ public:
 #endif
 
     DEF_KERNEL_METHOD_STR(sdp_decomp_kernel_t)
+    size_t get_scratchpad_size() const override {
+        return sdp_registry_.size() * sdp_cfg_.nthr;
+    }
     DNNL_DISALLOW_COPY_AND_ASSIGN(sdp_decomp_kernel_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -164,17 +164,17 @@ void sdp_primitive_kernel_t<quantized>::prepare_args_set(
 template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::execute_impl(
         const stream_t *g_stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
@@ -187,7 +187,7 @@ status_t sdp_primitive_kernel_t<quantized>::execute_impl(
 template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
         const stream_t *g_stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 // sdp_primitive_kernel_t only supports Intel GPU.
@@ -202,10 +202,10 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -214,7 +214,7 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -226,7 +226,7 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
 template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(
         const stream_t *g_stream, const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
     auto deps = cl_deps;
     cl_event returned_event {};
@@ -237,10 +237,10 @@ status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -250,7 +250,7 @@ status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
@@ -75,12 +75,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -89,10 +91,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(sdp_primitive_kernel_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(sdp_primitive_kernel_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -110,19 +110,16 @@ void shuffle_fwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t shuffle_fwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -130,7 +127,7 @@ status_t shuffle_fwd_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -138,7 +135,7 @@ status_t shuffle_fwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -150,13 +147,10 @@ status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -165,7 +159,7 @@ status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -176,7 +170,7 @@ status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t shuffle_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -187,13 +181,10 @@ status_t shuffle_fwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         if (subgraph_->is_constant_[i]) continue;
@@ -202,7 +193,7 @@ status_t shuffle_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/shuffle.hpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.hpp
@@ -72,12 +72,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -86,10 +88,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(shuffle_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(shuffle_fwd_t)
 };
 

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -120,7 +120,7 @@ void softmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -128,12 +128,9 @@ status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -180,7 +177,7 @@ status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -188,7 +185,7 @@ status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -201,13 +198,10 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -256,7 +250,7 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -267,7 +261,7 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t softmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -279,13 +273,10 @@ status_t softmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
     if (enabled_constant_cache()) {
@@ -334,7 +325,7 @@ status_t softmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps = {returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;
@@ -409,7 +400,7 @@ void softmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t softmax_bwd_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -417,19 +408,16 @@ status_t softmax_bwd_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -437,7 +425,7 @@ status_t softmax_bwd_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -450,13 +438,10 @@ status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -464,7 +449,7 @@ status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -475,7 +460,7 @@ status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t softmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -487,13 +472,10 @@ status_t softmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -501,7 +483,7 @@ status_t softmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/softmax.hpp
@@ -77,12 +77,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -91,10 +93,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(softmax_fwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(softmax_fwd_t)
 };
 
@@ -132,12 +136,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -146,6 +152,7 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
@@ -155,6 +162,7 @@ public:
     }
 
     DEF_KERNEL_METHOD_STR(softmax_bwd_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(softmax_bwd_t)
 };
 #endif

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -110,7 +110,7 @@ void sum_t::prepare_args_set(const execution_args_set_t *res,
 
 status_t sum_t::execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) {
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -118,19 +118,16 @@ status_t sum_t::execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    auto scratchpad = std::make_shared<temporary_scratchpad_t>(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad->size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_temporary_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(g_stream, scratchpad);
 
     return status::success;
 }
@@ -138,7 +135,7 @@ status_t sum_t::execute_impl(const stream_t *g_stream,
 #ifdef DNNL_WITH_SYCL
 status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
@@ -151,13 +148,10 @@ status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
@@ -165,7 +159,7 @@ status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
         if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    scratchpad->set_deps(returned_event ? *returned_event : ::sycl::event {});
     if (sycl_event)
         *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
@@ -176,7 +170,7 @@ status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 status_t sum_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
@@ -188,13 +182,10 @@ status_t sum_t::ocl_execute_impl(const stream_t *g_stream,
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
-    temporary_scratchpad_t scratchpad(
+    auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
             memory_planner_.total_internal_temporary_size(), p_engine_,
             *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
@@ -202,7 +193,7 @@ status_t sum_t::ocl_execute_impl(const stream_t *g_stream,
         deps.assign(1, returned_event);
     }
 
-    scratchpad.set_deps(returned_event);
+    scratchpad->set_deps(returned_event);
     if (ret_event) *ret_event = returned_event;
 
     return status::success;

--- a/src/graph/backend/dnnl/kernels/sum.hpp
+++ b/src/graph/backend/dnnl/kernels/sum.hpp
@@ -73,12 +73,14 @@ public:
 
     status_t execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs) override;
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
     status_t sycl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override;
 #endif
@@ -87,10 +89,12 @@ public:
     status_t ocl_execute_impl(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(sum_t)
+    DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()
     DNNL_DISALLOW_COPY_AND_ASSIGN(sum_t)
 };
 

--- a/src/graph/backend/dnnl/scratchpad.cpp
+++ b/src/graph/backend/dnnl/scratchpad.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "graph/interface/tensor.hpp"
+
+#include "graph/backend/dnnl/scratchpad.hpp"
+
+#include "common/stream.hpp"
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "cpu/cpu_stream.hpp"
+#endif
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+scratchpad_t::scratchpad_t(const tensor_t *user_buf, size_t size,
+        const dnnl::engine &eng, const allocator_t &alloc)
+    : buffer_(nullptr)
+    , size_(size)
+    , user_managed_(user_buf != nullptr)
+    , eng_(&eng)
+    , alloc_(&alloc)
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    , ocl_e_(nullptr)
+#endif
+{
+    if (user_buf) {
+        buffer_ = reinterpret_cast<char *>(user_buf->get_data_handle());
+    } else if (size > 0) {
+        buffer_ = reinterpret_cast<char *>(dnnl_allocator_t::malloc(
+                size, eng, &alloc, allocator_t::mem_type_t::temp));
+        if (!buffer_) { size_ = 0; }
+    }
+}
+
+scratchpad_t::~scratchpad_t() {
+    if (user_managed_) return;
+    if (eng_->get_kind() == dnnl::engine::kind::cpu) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
+        dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
+#else
+        dnnl_allocator_t::free(buffer_, *eng_, alloc_);
+#endif
+    } else if (eng_->get_kind() == dnnl::engine::kind::gpu) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+        dnnl_allocator_t::free(buffer_, *eng_, alloc_, ocl_e_);
+#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+        dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
+#else
+        assert(!"unsupport gpu runtime");
+#endif
+    }
+}
+
+void prolong_scratchpad_lifetime(const stream_t *g_stream,
+        const std::shared_ptr<scratchpad_t> &scratchpad) {
+    if (scratchpad->is_user_managed()) return;
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    auto *tp_stream
+            = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
+                    const_cast<stream_t *>(g_stream));
+    tp_stream->before_exec_hook();
+
+    parallel(1, [=](int, int) { UNUSED(scratchpad); });
+
+    tp_stream->after_exec_hook();
+#endif
+}
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl

--- a/src/graph/backend/dnnl/scratchpad.hpp
+++ b/src/graph/backend/dnnl/scratchpad.hpp
@@ -35,72 +35,40 @@ namespace impl {
 namespace graph {
 namespace dnnl_impl {
 
+// Unified scratchpad class that handles both library-managed (temporary) and
+// user-provided buffer modes. When user_buf is non-null, the buffer lifecycle
+// is managed by the user; otherwise the library allocates and frees the buffer.
 class scratchpad_t {
 public:
-    virtual ~scratchpad_t() = default;
-    virtual char *get_buffer() const = 0;
-    virtual size_t size() const = 0;
-};
+    scratchpad_t(const tensor_t *user_buf, size_t size, const dnnl::engine &eng,
+            const allocator_t &alloc);
 
-// The buffer is allocated when creating the temporary_scratchpad_t and
-// deallocated when destroying the temporary_scratchpad_t
-class temporary_scratchpad_t : public scratchpad_t {
-public:
-    temporary_scratchpad_t(
-            size_t size, const dnnl::engine &eng, const allocator_t &alloc)
-        : buffer_(nullptr)
-        , size_(size)
-        , eng_(&eng)
-        , alloc_(&alloc)
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        , ocl_e_(nullptr)
-#endif
-    {
-        if (size > 0) {
-            buffer_ = reinterpret_cast<char *>(dnnl_allocator_t::malloc(
-                    size, eng, &alloc, allocator_t::mem_type_t::temp));
-        }
-        if (!buffer_) { size_ = 0; }
-    }
-
-    ~temporary_scratchpad_t() override {
-        if (eng_->get_kind() == dnnl::engine::kind::cpu) {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-            dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
-#else
-            dnnl_allocator_t::free(buffer_, *eng_, alloc_);
-#endif
-        } else if (eng_->get_kind() == dnnl::engine::kind::gpu) {
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-            dnnl_allocator_t::free(buffer_, *eng_, alloc_, ocl_e_);
-#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-            dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
-#else
-            assert(!"unsupport gpu runtime");
-#endif
-        }
-        size_ = 0;
-    }
+    ~scratchpad_t();
 
     // Disable assignment and copy
-    temporary_scratchpad_t(const temporary_scratchpad_t &) = delete;
-    temporary_scratchpad_t &operator=(const temporary_scratchpad_t &) = delete;
+    scratchpad_t(const scratchpad_t &) = delete;
+    scratchpad_t &operator=(const scratchpad_t &) = delete;
 
-    char *get_buffer() const override { return buffer_; }
-
-    size_t size() const override { return size_; }
+    char *get_buffer() const { return buffer_; }
+    size_t size() const { return size_; }
+    bool is_user_managed() const { return user_managed_; }
 
 #ifdef DNNL_WITH_SYCL
-    void set_deps(::sycl::event event) { e_ = std::move(event); }
+    void set_deps(::sycl::event event) {
+        if (!user_managed_) e_ = std::move(event);
+    }
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    void set_deps(cl_event event) { ocl_e_ = event; }
+    void set_deps(cl_event event) {
+        if (!user_managed_) ocl_e_ = event;
+    }
 #endif
 
 private:
     char *buffer_;
     size_t size_;
+    bool user_managed_;
     const dnnl::engine *eng_;
     const allocator_t *alloc_;
 #ifdef DNNL_WITH_SYCL
@@ -111,6 +79,14 @@ private:
     cl_event ocl_e_;
 #endif
 };
+
+// This function artificially extends the `scratchpad_t` object's lifetime to
+// keep alive the handle this scratchpad object manages. An alternative approach
+// is to manage its handles through a system of caches the same way it's done
+// for memory objects before they are passed into a primitive execute call.
+// No-op if the scratchpad is user-managed.
+void prolong_scratchpad_lifetime(const stream_t *g_stream,
+        const std::shared_ptr<scratchpad_t> &scratchpad);
 
 class registrar_t;
 class grantor_t;

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -343,8 +343,9 @@ status_t DNNL_API dnnl_graph_compiled_partition_execute_v2(
         CHECK(compiled_partition->execute(stream, ins, outs, scratchpad));
         if (block_on_wait) stream->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
-        VPROF(start_ms, graph, exec, VERBOSE_profile,
-                compiled_partition->info(), duration_ms);
+        auto info = compiled_partition->exec_info(scratchpad != nullptr);
+        VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
+                duration_ms);
     } else {
         CHECK(compiled_partition->execute(stream, ins, outs, scratchpad));
     }
@@ -402,8 +403,9 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
         }
         stream->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
-        VPROF(start_ms, graph, exec, VERBOSE_profile,
-                compiled_partition->info(), duration_ms);
+        auto info = compiled_partition->exec_info(scratchpad != nullptr);
+        VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
+                duration_ms);
     } else {
         if (deps != nullptr) {
             const auto &sycl_deps = *(const std::vector<::sycl::event> *)deps;
@@ -477,8 +479,9 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute_v2(
         }
         stream->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
-        VPROF(start_ms, graph, exec, VERBOSE_profile,
-                compiled_partition->info(), duration_ms);
+        auto info = compiled_partition->exec_info(scratchpad != nullptr);
+        VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
+                duration_ms);
     } else {
         if (deps != nullptr) {
             std::vector<cl_event> ocl_deps(deps, deps + ndeps);

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -305,9 +305,16 @@ status_t DNNL_API dnnl_graph_compiled_partition_execute(
         const compiled_partition_t *compiled_partition, stream_t *stream,
         size_t num_inputs, const tensor_t **inputs, size_t num_outputs,
         const tensor_t **outputs) {
-    if (utils::any_null(stream, compiled_partition, inputs, outputs)) {
+    return dnnl_graph_compiled_partition_execute_v2(compiled_partition, stream,
+            num_inputs, inputs, num_outputs, outputs, nullptr);
+}
+
+status_t DNNL_API dnnl_graph_compiled_partition_execute_v2(
+        const compiled_partition_t *compiled_partition, stream_t *stream,
+        size_t num_inputs, const tensor_t **inputs, size_t num_outputs,
+        const tensor_t **outputs, const tensor_t *scratchpad) {
+    if (utils::any_null(stream, compiled_partition, inputs, outputs))
         return status::invalid_arguments;
-    }
 
     std::vector<tensor_t> ins, outs;
     ins.reserve(num_inputs);
@@ -333,13 +340,13 @@ status_t DNNL_API dnnl_graph_compiled_partition_execute(
 #endif
         if (block_on_wait) stream->wait();
         double start_ms = dnnl::impl::get_msec();
-        CHECK(compiled_partition->execute(stream, ins, outs));
+        CHECK(compiled_partition->execute(stream, ins, outs, scratchpad));
         if (block_on_wait) stream->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
         VPROF(start_ms, graph, exec, VERBOSE_profile,
                 compiled_partition->info(), duration_ms);
     } else {
-        CHECK(compiled_partition->execute(stream, ins, outs));
+        CHECK(compiled_partition->execute(stream, ins, outs, scratchpad));
     }
     return status::success;
 }
@@ -348,6 +355,16 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute(
         const compiled_partition_t *compiled_partition, stream_t *stream,
         size_t num_inputs, const tensor_t **inputs, size_t num_outputs,
         const tensor_t **outputs, const void *deps, void *sycl_event) {
+    return dnnl_graph_sycl_interop_compiled_partition_execute_v2(
+            compiled_partition, stream, num_inputs, inputs, num_outputs,
+            outputs, nullptr, deps, sycl_event);
+}
+
+status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
+        const compiled_partition_t *compiled_partition, stream_t *stream,
+        size_t num_inputs, const tensor_t **inputs, size_t num_outputs,
+        const tensor_t **outputs, const tensor_t *scratchpad, const void *deps,
+        void *sycl_event) {
 #ifdef DNNL_WITH_SYCL
     if (utils::any_null(stream, compiled_partition, inputs, outputs))
         return status::invalid_arguments;
@@ -376,11 +393,12 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute(
         double start_ms = dnnl::impl::get_msec();
         if (deps != nullptr) {
             const auto &sycl_deps = *(const std::vector<::sycl::event> *)deps;
-            CHECK(compiled_partition->execute_sycl(stream, ins, outs, sycl_deps,
+            CHECK(compiled_partition->execute_sycl(stream, ins, outs,
+                    scratchpad, sycl_deps,
                     static_cast<::sycl::event *>(sycl_event)));
         } else {
-            CHECK(compiled_partition->execute_sycl(stream, ins, outs, {},
-                    static_cast<::sycl::event *>(sycl_event)));
+            CHECK(compiled_partition->execute_sycl(stream, ins, outs,
+                    scratchpad, {}, static_cast<::sycl::event *>(sycl_event)));
         }
         stream->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
@@ -389,11 +407,12 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute(
     } else {
         if (deps != nullptr) {
             const auto &sycl_deps = *(const std::vector<::sycl::event> *)deps;
-            CHECK(compiled_partition->execute_sycl(stream, ins, outs, sycl_deps,
+            CHECK(compiled_partition->execute_sycl(stream, ins, outs,
+                    scratchpad, sycl_deps,
                     static_cast<::sycl::event *>(sycl_event)));
         } else {
-            CHECK(compiled_partition->execute_sycl(stream, ins, outs, {},
-                    static_cast<::sycl::event *>(sycl_event)));
+            CHECK(compiled_partition->execute_sycl(stream, ins, outs,
+                    scratchpad, {}, static_cast<::sycl::event *>(sycl_event)));
         }
     }
 
@@ -405,6 +424,7 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute(
     UNUSED(inputs);
     UNUSED(num_outputs);
     UNUSED(outputs);
+    UNUSED(scratchpad);
     UNUSED(deps);
     UNUSED(sycl_event);
     return status::unimplemented;
@@ -417,6 +437,16 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute(
         size_t num_inputs, const tensor_t **inputs, size_t num_outputs,
         const tensor_t **outputs, const cl_event *deps, int ndeps,
         cl_event *ocl_event) {
+    return dnnl_graph_ocl_interop_compiled_partition_execute_v2(
+            compiled_partition, stream, num_inputs, inputs, num_outputs,
+            outputs, nullptr, deps, ndeps, ocl_event);
+}
+
+status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute_v2(
+        const compiled_partition_t *compiled_partition, stream_t *stream,
+        size_t num_inputs, const tensor_t **inputs, size_t num_outputs,
+        const tensor_t **outputs, const tensor_t *scratchpad,
+        const cl_event *deps, int ndeps, cl_event *ocl_event) {
     if (utils::any_null(stream, compiled_partition, inputs, outputs))
         return status::invalid_arguments;
     if (stream->engine()->kind() != engine_kind::gpu) {
@@ -440,10 +470,10 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute(
         if (deps != nullptr) {
             std::vector<cl_event> ocl_deps(deps, deps + ndeps);
             CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, ocl_deps, ocl_event));
+                    stream, ins, outs, scratchpad, ocl_deps, ocl_event));
         } else {
             CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, {}, ocl_event));
+                    stream, ins, outs, scratchpad, {}, ocl_event));
         }
         stream->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
@@ -453,10 +483,10 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute(
         if (deps != nullptr) {
             std::vector<cl_event> ocl_deps(deps, deps + ndeps);
             CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, ocl_deps, ocl_event));
+                    stream, ins, outs, scratchpad, ocl_deps, ocl_event));
         } else {
             CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, {}, ocl_event));
+                    stream, ins, outs, scratchpad, {}, ocl_event));
         }
     }
 
@@ -487,6 +517,26 @@ status_t DNNL_API dnnl_graph_compiled_partition_get_inplace_ports(
     const auto &cp_inplace_pairs = compiled_partition->get_inplace_pairs();
     *num_inplace_pairs = cp_inplace_pairs.size();
     *inplace_pairs = cp_inplace_pairs.data();
+
+    return status::success;
+}
+
+status_t DNNL_API dnnl_graph_compiled_partition_get_scratchpad_logical_tensor(
+        const compiled_partition_t *compiled_partition, logical_tensor_t *lt) {
+    if (utils::any_null(compiled_partition, lt))
+        return status::invalid_arguments;
+
+    const size_t scratchpad_size = compiled_partition->get_scratchpad_size();
+
+    // Build a 1-D logical tensor with data_type u8 and strided layout
+    *lt = logical_tensor_t();
+    lt->id = std::numeric_limits<size_t>::max();
+    lt->ndims = 1;
+    lt->dims[0] = static_cast<dnnl_dim_t>(scratchpad_size);
+    lt->data_type = data_type::u8;
+    lt->property = property_type::variable;
+    lt->layout_type = layout_type::strided;
+    lt->layout.strides[0] = 1;
 
     return status::success;
 }
@@ -692,18 +742,19 @@ status_t dnnl_graph_partition::compile(
 
 status_t dnnl_graph_compiled_partition::execute(const stream_t *astream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs) const {
+        const std::vector<tensor_t> &outputs,
+        const tensor_t *scratchpad) const {
     if (astream->engine()->kind() == engine_kind::gpu) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-        return execute_sycl(astream, inputs, outputs, {}, nullptr);
+        return execute_sycl(astream, inputs, outputs, scratchpad, {}, nullptr);
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        return execute_ocl(astream, inputs, outputs, {}, nullptr);
+        return execute_ocl(astream, inputs, outputs, scratchpad, {}, nullptr);
 #else
         return status::runtime_error;
 #endif
     } else {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-        return execute_sycl(astream, inputs, outputs, {}, nullptr);
+        return execute_sycl(astream, inputs, outputs, scratchpad, {}, nullptr);
 #else
         // TODO(xxx): need to improve the check of two engines. On dev-graph, there
         // is a match function.
@@ -721,7 +772,8 @@ status_t dnnl_graph_compiled_partition::execute(const stream_t *astream,
         pre_process(processed_inputs, inputs, backend);
         pre_process(processed_outputs, outputs, backend);
 
-        return pimpl_->execute(astream, processed_inputs, processed_outputs);
+        return pimpl_->execute(
+                astream, processed_inputs, processed_outputs, scratchpad);
 #endif
     }
 }
@@ -729,15 +781,13 @@ status_t dnnl_graph_compiled_partition::execute(const stream_t *astream,
 #ifdef DNNL_WITH_SYCL
 status_t dnnl_graph_compiled_partition::execute_sycl(const stream_t *astream,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) const {
     // TODO(xxx): need to improve the check of two engines. On dev-graph, there
     // is a match function.
     if (!astream || (astream->engine()->kind() != pimpl_->get_engine()->kind()))
         return status::invalid_arguments;
-
-    status_t ret;
 
     const backend_t *backend = src_partition_.get_assigned_backend();
     if (!backend) return status::invalid_arguments;
@@ -748,10 +798,8 @@ status_t dnnl_graph_compiled_partition::execute_sycl(const stream_t *astream,
     pre_process(processed_inputs, inputs, backend);
     pre_process(processed_outputs, outputs, backend);
 
-    ret = pimpl_->execute_sycl(astream, processed_inputs, processed_outputs,
-            sycl_deps, sycl_event);
-
-    return ret;
+    return pimpl_->execute_sycl(astream, processed_inputs, processed_outputs,
+            scratchpad, sycl_deps, sycl_event);
 }
 #endif // DNNL_WITH_SYCL
 
@@ -762,11 +810,10 @@ graph::status_t dnnl_graph_compiled_partition::execute_ocl(
         const graph::stream_t *astream,
         const std::vector<graph::tensor_t> &inputs,
         const std::vector<graph::tensor_t> &outputs,
+        const graph::tensor_t *scratchpad,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) const {
     if (!astream || (astream->engine()->kind() != pimpl_->get_engine()->kind()))
         return status::invalid_arguments;
-
-    status_t ret;
 
     const backend_t *backend = src_partition_.get_assigned_backend();
     if (!backend) return status::invalid_arguments;
@@ -775,9 +822,7 @@ graph::status_t dnnl_graph_compiled_partition::execute_ocl(
     pre_process(processed_inputs, inputs, backend);
     pre_process(processed_outputs, outputs, backend);
 
-    ret = pimpl_->execute_ocl(
-            astream, processed_inputs, processed_outputs, ocl_deps, ocl_event);
-
-    return ret;
+    return pimpl_->execute_ocl(astream, processed_inputs, processed_outputs,
+            scratchpad, ocl_deps, ocl_event);
 }
 #endif

--- a/src/graph/interface/partition.hpp
+++ b/src/graph/interface/partition.hpp
@@ -236,6 +236,21 @@ public:
         return info_.c_str();
     }
 
+    // Returns verbose info string with scratchpad mode (user/library)
+    // inserted at execution time.
+    std::string exec_info(bool user_scratchpad) const {
+        std::string s(info());
+        // Replace "scratchpad:" with "scratchpad:user:" or
+        // "scratchpad:library:" to indicate runtime management mode.
+        auto pos = s.find(",scratchpad:");
+        if (pos != std::string::npos) {
+            // Insert mode after "scratchpad:"
+            size_t insert_at = pos + sizeof(",scratchpad:") - 1;
+            s.insert(insert_at, user_scratchpad ? "user:" : "library:");
+        }
+        return s;
+    }
+
 private:
     std::shared_ptr<graph::compiled_partition_impl_t> pimpl_;
 

--- a/src/graph/interface/partition.hpp
+++ b/src/graph/interface/partition.hpp
@@ -178,12 +178,14 @@ public:
 
     graph::status_t execute(const graph::stream_t *astream,
             const std::vector<graph::tensor_t> &inputs,
-            const std::vector<graph::tensor_t> &outputs) const;
+            const std::vector<graph::tensor_t> &outputs,
+            const graph::tensor_t *scratchpad = nullptr) const;
 
 #ifdef DNNL_WITH_SYCL
     graph::status_t execute_sycl(const graph::stream_t *astream,
             const std::vector<graph::tensor_t> &inputs,
             const std::vector<graph::tensor_t> &outputs,
+            const graph::tensor_t *scratchpad,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) const;
 #endif
@@ -192,8 +194,14 @@ public:
     graph::status_t execute_ocl(const graph::stream_t *astream,
             const std::vector<graph::tensor_t> &inputs,
             const std::vector<graph::tensor_t> &outputs,
-            const std::vector<cl_event> &sycl_deps, cl_event *sycl_event) const;
+            const graph::tensor_t *scratchpad,
+            const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) const;
 #endif
+
+    size_t get_scratchpad_size() const {
+        if (!pimpl_) return 0;
+        return pimpl_->get_scratchpad_size();
+    }
 
     graph::status_t query_logical_tensor(
             size_t tid, graph::logical_tensor_t *lt) const {

--- a/src/graph/interface/partition_impl.hpp
+++ b/src/graph/interface/partition_impl.hpp
@@ -351,13 +351,13 @@ public:
     ///     implemented outside oneDNN Graph.
     virtual status_t execute(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs)
+            const std::vector<tensor_t> &outputs, const tensor_t *scratchpad)
             = 0;
 
 #ifdef DNNL_WITH_SYCL
     virtual status_t execute_sycl(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs,
+            const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event)
             = 0;
@@ -366,10 +366,13 @@ public:
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     virtual status_t execute_ocl(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs,
+            const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
             const std::vector<cl_event> &ocl_deps, cl_event *ocl_event)
             = 0;
 #endif
+
+    /// Returns the required scratchpad size in bytes.
+    virtual size_t get_scratchpad_size() const = 0;
 
 protected:
     /// The engine which this compiled_partition_impl_t is specialized

--- a/src/graph/utils/verbose.cpp
+++ b/src/graph/utils/verbose.cpp
@@ -221,6 +221,8 @@ std::string init_info_partition(const engine_t *engine,
     ss << ",fpm:" << fpmath_mode2str(fpm.mode_);
     if (fpm.apply_to_int_) ss << ":true";
 
+    ss << ",scratchpad:" << compiled_partition->get_scratchpad_size();
+
     ss << "," << compiled_partition->get_pimpl()->str();
 
     ss << "," << partition.get_assigned_backend()->get_name();

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -632,6 +632,7 @@ int doit(const prb_t *prb, res_t *res) {
     std::unordered_set<size_t> id_to_set_any_layout;
     std::vector<compiled_partition> c_partitions;
     std::vector<std::vector<tensor>> input_ts_all, output_ts_all;
+    std::vector<tensor> scratchpad_ts_all;
     // Extend the partition_mem_map_t's lifecycle as input_ts/output_ts hold the
     // same addresses as in partition_mem_map_t for perf mode
     // TODO: Once the API allocating memory when creating tensors is provided by
@@ -671,6 +672,18 @@ int doit(const prb_t *prb, res_t *res) {
         record_queried_logical_tensors(
                 outputs, c_partitions.back(), id_to_queried_logical_tensors);
     }
+
+    // Allocate scratchpad buffer for each compiled partition.
+    scratchpad_ts_all.reserve(c_partitions.size());
+    for (auto &cp : c_partitions) {
+        auto scratchpad_lt = cp.get_scratchpad_logical_tensor();
+        if (scratchpad_lt.get_mem_size() > 0) {
+            scratchpad_ts_all.emplace_back(scratchpad_lt, eng);
+        } else {
+            scratchpad_ts_all.emplace_back();
+        }
+    }
+
     if (bench_mode == bench_mode_t::init) return res->state = INITIALIZED, OK;
 
     // `idx_offset` points to the correspondent `compiled_partition`, if any
@@ -769,7 +782,8 @@ int doit(const prb_t *prb, res_t *res) {
 
             std::function<void()> record_fn = std::bind(
                     compiled_partition_executor, c_partitions[i - idx_offset],
-                    std::ref(strm), input_ts, output_ts);
+                    std::ref(strm), input_ts, output_ts,
+                    scratchpad_ts_all[i - idx_offset]);
             auto exec = sycl_graph_ctx::record_and_finalize(
                     strm, queue, record_fn, res);
             if (!exec) return FAIL;
@@ -779,8 +793,9 @@ int doit(const prb_t *prb, res_t *res) {
             stream_staller_t staller(strm);
             // Need following clean-up steps as the memories have been mappped
             // to device. Otherwise the deconstruction will fail.
-            DNN_GRAPH_SAFE(c_partitions[i - idx_offset].execute(
-                                   strm, input_ts, output_ts),
+            DNN_GRAPH_SAFE(
+                    c_partitions[i - idx_offset].execute(strm, input_ts,
+                            output_ts, scratchpad_ts_all[i - idx_offset]),
                     (WARN | NEED_CLEANUP), res);
             staller.release();
 
@@ -825,7 +840,7 @@ int doit(const prb_t *prb, res_t *res) {
 
     if (has_bench_mode_bit(mode_bit_t::perf)) {
         SAFE(measure_perf(res->timer_map.perf_timer(), c_partitions,
-                     input_ts_all, output_ts_all, res),
+                     input_ts_all, output_ts_all, scratchpad_ts_all, res),
                 WARN);
     }
 

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -57,41 +57,29 @@ bdnn_state_t convert_state(const dnnl_status_t &s) {
 
 void compiled_partition_executor(dnnl::graph::compiled_partition &cp,
         dnnl::stream &stream, const std::vector<dnnl::graph::tensor> &inputs,
-        const std::vector<dnnl::graph::tensor> &outputs) {
+        const std::vector<dnnl::graph::tensor> &outputs,
+        const dnnl::graph::tensor &scratchpad) {
     if (is_cpu()) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
         dnnl::graph::sycl_interop::execute(cp, stream, inputs,
-                const_cast<std::vector<dnnl::graph::tensor> &>(outputs));
+                const_cast<std::vector<dnnl::graph::tensor> &>(outputs),
+                scratchpad);
 #else
-        cp.execute(stream, inputs, outputs);
+        cp.execute(stream, inputs, outputs, scratchpad);
 #endif
     } else {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
         dnnl::graph::sycl_interop::execute(cp, stream, inputs,
-                const_cast<std::vector<dnnl::graph::tensor> &>(outputs));
+                const_cast<std::vector<dnnl::graph::tensor> &>(outputs),
+                scratchpad);
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
         dnnl::graph::ocl_interop::execute(cp, stream, inputs,
-                const_cast<std::vector<dnnl::graph::tensor> &>(outputs));
+                const_cast<std::vector<dnnl::graph::tensor> &>(outputs),
+                scratchpad);
 #else
         assert(!"unsupported gpu runtime");
 #endif
     }
-}
-
-int execute_and_wait(const std::vector<dnnl::graph::compiled_partition> &cp_v,
-        const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
-        const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
-        res_t *res) {
-    cpp_stream_t stream {get_graph_engine()};
-    for (size_t i = 0; i < cp_v.size(); i++) {
-        perf_function_t perf_func = std::bind(&compiled_partition_executor,
-                cp_v[i], std::placeholders::_1, std::placeholders::_2,
-                std::placeholders::_3);
-        DNN_GRAPH_SAFE(perf_func(stream, inputs_v[i], outputs_v[i]), CRIT, res);
-        DNN_GRAPH_SAFE(stream.wait(), CRIT, res);
-    }
-    res->state = EXECUTED;
-    return OK;
 }
 
 inline dnnl::stream::flags get_profiling_flags() {
@@ -107,7 +95,7 @@ inline int measure_perf_aggregate(timer::timer_t &t,
         std::vector<perf_function_t> &perf_func_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
-        res_t *res) {
+        const std::vector<dnnl::graph::tensor> &scratchpads, res_t *res) {
     const int max_batch_times = 4096;
     // Nvidia/AMD don't support profiling.
     const bool use_profiling = is_gpu() && !is_nvidia_gpu() && !is_amd_gpu();
@@ -121,7 +109,8 @@ inline int measure_perf_aggregate(timer::timer_t &t,
     const auto sz = perf_func_v.size();
     if (!has_bench_mode_bit(mode_bit_t::sim)) {
         for (size_t i = 0; i < sz; i++) {
-            DNN_GRAPH_SAFE(perf_func_v[i](stream, inputs_v[i], outputs_v[i]),
+            DNN_GRAPH_SAFE(perf_func_v[i](stream, inputs_v[i], outputs_v[i],
+                                   scratchpads[i]),
                     WARN, res);
             DNN_GRAPH_SAFE(stream.wait(), WARN, res);
         }
@@ -138,7 +127,8 @@ inline int measure_perf_aggregate(timer::timer_t &t,
     while (true) {
         for_(int i = 0; i < cur_batch_times; i++)
         for (size_t j = 0; j < sz; j++) {
-            DNN_GRAPH_SAFE(perf_func_v[j](stream, inputs_v[j], outputs_v[j]),
+            DNN_GRAPH_SAFE(perf_func_v[j](stream, inputs_v[j], outputs_v[j],
+                                   scratchpads[j]),
                     WARN, res);
         }
         DNN_GRAPH_SAFE(stream.wait(), WARN, res);
@@ -197,7 +187,7 @@ inline int measure_perf_individual(timer::timer_t &t,
         std::vector<perf_function_t> &perf_func_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
-        res_t *res) {
+        const std::vector<dnnl::graph::tensor> &scratchpads, res_t *res) {
     const bool use_profiling = is_gpu() && !is_nvidia_gpu() && !is_amd_gpu();
     const dnnl::stream::flags flags = use_profiling
             ? dnnl::stream::flags::default_flags | get_profiling_flags()
@@ -208,7 +198,8 @@ inline int measure_perf_individual(timer::timer_t &t,
     while (true) {
         auto sz = perf_func_v.size();
         for (size_t i = 0; i < sz; i++) {
-            DNN_GRAPH_SAFE(perf_func_v[i](stream, inputs_v[i], outputs_v[i]),
+            DNN_GRAPH_SAFE(perf_func_v[i](stream, inputs_v[i], outputs_v[i],
+                                   scratchpads[i]),
                     WARN, res);
         }
         t.stamp();
@@ -220,17 +211,17 @@ inline int measure_perf_individual(timer::timer_t &t,
 int measure_perf(timer::timer_t &t, std::vector<perf_function_t> &perf_func_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
-        res_t *res) {
+        const std::vector<dnnl::graph::tensor> &scratchpads, res_t *res) {
     const auto &engine = get_test_engine();
     if (has_bench_mode_bit(mode_bit_t::perf)) {
         // enable GPU profiling, Nvidia/AMD dose not support profiling.
         int ret = OK;
         if (is_async(engine)) {
             ret = measure_perf_aggregate(
-                    t, perf_func_v, inputs_v, outputs_v, res);
+                    t, perf_func_v, inputs_v, outputs_v, scratchpads, res);
         } else {
             ret = measure_perf_individual(
-                    t, perf_func_v, inputs_v, outputs_v, res);
+                    t, perf_func_v, inputs_v, outputs_v, scratchpads, res);
         }
         return ret;
     } else {
@@ -242,16 +233,17 @@ int measure_perf(timer::timer_t &t,
         const std::vector<dnnl::graph::compiled_partition> &cp_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
-        res_t *res) {
+        const std::vector<dnnl::graph::tensor> &scratchpads, res_t *res) {
     std::vector<perf_function_t> perf_func_v;
     perf_func_v.reserve(cp_v.size());
     for (size_t i = 0; i < cp_v.size(); i++) {
         perf_func_v.emplace_back(std::bind(&compiled_partition_executor,
                 cp_v[i], std::placeholders::_1, std::placeholders::_2,
-                std::placeholders::_3));
+                std::placeholders::_3, std::placeholders::_4));
     }
 
-    int status = measure_perf(t, perf_func_v, inputs_v, outputs_v, res);
+    int status = measure_perf(
+            t, perf_func_v, inputs_v, outputs_v, scratchpads, res);
     if (res) res->state = EXECUTED;
 
     return status;

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -126,22 +126,19 @@ enum { CRIT = 0x001, WARN = 0x002, NEED_CLEANUP = 0x004 };
 
 using perf_function_t = std::function<void(dnnl::stream &,
         const std::vector<dnnl::graph::tensor> &inputs,
-        const std::vector<dnnl::graph::tensor> &outputs)>;
+        const std::vector<dnnl::graph::tensor> &outputs,
+        const dnnl::graph::tensor &scratchpad)>;
 
 void compiled_partition_executor(dnnl::graph::compiled_partition &cp,
         dnnl::stream &stream, const std::vector<dnnl::graph::tensor> &inputs,
-        const std::vector<dnnl::graph::tensor> &outputs);
-
-int execute_and_wait(const std::vector<dnnl::graph::compiled_partition> &cp_v,
-        const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
-        const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
-        res_t *res);
+        const std::vector<dnnl::graph::tensor> &outputs,
+        const dnnl::graph::tensor &scratchpad);
 
 int measure_perf(timer::timer_t &t,
         const std::vector<dnnl::graph::compiled_partition> &cp_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
-        res_t *res);
+        const std::vector<dnnl::graph::tensor> &scratchpads, res_t *res);
 
 dnnl::graph::op::kind opstr2kind(const std::string &kind);
 bool is_unary(const std::string &kind);

--- a/tests/gtests/graph/unit/backend/dnnl/test_scratchpad.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_scratchpad.cpp
@@ -32,24 +32,24 @@ namespace graph = dnnl::impl::graph;
 
 TEST(test_scratchpad, TemporaryScratchpad) {
     using dnnl::impl::graph::allocator_t;
-    using dnnl::impl::graph::dnnl_impl::temporary_scratchpad_t;
+    using dnnl::impl::graph::dnnl_impl::scratchpad_t;
 
     graph::engine_t *g_eng = get_engine();
     allocator_t *alloc = static_cast<allocator_t *>(g_eng->get_allocator());
     dnnl::engine p_eng = dnnl::impl::graph::dnnl_impl::make_dnnl_engine(*g_eng);
 
     // No seg fault here because the memory will be deleted when
-    // temporary_scratchpad_t is destroyed
+    // scratchpad_t is destroyed
     std::vector<size_t> buf_sizes = {512, 1024, 2048, 4096};
     for (size_t i = 0; i < buf_sizes.size(); i++) {
-        temporary_scratchpad_t scratchpad(buf_sizes[i], p_eng, *alloc);
+        scratchpad_t scratchpad(nullptr, buf_sizes[i], p_eng, *alloc);
         // the scratchpad size will be changed
         ASSERT_EQ(buf_sizes[i], scratchpad.size());
     }
 
     buf_sizes = {4096, 2048, 1024, 512};
     for (size_t i = 0; i < buf_sizes.size(); i++) {
-        temporary_scratchpad_t scratchpad(buf_sizes[i], p_eng, *alloc);
+        scratchpad_t scratchpad(nullptr, buf_sizes[i], p_eng, *alloc);
         // the scratchpad size will be changed
         ASSERT_EQ(buf_sizes[i], scratchpad.size());
     }


### PR DESCRIPTION
- Implementation for RFC #5173 
- Add API to query scratchpad size from a compiled partition object: `get_scratchpad_size()`
- Add API to execute a compiled partition with user-managed scratchpad buffer:
   - `compiled_partition::execute(stream, inputs, outputs, scratchpad)`
   - `sycl_interop::execute(compiled_partition, stream, inputs, outputs, scratchpad, deps)`
   - `ocl_interop::execute(compiled_partition, stream, inputs, outputs, scratchpad, deps)`
 - Backend kernel implementations:
   - if `scratchpad_buf == nullptr`, work as before.
   - if `scratchpad_buf != nullptr`, use the user-provided scratchpad buffer for computation.
 - Update verbose log to include the scratchpad information, eg: `scratchpad:user:12345` where `12345` means the size.
 - Update the GQA example to use user provided scratchpad buffer and demonstrate the API usage.
 - Update benchdnn graph driver to use user provided scratchpad buffer. Not test library allocated scratchpad intentionally to simplify the validation. We still have a few legacy examples and gtests which still rely on the old behavior.