### PR TITLE
cpu: aarch64: remove X_TRANSLATOR_STACK register

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
@@ -20,11 +20,8 @@
 
 #include "common/c_types_map.hpp"
 #include "common/nstl.hpp"
-#include "common/type_helpers.hpp"
-#include "common/utils.hpp"
 
 #include "cpu/aarch64/brgemm/brgemm_types.hpp"
-#include "cpu/aarch64/cpu_barrier.hpp"
 #include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
 
@@ -170,15 +167,13 @@ private:
         if ((ld_idx < idx) && (idx <= dsc_idx)) {
             is_push = false;
         } else {
-            str(z_tmp, ptr(X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+            str(z_tmp, ptr(X_SP, -1, Xbyak_aarch64::MUL_VL));
             is_push = true;
         }
         return z_tmp;
     }
     void pop_z_tmp(Xbyak_aarch64::ZReg z_tmp) {
-        if (is_push) {
-            ldr(z_tmp, ptr(X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
-        }
+        if (is_push) { ldr(z_tmp, ptr(X_SP, -1, Xbyak_aarch64::MUL_VL)); }
     }
 
     void init_masks();

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2025, 2026 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 *******************************************************************************/
 
 #include "cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp"
-#include "cpu/aarch64/jit_brgemm_conv_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -73,12 +72,12 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::store_accumulators(
     if (jcp_.src_zero_point) {
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
-            str(vmm_zp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            str(vmm_zp_shift, ptr(X_SP, -1, MUL_VL));
 
             auto vmm = accum(n_block, m, n);
             auto vmm_tmp = vmm_tmp_1();
             auto vmm_zp = vmm_zp_shift;
-            ldr(vmm_tmp, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            ldr(vmm_tmp, ptr(X_SP, -1, MUL_VL));
             add_imm(X_DEFAULT_ADDR, reg_zp_comp_out, out_oc_offset(n), X_TMP_0);
             ldr(vmm_zp, ptr(X_DEFAULT_ADDR));
 
@@ -86,19 +85,19 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::store_accumulators(
             add(vmm_tmp.s, vmm_tmp.s, vmm_zp.s);
             st1w(vmm_tmp.s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
 
-            ldr(vmm_zp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            ldr(vmm_zp_shift, ptr(X_SP, -1, MUL_VL));
         }
     }
 
     if (jcp_.s8s8_compensation_required) {
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
-            str(vmm_cp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            str(vmm_cp_shift, ptr(X_SP, -1, MUL_VL));
 
             auto vmm = accum(n_block, m, n);
             auto vmm_tmp = vmm_tmp_1();
             auto vmm_zp = vmm_cp_shift;
-            ldr(vmm_tmp, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            ldr(vmm_tmp, ptr(X_SP, -1, MUL_VL));
             add_imm(X_DEFAULT_ADDR, reg_comp_out, out_oc_offset(n), X_TMP_0);
             ldr(vmm_zp, ptr(X_DEFAULT_ADDR));
 
@@ -106,7 +105,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::store_accumulators(
             add(vmm_tmp.s, vmm_tmp.s, vmm_zp.s);
             st1w(vmm_tmp.s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
 
-            ldr(vmm_cp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            ldr(vmm_cp_shift, ptr(X_SP, -1, MUL_VL));
         }
     }
 }

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -173,7 +173,6 @@ public:
     const Xbyak_aarch64::XReg X_TMP_4 = x27;
     const Xbyak_aarch64::XReg X_DEFAULT_ADDR = x28;
     const Xbyak_aarch64::XReg X_SP = x21;
-    const Xbyak_aarch64::XReg X_TRANSLATOR_STACK = x22;
     const Xbyak_aarch64::PReg P_TMP = p7;
     const Xbyak_aarch64::PReg P_TMP_0 = p11;
     const Xbyak_aarch64::PReg P_TMP_1 = p12;
@@ -187,7 +186,6 @@ public:
     const int x_tmp_vec_size = x_tmp_vec.size();
 
     const Xbyak_aarch64::XReg param1 = abi_param1;
-    constexpr static size_t translator_stack_offset = 1024 * 128;
     constexpr static uint32_t DUMMY_IDX = 99;
 
     inline size_t get_size_of_abi_save_regs() const {
@@ -230,7 +228,6 @@ public:
         }
 
         mov(X_SP, sp);
-        sub_imm(X_TRANSLATOR_STACK, X_SP, translator_stack_offset, X_TMP_0);
     }
 
     void postamble() {

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
@@ -19,19 +19,15 @@
 #include <float.h>
 
 #include "common/c_types_map.hpp"
-#include "common/dnnl_thread.hpp"
-#include "common/memory.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/nstl.hpp"
-#include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
-#include "cpu/aarch64/cpu_barrier.hpp"
 #include "cpu/platform.hpp"
 
 #include "cpu/aarch64/injectors/injector_utils.hpp"
 #include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
-#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
+#include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/aarch64/jit_sve_1x1_conv_kernel.hpp"
 #include "cpu/aarch64/jit_uni_1x1_conv_utils.hpp"
 
@@ -502,14 +498,14 @@ void jit_sve_1x1_conv_kernel_t<isa>::generate() {
     if (load_dim_tail) {
         const WReg w_tmp(reg_load_dim_tail_mask.getIdx());
         mov_imm(w_tmp, (1 << load_dim_tail) - 1);
-        st1w(zreg_tmp1.s, P_ALL_ONE / T_z, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+        st1w(zreg_tmp1.s, P_ALL_ONE / T_z, ptr(X_SP, -1, MUL_VL));
         index(zreg_tmp.s, 0, 1);
         mov(zreg_tmp1.s, 1);
         lsl(zreg_tmp1.s, P_ALL_ONE / T_m, zreg_tmp.s);
         dup(zreg_tmp.s, w_tmp);
         and_(zreg_tmp.d, zreg_tmp.d, zreg_tmp1.d);
         cmpne(k_load_dim_tail_mask.s, P_ALL_ONE, zreg_tmp.s, 0);
-        ldr(zreg_tmp1, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+        ldr(zreg_tmp1, ptr(X_SP, -1, MUL_VL));
     }
 
     auto load_loop_body = [=](int load_loop_blk) {

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2020-2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#include "cpu/aarch64/jit_uni_i8i8_pooling.hpp"
-#include <math.h>
+
+#include <cmath>
 
 #include "common/dnnl_thread.hpp"
 #include "common/utils.hpp"
 
 #include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_uni_i8i8_pooling.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -610,15 +611,15 @@ template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::init_mask() {
     using namespace data_type;
 
-    sub(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 8 * max_num_ll);
+    sub(X_SP, X_SP, 8 * max_num_ll);
 
     for (int ll = 0; ll < max_num_ll; ll++) {
         mov_imm(reg_mask, jpp.tail[ll]);
-        str(reg_mask, ptr(X_TRANSLATOR_STACK, 8 * ll));
+        str(reg_mask, ptr(X_SP, 8 * ll));
     }
     for (int ll = 0; ll < max_num_ll; ll++) {
-        ldr(PReg(mask(ll)), ptr(X_TRANSLATOR_STACK));
-        add(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 8);
+        ldr(PReg(mask(ll)), ptr(X_SP));
+        add(X_SP, X_SP, 8);
     }
 }
 

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -17,10 +17,11 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <cstdint>
+
 #include "common/dnnl_thread.hpp"
 #include "common/pooling_pd.hpp"
 
-#include <cstdint>
 #include "cpu/aarch64/jit_uni_pool_kernel.hpp"
 
 #include "xbyak_aarch64/xbyak_aarch64_util.h"
@@ -512,8 +513,8 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
     }
 
     if (jpp.simple_alg && jpp.ndims == 5) {
-        str(reg_input, pre_ptr(X_TRANSLATOR_STACK, -8));
-        str(reg_output, pre_ptr(X_TRANSLATOR_STACK, -8));
+        str(reg_input, pre_ptr(X_SP, -8));
+        str(reg_output, pre_ptr(X_SP, -8));
 
         mov(aux_reg_input_d, reg_input);
         ldr(ki, ptr(reg_param, GET_OFF(kd_padding)));
@@ -572,8 +573,8 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
         subs(ki, ki, 1);
         cmp(ki, 0);
         b(GT, kd_label);
-        ldr(reg_output, post_ptr(X_TRANSLATOR_STACK, 8));
-        ldr(reg_input, post_ptr(X_TRANSLATOR_STACK, 8));
+        ldr(reg_output, post_ptr(X_SP, 8));
+        ldr(reg_input, post_ptr(X_SP, 8));
     }
 
     if (!jpp.is_backward) {
@@ -633,9 +634,9 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     }
     if (jpp.is_training) dup(vmm_k_offset, reg_k_shift);
     if (jpp.ndims == 5) {
-        str(reg_input, pre_ptr(X_TRANSLATOR_STACK, -8));
+        str(reg_input, pre_ptr(X_SP, -8));
 
-        str(reg_output, pre_ptr(X_TRANSLATOR_STACK, -8));
+        str(reg_output, pre_ptr(X_SP, -8));
         mov(aux_reg_input_d, reg_input);
         ldr(ki, ptr(reg_param, GET_OFF(kd_padding)));
         L(kd_label);
@@ -689,8 +690,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
         subs(ki, ki, 1);
         cmp(ki, 0);
         b(GT, kd_label);
-        ldr(reg_output, post_ptr(X_TRANSLATOR_STACK, 8));
-        ldr(reg_input, post_ptr(X_TRANSLATOR_STACK, 8));
+        ldr(reg_output, post_ptr(X_SP, 8));
+        ldr(reg_input, post_ptr(X_SP, 8));
     }
 
     if (jpp.with_postops)
@@ -774,8 +775,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
     dup(vmm_k_offset, reg_k_shift);
 
     if (jpp.simple_alg && jpp.ndims == 5) {
-        str(reg_input, pre_ptr(X_TRANSLATOR_STACK, -8));
-        str(reg_output, pre_ptr(X_TRANSLATOR_STACK, -8));
+        str(reg_input, pre_ptr(X_SP, -8));
+        str(reg_output, pre_ptr(X_SP, -8));
         mov(aux_reg_input_d, reg_input);
 
         ldr(ki, ptr(reg_param, GET_OFF(kd_padding)));
@@ -828,8 +829,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
         subs(ki, ki, 1);
         cmp(ki, 0);
         b(GT, kd_label);
-        ldr(reg_output, post_ptr(X_TRANSLATOR_STACK, 8));
-        ldr(reg_input, post_ptr(X_TRANSLATOR_STACK, 8));
+        ldr(reg_output, post_ptr(X_SP, 8));
+        ldr(reg_input, post_ptr(X_SP, 8));
     }
 }
 

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -642,9 +642,9 @@ void jit_softmax_sve_t::backward() {
 
 void jit_softmax_sve_t::prepare_mask() {
     if (simd_w_ > cpu_isa_traits<sve_128>::vlen / sizeof(float)) {
-        sub_imm(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 64 * 2, X_TMP_0);
-        str(p_shuff0, ptr(X_TRANSLATOR_STACK, 0, MUL_VL));
-        str(p_shuff1, ptr(X_TRANSLATOR_STACK, 1, MUL_VL));
+        sub_imm(X_SP, X_SP, 64 * 2, X_TMP_0);
+        str(p_shuff0, ptr(X_SP, 0, MUL_VL));
+        str(p_shuff1, ptr(X_SP, 1, MUL_VL));
         not_(P_TMP_1.b, P_ALL_ONE, P_ALL_ONE.b);
         trn1(p_shuff0.d, P_ALL_ONE.d, P_TMP_1.d);
         trn1(p_shuff0.d, p_shuff0.d, p_shuff0.d);
@@ -656,9 +656,9 @@ void jit_softmax_sve_t::prepare_mask() {
 }
 
 void jit_softmax_sve_t::restore_mask() {
-    ldr(p_shuff0, ptr(X_TRANSLATOR_STACK, 0, MUL_VL));
-    ldr(p_shuff1, ptr(X_TRANSLATOR_STACK, 1, MUL_VL));
-    add_imm(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 64 * 2, X_TMP_0);
+    ldr(p_shuff0, ptr(X_SP, 0, MUL_VL));
+    ldr(p_shuff1, ptr(X_SP, 1, MUL_VL));
+    add_imm(X_SP, X_SP, 64 * 2, X_TMP_0);
 }
 
 void jit_softmax_sve_t::generate() {

--- a/src/cpu/aarch64/utils/jit_io_helper.cpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.cpp
@@ -438,7 +438,7 @@ static void load_bytes(jit_generator *host, const Xbyak_aarch64::VReg &vmm,
     if (load_size > 16) {
         host->str(host->z31,
                 Xbyak_aarch64::ptr(
-                        host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+                        host->X_SP, -1, Xbyak_aarch64::MUL_VL));
         const Xbyak_aarch64::ZReg z_vmm(vmm.getIdx());
         const Xbyak_aarch64::ZReg z_tmp(host->z31.getIdx());
         host->ptrue(host->P_TMP.d, Xbyak_aarch64::VL2);
@@ -453,7 +453,7 @@ static void load_bytes(jit_generator *host, const Xbyak_aarch64::VReg &vmm,
         host->mov(z_vmm.s, host->P_NOT_256 / Xbyak_aarch64::T_m, 0);
         host->ldr(host->z31,
                 Xbyak_aarch64::ptr(
-                        host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+                        host->X_SP, -1, Xbyak_aarch64::MUL_VL));
     }
 }
 
@@ -487,7 +487,7 @@ static void load_bytes_to_dword_extension(jit_generator *host,
     }
     host->str(host->z31,
             Xbyak_aarch64::ptr(
-                    host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+                    host->X_SP, -1, Xbyak_aarch64::MUL_VL));
     // For load_size == 8/4, do load/extension in one go
     const Xbyak_aarch64::ZReg z_tmp(host->z31.getIdx());
     if (load_size == 8) {
@@ -528,7 +528,7 @@ static void load_bytes_to_dword_extension(jit_generator *host,
     }
     host->ldr(host->z31,
             Xbyak_aarch64::ptr(
-                    host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+                    host->X_SP, -1, Xbyak_aarch64::MUL_VL));
 }
 template <typename Vmm>
 void load_data(jit_generator *host, data_type_t type_in, const Vmm &vmm,
@@ -867,16 +867,14 @@ void jit_io_helper_t<Vmm>::store_i8_sdb(Xbyak_aarch64::XReg addr,
         const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
     UNUSED(tail);
     host_->str(host_->z31,
-            Xbyak_aarch64::ptr(
-                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
     const Xbyak_aarch64::ZReg z_tmp(host_->z31.getIdx());
     host_->mov(z_tmp.d, Xbyak_aarch64::ZRegD(src_vmm.getIdx()));
     host_->smin(z_tmp.s, 127);
     host_->smax(z_tmp.s, -128);
     host_->st1b(z_tmp.s, mask, Xbyak_aarch64::ptr(addr));
     host_->ldr(host_->z31,
-            Xbyak_aarch64::ptr(
-                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
 }
 
 template <>
@@ -931,15 +929,13 @@ void jit_io_helper_t<Vmm>::store_i8_udb(Xbyak_aarch64::XReg addr,
         const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
     UNUSED(tail);
     host_->str(host_->z31,
-            Xbyak_aarch64::ptr(
-                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
     const Xbyak_aarch64::ZReg z_tmp(host_->z31.getIdx());
     host_->mov(z_tmp.d, Xbyak_aarch64::ZRegD(src_vmm.getIdx()));
     host_->umin(z_tmp.s, 255);
     host_->st1b(z_tmp.s, mask, Xbyak_aarch64::ptr(addr));
     host_->ldr(host_->z31,
-            Xbyak_aarch64::ptr(
-                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
 }
 
 template <typename Vmm>


### PR DESCRIPTION
# Description

This removes a confusing, extra stack-tracking register and frees it up for general-purpose use.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?