### PR TITLE
doc: clarify that int8 is used as shorthand for s8/u8 in oneDNN docs

### DIFF
--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -176,6 +176,11 @@ oneDNN performance optimizations for Intel Architecture Processors are
 specialized based on Instruction Set Architecture (ISA). The following
 table indicates data types support for every supported ISA:
 
+@note
+    In oneDNN documentation, `int8` is used as a shorthand for both `s8`
+    (signed) and `u8` (unsigned) 8-bit integer types. See @ref
+    dev_guide_int8_computations for more details.
+
 | ISA                                                  | f64     | f32     | bf16    | f16     | s8/u8   | f8_e4m3 | f8_e5m2 | f4_e2m1 | s4/u4   |
 | ---------------------------------------------------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | 
 | Intel SSE4.1                                         |         | `+`     |         |         |         |         |         |         |         |


### PR DESCRIPTION
Closes #5189

## What this PR does

Adds a note to `doc/programming_model/data_types.md` clarifying 
that in oneDNN documentation, `int8` is used as an umbrella term 
for both `s8` (signed) and `u8` (unsigned) 8-bit integer data types.

This addresses the confusion raised in the issue, where `int8` can 
mean only signed 8-bit integer in some popular definitions 
(e.g. Microsoft, Protocol Buffers).

## Changes

- Added a note in `data_types.md` pointing users to 
  `dev_guide_int8_computations` for the full explanation of 
  `int8` terminology used in oneDNN docs.