### PR TITLE
graph: fix layout propagation for convtranspose + fused binary ops

### DIFF
--- a/src/graph/backend/dnnl/fusion_info.cpp
+++ b/src/graph/backend/dnnl/fusion_info.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2022 Intel Corporation
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -329,7 +330,8 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                         "input scale and zp",
                         op->get_name().c_str());
                 auto md = make_dnnl_memory_desc(psrc);
-                if (op->get_kind() == op_kind::_convolution)
+                if (impl::utils::one_of(op->get_kind(), op_kind::_convolution,
+                            op_kind::_convtranspose))
                     md = to_format_any(md);
                 dnnl_pops.append_binary(alg, md);
             }

--- a/src/graph/backend/dnnl/layout_propagator.cpp
+++ b/src/graph/backend/dnnl/layout_propagator.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2022 Intel Corporation
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,6 +247,36 @@ status_t layout_propagator_for_deconv(op_ptr &op, const dnnl::engine &p_engine,
         VCHECK_LAYOUT_PROPAGATOR(status == status::success, status,
                 "failed to fill layout info for reorder before deconv bias");
     }
+
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        const auto &post_ops = fusion_info.get_post_ops();
+        for (size_t i = 0; i < post_ops.size(); ++i) {
+            if (!post_ops[i]->is_post_binary()) continue;
+            const auto &binary = post_ops[i];
+            std::vector<size_t> binary_idx
+                    = binary->get_unfused_input_indices();
+            if (binary_idx.empty()) continue;
+
+            value_ptr binary_unfused_src = op->get_input_value(binary_idx[0]);
+            const auto &binary_unfused_src_opt_mdesc
+                    = pd.query_md(query::exec_arg_md,
+                            DNNL_ARG_SRC_1
+                                    | DNNL_ARG_ATTR_MULTIPLE_POST_OP(
+                                            static_cast<int>(i)));
+            insert_reorder_before(op, binary_idx[0],
+                    binary_unfused_src_opt_mdesc, p_engine, pd_cache, fpmath,
+                    use_block_layout, rewriter);
+            status = fill_layout_info(
+                    binary_unfused_src, binary_unfused_src_opt_mdesc);
+
+            VCHECK_LAYOUT_PROPAGATOR(status == status::success, status,
+                    "failed to fill layout info for reorder before "
+                    "deconv post_binary");
+        }
+    }
+
     // insert a reorder if output layout is different from output optimal layout
     // 1) output layout is opaque
     // 2) output is any, directly set optimal layout


### PR DESCRIPTION
# Description

When enabling binary post op fusion in https://github.com/uxlfoundation/oneDNN/pull/5207 I noticed intermediate failures in `test_graph_unit_dnnl_convtranspose_cpu`. For example, compare Attempt 1 vs Attempt 2 in the following Nightly:
https://github.com/uxlfoundation/oneDNN/actions/runs/26521221485/job/78115921953
A failed run looks like:
```
index = 0, a = 79, b = 0, diff = 79, atol = 1, rtol = 0.1. Failed.
/home/runner/work/oneDNN/oneDNN/oneDNN_build/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp:2486: Failure
Value of: allclose<int8_t>(dst_s8_ts, dst_s8_case2_ts, 0.1f, 1.f)
  Actual: false
Expected: true
[  FAILED  ] test_convtranspose_execute_subgraph_int8.ConvTranspose1d2d3dBinary (864 ms)
```

I also noticed that the dispatch observed from the graph test did not match the one from `benchdnn`.

