### PR TITLE
cpu: aarch64: fix register guard stack calculation and enable SVE binary injection

### DIFF
--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -127,23 +127,27 @@ register_preserve_guard_t<isa>::~register_preserve_guard_t() {
 
 template <cpu_isa_t isa>
 size_t register_preserve_guard_t<isa>::calc_vmm_to_preserve_size_bytes(
-        const std::initializer_list<Xbyak_aarch64::VReg> &vmm_to_preserve)
+        const std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
         const {
 
-    return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
-            std::size_t(0u),
-            [](std::size_t accum, const Xbyak_aarch64::VReg &vmm) {
-        return accum + simd_bytes(isa);
-    });
+    return vmm_to_preserve.size() * simd_bytes(isa);
 }
 
 template <cpu_isa_t isa>
 size_t register_preserve_guard_t<isa>::stack_space_occupied() const {
-    constexpr static size_t reg64_size = 8;
-    const size_t stack_space_occupied
-            = vmm_to_preserve_size_bytes_ + gpr_regs_.size() * reg64_size;
+    constexpr static size_t reg64_size_bytes = 8;
+    constexpr static size_t stack_alignment_bytes = 16;
 
-    return stack_space_occupied;
+    // If gpr_regs_ need to be backed up then round up to the nearest multiple
+    // of 16 to preserve stack alignment.
+    const size_t gpr_space = utils::rnd_up(
+            gpr_regs_.size() * reg64_size_bytes, stack_alignment_bytes);
+
+    // vec_space is always 16-aligned because simd_bytes() is always a multiple
+    // of 16;
+    const size_t vec_space = vec_regs_.size() * simd_bytes(isa);
+
+    return gpr_space + vec_space;
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/injectors/injector_utils.hpp
+++ b/src/cpu/aarch64/injectors/injector_utils.hpp
@@ -63,7 +63,7 @@ public:
     DNNL_DISALLOW_COPY_AND_ASSIGN(register_preserve_guard_t);
     ~register_preserve_guard_t();
     size_t calc_vmm_to_preserve_size_bytes(
-            const std::initializer_list<Xbyak_aarch64::VReg> &vmm_to_preserve)
+            const std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
             const;
     size_t stack_space_occupied() const;
 

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -51,10 +51,6 @@ bool is_data_supported(cpu_isa_t isa, data_type_t data_type) {
 bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
         const memory_desc_wrapper &dst_d,
         const bcast_set_t &supported_strategy_set) {
-    // FIXME: address SVE correctness issues (failing convs and matmuls when
-    // used with binary post-ops)
-    VCHECK_BIN_INJ_BOOL(isa == asimd, VERBOSE_UNSUPPORTED_ISA);
-
     VCHECK_BIN_INJ_BOOL(is_data_supported(isa, src1_desc.data_type),
             VERBOSE_ISA_DT_MISMATCH);
 


### PR DESCRIPTION
# Description
The stack space calculation for general purpose registers did not take the 16-alignment padding into account. This caused corrupted loads when guarding an odd number of registers.

Fixing this, along with the changes in https://github.com/uxlfoundation/oneDNN/pull/5184, mean we can enable SVE binary post-op injection.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?