### PR TITLE
benchdnn: deconv: remove f16 accumulator related workaround

### DIFF
--- a/tests/benchdnn/conv/cfg.cpp
+++ b/tests/benchdnn/conv/cfg.cpp
@@ -18,7 +18,8 @@
 
 namespace conv {
 
-cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
+cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds)
+    : base_cfg_t(prb->attr.acc_mode) {
     output_data_kind_ = (prb->dir & FLAG_FWD) ? DST
             : (prb->dir & FLAG_WEI)           ? WEI
                                               : SRC;
@@ -29,8 +30,6 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
                 cfg_entry_t {
                         kind, orig_data_type, data_type, get_cfg_map(kind)});
     }
-
-    acc_mode_ = prb->attr.acc_mode;
 
     // Keep legacy filling for Wino.
     if (prb->alg == WINO) {

--- a/tests/benchdnn/deconv/cfg.cpp
+++ b/tests/benchdnn/deconv/cfg.cpp
@@ -18,7 +18,8 @@
 
 namespace deconv {
 
-cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
+cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds)
+    : base_cfg_t(prb->attr.acc_mode) {
     output_data_kind_ = (prb->dir & FLAG_FWD) ? DST
             : (prb->dir & FLAG_WEI)           ? WEI
                                               : SRC;
@@ -29,15 +30,6 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
                 cfg_entry_t {
                         kind, orig_data_type, data_type, get_cfg_map(kind)});
     }
-
-    acc_mode_ = prb->attr.acc_mode;
-    bool inputs_f16 = true;
-    for (auto dk : {SRC, WEI, DST}) {
-        if (dk == output_data_kind_) continue;
-        inputs_f16 = inputs_f16 && get_dt(dk) == dnnl_f16;
-    }
-    // XXX: GPU deconvolution can use f16 accumulator when both inputs are f16.
-    if (is_gpu() && inputs_f16) acc_mode_ = dnnl_accumulation_mode_f16;
 
     adjust_ranges();
     print_fill_cfg_verbose();


### PR DESCRIPTION
Follow-up after https://github.com/uxlfoundation/oneDNN/pull/5041. Deconvolution workaround is no longer needed.