### PR TITLE
cpu: x64: matmul: fix a guard for merging batch into M

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -228,6 +228,15 @@ bool is_batch_layout_trivial(
     return max_batch_stride / min_batch_stride == batch;
 }
 
+bool dims_adjacent(const memory_desc_wrapper &mdw, const int outer_dim,
+        const int inner_dim) {
+    const auto &dims = mdw.dims();
+    const auto &strides = mdw.strides();
+    if (dims[outer_dim] == 1) return true;
+    const dim_t inner_stride = dims[inner_dim] > 1 ? strides[inner_dim] : 1;
+    return strides[outer_dim] == dims[inner_dim] * inner_stride;
+}
+
 status_t check_isa_with_datatype(
         const cpu_isa_t isa, const brgemm_matmul_conf_utils_t &bm_conf_utils) {
     const bool ok
@@ -1757,15 +1766,24 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     const bool plain_A_layout = bm_conf_utils.check_is_plain(bgmmc.src_tag)
             || bgmmc.treat_A_as_plain;
 
+    // Merging the batch dimensions into M is only valid when M and K are
+    // adjacent in memory, i.e. no batch dimension is physically interleaved
+    // between them (e.g. an acbd layout). The format tag is unreliable here
+    // since tag matching ignores strides of unit dimensions.
+    const bool m_and_k_contiguous
+            = dims_adjacent(src_d, bgmmc.ndims - 2, bgmmc.ndims - 1);
+
     // We cannot change M at this point as all gemv related parameters have
     // already been set up.
-    // For 4D tensors with acbd layout, avoid merging batches to prevent stride issues
+    // TODO: move this logic into a dedicated function. The conditions that
+    // guard the merge are currently scattered across several helpers and this
+    // call site.
     const bool merge_batch_dims_into_M = !(bgmmc.is_gemv && bgmmc.gemv_swap_a_b)
             && bgmmc.batch > 1 && bgmmc.bcast_B_desc.bcast_across_all_batch_dims
             && plain_A_layout && helper.is_src_dst_layout_batch_fusable()
             && post_ops_ok(
                     bgmmc, attr, dst_d, true /* limit_bcast_strategies_set */)
-            && !(bgmmc.ndims == 4 && src_d.matches_tag(format_tag::acbd));
+            && m_and_k_contiguous;
     if (merge_batch_dims_into_M) {
         bgmmc.M *= bgmmc.batch;
         bgmmc.batch = 1;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -502,6 +502,12 @@ void mem_advice_init(brgemm_matmul_conf_t &bgmmc);
 
 bool is_batch_layout_trivial(const memory_desc_wrapper &mdw, const dim_t batch);
 
+// Returns true if logical dimension `inner_dim` is nested immediately inside
+// `outer_dim` in memory, i.e. no other dimension is physically interleaved
+// between them (`stride(outer_dim) == dim(inner_dim) * stride(inner_dim)`).
+bool dims_adjacent(const memory_desc_wrapper &mdw, const int outer_dim,
+        const int inner_dim);
+
 /**
  * Returns the total block size along the K dimension, as the product of
  * the fixed outer block size and the VNNI granularity.


### PR DESCRIPTION
This PR fixes MFDNN-15137.

We introduced this issue in #4632 when we needed to fix the guard that restricted when the batch dimension could be merged into the M by prohibiting the optimization for the `acbd` format. The problem was that the check relied on format tags, which excluded degenerate shapes such as `59578x1x1x1024`. These are legitimate shapes for the optimization and excluding them led to performance regressions such as the one reported in MFDNN-15137.
```
./benchdnn --mode=P --matmul --dt=bf16:bf16:bf16 --stag=abdc --wtag=abdc --dtag=abcd 59578x1x1x1024:1x1x1024x1
```
I also created a task to migrate brgemm matmul layout decisions from format tags to strides: MFDNN-15148.

Perf results for RGAT on GNR: vs rls-v3.12
<img width="359" height="44" alt="image" src="https://github.com/user-attachments/assets/2d4c4dfc-acc5-4f75-9b71-b667575ecb30" />
Perf results for RGAT on GNR: vs main
<img width="359" height="44" alt="image" src="https://github.com/user-attachments/assets/9d3c1f83-c73d-45ca-afc9-95f57755d7ee" />

