### PR TITLE
[GPU] JIT GEMM: consolidate problem properties in kernel/exec configs

### DIFF
--- a/src/gpu/intel/gemm/conv.hpp
+++ b/src/gpu/intel/gemm/conv.hpp
@@ -20,8 +20,8 @@
 #ifdef DNNL_DEV_MODE
 
 #include "common/convolution_pd.hpp"
-#include "gpu/intel/gemm/config.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
+#include "gpu/intel/gemm/types.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/gemm/exec_types.hpp
+++ b/src/gpu/intel/gemm/exec_types.hpp
@@ -19,7 +19,7 @@
 
 #include "common/memory_storage.hpp"
 #include "common/primitive_exec_types.hpp"
-#include "gpu/intel/gemm/config.hpp"
+#include "gpu/intel/gemm/types.hpp"
 
 #define DNNL_ARG_A DNNL_ARG_WEIGHTS
 #define DNNL_ARG_B DNNL_ARG_SRC

--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -20,6 +20,7 @@
 #include "gemmstone/driver_info.hpp"
 #include "gpu/intel/compute/utils.hpp"
 #include "gpu/intel/gemm/host_scalars.hpp"
+#include "gpu/intel/gemm/jit/pd.hpp"
 #include "gpu/intel/gemm/jit/walk_orders.hpp"
 #include "gpu/intel/jit/ir/block_2d_utils.hpp"
 #include "gpu/intel/jit/utils/utils.hpp"
