### PR TITLE
common, cpu: move a key to a string to combine data types

### DIFF
--- a/src/common/impl_list_item.cpp
+++ b/src/common/impl_list_item.cpp
@@ -1,0 +1,96 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/impl_list_item.hpp"
+
+namespace dnnl {
+namespace impl {
+
+pk_dt_impl_key_t::pk_dt_impl_key_t(prop_kind_t kind, data_type_t src_dt,
+        data_type_t wei_dt, data_type_t dst_dt)
+    : kind_(kind) {
+    using namespace data_type;
+    using namespace prop_kind;
+
+    const bool is_fwd
+            = utils::one_of(kind_, forward_training, forward_inference);
+    const bool is_bwd_d = kind_ == backward_data;
+    const bool is_bwd_w = kind_ == backward_weights;
+
+    // src_dt
+    if (is_fwd) {
+        if (utils::one_of(src_dt, s8, u8)) {
+            s_dt_ += "xi8";
+        } else if (utils::one_of(src_dt, f8_e5m2, f8_e4m3)) {
+            s_dt_ += "xf8";
+        } else {
+            s_dt_ += dnnl_dt2str(src_dt);
+        }
+    } else if (is_bwd_d) {
+        s_dt_ += "*";
+    } else if (is_bwd_w) {
+        if (utils::one_of(src_dt, f8_e5m2, f8_e4m3)) {
+            s_dt_ += "xf8";
+        } else {
+            s_dt_ += dnnl_dt2str(src_dt);
+        }
+    } else {
+        assert(!"unexpected");
+    }
+    s_dt_ += ":";
+
+    // wei_dt
+    if (is_fwd) {
+        if (utils::one_of(wei_dt, f8_e5m2, f8_e4m3)) {
+            s_dt_ += "xf8";
+        } else if (src_dt == f32 && utils::one_of(wei_dt, f32, bf16, f16)) {
+            s_dt_ += "xf";
+        } else {
+            s_dt_ += dnnl_dt2str(wei_dt);
+        }
+    } else if (is_bwd_d) {
+        if (utils::one_of(wei_dt, f8_e5m2, f8_e4m3)) {
+            s_dt_ += "xf8";
+        } else if (dst_dt == f32 && utils::one_of(wei_dt, f32, bf16, f16)) {
+            s_dt_ += "xf";
+        } else {
+            s_dt_ += dnnl_dt2str(wei_dt);
+        }
+    } else if (is_bwd_w) {
+        s_dt_ += "*";
+    } else {
+        assert(!"unexpected");
+    }
+    s_dt_ += ":";
+
+    // dst_dt
+    if (is_fwd) {
+        s_dt_ += "*";
+    } else if (is_bwd_d || is_bwd_w) {
+        if (utils::one_of(dst_dt, s8, u8)) {
+            s_dt_ += "xi8";
+        } else if (utils::one_of(dst_dt, f8_e5m2, f8_e4m3)) {
+            s_dt_ += "xf8";
+        } else {
+            s_dt_ += dnnl_dt2str(dst_dt);
+        }
+    } else {
+        assert(!"unexpected");
+    }
+}
+
+} // namespace impl
+} // namespace dnnl

--- a/src/common/impl_list_item.hpp
+++ b/src/common/impl_list_item.hpp
@@ -21,26 +21,34 @@
 #include "primitive_desc.hpp"
 #include "utils.hpp"
 
