### PR TITLE
cpu: aarch64: Enable s8:s8:s32 jit_int8_matmul

### DIFF
--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -133,12 +133,24 @@ struct jit_int8_matmul_kernel_t : public jit_generator_t {
         const ZReg zp_b_prod0 = ZReg(4);
         const ZReg zp_b_prod1 = ZReg(5);
 
-        for (int a = 0; a < bdb; a++) {
-            for (int b = 0; b < ldb; b++) {
-                if (brg_.is_s8 || brg_.is_u8_s8)
-                    scvtf(acc(a, b).s, P_ALL_ONE, acc(a, b).s);
-                else
-                    ucvtf(acc(a, b).s, P_ALL_ONE, acc(a, b).s);
+        // Plain s32 dst stores the accumulators directly
+        // Convert to f32 when zero-point compensation, scales, bias addition, or eltwise post-op
+        // and then convert back to s32 when dst is s32
+        const bool can_store_s32_acc_directly = brg_.dst_dt == s32
+                && brg_.zp_type_a == jit_int8_broadcast_t::none
+                && brg_.zp_type_b == jit_int8_broadcast_t::none
+                && brg_.zp_type_c == jit_int8_broadcast_t::none
+                && !brg_.with_scales && !brg_.is_bias
+                && eltwise_injectors_.empty() && !brg_.with_dst_scales;
+
+        if (!can_store_s32_acc_directly) {
+            for (int a = 0; a < bdb; a++) {
+                for (int b = 0; b < ldb; b++) {
+                    if (brg_.is_s8 || brg_.is_u8_s8)
+                        scvtf(acc(a, b).s, P_ALL_ONE, acc(a, b).s);
+                    else
+                        ucvtf(acc(a, b).s, P_ALL_ONE, acc(a, b).s);
+                }
             }
         }
 
@@ -298,6 +310,32 @@ struct jit_int8_matmul_kernel_t : public jit_generator_t {
             const bool store_second_row
                     = !brg_.is_m_tail || (2 * a + 1) < brg_.m_tail;
             switch (brg_.dst_dt) {
+                case s32: {
+                    if (!can_store_s32_acc_directly) {
+                        init_saturate_f32(
+                                z31, z0, reg_aux_a, data_type::f32, s32);
+                    }
+
+                    auto store_s32 = [&](const ZReg &zreg, const XReg &dst,
+                                             const PReg &p, int vl) {
+                        if (!can_store_s32_acc_directly) {
+                            saturate_f32(zreg, z31, z0, s32, p);
+                            frinti(zreg.s, p, zreg.s);
+                            fcvtzs(zreg.s, p, zreg.s);
+                        }
+                        st1w(zreg.s, p, ptr(dst, vl, MUL_VL));
+                    };
+
+                    for (int b = 0; b < ldb; b += 2) {
+                        PReg p = (brg_.is_n_tail && b >= ldb - 2) ? prd_st
+                                                                  : P_ALL_ONE;
+                        const int vl = b / 2;
+                        store_s32(acc(a, b), reg_tmp, p, vl);
+                        if (store_second_row)
+                            store_s32(acc(a, b + 1), reg_tmp_1, p, vl);
+                    }
+                    break;
+                }
                 case f32:
                     for (int b = 0; b < ldb; b += 2) {
                         PReg p = (brg_.is_n_tail && b >= ldb - 2) ? prd_st
@@ -943,7 +981,7 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
     };
 
     const bool problem_dt_correct = (is_s8 || is_u8 || is_u8_s8)
-            && utils::one_of(dst_type, f32, bf16)
+            && utils::one_of(dst_type, f32, bf16, s32)
             && platform::has_data_type_support(dst_type);
 
     VDISPATCH_MATMUL(problem_dt_correct, VERBOSE_UNSUPPORTED_DT);


### PR DESCRIPTION
# Description

This enables s8:s8:s32 matmul

Tests already included in `./benchdnn/inputs/matmul/test_matmul_int8`

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

Threads=8, Matmul dims: m=n=k=1024

| gemm:jit avg time (ms) | jit:int8 avg time (ms) | Speedup |
|---:|---:|---:|
| 24.6715 | 0.51798 | **47.63x** |

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
