### PR TITLE
cpu: rv64: use agnostic vector policy in GEMM JIT kernels

### DIFF
--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -112,7 +112,8 @@ void jit_brgemm_kernel_t::generate() {
     lw(reg_beta, reg_param, 48); // beta bits
     ld(reg_bias, reg_param, 56); // bias pointer
 
-    vsetvli(x0, reg_tmp1, SEW::e32, LMUL::m4);
+    // Active lanes are overwritten and inactive lanes are never consumed.
+    vsetvli(x0, reg_tmp1, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     li(reg_lda, LDA_bytes);
     li(reg_ldb, LDB_bytes);

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
@@ -95,7 +95,8 @@ void jit_rvv_gemm_kernel_t::generate() {
     slli(reg_ldb_bytes, reg_ldb_bytes, 2);
     slli(reg_ldc_bytes, reg_ldc_bytes, 2);
 
-    vsetvli(x0, reg_m, SEW::e32, LMUL::m4);
+    // Active lanes are overwritten and inactive lanes are never consumed.
+    vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     const Reg &reg_tmp3 = reg_param;
 


### PR DESCRIPTION
# Description

  This PR updates the RV64 GEMM and BRGEMM JIT kernels to pass `VTA::ta` and `VMA::ma` explicitly for their `vsetvli` setup.

  The affected kernels overwrite the active vector lanes after `vsetvli` and do not consume inactive tail or masked-off lanes, so tail-agnostic and mask-agnostic policy is safe for these sites. This keeps the
  policy change local to the GEMM JIT kernels instead of changing the Xbyak RISC-V default behavior globally.

  Motivation: Xbyak's default `vsetvli` policy is tail-undisturbed and mask-undisturbed (`tu,mu`). On some out-of-order vector implementations, vector instructions may be split into uops before the effective VL
  is available in decode. With `tu,mu`, the implementation may need extra work to preserve inactive destination elements, even for VLMAX cases, which can create pipeline pressure and reduce GEMM throughput. Using
  `ta,ma` avoids that unnecessary preservation requirement for these kernels.

  No GitHub issue is associated with this change.

  Fixes #N/A

  Validation performed:

  - RV64 `dnnl_cpu_riscv` target builds successfully.
  - Tested on OoO Core, do have performance gains

  # Checklist

  ## General

  - [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
  - [x] Have you formatted the code using clang-format?

  ## Performance improvements

  - [ ] Have you submitted performance data that demonstrates performance improvements?

  ### New features

  - [ ] Have you published an RFC for the new feature?
  - [ ] Was the RFC approved?
  - [ ] Have you added relevant tests?

  ### Bug fixes

  - [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
  - [ ] Have you added relevant regression tests?