+#include <string>
+
 namespace dnnl {
 namespace impl {
 
-// This key takes prop_kind and correspondent data_type for src, wei and dst.
+// This key takes prop_kind and correspondent data types for src, wei and dst
+// and forms a regex string that compounds several data type configs.
+// Notation:
+// * To use exact data type, use its name as in include, e.g. f32, bf16, etc.
+// * To use any floating-point type, use xf. Adding a number will limit bits,
+//   e.g., xf8 means any fp8 type.
+// * To use any int8 type, use xi8.
+// * To use any data type use *.
 struct pk_dt_impl_key_t {
-    prop_kind_t kind;
-    data_type_t src_dt, wei_dt, dst_dt;
+    pk_dt_impl_key_t(prop_kind_t kind, const std::string &s)
+        : kind_(kind), s_dt_(s) {}
+
+    pk_dt_impl_key_t(prop_kind_t kind, data_type_t src_dt, data_type_t wei_dt,
+            data_type_t dst_dt);
 
     bool operator<(const pk_dt_impl_key_t &rhs) const {
-        return value() < rhs.value();
+        if (kind_ == rhs.kind_) return s_dt_ < rhs.s_dt_;
+        return kind_ < rhs.kind_;
     }
 
 private:
-    size_t value() const {
-        const size_t dtm = data_type::data_type_max;
-        const size_t m1 = static_cast<size_t>(kind) * dtm;
-        const size_t m2 = (m1 + static_cast<size_t>(src_dt)) * dtm;
-        const size_t m3 = (m2 + static_cast<size_t>(wei_dt)) * dtm;
-        return m3 + static_cast<size_t>(dst_dt);
-    }
+    prop_kind_t kind_;
+    std::string s_dt_;
 };
 
 // This is a simpler version of key to use only prop_kind.

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -91,44 +91,10 @@ using namespace dnnl::impl::data_type;
 using namespace dnnl::impl::prop_kind;
 
 // clang-format off
-#define BRGEMM_FP8_FWD_CONVS(dtsrc, dtwei, dtdst) { \
-    {forward, dtsrc, dtwei, dtdst}, { \
-        CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>) \
-        CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>) \
-        CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_1_512_amx_fp16>) \
-        CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_1_512_amx_fp16>) \
-        CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>) \
-        CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>) \
-        CPU_INSTANCE(ref_convolution_fwd_t) \
-        nullptr, \
-    } \
-}
-
-#define BRGEMM_FP8_BWD_D_CONVS(dtsrc, dtwei, dtdst) { \
-    {backward_data, dtsrc, dtwei, dtdst}, REG_BWD_D_PK({ \
-        CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx10_2_amx_2>) \
-        CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx10_1_512_amx_fp16>) \
-        CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx10_2_amx_2>) \
-        CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx10_1_512_amx_fp16>) \
-        CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx10_2>) \
-        CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx10_2>) \
-        CPU_INSTANCE(ref_convolution_bwd_data_t) \
-        nullptr, \
-    }) \
-}
-
-#define BRGEMM_FP8_BWD_W_CONVS(dtsrc, dtwei, dtdst) { \
-    {backward_weights, dtsrc, dtwei, dtdst}, REG_BWD_PK({ \
-        CPU_INSTANCE_AMX(brgemm_convolution_bwd_weights_t) \
-        CPU_INSTANCE(ref_convolution_bwd_weights_t) \
-        nullptr, \
-    }) \
-}
-
 const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
     static const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> the_map = REG_CONV_P({
         // FWD fp
-        {{forward, f32, f32, f32}, {
+        {{forward, "f32:xf:*"}, {
             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_X64(ip_convolution_fwd_t)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
@@ -152,15 +118,15 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_512>)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_512>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_512>)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_512,data_type::f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_512,f32>)
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_fwd_t<f32,f32,f32,sve_512>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_fwd_t<f32,f32,f32,sve_512>)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_256,data_type::f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_256,f32>)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_fwd_t<f32,f32,f32,sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_fwd_t<f32,f32,f32,sve_256>)
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_128,data_type::f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_128,f32>)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64_ACL(acl_depthwise_convolution_fwd_t)
@@ -180,27 +146,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_fused_convolution_fwd_t)
             nullptr,
         }},
-        {{forward, f32, f16, f32}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2>)
-            CPU_INSTANCE(ref_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, f32, bf16, f32}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE(ref_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, bf16, bf16, f32}, {
+        {{forward, "bf16:bf16:*"}, {
             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_X64(ip_convolution_fwd_t)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
@@ -210,68 +156,32 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_fwd_t<avx512_core, bf16, f32>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_fwd_t<f32>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_convolution_fwd_t)
-            CPU_INSTANCE_X64(jit_uni_ncsp_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(gemm_bf16_convolution_fwd_t<f32>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE(ref_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, bf16, bf16, bf16}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_bf16>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_fwd_t<avx512_core, bf16, bf16>)
+            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_fwd_t<f32>)
             CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_fwd_t<bf16>)
             CPU_INSTANCE_AVX512(jit_avx512_core_bf16_convolution_fwd_t)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_fwd_t)
