### PR TITLE
third_party: ngen: track s0 indirect descriptor dependency for sendg/sendgc

### DIFF
--- a/third_party/ngen/ngen_auto_swsb.hpp
+++ b/third_party/ngen/ngen_auto_swsb.hpp
@@ -479,6 +479,10 @@ DependencyRegion::DependencyRegion(HW hw_, int esize, RegData rr)
     checkWAW = false;
     rf = rr.getRegFile();
 
+    // Strip out the 0x100 ARFType::s marker so a directly-constructed scalar
+    // register matches the base decoded from an instruction.
+    if (rf == RegFileARF) base &= 0xFF;
+
     int hs = rr.getHS(), vs = rr.getVS();
     int nh = rr.getWidth();
     if (nh == 0) nh = 1;

--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -1349,6 +1349,15 @@ bool Instruction12::getOperandRegion(autoswsb::DependencyRegion &region, int opN
                     if (sendg.src1RegFile == RegFileARF) return false;
                     region = DependencyRegion(hw, GRFRange(sendg.src1Reg, sendg.src1Len));
                     break;
+                // ind0/ind1 are indirect descriptor reads from scalar register s0.
+                case 2:
+                    if (!sendg.ind0Present) return false;
+                    region = DependencyRegion(hw, 1, ScalarRegister(0).uq(sendg.ind0)(1));
+                    return true;
+                case 3:
+                    if (!sendg.ind1Present) return false;
+                    region = DependencyRegion(hw, 1, ScalarRegister(0).uq(sendg.ind1_desc42_46)(1));
+                    return true;
                 default: return false;
             }
             return true;
@@ -1370,6 +1379,15 @@ bool Instruction12::getOperandRegion(autoswsb::DependencyRegion &region, int opN
                     regNum = sendg.src1Reg | (sendgx.src1Reg8 << 8);
                     len = sendg.src1Len;
                     break;
+                // ind0/ind1 are indirect descriptor reads from scalar register s0.
+                case 2:
+                    if (!sendg.ind0Present) return false;
+                    region = DependencyRegion(hw, 1, ScalarRegister(0).uq(sendg.ind0)(1));
+                    return true;
+                case 3:
+                    if (!sendg.ind1Present) return false;
+                    region = DependencyRegion(hw, 1, ScalarRegister(0).uq(sendg.ind1_desc42_46)(1));
+                    return true;
                 default: return false;
             }
             if (regNum == 0x1FF)


### PR DESCRIPTION
Found and reported while investigating a page fault with OpenVINO on NVL-P.