For instance before this patch we can see 4 dispatches to `brg_conv` via `graph` but only 2 dispatches via `benchdnn` (the other 2 being to `conv:any+gemm_s8u8s32:ref`).
```
# Output from gtest:
$ ONEDNN_VERBOSE=profile_exec ./build/tests/gtests/graph/unit/test_graph_unit --gtest_filter='test_convtranspose_execute_subgraph_int8.ConvTranspose1d2d3dBinary' | grep 'cpu,deconv'
onednn_verbose,v1,primitive,exec,cpu,deconvolution,brg_deconv:sve_256+brgconv:sve_256,forward_inference,src:f32:a:blocked:acb::f0 wei:f32:a:blocked:Acb8a::f0 bia:undef::undef::: dst:f32:a:blocked:acb::f0,attr-scratchpad:user,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,0.019043
onednn_verbose,v1,primitive,exec,cpu,deconvolution,brg_deconv:sve_256+brgconv:sve_256,forward_inference,src:u8:a:blocked:acb::f0 wei:s8:a:blocked:AcB8a4b::f8:zpm1 bia:undef::undef::: dst:s8:a:blocked:acb::f0,attr-scratchpad:user attr-scales:src0:0:f32+wei:1:f32 attr-zero-points:src0:0:s32+dst:0:s32 attr-post-ops:binary_mul:f32:0,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,1.78261e-300
onednn_verbose,v1,primitive,exec,cpu,deconvolution,brg_deconv:sve_256+brgconv:sve_256,forward_inference,src:f32:a:blocked:acb::f0 wei:f32:a:blocked:Acb8a::f0 bia:undef::undef::: dst:f32:a:blocked:acb::f0,attr-scratchpad:user,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,0.00610352
onednn_verbose,v1,primitive,exec,cpu,deconvolution,brg_deconv:sve_256+brgconv:sve_256,forward_inference,src:u8:a:blocked:acb::f0 wei:s8:a:blocked:AcB8a4b::f8:zpm1 bia:undef::undef::: dst:s8:a:blocked:acb::f0,attr-scratchpad:user attr-scales:src0:0:f32+wei:1:f32 attr-zero-points:src0:0:s32+dst:0:s32 attr-post-ops:binary_max:f32:0,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,1.78262e-300

# Cases from scripts/verbose_converter/verbose_converter.py
$ ./build/tests/benchdnn/benchdnn --deconv --batch=./deconv.batch
0:PASSED (1 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
1:PASSED (0 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --dt=u8:s8:s8 --attr-scales=src:0:0.5+wei:1 --attr-zero-points=src:0:1+dst:0:1 --attr-post-ops=add:f32:0 --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
2:PASSED (0 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
3:PASSED (0 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --dt=u8:s8:s8 --attr-scales=src:0:0.5+wei:1 --attr-zero-points=src:0:1+dst:0:1 --attr-post-ops=max:f32:0 --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| brg_deconv:sve_256+brgconv:sve_256 : 2 (50%)             |
|          conv:any+gemm_s8u8s32:ref : 2 (50%)             |
============================================================
```

After the patch the data is reordered the same way as in `benchdnn and the dispatch matches.
```
$ ONEDNN_VERBOSE=profile_exec ./build/tests/gtests/graph/unit/test_graph_unit --gtest_filter='test_convtranspose_execute_subgraph_int8.ConvTranspose1d2d3dBinary' | grep 'cpu,deconv'
onednn_verbose,v1,primitive,exec,cpu,deconvolution,brg_deconv:sve_256+brgconv:sve_256,forward_inference,src:f32:a:blocked:acb::f0 wei:f32:a:blocked:Acb8a::f0 bia:undef::undef::: dst:f32:a:blocked:acb::f0,attr-scratchpad:user,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,0.0180664
onednn_verbose,v1,primitive,exec,cpu,deconvolution,conv:any+gemm_s8u8s32:ref,forward_inference,src:u8:a:blocked:acb::f0 wei:s8:a:blocked:cab::f0 bia:undef::undef::: dst:s8:a:blocked:acb::f0,attr-scratchpad:user attr-scales:src0:0:f32+wei:1:f32 attr-zero-points:src0:0:s32+dst:0:s32 attr-post-ops:binary_mul:f32:0:any,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,0.0629883
onednn_verbose,v1,primitive,exec,cpu,deconvolution,brg_deconv:sve_256+brgconv:sve_256,forward_inference,src:f32:a:blocked:acb::f0 wei:f32:a:blocked:Acb8a::f0 bia:undef::undef::: dst:f32:a:blocked:acb::f0,attr-scratchpad:user,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,0.00805664
onednn_verbose,v1,primitive,exec,cpu,deconvolution,conv:any+gemm_s8u8s32:ref,forward_inference,src:u8:a:blocked:acb::f0 wei:s8:a:blocked:cab::f0 bia:undef::undef::: dst:s8:a:blocked:acb::f0,attr-scratchpad:user attr-scales:src0:0:f32+wei:1:f32 attr-zero-points:src0:0:s32+dst:0:s32 attr-post-ops:binary_max:f32:0:any,alg:deconvolution_direct,mb1_ic8oc8_iw12ow14kw3sw1dw0pw0,0.0600586

$ ./build/tests/benchdnn/benchdnn --deconv --batch=./deconv.batch
0:PASSED (1 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
1:PASSED (0 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --dt=u8:s8:s8 --attr-scales=src:0:0.5+wei:1 --attr-zero-points=src:0:1+dst:0:1 --attr-post-ops=mul:f32:0 --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
2:PASSED (0 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
3:PASSED (0 ms) __REPRO: --deconv --allow-enum-tags-only=false --dir=FWD_I --dt=u8:s8:s8 --attr-scales=src:0:0.5+wei:1 --attr-zero-points=src:0:1+dst:0:1 --attr-post-ops=max:f32:0 --attr-scratchpad=user mb1ic8iw12oc8ow14kw3pw0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| brg_deconv:sve_256+brgconv:sve_256 : 2 (50%)             |
|          conv:any+gemm_s8u8s32:ref : 2 (50%)             |
============================================================
tests:4 passed:4 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.00s; create_pd: 0.00s (16%); create_prim: 0.00s (12%); fill: 0.00s (22%); execute: 0.00s (4%); compute_ref: 0.00s (3%); compare: 0.00s (6%);
```

Thank you to @TaoLv for patiently helping me navigate the Graph API.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?