+            CPU_INSTANCE_AVX512(gemm_bf16_convolution_fwd_t<f32>)
             CPU_INSTANCE_AVX512(gemm_bf16_convolution_fwd_t<bf16>)
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_256, bf16, bf16>)
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_128, bf16, bf16>)
-            CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
+            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_128, bf16, bf16>)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
+            CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE(ref_convolution_fwd_t)
             CPU_INSTANCE(ref_fused_convolution_fwd_t)
             nullptr,
         }},
-        {{forward, f16, f16, f32}, {
+        {{forward, "f16:f16:*"}, {
             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_X64(ip_convolution_fwd_t)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_fwd_t<avx512_core_fp16, f16, f32>)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx_fp16>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx_fp16>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_fp16>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_fp16>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE(ref_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, f16, f16, f16}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_fwd_t<avx512_core_fp16, f16, f16>)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx_fp16>)
@@ -289,44 +199,18 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_fused_convolution_fwd_t)
             nullptr,
         }},
-        {{forward, f32, f32, u8}, {
+        {{forward, "xf8:xf8:*"}, {
+            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
+            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
+            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_1_512_amx_fp16>)
+            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_1_512_amx_fp16>)
+            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>)
+            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>)
             CPU_INSTANCE(ref_convolution_fwd_t)
             nullptr,
         }},
-        {{forward, f32, f32, s8}, {
-            CPU_INSTANCE(ref_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, bf16, bf16, u8}, {
-            CPU_INSTANCE(ref_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, bf16, bf16, s8}, {
-            CPU_INSTANCE(ref_convolution_fwd_t)
-            nullptr,
-        }},
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f16),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f32),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, bf16),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e4m3, f16),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e4m3, f32),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e4m3, bf16),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e5m2, f16),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e5m2, f32),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e5m2, bf16),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e4m3, f16),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e4m3, f32),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e4m3, bf16),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_FWD_CONVS(f8_e4m3, f8_e4m3, f8_e4m3),
         // BWD_D fp
