### PR TITLE
xe: gated_mlp: extend ref gmlp quantization support

### DIFF
--- a/src/common/gated_mlp_iface.cpp
+++ b/src/common/gated_mlp_iface.cpp
@@ -27,9 +27,69 @@ status_t dnnl_gated_mlp_primitive_desc_create(
         const memory_desc_t *weights_up_desc,
         const memory_desc_t *weights_down_desc, const memory_desc_t *dst_desc,
         alg_kind_t activation, const primitive_attr_t *attr) {
+    auto arg_md = [&](int arg) -> const memory_desc_t * {
+        switch (arg) {
+            default: return &glob_zero_md;
+            case DNNL_ARG_DST: return dst_desc;
+            case DNNL_ARG_SRC: return src_desc;
+            case DNNL_ARG_WEIGHTS_GATE: return weights_gate_desc;
+            case DNNL_ARG_WEIGHTS_UP: return weights_up_desc;
+            case DNNL_ARG_WEIGHTS_DOWN: return weights_down_desc;
+        }
+    };
+    auto dims_md = [&](int arg) {
+        std::array<dim_t, DNNL_MAX_NDIMS> retn = {};
+        auto md = arg_md(arg);
+        switch (arg) {
+            case DNNL_ARG_DST:
+            case DNNL_ARG_SRC:
+                if ((md->ndims < 3) || (md->dims[1] == 1))
+                    retn = {md->dims[0], md->dims[md->ndims - 1]};
+                break;
+            case DNNL_ARG_WEIGHTS_GATE:
+            case DNNL_ARG_WEIGHTS_UP:
+            case DNNL_ARG_WEIGHTS_DOWN:
+                if ((md->ndims < 3) || (md->dims[0] == 1))
+                    retn = {md->dims[md->ndims - 2], md->dims[md->ndims - 1]};
+                break;
+        }
+        return retn;
+    };
+    auto str_md = [](int arg) {
+        switch (arg) {
+            default: return "[unknown]";
+            case DNNL_ARG_DST: return "dst";
+            case DNNL_ARG_SRC: return "src";
+            case DNNL_ARG_WEIGHTS_GATE: return "w_gate";
+            case DNNL_ARG_WEIGHTS_UP: return "w_up";
+            case DNNL_ARG_WEIGHTS_DOWN: return "w_down";
+        }
+    };
+    VCHECK_GATED_MLP(
+            utils::one_of(activation, alg_kind::eltwise_gelu_erf,
+                    alg_kind::eltwise_gelu_tanh, alg_kind::eltwise_swish),
+            "unsupported GMLP activation: %s", dnnl_alg_kind2str(activation));
+    const auto ndims = arg_md(DNNL_ARG_DST)->ndims;
+    VCHECK_GATED_MLP(utils::one_of(ndims, 2, 3), "invalid GMLP output dims");
+    const auto &idxs = gated_mlp_pd_t::all_idxs();
+    const auto dims = gated_mlp_pd_t::all_dims(dims_md(DNNL_ARG_SRC)[0],
+            dims_md(DNNL_ARG_SRC)[1], dims_md(DNNL_ARG_WEIGHTS_GATE)[1]);
+    for (int i = 0; i < int(dims.size()); i++) {
+        const auto md = arg_md(idxs[i]);
+        const auto dims_i = dims_md(idxs[i]);
+        VCHECK_GATED_MLP(!memory_desc_wrapper(md).format_any(),
+                "invalid GMLP %s format", str_md(idxs[i]));
+        VCHECK_GATED_MLP((md->ndims == ndims) && dims_i[0] && dims_i[1]
+                        && (dims_i[0] == dims[i][0])
+                        && (dims_i[1] == dims[i][1]),
+                "invalid GMLP %s dims", str_md(idxs[i]));
+    }
+    primitive_attr_t mlp_attr = *attr;
+    auto po = mlp_attr.post_ops_.set_default_formats(arg_md(DNNL_ARG_DST));
+    VCHECK_GATED_MLP(po == dnnl_success, "invalid GMLP post_ops formats");
     auto gated_mlp_desc
             = dnnl::impl::create_gated_mlp_desc(src_desc, weights_gate_desc,
                     weights_up_desc, weights_down_desc, dst_desc, activation);
     return dnnl::impl::primitive_desc_create(primitive_desc_iface, engine,
-            (const dnnl::impl::op_desc_t *)&gated_mlp_desc, nullptr, attr);
+            (const dnnl::impl::op_desc_t *)&gated_mlp_desc, nullptr, &mlp_attr);
 }

