### PR TITLE
[GPU] Refactor required s4 upconversion

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -1635,12 +1635,6 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
     state.repackA |= problem.earlyDequantizeA() && !slmA;
     state.repackB |= problem.earlyDequantizeB() && !slmB;
 
-    bool is_xe3p = (hw == ngen::HW::Xe3p);
-    state.upConvertATo8Bit =  is_xe3p && Ta.bits() == 4 && Tb.bits() == 8 && strategy.systolic;
-    state.upConvertBTo8Bit =  is_xe3p && Tb.bits() == 4 && Ta.bits() == 8 && strategy.systolic;
-
-    state.repackA |= state.upConvertATo8Bit;
-    state.repackB |= state.upConvertBTo8Bit;
     if (crosspackA == 0) crosspackA = 1;
     if (crosspackB == 0) crosspackB = 1;
 
@@ -1659,17 +1653,11 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
                 state.ka_repack = gcd(problem.aqGroupK, state.ka_repack);
                 repackN = std::max(state.ka_repack, outerProductCount(problem, strategy));
         }
-	    auto Ta_repack = Ta;
-	    if (state.upConvertATo8Bit)
-	    	Ta_repack = Ta == Type::s4 ? Type::s8 : Type::u8;
-	    state.Ar_layout = RegisterLayout(hw, Ta_repack, unrollM, repackN, state.A_layout.colMajor(), state.upConvertATo8Bit ? crosspackA/2 : crosspackA, tileM_A, tileK_A, true, splitA);
+	    state.Ar_layout = RegisterLayout(hw, Ta, unrollM, repackN, state.A_layout.colMajor(), crosspackA, tileM_A, tileK_A, true, splitA);
     }
 
     if (state.repackB) {
-	    auto Tb_repack = Tb;
-	    if (state.upConvertBTo8Bit)
-	        Tb_repack = Tb == Type::s4 ? Type::s8 : Type::u8;
-	    state.Br_layout = RegisterLayout(hw, Tb_repack, strategy.kb_load, unrollN, state.B_layout.colMajor(), state.upConvertBTo8Bit ? crosspackB/2 : crosspackB, tileK_B, tileN_B, true, splitB);
+	    state.Br_layout = RegisterLayout(hw, Tb, strategy.kb_load, unrollN, state.B_layout.colMajor(), crosspackB, tileK_B, tileN_B, true, splitB);
     }
     // Prepare to repack C if needed, and choose repack tile size.
     if (Tc != Tc_compute || problem.forceLateQuant(minOuterProductCount(problem, strategy))) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -377,8 +377,6 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                                          const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
     auto Ta = problem.Ta, Tb = problem.Tb, Tc = problem.Tc_compute();
-    if (state.upConvertATo8Bit) Ta = Ta == Type::s4 ? Type::s8 : Type::u8;
-    if (state.upConvertBTo8Bit) Tb = Tb == Type::s4 ? Type::s8 : Type::u8;
     bool globalCM = state.C_layout.colMajor();
     auto params = systolicParams(problem);
     auto ksys = params.ksys;

--- a/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
@@ -340,8 +340,6 @@ struct GEMMState : public CommonState {
     ngen::Subregister statusFlagAddr;                        // uq
     bool systolicSumA = false, systolicSumB = false;
     bool useBDPAS = false;
-    bool upConvertATo8Bit = false;
-    bool upConvertBTo8Bit = false;
     bool lateKLoopCheck = false;
     bool splitBarrierAlways = false;
     int ka_loadRem, kb_loadRem;

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -733,12 +733,18 @@ status_t pd_t::init_GEMMProblem(
         problem.cqGroupN = c_quant.group_n;
     }
 
-    if (problem.Ta_ext.isInt4() && problem.Tb_ext.isInt8()
-            && a_quant.zp_ndims >= 0)
-        problem.Ta = Type::s8;
-    if (problem.Tb_ext.isInt4() && problem.Ta_ext.isInt8()
-            && b_quant.zp_ndims >= 0)
-        problem.Tb = Type::s8;
+    // Mixed s8/s4 DPAS support:
+    // - Xe3p: Not supported, require s4->s8 upconversion
+    // - pre-Xe3p: supported, but only when s4 matrix doesn't have zero points
+    bool has_s8s4_dpas = getCore(problem.product.family) != ngen::HW::Xe3p;
+    if (problem.Ta_ext.isInt4() && problem.Tb_ext.isInt8()) {
+        bool s8s4_dpas_ok = has_s8s4_dpas && (a_quant.zp_ndims < 0);
+        if (!s8s4_dpas_ok) problem.Ta = Type::s8;
+    }
+    if (problem.Tb_ext.isInt4() && problem.Ta_ext.isInt8()) {
+        bool s8s4_dpas_ok = has_s8s4_dpas && (b_quant.zp_ndims < 0);
+        if (!s8s4_dpas_ok) problem.Tb = Type::s8;
+    }
 
     if (problem.Ta.isInteger()) problem.Ts = Type::f32;
 


### PR DESCRIPTION
Addresses [MFDNN-14317](https://jira.devtools.intel.com/browse/MFDNN-14317). Xe3p no longer supports mixed s4/s8 DPAS. The previous solution was to add a few state variables and fix on-the-fly during kernel generation by upconverting s4 to s8. This results in higher register pressure, including several cases where the kernel runs out of registers and fails to compile.

Instead, this PR just changes the internal type to s8 before kernel generation, and then looks for valid kernels in the catalog. Mixed s4/s8 kernels are no longer considered. This way, kernel performance is well-described by the performance model and we skip generation attempts that are likely to fail.

No performance or correctness changes are expected, but I do expect error messages to decrease (part of [MFDNN-15085](https://jira.devtools.intel.com/browse/MFDNN-15085)).