### PR TITLE
xe: conv: fix default cache settings on Xe3p

### DIFF
--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/send.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/send.hpp
@@ -49,7 +49,7 @@ inline ngen::CacheSettingsLSC get_cache_settings(
                     break;
                 case ngen::HW::Xe3p:
                     if (is_store) {
-                        ret = ngen::CacheSettingsLSC::L1UC_L2UC_L3WB;
+                        ret = ngen::CacheSettingsLSC::L1UC_L2WB_L3UC;
                     } else if (is_load || is_prefetch) {
                         ret = ngen::CacheSettingsLSC::L1C_L2C_L3C;
                     }


### PR DESCRIPTION
Jira: [MFDNN-15087](https://jira.devtools.intel.com/browse/MFDNN-15087).

PR aligns the store cache settings in the IR-based primitives with GEMM (`L1UC_L3WB` is the same as `L1UC_L2WB_L3UC`):

https://github.com/uxlfoundation/oneDNN/blob/0f8a431832a708e6527e154d3aee0ad34937940b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp#L144-L145

This is the cause of the large gap between convolution vs GEMM performance on NVL-P. As a data point: this fix boosts large-batch ResNet-50 by ~2x.