### PR TITLE
common: fix name matching with system struct 'user' in llvm-android toolchain

### DIFF
--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -461,8 +461,10 @@ status_t primitive_attr_t::set_accumulation_mode(accumulation_mode_t am) {
 
 status_t primitive_attr_t::set_scratchpad_mode(
         scratchpad_mode_t scratchpad_mode) {
-    const bool ok = one_of(
-            scratchpad_mode, scratchpad_mode::library, scratchpad_mode::user);
+    /* workaround for the name conflict with system struct 'user' in llvm-android toolchain */
+    using namespace dnnl::impl::scratchpad_mode;
+
+    const bool ok = one_of(scratchpad_mode, scratchpad_mode::library, scratchpad_mode::user);
     if (!ok) return invalid_arguments;
 
     scratchpad_mode_ = scratchpad_mode;


### PR DESCRIPTION
## Description

### Problem
Name matching in the affected code path could collide with the system-defined struct user when building with the LLVM Android toolchain.

### Fix
Adjusted the matching and naming logic to avoid the user symbol conflict and keep identifier resolution unambiguous.

### Impact
Restores stable Android LLVM builds with no intended runtime behavior change. Low impact on oneDNN.