@@ -35,6 +36,37 @@ namespace gpu {
 namespace intel {
 namespace gemm {
 
+namespace jit {
+struct exec_args_t {
+    const memory_storage_t *a = nullptr;
+    const memory_storage_t *b = nullptr;
+    const memory_storage_t *c = nullptr;
+
+    const memory_storage_t *ao = nullptr;
+    const memory_storage_t *bo = nullptr;
+    const memory_storage_t *a_scales = nullptr;
+    const memory_storage_t *b_scales = nullptr;
+    const memory_storage_t *c_scales = nullptr;
+    const memory_storage_t *ag = nullptr;
+    const memory_storage_t *bg = nullptr;
+
+    const memory_storage_t *co = nullptr;
+
+    const memory_storage_t *sround_seed = nullptr;
+
+    int16_t ao_host_scalar = 0;
+    int16_t bo_host_scalar = 0;
+    int16_t co_host_scalar = 0;
+
+    float alpha = 1.0f;
+
+    size_t off_a0 = 0;
+    size_t off_b0 = 0;
+    size_t off_c0 = 0;
+    int64_t off_co0 = 0;
+};
+} // namespace jit
+
 bool check_memory_storage(const memory_storage_t *storage, const char *name) {
     if (storage && *storage) return true;
     VERROR(primitive, gpu, "%s,%s: %s", "jit::gemm", "argument is not set",
@@ -44,23 +76,15 @@ bool check_memory_storage(const memory_storage_t *storage, const char *name) {
 
 status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         intel::stream_t *compute_stream, zero_pool_t *zero_pool,
-        const memory_storage_t &a, const memory_storage_t &b,
-        const memory_storage_t &c, const memory_storage_t *ao,
-        const memory_storage_t *bo, int16_t ao_host_scalar,
-        int16_t bo_host_scalar, const memory_storage_t *a_scales,
-        const memory_storage_t *b_scales, const memory_storage_t *c_scales,
-        const memory_storage_t *ag, const memory_storage_t *bg,
-        const memory_storage_t &co, int16_t co_host_scalar,
-        const memory_storage_t *c_temp,
-        const memory_storage_t *zero_buf_scratchpad,
-        const memory_storage_t *sround_seed, int po_count,
+        const jit::exec_args_t &exec_args, const memory_storage_t *c_temp,
+        const memory_storage_t *zero_buf_scratchpad, int po_count,
         const memory_storage_t **po_srcs, int64_t offset_a, int64_t offset_b,
         int64_t offset_c, int64_t offset_aq, int64_t offset_bq,
-        int64_t offset_co, int64_t *offset_po_src, int32_t lda, int32_t ldb,
-        int32_t ldc, int32_t m, int32_t n, int32_t k, int32_t k0, float alpha,
-        float beta, int32_t cmask, bool last_k_block, bool swap_ab,
+        int64_t offset_co, int64_t *offset_po_src, int32_t m, int32_t n,
+        int32_t k, int32_t k0, float alpha, float beta, bool last_k_block,
         bool disable_hilbert) const {
-    if (pd()->desc()->batch() == 0) return status::success;
+    const auto &cfg = pd()->cfg();
+    if (cfg.batch() == 0) return status::success;
 
     std::unique_ptr<memory_storage_t> zeros;
     const memory_storage_t *zero_buf = nullptr;
@@ -90,18 +114,22 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
             = (nocopy_info()->kParallel() || nocopy_info()->kParallelLocal())
             && !nocopy_info()->kParallelVariable();
 
-    auto problem = pd()->kernel_desc()->problem();
+    const auto &problem = cfg.problem;
 
     if (!last_k_block) flags |= gemmstone::FlagNonfinalKBlock;
-    if (cmask & 1) flags |= gemmstone::FlagCOColumn;
-    if (cmask & 2) flags |= gemmstone::FlagCORow;
+    if (cfg.cmask & 1) flags |= gemmstone::FlagCOColumn;
+    if (cfg.cmask & 2) flags |= gemmstone::FlagCORow;
+
+    const auto lda = into<int32_t>(cfg.lda);
+    const auto ldb = into<int32_t>(cfg.ldb);
+    const auto ldc = into<int32_t>(cfg.ldc);
 
     compute::kernel_arg_list_t arg_list;
     int argn = 0;
 
-    arg_list.set(argn++, a);
-    arg_list.set(argn++, b);
-    arg_list.set(argn++, c);
+    arg_list.set(argn++, *exec_args.a);
+    arg_list.set(argn++, *exec_args.b);
+    arg_list.set(argn++, *exec_args.c);
     arg_list.set(argn++, offset_a);
     arg_list.set(argn++, offset_b);
     arg_list.set(argn++, offset_c);
@@ -115,66 +143,68 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
     set_scalar_arg_cvt(arg_list, argn++, alpha, scalar_type_);
     set_scalar_arg_cvt(arg_list, argn++, beta, scalar_type_);
 
-    bool with_a_zp = pd()->with_a_zero_points();
-    bool with_b_zp = pd()->with_b_zero_points();
-    if (swap_ab) std::swap(with_a_zp, with_b_zp);
-    bool a_zp_ptr = with_a_zp && !problem->aOffsetHostScalar();
-    bool b_zp_ptr = with_b_zp && !problem->bOffsetHostScalar();
+    bool a_zp_ptr = problem.hasAOffsetPtr();
+    bool b_zp_ptr = problem.hasBOffsetPtr();
 
-    if (a_zp_ptr) arg_list.set(argn++, *ao);
-    if (b_zp_ptr) arg_list.set(argn++, *bo);
-    if (problem->aOffsetHostScalar()) arg_list.set(argn++, ao_host_scalar);
-    if (problem->bOffsetHostScalar()) arg_list.set(argn++, bo_host_scalar);
-    if (problem->aScale2D()) arg_list.set(argn++, *a_scales);
-    if (problem->bScale2D()) arg_list.set(argn++, *b_scales);
-    if (pd()->with_mx_scale()) arg_list.set(argn++, *c_scales);
-    if (problem->needsAGroupSums()) {
-        if (!check_memory_storage(ag, "ag")) return status::runtime_error;
-        arg_list.set(argn++, *ag);
+    if (a_zp_ptr) arg_list.set(argn++, *exec_args.ao);
+    if (b_zp_ptr) arg_list.set(argn++, *exec_args.bo);
+    if (problem.aOffsetHostScalar())
+        arg_list.set(argn++, exec_args.ao_host_scalar);
+    if (problem.bOffsetHostScalar())
+        arg_list.set(argn++, exec_args.bo_host_scalar);
+    if (problem.aScale2D()) arg_list.set(argn++, *exec_args.a_scales);
+    if (problem.bScale2D()) arg_list.set(argn++, *exec_args.b_scales);
+    if (problem.hasCMXScale()) arg_list.set(argn++, *exec_args.c_scales);
+    if (problem.needsAGroupSums()) {
+        if (!check_memory_storage(exec_args.ag, "ag"))
+            return status::runtime_error;
+        arg_list.set(argn++, *exec_args.ag);
     }
-    if (problem->needsBGroupSums()) {
-        if (!check_memory_storage(bg, "bg")) return status::runtime_error;
-        arg_list.set(argn++, *bg);
+    if (problem.needsBGroupSums()) {
+        if (!check_memory_storage(exec_args.bg, "bg"))
+            return status::runtime_error;
+        arg_list.set(argn++, *exec_args.bg);
     }
 
-    if (problem->aOffset2D() || problem->aScale2D()
-            || problem->needsAGroupSums()) {
-        auto layout = problem->needsAGroupSums() ? problem->Ag.layout
-                : problem->aScale2D()            ? problem->A_scale.layout
-                                                 : problem->AO.layout;
+    if (problem.aOffset2D() || problem.aScale2D()
+            || problem.needsAGroupSums()) {
+        auto layout = problem.needsAGroupSums() ? problem.Ag.layout
+                : problem.aScale2D()            ? problem.A_scale.layout
+                                                : problem.AO.layout;
         auto ldaq = into<int32_t>(isColMajor(layout)
-                        ? utils::div_up(m, problem->aqGroupM)
-                        : utils::div_up(pd()->desc()->k(), problem->aqGroupK));
+                        ? utils::div_up(cfg.m, problem.aqGroupM)
+                        : utils::div_up(cfg.k, problem.aqGroupK));
         arg_list.set(argn++, ldaq);
     }
-    if (problem->bOffset2D() || problem->bScale2D()
-            || problem->needsBGroupSums()) {
-        auto layout = problem->needsBGroupSums() ? problem->Bg.layout
-                : problem->bScale2D()            ? problem->B_scale.layout
-                                                 : problem->BO.layout;
+    if (problem.bOffset2D() || problem.bScale2D()
+            || problem.needsBGroupSums()) {
+        auto layout = problem.needsBGroupSums() ? problem.Bg.layout
+                : problem.bScale2D()            ? problem.B_scale.layout
+                                                : problem.BO.layout;
         auto ldbq = into<int32_t>(!isColMajor(layout)
-                        ? utils::div_up(n, problem->bqGroupN)
-                        : utils::div_up(pd()->desc()->k(), problem->bqGroupK));
+                        ? utils::div_up(cfg.n, problem.bqGroupN)
+                        : utils::div_up(cfg.k, problem.bqGroupK));
         arg_list.set(argn++, ldbq);
     }
-    if (pd()->with_mx_scale()) {
-        auto ldcq = pd()->desc()->m() / problem->cqGroupM;
+    if (problem.hasCMXScale()) {
+        auto ldcq = cfg.m / problem.cqGroupM;
         arg_list.set(argn++, ldcq);
     }
-    if (problem->usesCOPtr()) {
-        if (co.is_null()) return status::runtime_error;
-        arg_list.set(argn++, co);
+    if (problem.usesCOPtr()) {
+        if (!check_memory_storage(exec_args.co, "co"))
+            return status::runtime_error;
+        arg_list.set(argn++, *exec_args.co);
         arg_list.set(argn++, offset_co);
-        if (pd()->with_bias()) {
-            auto ldco = into<int32_t>(pd()->desc()->ld_bias());
+        if (cfg.with_bias()) {
+            auto ldco = into<int32_t>(cfg.ld_bias);
             arg_list.set(argn++, ldco);
         }
-    } else if (problem->cOffsetHostScalar()) {
-        arg_list.set(argn++, co_host_scalar);
+    } else if (problem.cOffsetHostScalar()) {
+        arg_list.set(argn++, exec_args.co_host_scalar);
     }
     if (nocopy_info()->needsTempC()) arg_list.set(argn++, *c_temp);
-    if (problem->postOps.cStochasticRound) {
-        arg_list.set(argn++, *sround_seed);
+    if (problem.postOps.cStochasticRound) {
+        arg_list.set(argn++, *exec_args.sround_seed);
     }
     arg_list.set(argn++, flags);
     if (k_parallel_fixed) arg_list.set(argn++, k0);
@@ -184,20 +214,19 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         arg_list.set(argn++, *po_srcs[i]);
         arg_list.set(argn++, offset_po_src[i]);
 
-        if (problem->postOps.binaryRow[i] && problem->postOps.binaryCol[i])
-            arg_list.set(argn++, int32_t(pd()->ld_binary(i)));
+        if (problem.postOps.binaryRow[i] && problem.postOps.binaryCol[i])
+            arg_list.set(argn++, int32_t(cfg.ld_binary(i)));
     }
 
     if (nocopy_info()->fusedBeta() || nocopy_info()->fusedPostOps()) {
         arg_list.set(argn++, *zero_buf);
     }
 
-    if (pd()->batch_dims() >= 1) {
-        for (int i = pd()->batch_dims() - 1; i >= 0; i--) {
-            auto stride_a = int64_t(pd()->stride(DNNL_ARG_A, i));
-            auto stride_b = int64_t(pd()->stride(DNNL_ARG_B, i));
-            if (swap_ab) std::swap(stride_a, stride_b);
-            auto stride_c = int64_t(pd()->desc()->stride_c(i));
+    if (problem.batchDims >= 1) {
+        for (int i = problem.batchDims - 1; i >= 0; i--) {
+            auto stride_a = int64_t(cfg.a_batch_strides[i]);
+            auto stride_b = int64_t(cfg.b_batch_strides[i]);
+            auto stride_c = int64_t(cfg.c_batch_strides[i]);
             if (jit::enable_generator_dsl()) {
                 auto *intel_engine = utils::downcast<intel::engine_t *>(
                         compute_stream->engine());
@@ -209,15 +238,12 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
                 // relaxed by rounding down the surface pointer and adjusting
                 // the width accordingly.
                 auto base_alignment = intel::jit::block_2d_base_alignment(hw);
-                auto a_type = pd()->get_type(DNNL_ARG_A);
-                auto b_type = pd()->get_type(DNNL_ARG_B);
-                if (swap_ab) std::swap(a_type, b_type);
-                auto a_size = types::data_type_size(a_type);
+                auto a_size = types::data_type_size(cfg.a_type());
                 if (stride_a * a_size % base_alignment) {
                     gpu_warning() << "Unimplemented load transform";
                     return status::runtime_error;
                 }
-                auto b_size = types::data_type_size(b_type);
+                auto b_size = types::data_type_size(cfg.b_type());
                 if (stride_b * b_size % base_alignment) {
                     gpu_warning() << "Unimplemented load transform";
                     return status::runtime_error;
@@ -226,40 +252,30 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
             arg_list.set(argn++, stride_a);
             arg_list.set(argn++, stride_b);
             arg_list.set(argn++, stride_c);
-            int eff_a_arg = DNNL_ARG_A;
-            int eff_b_arg = DNNL_ARG_B;
-            if (swap_ab) std::swap(eff_a_arg, eff_b_arg);
-            if (problem->hasAScalePtr()) {
-                arg_list.set(argn++, pd()->scale_stride(i, eff_a_arg));
-            }
-            if (problem->hasBScalePtr()) {
-                arg_list.set(argn++, pd()->scale_stride(i, eff_b_arg));
-            }
-            if (problem->hasCMXScale()) {
-                arg_list.set(argn++, stride_c / problem->cqGroupM);
-            }
-            if (problem->hasAOffsetPtr()) {
-                arg_list.set(argn++, pd()->zp_stride(i, eff_a_arg));
-            }
-            if (problem->hasBOffsetPtr()) {
-                arg_list.set(argn++, pd()->zp_stride(i, eff_b_arg));
-            }
-            if (problem->needsAGroupSums()) {
-                arg_list.set(argn++, pd()->gs_stride(i, eff_a_arg));
-            }
-            if (problem->needsBGroupSums()) {
-                arg_list.set(argn++, pd()->gs_stride(i, eff_b_arg));
-            }
+            if (problem.hasAScalePtr())
+                arg_list.set(argn++, cfg.a_scale_stride(i));
+            if (problem.hasBScalePtr())
+                arg_list.set(argn++, cfg.b_scale_stride(i));
+            if (problem.hasCMXScale())
+                arg_list.set(argn++, stride_c / problem.cqGroupM);
+            if (problem.hasAOffsetPtr())
+                arg_list.set(argn++, cfg.a_zp_stride(i));
+            if (problem.hasBOffsetPtr())
+                arg_list.set(argn++, cfg.b_zp_stride(i));
+            if (problem.needsAGroupSums())
+                arg_list.set(argn++, cfg.a_gs_stride(i));
+            if (problem.needsBGroupSums())
+                arg_list.set(argn++, cfg.b_gs_stride(i));
         }
         for (int i = 0; i < po_count; i++) {
-            if (problem->postOps.binaryBatch[i]) {
-                for (int b = pd()->batch_dims() - 1; b >= 0; b--) {
-                    arg_list.set(argn++, int64_t(pd()->stride_binary(i, b)));
+            if (problem.postOps.binaryBatch[i]) {
+                for (int b = problem.batchDims - 1; b >= 0; b--) {
+                    arg_list.set(argn++, int64_t(cfg.stride_binary(i, b)));
                 }
             }
         }
-        for (int i = 1; i < pd()->batch_dims(); i++) {
-            auto batchSize = uint32_t(pd()->desc()->c_desc.dims[i]);
+        for (int i = 1; i < problem.batchDims; i++) {
+            auto batchSize = uint32_t(cfg.c_batch_sizes[i]);
             arg_list.set(argn++, batchSize);
             if (jit::enable_generator_dsl()) {
                 uint64_t magic = dnnl::impl::gpu::intel::jit::ir_utils::
@@ -272,7 +288,7 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         }
     }
 
-    auto lws_k = pd()->kernel_desc()->aux_params()->wgK;
+    auto lws_k = pd()->kernel_desc().aux_params()->wgK;
 
     compute::range_t gws = compute::range_t::empty();
 
@@ -287,11 +303,11 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
     // C Interleave: pad up gws[N] to a multiple of the chunk size and add to gws[M] if misaligned ldc
     auto info = nocopy_info();
     gws[1] = utils::rnd_up(
-            gws[1], info->cInterleaveChunk(problem->Tc_ext) * lws[1]);
+            gws[1], info->cInterleaveChunk(problem.Tc_ext) * lws[1]);
     if (info->cInterleaveEnabled()
-            && (offset_c % 64 > 0 || ldc * problem->Tc % 64 > 0)) {
+            && (offset_c % 64 > 0 || ldc * problem.Tc % 64 > 0)) {
         auto wgTileM = info->wgTile(gemmstone::LoopM);
-        auto maxShift = 64 / problem->Tc_ext.size() - 1;
+        auto maxShift = 64 / problem.Tc_ext.size() - 1;
         gws[0] += lws[0] * utils::div_up(wgTileM + maxShift, wgTileM);
     }
 
@@ -327,10 +343,10 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
     lws[1] *= nocopy_info()->wgExpand;
     gws[1] *= nocopy_info()->wgExpand;
 
-    gws[2] *= pd()->desc()->batch();
+    gws[2] *= cfg.batch();
 
     jit::linear_order_args(arg_list, argn, lws, gws, m, n, k, disable_hilbert,
-            *nocopy_info(), pd()->kernel_desc()->aux_params(), pd()->dev_info_);
+            *nocopy_info(), pd()->kernel_desc().aux_params(), pd()->dev_info_);
 
     if (nocopy_info()->perKSLM > 0) {
         size_t slm = nocopy_info()->slm;
@@ -338,9 +354,9 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         arg_list.set(argn++, slm, nullptr);
     }
 
-    if (problem->aoPtrDims >= 1 || problem->aScale2D())
+    if (problem.aoPtrDims > 0 || problem.aScale2D())
         arg_list.set(argn++, offset_aq);
-    if (problem->boPtrDims >= 1 || problem->bScale2D())
+    if (problem.boPtrDims > 0 || problem.bScale2D())
         arg_list.set(argn++, offset_bq);
 
     lws[0] *= nocopy_info()->subgroupSize;
@@ -354,6 +370,101 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         zero_pool->async_release(zp_token, compute_stream->ctx().get_deps());
 
     return status;
+}
+
+static status_t init_exec_args(jit::exec_args_t &exec_args,
+        const jit::kernel_config_t &cfg, const exec_ctx_t &ctx) {
+
+    auto &a_phys = GEMM_CTX_ARG_STORAGE(a);
+    auto &b_phys = GEMM_CTX_ARG_STORAGE(b);
+    exec_args.a = cfg.swap_ab ? &a_phys : &b_phys;
+    exec_args.b = cfg.swap_ab ? &b_phys : &a_phys;
+    exec_args.c = &GEMM_CTX_ARG_STORAGE(c);
+    exec_args.sround_seed = &GEMM_CTX_ARG_STORAGE(sround_seed);
+
+    const memory_storage_t *co = &GEMM_CTX_ARG_STORAGE(c_zero_point);
+    if (cfg.with_c_zero_points()) {
+        exec_args.off_co0
+                = types::bytes_to_elements(cfg.c_type(), co->offset());
+        if (co->is_host_scalar()) {
+            int co_host = 0;
+            CHECK(maybe_get_host_scalar_value(*co, co_host));
+            // DST zero point is added to result (not subtracted like SRC/WEI).
+            exec_args.co_host_scalar = static_cast<int16_t>(co_host);
+        }
+    } else if (cfg.with_bias()) {
+        co = &GEMM_CTX_ARG_STORAGE(bias);
+        exec_args.off_co0
+                = types::bytes_to_elements(cfg.c_type(), co->offset());
+    } else if (cfg.with_sum_ab()) {
+        co = &GEMM_CTX_ARG_STORAGE(sum_ab);
+        exec_args.off_co0
+                = types::bytes_to_elements(cfg.c_type(), co->offset());
+    }
+    exec_args.co = co;
+
+    if (cfg.with_a_zero_points() || cfg.with_b_zero_points()) {
+        const auto *ao_phys = &GEMM_CTX_ARG_STORAGE(a_zero_point);
+        const auto *bo_phys = &GEMM_CTX_ARG_STORAGE(b_zero_point);
+        int ao_host = 0, bo_host = 0;
+        if (ao_phys->is_host_scalar())
+            CHECK(maybe_get_host_scalar_value(*ao_phys, ao_host));
+        if (bo_phys->is_host_scalar())
+            CHECK(maybe_get_host_scalar_value(*bo_phys, bo_host));
+        if (cfg.swap_ab) {
+            std::swap(ao_phys, bo_phys);
+            std::swap(ao_host, bo_host);
+        }
+        exec_args.ao = ao_phys;
+        exec_args.bo = bo_phys;
+        exec_args.ao_host_scalar = static_cast<int16_t>(-ao_host);
+        exec_args.bo_host_scalar = static_cast<int16_t>(-bo_host);
+    }
+
+    auto &a_scales_phys = GEMM_CTX_ARG_STORAGE(a_scales);
+    auto &b_scales_phys = GEMM_CTX_ARG_STORAGE(b_scales);
+    if (cfg.problem.aScale2D())
+        exec_args.a_scales = cfg.swap_ab ? &b_scales_phys : &a_scales_phys;
+    if (cfg.problem.bScale2D())
+        exec_args.b_scales = cfg.swap_ab ? &a_scales_phys : &b_scales_phys;
+    if (cfg.problem.hasCMXScale())
+        exec_args.c_scales = &GEMM_CTX_ARG_STORAGE(c_scales);
+
+    auto &ag_phys = GEMM_CTX_ARG_STORAGE(a_group_sums);
+    auto &bg_phys = GEMM_CTX_ARG_STORAGE(b_group_sums);
+    exec_args.ag = cfg.swap_ab ? &bg_phys : &ag_phys;
+    exec_args.bg = cfg.swap_ab ? &ag_phys : &bg_phys;
+
+    exec_args.off_a0
+            = types::bytes_to_elements(cfg.a_type(), exec_args.a->offset());
+    exec_args.off_b0
+            = types::bytes_to_elements(cfg.b_type(), exec_args.b->offset());
+    exec_args.off_c0
+            = types::bytes_to_elements(cfg.c_type(), exec_args.c->offset());
+
+    exec_args.alpha = cfg.alpha();
+    if (cfg.a_host_scale || cfg.b_host_scale || cfg.c_host_scale_to_alpha) {
+        exec_args.alpha = 1.0f;
+        float scale_val = 0;
+        const auto &a_hs = cfg.swap_ab ? b_scales_phys : a_scales_phys;
+        const auto &b_hs = cfg.swap_ab ? a_scales_phys : b_scales_phys;
+        if (cfg.a_host_scale) {
+            CHECK(maybe_get_host_scalar_value(a_hs, scale_val));
+            exec_args.alpha *= scale_val;
+        }
+        if (cfg.b_host_scale) {
+            CHECK(maybe_get_host_scalar_value(b_hs, scale_val));
+            exec_args.alpha *= scale_val;
+        }
+        // Limited support of host scalar dst scales.
+        if (cfg.c_host_scale_to_alpha) {
+            CHECK(maybe_get_host_scalar_value(
+                    GEMM_CTX_ARG_STORAGE(c_scales), scale_val));
+            gpu_assert(scale_val != 0);
+            exec_args.alpha /= scale_val;
+        }
+    }
+    return status::success;
 }
 
 status_t gen_t::execute(const exec_ctx_t &ctx) const {
@@ -370,59 +481,26 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
     if (sycl_stream->recording()) zero_pool = nullptr;
 #endif
 
-    const auto d = pd()->desc();
-    const auto &problem = *pd()->kernel_desc()->problem();
+    const auto &cfg = pd()->cfg();
+    jit::exec_args_t exec_args;
+    CHECK(init_exec_args(exec_args, cfg, ctx));
 
-    const bool swap_ab = pd()->swap_ab();
+    const auto &problem = cfg.problem;
+    const auto m = into<int32_t>(cfg.m);
+    const auto n = into<int32_t>(cfg.n);
+    const auto k = into<int32_t>(cfg.k);
+    const auto lda = into<int32_t>(cfg.lda);
+    const auto ldb = into<int32_t>(cfg.ldb);
+    const auto ldc = into<int32_t>(cfg.ldc);
+    const auto ldco = into<int32_t>(cfg.with_bias() ? cfg.ld_bias : 0);
 
-    auto a_type = pd()->get_type(DNNL_ARG_A);
-    auto b_type = pd()->get_type(DNNL_ARG_B);
-    auto c_type = d->c_type();
-
-    auto m = into<int32_t>(pd()->desc()->m());
-    auto n = into<int32_t>(pd()->desc()->n());
-    auto k = into<int32_t>(d->k());
-
-    bool trans_a = pd()->trans_a();
-    bool trans_b = pd()->trans_b();
-
-    auto lda = into<int32_t>(pd()->ld(DNNL_ARG_A));
-    auto ldb = into<int32_t>(pd()->ld(DNNL_ARG_B));
-    auto ldc = into<int32_t>(d->ldc());
-    auto ldco = into<int32_t>(pd()->with_bias() ? d->ld_bias() : 0);
-
-    if (swap_ab) {
-        std::swap(a_type, b_type);
-        std::swap(m, n);
-        std::swap(lda, ldb);
-        std::swap(trans_a, trans_b);
-        trans_a = !trans_a;
-        trans_b = !trans_b;
-    }
-
-    auto alpha = pd()->alpha();
-    auto beta = pd()->beta();
+    auto alpha = exec_args.alpha;
+    auto beta = cfg.beta;
 
     bool k_parallel_global = nocopy_info()->kParallel();
     bool k_parallel_fixed
             = (nocopy_info()->kParallel() || nocopy_info()->kParallelLocal())
             && !nocopy_info()->kParallelVariable();
-
-    auto &a = swap_ab ? GEMM_CTX_ARG_STORAGE(a) : GEMM_CTX_ARG_STORAGE(b);
-    auto &b = swap_ab ? GEMM_CTX_ARG_STORAGE(b) : GEMM_CTX_ARG_STORAGE(a);
-    auto &c = GEMM_CTX_ARG_STORAGE(c);
-    auto &c_zp = GEMM_CTX_ARG_STORAGE(c_zero_point);
-    auto &bias = GEMM_CTX_ARG_STORAGE(bias);
-    auto &sum_ab = GEMM_CTX_ARG_STORAGE(sum_ab);
-    auto *sround_seed = &GEMM_CTX_ARG_STORAGE(sround_seed);
-    auto *co = &c_zp;
-    const memory_storage_t *ao = nullptr, *bo = nullptr;
-    const memory_storage_t *a_scales = nullptr, *b_scales = nullptr;
-    const memory_storage_t *c_scales = nullptr;
-    const memory_storage_t *ag = nullptr, *bg = nullptr;
-    int16_t ao_host_scalar = 0;
-    int16_t bo_host_scalar = 0;
-    int16_t co_host_scalar = 0;
 
     std::unique_ptr<memory_storage_t> c_temp;
     if (nocopy_info()->needsTempC()) {
@@ -437,14 +515,15 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
     }
 
     const memory_storage_t *po_srcs[GEMM_MAX_PO];
+    auto &bias = GEMM_CTX_ARG_STORAGE(bias);
 
-    int po_count = pd()->post_ops()->len();
+    int po_count = int(cfg.binary_srcs.size());
     assert(po_count <= GEMM_MAX_PO);
 
     for (int i = 0; i < po_count; i++) {
-        auto &src = pd()->binary_srcs()[i];
+        auto &src = cfg.binary_srcs[i];
         switch (src.type) {
-            case pd_t::binary_src_t::binary:
+            case jit::binary_src_t::binary:
                 po_srcs[i]
                         = ctx.args()
                                   .exec_args
@@ -453,7 +532,7 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                                   .mem()
                                   ->memory_storage();
                 break;
-            case pd_t::binary_src_t::prelu:
+            case jit::binary_src_t::prelu:
                 po_srcs[i]
                         = ctx.args()
                                   .exec_args
@@ -462,8 +541,8 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                                   .mem()
                                   ->memory_storage();
                 break;
-            case pd_t::binary_src_t::bias: po_srcs[i] = &bias; break;
-            case pd_t::binary_src_t::scales:
+            case jit::binary_src_t::bias: po_srcs[i] = &bias; break;
+            case jit::binary_src_t::scales:
                 switch (src.index) {
                     case DNNL_ARG_WEIGHTS:
                         po_srcs[i] = &GEMM_CTX_ARG_STORAGE(a_scales);
@@ -484,105 +563,12 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
         }
     }
 
-    size_t off_a0
-            = types::bytes_to_elements(a_type, a.offset()) + pd()->dyn_offset_a;
-    size_t off_b0
-            = types::bytes_to_elements(b_type, b.offset()) + pd()->dyn_offset_b;
-    size_t off_c0
-            = types::bytes_to_elements(c_type, c.offset()) + pd()->dyn_offset_c;
-    int64_t off_aq0 = 0, off_bq0 = 0, off_co0 = 0;
-
     int64_t po_offsets0[GEMM_MAX_PO] = {0}, po_offsets[GEMM_MAX_PO] = {0};
     for (int i = 0; i < po_count; i++)
         if (po_srcs[i])
             po_offsets0[i] = po_srcs[i]->offset() / problem.Tbinary[i];
 
-    int cmask = 0;
-    if (pd()->with_c_zero_points()) {
-        off_co0 = types::bytes_to_elements(c_type, co->offset())
-                + pd()->dyn_offset_co;
-        cmask = pd()->attr()->zero_points_.get_mask(DNNL_ARG_DST);
-        int co_host_scalar_val = 0;
-        if (co->is_host_scalar()) {
-            CHECK(maybe_get_host_scalar_value(*co, co_host_scalar_val));
-        }
-        // DST zero point is added to result (not subtracted like SRC/WEI)
-        co_host_scalar = static_cast<int16_t>(co_host_scalar_val);
-    } else if (pd()->with_bias()) {
-        off_co0 = types::bytes_to_elements(c_type, bias.offset());
-        co = &bias;
-        cmask = pd()->bias_cmask();
-    } else if (pd()->with_sum_ab()) {
-        off_co0 = types::bytes_to_elements(c_type, sum_ab.offset());
-        co = &sum_ab;
-        cmask = pd()->sum_ab_cmask();
-        // TODO: Check if this swapping is still needed and correct with logic below
-        if (swap_ab) {
-            uint8_t swap_table[4] = {0, 2, 1, 3};
-            cmask = (cmask & ~3) | swap_table[cmask & 3];
-        }
-    }
-
-    // Get host scalar zero-poins values
-    if (pd()->with_a_zero_points() || pd()->with_b_zero_points()) {
-        ao = &GEMM_CTX_ARG_STORAGE(a_zero_point);
-        bo = &GEMM_CTX_ARG_STORAGE(b_zero_point);
-        int a_host_scalar_val = 0;
-        int b_host_scalar_val = 0;
-        if (ao->is_host_scalar())
-            CHECK(maybe_get_host_scalar_value(*ao, a_host_scalar_val));
-        if (bo->is_host_scalar())
-            CHECK(maybe_get_host_scalar_value(*bo, b_host_scalar_val));
-        ao_host_scalar = static_cast<int16_t>(-1 * a_host_scalar_val);
-        bo_host_scalar = static_cast<int16_t>(-1 * b_host_scalar_val);
-    }
-
-    // Convert host scalar scales to Alpha
-    if (pd()->attr()->scales_.has_host_scalars()) {
-        const auto &a_scales = pd()->attr()->scales_.get(DNNL_ARG_A);
-        const auto &b_scales = pd()->attr()->scales_.get(DNNL_ARG_B);
-        const auto &c_scales = pd()->attr()->scales_.get(DNNL_ARG_C);
-        const auto &a_scales_storage = GEMM_CTX_ARG_STORAGE(a_scales);
-        const auto &b_scales_storage = GEMM_CTX_ARG_STORAGE(b_scales);
-        const auto &c_scales_storage = GEMM_CTX_ARG_STORAGE(c_scales);
-        alpha = 1.0f;
-        float scale_val = 0;
-        if (a_scales.is_host_scalar()) {
-            CHECK(maybe_get_host_scalar_value(a_scales_storage, scale_val));
-            alpha *= scale_val;
-        }
-        if (b_scales.is_host_scalar()) {
-            CHECK(maybe_get_host_scalar_value(b_scales_storage, scale_val));
-            alpha *= scale_val;
-        }
-        // Limited support of host scalar dst scales
-        if (c_scales.is_host_scalar() && pd()->attr()->post_ops_.len() == 0) {
-            CHECK(maybe_get_host_scalar_value(c_scales_storage, scale_val));
-            gpu_assert(scale_val != 0);
-            alpha /= scale_val;
-        }
-    }
-
-    if (pd()->a_scales_2d()) { a_scales = &GEMM_CTX_ARG_STORAGE(a_scales); }
-    if (pd()->b_scales_2d()) { b_scales = &GEMM_CTX_ARG_STORAGE(b_scales); }
-    if (pd()->with_mx_scale()) { c_scales = &GEMM_CTX_ARG_STORAGE(c_scales); }
-
-    if (swap_ab) {
-        if (problem.needsAGroupSums()) ag = &GEMM_CTX_ARG_STORAGE(b_group_sums);
-        if (problem.needsBGroupSums()) bg = &GEMM_CTX_ARG_STORAGE(a_group_sums);
-    } else {
-        if (problem.needsAGroupSums()) ag = &GEMM_CTX_ARG_STORAGE(a_group_sums);
-        if (problem.needsBGroupSums()) bg = &GEMM_CTX_ARG_STORAGE(b_group_sums);
-    }
-
-    if (swap_ab) {
-        std::swap(ao, bo);
-        std::swap(ao_host_scalar, bo_host_scalar);
-        std::swap(a_scales, b_scales);
-
-        uint8_t swap_table[4] = {0, 2, 1, 3};
-        cmask = (cmask & ~3) | swap_table[cmask & 3];
-    }
+    int64_t off_aq0 = 0, off_bq0 = 0;
 
     status_t status;
 
@@ -596,14 +582,12 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
         block_n = nocopy_info()->blockingAlt[1];
     }
 
-    if (!utils::one_of(pd()->desc()->c_type(), data_type::f32, data_type::f16))
+    if (!utils::one_of(cfg.c_type(), data_type::f32, data_type::f16))
         block_k = k;
-    if (pd()->post_ops()->len() > 0
-            && pd()->post_ops()->entry_[0].kind != primitive_kind::sum)
-        block_k = k;
+    if (problem.postOps.len() > 0 && !problem.postOps[0].is_sum()) block_k = k;
 
     if (k_parallel_fixed)
-        block_k = into<int32_t>(pd()->kernel_desc()->aux_params()->k0);
+        block_k = into<int32_t>(pd()->kernel_desc().aux_params()->k0);
 
     block_m = utils::rnd_up(block_m, nocopy_info()->wgTile(gemmstone::LoopM));
     block_n = utils::rnd_up(block_n, nocopy_info()->wgTile(gemmstone::LoopN));
@@ -614,14 +598,12 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
         block_k = std::max(k, 1);
 
         if (k_parallel_global && !nocopy_info()->fusedBeta() && beta != 1.0f
-                && (k > k0 * pd()->kernel_desc()->aux_params()->wgK)) {
-            status = launch_nocopy(ctx, compute_stream, zero_pool, a, b, c, ao,
-                    bo, ao_host_scalar, bo_host_scalar, a_scales, b_scales,
-                    c_scales, ag, bg, *co, co_host_scalar, nullptr,
-                    zero_buf_scratchpad.get(), sround_seed, po_count, po_srcs,
-                    off_a0, off_b0, off_c0, off_aq0, off_bq0, off_co0,
-                    po_offsets0, lda, ldb, ldc, m, n, 0, 1, 1.0f, beta, 0,
-                    false, swap_ab, true);
+                && (k > k0 * pd()->kernel_desc().aux_params()->wgK)) {
+            status = launch_nocopy(ctx, compute_stream, zero_pool, exec_args,
+                    nullptr, zero_buf_scratchpad.get(), po_count, po_srcs,
+                    exec_args.off_a0, exec_args.off_b0, exec_args.off_c0,
+                    off_aq0, off_bq0, exec_args.off_co0, po_offsets0, m, n, 0,
+                    1, 1.0f, beta, false, true);
             if (status) return status;
             beta = 1.0f;
         }
@@ -636,25 +618,25 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
             int64_t size_m = m - Bm;
             if (size_m > block_m) size_m = block_m;
 
-            auto off_a_src
-                    = off_a0 + (!trans_a ? (Bm + Bk * lda) : (Bk + Bm * lda));
+            auto off_a_src = exec_args.off_a0
+                    + (!cfg.trans_a() ? (Bm + Bk * lda) : (Bk + Bm * lda));
 
             for (int64_t Bn = 0; Bn < n; Bn += block_n) {
                 int64_t size_n = n - Bn;
                 if (size_n > block_n) size_n = block_n;
 
-                auto off_b_src = off_b0
-                        + (!trans_b ? (Bk + Bn * ldb) : (Bn + Bk * ldb));
+                auto off_b_src = exec_args.off_b0
+                        + (!cfg.trans_b() ? (Bk + Bn * ldb) : (Bn + Bk * ldb));
 
-                auto off_c = off_c0 + Bm + Bn * ldc;
+                auto off_c = exec_args.off_c0 + Bm + Bn * ldc;
 
                 auto off_aq = off_aq0;
                 auto off_bq = off_bq0;
-                if (problem.aoPtrDims >= 1 || a_scales) off_aq += Bm;
-                if (problem.boPtrDims >= 1 || b_scales) off_bq += Bn;
+                if (problem.aoPtrDims >= 1 || exec_args.a_scales) off_aq += Bm;
+                if (problem.boPtrDims >= 1 || exec_args.b_scales) off_bq += Bn;
 
-                auto off_co = off_co0;
-                switch (cmask & 3) {
+                auto off_co = exec_args.off_co0;
+                switch (cfg.cmask & 3) {
                     case 1: off_co += Bn; break;
                     case 2: off_co += Bm; break;
                     case 3:
@@ -669,7 +651,7 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                     bool row = problem.postOps.binaryRow[i],
                          col = problem.postOps.binaryCol[i];
                     if (row && col) {
-                        auto ld = pd()->ld_binary(i);
+                        auto ld = cfg.ld_binary(i);
                         po_offsets[i] += isColMajor(problem.binary[i].layout)
                                 ? (Bn * ld + Bm)
                                 : (Bm * ld + Bn);
@@ -680,15 +662,12 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                 }
 
                 float eff_beta = (Bk == 0) ? beta : 1.0f;
-                status = launch_nocopy(ctx, compute_stream, zero_pool, a, b, c,
-                        ao, bo, ao_host_scalar, bo_host_scalar, a_scales,
-                        b_scales, c_scales, ag, bg, *co, co_host_scalar,
-                        c_temp.get(), zero_buf_scratchpad.get(), sround_seed,
+                status = launch_nocopy(ctx, compute_stream, zero_pool,
+                        exec_args, c_temp.get(), zero_buf_scratchpad.get(),
                         po_count, po_srcs, off_a_src, off_b_src, off_c, off_aq,
-                        off_bq, off_co, po_offsets, lda, ldb, ldc,
-                        into<int32_t>(size_m), into<int32_t>(size_n),
-                        into<int32_t>(size_k), k0, alpha, eff_beta, cmask,
-                        last_k_block, swap_ab, disable_hilbert);
+                        off_bq, off_co, po_offsets, into<int32_t>(size_m),
+                        into<int32_t>(size_n), into<int32_t>(size_k), k0, alpha,
+                        eff_beta, last_k_block, disable_hilbert);
 
                 if (status) return status;
             }

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -32,12 +32,17 @@
 #include "gpu/intel/gemm/jit/pd.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
 #include "gpu/intel/gemm/utils.hpp"
+#include "gpu/intel/utils.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace gpu {
 namespace intel {
 namespace gemm {
+
+namespace jit {
+struct exec_args_t;
+}
 
 // The zero-buffer scratchpad path is prepared when the zero pool is disabled,
 // or (under SYCL) as a fallback while recording a graph.
@@ -84,27 +89,29 @@ struct gen_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:gemm:any", gen_t);
 
-        status_t init(impl::engine_t *engine) {
-            using namespace prop_kind;
+        bool decide_swap_ab(const jit::kernel_config_t &cfg) const override {
+            bool check_lda
+                    = ((!cfg.trans_a() && cfg.lda == 1) || cfg.trans_a());
+            bool s = (cfg.m == 1 && cfg.ldc == 1 && check_lda) || cfg.trans_c();
+            // We cannot swap A/B if we don't have kernels to support the
+            // swapped data type/alignment requirements. Currently mostly
+            // affects weights-only compression cases, since A/B have
+            // different data types.
+            s &= !cfg.wei_decomp;
+            return s;
+        }
+
+        // desc()/attr() checks only; run before apply_swap_ab folds A/B.
+        status_t check_problem(impl::engine_t *engine) const {
             using namespace data_type;
-            using namespace primitive_kind;
-            using namespace alg_kind;
             using smask_t = primitive_attr_t::skip_mask_t;
             using arch_t = compute::gpu_arch_t;
 
-            assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
-
-            CHECK(set_default_formats(false));
-
-            dev_info_ = intel_engine->device_info();
-            arch_ = dev_info_->gpu_arch();
-
-            CHECK(jit::pd_t::init(engine, arch_));
-
             const auto d = desc();
-            auto m = desc()->m();
-            auto n = desc()->n();
+            const auto *attr = this->attr();
+            const auto arch = arch_;
+            const auto *dev_info = dev_info_;
+            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
 
             // Basic implementation attr support:
             auto attr_skip_mask = smask_t::post_ops | smask_t::fpmath_mode
@@ -113,58 +120,21 @@ struct gen_t : public primitive_t {
                     | smask_t::scales_groups | smask_t::precomputed_reductions
                     | smask_t::zero_points | smask_t::zero_points_data_type
                     | smask_t::zero_points_groups;
-            VDISPATCH_GEMM(attr()->has_default_values(attr_skip_mask),
+            VDISPATCH_GEMM(attr->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_GEMM(
                     !utils::one_of(DNNL_RUNTIME_DIM_VAL, d->m(), d->n(), d->k(),
                             d->lda(), d->ldb(), d->ldc(), d->batch()),
-                    VERBOSE_RUNTIMEDIM_UNSUPPORTED);
-
-            // If m = 1, swap A/B to use more efficient n = 1 kernels if possible.
-            bool check_lda = ((d->transa() == dnnl_notrans && d->lda() == 1)
-                    || (d->transa() == dnnl_trans));
-            swap_ab_ = (d->m() == 1 && d->ldc() == 1 && check_lda)
-                    || d->transc() == dnnl_trans;
-
-            // We cannot swap A/B if we don't have kernels to support the
-            // swapped data type/alignment requirements. Currently mostly affects
-            // weights-only compression cases, since A/B have different data types
-            swap_ab_ &= !wei_decomp_;
-
-            // No kernels with transposed C, if swap_ab is disabled (e.g. due
-            // to wei_decomp_) - this case cannot be handled.
-            VDISPATCH_GEMM(IMPLICATION(d->transc() == dnnl_trans, swap_ab_),
                     VERBOSE_UNSUPPORTED_TAG);
 
-            if (swap_ab_) {
-                // Do not use transposed B when it is unnecessary
-                if (!transa_ && m == 1) {
-                    transa_ = true;
-                    lda_ = d->k();
-                }
-            }
-
-            // Pad leading dimensions in case of a single row/column.
-            if ((d->k() == 1 && !trans_a()) || (m == 1 && trans_a())) {
-                lda_ = utils::rnd_up(lda_, 16);
-            }
-
-            if ((n == 1 && !trans_b()) || (d->k() == 1 && trans_b())) {
-                ldb_ = utils::rnd_up(ldb_, 16);
-            }
-
-            if (swap_ab_) std::swap(m, n);
-
-            // Check parameters.
             if (utils::one_of(d->c_type(), s32, f16, bf16, f32, u8, s8)
                     && utils::one_of(d->a_type(), u8, s8, u4, s4)) {
                 VDISPATCH_GEMM(
-                        (utils::one_of(d->b_type(), u8, s8) || wei_decomp_),
+                        (utils::one_of(d->b_type(), u8, s8) || wei_decomp()),
                         VERBOSE_UNSUPPORTED_DT);
-
                 VDISPATCH_GEMM(IMPLICATION(utils::one_of(d->c_type(), f32, s8,
                                                    u8, f16, bf16),
-                                       arch_ >= arch_t::xe_hp),
+                                       arch >= arch_t::xe_hp),
                         VERBOSE_ISA_DT_MISMATCH);
             } else if (utils::one_of(d->a_type(), f16, bf16)) {
                 VDISPATCH_GEMM(d->b_type() == d->a_type(),
@@ -174,7 +144,7 @@ struct gen_t : public primitive_t {
                         VERBOSE_INCONSISTENT_DT, "a", "c");
                 VDISPATCH_GEMM(utils::one_of(d->acc_type, d->a_type(), f32),
                         VERBOSE_INCONSISTENT_DT, "a", "acc");
-            } else if (!wei_decomp_) {
+            } else if (!wei_decomp()) {
                 VDISPATCH_GEMM(utils::one_of(d->a_type(), f64, f32, f16, bf16,
                                        f8_e5m2, f8_e4m3, f4_e2m1, f4_e3m0),
                         VERBOSE_UNSUPPORTED_DT);
@@ -191,7 +161,7 @@ struct gen_t : public primitive_t {
                         VERBOSE_UNSUPPORTED_DT);
                 VDISPATCH_GEMM(IMPLICATION(utils::one_of(f64, d->a_type(),
                                                    d->b_type()),
-                                       dev_info_->has_native(f64)),
+                                       dev_info->has_native(f64)),
                         VERBOSE_UNSUPPORTED_DT);
             }
 
@@ -201,8 +171,6 @@ struct gen_t : public primitive_t {
             VDISPATCH_GEMM(intel_engine->mayiuse_ngen_kernels(),
                     VERBOSE_UNSUPPORTED_DEVICE_FEATURE, "ngen_kernels");
 
-            // Do not use `with_bias()` as the bias operation may have been
-            // moved into a post-op.
             bool with_bias = d->bias_type() != data_type::undef;
             VDISPATCH_GEMM(utils::one_of(d->bias_type(), data_type::undef, f64,
                                    f32, bf16, f16, f8_e5m2, f8_e4m3)
@@ -213,145 +181,167 @@ struct gen_t : public primitive_t {
                             (d->c_type() != f64 || d->bias_type() == f64)),
                     VERBOSE_UNSUPPORTED_BIAS_CFG);
             VDISPATCH_GEMM(
-                    IMPLICATION(with_sum_ab(),
+                    IMPLICATION(sum_ab() != dnnl_sum_none,
                             !with_bias
-                                    && (attr()->zero_points_.has_default_values(
-                                            DNNL_ARG_DST))),
+                                    && attr->zero_points_.has_default_values(
+                                            DNNL_ARG_DST)),
                     VERBOSE_UNSUPPORTED_ATTR);
 
-            VDISPATCH_GEMM(attr()->post_ops_.check_sum_consistency(d->c_type(),
+            VDISPATCH_GEMM(attr->post_ops_.check_sum_consistency(d->c_type(),
                                    utils::one_of(d->a_type(), s8, u8)),
                     VERBOSE_UNSUPPORTED_POSTOP);
+
             auto c_kernel_type
-                    = jit::convert_dnnl_to_kernel_type(desc_.c_desc.data_type);
-            for (int i = 0; i < desc_.c_desc.ndims; i++) {
-                auto c_stride = desc_.c_desc.format_desc.blocking.strides[i];
+                    = jit::convert_dnnl_to_kernel_type(d->c_desc.data_type);
+            for (int i = 0; i < d->c_desc.ndims; i++) {
+                auto c_stride = d->c_desc.format_desc.blocking.strides[i];
                 VDISPATCH_GEMM(IMPLICATION(c_kernel_type.is4(),
                                        c_stride == 1 || c_stride % 2 == 0),
                         VERBOSE_SHAPE_RESTRICTION);
             }
 
-            bool with_binary = (post_ops_.find(binary) != -1)
-                    || (post_ops_.find(prelu) != -1);
-            bool with_eltwise = (post_ops_.find(eltwise) != -1);
-
             // Check GPU architecture.
-            bool arch_ok = utils::one_of(arch_, arch_t::xe_lp, arch_t::xe_hp,
+            bool arch_ok = utils::one_of(arch, arch_t::xe_lp, arch_t::xe_hp,
                     arch_t::xe_hpg, arch_t::xe_hpc, arch_t::xe2, arch_t::xe3);
-            arch_ok |= (arch_ >= arch_t::xe3p);
-
+            arch_ok |= (arch >= arch_t::xe3p);
             VDISPATCH_GEMM(arch_ok, VERBOSE_UNSUPPORTED_ARCH, "gpu");
-            VDISPATCH_GEMM(IMPLICATION(with_binary, arch_ >= arch_t::xe_hp),
-                    VERBOSE_UNSUPPORTED_ARCH, "gpu");
-
-            // Grouped scales break pre-XeHPG kernels due to increased register pressure
-            bool A_grouped
-                    = 1 < a_quant.group_k && a_quant.group_k < desc()->k();
-            bool B_grouped
-                    = 1 < b_quant.group_k && b_quant.group_k < desc()->k();
-            VDISPATCH_GEMM(IMPLICATION(arch_ == compute::gpu_arch_t::xe_lp,
-                                   !(A_grouped || B_grouped)),
-                    VERBOSE_UNSUPPORTED_FEATURE, "grouped scales");
 
             // Size checks for fused reduction kernels.
-            if (with_sum_ab()) {
+            if (sum_ab() != dnnl_sum_none) {
                 auto mnk = d->m() * d->n() * d->k();
-                if (arch_ == arch_t::xe_hpc && d->a_type() == f32)
+                if (arch == arch_t::xe_hpc && d->a_type() == f32)
                     VDISPATCH_GEMM(
                             (mnk <= 256 * 1024 * 1024), VERBOSE_LARGE_SHAPES);
             }
 
+            return status::success;
+        }
+
+        status_t init(impl::engine_t *engine) {
+            using namespace data_type;
+            using arch_t = compute::gpu_arch_t;
+
+            assert(engine->kind() == engine_kind::gpu);
+            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+
+            CHECK(set_default_formats(false));
+
+            dev_info_ = intel_engine->device_info();
+            arch_ = dev_info_->gpu_arch();
+
+            CHECK(check_problem(engine));
+
+            CHECK(jit::pd_t::init(engine, arch_));
+
+            bool swap = decide_swap_ab(cfg_);
+            // No kernels with transposed C, if swap_ab is disabled (e.g.
+            // due to wei_decomp()) - this case cannot be handled.
+            VDISPATCH_GEMM(
+                    IMPLICATION(cfg_.trans_c(), swap), VERBOSE_UNSUPPORTED_TAG);
+            jit::pad_leading_dims(cfg_, swap);
+            jit::apply_swap_ab(cfg_, swap);
+
+            const auto &cfg = cfg_;
+
+            // Grouped scales break pre-XeHPG kernels due to increased register pressure
+            bool A_grouped
+                    = 1 < cfg.problem.aqGroupK && cfg.problem.aqGroupK < cfg.k;
+            bool B_grouped
+                    = 1 < cfg.problem.bqGroupK && cfg.problem.bqGroupK < cfg.k;
+            VDISPATCH_GEMM(IMPLICATION(arch_ == compute::gpu_arch_t::xe_lp,
+                                   !(A_grouped || B_grouped)),
+                    VERBOSE_UNSUPPORTED_FEATURE, "grouped scales");
+
             // Handle special compute modes.
             kernel_desc_t::compute_mode mode = kernel_desc_t::mode_default;
 
-            if (attr()->mayiconvert(f32, tf32))
-                set_mode(mode, kernel_desc_t::mode_tf32);
-            if (attr()->mayiconvert(f32, bf16))
-                set_mode(mode, kernel_desc_t::mode_bf16x1);
-            if (attr()->mayiconvert(f32, f16))
-                set_mode(mode, kernel_desc_t::mode_f16x1);
-            if (attr()->mayiconvert(f32, f32))
-                set_mode(mode, kernel_desc_t::mode_strict);
-            if (attr()->deterministic_)
+            set_mode(mode,
+                    static_cast<kernel_desc_t::compute_mode>(cfg.fpmath_modes));
+            if (cfg.deterministic)
                 set_mode(mode, kernel_desc_t::mode_deterministic);
-            if (attr()->acc_mode_ == accumulation_mode::relaxed)
+            if (cfg.acc_mode == accumulation_mode::relaxed)
                 set_mode(mode, kernel_desc_t::mode_relaxed_acc);
 
-            if (wei_decomp_) { set_mode(mode, kernel_desc_t::mode_w_decomp); }
+            if (cfg.wei_decomp) {
+                set_mode(mode, kernel_desc_t::mode_w_decomp);
+            }
 
             // GEMM kernels down convert the following parameters to
             // int/uint32_t
-            VDISPATCH_GEMM(std::max({m, n, d->k(), d->batch()})
+            VDISPATCH_GEMM(std::max({cfg.m, cfg.n, cfg.k, cfg.batch()})
                             <= std::numeric_limits<int32_t>::max(),
                     VERBOSE_SHAPE_RESTRICTION);
-            VDISPATCH_GEMM(
-                    std::max({ld(DNNL_ARG_A), ld(DNNL_ARG_B), ld(DNNL_ARG_C)})
+            VDISPATCH_GEMM(std::max({cfg.lda, cfg.ldb, cfg.ldc})
                             <= std::numeric_limits<uint32_t>::max(),
                     VERBOSE_SHAPE_RESTRICTION);
 
-            gemmstone::GEMMProblem problem;
-            CHECK(init_GEMMProblem(problem, intel_engine));
+            CHECK(finalize_problem(cfg_, intel_engine));
 
-            VDISPATCH_GEMM(IMPLICATION(problem.Tc == gemmstone::Type::f64,
+            // Post-op flags valid only after finalize_problem lowers bias/scale.
+            bool with_binary = cfg.problem.hasBinaryPostOp();
+            bool with_eltwise = cfg.problem.hasEltwisePostOp();
+            VDISPATCH_GEMM(IMPLICATION(with_binary, arch_ >= arch_t::xe_hp),
+                    VERBOSE_UNSUPPORTED_ARCH, "gpu");
+            VDISPATCH_GEMM(IMPLICATION(cfg.problem.Tc == gemmstone::Type::f64,
                                    !with_eltwise && !with_binary),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
+            kernel_desc_t kernel_desc;
             if (arch_ >= arch_t::xe3p)
-                kernel_desc_.set_efficient_64b(dev_info_->is_efficient_64bit());
+                kernel_desc.set_efficient_64b(dev_info_->is_efficient_64bit());
 
             bool print_verbose = get_verbose(verbose_t::debuginfo) >= 5;
             bool kernel_success = false;
-            auto lda = ld(DNNL_ARG_A);
-            auto ldb = ld(DNNL_ARG_B);
-            if (swap_ab_) std::swap(lda, ldb);
-            auto entries = kernel_desc_.select_kernel(*dev_info_, mode, problem,
-                    alpha(), beta(), m, n, d->k(), lda, ldb, d->ldc(),
-                    d->batch());
+            gpu_assert(cfg.finalized_)
+                    << "select_kernel reads an unfinalized problem";
+            auto entries = kernel_desc.select_kernel(*dev_info_, mode,
+                    cfg.problem, cfg.alpha(), cfg.beta, cfg.m, cfg.n, cfg.k,
+                    cfg.lda, cfg.ldb, cfg.ldc, cfg.batch());
 
             for (auto &entry : entries) {
-                kernel_desc_.set_entry(entry);
-                kernel_desc_.set_problem(problem);
-                auto status = kernel_desc_.finalize();
+                kernel_desc.set_entry(entry);
+                kernel_desc.set_problem(cfg.problem);
+                auto status = kernel_desc.finalize();
                 // select_kernel can return a strategy that failed in the finalize call
                 bool valid = status == status::success;
                 if (!valid && print_verbose)
                     dnnl::impl::verbose_printf(
                             "info,gpu,gemm,skipping:%s,Strategy finalization "
                             "failed.\n",
-                            kernel_desc_.entry().str().c_str());
+                            kernel_desc.entry().str().c_str());
                 // Global k-parallel kernels don't support post-ops or non-f32/s32
                 //   accumulation unless fusion is enabled.
-                if (kernel_desc_.driver_info()->kParallel()
-                        && !kernel_desc_.driver_info()->fusedPostOps()) {
-                    bool po_valid = !non_scale_po_
-                            && !(with_sum_ && with_c_scales())
-                            && utils::one_of(d->c_type(), f32, s32);
+                if (kernel_desc.driver_info()->kParallel()
+                        && !kernel_desc.driver_info()->fusedPostOps()) {
+                    bool po_valid = !cfg.non_scale_po()
+                            && !(cfg.with_sum() && cfg.with_c_scales())
+                            && utils::one_of(cfg.c_type(), f32, s32);
                     if (!po_valid && print_verbose)
                         dnnl::impl::verbose_printf(
                                 "info,gpu,gemm,skipping:%s,Invalid post op.\n",
-                                kernel_desc_.entry().str().c_str());
+                                kernel_desc.entry().str().c_str());
                     valid &= po_valid;
                 }
                 // Limited post-op support for low-precision accumulation.
-                if (kernel_desc_.problem()->Tc.size() < 4) {
+                if (kernel_desc.problem()->Tc.size() < 4) {
                     bool need_x32_acc = with_binary
-                            || !IMPLICATION(with_sum_, sum_at_begin_);
+                            || !IMPLICATION(cfg.with_sum(), cfg.sum_at_begin());
                     valid &= !need_x32_acc;
                     if (need_x32_acc && print_verbose)
                         dnnl::impl::verbose_printf(
                                 "info,gpu,gemm,skipping:%s,Invalid post op.\n",
-                                kernel_desc_.entry().str().c_str());
+                                kernel_desc.entry().str().c_str());
                 }
                 // Ensure kernel can be run deterministically if required.
-                if (attr()->deterministic_) {
+                if (cfg.deterministic) {
                     bool deterministic
-                            = !kernel_desc_.driver_info()->nondeterministic();
+                            = !kernel_desc.driver_info()->nondeterministic();
                     valid &= deterministic;
                     if (!deterministic && print_verbose)
                         dnnl::impl::verbose_printf(
                                 "info,gpu,gemm,skipping:%s,Non deterministic "
                                 "kernel.\n",
-                                kernel_desc_.entry().str().c_str());
+                                kernel_desc.entry().str().c_str());
                 }
 
                 if (valid) {
@@ -362,7 +352,7 @@ struct gen_t : public primitive_t {
                         auto key = std::make_shared<
                                 trivial_key_container_t<dnnl::impl::gpu::intel::
                                                 gemm::jit::gen_nocopy_desc_t>>(
-                                kernel_desc_, intel_engine->engine_id());
+                                kernel_desc, intel_engine->engine_id());
                         cache_state_t kernel_cache_status;
                         auto kernel_name = "gemm_kernel";
                         auto verbose
@@ -393,6 +383,10 @@ struct gen_t : public primitive_t {
 
             VDISPATCH_GEMM(
                     kernel_success, "matching kernel not found in catalog");
+
+            // Keep the finalized desc; cfg exposes only the problem.
+            kernel_desc_ = kernel_desc;
+            cfg_.problem = *kernel_desc.problem();
 
             init_scratchpad();
 
@@ -534,14 +528,14 @@ struct gen_t : public primitive_t {
 
         void init_scratchpad() {
             using namespace gemmstone;
-            const auto *info = kernel_desc()->driver_info();
+            const auto *info = kernel_desc_.driver_info();
             if (info->needsTempC()) {
                 auto scratchpad = scratchpad_registry().registrar();
 
                 int temp_c_sz = nstl::max(
-                        (int)types::data_type_size(desc()->c_type()), 4);
+                        (int)types::data_type_size(cfg_.c_type()), 4);
                 int temp_c_elems = info->wgTile(LoopM) * info->wgTile(LoopN);
-                if (with_sum_ab())
+                if (cfg_.with_sum_ab())
                     temp_c_elems += nstl::max(
                             info->wgTile(LoopM), info->wgTile(LoopN));
                 temp_c_elems = utils::rnd_up(temp_c_elems, 64);
@@ -562,12 +556,8 @@ struct gen_t : public primitive_t {
             }
         }
 
-        const jit::gen_nocopy_desc_t *kernel_desc() const {
-            return &kernel_desc_;
-        }
-
         int max_k_sliced_groups() const {
-            const auto *info = kernel_desc()->driver_info();
+            const auto *info = kernel_desc_.driver_info();
 
             auto groups = dev_info_->hw_threads(info->grfCount)
                     / (info->wg[gemmstone::LoopM] * info->wg[gemmstone::LoopN]);
@@ -576,14 +566,12 @@ struct gen_t : public primitive_t {
             return groups;
         }
 
-        size_t dyn_offset_a = 0;
-        size_t dyn_offset_b = 0;
-        size_t dyn_offset_c = 0;
-        size_t dyn_offset_co = 0;
+        const kernel_desc_t &kernel_desc() const { return kernel_desc_; }
 
         const compute::device_info_t *dev_info_ = nullptr;
         compute::gpu_arch_t arch_ = compute::gpu_arch_t::unknown;
 
+        // Finalized kernel desc selected in init(); cfg keeps only the problem.
         kernel_desc_t kernel_desc_;
     };
 
@@ -599,11 +587,11 @@ struct gen_t : public primitive_t {
 
     status_t init_nocopy(impl::engine_t *engine) {
         using namespace data_type;
-        auto kd = pd()->kernel_desc();
+        const auto &desc = pd()->kernel_desc();
 
-        CHECK(create_kernel(engine, nocopy_kernel_, "gemm_kernel", *kd));
+        CHECK(create_kernel(engine, nocopy_kernel_, "gemm_kernel", desc));
 
-        scalar_type_ = kd->scalar_type();
+        scalar_type_ = desc.scalar_type();
         const auto *info = nocopy_info();
 
         if (need_zero_buffer()) {
@@ -629,7 +617,7 @@ struct gen_t : public primitive_t {
                 // IFP on (default) forces round-robin thread arbitration.
                 // Disable it on a clear mismatch with the main kernel to
                 // avoid a thread arbitration switch between dispatches.
-                params.no_subgroup_ifp = (kd->strategy()->arbitrationMode
+                params.no_subgroup_ifp = (desc.strategy()->arbitrationMode
                         != ngen::ThreadArbitrationMode::RoundRobin);
                 CHECK(create_kernel(
                         engine, zero_fill_kernel_, "gemm_zero_fill", params));
@@ -643,26 +631,18 @@ struct gen_t : public primitive_t {
 
 private:
     status_t launch_nocopy(const exec_ctx_t &ctx, intel::stream_t *s,
-            zero_pool_t *zero_pool, const memory_storage_t &a,
-            const memory_storage_t &b, const memory_storage_t &c,
-            const memory_storage_t *ao, const memory_storage_t *bo,
-            int16_t ao_host_scalar, int16_t bo_host_scalar,
-            const memory_storage_t *a_scales, const memory_storage_t *b_scales,
-            const memory_storage_t *c_scales, const memory_storage_t *ag,
-            const memory_storage_t *bg, const memory_storage_t &co,
-            int16_t co_host_scalar, const memory_storage_t *c_temp,
-            const memory_storage_t *zero_buf_scratchpad,
-            const memory_storage_t *sround_seed, int po_count,
+            zero_pool_t *zero_pool, const jit::exec_args_t &exec_args,
+            const memory_storage_t *c_temp,
+            const memory_storage_t *zero_buf_scratchpad, int po_count,
             const memory_storage_t **po_src, int64_t offset_a, int64_t offset_b,
             int64_t offset_c, int64_t offset_aq, int64_t offset_bq,
-            int64_t offset_co, int64_t *offset_po_src, int32_t lda, int32_t ldb,
-            int32_t ldc, int32_t m, int32_t n, int32_t k, int32_t k0,
-            float alpha, float beta, int32_t cmask, bool last_k_block,
-            bool swap_ab, bool disable_hilbert) const;
+            int64_t offset_co, int64_t *offset_po_src, int32_t m, int32_t n,
+            int32_t k, int32_t k0, float alpha, float beta, bool last_k_block,
+            bool disable_hilbert) const;
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     const gemmstone::CommonDriverInfo *nocopy_info() const {
-        return pd()->kernel_desc()->driver_info();
+        return pd()->kernel_desc().driver_info();
     }
 
     bool need_zero_buffer() const {

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -607,16 +607,21 @@ status_t gen_nocopy_desc_t::finalize() {
     return gen_desc_t::finalize(tags_.c_str());
 }
 
-status_t gen_xe_systolic_kernel_desc_t::select_kernel(
-        const compute::device_info_t &dev_info, int batch_dims, bool packed_c,
-        bool trans_co, bool a_offset, bool b_offset, bool c_offset, bool bias,
-        float alpha, float beta, data_type_t a_type, data_type_t b_type,
-        data_type_t c_type, data_type_t ao_type, data_type_t bo_type,
-        data_type_t co_type, data_type_t acc_type, dim_t m, dim_t n, dim_t k,
-        dim_t batch, int unroll_m, int unroll_n, bool alt,
-        gpu_post_ops_t &&post_ops) {
+status_t gen_xe_systolic_desc_t::select_kernel(
+        const compute::device_info_t &dev_info,
+        const gemmstone::GEMMProblem &in, int batch_dims, bool packed_c,
+        float alpha, float beta, dim_t m, dim_t n, dim_t k, dim_t batch,
+        int unroll_m, int unroll_n, bool alt) {
     using namespace ngen;
     using namespace kcatalog;
+
+    auto a_type = convert_kernel_to_dnnl_type(in.Ta_ext);
+    auto c_type = convert_kernel_to_dnnl_type(in.Tc_ext);
+    bool a_offset = (in.aOffset != ABOffset::None);
+    bool b_offset = (in.bOffset != ABOffset::None);
+    bool c_offset = (in.cOffset == COffset::Post);
+    bool bias = (in.cOffset == COffset::Pre);
+    bool trans_co = (in.CO.layout == MatrixLayout::T);
 
     product_ = dev_info.product();
     hw_ = getCore(product_.family);
@@ -638,14 +643,14 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     auto ksys = int(32 / types::data_type_size(a_type));
     auto csys = int(4 / types::data_type_size(a_type));
 
-    problem_.Ta = problem_.Ta_ext = convert_dnnl_to_kernel_type(a_type);
-    problem_.Tb = problem_.Tb_ext = convert_dnnl_to_kernel_type(b_type);
-    problem_.Tc = convert_dnnl_to_kernel_type(acc_type);
-    problem_.Tc_ext = convert_dnnl_to_kernel_type(c_type);
+    problem_.Ta = problem_.Ta_ext = in.Ta_ext;
+    problem_.Tb = problem_.Tb_ext = in.Tb_ext;
+    problem_.Tc = in.Tc;
+    problem_.Tc_ext = in.Tc_ext;
     problem_.Ts = Type::f32;
-    problem_.Tao = convert_dnnl_to_kernel_type(ao_type);
-    problem_.Tbo = convert_dnnl_to_kernel_type(bo_type);
-    problem_.Tco = convert_dnnl_to_kernel_type(co_type);
+    problem_.Tao = Type::s32;
+    problem_.Tbo = Type::s32;
+    problem_.Tco = in.Tco;
     problem_.A.layout = MatrixLayout::PackedColumns;
     problem_.B.layout = MatrixLayout::PackedRows;
     problem_.C.layout = MatrixLayout::N;
@@ -665,7 +670,8 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     if (packed_c) problem_.C = problem_.B;
     if (batch_dims > 0) {
         problem_.batch = BatchMode::Strided;
-        problem_.batchDims = batch_dims;
+        // Multi-dim batch (ndims>3) is rejected upstream, so this is 1.
+        problem_.batchDims = in.batchDims;
     }
     if (a_offset) {
         problem_.aOffset = ABOffset::Load;
@@ -678,8 +684,9 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     if (alpha == 1.0f) problem_.alpha = (int)alpha;
     if (beta == 0.0f || beta == 1.0f) problem_.beta = (int)beta;
 
-    auto status = transfer_post_ops(problem_, std::move(post_ops));
-    if (status != status::success) return status;
+    problem_.postOps = in.postOps;
+    problem_.binary = in.binary;
+    problem_.Tbinary = in.Tbinary;
 
     if (c_offset) problem_.cOffset = COffset::Post;
 
@@ -693,6 +700,8 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
         problem_.CO.crosspack = 1;
         problem_.CO.alignment = problem_.C.alignment;
     }
+
+    problem_.coPtrDims = in.coPtrDims;
 
     // Find it in the catalog.
     MatchParams match_params(hw_, true, product_, problem_);
@@ -725,7 +734,7 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     eval_params.beta = beta;
     eval_params.euCount = dev_info.eu_count();
     eval_params.postOps = !problem_.postOps.empty();
-    eval_params.cConvert = (acc_type != c_type);
+    eval_params.cConvert = (in.Tc != in.Tc_ext);
     eval_params.batch = (batch_dims > 0);
     eval_params.Tc_ext = problem_.Tc_ext;
 
@@ -739,7 +748,7 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     return finalize(match_params.tags);
 }
 
-void gen_xe_systolic_kernel_desc_t::choose_unrolls(compute::gpu_arch_t arch,
+void gen_xe_systolic_desc_t::choose_unrolls(compute::gpu_arch_t arch,
         int eu_count, data_type_t a_type, data_type_t b_type,
         data_type_t c_type, dim_t m, dim_t n, dim_t k, dim_t batch,
         int &unroll_m, int &unroll_n, bool &alt) {
@@ -1042,7 +1051,7 @@ void gen_kernel_t::maybe_print_verbose() {
     int level = get_verbose(verbose_t::debuginfo);
     if (level < 2) return;
 
-    if (level >= 10)
+    if (level >= 10 && desc_.has_entry())
         verbose_printf("info,gpu,gemm,catalog entry:%s\n",
                 desc()->entry().str().c_str());
 

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -84,7 +84,7 @@ struct gen_desc_t {
     }
     compute::gpu_arch_t arch() const { return arch_; }
 
-    bool has_entry() { return entry_ != nullptr; }
+    bool has_entry() const { return entry_ != nullptr; }
 
     const gemmstone::kcatalog::Entry &entry() const {
         assert(entry_ != nullptr);
@@ -154,14 +154,11 @@ private:
     gemmstone::Scalar beta_;
 };
 
-struct gen_xe_systolic_kernel_desc_t : public gen_desc_t {
+struct gen_xe_systolic_desc_t : public gen_desc_t {
     status_t select_kernel(const compute::device_info_t &dev_info,
-            int batch_dims, bool packed_c, bool trans_co, bool a_offset,
-            bool b_offset, bool c_offset, bool bias, float alpha, float beta,
-            data_type_t a_type, data_type_t b_type, data_type_t c_type,
-            data_type_t ao_type, data_type_t bo_type, data_type_t co_type,
-            data_type_t acc_type, dim_t m, dim_t n, dim_t k, dim_t batch,
-            int unroll_m, int unroll_n, bool alt, gpu_post_ops_t &&post_ops);
+            const gemmstone::GEMMProblem &in, int batch_dims, bool packed_c,
+            float alpha, float beta, dim_t m, dim_t n, dim_t k, dim_t batch,
+            int unroll_m, int unroll_n, bool alt);
 
     static void choose_unrolls(compute::gpu_arch_t arch, int eu_count,
             data_type_t a_type, data_type_t b_type, data_type_t c_type, dim_t m,
@@ -205,9 +202,8 @@ struct key_validator_t<gemm::jit::gen_nocopy_desc_t> {
 };
 
 template <>
-struct key_validator_t<gemm::jit::gen_xe_systolic_kernel_desc_t> {
-    static bool is_valid(
-            const gemm::jit::gen_xe_systolic_kernel_desc_t &derived) {
+struct key_validator_t<gemm::jit::gen_xe_systolic_desc_t> {
+    static bool is_valid(const gemm::jit::gen_xe_systolic_desc_t &derived) {
         return key_validator_t<gemm::jit::gen_desc_t>::is_valid(derived);
     }
 };

--- a/src/gpu/intel/gemm/jit/generator/pieces/problem_utils.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/problem_utils.cpp
@@ -39,7 +39,9 @@ void GEMMProblem::transpose()
     std::swap(asPtrDims, bsPtrDims);
     std::swap(aqGroupM, bqGroupN);
     std::swap(aqGroupK, bqGroupK);
+    std::swap(cqGroupM, cqGroupN);
     std::swap(sumA, sumB);
+    std::swap(hasGroupSumsA, hasGroupSumsB);
     postOps.transpose();
     for (auto &bsrc: binary)
         bsrc.transpose();

--- a/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
@@ -214,6 +214,11 @@ struct GEMMProblem : public CommonProblem {
             if (e.is_binary()) return true;
         return false;
     }
+    bool hasEltwisePostOp() const {
+        for (auto &e : postOps.ops)
+            if (e.is_eltwise()) return true;
+        return false;
+    }
     bool hasSum1PostOpAtEnd() const {
         return !postOps.empty() && postOps.ops.back().is_sum();
     }
@@ -342,6 +347,7 @@ struct GEMMProblem : public CommonProblem {
         s.append(aOffset, bOffset);
         s.append(aoPtrDims, boPtrDims, coPtrDims);
         s.append(asPtrDims, bsPtrDims, csPtrDims);
+        s.append(hasGroupSumsA, hasGroupSumsB);
         s.append(aqGroupM, aqGroupK);
         s.append(bqGroupN, bqGroupK);
         s.append(cqGroupM, cqGroupN);

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -15,6 +15,9 @@
 *******************************************************************************/
 
 #include "gpu/intel/gemm/jit/pd.hpp"
+
+#include <utility>
+
 #include "common/c_types_map.hpp"
 #include "common/primitive_attr_quant.hpp"
 #include "gpu/intel/gemm/exec_types.hpp"
@@ -65,84 +68,143 @@ int quant_entry_ndims(
 
     return count;
 }
+
+bool a_grouped(const kernel_config_t &cfg) {
+    bool k_grouped = 1 < cfg.problem.aqGroupK && cfg.problem.aqGroupK < cfg.k;
+    bool m_grouped = 1 < cfg.problem.aqGroupM && cfg.problem.aqGroupM < cfg.m;
+    return k_grouped || m_grouped;
+}
+
+bool b_grouped(const kernel_config_t &cfg) {
+    bool k_grouped = 1 < cfg.problem.bqGroupK && cfg.problem.bqGroupK < cfg.k;
+    bool n_grouped = 1 < cfg.problem.bqGroupN && cfg.problem.bqGroupN < cfg.n;
+    return k_grouped || n_grouped;
+}
+
+// Ungrouped allow-list mask bits, named by logical dim index (not M/N/K):
+// which gemm dim a bit denotes depends on operand/rank. 2D: valid_2d_mask().
+constexpr int mask_dim0 = 1 << 0;
+constexpr int mask_dim1 = 1 << 1;
+constexpr int mask_dim2 = 1 << 2;
+
+bool valid_2d_mask(int mask, int ndims, bool per_tensor_ok = true) {
+    return (mask == ((1 << ndims) - 1) && per_tensor_ok)
+            || utils::one_of(mask, (1 << (ndims - 1)),
+                    (1 << (ndims - 1)) + (1 << (ndims - 2)));
+}
+
 } // anonymous namespace
 
-status_t pd_t::init_post_ops(impl::engine_t *engine) {
+status_t pd_t::init(impl::engine_t *engine, compute::gpu_arch_t arch) {
+    arch_ = arch;
+
+    // Desc/attr-only checks; run before the cfg is built.
+    CHECK(scales_ok(this, engine));
+    CHECK(zp_ok(this, engine));
+    CHECK(gs_ok(this, engine));
+
+    CHECK(init_kernel_config(cfg_, this, engine));
+
+    return status::success;
+}
+
+// Like VDISPATCH_GEMM, but for free functions taking an explicit pd.
+#define VDISPATCH_GEMM_F(cond, msg, ...) \
+    VCONDCHECK(primitive, create, dispatch, gemm, (cond), \
+            status::unimplemented, "%s," msg, pd->info(engine), ##__VA_ARGS__)
+#define VDISPATCH_GEMM_F_SC(f, msg, ...) \
+    VCHECK(primitive, create, dispatch, gemm, (f), "%s," msg, \
+            pd->info(engine), ##__VA_ARGS__)
+
+static status_t init_post_ops(
+        kernel_config_t &cfg, const pd_t *pd, impl::engine_t *engine) {
     using namespace primitive_kind;
     using namespace alg_kind;
     using namespace data_type;
 
-    const auto d = desc();
+    const auto d = pd->desc();
 
     // Examine post-ops and remember binary srcs.
-    post_ops_ = attr()->post_ops_;
-    binary_srcs_.reserve(post_ops_.len() + 4);
+    post_ops_t po = pd->attr()->post_ops_;
+    cfg.binary_srcs.reserve(po.len() + 4);
 
     bool ok = true;
+    bool seen_sum = false;
     int prelu_count = 0;
-    const int num_orig_postops = post_ops_.len();
-    for (int i = 0; i < post_ops_.len(); i++) {
-        const auto &e = post_ops_.entry_[i];
+    const int num_orig_postops = po.len();
+    for (int i = 0; i < po.len(); i++) {
+        const auto &e = po.entry_[i];
         switch (e.kind) {
             case binary:
-                ok &= supported_binary_op(e.binary.alg)
+                ok &= pd_t::supported_binary_op(e.binary.alg)
                         && is_md_gemm_compatible_plain_format(
                                 &e.binary.src1_desc);
-                binary_srcs_.push_back(
+                cfg.binary_srcs.push_back(
                         binary_src_t {binary_src_t::binary, int(i)});
-                non_scale_po_ = true;
+                cfg.binary_srcs.back().src_md = e.binary.src1_desc;
                 break;
             case sum:
-                ok &= !with_sum_;
-                with_sum_ = true;
-                sum_at_begin_ = (i == 0);
-                binary_srcs_.push_back(binary_src_t {binary_src_t::none, 0});
-                beta_ = e.sum.scale;
+                ok &= !seen_sum;
+                seen_sum = true;
+                cfg.binary_srcs.push_back(binary_src_t {binary_src_t::none, 0});
+                cfg.beta = e.sum.scale;
                 break;
             case eltwise:
                 ok &= eltwise_injector_f32_is_supported(e.eltwise.alg);
-                binary_srcs_.push_back(binary_src_t {binary_src_t::none, 0});
-                non_scale_po_ = true;
+                cfg.binary_srcs.push_back(binary_src_t {binary_src_t::none, 0});
                 break;
-            case prelu:
-                binary_srcs_.push_back(
-                        binary_src_t {binary_src_t::prelu, int(i)});
-                ok &= get_prelu_md(e.prelu.mask, dst_md()->dims, prelu_wei_md,
-                              dst_md()->ndims)
+            case prelu: {
+                memory_desc_t prelu_md = {};
+                ok &= get_prelu_md(e.prelu.mask, pd->dst_md()->dims, prelu_md,
+                              pd->dst_md()->ndims)
                         == status::success;
+                cfg.binary_srcs.push_back(
+                        binary_src_t {binary_src_t::prelu, int(i)});
+                cfg.binary_srcs.back().src_md = prelu_md;
                 prelu_count++;
                 ok &= prelu_count <= 1;
-                non_scale_po_ = true;
                 break;
-            default: VDISPATCH_GEMM(false, VERBOSE_UNSUPPORTED_POSTOP);
+            }
+            default: VDISPATCH_GEMM_F(false, VERBOSE_UNSUPPORTED_POSTOP);
         }
     }
 
-    VDISPATCH_GEMM(ok, VERBOSE_UNSUPPORTED_POSTOP);
+    VDISPATCH_GEMM_F(ok, VERBOSE_UNSUPPORTED_POSTOP);
 
     // If scales are present, convert them and any bias to binary post-ops.
     //   Exception: 2D scales.
     // Also convert bias to binary post-op if dst zp are present.
-    const auto &a_scales = attr()->scales_.get(DNNL_ARG_A);
-    const auto &b_scales = attr()->scales_.get(DNNL_ARG_B);
-    const auto &c_scales = attr()->scales_.get(DNNL_ARG_C);
+    const auto &a_scales = pd->attr()->scales_.get(DNNL_ARG_A);
+    const auto &b_scales = pd->attr()->scales_.get(DNNL_ARG_B);
+    const auto &c_scales = pd->attr()->scales_.get(DNNL_ARG_C);
 
-    bias_via_binary_ = (desc()->bias_type() != data_type::undef)
+    const bool bias_via_binary = (d->bias_type() != data_type::undef)
             && (d->bias_desc.ndims >= 1 || !a_scales.has_default_values()
                     || !b_scales.has_default_values()
-                    || !attr()->zero_points_.has_default_values(DNNL_ARG_C));
-    if (bias_via_binary_) {
-        VDISPATCH_GEMM_SC(post_ops_.prepend_binary(binary_add, &d->bias_desc),
+                    || !pd->attr()->zero_points_.has_default_values(
+                            DNNL_ARG_C));
+    if (bias_via_binary) {
+        VDISPATCH_GEMM_F_SC(po.prepend_binary(binary_add, &d->bias_desc),
                 "%s: bias via binary post-op", VERBOSE_UNSUPPORTED_POSTOP);
-        binary_srcs_.insert(
-                binary_srcs_.begin(), binary_src_t {binary_src_t::bias, 0});
+        cfg.binary_srcs.insert(
+                cfg.binary_srcs.begin(), binary_src_t {binary_src_t::bias, 0});
+        cfg.binary_srcs.front().src_md = d->bias_desc;
     }
-    non_scale_po_ |= bias_via_binary_;
+
+    // ld_bias is needed even when bias is lowered to a binary post-op
+    // (ld_binary reads it).
+    int bias_cmask = -1;
+    if (d->bias_type() != data_type::undef) {
+        unsigned char to_cmask[8] = {0, 4, 2, 6, 1, 5, 3, 7};
+        assert(unsigned(d->bias_mask()) < 8);
+        bias_cmask = !bias_via_binary ? to_cmask[d->bias_mask() & 7] : -1;
+        cfg.ld_bias = d->ld_bias();
+    }
 
     auto maybe_convert_scales_to_postop
-            = [this, engine](const memory_desc_t &scale_md, int arg,
+            = [d, &cfg, &po, pd, engine](const memory_desc_t &scale_md, int arg,
                       int scale_ndims, bool mx, bool &converted) -> status_t {
-        auto ndims = desc()->c_desc.ndims;
+        auto ndims = d->c_desc.ndims;
         // Scales on A/B can be converted to postops if
         // the scales md has K=1 and M/N is not bcast.
         converted = false;
@@ -152,19 +214,19 @@ status_t pd_t::init_post_ops(impl::engine_t *engine) {
         convert &= !mx;
         if (convert) {
             if (arg == DNNL_ARG_C) {
-                VDISPATCH_GEMM_SC(
-                        post_ops_.append_binary(binary_div, &scale_md),
+                VDISPATCH_GEMM_F_SC(po.append_binary(binary_div, &scale_md),
                         "%s: %s scales via binary post-op",
                         VERBOSE_UNSUPPORTED_POSTOP, arg2str(arg).c_str());
-                binary_srcs_.push_back(
+                cfg.binary_srcs.push_back(
                         binary_src_t {binary_src_t::scales, arg});
+                cfg.binary_srcs.back().src_md = scale_md;
             } else {
-                VDISPATCH_GEMM_SC(
-                        post_ops_.prepend_binary(binary_mul, &scale_md),
+                VDISPATCH_GEMM_F_SC(po.prepend_binary(binary_mul, &scale_md),
                         "%s: %s scales via binary post-op",
                         VERBOSE_UNSUPPORTED_POSTOP, arg2str(arg).c_str());
-                binary_srcs_.insert(binary_srcs_.begin(),
+                cfg.binary_srcs.insert(cfg.binary_srcs.begin(),
                         binary_src_t {binary_src_t::scales, arg});
+                cfg.binary_srcs.front().src_md = scale_md;
             }
             converted = true;
         }
@@ -174,46 +236,130 @@ status_t pd_t::init_post_ops(impl::engine_t *engine) {
     if (!a_scales.has_default_values() && !a_scales.is_host_scalar()) {
         // Host scalar scale will be converted to Alpha
         bool converted;
-        CHECK(maybe_convert_scales_to_postop(a_scale_md_, DNNL_ARG_A,
-                a_quant.scale_ndims, a_scales.is_mx(), converted));
-        if (converted) a_quant.scale_ndims = -1;
+        CHECK(maybe_convert_scales_to_postop(cfg.a_scale_md, DNNL_ARG_A,
+                cfg.problem.asPtrDims, a_scales.is_mx(), converted));
+        if (converted) cfg.problem.asPtrDims = -1;
     }
 
     if (!b_scales.has_default_values() && !b_scales.is_host_scalar()) {
         bool converted;
-        CHECK(maybe_convert_scales_to_postop(b_scale_md_, DNNL_ARG_B,
-                b_quant.scale_ndims, b_scales.is_mx(), converted));
-        if (converted) b_quant.scale_ndims = -1;
+        CHECK(maybe_convert_scales_to_postop(cfg.b_scale_md, DNNL_ARG_B,
+                cfg.problem.bsPtrDims, b_scales.is_mx(), converted));
+        if (converted) cfg.problem.bsPtrDims = -1;
     }
 
     bool try_c_scale = !c_scales.is_host_scalar()
             || (c_scales.is_host_scalar() && num_orig_postops > 0);
     if (!c_scales.has_default_values() && try_c_scale) {
+        memory_desc_t c_scale_md;
+        VDISPATCH_GEMM_F_SC(c_scales.get_md(c_scale_md, d->c_desc),
+                VERBOSE_DESC_CREATION_FAIL, "C scales");
         bool converted;
-        CHECK(maybe_convert_scales_to_postop(c_scale_md_, DNNL_ARG_C,
-                c_quant.scale_ndims, c_scales.is_mx(), converted));
+        CHECK(maybe_convert_scales_to_postop(c_scale_md, DNNL_ARG_C,
+                cfg.problem.csPtrDims, c_scales.is_mx(), converted));
         // Conversion of dst scales to post ops is currently supported for all
         // cases supported in the library.
         gpu_assert(converted || c_scales.is_mx())
                 << "Unable to convert dst scales to a post op";
     }
 
+    gpu_post_ops_t gpu_post_ops;
+    CHECK(gpu_post_ops_t::make(gpu_post_ops, po, pd->dst_md(),
+            pd_t::get_post_op_specializations()));
+    CHECK(transfer_post_ops(cfg.problem, std::move(gpu_post_ops)));
+
+    // Exec arg-routing relies on binary_srcs being 1:1 with the post-op chain.
+    gpu_assert(int(cfg.binary_srcs.size()) == int(cfg.problem.postOps.len()));
+
+    cfg.problem.postOps.cStochasticRound
+            = pd->attr()->rounding_mode_.get(DNNL_ARG_DST)
+            == rounding_mode::stochastic;
+
+    if (cfg.with_c_zero_points())
+        cfg.cmask = pd->attr()->zero_points_.get_mask(DNNL_ARG_DST);
+    else if (cfg.with_bias())
+        cfg.cmask = bias_cmask;
+    else if (cfg.with_sum_ab())
+        cfg.cmask = d->sum_ab == sum_ab::sum_a_row ? 1 : 2;
+
     return status::success;
 }
 
-bool pd_t::dy_quant_enabled() {
-    const auto d = desc();
+static status_t init_attrs(
+        kernel_config_t &cfg, const pd_t *pd, impl::engine_t *engine);
+
+status_t init_kernel_config(
+        kernel_config_t &cfg, const pd_t *pd, impl::engine_t *engine) {
+    const auto d = pd->desc();
+
+    cfg.m = d->m();
+    cfg.n = d->n();
+    cfg.k = d->k();
+    // Packed/blocked operands have no plain leading dim; the kernel gets
+    // ld = 0.
+    auto leading_dim = [](const memory_desc_t &md) -> dnnl_dim_t {
+        return md.format_desc.blocking.inner_nblks > 0
+                ? 0
+                : gemm_desc_t::get_ld(md);
+    };
+    cfg.lda = leading_dim(d->b_desc);
+    cfg.ldb = leading_dim(d->a_desc);
+    cfg.ldc = leading_dim(d->c_desc);
+
+    using gemmstone::MatrixLayout;
+    auto to_layout
+            = [](bool t) { return t ? MatrixLayout::T : MatrixLayout::N; };
+    cfg.problem.Ta_ext = convert_dnnl_to_kernel_type(d->a_type());
+    cfg.problem.Tb_ext = convert_dnnl_to_kernel_type(d->b_type());
+    cfg.problem.Tc_ext = convert_dnnl_to_kernel_type(d->c_type());
+    cfg.problem.A.layout = to_layout(d->transa() == dnnl_trans);
+    cfg.problem.B.layout = to_layout(d->transb() == dnnl_trans);
+    // Seeded like A/B; apply_swap_ab folds a transposed C to N and
+    // finalize_problem asserts the kernel-required N orientation.
+    cfg.problem.C.layout = to_layout(d->transc() == dnnl_trans);
+    cfg.problem.CO.layout = to_layout(d->trans_bias() == dnnl_trans);
+
+    const int bd = pd->batch_dims();
+    gpu_assert(bd <= kernel_config_t::max_batch_dims);
+    // batchDims > 0 <=> Strided; keep both in sync.
+    cfg.problem.batchDims = bd;
+    if (bd > 0) cfg.problem.batch = gemmstone::BatchMode::Strided;
+    for (int b = 0; b < bd; b++) {
+        cfg.a_batch_strides[b] = d->stride_a(b);
+        cfg.b_batch_strides[b] = d->stride_b(b);
+        cfg.c_batch_strides[b] = d->stride_c(b);
+        cfg.c_batch_sizes[b] = d->c_desc.dims[b];
+    }
+    cfg.bias_type = d->bias_type();
+    cfg.sum_ab_type = d->sum_ab_type;
+    cfg.acc_mode = pd->attr()->acc_mode_;
+    cfg.wei_decomp = pd->wei_decomp();
+
     using namespace data_type;
-    bool all_f8 = (utils::one_of(d->a_type(), f8_e5m2, f8_e4m3)
-            && utils::one_of(d->b_type(), f8_e5m2, f8_e4m3)
-            && utils::one_of(d->c_type(), f8_e5m2, f8_e4m3, f16, bf16, f32));
-    return (utils::one_of(d->c_type(), f32, f16, bf16, u8, s8)
-                   && utils::one_of(d->a_type(), u8, s8, s4, u4)
-                   && utils::one_of(d->b_type(), u8, s8))
-            || all_f8;
+    const auto *attr = pd->attr();
+    cfg.fpmath_modes
+            = (attr->mayiconvert(f32, tf32) ? gen_nocopy_desc_t::mode_tf32 : 0)
+            | (attr->mayiconvert(f32, bf16) ? gen_nocopy_desc_t::mode_bf16x1
+                                            : 0)
+            | (attr->mayiconvert(f32, f16) ? gen_nocopy_desc_t::mode_f16x1 : 0)
+            | (attr->mayiconvert(f32, f32) ? gen_nocopy_desc_t::mode_strict
+                                           : 0);
+    cfg.deterministic = pd->attr()->deterministic_;
+
+    cfg.a_host_scale = pd->a_host_scale();
+    cfg.b_host_scale = pd->b_host_scale();
+    cfg.c_host_scale_to_alpha = pd->c_host_scale_to_alpha();
+    const bool any_host_scale
+            = cfg.a_host_scale || cfg.b_host_scale || cfg.c_host_scale_to_alpha;
+    cfg.alpha_ = any_host_scale ? 9.99f : 1.0f;
+
+    CHECK(init_attrs(cfg, pd, engine));
+    CHECK(init_post_ops(cfg, pd, engine));
+
+    return status::success;
 }
 
-bool pd_t::wei_decomp() {
+bool pd_t::wei_decomp() const {
     const auto d = desc();
     using namespace data_type;
     return (utils::one_of(d->c_type(), f32, f16, bf16, f8_e5m2, f8_e4m3)
@@ -226,161 +372,188 @@ bool pd_t::wei_decomp() {
             && attr()->mayiconvert(d->a_type(), f32);
 }
 
-bool pd_t::quant_enabled() {
-    return wei_decomp() || dy_quant_enabled();
+bool pd_t::dy_quant_enabled() const {
+    const auto d = desc();
+    using namespace data_type;
+    bool all_f8 = (utils::one_of(d->a_type(), f8_e5m2, f8_e4m3)
+            && utils::one_of(d->b_type(), f8_e5m2, f8_e4m3)
+            && utils::one_of(d->c_type(), f8_e5m2, f8_e4m3, f16, bf16, f32));
+    return (utils::one_of(d->c_type(), f32, f16, bf16, u8, s8)
+                   && utils::one_of(d->a_type(), u8, s8, s4, u4)
+                   && utils::one_of(d->b_type(), u8, s8))
+            || all_f8;
 }
 
-status_t pd_t::init_attrs(impl::engine_t *engine) {
-    wei_decomp_ = wei_decomp();
-    dy_quant_enabled_ = dy_quant_enabled();
-    quant_enabled_ = quant_enabled();
-    const auto &d = desc();
+static status_t init_attrs(
+        kernel_config_t &cfg, const pd_t *pd, impl::engine_t *engine) {
+    const auto &d = pd->desc();
 
-    const auto &attr_zps = attr()->zero_points_;
+    const auto &attr_zps = pd->attr()->zero_points_;
     const auto a_zps = attr_zps.get(DNNL_ARG_A);
     const auto b_zps = attr_zps.get(DNNL_ARG_B);
     const auto c_zps = attr_zps.get(DNNL_ARG_C);
 
-    const auto &attr_gs = attr()->precomputed_reductions_;
+    const auto &attr_gs = pd->attr()->precomputed_reductions_;
     const auto a_gs = attr_gs.get(DNNL_ARG_A);
     const auto b_gs = attr_gs.get(DNNL_ARG_B);
 
-    const auto &scales = attr()->scales_;
+    const auto &scales = pd->attr()->scales_;
     const auto a_scales = scales.get(DNNL_ARG_A);
     const auto b_scales = scales.get(DNNL_ARG_B);
     const auto c_scales = scales.get(DNNL_ARG_C);
 
-    cmask_a_ = a_zps.get_mask();
-    cmask_b_ = b_zps.get_mask();
-    cmask_c_ = c_zps.get_mask();
+    // C-side quant mds are consumed only here; keep them local.
+    memory_desc_t c_zp_md;
+    memory_desc_t c_scale_md;
 
-    // Swap descriptors to follow column major format
-    VDISPATCH_GEMM_SC(a_zps.get_md(a_zp_md_, d->b_desc),
+    // Swap descriptors to follow column major format.
+    VDISPATCH_GEMM_F_SC(a_zps.get_md(cfg.a_zp_md, d->b_desc),
             VERBOSE_DESC_CREATION_FAIL, "A zero points");
-    VDISPATCH_GEMM_SC(b_zps.get_md(b_zp_md_, d->a_desc),
+    VDISPATCH_GEMM_F_SC(b_zps.get_md(cfg.b_zp_md, d->a_desc),
             VERBOSE_DESC_CREATION_FAIL, "B zero points");
-    VDISPATCH_GEMM_SC(c_zps.get_md(c_zp_md_, d->c_desc),
+    VDISPATCH_GEMM_F_SC(c_zps.get_md(c_zp_md, d->c_desc),
             VERBOSE_DESC_CREATION_FAIL, "C zero points");
-    VDISPATCH_GEMM_SC(a_gs.get_md(a_gs_md_, d->b_desc),
+    VDISPATCH_GEMM_F_SC(a_gs.get_md(cfg.a_gs_md, d->b_desc),
             VERBOSE_DESC_CREATION_FAIL, "A group sums");
-    VDISPATCH_GEMM_SC(b_gs.get_md(b_gs_md_, d->a_desc),
+    VDISPATCH_GEMM_F_SC(b_gs.get_md(cfg.b_gs_md, d->a_desc),
             VERBOSE_DESC_CREATION_FAIL, "B group sums");
-    VDISPATCH_GEMM_SC(a_scales.get_md(a_scale_md_, desc_.b_desc),
+    VDISPATCH_GEMM_F_SC(a_scales.get_md(cfg.a_scale_md, d->b_desc),
             VERBOSE_DESC_CREATION_FAIL, "A scales");
-    VDISPATCH_GEMM_SC(b_scales.get_md(b_scale_md_, desc_.a_desc),
+    VDISPATCH_GEMM_F_SC(b_scales.get_md(cfg.b_scale_md, d->a_desc),
             VERBOSE_DESC_CREATION_FAIL, "B scales");
-    VDISPATCH_GEMM_SC(c_scales.get_md(c_scale_md_, desc_.c_desc),
+    VDISPATCH_GEMM_F_SC(c_scales.get_md(c_scale_md, d->c_desc),
             VERBOSE_DESC_CREATION_FAIL, "C scales");
 
+    auto &p = cfg.problem;
     auto ndims = d->c_desc.ndims;
-    a_quant.zp_ndims = quant_entry_ndims(a_zps, a_zp_md_, ndims - 2);
-    b_quant.zp_ndims = quant_entry_ndims(b_zps, b_zp_md_, ndims - 1);
-    c_quant.zp_ndims = quant_entry_ndims(c_zps, c_zp_md_, -1);
-    a_quant.gs_ndims = quant_entry_ndims(a_gs, a_gs_md_, ndims - 2);
-    b_quant.gs_ndims = quant_entry_ndims(b_gs, b_gs_md_, ndims - 1);
-    a_quant.scale_ndims = quant_entry_ndims(a_scales, a_scale_md_, ndims - 2);
-    b_quant.scale_ndims = quant_entry_ndims(b_scales, b_scale_md_, ndims - 1);
-    c_quant.scale_ndims = quant_entry_ndims(c_scales, c_scale_md_, -1);
 
-    a_quant.scales_type = a_scales.get_data_type();
-    a_quant.zp_type = a_zps.get_data_type();
-    a_quant.gs_type = a_gs.get_data_type();
-    a_quant.force_gs = !a_gs.has_default_values();
-    a_quant.zp_host_scalar = a_zp_host_scalar();
+    const int a_zp_ndims = quant_entry_ndims(a_zps, cfg.a_zp_md, ndims - 2);
+    const int b_zp_ndims = quant_entry_ndims(b_zps, cfg.b_zp_md, ndims - 1);
+    const bool a_zp_hs = a_zps.is_host_scalar();
+    const bool b_zp_hs = b_zps.is_host_scalar();
+    p.Tao = convert_dnnl_to_kernel_type(a_zps.get_data_type());
+    p.Tbo = convert_dnnl_to_kernel_type(b_zps.get_data_type());
+    if (a_zp_ndims >= 0 || a_zp_hs) p.aOffset = gemmstone::ABOffset::Calc;
+    if (b_zp_ndims >= 0 || b_zp_hs) p.bOffset = gemmstone::ABOffset::Calc;
+    p.aoPtrDims = a_zp_hs ? -1 : a_zp_ndims;
+    p.boPtrDims = b_zp_hs ? -1 : b_zp_ndims;
+
+    p.asPtrDims = quant_entry_ndims(a_scales, cfg.a_scale_md, ndims - 2);
+    p.bsPtrDims = quant_entry_ndims(b_scales, cfg.b_scale_md, ndims - 1);
+    if (a_scales.get_data_type() != data_type::undef)
+        p.Ta_scale = convert_dnnl_to_kernel_type(a_scales.get_data_type());
+    if (b_scales.get_data_type() != data_type::undef)
+        p.Tb_scale = convert_dnnl_to_kernel_type(b_scales.get_data_type());
+
+    p.hasGroupSumsA = !a_gs.has_default_values();
+    p.hasGroupSumsB = !b_gs.has_default_values();
+
+    // -1 for host-scalar, like aoPtrDims/boPtrDims.
+    p.coPtrDims = c_zps.is_host_scalar()
+            ? -1
+            : quant_entry_ndims(c_zps, c_zp_md, -1);
+    // cOffset == Post marks c-zp presence (cf. with_c_zero_points()).
+    if (!c_zps.has_default_values()) p.cOffset = gemmstone::COffset::Post;
+    if (c_scales.get_data_type() != data_type::undef) {
+        p.csPtrDims = quant_entry_ndims(c_scales, c_scale_md, -1);
+        p.Tc_scale = convert_dnnl_to_kernel_type(c_scales.get_data_type());
+        p.cMXScale = c_scales.is_mx();
+        if (!c_scales.has_default_groups()) {
+            p.cqGroupM = into<int>(c_scales.get_group(1));
+            p.cqGroupN = into<int>(c_scales.get_group(0));
+        }
+    }
+
+    p.sumA = (d->sum_ab == sum_ab::sum_b_col);
+    p.sumB = (d->sum_ab == sum_ab::sum_a_row);
+
     // XXX, gemmstone support: if multiple grouped quantization attributes exist
-    // for one matrix, they must have the same group size (default/unset is 0)
+    // for one matrix, they must have the same group size (default/unset is 0).
     const auto &set_if_consistent
-            = [this, engine](int &quant_dim, int new_dim, int arg) -> status_t {
-        VDISPATCH_GEMM(utils::one_of(quant_dim, 0, new_dim),
+            = [pd, engine](int &group, int new_group, int arg) -> status_t {
+        VDISPATCH_GEMM_F(utils::one_of(group, 0, new_group),
                 "%s: %s quantization attrs with different group sizes",
                 VERBOSE_UNSUPPORTED_ATTR, arg2str(arg).c_str());
-        quant_dim = new_dim;
+        group = new_group;
         return status::success;
     };
-    const auto &set_a_groups = [&set_if_consistent](quant_params &quant,
-                                       const quant_entry_t &entry) -> status_t {
+    // g0/g1 receive get_group(0)/get_group(1): for A that is (K, M), for B (N, K).
+    const auto &set_groups
+            = [&set_if_consistent](int &g0, int &g1, const quant_entry_t &entry,
+                      int arg) -> status_t {
         if (entry.has_default_groups()) return status::success;
-        CHECK(set_if_consistent(
-                quant.group_k, into<int>(entry.get_group(0)), DNNL_ARG_A));
-        CHECK(set_if_consistent(
-                quant.group_m, into<int>(entry.get_group(1)), DNNL_ARG_A));
+        CHECK(set_if_consistent(g0, into<int>(entry.get_group(0)), arg));
+        CHECK(set_if_consistent(g1, into<int>(entry.get_group(1)), arg));
         return status::success;
     };
-    CHECK(set_a_groups(a_quant, a_zps));
-    CHECK(set_a_groups(a_quant, a_gs));
-    CHECK(set_a_groups(a_quant, a_scales));
-
-    b_quant.scales_type = b_scales.get_data_type();
-    b_quant.zp_type = b_zps.get_data_type();
-    b_quant.gs_type = b_gs.get_data_type();
-    b_quant.force_gs = !b_gs.has_default_values();
-    b_quant.zp_host_scalar = b_zp_host_scalar();
-    const auto &set_b_groups = [&set_if_consistent](quant_params &quant,
-                                       const quant_entry_t &entry) -> status_t {
-        if (entry.has_default_groups()) return status::success;
-        CHECK(set_if_consistent(
-                quant.group_n, into<int>(entry.get_group(0)), DNNL_ARG_B));
-        CHECK(set_if_consistent(
-                quant.group_k, into<int>(entry.get_group(1)), DNNL_ARG_B));
-        return status::success;
-    };
-    CHECK(set_b_groups(b_quant, b_zps));
-    CHECK(set_b_groups(b_quant, b_gs));
-    CHECK(set_b_groups(b_quant, b_scales));
-
-    c_quant.scales_type = c_scales.get_data_type();
-    c_quant.zp_type = c_zps.get_data_type();
-    if (!c_scales.has_default_groups()) {
-        c_quant.group_m = into<int>(c_scales.get_group(1));
-        c_quant.group_n = into<int>(c_scales.get_group(0));
-        with_mx_scale_ = c_scales.is_mx();
-    }
-    c_quant.zp_host_scalar = c_zp_host_scalar();
+    CHECK(set_groups(p.aqGroupK, p.aqGroupM, a_zps, DNNL_ARG_A));
+    CHECK(set_groups(p.aqGroupK, p.aqGroupM, a_gs, DNNL_ARG_A));
+    CHECK(set_groups(p.aqGroupK, p.aqGroupM, a_scales, DNNL_ARG_A));
+    CHECK(set_groups(p.bqGroupN, p.bqGroupK, b_zps, DNNL_ARG_B));
+    CHECK(set_groups(p.bqGroupN, p.bqGroupK, b_gs, DNNL_ARG_B));
+    CHECK(set_groups(p.bqGroupN, p.bqGroupK, b_scales, DNNL_ARG_B));
 
     return status::success;
 }
 
-status_t pd_t::zp_ok(impl::engine_t *engine) {
+status_t zp_ok(const pd_t *pd, impl::engine_t *engine) {
     using namespace data_type;
-    auto &attr_zps = attr()->zero_points_;
+    const auto d = pd->desc();
+    auto &attr_zps = pd->attr()->zero_points_;
     if (attr_zps.has_default_values()) return status::success;
-    auto &a_zps = attr_zps.get(DNNL_ARG_A);
-    auto &b_zps = attr_zps.get(DNNL_ARG_B);
-    auto &c_zps = attr_zps.get(DNNL_ARG_C);
 
-    int ndims = desc()->a_desc.ndims;
-    const bool a_int4 = utils::one_of(desc()->a_type(), s4, u4);
-    const bool b_int4 = utils::one_of(desc()->b_type(), s4, u4);
-    const bool weights_upconversion
-            = wei_decomp_ || (a_int4 && dy_quant_enabled_);
+    const auto a_zps = attr_zps.get(DNNL_ARG_A);
+    const auto b_zps = attr_zps.get(DNNL_ARG_B);
+    const auto c_zps = attr_zps.get(DNNL_ARG_C);
+    const auto a_scales = pd->attr()->scales_.get(DNNL_ARG_A);
+
+    const int ndims = d->a_desc.ndims;
+    const bool a_int4 = utils::one_of(d->a_type(), s4, u4);
+    const bool b_int4 = utils::one_of(d->b_type(), s4, u4);
+    const bool dy_quant = pd->dy_quant_enabled();
+    const bool weights_upconversion = pd->wei_decomp() || (a_int4 && dy_quant);
+
+    // Rebuild the quant md to derive 2D-ness from attr alone.
+    const auto entry_2d
+            = [](const quant_entry_t &e, const memory_desc_t &base, int k_idx) {
+        if (e.is_host_scalar()) return false;
+        memory_desc_t md;
+        if (e.get_md(md, base) != status::success) return false;
+        return quant_entry_ndims(e, md, k_idx) >= 2;
+    };
+    const bool a_zp_2d = entry_2d(a_zps, d->b_desc, ndims - 2);
+    const bool b_zp_2d = entry_2d(b_zps, d->a_desc, ndims - 1);
+    const bool a_scales_2d = entry_2d(a_scales, d->b_desc, ndims - 2);
 
     if (!a_zps.has_default_values()) {
         // Groups determine supported masks.
         if (!a_zps.has_default_groups()) {
-            VDISPATCH_GEMM(valid_2d_mask(cmask_a_, ndims, weights_upconversion),
+            VDISPATCH_GEMM_F(valid_2d_mask(a_zps.get_mask(), ndims,
+                                     weights_upconversion),
                     "%s: unsupported A mask", VERBOSE_UNSUPPORTED_ZP_CFG);
-            const auto a_q2d_group_n = a_zps.get_group(1);
             // Non-trivial N group unsupported.
-            VDISPATCH_GEMM(a_q2d_group_n == 1,
+            VDISPATCH_GEMM_F(a_zps.get_group(1) == 1,
                     "%s: Grouped N dimension on A matrix",
                     VERBOSE_UNSUPPORTED_ZP_CFG);
             // Zero points with non-trivial groups only supported with
             // precomputed reductions or when target tensor is being dequantized.
-            bool has_prB = !attr()->precomputed_reductions_.has_default_values(
-                    DNNL_ARG_B);
+            const bool has_prB
+                    = !pd->attr()->precomputed_reductions_.has_default_values(
+                            DNNL_ARG_B);
             // TODO: Re-examine this condition
-            bool is_dequantized = !dy_quant_enabled_ || !b_int4 || a_int4;
-            VDISPATCH_GEMM(IMPLICATION(a_zp_2d(), is_dequantized || has_prB),
+            bool is_dequantized = !dy_quant || !b_int4 || a_int4;
+            VDISPATCH_GEMM_F(IMPLICATION(a_zp_2d, is_dequantized || has_prB),
                     "%s: Nontrivial groups on A matrix, and no precomputed "
                     "reductions or dequantization",
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         } else {
-            VDISPATCH_GEMM(utils::one_of(cmask_a_, 0, mask_per_oc, mask_per_ic),
+            VDISPATCH_GEMM_F(
+                    utils::one_of(a_zps.get_mask(), 0, mask_dim1, mask_dim2),
                     "%s: unsupported A mask", VERBOSE_UNSUPPORTED_ZP_CFG);
             // Weights zp can only be performantly enabled during upconversion
             // for cases that perform decompression.
-            VDISPATCH_GEMM(IMPLICATION(a_scales_2d(),
-                                   !(b_int4 && !wei_decomp_ && !a_int4)),
+            VDISPATCH_GEMM_F(IMPLICATION(a_scales_2d,
+                                     !(b_int4 && !pd->wei_decomp() && !a_int4)),
                     "%s: 2D scales on A matrix, but no weights "
                     "decompression",
                     VERBOSE_UNSUPPORTED_ZP_CFG);
@@ -389,66 +562,68 @@ status_t pd_t::zp_ok(impl::engine_t *engine) {
 
     if (!b_zps.has_default_values()) {
         // INT4 ZPs on SRC do not expand the range in a meaningful way, skipping
-        VDISPATCH_GEMM(!utils::one_of(b_zps.get_data_type(), s4, u4),
+        VDISPATCH_GEMM_F(!utils::one_of(b_zps.get_data_type(), s4, u4),
                 VERBOSE_UNSUPPORTED_ZP_CFG);
 
         // Groups determine supported masks.
         if (!b_zps.has_default_groups()) {
-            VDISPATCH_GEMM(valid_2d_mask(cmask_b_, ndims, false),
+            VDISPATCH_GEMM_F(valid_2d_mask(b_zps.get_mask(), ndims, false),
                     "%s: unsupported B mask", VERBOSE_UNSUPPORTED_ZP_CFG);
-            const auto b_q2d_group_n = b_zps.get_group(0);
             // Non-trivial M group unsupported.
-            VDISPATCH_GEMM(utils::one_of(b_q2d_group_n, 1, desc()->n()),
+            VDISPATCH_GEMM_F(
+                    utils::one_of(b_zps.get_group(0), dim_t(1), d->n()),
                     "%s: Nontrivial N groups on B matrix",
                     VERBOSE_UNSUPPORTED_ZP_CFG);
             // Zero points with non-trivial groups only supported
             // when target tensor is being dequantized.
             // TODO: Re-examine this condition
-            bool is_dequantized = !dy_quant_enabled_ || !a_int4 || b_int4;
-            VDISPATCH_GEMM(IMPLICATION(b_zp_2d(), is_dequantized),
+            bool is_dequantized = !dy_quant || !a_int4 || b_int4;
+            VDISPATCH_GEMM_F(IMPLICATION(b_zp_2d, is_dequantized),
                     "%s: Grouped B zero points, and no dequantization",
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         } else {
-            VDISPATCH_GEMM(utils::one_of(cmask_b_, 0, mask_scalar,
-                                   mask_per_oc | mask_per_ic),
+            VDISPATCH_GEMM_F(utils::one_of(b_zps.get_mask(), 0, mask_dim0,
+                                     mask_dim1 | mask_dim2),
                     "%s: unsupported B mask", VERBOSE_UNSUPPORTED_ZP_CFG);
         }
     }
 
     if (!attr_zps.has_default_values(DNNL_ARG_C)) {
-        VDISPATCH_GEMM(
-                IMPLICATION(!c_zps.is_host_scalar(),
-                        utils::one_of(cmask_c_, 0, mask_scalar, mask_per_oc)),
+        VDISPATCH_GEMM_F(IMPLICATION(!c_zps.is_host_scalar(),
+                                 utils::one_of(c_zps.get_mask(), 0, mask_dim0,
+                                         mask_dim1)),
                 "%s: unsupported C mask", VERBOSE_UNSUPPORTED_ZP_CFG);
     }
 
     return status::success;
 }
 
-status_t pd_t::gs_ok(impl::engine_t *engine) {
-    auto &attr_gs = attr()->precomputed_reductions_;
+status_t gs_ok(const pd_t *pd, impl::engine_t *engine) {
+    auto &attr_gs = pd->attr()->precomputed_reductions_;
     if (attr_gs.has_default_values()) return status::success;
 
-    VDISPATCH_GEMM(attr_gs.has_default_values(DNNL_ARG_DST),
+    VDISPATCH_GEMM_F(attr_gs.has_default_values(DNNL_ARG_DST),
             VERBOSE_UNSUPPORTED_PR_CFG);
 
     bool with_a_group_sums_ = !attr_gs.has_default_values(DNNL_ARG_A);
     bool with_b_group_sums_ = !attr_gs.has_default_values(DNNL_ARG_B);
 
-    VDISPATCH_GEMM(IMPLICATION(with_a_group_sums_,
-                           attr_gs.get_data_type(DNNL_ARG_A) == data_type::s32),
+    VDISPATCH_GEMM_F(
+            IMPLICATION(with_a_group_sums_,
+                    attr_gs.get_data_type(DNNL_ARG_A) == data_type::s32),
             VERBOSE_UNSUPPORTED_DT_CFG);
-    VDISPATCH_GEMM(IMPLICATION(with_b_group_sums_,
-                           attr_gs.get_data_type(DNNL_ARG_B) == data_type::s32),
+    VDISPATCH_GEMM_F(
+            IMPLICATION(with_b_group_sums_,
+                    attr_gs.get_data_type(DNNL_ARG_B) == data_type::s32),
             VERBOSE_UNSUPPORTED_DT_CFG);
 
     return status::success;
 }
 
-status_t pd_t::scales_ok(impl::engine_t *engine) {
-    const auto &scales = attr()->scales_;
+status_t scales_ok(const pd_t *pd, impl::engine_t *engine) {
+    const auto &scales = pd->attr()->scales_;
     if (scales.has_default_values()) return status::success;
-    int ndims = desc()->a_desc.ndims;
+    int ndims = pd->desc()->a_desc.ndims;
     using namespace data_type;
 
     for (auto s : {DNNL_ARG_A, DNNL_ARG_B}) {
@@ -458,10 +633,10 @@ status_t pd_t::scales_ok(impl::engine_t *engine) {
 
         auto mask = x_scales.get_mask();
         bool supportedMask
-                = utils::one_of(mask, 0, mask_scalar, mask_per_oc, mask_per_ic)
+                = utils::one_of(mask, 0, mask_dim0, mask_dim1, mask_dim2)
                 || (!x_scales.has_default_groups()
                         && valid_2d_mask(mask, ndims));
-        VDISPATCH_GEMM(supportedMask, "%s: unsupported A/B mask",
+        VDISPATCH_GEMM_F(supportedMask, "%s: unsupported A/B mask",
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
     }
 
@@ -469,39 +644,33 @@ status_t pd_t::scales_ok(impl::engine_t *engine) {
     if (!dst_scales.has_default_values() && !dst_scales.is_host_scalar()) {
         auto mask = dst_scales.get_mask();
         bool supportedMask
-                = utils::one_of(mask, 0, mask_scalar, mask_per_oc, mask_per_ic)
-                || (!dst_scales.has_default_groups() && with_mx_scale()
+                = utils::one_of(mask, 0, mask_dim0, mask_dim1, mask_dim2)
+                || (!dst_scales.has_default_groups() && dst_scales.is_mx()
                         && valid_2d_mask(mask, ndims));
-        VDISPATCH_GEMM(supportedMask, "%s: unsupported C mask",
+        VDISPATCH_GEMM_F(supportedMask, "%s: unsupported C mask",
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
     }
 
-    if (!dst_scales.has_default_values() && with_mx_scale()) {
+    if (!dst_scales.has_default_values() && dst_scales.is_mx()) {
         // Dynamic Dst Quant only supported with `1x32` groups.
-        VDISPATCH_GEMM(dst_scales.get_group(0) == 1
+        VDISPATCH_GEMM_F(dst_scales.get_group(0) == 1
                         && dst_scales.get_group(1) == 32
-                        && arch_ >= compute::gpu_arch_t::xe_hpc,
+                        && pd->arch_ >= compute::gpu_arch_t::xe_hpc,
                 "%s: unsupported mx_scale groups",
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
 
         // M+N dimensions must have trivial strides for Dynamic Dst Quant
-        auto md = &desc()->c_desc;
+        auto md = &pd->desc()->c_desc;
         auto strides = md->format_desc.blocking.strides;
-        VDISPATCH_GEMM(strides[md->ndims - 1] == 1,
+        VDISPATCH_GEMM_F(strides[md->ndims - 1] == 1,
                 "%s: unsupported mx_scale strides",
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
-        VDISPATCH_GEMM(strides[md->ndims - 2] == md->dims[md->ndims - 1],
+        VDISPATCH_GEMM_F(strides[md->ndims - 2] == md->dims[md->ndims - 1],
                 "%s: unsupported mx_scale strides",
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
     }
 
     return status::success;
-}
-
-bool pd_t::valid_2d_mask(int mask, int ndims, bool per_tensor_ok) {
-    return (mask == full_tensor_mask() && per_tensor_ok)
-            || utils::one_of(mask, (1 << (ndims - 1)),
-                    (1 << (ndims - 1)) + (1 << (ndims - 2)));
 }
 
 status_t transfer_post_ops(
@@ -519,9 +688,6 @@ status_t transfer_post_ops(
         problem.postOps.binaryCol = {};
         problem.postOps.binaryBatch = {};
         problem.postOps.binaryTrans = {};
-
-        if (problem.Ta == Type::f16) problem.Ts = Type::f32;
-        if (problem.Ta.isF8() || problem.Tb.isF8()) problem.Ts = Type::f32;
 
         for (size_t i = 0; i < po_count; i++) {
             const auto &entry = post_ops[i];
@@ -561,11 +727,10 @@ status_t transfer_post_ops(
     return status::success;
 }
 
-status_t pd_t::init_GEMMProblem(
-        gemmstone::GEMMProblem &problem, const intel::engine_t *engine) const {
+status_t finalize_problem(kernel_config_t &cfg, const intel::engine_t *engine) {
     // Set up problem structure.
     using namespace gemmstone;
-    problem = {};
+    auto &problem = cfg.problem;
 
     problem.product = engine->device_info()->product();
     bool has_systolic
@@ -574,66 +739,48 @@ status_t pd_t::init_GEMMProblem(
             || engine->mayiuse(compute::device_ext_t::
                             intel_subgroup_split_matrix_multiply_accumulate);
 
-    auto a_type = get_type(DNNL_ARG_A);
-    auto b_type = get_type(DNNL_ARG_B);
+    auto align_a = nstl::max(
+            cfg.align_bytes(cfg.lda, cfg.a_type(), cfg.a_batch_strides),
+            (int)types::data_type_size(cfg.a_type()));
+    auto a_size = (cfg.trans_a() ? cfg.m : cfg.k) * cfg.lda
+            * types::data_type_size(cfg.a_type());
 
-    auto m = desc()->m();
-    auto n = desc()->n();
-    auto k = desc()->k();
+    auto align_b = nstl::max(
+            cfg.align_bytes(cfg.ldb, cfg.b_type(), cfg.b_batch_strides),
+            (int)types::data_type_size(cfg.b_type()));
+    auto b_size = (cfg.trans_b() ? cfg.k : cfg.n) * cfg.ldb
+            * types::data_type_size(cfg.b_type());
 
-    auto align_a = align(DNNL_ARG_A);
-    auto align_b = align(DNNL_ARG_B);
+    bool int_acc = utils::one_of(cfg.a_type(), data_type::s8, data_type::u8)
+            || (types::is_integral_dt(cfg.a_type())
+                    && types::is_integral_dt(cfg.b_type()));
+    int_acc &= !(a_grouped(cfg) || b_grouped(cfg));
+    auto align_c = nstl::max(
+            cfg.align_bytes(cfg.ldc, cfg.c_type(), cfg.c_batch_strides),
+            (int)types::data_type_size(cfg.c_type()));
+    auto c_size = cfg.n * cfg.ldc * types::data_type_size(cfg.c_type());
 
-    auto lda = ld(DNNL_ARG_A);
-    auto ldb = ld(DNNL_ARG_B);
-
-    auto trans_a = this->trans_a();
-    auto trans_b = this->trans_b();
-
-    if (swap_ab_) {
-        std::swap(a_type, b_type);
-        std::swap(m, n);
-        std::swap(align_a, align_b);
-        std::swap(lda, ldb);
-        std::swap(trans_a, trans_b);
-        trans_a = !trans_a;
-        trans_b = !trans_b;
-    }
-
-    align_a = nstl::max(align_a, (int)types::data_type_size(a_type));
-    auto a_size = (trans_a ? m : k) * lda * types::data_type_size(a_type);
-
-    align_b = nstl::max(align_b, (int)types::data_type_size(b_type));
-    auto b_size = (trans_b ? k : n) * ldb * types::data_type_size(b_type);
-
-    bool int_acc = utils::one_of(a_type, data_type::s8, data_type::u8)
-            || (types::is_integral_dt(a_type) && types::is_integral_dt(b_type));
-    int_acc &= !(a_grouped() || b_grouped());
-    auto c_type = desc()->c_type();
-    auto align_c
-            = nstl::max(align(DNNL_ARG_C), (int)types::data_type_size(c_type));
-    auto ldc = desc()->ldc();
-    auto c_size = n * ldc * types::data_type_size(c_type);
-
-    auto co_type = with_bias() ? desc()->bias_type()
-            : with_sum_ab()    ? desc()->sum_ab_type
-            : int_acc          ? data_type::s32
-                               : desc()->c_type();
+    auto co_type = cfg.with_bias() ? cfg.bias_type
+            : cfg.with_sum_ab()    ? cfg.sum_ab_type
+            : int_acc              ? data_type::s32
+                                   : cfg.c_type();
 
     // Choose accumulation data type.
     auto acc_type = int_acc
             ? data_type::s32
-            : (utils::one_of(data_type::f64, a_type, b_type) ? data_type::f64
-                                                             : data_type::f32);
+            : (utils::one_of(data_type::f64, cfg.a_type(), cfg.b_type())
+                              ? data_type::f64
+                              : data_type::f32);
 
-    bool with_binary = (post_ops_.find(primitive_kind::binary) != -1)
-            || (post_ops_.find(primitive_kind::prelu) != -1);
+    bool with_binary = problem.hasBinaryPostOp();
 
-    bool need_x32_acc = with_binary || !IMPLICATION(with_sum_, sum_at_begin_);
-    auto acc_mode = attr()->acc_mode_;
+    bool need_x32_acc
+            = with_binary || !IMPLICATION(cfg.with_sum(), cfg.sum_at_begin());
+    auto acc_mode = cfg.acc_mode;
 
-    // Strict acc mode default.
-    auto Tacc_mode = problem.Tc_ext.isFP() ? data_type::f32 : data_type::s32;
+    // Strict default must be f32, not Tc_ext: Tacc gates atomic-C
+    // (useAutoAtomic); an s32 dst would re-enable atomics.
+    auto Tacc_mode = data_type::f32;
 
     // Initialize non-strict acc mode.
     switch (acc_mode) {
@@ -652,33 +799,16 @@ status_t pd_t::init_GEMMProblem(
 
     if (acc_mode != accumulation_mode::strict) acc_type = Tacc_mode;
 
-    if (wei_decomp_) { acc_type = data_type::f32; }
+    if (cfg.wei_decomp) { acc_type = data_type::f32; }
 
-    auto trans_co = trans_bias();
-    if (swap_ab_) trans_co = !trans_co;
-    auto dst_sround = with_sround_;
-    bool c_offset = with_c_zero_points();
-    bool bias = with_bias();
+    bool c_offset = cfg.with_c_zero_points();
+    bool bias = cfg.with_bias();
 
-    jit::quant_params a_quant = this->a_quant;
-    jit::quant_params b_quant = this->b_quant;
-
-    if (swap_ab()) {
-        std::swap(a_quant, b_quant);
-        std::swap(a_quant.group_m, a_quant.group_n);
-        std::swap(b_quant.group_m, b_quant.group_n);
-    }
-
-    problem.Ta = problem.Ta_ext = convert_dnnl_to_kernel_type(a_type);
-    problem.Tb = problem.Tb_ext = convert_dnnl_to_kernel_type(b_type);
+    problem.Ta = problem.Ta_ext;
+    problem.Tb = problem.Tb_ext;
     problem.Tc = convert_dnnl_to_kernel_type(acc_type);
-    problem.Tc_ext = convert_dnnl_to_kernel_type(c_type);
     problem.Ts = problem.Tc;
-    problem.Tao = convert_dnnl_to_kernel_type(a_quant.zp_type);
-    problem.Tbo = convert_dnnl_to_kernel_type(b_quant.zp_type);
     problem.Tco = convert_dnnl_to_kernel_type(co_type);
-    problem.A.layout = trans_a ? MatrixLayout::T : MatrixLayout::N;
-    problem.B.layout = trans_b ? MatrixLayout::T : MatrixLayout::N;
     problem.C.layout = MatrixLayout::N;
     problem.A.crosspack = problem.B.crosspack = problem.C.crosspack = 1;
     problem.A.packSize = problem.B.packSize = problem.C.packSize = 0;
@@ -693,20 +823,10 @@ status_t pd_t::init_GEMMProblem(
     problem.B.needA64 = needA64;
     problem.C.needA64 = needA64;
 
-    if (batch_dims() > 0) {
-        problem.batch = BatchMode::Strided;
-        problem.batchDims = batch_dims();
-    }
-    if (a_quant.zp_ndims >= 0 || a_quant.zp_host_scalar)
-        problem.aOffset = ABOffset::Calc;
-    if (b_quant.zp_ndims >= 0 || b_quant.zp_host_scalar)
-        problem.bOffset = ABOffset::Calc;
-    problem.aoPtrDims = a_quant.zp_host_scalar ? -1 : a_quant.zp_ndims;
-    problem.boPtrDims = b_quant.zp_host_scalar ? -1 : b_quant.zp_ndims;
-    problem.asPtrDims = a_quant.scale_ndims;
-    problem.bsPtrDims = b_quant.scale_ndims;
+    const auto layout_N = cfg.ab_layout_N();
+    const auto layout_T = cfg.ab_layout_T();
 
-    problem.AO.layout = problem.BO.layout = MatrixLayout::N;
+    problem.AO.layout = problem.BO.layout = layout_N;
     problem.AO.crosspack = problem.BO.crosspack = 1;
     problem.AO.packSize = problem.BO.packSize = 0;
     problem.A_scale = problem.Ag = problem.AO;
@@ -714,93 +834,62 @@ status_t pd_t::init_GEMMProblem(
 
     // 1D tensors can be treated as either transposition - choose the one that
     // allows block loads (i.e. A -> N and B -> T)
-    if (!problem.bOffset2D()) problem.BO.layout = MatrixLayout::T;
-    if (!problem.bScale2D()) problem.B_scale.layout = MatrixLayout::T;
-    if (b_quant.gs_ndims < 2) problem.Bg.layout = MatrixLayout::T;
+    if (!problem.bOffset2D()) problem.BO.layout = layout_T;
+    if (!problem.bScale2D()) problem.B_scale.layout = layout_T;
+    if (!problem.hasGroupSumsB) problem.Bg.layout = layout_T;
 
-    if (a_quant.zp_type != data_type::undef)
-        problem.AO.setAlignment(int(types::data_type_size(a_quant.zp_type)));
-    if (b_quant.zp_type != data_type::undef)
-        problem.BO.setAlignment(int(types::data_type_size(b_quant.zp_type)));
-    problem.aqGroupK = a_quant.group_k;
-    problem.bqGroupK = b_quant.group_k;
-    problem.aqGroupM = a_quant.group_m;
-    problem.bqGroupN = b_quant.group_n;
-    if (a_quant.scales_type != data_type::undef) {
-        problem.Ta_scale = convert_dnnl_to_kernel_type(a_quant.scales_type);
-        problem.A_scale.setAlignment(
-                int(types::data_type_size(a_quant.scales_type)));
-    }
-    if (b_quant.scales_type != data_type::undef) {
-        problem.Tb_scale = convert_dnnl_to_kernel_type(b_quant.scales_type);
-        problem.B_scale.setAlignment(
-                int(types::data_type_size(b_quant.scales_type)));
-    }
-
-    if (c_quant.scales_type != data_type::undef) {
-        problem.csPtrDims = c_quant.scale_ndims;
-        problem.cMXScale = with_mx_scale_;
-        problem.Tc_scale = convert_dnnl_to_kernel_type(c_quant.scales_type);
-        problem.cqGroupM = c_quant.group_m;
-        problem.cqGroupN = c_quant.group_n;
-    }
+    if (problem.Tao != Type::invalid)
+        problem.AO.setAlignment(problem.Tao.paddedSize());
+    if (problem.Tbo != Type::invalid)
+        problem.BO.setAlignment(problem.Tbo.paddedSize());
+    if (problem.Ta_scale != Type::invalid)
+        problem.A_scale.setAlignment(problem.Ta_scale.paddedSize());
+    if (problem.Tb_scale != Type::invalid)
+        problem.B_scale.setAlignment(problem.Tb_scale.paddedSize());
 
     // Mixed s8/s4 DPAS support:
     // - Xe3p: Not supported, require s4->s8 upconversion
     // - pre-Xe3p: supported, but only when s4 matrix doesn't have zero points
     bool has_s8s4_dpas = getCore(problem.product.family) != ngen::HW::Xe3p;
+    // Gate on aOffset == None, not aoPtrDims < 0: a host-scalar zp satisfies
+    // the latter but must still upconvert.
     if (problem.Ta_ext.isInt4() && problem.Tb_ext.isInt8()) {
-        bool s8s4_dpas_ok = has_s8s4_dpas && (a_quant.zp_ndims < 0);
+        bool s8s4_dpas_ok
+                = has_s8s4_dpas && (problem.aOffset == ABOffset::None);
         if (!s8s4_dpas_ok) problem.Ta = Type::s8;
     }
     if (problem.Tb_ext.isInt4() && problem.Ta_ext.isInt8()) {
-        bool s8s4_dpas_ok = has_s8s4_dpas && (b_quant.zp_ndims < 0);
+        bool s8s4_dpas_ok
+                = has_s8s4_dpas && (problem.bOffset == ABOffset::None);
         if (!s8s4_dpas_ok) problem.Tb = Type::s8;
     }
 
     if (problem.Ta.isInteger()) problem.Ts = Type::f32;
 
-    if (alpha() == 1.0f) problem.alpha = (int)alpha();
-    if (beta() == 0.0f || beta() == 1.0f) problem.beta = (int)beta();
-
-    gpu_post_ops_t gpu_post_ops;
-    CHECK(gpu_post_ops_t::make(
-            gpu_post_ops, post_ops_, dst_md(), get_post_op_specializations()));
-
-    CHECK(transfer_post_ops(problem, std::move(gpu_post_ops)));
-    if (swap_ab()) {
-        problem.postOps.transpose();
-        for (auto &b : problem.binary)
-            b.transpose();
+    // Must follow the upconversion above (reads final Ta/Tb).
+    if (problem.postOps.len() > 0) {
+        if (problem.Ta == Type::f16) problem.Ts = Type::f32;
+        if (problem.Ta.isF8() || problem.Tb.isF8()) problem.Ts = Type::f32;
     }
 
-    auto reduce_ab = sum_ab();
-    if (c_offset || bias || reduce_ab != sum_ab::sum_none) {
+    if (cfg.alpha() == 1.0f) problem.alpha = (int)cfg.alpha();
+    if (cfg.beta == 0.0f || cfg.beta == 1.0f) problem.beta = (int)cfg.beta;
+
+    if (c_offset || bias || problem.sumA || problem.sumB) {
         assert(!(c_offset && bias));
         if (bias) problem.cOffset = COffset::Pre;
         if (c_offset) problem.cOffset = COffset::Post;
         problem.CO.crosspack = 1;
         problem.CO.alignment = problem.C.alignment;
-        problem.CO.layout = trans_co ? MatrixLayout::T : MatrixLayout::N;
-        problem.coPtrDims = c_quant.zp_host_scalar ? -1 : c_quant.zp_ndims;
     }
-
-    problem.sumA = (reduce_ab == sum_ab::sum_b_col);
-    problem.sumB = (reduce_ab == sum_ab::sum_a_row);
-    if (swap_ab_) std::swap(problem.sumA, problem.sumB);
-    problem.hasGroupSumsA = a_quant.force_gs;
-    problem.hasGroupSumsB = b_quant.force_gs;
-
-    problem.postOps.cStochasticRound = dst_sround;
 
     if (problem.needsAGroupSums() || problem.needsBGroupSums())
         problem.autoTypeConversions(has_systolic);
 
     if (problem.needsAGroupSums()) {
         if (!problem.hasGroupSumsA) return status::unimplemented;
-        data_type_t gs_dt = a_quant.gs_type == data_type::undef
-                ? data_type::s32
-                : a_quant.gs_type;
+        data_type_t gs_dt = memory_desc_wrapper(cfg.a_gs_md).data_type();
+        if (gs_dt == data_type::undef) gs_dt = data_type::s32;
         problem.Tag = convert_dnnl_to_kernel_type(gs_dt);
         problem.Ag.setAlignment(problem.Tag.paddedSize());
         if (problem.bqGroupK == 0) problem.bqGroupK = problem.aqGroupK;
@@ -808,9 +897,8 @@ status_t pd_t::init_GEMMProblem(
     }
     if (problem.needsBGroupSums()) {
         if (!problem.hasGroupSumsB) return status::unimplemented;
-        data_type_t gs_dt = b_quant.gs_type == data_type::undef
-                ? data_type::s32
-                : b_quant.gs_type;
+        data_type_t gs_dt = memory_desc_wrapper(cfg.b_gs_md).data_type();
+        if (gs_dt == data_type::undef) gs_dt = data_type::s32;
         problem.Tbg = convert_dnnl_to_kernel_type(gs_dt);
         problem.Bg.setAlignment(problem.Tbg.paddedSize());
         if (problem.aqGroupK == 0) problem.aqGroupK = problem.bqGroupK;
@@ -819,86 +907,123 @@ status_t pd_t::init_GEMMProblem(
     // Disable bdpas with unsupported k dim.
     // TODO: Enable 2D block, masking scale loads.
     if (problem.nativeBDPAS()) {
-        if (((!problem.Ta.isF4() || !problem.Tb.isF4()) || k % 64 == 0))
+        if (((!problem.Ta.isF4() || !problem.Tb.isF4()) || cfg.k % 64 == 0))
             problem.bdpasEnabled = true;
     }
 
-    if (swap_ab_) {
-        // problem.A and problem.B are already swapped + transposed
-        // TODO: use problem.transpose() instead
-        problem.AO.transpose();
-        problem.BO.transpose();
-        problem.A_scale.transpose();
-        problem.B_scale.transpose();
-        problem.Ag.transpose();
-        problem.Bg.transpose();
-    }
+    gpu_assert(problem.C.layout == MatrixLayout::N);
 
+    cfg.finalized_ = true;
     return status::success;
 }
 
-dim_t pd_t::ld_binary(int idx) const {
-    switch (binary_srcs_[idx].type) {
-        case binary_src_t::binary: {
-            const auto &entry = post_ops_.entry_[idx];
-            assert(entry.kind == primitive_kind::binary);
-            return gemm_desc_t::get_ld(entry.binary.src1_desc);
-        }
-        case binary_src_t::bias: return desc()->ld_bias();
-        case binary_src_t::prelu: {
-            return gemm_desc_t::get_ld(prelu_wei_md);
-        }
+// Per-batch-dim stride of a quant md.
+static dim_t quant_md_stride(const memory_desc_t &md, int idx) {
+    const memory_desc_wrapper mdw(&md);
+    if (mdw.is_host_scalar_desc()) return 0;
+    gpu_assert(mdw.is_plain()) << "Expected plain quant md";
+    if (md.dims[idx] == 1) return 0;
+    return md.format_desc.blocking.strides[idx];
+}
 
+dim_t kernel_config_t::a_scale_stride(int idx) const {
+    return quant_md_stride(a_scale_md, idx);
+}
+dim_t kernel_config_t::b_scale_stride(int idx) const {
+    return quant_md_stride(b_scale_md, idx);
+}
+dim_t kernel_config_t::a_zp_stride(int idx) const {
+    return quant_md_stride(a_zp_md, idx);
+}
+dim_t kernel_config_t::b_zp_stride(int idx) const {
+    return quant_md_stride(b_zp_md, idx);
+}
+dim_t kernel_config_t::a_gs_stride(int idx) const {
+    return quant_md_stride(a_gs_md, idx);
+}
+dim_t kernel_config_t::b_gs_stride(int idx) const {
+    return quant_md_stride(b_gs_md, idx);
+}
+
+dim_t kernel_config_t::ld_binary(int idx) const {
+    const auto &src = binary_srcs[idx];
+    switch (src.type) {
+        case binary_src_t::binary: return gemm_desc_t::get_ld(src.src_md);
+        case binary_src_t::bias: return ld_bias;
+        case binary_src_t::prelu: return gemm_desc_t::get_ld(src.src_md);
         default: return 1;
     }
 }
 
-dim_t pd_t::stride_binary(int idx, int stride) const {
-    switch (binary_srcs_[idx].type) {
+dim_t kernel_config_t::stride_binary(int idx, int stride) const {
+    const auto &src = binary_srcs[idx];
+    switch (src.type) {
         case binary_src_t::binary:
         case binary_src_t::scales:
-        case binary_src_t::bias: {
-            const auto &entry = post_ops_.entry_[idx];
-            assert(entry.kind == primitive_kind::binary);
-            return gemm_desc_t::get_stride(entry.binary.src1_desc, stride);
-        }
-        case binary_src_t::prelu: {
-            return gemm_desc_t::get_stride(prelu_wei_md, stride);
-        }
+        case binary_src_t::bias:
+        case binary_src_t::prelu:
+            return gemm_desc_t::get_stride(src.src_md, stride);
         default: return 0;
     }
 }
 
-dim_t pd_t::scale_stride(int idx, int arg) const {
-    gpu_assert(utils::one_of(arg, DNNL_ARG_A, DNNL_ARG_B));
-    const memory_desc_t *md_ptr
-            = (arg == DNNL_ARG_A) ? &a_scale_md_ : &b_scale_md_;
-    const memory_desc_wrapper mdw(md_ptr);
-    if (mdw.is_host_scalar_desc()) return 0;
-    gpu_assert(mdw.is_plain()) << "Expected plain scale_md_";
-    if (mdw.dims()[idx] == 1) return 0;
-    return mdw.strides()[idx];
+// Runs in user orientation, before apply_swap_ab.
+void pad_leading_dims(kernel_config_t &cfg, bool swap) {
+    if (swap && !cfg.trans_a() && cfg.m == 1) {
+        cfg.problem.A.layout = gemmstone::MatrixLayout::T;
+        cfg.lda = cfg.k;
+    }
+
+    // Pad leading dimensions in case of a single row/column.
+    if ((cfg.k == 1 && !cfg.trans_a()) || (cfg.m == 1 && cfg.trans_a()))
+        cfg.lda = utils::rnd_up(cfg.lda, 16);
+    if ((cfg.n == 1 && !cfg.trans_b()) || (cfg.k == 1 && cfg.trans_b()))
+        cfg.ldb = utils::rnd_up(cfg.ldb, 16);
 }
 
-dim_t pd_t::zp_stride(int idx, int arg) const {
-    gpu_assert(utils::one_of(arg, DNNL_ARG_A, DNNL_ARG_B));
-    const memory_desc_t *md_ptr = (arg == DNNL_ARG_A) ? &a_zp_md_ : &b_zp_md_;
-    const memory_desc_wrapper mdw(md_ptr);
-    if (mdw.is_host_scalar_desc()) return 0;
-    gpu_assert(mdw.is_plain()) << "Expected plain zp_md_";
-    if (mdw.dims()[idx] == 1) return 0;
-    return mdw.strides()[idx];
+void apply_swap_ab(kernel_config_t &cfg, bool swap) {
+    cfg.swap_ab = swap;
+    if (swap) {
+        std::swap(cfg.m, cfg.n);
+        std::swap(cfg.lda, cfg.ldb);
+        std::swap(cfg.a_scale_md, cfg.b_scale_md);
+        std::swap(cfg.a_zp_md, cfg.b_zp_md);
+        std::swap(cfg.a_gs_md, cfg.b_gs_md);
+        std::swap(cfg.a_host_scale, cfg.b_host_scale);
+        // Loop the full array (not batch_dims) so the fold is swap-symmetric.
+        for (int b = 0; b < kernel_config_t::max_batch_dims; b++)
+            std::swap(cfg.a_batch_strides[b], cfg.b_batch_strides[b]);
+
+        // Column<->row swap of the C-side mask's low 2 bits (M<->N transpose).
+        const uint8_t cmask_swap[4] = {0, 2, 1, 3};
+        cfg.cmask = (cfg.cmask & ~3) | cmask_swap[cfg.cmask & 3];
+
+        // Tag/Tbg derived post-swap in finalize_problem; no swap here.
+        cfg.problem.transpose();
+    }
+
+    // Swapped mds must agree with swapped problem ptr-dims. One-directional:
+    // a host-scalar zp folds the ptr-dim to -1 but keeps the md populated.
+    auto md_present = [](const memory_desc_t &md) { return md.ndims > 0; };
+    gpu_assert(IMPLICATION(
+            cfg.problem.hasAScalePtr(), md_present(cfg.a_scale_md)));
+    gpu_assert(IMPLICATION(
+            cfg.problem.hasBScalePtr(), md_present(cfg.b_scale_md)));
+    gpu_assert(
+            IMPLICATION(cfg.problem.hasAOffsetPtr(), md_present(cfg.a_zp_md)));
+    gpu_assert(
+            IMPLICATION(cfg.problem.hasBOffsetPtr(), md_present(cfg.b_zp_md)));
+    gpu_assert(IMPLICATION(cfg.problem.hasGroupSumsA, md_present(cfg.a_gs_md)));
+    gpu_assert(IMPLICATION(cfg.problem.hasGroupSumsB, md_present(cfg.b_gs_md)));
+
+    gpu_assert(IMPLICATION(
+            cfg.problem.aqGroupM > 1, cfg.problem.aqGroupM <= cfg.m));
+    gpu_assert(IMPLICATION(
+            cfg.problem.bqGroupN > 1, cfg.problem.bqGroupN <= cfg.n));
 }
 
-dim_t pd_t::gs_stride(int idx, int arg) const {
-    gpu_assert(utils::one_of(arg, DNNL_ARG_A, DNNL_ARG_B));
-    const memory_desc_t *md_ptr = (arg == DNNL_ARG_A) ? &a_gs_md_ : &b_gs_md_;
-    const memory_desc_wrapper mdw(md_ptr);
-    if (mdw.is_host_scalar_desc()) return 0;
-    gpu_assert(mdw.is_plain()) << "Expected plain gs_md_";
-    if (mdw.dims()[idx] == 1) return 0;
-    return mdw.strides()[idx];
-}
+#undef VDISPATCH_GEMM_F
+#undef VDISPATCH_GEMM_F_SC
 
 } // namespace jit
 } // namespace gemm

--- a/src/gpu/intel/gemm/jit/pd.hpp
+++ b/src/gpu/intel/gemm/jit/pd.hpp
@@ -21,9 +21,13 @@
 
 #include "common/c_types_map.hpp"
 #include "common/gemm_types.hpp"
+#include "common/memory_storage.hpp"
+#include "gemmstone/driver_info.hpp"
+#include "gemmstone/kernel_evaluator.hpp"
 #include "gemmstone/problem.hpp"
-#include "gpu/intel/gemm/config.hpp"
+#include "gemmstone/strategy.hpp"
 #include "gpu/intel/gemm/exec_types.hpp"
+#include "gpu/intel/gemm/types.hpp"
 #include "gpu/intel/post_ops.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 
@@ -36,52 +40,200 @@ namespace jit {
 
 #define GEMM_MAX_PO 36
 
-struct quant_params {
-    data_type_t scales_type = data_type::undef;
-    data_type_t zp_type = data_type::undef;
-    data_type_t gs_type = data_type::undef;
-    int scale_ndims = -1;
-    int zp_ndims = -1;
-    int gs_ndims = -1;
-    int group_k = 0;
-    int group_m = 0;
-    int group_n = 0;
-    bool force_gs = false;
-    bool zp_host_scalar = false;
+inline data_type_t convert_kernel_to_dnnl_type(gemmstone::Type type) {
+    using gemmstone::Type;
+    switch (type) {
+        case Type::f64: return data_type::f64;
+        case Type::f32: return data_type::f32;
+        // tf32 buffers are physically f32.
+        case Type::tf32: return data_type::f32;
+        case Type::f16: return data_type::f16;
+        case Type::bf16: return data_type::bf16;
+        case Type::bf8: return data_type::f8_e5m2;
+        case Type::hf8: return data_type::f8_e4m3;
+        case Type::f8_e8m0: return data_type::e8m0;
+        case Type::f4_e2m1: return data_type::f4_e2m1;
+        case Type::f4_e3m0: return data_type::f4_e3m0;
+        case Type::s32: return data_type::s32;
+        case Type::u8: return data_type::u8;
+        case Type::s8: return data_type::s8;
+        case Type::u4: return data_type::u4;
+        case Type::s4: return data_type::s4;
+        case Type::invalid: return data_type::undef;
+        default: gpu_error_not_expected(); return data_type::undef;
+    }
+}
+
+struct binary_src_t {
+    enum type_t { none, scales, bias, binary, prelu } type;
+    int index;
+    // Post-op input src md, user (pre-swap) orientation.
+    memory_desc_t src_md = {};
+
+    binary_src_t(type_t type_, int index_) : type(type_), index(index_) {}
 };
 
-status_t transfer_post_ops(
-        gemmstone::GEMMProblem &problem, gpu_post_ops_t &&post_ops_);
+// Kernel-facing snapshot of pd_t state; swap_ab is folded once in
+// apply_swap_ab.
+struct kernel_config_t {
+    gemmstone::GEMMProblem problem;
+
+    data_type_t a_type() const {
+        return convert_kernel_to_dnnl_type(problem.Ta_ext);
+    }
+    data_type_t b_type() const {
+        return convert_kernel_to_dnnl_type(problem.Tb_ext);
+    }
+    data_type_t c_type() const {
+        return convert_kernel_to_dnnl_type(problem.Tc_ext);
+    }
+    bool trans_a() const {
+        return problem.A.layout == gemmstone::MatrixLayout::T;
+    }
+    bool trans_b() const {
+        return problem.B.layout == gemmstone::MatrixLayout::T;
+    }
+    // Valid pre-swap only; apply_swap_ab/finalize_problem fold C back to N.
+    bool trans_c() const {
+        return problem.C.layout == gemmstone::MatrixLayout::T;
+    }
+
+    // Covers tensor and host-scalar zps (a host scalar keeps Calc,
+    // aoPtrDims = -1).
+    bool with_a_zero_points() const {
+        return problem.aOffset == gemmstone::ABOffset::Calc;
+    }
+    bool with_b_zero_points() const {
+        return problem.bOffset == gemmstone::ABOffset::Calc;
+    }
+    // Covers tensor and host-scalar c-zp; set in init_attrs.
+    bool with_c_zero_points() const {
+        return problem.cOffset == gemmstone::COffset::Post;
+    }
+    // Tc_scale is set for any present dst scale (converted/mx/host-scalar).
+    bool with_c_scales() const {
+        return problem.Tc_scale != gemmstone::Type::invalid;
+    }
+
+    // sumA/sumB carry the sum_ab reduction; the OR is swap-invariant.
+    bool with_sum_ab() const { return problem.sumA || problem.sumB; }
+
+    // Valid after init_post_ops (reads the lowered post-op chain).
+    bool with_sum() const {
+        for (const auto &e : problem.postOps.ops)
+            if (e.is_sum()) return true;
+        return false;
+    }
+    bool sum_at_begin() const {
+        const auto &ops = problem.postOps.ops;
+        return ops.len() > 0 && ops[0].is_sum();
+    }
+
+    dim_t m = 0, n = 0, k = 0;
+    dim_t lda = 0, ldb = 0, ldc = 0;
+
+    // Quant mds: A/B-side are swap_ab-folded; C-side is passthrough.
+    memory_desc_t a_scale_md = {}, b_scale_md = {};
+    memory_desc_t a_zp_md = {}, b_zp_md = {};
+    memory_desc_t a_gs_md = {}, b_gs_md = {};
+
+    std::vector<binary_src_t> binary_srcs;
+
+    // Any post-op besides sum and the converted A/B/C scale binaries.
+    bool non_scale_po() const {
+        int n = 0;
+        for (const auto &s : binary_srcs)
+            if (s.type != binary_src_t::scales) n++;
+        return n > (with_sum() ? 1 : 0);
+    }
+
+    // Bias present and not lowered to a binary post-op (dedicated C-offset).
+    bool with_bias() const {
+        if (bias_type == data_type::undef) return false;
+        for (const auto &s : binary_srcs)
+            if (s.type == binary_src_t::bias) return false;
+        return true;
+    }
+    dim_t ld_bias = 0;
+
+    int cmask = 0;
+
+    float beta = 0.0f;
+
+    bool swap_ab = false;
+
+    static constexpr int max_batch_dims = DNNL_MAX_NDIMS - 2;
+    dim_t a_batch_strides[max_batch_dims] = {};
+    dim_t b_batch_strides[max_batch_dims] = {};
+    dim_t c_batch_strides[max_batch_dims] = {};
+
+    data_type_t bias_type = data_type::undef;
+    data_type_t sum_ab_type = data_type::undef;
+    accumulation_mode_t acc_mode = accumulation_mode::strict;
+    bool wei_decomp = false;
+
+    // Host-scalar scales fold into alpha at exec; until then the 9.99 sentinel
+    // makes the kernel emit a multiply. Seeded at init from pd host-scale flags.
+    float alpha_ = 1.0f;
+    float alpha() const { return alpha_; }
+
+    bool a_host_scale = false;
+    bool b_host_scale = false;
+    bool c_host_scale_to_alpha = false;
+
+    // fpmath compute-mode bits (gen_nocopy_desc_t::compute_mode).
+    int fpmath_modes = 0;
+    bool deterministic = false;
+    dim_t c_batch_sizes[max_batch_dims] = {};
+    dim_t batch() const {
+        dim_t b = 1;
+        for (int i = 0; i < problem.batchDims; i++)
+            b *= c_batch_sizes[i];
+        return b;
+    }
+    // Swap-folded orientation defaults (N/T, exchanged under swap_ab).
+    gemmstone::MatrixLayout ab_layout_N() const {
+        return swap_ab ? gemmstone::MatrixLayout::T
+                       : gemmstone::MatrixLayout::N;
+    }
+    gemmstone::MatrixLayout ab_layout_T() const {
+        return swap_ab ? gemmstone::MatrixLayout::N
+                       : gemmstone::MatrixLayout::T;
+    }
+
+    // Byte alignment of a leading dim combined with its batch strides.
+    int align_bytes(dim_t ld, data_type_t dt, const dim_t *bstr) const {
+        auto a = utils::max_pow2_div(types::elements_to_bytes(dt, ld));
+        for (int b = 0; b < problem.batchDims; b++) {
+            auto sb = utils::max_pow2_div(
+                    types::elements_to_bytes(dt, bstr[b]));
+            a = (sb ? nstl::min(a, sb) : a);
+        }
+        return int(a);
+    }
+
+    // Set by finalize_problem; guards finalized-problem reads.
+    bool finalized_ = false;
+
+    dim_t ld_binary(int idx) const;
+    dim_t stride_binary(int idx, int stride = 0) const;
+
+    // Strides of the swap_ab-folded quant mds, named by kernel side.
+    dim_t a_scale_stride(int idx) const;
+    dim_t b_scale_stride(int idx) const;
+    dim_t a_zp_stride(int idx) const;
+    dim_t b_zp_stride(int idx) const;
+    dim_t a_gs_stride(int idx) const;
+    dim_t b_gs_stride(int idx) const;
+};
 
 struct pd_t : public gemm::pd_t {
     using gemm::pd_t::pd_t;
 
-    // Assumes desc() was already initialized with default formats
-    status_t init(impl::engine_t *engine, compute::gpu_arch_t arch) {
+    using binary_src_t = jit::binary_src_t;
 
-        arch_ = arch;
-        with_sround_ = attr()->rounding_mode_.get(DNNL_ARG_DST)
-                == rounding_mode::stochastic;
-
-        lda_ = desc()->lda();
-        ldb_ = desc()->ldb();
-        transa_ = desc()->transa() == dnnl_trans;
-        transb_ = desc()->transb() == dnnl_trans;
-
-        CHECK(init_attrs(engine));
-        CHECK(scales_ok(engine));
-        CHECK(zp_ok(engine));
-        CHECK(gs_ok(engine));
-        CHECK(init_post_ops(engine));
-        return status::success;
-    }
-
-    struct binary_src_t {
-        enum type_t { none, scales, bias, binary, prelu } type;
-        int index;
-
-        binary_src_t(type_t type_, int index_) : type(type_), index(index_) {}
-    };
+    // Builds the kernel cfg; assumes default formats are already set.
+    status_t init(impl::engine_t *engine, compute::gpu_arch_t arch);
 
     static constexpr post_op::specializations_t get_post_op_specializations() {
         using mode_t = post_op::specializations_t::inline_mode_t;
@@ -96,199 +248,49 @@ struct pd_t : public gemm::pd_t {
                 binary_div, binary_min, binary_max);
     }
 
-    status_t init_post_ops(impl::engine_t *engine);
-    status_t init_attrs(impl::engine_t *engine);
-    status_t scales_ok(impl::engine_t *engine);
-    status_t zp_ok(impl::engine_t *engine);
-    status_t gs_ok(impl::engine_t *engine);
-
-    dim_t ld_binary(int idx) const;
-    dim_t stride_binary(int idx, int stride = 0) const;
-
-    const post_ops_t *post_ops() const { return &post_ops_; }
-    const std::vector<binary_src_t> &binary_srcs() const {
-        return binary_srcs_;
+    virtual bool decide_swap_ab(const kernel_config_t &cfg) const {
+        return false;
     }
-    bool valid_2d_mask(int mask, int ndims, bool per_tensor_ok = true);
 
-    status_t init_GEMMProblem(gemmstone::GEMMProblem &problem,
-            const intel::engine_t *engine) const;
+    kernel_config_t cfg_;
+    const kernel_config_t &cfg() const { return cfg_; }
 
-    float beta_ = 0.0f;
-
-    bool with_sum_ = false;
-    bool sum_at_begin_ = false;
-
-    bool bias_via_binary_ = false;
-    bool wei_decomp_ = false;
-    bool dy_quant_enabled_ = false;
-    bool quant_enabled_ = false;
-
-    quant_params a_quant, b_quant, c_quant;
-
-    bool non_scale_po_ = false;
-
-    post_ops_t post_ops_;
-    std::vector<binary_src_t> binary_srcs_;
-
-    int cmask_a_ = INT_MIN;
-    int cmask_b_ = INT_MIN;
-    int cmask_c_ = INT_MIN;
-
-    const int mask_scalar = 1 << 0;
-    const int mask_per_oc = 1 << 1;
-    const int mask_per_ic = 1 << 2;
-
-    const int idx_a = DNNL_ARG_WEIGHTS;
-    memory_desc_t prelu_wei_md, a_scale_md_, b_scale_md_, c_scale_md_;
-    memory_desc_t a_zp_md_, b_zp_md_, c_zp_md_;
-    memory_desc_t a_gs_md_, b_gs_md_;
-    bool swap_ab_ = false;
-    dim_t lda_ = 0, ldb_ = 0;
-    bool transa_ = false, transb_ = false;
-    bool with_sround_ = false;
-    bool with_mx_scale_ = false;
     compute::gpu_arch_t arch_ = compute::gpu_arch_t::unknown;
-
-    float alpha() const {
-        auto attr_info = attr_info_t::create(attr());
-        bool host_scales_by_alpha = attr_info.with_host_src_scale
-                || attr_info.with_host_wei_scale
-                || (attr_info.with_host_dst_scale
-                        && attr()->post_ops_.len() == 0);
-        // Bogus non-one value for host scalar.
-        // Actual value will be passed on execution step
-        if (host_scales_by_alpha) return 9.99f;
-        return 1.0f;
-    }
-
-    float beta() const { return beta_; }
-
-    bool with_bias() const {
-        return desc()->bias_type() != data_type::undef && !bias_via_binary_;
-    }
-
-    int bias_cmask() const {
-        unsigned char to_cmask[8] = {0, 4, 2, 6, 1, 5, 3, 7};
-        assert(unsigned(desc()->bias_mask()) < 8);
-        return with_bias() ? to_cmask[desc()->bias_mask() & 7] : -1;
-    }
 
     sum_ab_t sum_ab() const { return desc()->sum_ab; }
 
-    bool a_zp_2d() const { return a_quant.zp_ndims >= 2; }
-    bool b_zp_2d() const { return b_quant.zp_ndims >= 2; }
+    bool wei_decomp() const;
+    bool dy_quant_enabled() const;
 
-    bool a_gs_2d() const { return a_quant.gs_ndims >= 2; }
-    bool b_gs_2d() const { return b_quant.gs_ndims >= 2; }
-
-    bool with_sum_ab() const { return sum_ab() != sum_ab::sum_none; }
-
-    int sum_ab_cmask() const {
-        switch (sum_ab()) {
-            default:
-            case sum_ab::sum_none: return 0;
-            case sum_ab::sum_a_row: return 1;
-            case sum_ab::sum_b_col: return 2;
-        }
+    // Host-scalar scale presence; values are resolved from memory args at exec.
+    bool a_host_scale() const {
+        return attr()->scales_.get(DNNL_ARG_A).is_host_scalar();
     }
-    bool with_a_scales() const { return (a_quant.scale_ndims >= 0); }
-    bool with_b_scales() const { return (b_quant.scale_ndims >= 0); }
-    bool with_c_scales() const {
-        return !attr()->scales_.has_default_values(DNNL_ARG_DST);
+    bool b_host_scale() const {
+        return attr()->scales_.get(DNNL_ARG_B).is_host_scalar();
     }
-
-    bool with_a_zero_points() const { return (a_quant.zp_ndims >= 0); }
-    bool with_b_zero_points() const { return (b_quant.zp_ndims >= 0); }
-    bool with_c_zero_points() const {
-        return !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
+    // C host-scalar scale folds to alpha only without other post-ops.
+    bool c_host_scale_to_alpha() const {
+        return attr()->scales_.get(DNNL_ARG_C).is_host_scalar()
+                && attr()->post_ops_.len() == 0;
     }
-
-    bool with_a_group_sums() const { return (a_quant.gs_ndims >= 0); }
-    bool with_b_group_sums() const { return (b_quant.gs_ndims >= 0); }
-
-    bool with_sround() const { return with_sround_; }
-    bool with_mx_scale() const { return with_mx_scale_; }
-
-    bool a_scales_2d() const { return a_quant.scale_ndims > 1; }
-    bool b_scales_2d() const { return b_quant.scale_ndims > 1; }
-    bool c_scales_2d() const { return c_quant.scale_ndims > 1; }
-
-    bool dy_quant_enabled();
-    bool wei_decomp();
-    bool quant_enabled();
-
-    bool swap_ab() const { return swap_ab_; }
 
     int batch_dims() const { return nstl::max(desc()->c_desc.ndims - 2, 0); }
-    bool trans_a() const { return transa_; }
-    bool trans_b() const { return transb_; }
-    bool trans_bias() const { return desc()->trans_bias() == dnnl_trans; }
-
-    dim_t ld(int arg) const {
-        if (arg == DNNL_ARG_A) return lda_;
-        if (arg == DNNL_ARG_B) return ldb_;
-        if (arg == DNNL_ARG_C) return desc()->ldc();
-        gpu_error_not_expected();
-        return 0;
-    }
-    dim_t stride(int arg, int dim) const {
-        if (arg == DNNL_ARG_A) return desc()->stride_a(dim);
-        if (arg == DNNL_ARG_B) return desc()->stride_b(dim);
-        if (arg == DNNL_ARG_C) return desc()->stride_c(dim);
-        gpu_error_not_expected();
-        return 0;
-    }
-    data_type_t get_type(int arg) const {
-        if (arg == DNNL_ARG_A) return desc()->a_type();
-        if (arg == DNNL_ARG_B) return desc()->b_type();
-        if (arg == DNNL_ARG_C) return desc()->c_type();
-        gpu_error_not_expected();
-        return data_type::undef;
-    }
-
-    dim_t scale_stride(int idx, int arg) const;
-    dim_t zp_stride(int idx, int arg) const;
-    dim_t gs_stride(int idx, int arg) const;
-    bool a_grouped() const {
-        bool k_grouped = 1 < a_quant.group_k && a_quant.group_k < desc()->k();
-        bool m_grouped = 1 < a_quant.group_m && a_quant.group_m < desc()->m();
-        return k_grouped || m_grouped;
-    }
-    bool b_grouped() const {
-        bool k_grouped = 1 < b_quant.group_k && b_quant.group_k < desc()->k();
-        bool n_grouped = 1 < b_quant.group_n && b_quant.group_n < desc()->n();
-        return k_grouped || n_grouped;
-    }
-    bool a_zp_host_scalar() const {
-        auto attr_info = attr_info_t::create(attr());
-        return attr_info.with_host_wei_zp;
-    }
-    bool b_zp_host_scalar() const {
-        auto attr_info = attr_info_t::create(attr());
-        return attr_info.with_host_src_zp;
-    }
-    bool c_zp_host_scalar() const {
-        auto attr_info = attr_info_t::create(attr());
-        return attr_info.with_host_dst_zp;
-    }
-    int a_q2d_group_k() const { return a_quant.group_k; }
-    int a_q2d_group_m() const { return a_quant.group_m; }
-    int b_q2d_group_k() const { return b_quant.group_k; }
-    int b_q2d_group_n() const { return b_quant.group_n; }
-    int c_q2d_group_m() const { return c_quant.group_m; }
-    int c_q2d_group_n() const { return c_quant.group_n; }
-    int align(int arg) const {
-        auto dt = get_type(arg);
-        auto align = utils::max_pow2_div(types::elements_to_bytes(dt, ld(arg)));
-        for (int b = 0; b < batch_dims(); b++) {
-            auto stride_bytes = utils::max_pow2_div(
-                    types::elements_to_bytes(dt, stride(arg, b)));
-            align = (stride_bytes ? nstl::min(align, stride_bytes) : align);
-        }
-        return int(align);
-    }
 };
+
+status_t init_kernel_config(
+        kernel_config_t &cfg, const pd_t *pd, impl::engine_t *engine);
+status_t scales_ok(const pd_t *pd, impl::engine_t *engine);
+status_t zp_ok(const pd_t *pd, impl::engine_t *engine);
+status_t gs_ok(const pd_t *pd, impl::engine_t *engine);
+
+status_t finalize_problem(kernel_config_t &cfg, const intel::engine_t *engine);
+
+void pad_leading_dims(kernel_config_t &cfg, bool swap);
+void apply_swap_ab(kernel_config_t &cfg, bool swap);
+
+status_t transfer_post_ops(
+        gemmstone::GEMMProblem &problem, gpu_post_ops_t &&post_ops);
 
 } // namespace jit
 } // namespace gemm

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -20,9 +20,11 @@
 #include "common/type_helpers.hpp"
 #include "common/verbose_msg.hpp"
 #include "gpu/intel/compute/utils.hpp"
+#include "gpu/intel/gemm/jit/pd.hpp"
 #include "gpu/intel/gemm/jit/walk_orders.hpp"
 #include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/gemm/xe_systolic_copy_kernel.hpp"
+#include "gpu/intel/utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -50,22 +52,11 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
     dev_info_ = intel_engine->device_info();
     auto arch = dev_info_->gpu_arch();
 
-    CHECK(init_attrs(engine));
     const auto &d = desc();
 
     bool dt_float_ok = (d->a_type() == d->b_type()
             && utils::one_of(d->a_type(), bf16, f16)
             && utils::one_of(d->c_type(), f32, d->a_type()));
-
-    bool dt_int_ok = (utils::one_of(d->a_type(), u8, s8)
-            && utils::one_of(d->b_type(), u8, s8)
-            && utils::one_of(d->c_type(), s32, f32, s8, u8, f16));
-
-    if (dt_int_ok) {
-        a_zp_ = !attr()->zero_points_.has_default_values(DNNL_ARG_A);
-        b_zp_ = !attr()->zero_points_.has_default_values(DNNL_ARG_B);
-        c_zp_ = !attr()->zero_points_.has_default_values(DNNL_ARG_C);
-    }
 
     // LIMITATIONS:
     // - batch is not supported for unpacked inputs.
@@ -98,13 +89,13 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
 
     auto attr_skip_mask = smask_t::scales | smask_t::post_ops;
 
-    if (dt_int_ok) attr_skip_mask |= smask_t::zero_points;
+    if (dt_int_ok()) attr_skip_mask |= smask_t::zero_points;
 
     bool arch_ok = utils::one_of(arch, arch_t::xe_hp, arch_t::xe_hpg,
             arch_t::xe_hpc, arch_t::xe2, arch_t::xe3);
 
     VDISPATCH_GEMM(limits_ok, VERBOSE_RUNTIMEDIM_UNSUPPORTED);
-    VDISPATCH_GEMM((dt_float_ok || dt_int_ok), VERBOSE_UNSUPPORTED_DT_CFG);
+    VDISPATCH_GEMM((dt_float_ok || dt_int_ok()), VERBOSE_UNSUPPORTED_DT_CFG);
     VDISPATCH_GEMM(arch_ok, VERBOSE_UNSUPPORTED_ARCH, "gpu");
     VDISPATCH_GEMM(
             intel_engine->mayiuse(compute::device_ext_t::
@@ -114,7 +105,7 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
             VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_GEMM(desc()->sum_ab == sum_ab::sum_none,
             VERBOSE_UNSUPPORTED_FEATURE, "bias reduction");
-    VDISPATCH_GEMM(IMPLICATION(with_bias(),
+    VDISPATCH_GEMM(IMPLICATION(d->bias_type() != data_type::undef,
                            utils::one_of(d->bias_type(), d->a_type(), f32)
                                    && d->bias_mask() < 8),
             VERBOSE_UNSUPPORTED_BIAS_CFG);
@@ -128,19 +119,26 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
                     <= (size_t)std::numeric_limits<int32_t>::max(),
             VERBOSE_SHAPE_RESTRICTION);
 
-    CHECK(scales_ok(engine));
+    // Seed packed ld* strides; must precede jit::pd_t::init().
+    a_packed_stride_
+            = d->b_desc.format_desc.blocking.strides[batch_dims() ? 2 : 1];
+    b_packed_stride_
+            = d->a_desc.format_desc.blocking.strides[batch_dims() ? 1 : 0];
+    c_packed_stride_
+            = d->c_desc.format_desc.blocking.strides[batch_dims() ? 1 : 0];
+    acc_type_ = d->acc_type;
 
-    if (!attr()->zero_points_.has_default_values()) {
-        VDISPATCH_GEMM(!attr()->zero_points_.has_host_scalars(),
-                VERBOSE_UNSUPPORTED_ZP_CFG);
-        CHECK(zp_ok(engine));
-    }
+    CHECK(jit::pd_t::init(engine, arch));
 
-    CHECK(init_post_ops(engine));
+    VDISPATCH_GEMM(!attr()->zero_points_.has_host_scalars(),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
 
-    if (dt_int_ok) {
-        VDISPATCH_GEMM(IMPLICATION(a_zp_, !packed_b())
-                        && IMPLICATION(b_zp_, !packed_a()),
+    VDISPATCH_GEMM(!attr()->scales_.has_host_scalars(),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+    if (dt_int_ok()) {
+        VDISPATCH_GEMM(IMPLICATION(cfg().with_a_zero_points(), !packed_b())
+                        && IMPLICATION(cfg().with_b_zero_points(), !packed_a()),
                 VERBOSE_UNSUPPORTED_ZP_CFG);
 
         const auto &zp = attr()->zero_points_;
@@ -158,6 +156,23 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
                                    (1 << 1)),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         }
+    }
+
+    VDISPATCH_GEMM(
+            !decide_swap_ab(cfg_), VERBOSE_UNSUPPORTED_FEATURE, "swap_ab");
+
+    CHECK(finalize_problem(cfg_, intel_engine));
+
+    // Select here to gate dispatch and snapshot driver_info (shared by all
+    // k-block variants).
+    {
+        jit::gen_xe_systolic_desc_t kd;
+        VDISPATCH_GEMM_SC(
+                kd.select_kernel(*dev_info_, cfg_.problem, with_batch(),
+                        packed_c(), 1.0f, cfg_.beta, cfg_.m, cfg_.n, cfg_.k,
+                        cfg_.batch(), unroll_m(), unroll_n(), alt()),
+                VERBOSE_UNSUPPORTED_FEATURE, "systolic kernel selection");
+        driver_info_ = *kd.driver_info();
     }
 
     init_scratchpad();
@@ -305,7 +320,7 @@ bool xe_hp_systolic_t::pd_t::use_nocopy_xehpg(
 
 status_t xe_hp_systolic_t::pd_t::set_default_formats(data_type_t dt) {
     using namespace format_tag;
-    using new_kd_t = jit::gen_xe_systolic_kernel_desc_t;
+    using new_kd_t = jit::gen_xe_systolic_desc_t;
 
     auto sz = types::data_type_size(dt);
     const auto &d = desc();
@@ -388,7 +403,7 @@ status_t xe_hp_systolic_t::pd_t::set_default_formats(data_type_t dt) {
     packed_a_ = packed_b_ = packed_c_ = false;
 
     if (a_any) {
-        if (b_zp_) {
+        if (!attr()->zero_points_.has_default_values(DNNL_ARG_B)) {
             CHECK(memory_desc_init_by_tag(a_desc, unpacked_tag));
         } else {
             CHECK(memory_desc_init_by_tag(a_desc, a_packed_tag));
@@ -407,7 +422,7 @@ status_t xe_hp_systolic_t::pd_t::set_default_formats(data_type_t dt) {
         return status::unimplemented;
 
     if (b_any) {
-        if (a_zp_) {
+        if (!attr()->zero_points_.has_default_values(DNNL_ARG_A)) {
             CHECK(memory_desc_init_by_tag(b_desc, unpacked_tag));
         } else {
             CHECK(memory_desc_init_by_tag(b_desc, b_packed_tag));
@@ -460,12 +475,12 @@ status_t xe_hp_systolic_t::pd_t::set_default_formats(data_type_t dt) {
 void xe_hp_systolic_t::pd_t::init_scratchpad() {
     if (packed_a() && packed_b()) return;
 
-    auto a_type = desc()->a_type();
-    auto b_type = desc()->b_type();
+    auto a_type = cfg().a_type();
+    auto b_type = cfg().b_type();
 
-    auto m = desc()->m();
-    auto n = desc()->n();
-    auto k = desc()->k();
+    auto m = cfg().m;
+    auto n = cfg().n;
+    auto k = cfg().k;
 
     int64_t align_m = unroll_m_ * 8; // TODO: this should not be hardcoded
     int64_t align_n = unroll_n_ * 8; // instead read from DriverInfo
@@ -494,24 +509,8 @@ status_t xe_hp_systolic_t::init(impl::engine_t *engine) {
     arch_ = pd()->dev_info_->gpu_arch();
     eu_count_ = pd()->dev_info_->eu_count();
 
-    auto a_type = pd()->desc()->a_type();
-    auto b_type = pd()->desc()->b_type();
-
-    int cmask = -1;
-
-    if (pd()->with_c_zero_points())
-        cmask = pd()->attr()->zero_points_.get_mask(DNNL_ARG_DST);
-    else if (pd()->with_bias())
-        cmask = pd()->bias_cmask();
-
-    switch (cmask) {
-        case 0: co_kind_ = 'F'; break;
-        case (1 << 1): co_kind_ = 'R'; break;
-        case (1 << 0): co_kind_ = 'C'; break;
-        case 3: co_kind_ = 'M'; break;
-        case -1:
-        default: co_kind_ = 'N'; break;
-    }
+    auto a_type = pd()->cfg().a_type();
+    auto b_type = pd()->cfg().b_type();
 
     // Initialize compute kernels (assembly)
     {
@@ -525,8 +524,8 @@ status_t xe_hp_systolic_t::init(impl::engine_t *engine) {
             if (clear_sum && !pd()->with_ab_zero_points()) continue;
             if (!copy_b ? pd()->packed_a() : pd()->packed_b()) continue;
 
-            auto trans
-                    = !copy_b ? pd()->desc()->transa() : pd()->desc()->transb();
+            bool trans
+                    = !copy_b ? pd()->cfg().trans_a() : pd()->cfg().trans_b();
             xe_systolic_copy_kernel_t params;
             CHECK(params.init(arch_, !copy_b ? a_type : b_type,
                     pd()->unroll_n(), copy_b, trans,
@@ -543,99 +542,63 @@ status_t xe_hp_systolic_t::init(impl::engine_t *engine) {
 
     if (get_verbose(verbose_t::debuginfo) >= 2) {
         verbose_printf("info,gpu,gemm,kernel:%dx%d,%dx%dx%d\n",
-                pd()->unroll_m(), pd()->unroll_n(), compute_info_.wg[LoopM],
-                compute_info_.wg[LoopN], compute_info_.wg[LoopK]);
+                pd()->unroll_m(), pd()->unroll_n(),
+                pd()->driver_info().wg[LoopM], pd()->driver_info().wg[LoopN],
+                pd()->driver_info().wg[LoopK]);
     }
 
     return status::success;
 }
 
 status_t xe_hp_systolic_t::init_compute(impl::engine_t *engine) {
-    using kd_t = jit::gen_xe_systolic_kernel_desc_t;
+    using kd_t = jit::gen_xe_systolic_desc_t;
+    using namespace gemmstone;
 
     auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto &dev_info = *intel_engine->device_info();
 
-    const auto d = pd()->desc();
+    const auto &cfg = pd()->cfg();
+    auto a_type = cfg.a_type();
 
-    auto a_type = d->a_type();
-    auto b_type = d->b_type();
-    auto c_type = d->c_type();
-    auto co_type = pd()->impl_co_type();
-    auto acc_type = pd()->impl_acc_type();
-    bool trans_co = pd()->with_bias() && (d->trans_bias() == dnnl_trans);
+    gpu_assert(cfg.finalized_) << "init_compute reads an unfinalized problem";
+    const GEMMProblem &base = cfg.problem;
 
     bool may_k_block
-            = (d->k() > kd_t::min_block_k(a_type)) && pd()->allow_k_blocking();
-    bool got_info = false;
+            = (cfg.k > kd_t::min_block_k(a_type)) && pd()->allow_k_blocking();
 
-    auto post_ops_ = pd()->post_ops();
-    bool with_post_ops = (post_ops_->find(primitive_kind::eltwise) != -1)
-            || (post_ops_->find(primitive_kind::binary) != -1)
-            || (post_ops_->find(primitive_kind::prelu) != -1);
-    gpu_post_ops_t gpu_post_ops;
-    CHECK(gpu_post_ops_t::make(gpu_post_ops, *post_ops_, pd()->dst_md(),
-            pd()->get_post_op_specializations()));
+    bool with_post_ops = base.hasNonSum1PostOp();
 
-    kd_t kd_full;
-
-    auto status = kd_full.select_kernel(*intel_engine->device_info(),
-            pd()->with_batch(), pd()->packed_c(), trans_co,
-            pd()->with_a_zero_points(), pd()->with_b_zero_points(),
-            pd()->with_c_zero_points(), pd()->with_bias(), pd()->alpha(),
-            pd()->beta(), a_type, b_type, c_type, dnnl_s32, dnnl_s32, co_type,
-            acc_type, d->m(), d->n(), d->k(), d->batch(), pd()->unroll_m(),
-            pd()->unroll_n(), pd()->alt(), std::move(gpu_post_ops));
-
-    if (status != status::success) return status;
-
-    problem_ = *kd_full.problem();
+    auto select = [&](kd_t &kd, const GEMMProblem &p, float beta) {
+        return kd.select_kernel(dev_info, p, pd()->with_batch(),
+                pd()->packed_c(), 1.0f, beta, cfg.m, cfg.n, cfg.k, cfg.batch(),
+                pd()->unroll_m(), pd()->unroll_n(), pd()->alt());
+    };
 
     for (bool first_k_block : {false, true}) {
         for (bool last_k_block : {false, true}) {
             if ((!first_k_block || !last_k_block) && !may_k_block) continue;
-            if (may_k_block && last_k_block && !pd()->with_c_zero_points()
+            if (may_k_block && last_k_block && !pd()->cfg().with_c_zero_points()
                     && !with_post_ops)
                 kernel_[first_k_block][last_k_block]
                         = kernel_[first_k_block][false];
-            else if (may_k_block && first_k_block && pd()->beta() == 1.0f)
+            else if (may_k_block && first_k_block && pd()->cfg().beta == 1.0f)
                 kernel_[first_k_block][last_k_block]
                         = kernel_[false][last_k_block];
             else {
-                auto this_beta = pd()->beta();
-                bool this_c_offset = pd()->with_c_zero_points();
-                auto *this_post_ops = pd()->post_ops();
-                post_ops_t no_post_ops;
+                float this_beta = first_k_block ? pd()->cfg().beta : 1.0f;
 
-                if (!first_k_block) this_beta = 1.0f;
+                // Non-final k-blocks drop C zero-point and post-ops (keep bias).
+                GEMMProblem p = base;
                 if (!last_k_block) {
-                    this_c_offset = false;
-                    this_post_ops = &no_post_ops;
+                    if (p.cOffset == COffset::Post) p.cOffset = COffset::None;
+                    p.postOps = {};
+                    p.binary.clear();
+                    p.Tbinary.clear();
                 }
-                CHECK(gpu_post_ops_t::make(gpu_post_ops, *this_post_ops,
-                        pd()->dst_md(), pd()->get_post_op_specializations()));
 
                 kd_t kd;
-
-                auto status = kd.select_kernel(*intel_engine->device_info(),
-                        pd()->with_batch(), pd()->packed_c(), trans_co,
-                        pd()->with_a_zero_points(), pd()->with_b_zero_points(),
-                        this_c_offset, pd()->with_bias(), pd()->alpha(),
-                        this_beta, a_type, b_type, c_type, dnnl_s32, dnnl_s32,
-                        co_type, acc_type, d->m(), d->n(), d->k(), d->batch(),
-                        pd()->unroll_m(), pd()->unroll_n(), pd()->alt(),
-                        std::move(gpu_post_ops));
-
+                auto status = select(kd, p, this_beta);
                 if (status != status::success) return status;
-
-                // Protection against C zero-point host scalar implementation in gen gemm
-                auto *kd_problem
-                        = const_cast<gemmstone::GEMMProblem *>(kd.problem());
-                kd_problem->coPtrDims = pd()->c_quant.zp_ndims;
-
-                if (!got_info) {
-                    compute_info_ = *kd.driver_info();
-                    got_info = true;
-                }
 
                 CHECK(create_kernel(engine,
                         kernel_[first_k_block][last_k_block], "gemm_kernel",
@@ -651,25 +614,25 @@ status_t xe_hp_systolic_t::init_compute(impl::engine_t *engine) {
 }
 
 bool xe_hp_systolic_t::enable_mn_blocking() const {
-    return (pd()->desc()->m() >= 8192) && (pd()->desc()->n() >= 8192);
+    return (pd()->cfg().m >= 8192) && (pd()->cfg().n >= 8192);
 }
 
 std::tuple<int64_t, int64_t, int64_t> xe_hp_systolic_t::get_blocking() const {
-    int64_t m = pd()->desc()->m();
-    int64_t n = pd()->desc()->n();
-    int64_t k = pd()->desc()->k();
+    int64_t m = pd()->cfg().m;
+    int64_t n = pd()->cfg().n;
+    int64_t k = pd()->cfg().k;
 
-    int64_t unroll_k = compute_info_.unroll[LoopK];
+    int64_t unroll_k = pd()->driver_info().unroll[LoopK];
 
-    int64_t align_m = compute_info_.wgTile(LoopM);
-    int64_t align_n = compute_info_.wgTile(LoopN);
+    int64_t align_m = pd()->driver_info().wgTile(LoopM);
+    int64_t align_n = pd()->driver_info().wgTile(LoopN);
 
     m = utils::rnd_up(m, align_m);
     n = utils::rnd_up(n, align_n);
 
     // Decide on m/n blocking.
-    int64_t block_m = compute_info_.blocking[LoopM];
-    int64_t block_n = compute_info_.blocking[LoopN];
+    int64_t block_m = pd()->driver_info().blocking[LoopM];
+    int64_t block_n = pd()->driver_info().blocking[LoopN];
     int64_t max_block_m = utils::rnd_up(m, align_m);
     int64_t max_block_n = utils::rnd_up(n, align_n);
 
@@ -694,7 +657,7 @@ std::tuple<int64_t, int64_t, int64_t> xe_hp_systolic_t::get_blocking() const {
     }
 
     // Decide on k blocking.
-    int64_t block_k = compute_info_.blocking[LoopK];
+    int64_t block_k = pd()->driver_info().blocking[LoopK];
     int64_t nblock_k = utils::div_up(k, block_k);
     nblock_k = nstl::max<int64_t>(nblock_k, 1);
     block_k = utils::div_up(k, nblock_k);
@@ -718,21 +681,19 @@ status_t xe_hp_systolic_t::launch_copy(const exec_ctx_t &ctx, int64_t r,
         if (status) return status;
     }
 
-    int64_t unroll_k = compute_info_.unroll[LoopK];
+    int64_t unroll_k = pd()->driver_info().unroll[LoopK];
 
     int64_t align_r = 0, align_c = 0;
 
     if (!copyb) {
-        align_r = compute_info_.wgTile(LoopM);
+        align_r = pd()->driver_info().wgTile(LoopM);
         align_c = unroll_k;
     } else {
         align_r = unroll_k;
-        align_c = compute_info_.wgTile(LoopN);
+        align_c = pd()->driver_info().wgTile(LoopN);
     }
 
-    bool transa = (pd()->desc()->transa() == dnnl_trans);
-    bool transb = (pd()->desc()->transb() == dnnl_trans);
-    bool trans = !copyb ? transa : transb;
+    bool trans = !copyb ? pd()->cfg().trans_a() : pd()->cfg().trans_b();
 
     auto &kernel = copy_kernel_[copyb][false];
 
@@ -747,7 +708,7 @@ status_t xe_hp_systolic_t::launch_copy(const exec_ctx_t &ctx, int64_t r,
     arg_list.set(6, offset_dst);
     arg_list.set(7, ld_dst);
 
-    auto elt_size = types::data_type_size(pd()->desc()->a_type());
+    auto elt_size = types::data_type_size(pd()->cfg().a_type());
     size_t r_threads = utils::div_up(utils::rnd_up(r, align_r),
             copy_kernel_t::unroll_r(arch_, elt_size, copyb));
     size_t c_threads = utils::div_up(utils::rnd_up(c, align_c),
@@ -812,8 +773,8 @@ status_t xe_hp_systolic_t::launch_compute(const exec_ctx_t &ctx, int32_t m,
         int32_t stride_b, int32_t stride_c) const {
     if (batch == 0) return status::success;
 
-    auto tg_m = compute_info_.wg[LoopM];
-    auto tg_n = compute_info_.wg[LoopN];
+    auto tg_m = pd()->driver_info().wg[LoopM];
+    auto tg_n = pd()->driver_info().wg[LoopN];
 
     auto &kernel = kernel_[first_k_block][last_k_block];
 
@@ -843,21 +804,22 @@ status_t xe_hp_systolic_t::launch_compute(const exec_ctx_t &ctx, int32_t m,
     arg_list.set(argn++, alpha);
     arg_list.set(argn++, beta);
 
-    if (pd()->with_a_zero_points()) arg_list.set(argn++, *ao);
-    if (pd()->with_b_zero_points()) arg_list.set(argn++, *bo);
-    if ((pd()->with_bias() || pd()->with_c_zero_points())) {
+    if (pd()->cfg().with_a_zero_points()) arg_list.set(argn++, *ao);
+    if (pd()->cfg().with_b_zero_points()) arg_list.set(argn++, *bo);
+    if ((pd()->cfg().with_bias() || pd()->cfg().with_c_zero_points())) {
         arg_list.set(argn++, co);
         arg_list.set(argn++, offset_co);
-        if (pd()->with_bias()) {
-            auto ldco = into<int32_t>(pd()->desc()->ld_bias());
+        if (pd()->cfg().with_bias()) {
+            auto ldco = into<int32_t>(pd()->cfg().ld_bias);
             arg_list.set(argn++, ldco);
         }
     }
 
+    auto co_kind = pd()->co_kind();
     uint32_t flags = 0;
-    if (co_kind_ == 'R') flags |= FlagCORow;
-    if (co_kind_ == 'C') flags |= FlagCOColumn;
-    if (co_kind_ == 'M') flags |= FlagCORow | FlagCOColumn;
+    if (co_kind == 'R') flags |= FlagCORow;
+    if (co_kind == 'C') flags |= FlagCOColumn;
+    if (co_kind == 'M') flags |= FlagCORow | FlagCOColumn;
     if (!first_k_block) flags |= FlagNoninitialKBlock;
     if (!last_k_block) flags |= FlagNonfinalKBlock;
     arg_list.set(argn++, flags);
@@ -867,29 +829,31 @@ status_t xe_hp_systolic_t::launch_compute(const exec_ctx_t &ctx, int32_t m,
         arg_list.set(argn++, *po_srcs[i]);
         arg_list.set(argn++, offset_po_src[i]);
 
-        if (problem_.postOps.binaryRow[i] && problem_.postOps.binaryCol[i])
-            arg_list.set(argn++, int32_t(pd()->ld_binary(i)));
+        const auto &problem = pd()->cfg().problem;
+        if (problem.postOps.binaryRow[i] && problem.postOps.binaryCol[i])
+            arg_list.set(argn++, int32_t(pd()->cfg().ld_binary(i)));
     }
 
     if (pd()->with_batch()) {
-        for (int i = pd()->batch_dims() - 1; i >= 0; i--) {
-            auto stride_a = int32_t(pd()->desc()->stride_a(i));
-            auto stride_b = int32_t(pd()->desc()->stride_b(i));
-            auto stride_c = int32_t(pd()->desc()->stride_c(i));
+        const auto &cfg = pd()->cfg();
+        for (int i = cfg.problem.batchDims - 1; i >= 0; i--) {
+            auto stride_a = int32_t(cfg.a_batch_strides[i]);
+            auto stride_b = int32_t(cfg.b_batch_strides[i]);
+            auto stride_c = int32_t(cfg.c_batch_strides[i]);
             arg_list.set(argn++, stride_a);
             arg_list.set(argn++, stride_b);
             arg_list.set(argn++, stride_c);
         }
         for (int i = 0; i < po_count; i++) {
-            if (problem_.postOps.binaryBatch[i]) {
-                for (int b = 0; b < pd()->batch_dims(); b++) {
-                    auto top = pd()->batch_dims() - b - 1;
-                    arg_list.set(argn++, int32_t(pd()->stride_binary(i, top)));
+            if (cfg.problem.postOps.binaryBatch[i]) {
+                for (int b = 0; b < cfg.problem.batchDims; b++) {
+                    auto top = cfg.problem.batchDims - b - 1;
+                    arg_list.set(argn++, int32_t(cfg.stride_binary(i, top)));
                 }
             }
         }
-        for (int i = 1; i < pd()->batch_dims(); i++) {
-            auto batchSize = uint32_t(pd()->desc()->c_desc.dims[i]);
+        for (int i = 1; i < cfg.problem.batchDims; i++) {
+            auto batchSize = uint32_t(cfg.c_batch_sizes[i]);
             uint32_t recipBatchSize = jit::uint32_reciprocal(batchSize);
             arg_list.set(argn++, batchSize);
             arg_list.set(argn++, recipBatchSize);
@@ -899,25 +863,23 @@ status_t xe_hp_systolic_t::launch_compute(const exec_ctx_t &ctx, int32_t m,
     auto thread_m = utils::div_up(m, pd()->unroll_m() * tg_m) * tg_m;
     auto thread_n = utils::div_up(n, pd()->unroll_n() * tg_n) * tg_n;
 
-    if (walk_n_first_) std::swap(thread_m, thread_n);
-
     compute::range_t gws(size_t(thread_m), size_t(thread_n), 1);
     compute::range_t lws(size_t(tg_m), size_t(tg_n), 1);
     if (pd()->with_batch()) gws[2] = batch;
 
-    if (compute_info_.isNMK()) {
+    if (pd()->driver_info().isNMK()) {
         std::swap(lws[0], lws[1]);
         std::swap(gws[0], gws[1]);
     }
 
-    lws[1] *= compute_info_.wgExpand;
-    gws[1] *= compute_info_.wgExpand;
+    lws[1] *= pd()->driver_info().wgExpand;
+    gws[1] *= pd()->driver_info().wgExpand;
 
     jit::linear_order_args(arg_list, argn, lws, gws, m, n, k, false,
-            compute_info_, nullptr, pd()->dev_info_);
+            pd()->driver_info(), nullptr, pd()->dev_info_);
 
-    lws[0] *= compute_info_.subgroupSize;
-    gws[0] *= compute_info_.subgroupSize;
+    lws[0] *= pd()->driver_info().subgroupSize;
+    gws[0] *= pd()->driver_info().subgroupSize;
 
     auto nd_range = compute::nd_range_t(gws, lws);
 
@@ -925,32 +887,34 @@ status_t xe_hp_systolic_t::launch_compute(const exec_ctx_t &ctx, int32_t m,
 }
 
 status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
-    auto a_type = pd()->desc()->a_type();
-    auto b_type = pd()->desc()->b_type();
-    auto c_type = pd()->desc()->c_type();
-    auto bias_type = pd()->desc()->bias_type();
+    const auto &cfg = pd()->cfg();
+    gpu_assert(cfg.finalized_) << "execute reads an unfinalized problem";
 
-    auto m = pd()->desc()->m();
-    auto n = pd()->desc()->n();
-    auto k = pd()->desc()->k();
-    auto batch = into<int32_t>(pd()->desc()->batch());
+    auto a_type = cfg.a_type();
+    auto b_type = cfg.b_type();
+    auto c_type = cfg.c_type();
+    auto bias_type = cfg.bias_type;
+
+    auto m = cfg.m;
+    auto n = cfg.n;
+    auto k = cfg.k;
+    auto batch = into<int32_t>(cfg.batch());
 
     bool packed_a = pd()->packed_a();
     bool packed_b = pd()->packed_b();
     bool packed_c = pd()->packed_c();
 
-    auto lda = packed_a ? 0 : pd()->desc()->lda();
-    auto ldb = packed_b ? 0 : pd()->desc()->ldb();
-    auto ldc = into<int32_t>(
-            packed_c ? pd()->ldc_packed() : pd()->desc()->ldc());
-    auto ldco = into<int32_t>(pd()->with_bias() ? pd()->desc()->ld_bias() : 0);
+    auto lda = packed_a ? 0 : cfg.lda;
+    auto ldb = packed_b ? 0 : cfg.ldb;
+    auto ldc = into<int32_t>(packed_c ? pd()->ldc_packed() : cfg.ldc);
+    auto ldco = into<int32_t>(cfg.with_bias() ? cfg.ld_bias : 0);
 
-    auto stride_a = into<int32_t>(pd()->desc()->stride_a());
-    auto stride_b = into<int32_t>(pd()->desc()->stride_b());
-    auto stride_c = into<int32_t>(pd()->desc()->stride_c());
+    auto stride_a = into<int32_t>(cfg.a_batch_strides[0]);
+    auto stride_b = into<int32_t>(cfg.b_batch_strides[0]);
+    auto stride_c = into<int32_t>(cfg.c_batch_strides[0]);
 
-    auto alpha = pd()->alpha();
-    auto beta = pd()->beta();
+    float alpha = 1.0f; // systolic never applies alpha (host scalars rejected)
+    auto beta = cfg.beta;
 
     auto &a = GEMM_CTX_ARG_STORAGE(b);
     auto &b = GEMM_CTX_ARG_STORAGE(a);
@@ -974,13 +938,13 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
 
     const memory_storage_t *po_srcs[GEMM_MAX_PO];
 
-    int po_count = pd()->post_ops()->len();
+    int po_count = int(cfg.binary_srcs.size());
     assert(po_count <= GEMM_MAX_PO);
 
     for (int i = 0; i < po_count; i++) {
-        auto &src = pd()->binary_srcs()[i];
+        auto &src = cfg.binary_srcs[i];
         switch (src.type) {
-            case pd_t::binary_src_t::binary:
+            case jit::binary_src_t::binary:
                 po_srcs[i]
                         = ctx.args()
                                   .exec_args
@@ -989,7 +953,7 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
                                   .mem()
                                   ->memory_storage();
                 break;
-            case pd_t::binary_src_t::prelu:
+            case jit::binary_src_t::prelu:
                 po_srcs[i]
                         = ctx.args()
                                   .exec_args
@@ -998,8 +962,8 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
                                   .mem()
                                   ->memory_storage();
                 break;
-            case pd_t::binary_src_t::bias: po_srcs[i] = &bias; break;
-            case pd_t::binary_src_t::scales:
+            case jit::binary_src_t::bias: po_srcs[i] = &bias; break;
+            case jit::binary_src_t::scales:
                 switch (src.index) {
                     case DNNL_ARG_WEIGHTS:
                         po_srcs[i] = &GEMM_CTX_ARG_STORAGE(a_scales);
@@ -1020,25 +984,22 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
         }
     }
 
-    size_t off_a0
-            = a.offset() / types::data_type_size(a_type) + pd()->dyn_offset_a;
-    size_t off_b0
-            = b.offset() / types::data_type_size(b_type) + pd()->dyn_offset_b;
-    size_t off_c0
-            = c.offset() / types::data_type_size(c_type) + pd()->dyn_offset_c;
+    size_t off_a0 = a.offset() / types::data_type_size(a_type);
+    size_t off_b0 = b.offset() / types::data_type_size(b_type);
+    size_t off_c0 = c.offset() / types::data_type_size(c_type);
     int64_t off_co0 = 0;
 
     int64_t po_offsets0[GEMM_MAX_PO] = {0}, po_offsets[GEMM_MAX_PO] = {0};
     for (int i = 0; i < po_count; i++)
         if (po_srcs[i])
-            po_offsets0[i] = po_srcs[i]->offset() / problem_.Tbinary[i];
+            po_offsets0[i] = po_srcs[i]->offset() / cfg.problem.Tbinary[i];
 
     if (pd()->with_ab_zero_points()) {
         ao = &GEMM_CTX_ARG_STORAGE(a_zero_point);
         bo = &GEMM_CTX_ARG_STORAGE(b_zero_point);
     }
 
-    if (pd()->with_bias()) {
+    if (cfg.with_bias()) {
         off_co0 = bias.offset() / types::data_type_size(bias_type);
         co = &bias;
     }
@@ -1087,11 +1048,11 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
 
                 auto off_c = off_c0 + Bm + Bn * ldc;
                 auto off_co = off_co0;
-                switch (co_kind_) {
+                switch (pd()->co_kind()) {
                     case 'R': off_co += Bm; break;
                     case 'C': off_co += Bn; break;
                     case 'M':
-                        off_co += isColMajor(problem_.CO.layout)
+                        off_co += isColMajor(cfg.problem.CO.layout)
                                 ? (Bn * ldco + Bm)
                                 : (Bm * ldco + Bn);
                         break;
@@ -1100,11 +1061,12 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
 
                 for (int i = 0; i < po_count; i++) {
                     po_offsets[i] = po_offsets0[i];
-                    bool row = problem_.postOps.binaryRow[i],
-                         col = problem_.postOps.binaryCol[i];
+                    bool row = cfg.problem.postOps.binaryRow[i],
+                         col = cfg.problem.postOps.binaryCol[i];
                     if (row && col) {
-                        auto ld = pd()->ld_binary(i);
-                        po_offsets[i] += isColMajor(problem_.binary[i].layout)
+                        auto ld = cfg.ld_binary(i);
+                        po_offsets[i]
+                                += isColMajor(cfg.problem.binary[i].layout)
                                 ? (Bn * ld + Bm)
                                 : (Bm * ld + Bn);
                     } else if (row)

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
@@ -44,39 +44,6 @@ struct xe_hp_systolic_t : public gemm::primitive_t {
         bool use_nocopy_xehpg(data_type_t dt, unsigned ld_align);
         status_t set_default_formats(data_type_t dt);
 
-        size_t dyn_offset_a = 0;
-        size_t dyn_offset_b = 0;
-        size_t dyn_offset_c = 0;
-
-        data_type_t impl_co_type() const {
-            using namespace data_type;
-            return with_bias() ? desc()->bias_type()
-                               : (utils::one_of(desc()->a_type(), s8, u8)
-                                                 ? s32
-                                                 : desc()->c_type());
-        }
-
-        data_type_t impl_acc_type() const {
-            using namespace data_type;
-            return utils::one_of(desc()->c_type(), s8, u8, f16, bf16, f32)
-                    ? (utils::one_of(desc()->a_type(), s8, u8) ? s32 : f32)
-                    : s32;
-        }
-
-        float alpha() const { return 1.0f; }
-        float beta() const { return beta_; }
-
-        bool with_bias() const {
-            return (desc()->bias_type() != data_type::undef)
-                    && !bias_via_binary_;
-        }
-
-        int bias_cmask() const {
-            unsigned char to_cmask[8] = {0, 4, 2, 6, 1, 5, 3, 7};
-            assert(unsigned(desc()->bias_mask()) < 8);
-            return with_bias() ? to_cmask[desc()->bias_mask() & 7] : -1;
-        }
-
         bool packed_a() const { return packed_a_; }
         bool packed_b() const { return packed_b_; }
         bool packed_c() const { return packed_c_; }
@@ -92,7 +59,7 @@ struct xe_hp_systolic_t : public gemm::primitive_t {
         }
 
         int64_t get_ld_packed(int64_t k, bool get_max = false) const {
-            auto a_sz = types::data_type_size(desc()->a_type());
+            auto a_sz = types::data_type_size(cfg().a_type());
 
             int unroll_k = int(32 / a_sz);
             auto ld = utils::rnd_up(k, unroll_k);
@@ -106,43 +73,59 @@ struct xe_hp_systolic_t : public gemm::primitive_t {
         }
 
         dim_t lda_packed(int64_t k) const {
-            return packed_a() ? desc()->b_desc.format_desc.blocking
-                                        .strides[with_batch() ? 2 : 1]
-                            / unroll_m()
+            return packed_a() ? a_packed_stride_ / unroll_m()
                               : get_ld_packed(k);
         }
         dim_t ldb_packed(int64_t k) const {
-            return packed_b() ? desc()->a_desc.format_desc.blocking
-                                        .strides[with_batch() ? 1 : 0]
-                            / unroll_n()
+            return packed_b() ? b_packed_stride_ / unroll_n()
                               : get_ld_packed(k);
         }
         dim_t ldc_packed() const {
-            return packed_c() ? desc()->c_desc.format_desc.blocking
-                                        .strides[with_batch() ? 1 : 0]
-                            / unroll_n()
-                              : 0;
+            return packed_c() ? c_packed_stride_ / unroll_n() : 0;
         }
 
-        int batch_dims() const {
-            return nstl::max(desc()->c_desc.ndims - 2, 0);
+        // C-offset kind from the active C-side mask:
+        // 'F' full / 'R' row / 'C' column / 'M' both / 'N' none.
+        char co_kind() const {
+            int m = -1;
+            if (cfg().with_c_zero_points() || cfg().with_bias())
+                m = cfg().cmask;
+            switch (m) {
+                case 0: return 'F';
+                case (1 << 1): return 'R';
+                case (1 << 0): return 'C';
+                case 3: return 'M';
+                default: return 'N';
+            }
         }
 
-        bool with_batch() const { return desc()->is_batched(); }
-        bool with_a_zero_points() const { return a_zp_; }
-        bool with_b_zero_points() const { return b_zp_; }
-        bool with_ab_zero_points() const { return a_zp_ || b_zp_; }
-        bool with_c_zero_points() const { return c_zp_; }
+        bool with_batch() const { return cfg().problem.batchDims >= 1; }
+        // Int-only datatype config; reads desc() since it is used pre-cfg-seed.
+        bool dt_int_ok() const {
+            using namespace data_type;
+            const auto &d = desc();
+            return utils::one_of(d->a_type(), u8, s8)
+                    && utils::one_of(d->b_type(), u8, s8)
+                    && utils::one_of(d->c_type(), s32, f32, s8, u8, f16);
+        }
+        bool with_ab_zero_points() const {
+            return cfg().with_a_zero_points() || cfg().with_b_zero_points();
+        }
 
         bool allow_k_blocking() const {
-            return (desc()->acc_type == desc()->c_type())
-                    && IMPLICATION(post_ops()->len() > 0,
-                            post_ops()->entry_[0].kind == primitive_kind::sum);
+            const auto &po = cfg().problem.postOps;
+            return (acc_type_ == cfg().c_type())
+                    && IMPLICATION(po.len() > 0, po[0].is_sum());
         }
 
         int unroll_m() const { return unroll_m_; }
         int unroll_n() const { return unroll_n_; }
         bool alt() const { return alt_; }
+
+        // Shared kernel geometry, snapshotted from selection in init().
+        const gemmstone::CommonDriverInfo &driver_info() const {
+            return driver_info_;
+        }
 
         status_t query(query_t what, int idx, void *result) const override {
             switch ((int)what) {
@@ -160,10 +143,13 @@ struct xe_hp_systolic_t : public gemm::primitive_t {
     private:
         bool any_prepacked_ = false;
         bool packed_a_ = false, packed_b_ = false, packed_c_ = false;
-        bool a_zp_ = false, b_zp_ = false, c_zp_ = false;
         int unroll_m_ = 0;
         int unroll_n_ = 0;
         bool alt_ = false;
+        // Prepacked input leading-dim strides (raw, pre-/unroll), seeded in init.
+        dim_t a_packed_stride_ = 0, b_packed_stride_ = 0, c_packed_stride_ = 0;
+        data_type_t acc_type_ = data_type::undef;
+        gemmstone::CommonDriverInfo driver_info_;
     };
 
     status_t init(impl::engine_t *engine) override;
@@ -203,15 +189,8 @@ private:
     compute::kernel_t kernel_[2][2]; // [first_k_block][last_k_block]
     compute::kernel_t copy_kernel_[2][2]; // [trans][clear_sum]
 
-    gemmstone::CommonDriverInfo compute_info_;
-
     compute::gpu_arch_t arch_ = compute::gpu_arch_t::unknown;
     int eu_count_ = 0;
-
-    char co_kind_ = 'N';
-    bool walk_n_first_ = false;
-
-    gemmstone::GEMMProblem problem_;
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 };

--- a/src/gpu/intel/gemm/ref.hpp
+++ b/src/gpu/intel/gemm/ref.hpp
@@ -18,8 +18,8 @@
 #define GPU_INTEL_GEMM_REF_HPP
 
 #include "common/serialization.hpp"
-#include "gpu/intel/gemm/config.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
+#include "gpu/intel/gemm/types.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 
 namespace dnnl {

--- a/src/gpu/intel/gemm/types.cpp
+++ b/src/gpu/intel/gemm/types.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "gpu/intel/gemm/config.hpp"
+#include "gpu/intel/gemm/types.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 
 namespace dnnl {

--- a/src/gpu/intel/gemm/types.hpp
+++ b/src/gpu/intel/gemm/types.hpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef GPU_INTEL_GEMM_CONFIG_HPP
-#define GPU_INTEL_GEMM_CONFIG_HPP
+#ifndef GPU_INTEL_GEMM_TYPES_HPP
+#define GPU_INTEL_GEMM_TYPES_HPP
 
 #include "common/primitive_exec_types.hpp"
 #include "gpu/gpu_gemm_pd.hpp"

--- a/src/gpu/intel/gemm/with_post_ops.hpp
+++ b/src/gpu/intel/gemm/with_post_ops.hpp
@@ -17,8 +17,8 @@
 #ifndef GPU_INTEL_GEMM_WITH_POST_OPS_HPP
 #define GPU_INTEL_GEMM_WITH_POST_OPS_HPP
 
-#include "gpu/intel/gemm/config.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
+#include "gpu/intel/gemm/types.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 
 namespace dnnl {

--- a/src/gpu/intel/matmul/gemm.cpp
+++ b/src/gpu/intel/matmul/gemm.cpp
@@ -15,8 +15,8 @@
 *******************************************************************************/
 
 #include "gpu/intel/matmul/gemm.hpp"
-#include "gpu/intel/gemm/config.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
+#include "gpu/intel/gemm/types.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -24,7 +24,7 @@
 #include "common/primitive_attr_quant.hpp"
 #include "common/primitive_desc_iterator.hpp"
 #include "gpu/intel/gemm/utils.hpp"
-#include "gpu/intel/matmul/config.hpp"
+#include "gpu/intel/matmul/types.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/utils.hpp"
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.hpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.hpp
@@ -23,8 +23,8 @@
 
 #include "common/utils.hpp"
 #include "gemmstone/microkernel/package.hpp"
-#include "gpu/intel/matmul/config.hpp"
 #include "gpu/intel/matmul/grouped_post_ops_gen.hpp"
+#include "gpu/intel/matmul/types.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -25,7 +25,7 @@
 #include "common/primitive.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
-#include "gpu/intel/matmul/config.hpp"
+#include "gpu/intel/matmul/types.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 

--- a/src/gpu/intel/matmul/ref_grouped_gemm.hpp
+++ b/src/gpu/intel/matmul/ref_grouped_gemm.hpp
@@ -26,8 +26,8 @@
 #include "common/c_types_map.hpp"
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
-#include "gpu/intel/matmul/config.hpp"
 #include "gpu/intel/matmul/grouped_post_ops_gen.hpp"
+#include "gpu/intel/matmul/types.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 

--- a/src/gpu/intel/matmul/sparse_ref.hpp
+++ b/src/gpu/intel/matmul/sparse_ref.hpp
@@ -22,7 +22,7 @@
 #include "common/c_types_map.hpp"
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
-#include "gpu/intel/matmul/config.hpp"
+#include "gpu/intel/matmul/types.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 

--- a/src/gpu/intel/matmul/types.hpp
+++ b/src/gpu/intel/matmul/types.hpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef GPU_INTEL_MATMUL_CONFIG_HPP
-#define GPU_INTEL_MATMUL_CONFIG_HPP
+#ifndef GPU_INTEL_MATMUL_TYPES_HPP
+#define GPU_INTEL_MATMUL_TYPES_HPP
 
 #include "gpu/gpu_matmul_pd.hpp"
 


### PR DESCRIPTION
This is the groundwork for https://github.com/uxlfoundation/oneDNN/pull/5181. PR consolidates GEMM problem properties in `kernel_config_t` and `exec_config_t` reducing the scattered swap-AB logic.


The PR reworks how the GPU JIT GEMM primitive descriptor carries problem state. Previously the PD re-derived GEMM state from `desc()`/`attr()`/mds at each call site, recomputing the same facts across kernel selection and execute. Now init captures that state once into a `kernel_config_t` (`cfg`).

**Responsibility split.** Init translates `desc()`/`attr()`/mds into `cfg`. Once `cfg` is initialized, kernel selection and execute read it for problem state, not the descriptor or attributes. Two narrow reads stay on the originals:

- Format setup and support checks run earlier in init, before `cfg` exists
- Exec-time host-scalar scale folding still reads `attr()`

`cfg` wraps a `gemmstone::GEMMProblem` plus the dnnl-side state the problem doesn't carry - dims, leading dims, batch strides, quant mds, post-op/bias metadata.

**Problem is the source of truth.** Inside `cfg`, feature queries (transpose, zero points, sum, sum_ab, ...) derive from the wrapped problem instead of cachingtheir own bools or re-reading attributes.

**Build is two phases.** `init_kernel_config` seeds `cfg` from the descriptor, `finalize_problem` then finalizes it for the target hardware.
