### PR TITLE
common: minor fixes for verbose

### DIFF
--- a/src/common/dnnl_debug.cpp
+++ b/src/common/dnnl_debug.cpp
@@ -49,6 +49,7 @@ const char *dnnl_fmt_kind2str(dnnl_format_kind_t v) {
     if (v == format_kind::wino || v == format_kind::rnn_packed
             || v == format_kind::cublaslt_blocked)
         return "opaque";
+    if (v == dnnl_format_kind_host_scalar) return "host_scalar";
     if (v == dnnl_format_kind_max) return "max";
     assert(!"unknown fmt_kind");
     return "unknown fmt_kind";

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -465,7 +465,10 @@ struct primitive_desc_t : public c_compatible {
         // up from the cache and lead to the errornous deserialization process
         // of further nested primitives which may not hit the primitive cache.
         const bool force_create_from_blob = static_cast<bool>(cache_blob);
-        if (get_verbose(verbose_t::debuginfo) >= 1) {
+        // Only top-level primitive create profile is printed. Nested primitive
+        // create profile is printed under debuginfo.
+        if (get_verbose(verbose_t::create_profile)
+                && get_verbose(verbose_t::debuginfo) >= 1) {
             double start_ms = get_msec();
             CHECK(create_primitive(
                     primitive, engine, cache_blob, force_create_from_blob));


### PR DESCRIPTION
1. Verbose string of host scalar md.
2. Verbose string of create nested may appear before verbose header.