-        {{backward_data, f32, f32, f32}, REG_BWD_D_PK({
+        {{backward_data, "*:xf:f32"}, REG_BWD_D_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx10_2_amx_2>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx>)
@@ -345,10 +229,10 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64(brgemm_convolution_bwd_t<sve_512>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_bwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_bwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_data_t<sve_512,data_type::f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_data_t<sve_512,f32>)
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_bwd_data_t<f32,f32,f32,sve_512>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_bwd_data_t<f32,f32,f32,sve_512>)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_data_t<sve_256,data_type::f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_data_t<sve_256,f32>)
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_bwd_data_t<f32,f32,f32,sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_bwd_data_t<f32,f32,f32,sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_bwd_data_t<f32,f32,f32,sve_128>)
@@ -358,23 +242,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
-        {{backward_data, f32, bf16, f32}, REG_BWD_D_PK({
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_t<avx2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx2>)
-            CPU_INSTANCE(ref_convolution_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, f32, f16, f32}, REG_BWD_D_PK({
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_t<avx2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx2>)
-            CPU_INSTANCE(ref_convolution_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, f32, bf16, bf16}, REG_BWD_D_PK({
+        {{backward_data, "*:bf16:bf16"}, REG_BWD_D_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
@@ -382,33 +250,19 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_bwd_data_t<avx512_core, bf16, f32>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_bwd_data_t<f32>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_convolution_bwd_data_t)
-            CPU_INSTANCE_X64(jit_uni_ncsp_convolution_bwd_data_t)
-            CPU_INSTANCE_AVX512(gemm_bf16_convolution_bwd_data_t<f32>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE(ref_convolution_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, bf16, bf16, bf16}, REG_BWD_D_PK({
-            CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_bwd_data_t)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core_bf16>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_bwd_data_t<avx512_core, bf16, bf16>)
+            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_bwd_data_t<f32>)
             CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_bwd_data_t<bf16>)
             CPU_INSTANCE_AVX512(jit_avx512_core_bf16_convolution_bwd_data_t)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_bwd_data_t)
+            CPU_INSTANCE_AVX512(gemm_bf16_convolution_bwd_data_t<f32>)
             CPU_INSTANCE_AVX512(gemm_bf16_convolution_bwd_data_t<bf16>)
             CPU_INSTANCE_AVX2(brgemm_convolution_bwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
             CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
-        {{backward_data, f32, f16, f16}, REG_BWD_D_PK({
+        {{backward_data, "*:f16:f16"}, REG_BWD_D_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx_fp16>)
@@ -422,42 +276,18 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
-        {{backward_data, f16, f16, f16}, REG_BWD_D_PK({
-            CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx_fp16>)
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx_fp16>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_bwd_data_t)
+        {{backward_data, "*:xf8:xf8"}, REG_BWD_D_PK({
+            CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx10_2_amx_2>)
+            CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx10_1_512_amx_fp16>)
+            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx10_2_amx_2>)
+            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx10_1_512_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx10_2>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core_fp16>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_fp16>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
             CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
-        BRGEMM_FP8_BWD_D_CONVS(f8_e5m2, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f8_e5m2, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(f8_e5m2, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f8_e5m2, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(f32, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f32, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(f16, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f16, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(bf16, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(bf16, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(f8_e4m3, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f8_e4m3, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(f8_e4m3, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f8_e4m3, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(f32, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f32, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(f16, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(f16, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_BWD_D_CONVS(bf16, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_D_CONVS(bf16, f8_e4m3, f8_e4m3),
         // BWD_W fp
-        {{backward_weights, f32, f32, f32}, REG_BWD_PK({
+        {{backward_weights, "f32:*:f32"}, REG_BWD_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_weights_t)
             CPU_INSTANCE_AVX512(jit_avx512_common_dw_convolution_bwd_weights_t)
             CPU_INSTANCE_AVX512(jit_avx512_common_1x1_convolution_bwd_weights_t)
@@ -466,10 +296,10 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(jit_avx2_1x1_convolution_bwd_weights_t)
             CPU_INSTANCE_SSE41(jit_sse41_dw_convolution_bwd_weights_t)
             CPU_INSTANCE_AVX2(jit_avx2_convolution_bwd_weights_t)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_weights_t<sve_512,data_type::f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_weights_t<sve_512,f32>)
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_bwd_weights_t<f32,f32,f32,sve_512>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_bwd_weights_t<f32,f32,f32,sve_512>)
-            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_weights_t<sve_256,data_type::f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_bwd_weights_t<sve_256,f32>)
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_bwd_weights_t<f32,f32,f32,sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_bwd_weights_t<f32,f32,f32,sve_256>)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_bwd_weights_t)
@@ -477,66 +307,44 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_convolution_bwd_weights_t)
             nullptr,
         })},
-        {{backward_weights, bf16, f32, bf16}, REG_BWD_PK({
+        {{backward_weights, "bf16:*:bf16"}, REG_BWD_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_weights_t)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_bwd_weights_t<avx512_core, bf16, f32>)
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_weights_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_bwd_weights_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<f32>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_convolution_bwd_weights_t)
-            CPU_INSTANCE_X64(jit_uni_ncsp_convolution_bwd_weights_t)
-            CPU_INSTANCE_AVX512(gemm_bf16_convolution_bwd_weights_t<f32>)
-            CPU_INSTANCE(ref_convolution_bwd_weights_t)
-            nullptr,
-        })},
-        {{backward_weights, bf16, bf16, bf16}, REG_BWD_PK({
-            CPU_INSTANCE_X64(ip_convolution_bwd_weights_t)
             CPU_INSTANCE_AVX512(jit_uni_dw_convolution_bwd_weights_t<avx512_core, bf16, bf16>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_weights_t)
             CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_bwd_weights_t)
+            CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<f32>)
             CPU_INSTANCE_AVX512(jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<bf16>)
             CPU_INSTANCE_AVX512(jit_avx512_core_bf16_convolution_bwd_weights_t)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_bwd_weights_t)
+            CPU_INSTANCE_AVX512(gemm_bf16_convolution_bwd_weights_t<f32>)
             CPU_INSTANCE_AVX512(gemm_bf16_convolution_bwd_weights_t<bf16>)
             CPU_INSTANCE(ref_convolution_bwd_weights_t)
             nullptr,
         })},
-        {{backward_weights, f16, f32, f16}, REG_BWD_PK({
+        {{backward_weights, "f16:*:f16"}, REG_BWD_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_weights_t)
             CPU_INSTANCE(ref_convolution_bwd_weights_t)
             nullptr,
         })},
-        {{backward_weights, f16, f16, f16}, REG_BWD_PK({
-            CPU_INSTANCE_X64(ip_convolution_bwd_weights_t)
+        {{backward_weights, "xf8:*:xf8"}, REG_BWD_PK({
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_weights_t)
             CPU_INSTANCE(ref_convolution_bwd_weights_t)
             nullptr,
         })},
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f32, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f32, f8_e4m3),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f16, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e5m2, f16, f8_e4m3),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f32, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f32, f8_e4m3),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f16, f8_e5m2),
-        BRGEMM_FP8_BWD_W_CONVS(f8_e4m3, f16, f8_e4m3),
-        // FWD int8 (src:s8)
-        {{forward, s8, s8, f32}, {
+        // FWD int8
+        {{forward, "xi8:s8:*"}, {
             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_X64(ip_convolution_fwd_t)
+            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
+            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
+            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>)
             CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
             CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
+            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>)
             CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
             CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
             CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
@@ -558,320 +366,21 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<s8, f32>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            CPU_INSTANCE(ref_fused_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, bf16}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, f16}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, s32}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<s8, s32>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            CPU_INSTANCE(ref_fused_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, s8}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_convolution_fwd_t<sse41>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<s8, s8>)
-            CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<s8, s8, s8, s32>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            CPU_INSTANCE(ref_fused_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, u8}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<s8, u8>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            CPU_INSTANCE(ref_fused_convolution_fwd_t)
-            nullptr,
-        }},
-        // FWD int8 (src:u8)
-        {{forward, u8, s8, f32}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<u8, f32>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, bf16}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, f16}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, s32}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<u8, s32>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, s8}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<u8, s8>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE(ref_convolution_int8_fwd_t)
-            CPU_INSTANCE(ref_fused_convolution_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, u8}, {
-            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
-            CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t)
-            CPU_INSTANCE_AVX512(jit_avx512_core_x8s8s32x_convolution_fwd_t)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_1x1_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_convolution_fwd_t<avx2>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_convolution_fwd_t<sse41>)
-            CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
-            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_512_x8s8s32x_convolution_fwd_t<u8, u8>)
+            CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<s8, s8, s8, s32>)
             CPU_INSTANCE(gemm_x8s8s32x_convolution_fwd_t)
             CPU_INSTANCE(ref_convolution_int8_fwd_t)
             CPU_INSTANCE(ref_fused_convolution_fwd_t)
             nullptr,
         }},
