### PR TITLE
[rls-v3.12] graph: backport fixes for sycl graph recording

### DIFF
--- a/src/graph/backend/dnnl/executables/base.hpp
+++ b/src/graph/backend/dnnl/executables/base.hpp
@@ -17,6 +17,7 @@
 #define GRAPH_BACKEND_DNNL_EXECUTABLES_BASE_HPP
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -117,7 +118,15 @@ struct op_executable_t {
             const std::unordered_map<int, memory> &args) const
             = 0;
 #ifdef DNNL_WITH_SYCL
-    virtual ::sycl::event execute_sycl(const stream &stream,
+    // The returned event is used to indicate when the execution is finished.
+    // The caller can use the event to build dependency for later execution. But
+    // some executables actually do nothing and may return a default empty
+    // event. The default empty event cannot be recorded in SYCL graph and need
+    // to be skipped when passing it to the next executable. So we use
+    // std::optional here to indicate whether the returned event is valid or
+    // not. std::optional is available since C++17 which is required to build
+    // with SYCL support.
+    virtual std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const
             = 0;
@@ -193,13 +202,13 @@ struct dummy_impl_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         UNUSED(stream);
 
-        // Fast path: if no event, return an immediate event.
-        if (deps.empty()) return {};
+        // No-op: return nullopt to indicate no real work was submitted.
+        if (deps.empty()) return std::nullopt;
 
         // Fast path: if only one event, return it.
         if (deps.size() == 1) return deps[0];

--- a/src/graph/backend/dnnl/executables/batch_norm.cpp
+++ b/src/graph/backend/dnnl/executables/batch_norm.cpp
@@ -124,7 +124,7 @@ void bn_folding_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event bn_folding_t::execute_sycl(const stream &stream,
+std::optional<::sycl::event> bn_folding_t::execute_sycl(const stream &stream,
         const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     UNUSED(args);
@@ -655,8 +655,8 @@ void batchnorm_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event batchnorm_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> batchnorm_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     if (!is_training_) {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/batch_norm.hpp
+++ b/src/graph/backend/dnnl/executables/batch_norm.hpp
@@ -69,7 +69,7 @@ struct bn_folding_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif
@@ -114,7 +114,7 @@ struct batchnorm_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif
@@ -150,7 +150,7 @@ struct batchnorm_bwd_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/concat.hpp
+++ b/src/graph/backend/dnnl/executables/concat.hpp
@@ -42,7 +42,7 @@ struct concat_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/const_memory_filler.hpp
+++ b/src/graph/backend/dnnl/executables/const_memory_filler.hpp
@@ -72,7 +72,7 @@ struct const_memory_filler_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         void *data_handle = static_cast<void *>(

--- a/src/graph/backend/dnnl/executables/conv.cpp
+++ b/src/graph/backend/dnnl/executables/conv.cpp
@@ -64,8 +64,8 @@ void conv_fwd_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event conv_fwd_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> conv_fwd_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto sycl_deps = deps;
     if (with_sum_) {

--- a/src/graph/backend/dnnl/executables/conv.hpp
+++ b/src/graph/backend/dnnl/executables/conv.hpp
@@ -42,7 +42,7 @@ struct conv_fwd_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif
@@ -77,7 +77,7 @@ struct conv_bwd_data_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -118,7 +118,7 @@ struct conv_bwd_weights_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/deconv.cpp
+++ b/src/graph/backend/dnnl/executables/deconv.cpp
@@ -39,8 +39,8 @@ void deconv_fwd_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event deconv_fwd_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> deconv_fwd_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto sycl_deps = deps;
     if (with_sum_) {

--- a/src/graph/backend/dnnl/executables/deconv.hpp
+++ b/src/graph/backend/dnnl/executables/deconv.hpp
@@ -42,7 +42,7 @@ struct deconv_fwd_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif
@@ -77,7 +77,7 @@ struct deconv_bwd_data_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -118,7 +118,7 @@ struct deconv_bwd_weights_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/eltwise.cpp
+++ b/src/graph/backend/dnnl/executables/eltwise.cpp
@@ -136,8 +136,8 @@ void binary_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event binary_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> binary_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     if (is_dummy_) { return dummy_impl_.execute_sycl(stream, args, deps); }
 
@@ -146,8 +146,10 @@ void binary_executable_t::execute(const stream &stream,
         auto it_dst = args.find(DNNL_ARG_DST);
         auto it_src = args.find(DNNL_GRAPH_ARG_POST_SRC);
         if (it_dst == args.end() || it_src == args.end()) {
-            assert(!("cannot find the required memory"));
-            return {};
+            // TODO(xxx): this case should not happen. We may want to convert it to
+            // a verbose error.
+            assert(!"cannot find memory for DNNL_ARG_POST_SRC or DNNL_ARG_DST");
+            return std::nullopt;
         }
 
         memory &dst_mem = const_cast<memory &>(it_dst->second);

--- a/src/graph/backend/dnnl/executables/eltwise.hpp
+++ b/src/graph/backend/dnnl/executables/eltwise.hpp
@@ -41,7 +41,7 @@ struct eltwise_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -81,7 +81,7 @@ struct eltwise_bwd_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -131,7 +131,7 @@ struct binary_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif
@@ -167,7 +167,7 @@ struct prelu_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -207,7 +207,7 @@ struct prelu_bwd_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/gated_mlp.cpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.cpp
@@ -63,8 +63,8 @@ void gated_mlp_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event gated_mlp_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> gated_mlp_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     std::vector<dnnl_exec_arg_t> c_args;
     c_args.reserve(args.size());

--- a/src/graph/backend/dnnl/executables/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.hpp
@@ -37,7 +37,7 @@ struct gated_mlp_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif

--- a/src/graph/backend/dnnl/executables/gen_index.cpp
+++ b/src/graph/backend/dnnl/executables/gen_index.cpp
@@ -99,8 +99,8 @@ void genindex_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event genindex_executable_t::execute_sycl_impl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> genindex_executable_t::execute_sycl_impl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     if (stream.get_engine().get_kind() == engine::kind::cpu) {
         auto strm_t = stream.get();
@@ -147,8 +147,8 @@ void genindex_executable_t::execute(const stream &stream,
 #endif
 }
 
-::sycl::event genindex_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> genindex_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
@@ -159,7 +159,7 @@ void genindex_executable_t::execute(const stream &stream,
         double duration_ms = dnnl::impl::get_msec() - start_ms;
         VPROF(start_ms, graph, exec, VERBOSE_profile, info_.c_str(),
                 duration_ms);
-        return {}; // no event returned in profiling mode
+        return std::nullopt; // no event returned in profiling mode
     } else {
         return execute_sycl_impl(stream, args, deps);
     }

--- a/src/graph/backend/dnnl/executables/gen_index.hpp
+++ b/src/graph/backend/dnnl/executables/gen_index.hpp
@@ -42,10 +42,10 @@ struct genindex_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
-    ::sycl::event execute_sycl_impl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl_impl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const;
 #endif

--- a/src/graph/backend/dnnl/executables/group_norm.hpp
+++ b/src/graph/backend/dnnl/executables/group_norm.hpp
@@ -43,7 +43,7 @@ struct groupnorm_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -54,22 +54,18 @@ void host_scalar_executable_t::execute(const stream &stream,
     const memory &src_mem = it_src->second;
     const memory &dst_mem = it_dst->second;
 
-    // Use queue.memcpy() to copy the host scalar value to device memory. We
-    // have to wait here as the val is on stack and will become invalid if
-    // queue.memcpy() is asynchronous. A better solution may be supporting
-    // host scalar memory to device memory reorder primitive.
-    auto sycl_queue = dnnl::sycl_interop::get_queue(stream);
+    // get_data_handle() is blocked for host scalar memories at the C API
+    // level, so we access the underlying storage pointer directly.
+    void *src_ptr = const_cast<memory_t *>(src_mem.get())
+                            ->memory_storage()
+                            ->data_handle();
+    void *dst_ptr = dst_mem.get_data_handle();
     const size_t size = src_mem.get_desc().get_size();
-    const auto dt = src_mem.get_desc().get_data_type();
-    assert(size == types::data_type_size(static_cast<impl::data_type_t>(dt)));
-    DNNL_HOST_SCALAR_TYPE_SWITCH(dt, DType, {
-        const DType val = src_mem.get_host_scalar_value<DType>();
-        sycl_queue
-                .memcpy(dst_mem.get_data_handle(),
-                        static_cast<const void *>(&val), size)
-                .wait();
+    auto sycl_queue = dnnl::sycl_interop::get_queue(stream);
+    return sycl_queue.submit([&](::sycl::handler &cgh) {
+        cgh.depends_on(deps);
+        cgh.memcpy(dst_ptr, src_ptr, size);
     });
-    return {};
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -40,15 +40,17 @@ void host_scalar_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event host_scalar_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> host_scalar_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto it_src = args.find(DNNL_ARG_FROM);
     auto it_dst = args.find(DNNL_ARG_TO);
 
     if (it_src == args.end() || it_dst == args.end()) {
+        // TODO(xxx): this case should not happen. We may want to convert it to
+        // a verbose error.
         assert(!"cannot find memory for DNNL_ARG_FROM or DNNL_ARG_TO");
-        return {};
+        return std::nullopt;
     }
 
     const memory &src_mem = it_src->second;

--- a/src/graph/backend/dnnl/executables/host_scalar.hpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.hpp
@@ -41,7 +41,7 @@ struct host_scalar_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif

--- a/src/graph/backend/dnnl/executables/layer_norm.hpp
+++ b/src/graph/backend/dnnl/executables/layer_norm.hpp
@@ -43,7 +43,7 @@ struct layernorm_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -84,7 +84,7 @@ struct layernorm_bwd_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/matmul.cpp
+++ b/src/graph/backend/dnnl/executables/matmul.cpp
@@ -84,8 +84,8 @@ void matmul_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event matmul_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> matmul_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     if (is_dummy_) { return dummy_impl_.execute_sycl(stream, args, deps); }
 
@@ -94,8 +94,10 @@ void matmul_executable_t::execute(const stream &stream,
         auto it_dst = args.find(DNNL_ARG_DST);
         auto it_src = args.find(DNNL_GRAPH_ARG_POST_SRC);
         if (it_dst == args.end() || it_src == args.end()) {
-            assert(!("cannot find the required memory"));
-            return {};
+            // TODO(xxx): this case should not happen. We may want to convert it to
+            // a verbose error.
+            assert(!"cannot find memory for DNNL_ARG_POST_SRC or DNNL_ARG_DST");
+            return std::nullopt;
         }
 
         memory &dst_mem = const_cast<memory &>(it_dst->second);

--- a/src/graph/backend/dnnl/executables/matmul.hpp
+++ b/src/graph/backend/dnnl/executables/matmul.hpp
@@ -36,7 +36,7 @@ struct matmul_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif

--- a/src/graph/backend/dnnl/executables/memory_reparser.cpp
+++ b/src/graph/backend/dnnl/executables/memory_reparser.cpp
@@ -41,12 +41,17 @@ void memory_reparser_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event memory_reparser_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> memory_reparser_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto from = args.find(DNNL_ARG_FROM);
     auto to = args.find(DNNL_ARG_TO);
-    if (from == args.end() || to == args.end()) return {};
+    if (from == args.end() || to == args.end()) {
+        // TODO(xxx): this case should not happen. We may want to convert it to
+        // a verbose error.
+        assert(!"cannot find memory for DNNL_ARG_FROM or DNNL_ARG_TO");
+        return std::nullopt;
+    }
 
     if (from->second.get_data_handle() == to->second.get_data_handle())
         return dummy_impl_t::execute_sycl(stream, args, deps);

--- a/src/graph/backend/dnnl/executables/memory_reparser.hpp
+++ b/src/graph/backend/dnnl/executables/memory_reparser.hpp
@@ -41,7 +41,7 @@ struct memory_reparser_t : public dummy_impl_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif

--- a/src/graph/backend/dnnl/executables/pool.hpp
+++ b/src/graph/backend/dnnl/executables/pool.hpp
@@ -41,7 +41,7 @@ struct pool_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -81,7 +81,7 @@ struct pool_bwd_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/reduction.cpp
+++ b/src/graph/backend/dnnl/executables/reduction.cpp
@@ -37,8 +37,8 @@ void reduction_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event reduction_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> reduction_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto sycl_deps = deps;
     if (with_sum_) {

--- a/src/graph/backend/dnnl/executables/reduction.hpp
+++ b/src/graph/backend/dnnl/executables/reduction.hpp
@@ -43,7 +43,7 @@ struct reduction_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif

--- a/src/graph/backend/dnnl/executables/reorder.cpp
+++ b/src/graph/backend/dnnl/executables/reorder.cpp
@@ -43,16 +43,18 @@ void reorder_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event reorder_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> reorder_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto sycl_deps = deps;
     if (with_sum_) {
         auto it_dst = args.find(DNNL_ARG_DST);
         auto it_src = args.find(DNNL_GRAPH_ARG_POST_SRC);
         if (it_dst == args.end() || it_src == args.end()) {
-            assert(!("cannot find the required memory"));
-            return {};
+            // TODO(xxx): this case should not happen. We may want to convert it to
+            // a verbose error.
+            assert(!"cannot find memory for DNNL_ARG_POST_SRC or DNNL_ARG_DST");
+            return std::nullopt;
         }
 
         const memory &psrc_mem = it_src->second;

--- a/src/graph/backend/dnnl/executables/reorder.hpp
+++ b/src/graph/backend/dnnl/executables/reorder.hpp
@@ -42,7 +42,7 @@ struct reorder_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif

--- a/src/graph/backend/dnnl/executables/resampling.cpp
+++ b/src/graph/backend/dnnl/executables/resampling.cpp
@@ -43,8 +43,8 @@ void resampling_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event resampling_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> resampling_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto sycl_deps = deps;
     if (with_sum_) {

--- a/src/graph/backend/dnnl/executables/resampling.hpp
+++ b/src/graph/backend/dnnl/executables/resampling.hpp
@@ -42,7 +42,7 @@ struct resampling_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif
@@ -76,7 +76,7 @@ struct resampling_bwd_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/sdpa.cpp
+++ b/src/graph/backend/dnnl/executables/sdpa.cpp
@@ -118,8 +118,8 @@ void sdpa_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event sdpa_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> sdpa_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     std::vector<dnnl_exec_arg_t> c_args;
     c_args.reserve(args.size());
@@ -326,8 +326,8 @@ void sdpa_bwd_executable_t::execute(const stream &stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-::sycl::event sdpa_bwd_executable_t::execute_sycl(const stream &stream,
-        const std::unordered_map<int, memory> &args,
+std::optional<::sycl::event> sdpa_bwd_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     std::vector<dnnl_exec_arg_t> c_args;
     c_args.reserve(args.size());

--- a/src/graph/backend/dnnl/executables/sdpa.hpp
+++ b/src/graph/backend/dnnl/executables/sdpa.hpp
@@ -51,7 +51,7 @@ struct sdpa_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif
@@ -88,7 +88,7 @@ struct sdpa_bwd_executable_t : public op_executable_t {
             const std::unordered_map<int, memory> &args) const override;
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
 #endif

--- a/src/graph/backend/dnnl/executables/shuffle.hpp
+++ b/src/graph/backend/dnnl/executables/shuffle.hpp
@@ -42,7 +42,7 @@ struct shuffle_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/softmax.hpp
+++ b/src/graph/backend/dnnl/executables/softmax.hpp
@@ -42,7 +42,7 @@ struct softmax_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);
@@ -82,7 +82,7 @@ struct softmax_bwd_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/executables/sum.hpp
+++ b/src/graph/backend/dnnl/executables/sum.hpp
@@ -42,7 +42,7 @@ struct sum_executable_t : public op_executable_t {
     }
 
 #ifdef DNNL_WITH_SYCL
-    ::sycl::event execute_sycl(const stream &stream,
+    std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override {
         auto e = dnnl::sycl_interop::execute(prim_, stream, args, deps);

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -190,7 +190,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -239,7 +239,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -250,11 +250,12 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -440,7 +441,7 @@ status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -459,11 +460,12 @@ status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -146,7 +146,7 @@ status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -165,11 +165,12 @@ status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -141,7 +141,7 @@ status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -159,11 +159,12 @@ status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -118,7 +118,7 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -167,7 +167,7 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -178,11 +178,12 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -207,7 +207,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -256,7 +256,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -267,11 +267,12 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -453,7 +454,7 @@ status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -471,11 +472,12 @@ status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
@@ -174,7 +174,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
     return status::unimplemented;
 #endif
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
 
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *stream);
 
@@ -191,11 +191,12 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (ret_event)
+        *ret_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -141,7 +141,7 @@ status_t genindex_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
     if (p_engine_.get_kind() == engine::kind::gpu) {
         auto deps = sycl_deps;
-        ::sycl::event returned_event;
+        std::optional<::sycl::event> returned_event;
         dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
         thread_local_cache_t<execution_args_set_t> res_cache;
@@ -152,10 +152,11 @@ status_t genindex_t::sycl_execute_impl(const stream_t *g_stream,
             if (subgraph_->is_constant_[i]) continue;
             returned_event = subgraph_->execs_[i]->execute_sycl(
                     p_stream, res->get_exec_args()[i], deps);
-            deps = {returned_event};
+            if (returned_event) deps = {*returned_event};
         }
 
-        if (sycl_event) *sycl_event = returned_event;
+        if (sycl_event)
+            *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
         return status::success;
     }

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -198,7 +198,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -247,7 +247,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -258,11 +258,12 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -325,7 +325,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -373,7 +373,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -384,11 +384,12 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -195,7 +195,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -244,7 +244,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -255,11 +255,12 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -439,7 +440,7 @@ status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -457,11 +458,12 @@ status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -128,7 +128,7 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -147,11 +147,12 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -294,7 +295,7 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -313,11 +314,12 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -267,7 +267,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -316,7 +316,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -327,11 +327,12 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -226,7 +226,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -275,7 +275,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -286,11 +286,12 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -486,7 +487,7 @@ status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -506,11 +507,12 @@ status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -145,7 +145,7 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -164,11 +164,12 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -314,7 +315,7 @@ status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -333,11 +334,12 @@ status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -194,7 +194,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -243,7 +243,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -254,11 +254,12 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -144,7 +144,7 @@ status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -162,11 +162,12 @@ status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -209,7 +209,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -258,7 +258,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -269,11 +269,12 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -146,7 +146,7 @@ status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -164,11 +164,12 @@ status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -308,7 +309,7 @@ status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -326,11 +327,12 @@ status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -186,8 +186,7 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
     return status::unimplemented;
 #endif
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
-
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -203,11 +202,12 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -195,8 +195,7 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
     return status::unimplemented;
 #endif
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
-
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -212,11 +211,12 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -143,7 +143,7 @@ status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -162,11 +162,12 @@ status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -193,7 +193,7 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -242,7 +242,7 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_sycl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps = {returned_event};
+                if (returned_event) deps = {*returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -253,11 +253,12 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }
@@ -441,7 +442,7 @@ status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -460,11 +461,12 @@ status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -143,7 +143,7 @@ status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
         ::sycl::event *sycl_event) {
 
     auto deps = sycl_deps;
-    ::sycl::event returned_event;
+    std::optional<::sycl::event> returned_event;
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     // each thread's own local resource
@@ -162,11 +162,12 @@ status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_sycl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps = {returned_event};
+        if (returned_event) deps = {*returned_event};
     }
 
-    scratchpad.set_deps(returned_event);
-    if (sycl_event) *sycl_event = returned_event;
+    scratchpad.set_deps(returned_event ? *returned_event : ::sycl::event {});
+    if (sycl_event)
+        *sycl_event = returned_event ? *returned_event : ::sycl::event {};
 
     return status::success;
 }

--- a/tests/gtests/graph/unit/backend/dnnl/test_op_executable.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_op_executable.cpp
@@ -65,32 +65,29 @@ TEST(test_op_executable, DummyImpl) {
 
     // test empty input events
     auto returned_event0 = op_exec->execute_sycl(p_stream, {}, {});
-    const auto &event_list0 = returned_event0.get_wait_list();
-    ASSERT_EQ(event_list0.size(), 0U);
-    ASSERT_EQ(
-            returned_event0
-                    .get_info<::sycl::info::event::command_execution_status>(),
-            ::sycl::info::event_command_status::complete);
+    ASSERT_FALSE(returned_event0.has_value());
 
     // test one input event
     ::sycl::event input_event0;
     auto returned_event1 = op_exec->execute_sycl(p_stream, {}, {input_event0});
-    ASSERT_EQ(returned_event1, input_event0);
+    ASSERT_TRUE(returned_event1.has_value());
+    ASSERT_EQ(*returned_event1, input_event0);
     ASSERT_EQ(
             returned_event1
-                    .get_info<::sycl::info::event::command_execution_status>(),
+                    ->get_info<::sycl::info::event::command_execution_status>(),
             ::sycl::info::event_command_status::complete);
 
     // test two input events
     ::sycl::event input_event1;
     auto returned_event2 = op_exec->execute_sycl(
             p_stream, {}, {std::move(input_event0), std::move(input_event1)});
-    const auto &event_list2 = returned_event2.get_wait_list();
+    ASSERT_TRUE(returned_event2.has_value());
+    const auto &event_list2 = returned_event2->get_wait_list();
     ASSERT_LE(event_list2.size(), 2U);
-    returned_event2.wait();
+    returned_event2->wait();
     ASSERT_EQ(
             returned_event2
-                    .get_info<::sycl::info::event::command_execution_status>(),
+                    ->get_info<::sycl::info::event::command_execution_status>(),
             ::sycl::info::event_command_status::complete);
 }
 #endif


### PR DESCRIPTION
Backports below PRs from main to rls-v3.12:

- #5088 
- #5219 

Orphan CI: https://intel-ci.intel.com/f1610789-305f-f1e9-8639-d4f5ef20c6a0