--- a/src/common/gated_mlp_pd.hpp
+++ b/src/common/gated_mlp_pd.hpp
@@ -28,6 +28,10 @@ namespace impl {
 #define DNNL_ARG_WEIGHTS_UP DNNL_ARG_WEIGHTS_1
 #define DNNL_ARG_WEIGHTS_DOWN DNNL_ARG_WEIGHTS_2
 
+#define VCHECK_GATED_MLP(cond, msg, ...) \
+    VCONDCHECK(primitive, create, check, gated_mlp, (cond), \
+            status::invalid_arguments, msg, ##__VA_ARGS__)
+
 #define VDISPATCH_GATED_MLP(cond, msg, ...) \
     VCONDCHECK(primitive, create, dispatch, gated_mlp, (cond), \
             status::unimplemented, "%s," msg, this->info(engine), \
@@ -60,8 +64,14 @@ struct gated_mlp_pd_t : public primitive_desc_t {
 
     const gated_mlp_desc_t *desc() const { return &desc_; }
     dim_t MB() const { return arg_md(DNNL_ARG_SRC)->dims[0]; }
-    dim_t IC() const { return arg_md(DNNL_ARG_SRC)->dims[1]; }
-    dim_t OC() const { return arg_md(DNNL_ARG_WEIGHTS_GATE)->dims[1]; }
+    dim_t IC() const {
+        auto md = arg_md(DNNL_ARG_SRC);
+        return md->dims[md->ndims - 1];
+    }
+    dim_t OC() const {
+        auto md = arg_md(DNNL_ARG_WEIGHTS_GATE);
+        return md->dims[md->ndims - 1];
+    }
     alg_kind_t activation() const { return desc_.activation; }
 
     int n_outputs() const override { return 1; }
@@ -112,49 +122,6 @@ struct gated_mlp_pd_t : public primitive_desc_t {
         }
     }
 
-protected:
-    gated_mlp_pd_t(const op_desc_t *adesc, const primitive_attr_t *attr,
-            const hint_class *hint_fwd_pd)
-        : primitive_desc_t(attr, base_pkind)
-        , desc_(*op_desc_t::to_desc<gated_mlp_desc_t>(adesc)) {}
-
-    bool pd_ok() const {
-        if (!utils::one_of(activation(), alg_kind::eltwise_gelu_erf,
-                    alg_kind::eltwise_gelu_tanh, alg_kind::eltwise_swish))
-            return false;
-        const auto &idxs = all_idxs();
-        const auto dims = all_dims(MB(), IC(), OC());
-        for (int i = 0; i < int(dims.size()); i++) {
-            const auto *md = arg_md(idxs[i]);
-            if ((md->dims[0] != dims[i][0]) || (md->dims[1] != dims[i][1])
-                    || (md->ndims != 2))
-                return false;
-        }
-        return true;
-    }
-
-    bool set_default_format(const memory_desc_t *md) {
-        return !memory_desc_wrapper(md).format_any();
-    }
-
-    bool set_default_formats() {
-        bool ok = true;
-        for (auto idx : all_idxs())
-            ok &= set_default_format(arg_md(idx));
-        ok &= attr_.post_ops_.set_default_formats(arg_md(DNNL_ARG_DST))
-                == status::success;
-        return ok;
-    }
-
-private:
-    gated_mlp_desc_t desc_;
-
-    const memory_desc_t *src0_md() const { return &desc_.src_desc; }
-    const memory_desc_t *w_gate_md() const { return &desc_.w_gate_desc; }
-    const memory_desc_t *w_up_md() const { return &desc_.w_up_desc; }
-    const memory_desc_t *w_down_md() const { return &desc_.w_down_desc; }
-    const memory_desc_t *dst0_md() const { return &desc_.dst_desc; }
-
     static const std::vector<int> &all_idxs() {
         static const std::vector<int> idx {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS_GATE,
                 DNNL_ARG_WEIGHTS_UP, DNNL_ARG_WEIGHTS_DOWN, DNNL_ARG_DST};
@@ -172,18 +139,20 @@ private:
         };
     }
 
-    static int group_size(
-            const quant_entries_t &q, const memory_desc_t &desc, int arg) {
-        dim_t out = utils::array_product(desc.dims, desc.ndims);
-        if (q.has_default_groups(arg)) {
-            for (int idx : mask_iterator(q.get_mask(arg)))
-                out /= desc.dims[idx];
-        } else {
-            for (int idx : mask_iterator(q.get_mask(arg)))
-                out /= (desc.dims[idx] / q.get_group(arg, idx));
-        }
-        return static_cast<int>(out);
-    }
+protected:
+    gated_mlp_pd_t(const op_desc_t *adesc, const primitive_attr_t *attr,
+            const hint_class *hint_fwd_pd)
+        : primitive_desc_t(attr, base_pkind)
+        , desc_(*op_desc_t::to_desc<gated_mlp_desc_t>(adesc)) {}
+
+private:
+    gated_mlp_desc_t desc_;
+
+    const memory_desc_t *src0_md() const { return &desc_.src_desc; }
+    const memory_desc_t *w_gate_md() const { return &desc_.w_gate_desc; }
+    const memory_desc_t *w_up_md() const { return &desc_.w_up_desc; }
+    const memory_desc_t *w_down_md() const { return &desc_.w_down_desc; }
+    const memory_desc_t *dst0_md() const { return &desc_.dst_desc; }
 };
 // NOLINTEND(google-default-arguments)
 

--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -116,15 +116,9 @@ status_t micro_horz_t::pd_t::init(impl::engine_t *engine) {
     //        VERBOSE_SKIP_PRIMITIVE_IMPL);
     memory_desc_t inter_md;
     CHECK(get_gate_dst_md(inter_md));
-
-#ifdef UGEMM_UP_ONLY
-    CHECK(init_microkernels(engine, &inter_md));
-#else
-    VDISPATCH_GATED_MLP(pd_ok(), VERBOSE_INCONSISTENT_PRB);
-    VDISPATCH_GATED_MLP_SC(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
-
     CHECK(init_microkernels(engine, &inter_md));
 
+#ifndef UGEMM_UP_ONLY
     primitive_attr_t down_attr;
     CHECK(move_attr(down_attr, DNNL_ARG_WEIGHTS_DOWN, DNNL_ARG_WEIGHTS));
     auto down_desc = matmul_desc_t();

--- a/src/gpu/intel/gated_mlp/ref.hpp
+++ b/src/gpu/intel/gated_mlp/ref.hpp
@@ -42,9 +42,6 @@ struct ref_t : public primitive_t {
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
         status_t init(impl::engine_t *engine) {
-            VDISPATCH_GATED_MLP(pd_ok(), VERBOSE_INCONSISTENT_PRB);
-            VDISPATCH_GATED_MLP(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
-
             memory_desc_t gate_dst_md, up_dst_md;
             CHECK(get_gate_dst_md(gate_dst_md));
             CHECK(get_up_dst_md(up_dst_md));
@@ -124,24 +121,53 @@ struct ref_t : public primitive_t {
 
     private:
         status_t get_gate_up_dst_md(memory_desc_t &retn, data_type_t dt) const {
-            std::vector<dim_t> dims {MB(), OC()};
+            std::vector<dim_t> dims {MB(), 1};
+            format_tag_t tag = format_tag::abc;
+            if (arg_md(DNNL_ARG_WEIGHTS_GATE)->ndims == 2) {
+                dims[1] = OC();
+                tag = format_tag::ab;
+            } else {
+                gpu_assert(arg_md(DNNL_ARG_WEIGHTS_GATE)->ndims == 3);
+                dims.emplace_back(OC());
+            }
             CHECK(memory_desc_init_by_tag(
-                    retn, int(dims.size()), dims.data(), dt, format_tag::ab));
+                    retn, int(dims.size()), dims.data(), dt, tag));
             return status::success;
         }
 
-        status_t move_attr(primitive_attr_t &retn, int from, int to) {
-            CHECK(retn.set_fpmath_mode(
-                    attr()->fpmath_.mode_, attr()->fpmath_.apply_to_int_));
-            CHECK(retn.scales_.set(to, attr()->scales_.get(from)));
-            CHECK(retn.zero_points_.set(to, attr()->zero_points_.get(from)));
+        status_t move_attr(primitive_attr_t &retn, int w_from, int w_to) const {
+            if (w_from == DNNL_ARG_WEIGHTS_DOWN) { // Down
+                auto wd_dt = arg_md(w_from)->data_type;
+                // Down SRC is always floating-point, but WEI isn't
+                CHECK((utils::one_of(wd_dt, dnnl_f32, dnnl_f16, dnnl_bf16))
+                                ? retn.set_fpmath_mode(
+                                          fpmath_mode::strict, false)
+                                : retn.set_fpmath_mode(fpmath_mode::any, true));
+                // all per-primitive post-ops are for Down, not for Gate/Up
+                CHECK(retn.set_post_ops(attr()->post_ops_));
+            } else { // Gate or Up
+                CHECK(retn.set_fpmath_mode(
+                        attr()->fpmath_.mode_, attr()->fpmath_.apply_to_int_));
+                // Quant on SRC
+                CHECK(retn.scales_.set(
+                        DNNL_ARG_SRC, attr()->scales_.get(DNNL_ARG_SRC)));
+                CHECK(retn.zero_points_.set(
+                        DNNL_ARG_SRC, attr()->zero_points_.get(DNNL_ARG_SRC)));
+                // Precomp on WEI
+                CHECK(retn.precomputed_reductions_.set(
+                        w_to, attr()->precomputed_reductions_.get(w_from)));
+            }
+            // Quant on WEI, same logic for all 3 of the GEMMs
+            CHECK(retn.scales_.set(w_to, attr()->scales_.get(w_from)));
+            CHECK(retn.zero_points_.set(
+                    w_to, attr()->zero_points_.get(w_from)));
             return status::success;
         }
 
         status_t create_matmul(std::shared_ptr<primitive_desc_t> &retn,
                 impl::engine_t *e, const primitive_attr_t &attr,
                 const memory_desc_t *src_desc, const memory_desc_t *wei_desc,
-                const memory_desc_t *dst_desc) {
+                const memory_desc_t *dst_desc) const {
             auto desc = matmul_desc_t();
             CHECK(impl::matmul_desc_init(
                     &desc, src_desc, wei_desc, nullptr, dst_desc));
@@ -160,20 +186,32 @@ struct ref_t : public primitive_t {
     }
 
     status_t execute(const exec_ctx_t &ctx) const override {
-        auto prep_weights_and_run
-                = [&](exec_args_t &&args, int idx,
+        auto prep_quant_and_run
+                = [&](exec_args_t &&args, int src, int wei,
                           const std::shared_ptr<impl::primitive_t> &prim) {
-            args[DNNL_ARG_WEIGHTS] = ctx.args().at(idx);
-            if (!pd()->attr()->scales_.has_default_values(idx))
+            if (!pd()->attr()->scales_.has_default_values(src))
+                args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC]
+                        = ctx.args().at(DNNL_ARG_ATTR_SCALES | src);
+            if (!pd()->attr()->zero_points_.has_default_values(src))
+                args[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC]
+                        = ctx.args().at(DNNL_ARG_ATTR_ZERO_POINTS | src);
+
+            args[DNNL_ARG_WEIGHTS] = ctx.args().at(wei);
+            if (!pd()->attr()->scales_.has_default_values(wei))
                 args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS]
-                        = ctx.args().at(DNNL_ARG_ATTR_SCALES | idx);
-            if (!pd()->attr()->zero_points_.has_default_values(idx))
+                        = ctx.args().at(DNNL_ARG_ATTR_SCALES | wei);
+            if (!pd()->attr()->zero_points_.has_default_values(wei))
                 args[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS]
-                        = ctx.args().at(DNNL_ARG_ATTR_ZERO_POINTS | idx);
+                        = ctx.args().at(DNNL_ARG_ATTR_ZERO_POINTS | wei);
+            if (!pd()->attr()->precomputed_reductions_.has_default_values(wei))
+                args[DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS | DNNL_ARG_WEIGHTS]
+                        = ctx.args().at(
+                                DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS | wei);
+
             exec_ctx_t nested_ctx(ctx, std::move(args));
             auto *nested_grantor
                     = create_nested_grantor(ctx.get_scratchpad_grantor(),
-                            memory_tracking::names::key_nested_multiple + idx,
+                            memory_tracking::names::key_nested_multiple + wei,
                             prim->pd()->scratchpad_registry());
             nested_ctx.set_scratchpad_grantor(nested_grantor);
             CHECK(prim->execute(nested_ctx));
@@ -201,8 +239,8 @@ struct ref_t : public primitive_t {
             exec_args_t args;
             args[DNNL_ARG_SRC] = ctx.args().at(DNNL_ARG_SRC);
             args[DNNL_ARG_DST] = memory_arg_t {inter_src_mem.get(), false};
-            CHECK(prep_weights_and_run(
-                    std::move(args), DNNL_ARG_WEIGHTS_UP, gemm_up_));
+            CHECK(prep_quant_and_run(std::move(args), DNNL_ARG_SRC,
+                    DNNL_ARG_WEIGHTS_UP, gemm_up_));
         } while (false);
         do {
             exec_args_t args;
@@ -211,15 +249,21 @@ struct ref_t : public primitive_t {
             // N.B.: not POST_OP(0), since POST_OP(0) is occupied by activation
             args[DNNL_ARG_ATTR_MULTIPLE_POST_OP(1) | DNNL_ARG_SRC_1]
                     = memory_arg_t {inter_src_mem.get(), true};
-            CHECK(prep_weights_and_run(
-                    std::move(args), DNNL_ARG_WEIGHTS_GATE, gemm_gate_));
+            CHECK(prep_quant_and_run(std::move(args), DNNL_ARG_SRC,
+                    DNNL_ARG_WEIGHTS_GATE, gemm_gate_));
         } while (false);
         do {
             exec_args_t args;
             args[DNNL_ARG_SRC] = memory_arg_t {inter_wei_mem.get(), true};
             args[DNNL_ARG_DST] = ctx.args().at(DNNL_ARG_DST);
-            CHECK(prep_weights_and_run(
-                    std::move(args), DNNL_ARG_WEIGHTS_DOWN, gemm_down_));
+            const auto &post_ops = pd()->attr()->post_ops_;
+            for (int p = 0, pl = post_ops.len(); p < pl; p++) {
+                if (!post_ops.entry_[p].is_like_binary()) continue;
+                auto idx = DNNL_ARG_ATTR_MULTIPLE_POST_OP(p) | DNNL_ARG_SRC_1;
+                args[idx] = ctx.args().at(idx);
+            }
+            CHECK(prep_quant_and_run(std::move(args), DNNL_ARG_UNDEF,
+                    DNNL_ARG_WEIGHTS_DOWN, gemm_down_));
         } while (false);
 
         return status::success;


### PR DESCRIPTION
This PR is a part of [MFDNN-14598](https://jira.devtools.intel.com/browse/MFDNN-14598) and the second prerequisite of #4951.

Extends reference GatedMLP by adding dual scales/ZPs and precomputed reductions, as well as Down post-ops and fake-3D matrices (M×1×K:1×K×N instead of M×K:K×N).