### PR TITLE
tests: benchdnn: correction to skip condition wrt sparse vs grouped

### DIFF
--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_ci
@@ -203,7 +203,7 @@
 --dt=f16:f16:f16
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8,0:4:8+0+16+8
---attr-post-ops=eltwise_swish:1.0+mul:f32:3:grouped,eltwise_swish:1.0+mul:f16:3:grouped,eltwise_swish:1.0+mul:bf16:3:grouped
+--attr-post-ops=eltwise_swish:1.0+mul:f32:3:grouped,eltwise_swish:1.0+mul:f16:3:grouped,eltwise_swish:1.0+mul:bf16:3:grouped,eltwise_swish:1.0+mul:f32:1:ab,eltwise_swish:1.0+mul:f16:1:ab
 32x64:4x64x32
 
 # Post-ops + bias: binary_mul per-row and grouped with bias
@@ -224,3 +224,11 @@
 --attr-scales=wei:7:f16:32x1
 --attr-post-ops=mul:f32:1:ab,mul:f16:1:ab,mul:f32:3:grouped,mul:f16:3:grouped
 32x128:4x128x64
+
+# Post-ops: multi-binary chains (grouped + dense, 3-op)
+--reset
+--dt=f16:f16:f16
+--wtag=abc
+--grouped=0:4:8+8+8+8
+--attr-post-ops=mul:f16:3:grouped+mul:f32:1:ab,eltwise_swish:1.0+mul:f16:3:grouped+mul:f32:1:ab
+32x64:4x64x32

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -639,7 +639,11 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     bool is_wei_dense = (wei_encoding == dnnl_sparse_encoding_undef);
     bool is_src_coo_sparse
             = (prb->sparse_options.get_encoding(DNNL_ARG_SRC) == dnnl_coo);
-    if (!prb->sparse_options.is_def() && is_gpu()
+    // Guard grouped configs so they get UNIMPLEMENTED (not a SKIPPED)
+    const bool is_any_grouped = prb->sparse_options.is_grouped(DNNL_ARG_SRC)
+            || prb->sparse_options.is_grouped(DNNL_ARG_WEIGHTS)
+            || prb->sparse_options.is_grouped(DNNL_ARG_DST);
+    if (!prb->sparse_options.is_def() && is_gpu() && !is_any_grouped
             && (!is_wei_dense || !is_src_coo_sparse)) {
         BENCHDNN_PRINT(2,
                 "[SKIP][%s:%d]: GPU sparse matmul only supports COO encoding "


### PR DESCRIPTION
Avoiding incorrect post-processing for the unimplemented cases.
Currently this resolves into a bunch of unimplemented for GPU due to missing post-ops support, but those would be gone once https://github.com/uxlfoundation/oneDNN/pull/5134 is merged

++ added extra commit with more configs for post-ops testing