### PR TITLE
cpu: aarch64: matmul: fix int8 eltwise post-op predicate clobber

### DIFF
--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -718,9 +718,10 @@ struct jit_int8_matmul_kernel_t : public jit_generator_t {
             const brg_int8_t &k, const dnnl::impl::post_ops_t &eltwise = {})
         : brg_(k) {
         for (auto &e : eltwise.entry_) {
+            // Keep p1-p5 intact: this kernel reuses them for tail loads/stores.
             eltwise_injectors_.emplace_back(utils::make_unique<
                     jit_uni_eltwise_injector_t<to_vla_sve(isa)>>(
-                    this, e.eltwise));
+                    this, e.eltwise, true, XReg(0), p6, p7));
         }
     }
     ~jit_int8_matmul_kernel_t() override = default;


### PR DESCRIPTION
# Description
This commit fixes a bug exposed in #5194, where the eltwise injector reused `p1` and clobbered the kernel's N-tail load predicate. Subsequent M-block iterations then used a data-dependent ReLU mask for tail loads, producing incorrect results.

## Reproducer
Command: 
```
./build/tests/benchdnn/benchdnn --mode=c --matmul --impl=jit:int8 --dt=s8:s8:f32 --attr-post-ops=relu:0.5 3x30x1:3x1x20
```
Before fix:
```
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:FAILED (errors:58 total:1800) (7 ms) __REPRO: --matmul --dt=s8:s8:f32 --attr-post-ops=relu:0.5 --impl=jit:int8 3x30x1:3x1x20
============================
```
After fix:
```
0:PASSED (7 ms) __REPRO: --matmul --dt=s8:s8:f32 --attr-post-ops=relu:0.5 --impl=jit:int8 3x30x1:3x1x20
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:int8 : 1 (100%)                                      |
============================================================
```