### PR TITLE
Functional fixes

### DIFF
--- a/doc/primitives/layer_normalization.md
+++ b/doc/primitives/layer_normalization.md
@@ -171,6 +171,7 @@ primitive:
 | Propagation | Type      | Operation                                            | Description                                                   | Restrictions                                                                       |
 |:------------|:----------|:-----------------------------------------------------|:--------------------------------------------------------------|:-----------------------------------------------------------------------------------|
 | forward     | attribute | [Scales](@ref dnnl::primitive_attr::set_scales_mask) | Scales the corresponding tensor by the given scale factor(s). | Supported only for int8 layer normalization and one scale per tensor is supported. |
+| forward     | Post-op   | [Eltwise](@ref dnnl::post_ops::append_eltwise)       | Applies an @ref dnnl_api_eltwise operation to the result      |                                                                                    |
 | forward     | Post-op   | [Binary](@ref dnnl::post_ops::append_binary)         | Applies a @ref dnnl_api_binary operation to the result.       | General binary post-op restrictions.                                               |
 
 ### Data Type Support

--- a/src/common/layer_normalization.cpp
+++ b/src/common/layer_normalization.cpp
@@ -193,7 +193,7 @@ status_t layer_normalization_attr_check(const layer_normalization_desc_t &desc,
         if (!attr->post_ops_.has_default_values()) {
             const auto &po = attr->post_ops_;
             using namespace primitive_kind;
-            VCHECK_LNORM_UNIMPL(po.has_default_values({binary, eltwise, sum}),
+            VCHECK_LNORM_UNIMPL(po.has_default_values({binary, eltwise}),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -185,6 +185,12 @@ size_t get_md_hash(const memory_desc_t &md) {
                     sparse_desc_t::max_metadata_types);
             // User cannot initialize `packed_desc` therefore `packed_desc`
             // is always zero initialized.
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+            seed = hash_combine(
+                    seed, md.format_desc.sparse_desc.grouped_desc.group_count);
+            seed = hash_combine(seed,
+                    md.format_desc.sparse_desc.grouped_desc.variable_dim_idx);
+#endif
             break;
         default: assert(!"unknown format_kind");
     }

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -58,6 +58,14 @@ status_t serialize_desc(
     return status::success;
 }
 
+void serialize_md_blocking_desc(
+        serialization_stream_t &sstream, const blocking_desc_t &bd, int ndims) {
+    sstream.append_array(ndims, bd.strides);
+    sstream.append(bd.inner_nblks);
+    sstream.append_array(bd.inner_nblks, bd.inner_blks);
+    sstream.append_array(bd.inner_nblks, bd.inner_idxs);
+}
+
 void serialize(serialization_stream_t &sstream, const memory_desc_t &md) {
     sstream.append(md.ndims);
     sstream.append_array(md.ndims, md.dims);
@@ -68,17 +76,29 @@ void serialize(serialization_stream_t &sstream, const memory_desc_t &md) {
     sstream.append(md.format_kind);
     // format desc
     switch ((int)md.format_kind) {
-        case format_kind::sparse:
         case format_kind::undef:
         case format_kind::any:
         case format_kind::host_scalar: break; // no additional data to serialize
+        case format_kind::sparse:
+            sstream.append(md.format_desc.sparse_desc.encoding);
+            sstream.append(md.format_desc.sparse_desc.nnz);
+            sstream.append_array(sparse_desc_t::max_metadata_types,
+                    md.format_desc.sparse_desc.metadata_types);
+            // User cannot initialize `packed_desc` therefore `packed_desc`
+            // is always zero initialized.
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+            if (md.format_desc.sparse_desc.encoding
+                    == sparse_encoding::grouped) {
+                sstream.append(
+                        md.format_desc.sparse_desc.grouped_desc.group_count);
+                sstream.append(md.format_desc.sparse_desc.grouped_desc
+                                       .variable_dim_idx);
+            }
+#endif
+            break;
         case format_kind::blocked:
-            sstream.append_array(md.ndims, md.format_desc.blocking.strides);
-            sstream.append(md.format_desc.blocking.inner_nblks);
-            sstream.append_array(md.format_desc.blocking.inner_nblks,
-                    md.format_desc.blocking.inner_blks);
-            sstream.append_array(md.format_desc.blocking.inner_nblks,
-                    md.format_desc.blocking.inner_idxs);
+            serialize_md_blocking_desc(
+                    sstream, md.format_desc.blocking, md.ndims);
             break;
         case format_kind::wino:
             sstream.append(md.format_desc.wino_desc.wino_format);

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -2706,13 +2706,6 @@ struct simple_reorder_t : public primitive_t {
 
             const memory_desc_wrapper input_d(src_md);
 
-            int mask = -1;
-            if (!attr->scales_.has_default_values(DNNL_ARG_DST)) {
-                mask = attr->scales_.get_mask(DNNL_ARG_DST);
-                if (input_d.has_runtime_dims_or_strides() && mask > 0)
-                    return status::unimplemented;
-            }
-
             auto _pd = make_unique_pd<pd_t>(attr, src_engine->kind(), src_md,
                     dst_engine->kind(), dst_md);
             if (_pd == nullptr) return status::out_of_memory;
@@ -2724,15 +2717,6 @@ struct simple_reorder_t : public primitive_t {
             auto scratchpad = _pd->scratchpad_registry().registrar();
             scratchpad.book(memory_tracking::names::key_reorder_space,
                     scratchpad_sz_, 1, 16);
-
-            if (mask > 0) {
-                dim_t D_mask;
-                _pd->get_D_values(input_d, mask, nullptr, &D_mask, nullptr);
-                scratchpad.template book<float>(
-                        memory_tracking::names::
-                                key_reorder_precomputed_dst_scales,
-                        D_mask);
-            }
 
             CHECK(_pd->init_scratchpad_md());
             return safe_ptr_assign(*reorder_pd, _pd.release());

--- a/tests/benchdnn/inputs/lnorm/test_lnorm_ci
+++ b/tests/benchdnn/inputs/lnorm/test_lnorm_ci
@@ -6,7 +6,7 @@
 --inplace=true
 --dt=f32,bf16,f16
 --dir=FWD_D
---attr-post-ops=,sum,sum+add:f32:per_oc,mul:f32:common+linear:0.5:-1
+--attr-post-ops=,add:f32:per_oc,mul:f32:common+linear:0.5:-1
 --flags=,G,C,H,M,CH,GCH,GCHM
 --batch=shapes_ci
 
@@ -55,6 +55,6 @@
 --dt=s8:f32,u8:f32,s8:bf16,u8:bf16
 --dir=FWD_I
 --attr-scales=,src:common:64+dst:common:0.5
---attr-post-ops=,sum,sum+add:f32:per_oc,mul:f32:common+linear:0.5:-1,add:f32:per_tensor
+--attr-post-ops=,add:f32:per_oc,mul:f32:common+linear:0.5:-1,add:f32:per_tensor
 --flags=,CH
 --batch=shapes_ci

--- a/tests/gtests/test_layer_normalization.cpp
+++ b/tests/gtests/test_layer_normalization.cpp
@@ -173,7 +173,6 @@ protected:
         const bool is_cpu = get_test_engine_kind() == engine::kind::cpu;
         aa.po_eltwise = is_cpu;
         aa.po_binary = is_cpu;
-        aa.po_sum = is_cpu;
 
         if (is_int8) aa.scales = true;
 


### PR DESCRIPTION
* Remove sum post-op as allowed from Layer Normalization (ping @Sqvid)
* Remove dead code from cpu simple reorder (this scratchpad is not used anywhere with the move to runtime scales)
* Fix serialization for sparse desc (will be needed in the future)