-        // BWD int8 (diff_dst:u8)
-        {{backward_data, f32, s8, u8}, REG_BWD_D_PK({
+        // BWD int8
+        {{backward_data, "*:s8:xi8"}, REG_BWD_D_PK({
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
@@ -879,113 +388,6 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
             CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
             CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, bf16, s8, u8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, s32, s8, u8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, s8, s8, u8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, u8, s8, u8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        // BWD int8 (src:u8)
-        {{backward_data, u8, f32, f32}, REG_BWD_D_PK({
-            CPU_INSTANCE(ref_convolution_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, u8, bf16, bf16}, REG_BWD_D_PK({
-            CPU_INSTANCE(ref_convolution_bwd_data_t)
-            nullptr,
-        })},
-        // BWD int8 (diff_dst:s8)
-        {{backward_data, f32, s8, s8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, bf16, s8, s8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, s32, s8, s8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, s8, s8, s8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, u8, s8, s8}, REG_BWD_D_PK({
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
-            CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
-            CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
-            nullptr,
-        })},
-        // BWD int8 (src:s8)
-        {{backward_data, s8, f32, f32}, REG_BWD_D_PK({
-            CPU_INSTANCE(ref_convolution_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, s8, bf16, bf16}, REG_BWD_D_PK({
-            CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
     });
@@ -1002,12 +404,11 @@ const impl_list_item_t *get_convolution_impl_list(
             desc->prop_kind, forward_training, forward_inference);
     prop_kind_t prop_kind = is_fwd ? forward : desc->prop_kind;
 
-    pk_dt_impl_key_t key {
-            prop_kind,
-            conv_prop_invariant_src_d(desc)->data_type,
-            conv_prop_invariant_wei_d(desc)->data_type,
-            conv_prop_invariant_dst_d(desc)->data_type,
-    };
+    const auto src_dt = conv_prop_invariant_src_d(desc)->data_type;
+    const auto wei_dt = conv_prop_invariant_wei_d(desc)->data_type;
+    const auto dst_dt = conv_prop_invariant_dst_d(desc)->data_type;
+
+    pk_dt_impl_key_t key(prop_kind, src_dt, wei_dt, dst_dt);
 
     const auto impl_list_it = impl_list_map().find(key);
     return impl_list_it != impl_list_map().cend() ? impl_list_it->second.data()

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -49,19 +49,10 @@ namespace {
 using namespace dnnl::impl::data_type;
 using namespace dnnl::impl::prop_kind;
 
-#define BRGEMM_FP8_FWD_IP(dtsrc, dtwei, dtdst) \
-    { \
-        {forward, dtsrc, dtwei, dtdst}, { \
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t) \
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_1_512_amx_fp16>) \
-            CPU_INSTANCE(ref_inner_product_fwd_t) nullptr, \
-        } \
-    }
-
 // clang-format off
 const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
     static const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> the_map = REG_IP_P({
-        {{forward, f32, f32, f32}, {
+        {{forward, "f32:xf:*"}, {
             CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>) // bf32
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
@@ -73,35 +64,18 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,
         }},
-        {{forward, bf16, bf16, f32}, {
+        {{forward, "bf16:bf16:*"}, {
             CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_fwd_t<f32>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE(ref_inner_product_fwd_t)
-            nullptr,
-        }},
-        {{forward, bf16, bf16, bf16}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_fwd_t<bf16>)
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
             CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,
         }},
-        {{forward, f16, f16, f32}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx_fp16>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_fp16>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE(ref_inner_product_fwd_t)
-            nullptr,
-        }},
-        {{forward, f16, f16, f16}, {
+        {{forward, "f16:f16:*"}, {
             CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
@@ -111,34 +85,13 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,
         }},
-        /* With graph compilation, we are able to reorder and pre-pack the weights during the model load
-         * and compilation phase itself so that redundant and on-the-fly reorders can be avoided.
-         * This primitive definition is to support gemm fastmath mode for the compile scenario where src is
-         * in fp32 and weights are in bf16
-         */
-        {{forward, f32, bf16, f32}, {
-            CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
+        {{forward, "xf8:xf8:*"}, {
+            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
+            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_1_512_amx_fp16>)
+            CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,
         }},
-
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e5m2, f16),
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e5m2, f32),
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e4m3, f16),
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e4m3, f32),
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_FWD_IP(f8_e5m2, f8_e4m3, f8_e4m3),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e5m2, f16),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e5m2, f32),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e5m2, f8_e5m2),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e5m2, f8_e4m3),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e4m3, f16),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e4m3, f32),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e4m3, f8_e5m2),
-        BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e4m3, f8_e4m3),
-
-        {{backward_data, f32, f32, f32}, REG_BWD_PK({
+        {{backward_data, "*:xf:f32"}, REG_BWD_PK({
             CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx>) // bf32
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core>)
@@ -147,23 +100,16 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_inner_product_bwd_data_t)
             nullptr,
         })},
-        {{backward_data, f32, bf16, bf16}, REG_BWD_PK({
+        {{backward_data, "*:bf16:bf16"}, REG_BWD_PK({
             CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_data_t<f32>)
-            CPU_INSTANCE(ref_inner_product_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_data, bf16, bf16, bf16}, REG_BWD_PK({
-            CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_data_t<bf16>)
             CPU_INSTANCE(ref_inner_product_bwd_data_t)
             nullptr,
         })},
-        {{backward_data, f32, f16, f16}, REG_BWD_PK({
+        {{backward_data, "*:f16:f16"}, REG_BWD_PK({
             CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx10_2>)
@@ -171,15 +117,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_inner_product_bwd_data_t)
             nullptr,
         })},
-        {{backward_data, f16, f16, f16}, REG_BWD_PK({
-            CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx_fp16>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core_fp16>)
-            CPU_INSTANCE(ref_inner_product_bwd_data_t)
-            nullptr,
-        })},
-        {{backward_weights, f32, f32, f32}, REG_BWD_PK({
+        {{backward_weights, "f32:*:f32"}, REG_BWD_PK({
             CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx>) // bf32
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core>)
@@ -188,23 +126,16 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_inner_product_bwd_weights_t)
             nullptr,
         })},
-        {{backward_weights, bf16, f32, bf16}, REG_BWD_PK({
+        {{backward_weights, "bf16:*:bf16"}, REG_BWD_PK({
             CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_weights_t<f32>)
-            CPU_INSTANCE(ref_inner_product_bwd_weights_t)
-            nullptr,
-        })},
-        {{backward_weights, bf16, bf16, bf16}, REG_BWD_PK({
-            CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_weights_t<bf16>)
             CPU_INSTANCE(ref_inner_product_bwd_weights_t)
             nullptr,
         })},
-        {{backward_weights, f16, f32, f16}, REG_BWD_PK({
+        {{backward_weights, "f16:*:f16"}, REG_BWD_PK({
             CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx10_2>)
@@ -212,15 +143,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_inner_product_bwd_weights_t)
             nullptr,
         })},
-        {{backward_weights, f16, f16, f16}, REG_BWD_PK({
-            CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx_fp16>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core_fp16>)
-            CPU_INSTANCE(ref_inner_product_bwd_weights_t)
-            nullptr,
-        })},
-        {{forward, s8, s8, f32}, {
+        {{forward, "xi8:s8:*"}, {
             CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
             CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
@@ -231,136 +154,6 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
             CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
             CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, s32}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
-            CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, s8}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
-            CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, u8}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
-            CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, f32}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
-            CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, s32}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
-            CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, s8}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
-            CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, u8}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
-            CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, f16}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, f16}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, s8, s8, bf16}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
-            CPU_INSTANCE(ref_inner_product_int8_fwd_t)
-            nullptr,
-        }},
-        {{forward, u8, s8, bf16}, {
-            CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx10_2>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_vnni>)
-            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
-            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE(ref_inner_product_int8_fwd_t)
             nullptr,
         }},
@@ -386,12 +179,12 @@ const impl_list_item_t *get_inner_product_impl_list(
             : &desc->weights_desc;
     const memory_desc_t *dst_md
             = is_fwd ? &desc->dst_desc : &desc->diff_dst_desc;
-    pk_dt_impl_key_t key {
-            prop_kind,
-            src_md->data_type,
-            wei_md->data_type,
-            dst_md->data_type,
-    };
+
+    const auto src_dt = src_md->data_type;
+    const auto wei_dt = wei_md->data_type;
+    const auto dst_dt = dst_md->data_type;
+
+    pk_dt_impl_key_t key(prop_kind, src_dt, wei_dt, dst_dt);
 
     const auto impl_list_it = impl_list_map().find(key);
     return impl_list_it != impl_list_map().cend() ? impl_list_it->second.data()


### PR DESCRIPTION
Key notations are described next to a key struct.
The idea is to express supported configs by regex strings to combine those who share identical implementations that support such configs.
