### PR TITLE
graph: backend: dnnl: support device-side seed/offset/prob in dropout

### DIFF
--- a/doc/graph/operations/Dropout.md
+++ b/doc/graph/operations/Dropout.md
@@ -59,8 +59,3 @@ Dropout operation supports the following data type combinations.
 | f32   | f32   | u8   | u64   | u64    | f32         |
 | bf16  | bf16  | u8   | u64   | u64    | f32         |
 | f16   | f16   | u8   | u64   | u64    | f32         |
-
-## Implementation Limitations
-
-1. The `seed`, `offset`, and `probability` inputs only support logical tensors
-   with property type set to `host_scalar`.

--- a/src/graph/backend/dnnl/executables/sdpa.cpp
+++ b/src/graph/backend/dnnl/executables/sdpa.cpp
@@ -23,6 +23,8 @@ namespace impl {
 namespace graph {
 namespace dnnl_impl {
 
+using ltw = logical_tensor_wrapper_t;
+
 sdpa_executable_t::sdpa_executable_t(std::shared_ptr<op_t> &op,
         const dnnl::engine &p_engine, pd_cache_t &pd_cache,
         const fpmath_t &fpmath, bool use_block_layout)
@@ -52,8 +54,11 @@ sdpa_executable_t::sdpa_executable_t(std::shared_ptr<op_t> &op,
     attr.set_fpmath_mode(static_cast<dnnl::fpmath_mode>(fpmath.mode_));
     if (with_dropout_) {
         dnnl::memory::desc dropout_mask_desc;
+        auto prop_type
+                = ltw(op->get_input_logical_tensor(idx++)).property_type();
         attr.set_dropout(dropout_mask_desc, dnnl::memory::data_type::s64,
-                /*use_offset*/ true, /*use_host_scalars*/ true);
+                /*use_offset*/ true,
+                /*use_host_scalars*/ prop_type == property_type::host_scalar);
     }
 
     is_invert_scale_ = op->has_attr(op_attr::is_invert_scale)
@@ -265,8 +270,11 @@ sdpa_bwd_executable_t::sdpa_bwd_executable_t(std::shared_ptr<op_t> &op,
 
     if (with_dropout_) {
         dnnl::memory::desc dropout_mask_desc;
+        auto prop_type
+                = ltw(op->get_input_logical_tensor(idx++)).property_type();
         attr.set_dropout(dropout_mask_desc, dnnl::memory::data_type::s64,
-                /*use_offset*/ true, /*use_host_scalars*/ true);
+                /*use_offset*/ true,
+                /*use_host_scalars*/ prop_type == property_type::host_scalar);
     }
 
     dim_t kv_head_number = op->get_input_logical_tensor(1).dims[1];

--- a/src/graph/backend/dnnl/fusion_info.cpp
+++ b/src/graph/backend/dnnl/fusion_info.cpp
@@ -39,6 +39,7 @@ namespace graph {
 namespace dnnl_impl {
 
 using value_ptr = std::shared_ptr<value_t>;
+using ltw = logical_tensor_wrapper_t;
 
 dnnl::primitive_attr make_dnnl_primitive_attr(
         const std::shared_ptr<op_t> &op, const fusion_info_t &fusion_info) {
@@ -209,10 +210,14 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
     }
 
     if (fusion_info.dropout_) {
-        // TODO: output mask and non-host-scalar seed/offset/probability are not enabled yet
+        // TODO: output mask is not enabled yet.
+        const auto prop_type = ltw(
+                fusion_info.dropout_->get_op()->get_input_logical_tensor(1))
+                                       .property_type();
         memory::desc mask_desc;
         attr.set_dropout(mask_desc, /*seed_dt*/ memory::data_type::s64,
-                /*use_offset*/ true, /*use_host_scalars*/ true);
+                /*use_offset*/ true,
+                /*use_host_scalars*/ prop_type == property_type::host_scalar);
     }
 
     // convert post ops

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -1507,6 +1507,20 @@ status_t fuse_dropout(std::shared_ptr<subgraph_t> &sg) {
         auto base_op = fuse_group.first;
         auto dropout_op = fuse_group.second;
 
+        // check if the seed, offset, and probability have the same property.
+        const auto seed_prop
+                = ltw(dropout_op->get_input_logical_tensor(1)).property_type();
+        const auto offset_prop
+                = ltw(dropout_op->get_input_logical_tensor(2)).property_type();
+        const auto prob_prop
+                = ltw(dropout_op->get_input_logical_tensor(3)).property_type();
+
+        VCHECK_TRANSFORM(seed_prop == offset_prop && offset_prop == prob_prop,
+                status::unimplemented,
+                "The seed, offset, and probability inputs of dropout should "
+                "all have the same property (either all host scalars or all "
+                "device tensors)");
+
         if (!base_op->has_attr(op_attr::fusion_info)) {
             fusion_info_t fusion_info;
             base_op->set_attr<fusion_info_t>(op_attr::fusion_info, fusion_info);

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/gqa-plain-training-fwd-w-dropout-device-seed-bf16-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/gqa-plain-training-fwd-w-dropout-device-seed-bf16-f32.json
@@ -1,0 +1,533 @@
+{
+  "version": "3.11.0",
+  "engine_kind": "cpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    200,
+    201,
+    202,
+    203,
+    205,
+    206,
+    207,
+    204
+  ],
+  "output_ports": [
+    8,
+    12
+  ],
+  "graph": [
+    {
+      "id": 2,
+      "name": "bmm1",
+      "kind": "MatMul",
+      "attrs": {
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 1
+        },
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        }
+      },
+      "inputs": [
+        {
+          "id": 200,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            64
+          ],
+          "stride": [
+            131072,
+            65536,
+            8192,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 201,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            1,
+            128,
+            64
+          ],
+          "stride": [
+            16384,
+            8192,
+            8192,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 1,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "scale_div",
+      "kind": "Divide",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 1,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 202,
+          "dtype": "bf16",
+          "shape": [
+            1
+          ],
+          "stride": [
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 3,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "mask_add",
+      "kind": "Add",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 3,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 203,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "name": "softmax",
+      "kind": "SoftMax",
+      "attrs": {
+        "mode": {
+          "type": "string",
+          "value": "inf_as_zero"
+        },
+        "axis": {
+          "type": "s64",
+          "value": -1
+        }
+      },
+      "inputs": [
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 8,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            1
+          ],
+          "stride": [
+            2048,
+            1024,
+            128,
+            1,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "name": "dropout",
+      "kind": "Dropout",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 205,
+          "dtype": "s64",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 206,
+          "dtype": "s64",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 207,
+          "dtype": "f32",
+          "shape": [],
+          "stride": [],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 10,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "name": "typecast",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 10,
+          "dtype": "f32",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 11,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "name": "bmm2",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        }
+      },
+      "inputs": [
+        {
+          "id": 11,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            128
+          ],
+          "stride": [
+            262144,
+            131072,
+            16384,
+            128,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 204,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            1,
+            128,
+            64
+          ],
+          "stride": [
+            16384,
+            8192,
+            8192,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 12,
+          "dtype": "bf16",
+          "shape": [
+            2,
+            2,
+            8,
+            128,
+            64
+          ],
+          "stride": [
+            131072,
+            65536,
+            8192,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Support device-side seed/offset/probability through the `use_host_scalars` flag of `set_dropout()` interface.
- Add a GQA training forward case with device side seed/offset/probability. Currently we don't support logical tensor property rewrite, hence duplicate the JSON file (gqa-plain-training-fwd-w-dropout-bf16-f32.json).
- Update the document of dropout operation.

Fixes MFDNN-15062