### PR TITLE
[GPU] gemm fix - claim strideScaleC register for strided batch MX scale

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -3005,6 +3005,9 @@ void Generator<hw>::gemmInitInterface(GEMMProblem &problem, GEMMStrategy &strate
             if(problem.hasBScalePtr()){
                     state.ra.claim(state.inputs.strideScaleB[i]);
             }
+            if(problem.hasCMXScale()){
+                    state.ra.claim(state.inputs.strideScaleC[i]);
+            }
             if(problem.hasAOffsetPtr()){
                     state.ra.claim(state.inputs.strideOffsetA[i]);
             }


### PR DESCRIPTION
PR fixes the last part of https://jira.devtools.intel.com/browse/MFDNN-14935, with f4 dt, for example:
 18937:FAILED (errors:8 total:5544) (2902 ms) __REPRO: --mode-modifier=P --matmul --engine=gpu --dt=f4_e2m1:f4_e2m1:f4_e2m1 --dtag=abx --bia-dt=f32 --attr-scales=src:per_tensor:e8m0:1x32+dst:mx:e8m0:1x32+wei:per_tensor:e8m0:32x1 --skip-impl=ref 6x2x14x96:6x2x96x32
 
strideScaleC (per-batch stride of the C MX scale) was never claimed in the register allocator. This left this register free to be reused for temporaries => dynamic dst MX scale computation for batched matmul/GEMM could be corrupted.
