### PR TITLE
[GPU] More threads/EU changes

### DIFF
--- a/src/gpu/intel/bnorm/lookup_table.hpp
+++ b/src/gpu/intel/bnorm/lookup_table.hpp
@@ -22,6 +22,7 @@
 #include <unordered_map>
 
 #include "gpu/intel/bnorm/config.hpp"
+#include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/config.hpp"
 
 namespace dnnl {

--- a/src/gpu/intel/bnorm/model.cpp
+++ b/src/gpu/intel/bnorm/model.cpp
@@ -93,7 +93,7 @@ void init_hw_params(hw_params_t &hw_params, impl::engine_t *engine) {
     hw_params.eus_per_ss = device_info.max_eus_per_wg();
     hw_params.max_ss = div_up(hw_params.eu_count, hw_params.eus_per_ss);
     hw_params.max_slm_size
-            = compute::device_info_t::max_slm_size(device_info.gpu_product());
+            = compute::device_info_t::max_slm_size(device_info.product());
     hw_params.engine = engine;
 
     // Experimentally selected, based on microbenchmarks results

--- a/src/gpu/intel/bnorm/model.cpp
+++ b/src/gpu/intel/bnorm/model.cpp
@@ -85,15 +85,15 @@ dim_t get_nhwc_calc_stat_ic(dim_t ic, int ic_block, int sg_size) {
 
 void init_hw_params(hw_params_t &hw_params, impl::engine_t *engine) {
     auto *intel_engine = downcast<intel::engine_t *>(engine);
-    auto gpu_arch = intel_engine->device_info()->gpu_arch();
-    hw_params.gpu_arch = gpu_arch;
-    hw_params.eu_count = intel_engine->device_info()->eu_count();
-    hw_params.threads_per_eu = compute::device_info_t::threads_per_eu(gpu_arch);
-    hw_params.max_lws = intel_engine->device_info()->max_wg_size();
-    hw_params.eus_per_ss = intel_engine->device_info()->max_eus_per_wg();
+    auto &device_info = *intel_engine->device_info();
+    hw_params.gpu_arch = device_info.gpu_arch();
+    hw_params.eu_count = device_info.eu_count();
+    hw_params.threads_per_eu = device_info.threads_per_eu();
+    hw_params.max_lws = device_info.max_wg_size();
+    hw_params.eus_per_ss = device_info.max_eus_per_wg();
     hw_params.max_ss = div_up(hw_params.eu_count, hw_params.eus_per_ss);
-    hw_params.max_slm_size = compute::device_info_t::max_slm_size(
-            intel_engine->device_info()->gpu_product());
+    hw_params.max_slm_size
+            = compute::device_info_t::max_slm_size(device_info.gpu_product());
     hw_params.engine = engine;
 
     // Experimentally selected, based on microbenchmarks results

--- a/src/gpu/intel/bnorm/nhwc.cpp
+++ b/src/gpu/intel/bnorm/nhwc.cpp
@@ -55,7 +55,7 @@ static void adjust_lws_calc_kernel(int ic_block, nhwc_params_t &conf,
     auto eus_per_ss = intel_engine->device_info()->max_eus_per_wg();
     const int max_ss = div_up(eu_count, eus_per_ss);
     const int max_slm_size = compute::device_info_t::max_slm_size(
-            intel_engine->device_info()->gpu_product());
+            intel_engine->device_info()->product());
 
     auto generated_nd = dispatch.nd_range();
     const compute::range_t &base_gws = generated_nd.global_range();

--- a/src/gpu/intel/bnorm/xe.cpp
+++ b/src/gpu/intel/bnorm/xe.cpp
@@ -67,7 +67,7 @@ static void adjust_lws_calc_kernel(lookup_table::params_t &conf,
     const int max_ss = div_up(eu_count, eus_per_ss);
 
     const int max_slm_size = compute::device_info_t::max_slm_size(
-            intel_engine->device_info()->gpu_product());
+            intel_engine->device_info()->product());
     auto generated_nd = dispatch.nd_range();
     const compute::range_t &base_gws = generated_nd.global_range();
     const compute::range_t &base_lws = generated_nd.local_range();

--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -247,21 +247,24 @@ size_t device_info_t::max_wg_size(
     return device_max_wg_size;
 }
 
-int device_info_t::grf_per_eu(gpu_arch_t gpu_arch) {
-    switch (gpu_arch) {
-        case gpu::intel::compute::gpu_arch_t::xe_lp: return 896;
-        case gpu::intel::compute::gpu_arch_t::xe_hp:
-        case gpu::intel::compute::gpu_arch_t::xe_hpg:
-        case gpu::intel::compute::gpu_arch_t::xe_hpc:
-        case gpu::intel::compute::gpu_arch_t::xe2:
-        case gpu::intel::compute::gpu_arch_t::xe3p:
-        case gpu::intel::compute::gpu_arch_t::xe3: return 1024;
-        case gpu::intel::compute::gpu_arch_t::unknown: return 896;
+namespace {
+int grf_per_eu(const ngen::Product &product) {
+    ngen::HW hw = ngen::getCore(product.family);
+    switch (hw) {
+        case ngen::HW::XeLP: return 896;
+        case ngen::HW::XeHP:
+        case ngen::HW::XeHPG:
+        case ngen::HW::XeHPC:
+        case ngen::HW::Xe2:
+        case ngen::HW::Xe3: return 1024;
+        case ngen::HW::Xe3p:
+            return product.family == ngen::ProductFamily::CRI ? 2048 : 1024;
+        case ngen::HW::Unknown: return 896;
+        default: gpu_error_not_expected();
     }
     return 1024;
 }
 
-namespace {
 int max_threads_per_eu(const ngen::Product &product) {
     ngen::HW hw = ngen::getCore(product.family);
     gpu_arch_t arch = jit::convert_ngen_arch_to_dnnl(hw);
@@ -285,10 +288,8 @@ int max_threads_per_eu(const ngen::Product &product) {
 int device_info_t::threads_per_eu(
         const ngen::Product &product, int grf_per_thread) {
     gpu_assert(grf_per_thread > 0) << "Invalid GRF per thread";
-    ngen::HW hw = ngen::getCore(product.family);
-    gpu_arch_t arch = jit::convert_ngen_arch_to_dnnl(hw);
     int hw_max = max_threads_per_eu(product);
-    return std::min(hw_max, grf_per_eu(arch) / grf_per_thread);
+    return std::min(hw_max, grf_per_eu(product) / grf_per_thread);
 }
 
 int device_info_t::max_slm_size(const ngen::Product &product) {

--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -65,6 +65,8 @@ uint64_t get_future_extensions(
     return extensions;
 }
 
+device_info_t::~device_info_t() = default;
+
 status_t device_info_t::init(
         impl::engine_t *engine, const std::vector<uint8_t> &cache_blob) {
     if (!cache_blob.empty()) {
@@ -88,25 +90,16 @@ status_t device_info_t::init(
     return status::success;
 }
 
-const ngen::Product &device_info_t::ngen_product(const gpu_product_t &product) {
-    static_assert(sizeof(ngen::Product) == sizeof(compute::gpu_product_t),
-            "Can't cast gpu_product_t to ngen::Product");
-    return reinterpret_cast<const ngen::Product &>(product);
-}
-
 ngen::HW device_info_t::ngen_hw() const {
-    ngen::Product p = jit::get_ngen_product(*this);
-    return ngen::getCore(p.family);
+    return ngen::getCore(product_->family);
 }
 
 int device_info_t::stepping_id() const {
-    ngen::Product p = jit::get_ngen_product(*this);
-    return p.stepping;
+    return product_->stepping;
 }
 
 bool device_info_t::is_integrated() const {
-    ngen::Product p = jit::get_ngen_product(*this);
-    return p.type == ngen::PlatformType::Integrated;
+    return product_->type == ngen::PlatformType::Integrated;
 }
 
 std::string device_info_t::get_cl_ext_options() const {
@@ -290,17 +283,16 @@ int max_threads_per_eu(const ngen::Product &product) {
 } // namespace
 
 int device_info_t::threads_per_eu(
-        const gpu_product_t &product, int grf_per_thread) {
+        const ngen::Product &product, int grf_per_thread) {
     gpu_assert(grf_per_thread > 0) << "Invalid GRF per thread";
-    const ngen::Product &ngen_product = device_info_t::ngen_product(product);
-    ngen::HW hw = ngen::getCore(ngen_product.family);
+    ngen::HW hw = ngen::getCore(product.family);
     gpu_arch_t arch = jit::convert_ngen_arch_to_dnnl(hw);
-    int hw_max = max_threads_per_eu(ngen_product);
+    int hw_max = max_threads_per_eu(product);
     return std::min(hw_max, grf_per_eu(arch) / grf_per_thread);
 }
 
-int device_info_t::max_slm_size(gpu_product_t product) {
-    auto family = ngen_product(product).family;
+int device_info_t::max_slm_size(const ngen::Product &product) {
+    auto family = product.family;
     auto gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(family));
     int slm_size = 0; // SLM size per SS or DSS.
     switch (gpu_arch) {
@@ -321,9 +313,9 @@ int device_info_t::max_slm_size(gpu_product_t product) {
     return slm_size;
 }
 
-int device_info_t::max_slm_size_per_tg(gpu_product_t product) {
-    auto gpu_arch = jit::convert_ngen_arch_to_dnnl(
-            ngen::getCore(ngen_product(product).family));
+int device_info_t::max_slm_size_per_tg(const ngen::Product &product) {
+    auto gpu_arch
+            = jit::convert_ngen_arch_to_dnnl(ngen::getCore(product.family));
     switch (gpu_arch) {
         case gpu::intel::compute::gpu_arch_t::xe_hp:
         case gpu::intel::compute::gpu_arch_t::xe_hpg: return (1 << 16);
@@ -332,8 +324,8 @@ int device_info_t::max_slm_size_per_tg(gpu_product_t product) {
 }
 
 int device_info_t::max_slm_size_per_tg(
-        int tg_size, int grf_per_thread, gpu_product_t product) {
-    ngen::HW hw = ngen::getCore(ngen_product(product).family);
+        int tg_size, int grf_per_thread, const ngen::Product &product) {
+    ngen::HW hw = ngen::getCore(product.family);
     auto gpu_arch = jit::convert_ngen_arch_to_dnnl(hw);
     int eus_per_ss = max_eus_per_wg(gpu_arch);
     int tgs_per_ss
@@ -385,7 +377,8 @@ status_t device_info_t::init_serialized_device_info(
     }
 
     serialized_device_info_.append(gpu_arch_);
-    serialized_device_info_.append(gpu_product_);
+    serialized_device_info_.append(product_ != nullptr);
+    if (product_) serialized_device_info_.append(*product_);
     serialized_device_info_.append(ip_version_);
     serialized_device_info_.append(runtime_version_.major);
     serialized_device_info_.append(runtime_version_.minor);
@@ -421,7 +414,10 @@ status_t device_info_t::init_from_cache_blob(
     deserializer_t d(s);
 
     d.pop(gpu_arch_);
-    d.pop(gpu_product_);
+    auto hadProduct = d.pop<bool>();
+    if (hadProduct) {
+        product_ = utils::make_unique<ngen::Product>(d.pop<ngen::Product>());
+    }
     d.pop(ip_version_);
     d.pop(runtime_version_.major);
     d.pop(runtime_version_.minor);
@@ -457,11 +453,6 @@ void device_info_t::fixup_l3_cache_size() {
         l3_cache_size_ = (1 << 23);
     }
 }
-
-static_assert(std::is_trivially_copyable<ngen::Product>(),
-        "ngen::Product cannot safely be copied into gpu_product_t");
-static_assert(sizeof(ngen::Product) == sizeof(compute::gpu_product_t),
-        "ngen::Product cannot safely be copied into gpu_product_t");
 
 } // namespace compute
 } // namespace intel

--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -243,8 +243,8 @@ int device_info_t::max_subgroup_size(data_type_t type) const {
 size_t device_info_t::max_wg_size(
         int grf_per_thread, size_t subgroup_size) const {
     // max_wg_size_ implicitly assumes 128 GRF/thread - other GRF modes will vary
-    size_t thread_per_eu = threads_per_eu(gpu_arch_, grf_per_thread);
-    size_t base_thread_per_eu = threads_per_eu(gpu_arch_, 128);
+    size_t thread_per_eu = threads_per_eu(grf_per_thread);
+    size_t base_thread_per_eu = threads_per_eu(128);
     size_t device_max_wg_size
             = max_wg_size_ * thread_per_eu / base_thread_per_eu;
     if (subgroup_size > 0) {
@@ -268,9 +268,35 @@ int device_info_t::grf_per_eu(gpu_arch_t gpu_arch) {
     return 1024;
 }
 
-int device_info_t::threads_per_eu(gpu_arch_t gpu_arch, int grf_per_thread) {
+namespace {
+int max_threads_per_eu(const ngen::Product &product) {
+    ngen::HW hw = ngen::getCore(product.family);
+    gpu_arch_t arch = jit::convert_ngen_arch_to_dnnl(hw);
+    using namespace gpu::intel::compute;
+    switch (arch) {
+        case gpu_arch_t::xe_lp: return 7;
+        case gpu_arch_t::xe_hp:
+        case gpu_arch_t::xe_hpg:
+        case gpu_arch_t::xe_hpc:
+        case gpu_arch_t::xe2:
+        case gpu_arch_t::xe3: return 8;
+        case gpu_arch_t::xe3p:
+            return product.family == ngen::ProductFamily::NVLP ? 10 : 8;
+        case gpu_arch_t::unknown: return 8;
+    }
+    gpu_error_not_expected();
+    return 8;
+}
+} // namespace
+
+int device_info_t::threads_per_eu(
+        const gpu_product_t &product, int grf_per_thread) {
     gpu_assert(grf_per_thread > 0) << "Invalid GRF per thread";
-    return grf_per_eu(gpu_arch) / grf_per_thread;
+    const ngen::Product &ngen_product = device_info_t::ngen_product(product);
+    ngen::HW hw = ngen::getCore(ngen_product.family);
+    gpu_arch_t arch = jit::convert_ngen_arch_to_dnnl(hw);
+    int hw_max = max_threads_per_eu(ngen_product);
+    return std::min(hw_max, grf_per_eu(arch) / grf_per_thread);
 }
 
 int device_info_t::max_slm_size(gpu_product_t product) {
@@ -307,11 +333,11 @@ int device_info_t::max_slm_size_per_tg(gpu_product_t product) {
 
 int device_info_t::max_slm_size_per_tg(
         int tg_size, int grf_per_thread, gpu_product_t product) {
-    auto gpu_arch = jit::convert_ngen_arch_to_dnnl(
-            ngen::getCore(ngen_product(product).family));
+    ngen::HW hw = ngen::getCore(ngen_product(product).family);
+    auto gpu_arch = jit::convert_ngen_arch_to_dnnl(hw);
     int eus_per_ss = max_eus_per_wg(gpu_arch);
     int tgs_per_ss
-            = eus_per_ss * threads_per_eu(gpu_arch, grf_per_thread) / tg_size;
+            = eus_per_ss * threads_per_eu(product, grf_per_thread) / tg_size;
     int slm_per_tg = max_slm_size(product) / tgs_per_ss;
     return std::min(max_slm_size_per_tg(product), slm_per_tg);
 }

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -75,20 +75,6 @@ static inline const char *to_string(gpu_arch_t arch) {
 #undef CASE
 }
 
-static inline gpu_arch_t str2gpu_arch(const char *str) {
-#define CASE(_case) \
-    if (!strcmp(STRINGIFY(_case), str)) return gpu_arch_t::_case
-    CASE(xe_lp);
-    CASE(xe_hp);
-    CASE(xe_hpg);
-    CASE(xe_hpc);
-    CASE(xe2);
-    CASE(xe3);
-    CASE(xe3p);
-    return gpu_arch_t::unknown;
-#undef CASE
-}
-
 enum class device_ext_t : uint64_t {
     // clang-format off
     // OpenCL data types

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -23,12 +23,8 @@
 
 #include "common/c_types_map.hpp"
 #include "common/serialization.hpp"
-#include "common/utils.hpp"
 #include "common/z_magic.hpp"
-
 #include "xpu/utils.hpp"
-
-#include "oneapi/dnnl/dnnl_config.h"
 
 // NOLINTBEGIN(readability-identifier-naming)
 namespace ngen {
@@ -197,10 +193,14 @@ public:
             int grf_per_thread = 128, size_t subgroup_size = 0) const;
     int eu_count() const { return eu_count_; }
     int hw_threads(int grf_per_thread = 128) const {
-        return eu_count_ * threads_per_eu(gpu_arch_, grf_per_thread);
+        return eu_count_ * threads_per_eu(gpu_product_, grf_per_thread);
     }
     static int grf_per_eu(gpu_arch_t gpu_arch);
-    static int threads_per_eu(gpu_arch_t gpu_arch, int grf_per_thread = 128);
+    static int threads_per_eu(
+            const gpu_product_t &product, int grf_per_thread = 128);
+    int threads_per_eu(int grf_per_thread = 128) const {
+        return threads_per_eu(gpu_product_, grf_per_thread);
+    }
     static int max_slm_size(gpu_product_t product);
     static int max_slm_size_per_tg(gpu_product_t product);
     static int max_slm_size_per_tg(

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -24,6 +24,7 @@
 #include "common/c_types_map.hpp"
 #include "common/serialization.hpp"
 #include "common/z_magic.hpp"
+#include "gpu/intel/utils.hpp"
 #include "xpu/utils.hpp"
 
 // NOLINTBEGIN(readability-identifier-naming)
@@ -49,12 +50,6 @@ enum class gpu_arch_t {
     xe2,
     xe3,
     xe3p,
-};
-
-// Memory for storing ngen::Product to avoid directly including nGEN because of
-// header dependencies outside of src/gpu/intel.
-struct alignas(int) gpu_product_t {
-    unsigned char data[12];
 };
 
 static inline const char *to_string(gpu_arch_t arch) {
@@ -159,7 +154,7 @@ uint64_t get_future_extensions(
 
 struct device_info_t {
 public:
-    virtual ~device_info_t() = default;
+    virtual ~device_info_t();
 
     status_t init(impl::engine_t *engine,
             const std::vector<uint8_t> &cache_blob = {});
@@ -171,8 +166,10 @@ public:
         return native_extensions_ & (uint64_t)ext;
     }
     gpu_arch_t gpu_arch() const { return gpu_arch_; }
-    const gpu_product_t &gpu_product() const { return gpu_product_; }
-    static const ngen::Product &ngen_product(const gpu_product_t &product);
+    const ngen::Product &product() const {
+        gpu_assert(product_) << "Product information not available";
+        return *product_;
+    }
     ngen::HW ngen_hw() const;
     int stepping_id() const;
     uint64_t native_extensions() const { return native_extensions_; }
@@ -193,18 +190,18 @@ public:
             int grf_per_thread = 128, size_t subgroup_size = 0) const;
     int eu_count() const { return eu_count_; }
     int hw_threads(int grf_per_thread = 128) const {
-        return eu_count_ * threads_per_eu(gpu_product_, grf_per_thread);
+        return eu_count_ * threads_per_eu(*product_, grf_per_thread);
     }
     static int grf_per_eu(gpu_arch_t gpu_arch);
     static int threads_per_eu(
-            const gpu_product_t &product, int grf_per_thread = 128);
+            const ngen::Product &product, int grf_per_thread = 128);
     int threads_per_eu(int grf_per_thread = 128) const {
-        return threads_per_eu(gpu_product_, grf_per_thread);
+        return threads_per_eu(*product_, grf_per_thread);
     }
-    static int max_slm_size(gpu_product_t product);
-    static int max_slm_size_per_tg(gpu_product_t product);
+    static int max_slm_size(const ngen::Product &product);
+    static int max_slm_size_per_tg(const ngen::Product &product);
     static int max_slm_size_per_tg(
-            int tg_size, int grf_per_thread, gpu_product_t product);
+            int tg_size, int grf_per_thread, const ngen::Product &product);
     size_t memory_size() const { return memory_size_; }
     size_t l3_cache_size() const { return l3_cache_size_; }
     size_t icache_size() const;
@@ -262,7 +259,7 @@ protected:
     virtual status_t init_attributes(impl::engine_t *engine) = 0;
 
     gpu_arch_t gpu_arch_ = compute::gpu_arch_t::unknown;
-    gpu_product_t gpu_product_ = {};
+    std::unique_ptr<ngen::Product> product_;
     uint32_t ip_version_ = 0;
     bool mayiuse_systolic_ = false;
     bool mayiuse_ngen_kernels_ = false;

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -192,7 +192,6 @@ public:
     int hw_threads(int grf_per_thread = 128) const {
         return eu_count_ * threads_per_eu(*product_, grf_per_thread);
     }
-    static int grf_per_eu(gpu_arch_t gpu_arch);
     static int threads_per_eu(
             const ngen::Product &product, int grf_per_thread = 128);
     int threads_per_eu(int grf_per_thread = 128) const {

--- a/src/gpu/intel/conv/jit/tiler.cpp
+++ b/src/gpu/intel/conv/jit/tiler.cpp
@@ -765,8 +765,7 @@ private:
         auto &options = cfg_.options();
         dim_t tg_size = ctx.b_tg * ctx.m_tg * ctx.n_tg * ctx.k_tg;
         int max_slm_size = compute::device_info_t::max_slm_size_per_tg(
-                into<int>(tg_size), options.regs(),
-                to_gpu_product(cfg_.hw().product()));
+                into<int>(tg_size), options.regs(), cfg_.hw().product());
         if (slm_size > max_slm_size) return false;
 
         return true;

--- a/src/gpu/intel/conv/jit/v2/plan.cpp
+++ b/src/gpu/intel/conv/jit/v2/plan.cpp
@@ -841,7 +841,7 @@ private:
                 << plan.str() << "\ncheck_plan: out of registers";
         int slm_bound = compute::device_info_t::max_slm_size_per_tg(
                 into<int>(desc_.thread_group_tile.elems()), desc_.regs,
-                to_gpu_product(hw_.product()));
+                hw_.product());
         int slm_bytes = plan.slm_usage_bytes();
         gpu_check(slm_bytes <= slm_bound)
                 << "Plan:\n"

--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -178,12 +178,10 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
             if (swap_ab) std::swap(stride_a, stride_b);
             auto stride_c = int64_t(pd()->desc()->stride_c(i));
             if (jit::enable_generator_dsl()) {
+                auto *intel_engine = utils::downcast<intel::engine_t *>(
+                        compute_stream->engine());
                 auto hw = ngen::getCore(
-                        ((ngen::Product *)&utils::downcast<intel::engine_t *>(
-                                 compute_stream->engine())
-                                        ->device_info()
-                                        ->gpu_product())
-                                ->family);
+                        intel_engine->device_info()->product().family);
 
                 // 2d Surface pointer needs to be 64 byte aligned. When negative
                 // bounds checking is unnecessary, this restriction can be

--- a/src/gpu/intel/gemm/jit/dsl/hw.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/hw.cpp
@@ -80,8 +80,27 @@ int hw_t::grf_per_eu() const {
         default: gpu_error_not_expected(); return 1024;
     }
 }
+
+namespace {
+int max_threads_per_eu(const ngen::Product product) {
+    auto family = product.family;
+    switch (getCore(family)) {
+        case ngen::HW::XeLP: return 7;
+        case ngen::HW::XeHP:
+        case ngen::HW::XeHPG:
+        case ngen::HW::XeHPC:
+        case ngen::HW::Xe2:
+        case ngen::HW::Xe3: return 8;
+        case ngen::HW::Xe3p: return family == ngen::ProductFamily::CRI ? 10 : 8;
+        default: gpu_error_not_expected();
+    }
+    return 8;
+}
+} // namespace
+
 int hw_t::threads_per_eu(int regs) const {
-    return grf_per_eu() / regs;
+    int max_threads = max_threads_per_eu(product());
+    return std::min(max_threads, grf_per_eu() / regs);
 }
 
 int hw_t::cache_line_size() const {

--- a/src/gpu/intel/gemm/jit/dsl/hw.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/hw.cpp
@@ -75,20 +75,23 @@ int hw_t::eus_per_core() const {
         default: gpu_error_not_expected(); return 8;
     }
 }
-int hw_t::grf_per_eu() const {
-    switch (hw_) {
+
+namespace {
+int grf_per_eu(const ngen::Product &product) {
+    ngen::HW hw = ngen::getCore(product.family);
+    switch (hw) {
         case ngen::HW::XeLP: return 896;
         case ngen::HW::XeHP:
         case ngen::HW::XeHPG:
         case ngen::HW::XeHPC:
         case ngen::HW::Xe2:
         case ngen::HW::Xe3:
-        case ngen::HW::Xe3p: return 1024;
+        case ngen::HW::Xe3p:
+            return product.family == ngen::ProductFamily::CRI ? 2048 : 1024;
         default: gpu_error_not_expected(); return 1024;
     }
 }
 
-namespace {
 int max_threads_per_eu(const ngen::Product product) {
     auto family = product.family;
     switch (getCore(family)) {
@@ -108,7 +111,7 @@ int max_threads_per_eu(const ngen::Product product) {
 
 int hw_t::threads_per_eu(int regs) const {
     int max_threads = max_threads_per_eu(product());
-    return std::min(max_threads, grf_per_eu() / regs);
+    return std::min(max_threads, grf_per_eu(product()) / regs);
 }
 
 int hw_t::cache_line_size() const {

--- a/src/gpu/intel/gemm/jit/dsl/hw.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/hw.cpp
@@ -23,18 +23,25 @@ namespace dsl {
 
 hw_t::hw_t(const ngen::Product &product, int eu_count, int max_wg_size,
         size_t l3_cache_size, attr_t attr)
-    : product_(product)
+    : product_(make_unique<ngen::Product>(product))
     , hw_(ngen::getCore(product.family))
     , eu_count_(eu_count)
     , max_wg_size_(max_wg_size)
     , l3_cache_size_(l3_cache_size)
     , attr_(attr) {}
 
-ngen::Product hw_t::product() const {
-    ngen::Product product;
-    std::memcpy(static_cast<void *>(&product),
-            static_cast<const void *>(&product_), sizeof(product));
-    return product;
+hw_t::hw_t(const hw_t &other)
+    : product_(other.product_ ? make_unique<ngen::Product>(*other.product_)
+                              : nullptr)
+    , hw_(other.hw_)
+    , eu_count_(other.eu_count_)
+    , max_wg_size_(other.max_wg_size_)
+    , l3_cache_size_(other.l3_cache_size_)
+    , attr_(other.attr_) {}
+
+const ngen::Product &hw_t::product() const {
+    gpu_assert(product_) << "Product information not available";
+    return *product_;
 }
 
 ngen::ProductFamily hw_t::family() const {
@@ -91,7 +98,8 @@ int max_threads_per_eu(const ngen::Product product) {
         case ngen::HW::XeHPC:
         case ngen::HW::Xe2:
         case ngen::HW::Xe3: return 8;
-        case ngen::HW::Xe3p: return family == ngen::ProductFamily::CRI ? 10 : 8;
+        case ngen::HW::Xe3p:
+            return family == ngen::ProductFamily::NVLP ? 10 : 8;
         default: gpu_error_not_expected();
     }
     return 8;
@@ -123,12 +131,6 @@ std::string hw_t::str() const {
     oss << ", stepping: " << stepping();
     oss << ", EUs: " << eu_count();
     return oss.str();
-}
-
-hw_t::product_t::product_t(const ngen::Product &product) {
-    static_assert(sizeof(product) == sizeof(*this),
-            "ngen::Product and hw_t::product must be binary compatible");
-    std::memcpy(this, &product, sizeof(product));
 }
 
 } // namespace dsl

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -263,7 +263,7 @@ status_t gen_desc_t::finalize(const char *tags) {
                 thread_per_tg *= std::max(strategy_.wg[LoopK], 1);
             dim_t thread_gpu = eu_count_
                     * compute::device_info_t::threads_per_eu(
-                            arch_, strategy_.GRFs);
+                            jit::to_gpu_product(product_), strategy_.GRFs);
             dim_t tiles_gpu = thread_gpu / thread_per_tg;
 
             bool use_linear = (m_tiles * n_tiles <= tiles_gpu);

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -263,7 +263,7 @@ status_t gen_desc_t::finalize(const char *tags) {
                 thread_per_tg *= std::max(strategy_.wg[LoopK], 1);
             dim_t thread_gpu = eu_count_
                     * compute::device_info_t::threads_per_eu(
-                            jit::to_gpu_product(product_), strategy_.GRFs);
+                            product_, strategy_.GRFs);
             dim_t tiles_gpu = thread_gpu / thread_per_tg;
 
             bool use_linear = (m_tiles * n_tiles <= tiles_gpu);
@@ -392,9 +392,7 @@ gen_nocopy_desc_t::select_kernel(const compute::device_info_t &dev_info,
     using namespace ngen;
     using namespace kcatalog;
 
-    const compute::gpu_product_t &product = dev_info.gpu_product();
-
-    product_ = compute::device_info_t::ngen_product(product);
+    product_ = dev_info.product();
     hw_ = getCore(product_.family);
     arch_ = convert_ngen_arch_to_dnnl(hw_);
     stepping_ = dev_info.stepping_id();
@@ -623,9 +621,7 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     using namespace ngen;
     using namespace kcatalog;
 
-    const compute::gpu_product_t &product = dev_info.gpu_product();
-
-    product_ = compute::device_info_t::ngen_product(product);
+    product_ = dev_info.product();
     hw_ = getCore(product_.family);
     arch_ = convert_ngen_arch_to_dnnl(hw_);
     stepping_ = dev_info.stepping_id();

--- a/src/gpu/intel/gemm/jit/include/gemmstone/dsl/hw.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/dsl/hw.hpp
@@ -110,7 +110,6 @@ public:
 
     // Number of EUs per Xe core (maps to dual subslice on XeHPG).
     int eus_per_core() const;
-    int grf_per_eu() const;
     int threads_per_eu(int regs = 128) const;
     int cache_line_size() const;
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/dsl/hw.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/dsl/hw.hpp
@@ -76,8 +76,19 @@ public:
     hw_t() = default;
     explicit hw_t(const ngen::Product &product, int eu_count, int max_wg_size,
             size_t l3_cache_size, attr_t attr);
+    hw_t(const hw_t &);
+    hw_t operator=(const hw_t &other) {
+        hw_t tmp(other);
+        std::swap(product_, tmp.product_);
+        std::swap(hw_, tmp.hw_);
+        std::swap(eu_count_, tmp.eu_count_);
+        std::swap(max_wg_size_, tmp.max_wg_size_);
+        std::swap(l3_cache_size_, tmp.l3_cache_size_);
+        std::swap(attr_, tmp.attr_);
+        return *this;
+    }
 
-    ngen::Product product() const;
+    const ngen::Product &product() const;
     ngen::ProductFamily family() const;
     int stepping() const;
     ngen::HW ngen_hw() const { return hw_; }
@@ -111,23 +122,20 @@ public:
     bool operator>=(ngen::HW rhs) const { return hw_ >= rhs; }
     bool operator==(ngen::HW rhs) const { return hw_ == rhs; }
     bool operator!=(ngen::HW rhs) const { return hw_ != rhs; }
-#if __cplusplus >= 202002L
-    bool operator==(const hw_t &other) const = default;
-#endif
+    bool operator==(const hw_t &other) const {
+        return hw_ == other.hw_ && eu_count_ == other.eu_count_
+                && max_wg_size_ == other.max_wg_size_
+                && l3_cache_size_ == other.l3_cache_size_
+                && attr_ == other.attr_
+                && (product_ == other.product_
+                        || (product_ && other.product_
+                                && *product_ == *other.product_));
+    }
 
 protected:
-    // Memory for storing ngen::Product to avoid nGEN header dependency in IR
-    struct alignas(int) product_t {
-        unsigned char data[12] = {};
-        product_t() = default;
-        product_t(const ngen::Product &product);
-        const ngen::Product &operator()() const;
-#if __cplusplus >= 202002L
-        bool operator==(const product_t &other) const = default;
-#endif
-    };
-
-    product_t product_;
+    // use product_t as an opaque handle to ngen::Product to avoid ngen dependency here
+    using product_t = const ngen::Product *;
+    std::unique_ptr<ngen::Product> product_;
 
 private:
     size_t max_wg_size(int regs = 128) const {

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -567,7 +567,7 @@ status_t pd_t::init_GEMMProblem(
     using namespace gemmstone;
     problem = {};
 
-    problem.product = get_ngen_product(*engine->device_info());
+    problem.product = engine->device_info()->product();
     bool has_systolic
             = engine->mayiuse(compute::device_ext_t::
                               intel_subgroup_matrix_multiply_accumulate)

--- a/src/gpu/intel/jit/binary_format.cpp
+++ b/src/gpu/intel/jit/binary_format.cpp
@@ -176,9 +176,8 @@ public:
         *skip_check = false;
 
         if (hw != HW::Unknown) {
-            auto product = engine->device_info()->gpu_product();
-            binary_format_kernel_t<hw> binary_format_kernel(
-                    engine, compute::device_info_t::ngen_product(product));
+            const ngen::Product &product = engine->device_info()->product();
+            binary_format_kernel_t<hw> binary_format_kernel(engine, product);
             auto status = engine->create_kernel(&kernel, &binary_format_kernel);
             if (status != status::success) return nullptr;
             *skip_check = binary_format_kernel.binaryIsZebin();

--- a/src/gpu/intel/jit/codegen/kernel_ext.cpp
+++ b/src/gpu/intel/jit/codegen/kernel_ext.cpp
@@ -106,8 +106,7 @@ void ir_kernel_t::generate_from_ir(
 
     if (local_range_) {
         size_t max_slm_size = compute::device_info_t::max_slm_size_per_tg(
-                thread_group_size(), options_.regs(),
-                to_gpu_product(options_.hw().product()));
+                thread_group_size(), options_.regs(), options_.hw().product());
         if (interface.getSLMSize() > max_slm_size) {
             gpu_trace() << "SLM size limit exceeded: " << interface.getSLMSize()
                         << " > " << max_slm_size;

--- a/src/gpu/intel/jit/emulated_generator.hpp
+++ b/src/gpu/intel/jit/emulated_generator.hpp
@@ -43,7 +43,7 @@ protected:
 public:
     emulated_generator_t(const compute::device_info_t &device_info,
             const debug_config_t &debug_config)
-        : generator_t<hw>(get_ngen_product(device_info), debug_config)
+        : generator_t<hw>(device_info.product(), debug_config)
         , ra_(hw)
         , emu_strategy(hw, device_info.stepping_id()) {}
 

--- a/src/gpu/intel/jit/ir/config.hpp
+++ b/src/gpu/intel/jit/ir/config.hpp
@@ -322,7 +322,7 @@ public:
             const dsl::kernel::options_t &options, dim_t tg_elems) {
         auto arch = convert_ngen_arch_to_dnnl(options.hw());
         int threads_per_eu = compute::device_info_t::threads_per_eu(
-                jit::to_gpu_product(options.hw().product()), options.regs());
+                options.hw().product(), options.regs());
         int eus_per_subslice = compute::device_info_t::max_eus_per_wg(arch);
         int subslice_count = options.hw().eu_count() / eus_per_subslice;
 

--- a/src/gpu/intel/jit/ir/config.hpp
+++ b/src/gpu/intel/jit/ir/config.hpp
@@ -321,8 +321,8 @@ public:
     static int get_max_threadgroups_per_wave(
             const dsl::kernel::options_t &options, dim_t tg_elems) {
         auto arch = convert_ngen_arch_to_dnnl(options.hw());
-        int threads_per_eu
-                = compute::device_info_t::threads_per_eu(arch, options.regs());
+        int threads_per_eu = compute::device_info_t::threads_per_eu(
+                jit::to_gpu_product(options.hw().product()), options.regs());
         int eus_per_subslice = compute::device_info_t::max_eus_per_wg(arch);
         int subslice_count = options.hw().eu_count() / eus_per_subslice;
 

--- a/src/gpu/intel/jit/ir/hw.hpp
+++ b/src/gpu/intel/jit/ir/hw.hpp
@@ -36,7 +36,7 @@ inline dsl::hw_t make_ir_hw(const impl::engine_t *engine) {
     auto intel_engine = utils::downcast<const engine_t *>(engine);
 
     auto *device_info = intel_engine->device_info();
-    auto product = get_ngen_product(*device_info);
+    auto product = device_info->product();
     int eu_count = device_info->eu_count();
     int max_wg_size = static_cast<int>(device_info->max_wg_size());
     size_t l3_cache_size = device_info->l3_cache_size();

--- a/src/gpu/intel/jit/utils/type_bridge.hpp
+++ b/src/gpu/intel/jit/utils/type_bridge.hpp
@@ -28,14 +28,6 @@ namespace gpu {
 namespace intel {
 namespace jit {
 
-inline ngen::Product get_ngen_product(const compute::device_info_t &info) {
-    ngen::Product ret;
-    std::memcpy(static_cast<void *>(&ret),
-            static_cast<const void *>(&info.gpu_product()),
-            sizeof(ngen::Product));
-    return ret;
-}
-
 inline ngen::DataType convert_dnnl_type_to_ngen(data_type_t dt) {
     using namespace ngen;
 
@@ -153,13 +145,6 @@ inline gemmstone::dsl::type_t to_ir(const data_type_t &dt) {
         default: gpu_error_not_expected();
     }
     return {};
-}
-
-inline compute::gpu_product_t to_gpu_product(const ngen::Product &p) {
-    compute::gpu_product_t result;
-    static_assert(sizeof(ngen::Product) == sizeof(compute::gpu_product_t), "");
-    std::memcpy(&result, &p, sizeof(result));
-    return result;
 }
 
 } // namespace jit

--- a/src/gpu/intel/lnorm/vectorized.cpp
+++ b/src/gpu/intel/lnorm/vectorized.cpp
@@ -177,7 +177,8 @@ static status_t init_conf_common(
         conf_t &conf, const pd_t *pd, impl::engine_t *engine) {
 
     auto *intel_engine = utils::downcast<engine_t *>(engine);
-    auto gpu_arch = intel_engine->device_info()->gpu_arch();
+    auto &device_info = *intel_engine->device_info();
+    auto gpu_arch = device_info.gpu_arch();
 
     // Limited due to performance reasons
     // Vectorized implementation can be used for FWD on DG2+, for BWD on PVC+
@@ -245,13 +246,11 @@ static status_t init_conf_common(
     auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
             pd->attr()->gpu_attr_.get());
     int grf_per_thread = gpu_attr ? gpu_attr->grf_per_thread() : 128;
-    auto eu_count = intel_engine->device_info()->eu_count();
-    auto threads_per_eu
-            = device_info_t::threads_per_eu(gpu_arch, grf_per_thread);
+    auto eu_count = device_info.eu_count();
+    auto threads_per_eu = device_info.threads_per_eu(grf_per_thread);
     auto max_eus_per_wg = device_info_t::max_eus_per_wg(gpu_arch);
     const int max_ss = utils::div_up(eu_count, max_eus_per_wg);
-    const size_t max_wg_size
-            = intel_engine->device_info()->max_wg_size(grf_per_thread);
+    const size_t max_wg_size = device_info.max_wg_size(grf_per_thread);
 
     // Vectorized vs Reference heuristics.
     // PVC, FWD:

--- a/src/gpu/intel/lnorm/vectorized.cpp
+++ b/src/gpu/intel/lnorm/vectorized.cpp
@@ -47,7 +47,7 @@ bool is_fused_kernel_applicable(conf_t &conf, const pd_t *pd,
     const size_t max_wg_size
             = intel_engine->device_info()->max_wg_size(grf_per_thread);
     const size_t max_slm_size = device_info_t::max_slm_size(
-            intel_engine->device_info()->gpu_product());
+            intel_engine->device_info()->product());
 
     // Plain layout only
     const bool is_plain = src_mdw.matches_one_of_tag(ab, abc)

--- a/src/gpu/intel/ocl/device_info.cpp
+++ b/src/gpu/intel/ocl/device_info.cpp
@@ -43,7 +43,7 @@ status_t device_info_t::init_arch(impl::engine_t *engine) {
     OCL_CHECK(err);
 
     CHECK(init_gpu_hw_info(engine, device, context, ip_version_, gpu_arch_,
-            gpu_product_, native_extensions_, mayiuse_systolic_,
+            product_, native_extensions_, mayiuse_systolic_,
             mayiuse_ngen_kernels_, is_efficient_64bit_));
 
     err = xpu::ocl::clReleaseContext(context);

--- a/src/gpu/intel/ocl/hw_info.cpp
+++ b/src/gpu/intel/ocl/hw_info.cpp
@@ -58,18 +58,17 @@ xpu::runtime_version_t get_driver_version(cl_device_id device) {
 
 status_t init_gpu_hw_info(impl::engine_t *engine, cl_device_id device,
         cl_context ctx, uint32_t &ip_version, compute::gpu_arch_t &gpu_arch,
-        compute::gpu_product_t &product_, uint64_t &native_extensions,
+        std::unique_ptr<ngen::Product> &product_, uint64_t &native_extensions,
         bool &mayiuse_systolic, bool &mayiuse_ngen_kernels,
         bool &is_efficient_64bit) {
     using namespace ngen;
-    ngen::Product product
-            = ngen::OpenCLCodeGenerator<HW::Unknown>::detectHWInfo(ctx, device);
-    HW hw = getCore(product.family);
-    bool is_xelpg = (product.family == ngen::ProductFamily::ARL
-            || product.family == ngen::ProductFamily::MTL);
+    product_ = utils::make_unique<ngen::Product>(
+            OpenCLCodeGenerator<HW::Unknown>::detectHWInfo(ctx, device));
+    HW hw = getCore(product_->family);
+    bool is_xelpg = (product_->family == ngen::ProductFamily::ARL
+            || product_->family == ngen::ProductFamily::MTL);
 
-    gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(product.family));
-    std::memcpy(&product_, &product, sizeof(ngen::Product));
+    gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(product_->family));
 
     mayiuse_systolic = false;
     CHECK(get_ocl_device_enabled_systolic_intel(device, mayiuse_systolic));

--- a/src/gpu/intel/ocl/hw_info.hpp
+++ b/src/gpu/intel/ocl/hw_info.hpp
@@ -32,7 +32,7 @@ xpu::runtime_version_t get_driver_version(cl_device_id device);
 
 status_t init_gpu_hw_info(impl::engine_t *engine, cl_device_id device,
         cl_context ctx, uint32_t &ip_version, compute::gpu_arch_t &gpu_arch,
-        compute::gpu_product_t &product, uint64_t &native_extensions,
+        std::unique_ptr<ngen::Product> &product, uint64_t &native_extensions,
         bool &mayiuse_systolic, bool &mayiuse_ngen_kernels,
         bool &is_efficient_64bit_);
 

--- a/src/gpu/intel/reduction/atomic.cpp
+++ b/src/gpu/intel/reduction/atomic.cpp
@@ -111,8 +111,7 @@ atomic_conf_t::atomic_conf_t(const subproblem_t &subprb, alg_kind_t alg,
     const size_t max_sg_per_wg = utils::div_up(max_wg_size, conf.subgroup_size);
 
     // number of subgroups (threads) to saturate the GPU
-    const int threads_per_eu
-            = compute::device_info_t::threads_per_eu(arch, conf.grf_per_thread);
+    const int threads_per_eu = device_info.threads_per_eu(conf.grf_per_thread);
     const int target_subgroups = eu_count * threads_per_eu;
 
     const dim_t max_local_size

--- a/src/gpu/intel/reduction/combined.cpp
+++ b/src/gpu/intel/reduction/combined.cpp
@@ -78,6 +78,7 @@ phase_conf_t::phase_conf_t(const subproblem_t &subprb, data_type_t src_type,
     , src_type(src_type)
     , dst_type(dst_type)
     , subgroup_size(intel_engine->device_info()->max_subgroup_size()) {
+    auto &device_info = *intel_engine->device_info();
     // Short-circuit if zero-dim is present
     gpu_assert(reduction_block.block != 0) << "Reducing over 0 elements";
     if (outer_block.block == 0 || inner_block.block == 0) {
@@ -87,12 +88,11 @@ phase_conf_t::phase_conf_t(const subproblem_t &subprb, data_type_t src_type,
     }
     with_block_reads = can_use_block_reads();
 
-    const int num_EU = intel_engine->device_info()->eu_count();
-    const int max_wg_size = static_cast<int>(
-            intel_engine->device_info()->max_wg_size(grf_per_thread));
-    compute::gpu_arch_t arch = intel_engine->device_info()->gpu_arch();
-    int threads_per_eu
-            = compute::device_info_t::threads_per_eu(arch, grf_per_thread);
+    const int num_EU = device_info.eu_count();
+    const int max_wg_size
+            = static_cast<int>(device_info.max_wg_size(grf_per_thread));
+    compute::gpu_arch_t arch = device_info.gpu_arch();
+    int threads_per_eu = device_info.threads_per_eu(grf_per_thread);
     int num_threads = num_EU * threads_per_eu;
 
     // inner_dim can either be:
@@ -195,12 +195,10 @@ status_t split_into_phases(const subproblem_t &subprb,
     //Heuristic:
     // subsplitting has a high cost due to launching multiple sequential threads,
     // so only split when parallelism is low and reductions per thread is large
-    const bool low_parallelism
-            = [&intel_engine, &grf_per_thread, &try_phase]() {
-        compute::gpu_arch_t arch = intel_engine->device_info()->gpu_arch();
-        int threads_per_EU
-                = compute::device_info_t::threads_per_eu(arch, grf_per_thread);
-        const int num_EU = intel_engine->device_info()->eu_count();
+    auto &device_info = *intel_engine->device_info();
+    const bool low_parallelism = [&device_info, &grf_per_thread, &try_phase]() {
+        int threads_per_EU = device_info.threads_per_eu(grf_per_thread);
+        const int num_EU = device_info.eu_count();
         const int min_threads = gpu_utils::dev_getenv(
                 "combined_reduction_occ_thresh", threads_per_EU * num_EU / 2);
         const int dispatched_threads

--- a/src/gpu/intel/reduction/jit.cpp
+++ b/src/gpu/intel/reduction/jit.cpp
@@ -82,12 +82,10 @@ status_t gen_t::pd_t::init_conf(impl::engine_t *engine) {
     dim_t gws0 = inner_nelems / nregs;
     dim_t nthreads = gws0 / elems_per_reg;
     int tg_size = [this, &device_info, &nthreads]() {
-        const compute::gpu_arch_t arch = device_info.gpu_arch();
         auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
                 attr()->gpu_attr_.get());
         const int grf_per_thread = gpu_attr ? gpu_attr->grf_per_thread() : 128;
-        const int threads_per_eu
-                = compute::device_info_t::threads_per_eu(arch, grf_per_thread);
+        const int threads_per_eu = device_info.threads_per_eu(grf_per_thread);
         int tg_size = utils::rnd_down_pow2(
                 device_info.max_eus_per_wg() * threads_per_eu);
         while (nthreads % tg_size != 0) {

--- a/src/gpu/intel/sycl/device_info.cpp
+++ b/src/gpu/intel/sycl/device_info.cpp
@@ -47,14 +47,14 @@ status_t device_info_t::init_arch(impl::engine_t *engine) {
         auto ocl_ctx = xpu::sycl::compat::get_native<cl_context>(ctx);
 
         status = gpu::intel::ocl::init_gpu_hw_info(engine, ocl_dev, ocl_ctx,
-                ip_version_, gpu_arch_, gpu_product_, native_extensions_,
+                ip_version_, gpu_arch_, product_, native_extensions_,
                 mayiuse_systolic_, mayiuse_ngen_kernels_, is_efficient_64bit_);
     } else if (be == xpu::sycl::backend_t::ze) {
         auto ze_dev = xpu::sycl::compat::get_native<ze_device_handle_t>(device);
         auto ze_ctx = xpu::sycl::compat::get_native<ze_context_handle_t>(ctx);
 
         status = gpu::intel::ze::init_gpu_hw_info(engine, ze_dev, ze_ctx,
-                ip_version_, gpu_arch_, gpu_product_, native_extensions_,
+                ip_version_, gpu_arch_, product_, native_extensions_,
                 mayiuse_systolic_, mayiuse_ngen_kernels_, is_efficient_64bit_);
     } else {
         assert(!"not_expected");

--- a/src/gpu/intel/utils.hpp
+++ b/src/gpu/intel/utils.hpp
@@ -20,7 +20,6 @@
 
 #include "common/cpp_compat.hpp"
 #include "common/utils.hpp"
-#include "gpu/intel/compute/device_info.hpp"
 
 #define VCHECK_KERNEL(stat, msg, ...) \
     VCHECK(common, create, check, runtime, stat, msg, ##__VA_ARGS__);
@@ -159,40 +158,6 @@ inline std::string dev_getenv(const char *s, const std::string &def) {
     return def;
 #else
     return def;
-#endif
-}
-
-// Input is a comma separate list containing gpu_arch and optionally eu_count.
-inline compute::gpu_arch_t dev_getenv(const char *s, compute::gpu_arch_t arch,
-        int *eu_count = nullptr, int *max_wg_size = nullptr) {
-#ifdef DNNL_DEV_MODE
-    char buf[1024];
-    int ret = getenv(s, buf, sizeof(buf));
-    if (ret > 0) {
-        char *arch_str = buf, *eu_str = nullptr;
-        for (int i = 0; i < ret; i++) {
-            if (buf[i] == ',') {
-                buf[i] = 0;
-                if (i < ret - 1) { eu_str = &buf[i + 1]; }
-                break;
-            }
-        }
-        arch = compute::str2gpu_arch(arch_str);
-        if (eu_count && eu_str) { *eu_count = atoi(eu_str); }
-        if (max_wg_size) {
-            // Assume maximum wg size is basically the number of threads
-            // available in a subslice with simd_size 16
-            const int max_eus_per_wg
-                    = compute::device_info_t::max_eus_per_wg(arch);
-            const int simd_size = 16;
-            const int thr_per_eu = utils::rnd_down_pow2(
-                    compute::device_info_t::threads_per_eu(arch));
-            *max_wg_size = simd_size * max_eus_per_wg * thr_per_eu;
-        }
-    }
-    return arch;
-#else
-    return arch;
 #endif
 }
 

--- a/src/gpu/intel/ze/device_info.cpp
+++ b/src/gpu/intel/ze/device_info.cpp
@@ -43,7 +43,7 @@ status_t device_info_t::init_arch(impl::engine_t *engine) {
     auto device = ze_engine->device();
 
     return init_gpu_hw_info(engine, device, context, ip_version_, gpu_arch_,
-            gpu_product_, native_extensions_, mayiuse_systolic_,
+            product_, native_extensions_, mayiuse_systolic_,
             mayiuse_ngen_kernels_, is_efficient_64bit_);
 }
 

--- a/src/gpu/intel/ze/utils.cpp
+++ b/src/gpu/intel/ze/utils.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "gpu/intel/ze/utils.hpp"
+#include <memory>
 
 #include "gpu/intel/jit/binary_format.hpp"
 #include "gpu/intel/jit/utils/type_bridge.hpp"
@@ -162,15 +163,14 @@ status_t compile_native_module(ze_module_handle_t *module_ptr,
 
 status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
         ze_context_handle_t context, uint32_t &ip_version,
-        compute::gpu_arch_t &gpu_arch, compute::gpu_product_t &product_,
+        compute::gpu_arch_t &gpu_arch, std::unique_ptr<ngen::Product> &product_,
         uint64_t &native_extensions, bool &mayiuse_systolic,
         bool &mayiuse_ngen_kernels, bool &is_efficient_64bit) {
     using namespace ngen;
-    ngen::Product product = LevelZeroCodeGenerator<HW::Unknown>::detectHWInfo(
-            context, device);
+    product_ = utils::make_unique<ngen::Product>(
+            LevelZeroCodeGenerator<HW::Unknown>::detectHWInfo(context, device));
 
-    gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(product.family));
-    std::memcpy(&product_, &product, sizeof(ngen::Product));
+    gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(product_->family));
 
     mayiuse_systolic = false;
     if (get_ze_device_enabled_systolic_intel(device, mayiuse_systolic)
@@ -179,21 +179,21 @@ status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
 
     /* Some old drivers do not report systolic availability. Manually override
        systolic availability based on product family. */
-    switch (product.family) {
+    switch (product_->family) {
         case ProductFamily::DG2:
         case ProductFamily::ARL:
         case ProductFamily::PVC: mayiuse_systolic = true;
         default: break;
     }
 
-    bool is_xelpg = (product.family == ProductFamily::ARL
-            || product.family == ProductFamily::MTL);
+    bool is_xelpg = (product_->family == ProductFamily::ARL
+            || product_->family == ProductFamily::MTL);
     CHECK(get_ze_device_enabled_native_float_atomics(
             device, native_extensions, is_xelpg));
 
     is_efficient_64bit
             = LevelZeroCodeGenerator<HW::Unknown>::detectEfficient64Bit(
-                    context, device, getCore(product.family));
+                    context, device, getCore(product_->family));
     CHECK(jit::init_mayiuse_ngen_kernels(
             engine, gpu_arch, mayiuse_ngen_kernels));
 

--- a/src/gpu/intel/ze/utils.hpp
+++ b/src/gpu/intel/ze/utils.hpp
@@ -17,6 +17,7 @@
 #ifndef GPU_INTEL_ZE_UTILS_HPP
 #define GPU_INTEL_ZE_UTILS_HPP
 
+#include <memory>
 #include "gpu/intel/compute/device_info.hpp"
 
 #include "xpu/ze/utils.hpp"
@@ -29,7 +30,7 @@ namespace ze {
 
 status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
         ze_context_handle_t context, uint32_t &ip_version,
-        compute::gpu_arch_t &gpu_arch, compute::gpu_product_t &product,
+        compute::gpu_arch_t &gpu_arch, std::unique_ptr<ngen::Product> &product,
         uint64_t &native_extensions, bool &mayiuse_systolic,
         bool &mayiuse_ngen_kernels, bool &is_efficient_64bit);
 


### PR DESCRIPTION
My recent Variable Registers per Thread (VRT) PR didn't quite get the entire picture: CRI/NVLP have a few more changes compared to previous architectures:
- NVLP has 10 hardware threads per EU, up from 8 -- affects grf128 kernels
- CRI has 2048 GRF/EU, up from 1024 -- affects maximum workgroup size
 
Both of these are updated in this PR. But most of the lines changed are tangential: I noticed that we do a lot of conversion between `ngen::Product` and `gpu_product_t` in both device_info and dsl hw_t code. Rather than supporting two sets of interfaces for these functions, I removed the ad hoc `gpu_product_t` implementations and replaced them with unique pointers to `ngen::Product` in every case. We use the pointer everywhere we don't want an ngen dependency, and we dereference when we need to, in code where the ngen dependency is OK.