### PR TITLE
ze: fix parallel rnn scenario

### DIFF
--- a/src/xpu/ze/memory_storage.cpp
+++ b/src/xpu/ze/memory_storage.cpp
@@ -221,9 +221,9 @@ void memory_storage_t::free(impl::engine_t *engine, void *ptr) {
 status_t memory_storage_t::memcpy(
         impl::stream_t *stream, void *dst, const void *src, size_t size) const {
     auto *ze_stream_impl
-            = utils::downcast<const xpu::ze::stream_impl_t *>(stream->impl());
-    return ze::zeCommandListAppendMemoryCopy(
-            ze_stream_impl->list(), dst, src, size, nullptr, 0, nullptr);
+            = utils::downcast<xpu::ze::stream_impl_t *>(stream->impl());
+    return append_memory_copy(ze_stream_impl->list(),
+            ze_stream_impl->list_mutex(), dst, src, size, nullptr, 0, nullptr);
 }
 
 } // namespace ze

--- a/src/xpu/ze/stream_impl.cpp
+++ b/src/xpu/ze/stream_impl.cpp
@@ -147,7 +147,7 @@ status_t stream_impl_t::copy(const impl::memory_storage_t &src,
 
     const auto &ze_deps = event_t::from(deps);
     ze_event_handle_t out_event = create_event();
-    CHECK(ze::zeCommandListAppendMemoryCopy(list_, dst.data_handle(),
+    CHECK(append_memory_copy(list(), list_mutex(), dst.data_handle(),
             src.data_handle(), size, out_event, ze_deps.size(),
             ze_deps.data()));
     if (out_event) event_t::from(out_dep).append(out_event);
@@ -161,7 +161,7 @@ status_t stream_impl_t::fill(const impl::memory_storage_t &dst, uint8_t pattern,
 
     const auto &ze_deps = event_t::from(deps);
     ze_event_handle_t out_event = create_event();
-    CHECK(ze::zeCommandListAppendMemoryFill(list_, dst.data_handle(), &pattern,
+    CHECK(append_memory_fill(list(), list_mutex(), dst.data_handle(), &pattern,
             sizeof(pattern), size, out_event, ze_deps.size(), ze_deps.data()));
     if (out_event) event_t::from(out_dep).append(out_event);
 

--- a/src/xpu/ze/stream_impl.hpp
+++ b/src/xpu/ze/stream_impl.hpp
@@ -24,6 +24,7 @@
 #include "xpu/ze/utils.hpp"
 
 #include <list>
+#include <mutex>
 
 namespace dnnl {
 namespace impl {
@@ -63,11 +64,17 @@ public:
 
     ze_command_list_handle_t list() const { return list_; }
 
+    std::mutex &list_mutex() { return list_mutex_; }
+
     static status_t init_flags(
             unsigned *flags, ze_command_list_handle_t list, bool profiling);
 
 private:
     xpu::ze::wrapper_t<ze_command_list_handle_t> list_;
+    // Mutex secures all non-thread-safe operations over the `list_` are
+    // serialized. Lives in stream to ensure each list comes with its own mutex,
+    // as the requirement applies to the same command list during submission.
+    std::mutex list_mutex_;
     // TODO: `event_pool_` seems to belong to `ctx_` as events can't be created
     // in multithreaded scenario and having a thread_local event pool should
     // address it.

--- a/src/xpu/ze/usm_utils.cpp
+++ b/src/xpu/ze/usm_utils.cpp
@@ -32,8 +32,9 @@ status_t fill(impl::stream_t *stream, void *ptr, uint8_t pattern, size_t size) {
     auto *ze_stream_impl
             = utils::downcast<xpu::ze::stream_impl_t *>(stream->impl());
 
-    CHECK(ze::zeCommandListAppendMemoryFill(ze_stream_impl->list(), ptr,
-            &pattern, sizeof(pattern), size, nullptr, 0, nullptr));
+    CHECK(append_memory_fill(ze_stream_impl->list(),
+            ze_stream_impl->list_mutex(), ptr, &pattern, sizeof(pattern), size,
+            nullptr, 0, nullptr));
 
     return status::success;
 }
@@ -44,8 +45,8 @@ status_t copy(impl::stream_t *stream, void *dst, const void *src, size_t size) {
     auto *ze_stream_impl
             = utils::downcast<xpu::ze::stream_impl_t *>(stream->impl());
 
-    CHECK(ze::zeCommandListAppendMemoryCopy(
-            ze_stream_impl->list(), dst, src, size, nullptr, 0, nullptr));
+    CHECK(append_memory_copy(ze_stream_impl->list(),
+            ze_stream_impl->list_mutex(), dst, src, size, nullptr, 0, nullptr));
 
     return status::success;
 }

--- a/src/xpu/ze/utils.cpp
+++ b/src/xpu/ze/utils.cpp
@@ -122,6 +122,32 @@ ze_memory_type_t get_pointer_type(
     return memory_allocation_properties.type;
 }
 
+status_t append_memory_copy(ze_command_list_handle_t list,
+        std::mutex &list_mutex, void *dst, const void *src, size_t size,
+        ze_event_handle_t out_event, uint32_t num_deps_events,
+        ze_event_handle_t *deps_events) {
+    std::lock_guard<std::mutex> guard(list_mutex);
+
+    // This function is not thread-safe, guarding it with exclusive access.
+    CHECK(ze::zeCommandListAppendMemoryCopy(
+            list, dst, src, size, out_event, num_deps_events, deps_events));
+
+    return status::success;
+}
+
+status_t append_memory_fill(ze_command_list_handle_t list,
+        std::mutex &list_mutex, void *dst, const void *pattern,
+        size_t pattern_size, size_t size, ze_event_handle_t out_event,
+        uint32_t num_deps_events, ze_event_handle_t *deps_events) {
+    std::lock_guard<std::mutex> guard(list_mutex);
+
+    // This function is not thread-safe, guarding it with exclusive access.
+    CHECK(ze::zeCommandListAppendMemoryFill(list, dst, pattern, pattern_size,
+            size, out_event, num_deps_events, deps_events));
+
+    return status::success;
+}
+
 } // namespace ze
 } // namespace xpu
 } // namespace impl

--- a/src/xpu/ze/utils.hpp
+++ b/src/xpu/ze/utils.hpp
@@ -29,6 +29,8 @@
 
 #include "xpu/utils.hpp"
 
+#include <mutex>
+
 namespace dnnl {
 namespace impl {
 namespace xpu {
@@ -242,6 +244,14 @@ xpu::device_uuid_t get_device_uuid(ze_device_handle_t device);
 status_t get_device_index(size_t *index, ze_device_handle_t device);
 std::string get_kernel_name(ze_kernel_handle_t kernel);
 ze_memory_type_t get_pointer_type(ze_context_handle_t, const void *ptr);
+status_t append_memory_copy(ze_command_list_handle_t list,
+        std::mutex &list_mutex, void *dst, const void *src, size_t size,
+        ze_event_handle_t out_event, uint32_t num_deps_events,
+        ze_event_handle_t *deps_events);
+status_t append_memory_fill(ze_command_list_handle_t list,
+        std::mutex &list_mutex, void *dst, const void *pattern,
+        size_t pattern_size, size_t size, ze_event_handle_t out_event,
+        uint32_t num_deps_events, ze_event_handle_t *deps_events);
 
 } // namespace ze
 } // namespace xpu

--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -81,16 +81,6 @@ function(register_benchdnn_test engine driver test_file)
         set(mode_modifier "--mode-modifier=P")
     endif()
 
-    # TODO: workaround a hang in Level Zero backend when during parallel
-    # creation several resources are initialized.
-    # Remove me once resolved.
-    if(${engine} MATCHES "gpu"
-       AND ${driver} MATCHES "rnn"
-       AND ${DNNL_GPU_VENDOR} MATCHES "INTEL"
-       AND ${DNNL_GPU_RUNTIME} MATCHES "ZE")
-        set(mode_modifier "")
-    endif()
-
     foreach(tm ${test_mode})
         string(REPLACE "test_" "test_benchdnn_mode${tm}_" target_name ${test_file})
         set(cmd "--mode=${tm} ${mode_modifier} -v1 --engine=${engine} --${driver} --batch=${test_file}")


### PR DESCRIPTION
Fixes [MFDNN-14974](https://jira.devtools.intel.com/browse/MFDNN-14974)

Level Zero objects don't support copy APIs so I didn't find it convincing to rely on `thread_local_storage_t` abstraction and build a solution based on it over just applying a simple mutex.