### PR TITLE
[GPU] Fix build after GEMM update

### DIFF
--- a/src/gpu/intel/gemm/jit/dsl/hw.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/hw.cpp
@@ -32,7 +32,8 @@ hw_t::hw_t(const ngen::Product &product, int eu_count, int max_wg_size,
 
 ngen::Product hw_t::product() const {
     ngen::Product product;
-    std::memcpy(&product, &product_, sizeof(product));
+    std::memcpy(static_cast<void *>(&product),
+            static_cast<const void *>(&product_), sizeof(product));
     return product;
 }
 

--- a/src/gpu/intel/gemm/jit/selector/kernel_evaluator.cpp
+++ b/src/gpu/intel/gemm/jit/selector/kernel_evaluator.cpp
@@ -517,7 +517,7 @@ DerivedEvaluateParams getDerivedParams(const kcatalog::Entry &e, const EvaluateP
         auto ldc = static_cast<int>(Tc * (isColMajor(cLayout) ? p.sizes.m : p.sizes.n) * e.driverInfo.cInterleaveChunk(Tc));
         auto &wgCountX = isColMajor(cLayout) ? dp.wgCountM : dp.wgCountN;
         auto &wgCountY = isColMajor(cLayout) ? dp.wgCountN : dp.wgCountM;
-        wgCountY = align_up(wgCountY, e.driverInfo.cInterleaveChunk(Tc));
+        wgCountY = round_up(wgCountY, e.driverInfo.cInterleaveChunk(Tc));
         if (e.driverInfo.cInterleaveEnabled() && (ldc * Tc % 64 > 0)) {
             auto wgTileX = e.driverInfo.wgTile(isColMajor(cLayout) ? LoopM : LoopN);
             auto maxShift = 64 / Tc - 1;

--- a/src/gpu/intel/jit/utils/type_bridge.hpp
+++ b/src/gpu/intel/jit/utils/type_bridge.hpp
@@ -30,7 +30,9 @@ namespace jit {
 
 inline ngen::Product get_ngen_product(const compute::device_info_t &info) {
     ngen::Product ret;
-    std::memcpy(&ret, &info.gpu_product(), sizeof(ngen::Product));
+    std::memcpy(static_cast<void *>(&ret),
+            static_cast<const void *>(&info.gpu_product()),
+            sizeof(ngen::Product));
     return ret;
 }
 

--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -299,6 +299,7 @@ struct Product {
     int stepping = 0;
     PlatformType type = PlatformType::Unknown;
 };
+static_assert(std::is_trivially_copyable<Product>(), "Product must be trivially copyable");
 
 static inline bool operator==(const Product &p1, const Product &p2) { return p1.family == p2.family && p1.stepping == p2.stepping && p1.type == p2.type; }
 static inline bool operator!=(const Product &p1, const Product &p2) { return !(p1 == p2); }


### PR DESCRIPTION
After a few of my PRs merged yesterday, CI revealed some build errors:
- Since ngen::Product was given a constructor, it's no longer trivially-copyable. I need to cast to void* when copying into `gpu_product_t`.
- I inadvertently changed a `round_up` call to `align_up` which has a more restrictive signature that caused argument narrowing. Reverted that change.