### PR TITLE
oneDNN v3.12.1 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.12.0")
+set(PROJECT_VERSION "3.12.1")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.12:
* Enabled SYCL Graph record/replay mode support in Graph API on Intel GPUs (f0147241f57870ea719310cb9355e1a84cd2ffee, 3e19991d38fa5a3fce68c463fdbc6afbc9e81ab2, 982650a485b1ed949adc16a749f26769eaba4306)
* Fixed a performance regression in matmul with 4D shapes and `N == 1` or `M == 1` on x64 CPUs (de9498ff8862ab9e0c5e9b6fd8b3a8f8c6ab53ba, 540d53dbe9cdcec4cece82a9b7e3e474755ea8a5)
* Fixed correctness issue in matmul primitive with ReLU post-op on RV64 CPUs (772ca13e27124aa477b18e043cd83d5ddefc7cea)
* Fixed a `segfault` in `s8`/`u8` depthwise convolution on x64 processors with Intel AVX10.2 instruction set support (7f413f9fe0bf78cdf9c1dd59a92d3c7b03a838af, dac73991dfe806e3feba63b60c08ef1c58dbfed7)
* Fixed a correctness issue in `s8s8` convolution on x64 processors with Intel AVX-512 and Intel DL Boost instructions support (0dc2ca853ccef716a3ba1702000adcc2bad40e96)
* Fixed an issue with incorrect memory use estimation of layer normalization, group normalization, and batch normalization primitives in benchdnn (881e9b68d275a63979ebb6c82cea378959a487ec)
* Fixed an assertion in benchdnn graph driver (79b2593ac550bbe118335fad96649d087354b89f)
