### PR TITLE
benchdnn: add --mode=S for simulation environments

### DIFF
--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1149,9 +1149,10 @@ std::ostream &dump_global_params(std::ostream &s) {
     // updated default values take effect before parsing a state of a problem.
     if (canonical || bench_mode != default_bench_mode)
         s << "--mode=" << bench_mode << " ";
-    // Don't dump modifiers if F mode is used to keep the repro simple.
+    // Don't dump modifiers if F or S mode is used to keep the repro simple.
     if (canonical
             || (bench_mode != bench_mode_t::perf_fast
+                    && bench_mode != bench_mode_t::perf_sim
                     && bench_mode_modifier != default_bench_mode_modifier))
         s << "--mode-modifier=" << bench_mode_modifier << " ";
     // Don't dump max_ms_per_prb if F mode is used to keep the repro simple.
@@ -1159,7 +1160,10 @@ std::ostream &dump_global_params(std::ostream &s) {
             || (bench_mode != bench_mode_t::perf_fast
                     && max_ms_per_prb != default_max_ms_per_prb))
         s << "--max-ms-per-prb=" << max_ms_per_prb << " ";
-    if (canonical || fix_times_per_prb != default_fix_times_per_prb)
+    // Don't dump fix_times_per_prb if S mode is used to keep the repro simple.
+    if (canonical
+            || (bench_mode != bench_mode_t::perf_sim
+                    && fix_times_per_prb != default_fix_times_per_prb))
         s << "--fix-times-per-prb=" << fix_times_per_prb << " ";
 
     s << "--" << driver_name << " ";

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -700,9 +700,12 @@ int update_timer_with_profiling_info(timer::timer_t &t, bool use_profiling,
 
 inline int measure_perf_individual(timer::timer_t &t, dnnl_stream_t stream,
         perf_function_t &perf_func, std::vector<dnnl_exec_arg_t> &dnnl_args) {
-    // Warm-up run.
-    DNN_SAFE(perf_func(stream, dnnl_args), WARN);
-    DNN_SAFE(dnnl_stream_wait(stream), CRIT);
+    // Warm-up run, this is not measured due to possibility the associated
+    // kernel has not been built and skews the results.
+    if (!has_bench_mode_bit(mode_bit_t::sim)) {
+        DNN_SAFE(perf_func(stream, dnnl_args), WARN);
+        DNN_SAFE(dnnl_stream_wait(stream), CRIT);
+    }
 
     cold_cache_t cold_cache(dnnl_args, stream);
 
@@ -727,9 +730,14 @@ inline int measure_perf_aggregate(timer::timer_t &t,
 
     // Warm-up run, this is not measured due to possibility the associated
     // kernel has not been built and skews the results.
+    if (!has_bench_mode_bit(mode_bit_t::sim)) {
+        for (size_t j = 0; j < v_stream.size(); j++) {
+            DNN_SAFE(perf_func(v_stream[j], dnnl_args[j]), WARN);
+            DNN_SAFE(dnnl_stream_wait(v_stream[j]), CRIT);
+        }
+    }
+
     for (size_t j = 0; j < v_stream.size(); j++) {
-        DNN_SAFE(perf_func(v_stream[j], dnnl_args[j]), WARN);
-        DNN_SAFE(dnnl_stream_wait(v_stream[j]), CRIT);
         cold_cache[j] = cold_cache_t(dnnl_args[j], v_stream[j]);
         if (use_profiling) reset_gpu_profiling(v_stream[j]);
     }

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -1059,6 +1059,14 @@ int dnn_mem_t::initialize(
 
     SAFE(initialize_memory_create(handle_info), CRIT);
 
+    // In single-run/simulation mode, data values are not important since no
+    // correctness check is performed, so input data fill-in (and the associated
+    // map/unmap) is skipped to reduce overhead. The `no_ref_memory` modifier is
+    // set alongside `--mode=S` so the cleanup path skips unmapping. Sparse memory
+    // objects rely on metadata buffers that must always be filled to avoid
+    // out-of-bounds access, so they fall through to the regular handling.
+    if (has_bench_mode_bit(mode_bit_t::sim) && !is_sparse_md()) return OK;
+
     // If the memory object doesn't own its buffers, nothing to do.
     if (!handle_info.is_allocate()) return OK;
 

--- a/tests/benchdnn/doc/benchdnn_general_info.md
+++ b/tests/benchdnn/doc/benchdnn_general_info.md
@@ -96,6 +96,16 @@ otherwise. The following modes (`--mode`) are supported:
   enabled to align data filling with the Fast Performance mode.
 * Fast Performance (`F`): This flow executes Performance mode with `P` and `M`
   modifiers (see below) enabled and updated maximum measuring time per case.
+* Simulation Performance (`S`): This flow is intended for scenarios where
+  execution time is prohibitively expensive, such as running under a hardware
+  simulator. It behaves like Performance mode with the following specifics:
+  - Input tensor fill-in is skipped. Since data values are not important (no
+    correctness check is performed), the `M` modifier (see below) is enabled,
+    which also skips mapping/unmapping memory objects.
+  - The warm-up run is skipped.
+  - Execution is limited to a single run per problem (equivalent to
+    `--fix-times-per-prb=1`).
+  - Cold cache is not supported.
 
 ## Mode modifiers
 

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -154,6 +154,10 @@ runtimes. `KIND` values can be `usm` (default), `buffer`, `usm_device`
                automatically enabled to align data filling with `--mode=F`
   - `F` or `f` for fast performance testing, an alias for
                `--mode=P --mode-modifier=PM --max-ms-per-prb=10`
+  - `S` or `s` for simulation performance testing: skips warm-up, skips input
+    tensor fill-in, limits execution to a single run per problem, and disables
+    cold cache. Useful when execution time is prohibitively expensive, e.g.
+    when running under a hardware simulator.
   - `B` or `b` for bitwise (numerical determinism) testing
   - `R` or `r` for run mode, enables `--mode-modifier=M`
   - `I` or `i` for initialization mode

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -118,11 +118,13 @@ inline int measure_perf_aggregate(timer::timer_t &t,
 
     // Warm-up run, this is not measured due to possibility the associated
     // kernel has not been built and skews the results.
-    auto sz = perf_func_v.size();
-    for (size_t i = 0; i < sz; i++) {
-        DNN_GRAPH_SAFE(
-                perf_func_v[i](stream, inputs_v[i], outputs_v[i]), WARN, res);
-        DNN_GRAPH_SAFE(stream.wait(), WARN, res);
+    const auto sz = perf_func_v.size();
+    if (!has_bench_mode_bit(mode_bit_t::sim)) {
+        for (size_t i = 0; i < sz; i++) {
+            DNN_GRAPH_SAFE(perf_func_v[i](stream, inputs_v[i], outputs_v[i]),
+                    WARN, res);
+            DNN_GRAPH_SAFE(stream.wait(), WARN, res);
+        }
     }
 
     int cur_batch_times

--- a/tests/benchdnn/utils/bench_mode.cpp
+++ b/tests/benchdnn/utils/bench_mode.cpp
@@ -35,9 +35,11 @@ std::ostream &operator<<(std::ostream &s, bench_mode_t mode) {
     if (mode == bench_mode_t::exec) s << "R";
     if (has_bench_mode_bit(mode_bit_t::corr)) s << "C";
     if (has_bench_mode_bit(mode_bit_t::perf)
-            && !has_bench_mode_bit(mode_bit_t::fast))
+            && !has_bench_mode_bit(mode_bit_t::fast)
+            && !has_bench_mode_bit(mode_bit_t::sim))
         s << "P";
     if (has_bench_mode_bit(mode_bit_t::fast)) s << "F";
+    if (has_bench_mode_bit(mode_bit_t::sim)) s << "S";
     if (has_bench_mode_bit(mode_bit_t::bitwise)) s << "B";
     return s;
 }

--- a/tests/benchdnn/utils/bench_mode.hpp
+++ b/tests/benchdnn/utils/bench_mode.hpp
@@ -38,6 +38,8 @@ enum class mode_bit_t : unsigned {
     fast = 0x20,
     // `bitwise` bit is for a numerical determinism validation flow.
     bitwise = 0x40,
+    // `sim` bit is for a single-run simulation-friendly performance flow.
+    sim = 0x80,
 };
 
 // Mode modifiers is an extension of `bench_mode_t` abstraction which specifies
@@ -67,6 +69,7 @@ enum class bench_mode_t : unsigned {
     corr = exec | static_cast<unsigned>(mode_bit_t::corr),
     perf = exec | static_cast<unsigned>(mode_bit_t::perf),
     perf_fast = perf | static_cast<unsigned>(mode_bit_t::fast),
+    perf_sim = perf | static_cast<unsigned>(mode_bit_t::sim),
     bitwise = exec | static_cast<unsigned>(mode_bit_t::bitwise),
 };
 

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -366,6 +366,9 @@ bool cold_cache_t::should_stop() const {
 
 bool cold_cache_t::use_cold_cache(
         const std::vector<dnnl_exec_arg_t> &dnnl_args) const {
+    // Cold cache is not supported in single-run/simulation mode.
+    if (has_bench_mode_bit(mode_bit_t::sim)) return false;
+
     const bool cc_wei
             = cold_cache_input_.cold_cache_mode_ == cold_cache_mode_t::wei;
     const bool cc_all

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1549,7 +1549,15 @@ static bool parse_fix_times_per_prb(
     bool parsed = parse_single_value_option(fix_times_per_prb,
             default_fix_times_per_prb, utils::stoll_safe, str, option_name,
             help);
-    if (parsed) fix_times_per_prb = MAX2(0, fix_times_per_prb);
+    if (parsed) {
+        if (bench_mode == bench_mode_t::perf_sim) {
+            BENCHDNN_PRINT(0, "%s\n",
+                    "Error: mode=S can't be adjusted. It implies "
+                    "fix-times-per-prb=1.");
+            exit(2);
+        }
+        fix_times_per_prb = MAX2(0, fix_times_per_prb);
+    }
     return parsed;
 }
 
@@ -1648,6 +1656,7 @@ static bool parse_mode(
               "    * `C` for correctness testing.\n"
               "    * `P` for performance testing.\n"
               "    * `F` for fast performance testing (GPU only).\n"
+              "    * `S` for simulation performance testing.\n"
               "    * `B` for bitwise (numerical determinism) testing.\n"
               "    More details at "
             + doc_url + "benchdnn_general_info.md\n";
@@ -1683,6 +1692,12 @@ static bool parse_mode(
                     break;
                 case 'b':
                 case 'B': mode = bench_mode_t::bitwise; break;
+                case 's':
+                case 'S':
+                    mode = bench_mode_t::perf_sim;
+                    fix_times_per_prb = 1;
+                    bench_mode_modifier |= mode_modifier_t::no_ref_memory;
+                    break;
                 default:
                     BENCHDNN_PRINT(0, "%s\n%s", "Error: mode value is invalid.",
                             help.c_str());


### PR DESCRIPTION
# Description

New `--mode=s` performance mode is introduced in benchdnn. It is intended for scenarios where execution time is prohibitively expensive, such as running under a hardware simulator.

When `--mode=S` is used, the flow behaves like Performance mode (`P`) with the following specifics:

- **Input tensor fill-in is skipped.** Since data values are not important (no correctness check is performed in performance modes), the `M` (`no_ref_memory`) modifier is enabled, which also skips mapping/unmapping of memory objects. Sparse memory objects still get their metadata buffers filled to avoid out-of-bounds access.
- **The warm-up run is skipped.**
- **Execution is limited to a single run per problem** (equivalent to `--fix-times-per-prb=1`). Passing an explicit `--fix-times-per-prb` together with `--mode=S` is rejected.
- **Cold cache is not supported.**

This minimizes the number of kernel executions per problem (a single `exec` line per primitive), which is essential when each execution is very expensive (e.g. under simulation).

Documentation is added in `tests/benchdnn/doc/benchdnn_general_info.md` and `tests/benchdnn/doc/knobs_common.md`.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### New features

- [x] Have you added relevant tests?
