### PR TITLE
[backport] Handle K-tail descriptor case in BRGEMM exec_trans and add regression test

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -576,7 +576,13 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     if (jcp_.N > 0) Nv.push_back(false);
     if (has_N_tail) Nv.push_back(true);
 
-    const auto has_K_tail = jcp_.K_tail > 0 && jcp_.K_tail != jcp_.K;
+    // exec_trans may still require an is_K_tail kernel even when K_tail == K,
+    // because the last-IC-block path is keyed by the K-tail variant.
+    const auto has_K_tail = jcp_.K_tail > 0
+            && (jcp_.K_tail != jcp_.K
+                    || (jcp_.exec_type == exec_trans
+                            && jcp_.K_tail == jcp_.ic_block));
+
     std::vector<bool> Kv;
     if (jcp_.K > 0) Kv.push_back(false);
     if (has_K_tail) Kv.push_back(true);

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -447,3 +447,8 @@ mb1_ic1oc1_ih32oh16kh2sh2dh0ph0_iw64ow64kw4sw1dw0pw1
 --reset
 --dt=u8:s8:u8 --attr-zero-points=src:per_oc
 g960mb32ic960ih7oc960oh7kh5ph2
+
+# BRGEMM-based exec_trans case with IC tail and K_tail == ic_block
+--reset
+--dt=bf16:bf16:bf16 --dir=FWD_I
+g1mb1ic48ih10iw1oc48kh128kw1ph64pw0


### PR DESCRIPTION
This is a backport of #5259 :

This PR fixes [MFDNN-15008](https://jira.devtools.intel.com/browse/MFDNN-15008) by updating BRGEMM convolution kernel selection logic and adds a new regression test to cover this scenario. The main focus is ensuring that kernels for the K-tail path are generated correctly, even in certain edge cases, and validating this with an appropriate test.

Kernel selection logic improvements:

Updated the logic in jit_brgemm_conv.cpp to ensure that the K-tail kernel is generated when required by the exec_trans execution type, even if K_tail == K, specifically when K_tail == ic_block. This addresses a subtle edge case where the last-IC-block path needs a K-tail variant.
Test coverage:

Added a new test case to harness_conv_regression_general to exercise the BRGEMM-based exec_trans scenario with an IC tail and K_tail == ic_block, ensuring this path is validated in regression testing.
