### PR TITLE
Clean up dead stride-adjustment paths

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1770,7 +1770,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     // adjacent in memory, i.e. no batch dimension is physically interleaved
     // between them (e.g. an acbd layout). The format tag is unreliable here
     // since tag matching ignores strides of unit dimensions.
-    const bool m_and_k_contiguous
+    const bool m_and_k_adjacent
             = dims_adjacent(src_d, bgmmc.ndims - 2, bgmmc.ndims - 1);
 
     // We cannot change M at this point as all gemv related parameters have
@@ -1783,7 +1783,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             && plain_A_layout && helper.is_src_dst_layout_batch_fusable()
             && post_ops_ok(
                     bgmmc, attr, dst_d, true /* limit_bcast_strategies_set */)
-            && m_and_k_contiguous;
+            && m_and_k_adjacent;
     if (merge_batch_dims_into_M) {
         bgmmc.M *= bgmmc.batch;
         bgmmc.batch = 1;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1877,12 +1877,6 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.adjust_a_strides = merge_batch_dims_into_M && bgmmc.treat_A_as_plain;
     if (bgmmc.adjust_a_strides) bgmmc.A_strides[1] = bgmmc.A_strides[2];
 
-    // We need to correct C_strides if batched dimensions are merged in M and
-    // C layout is formally transposed but could be treated as plain
-    if (merge_batch_dims_into_M && dst_d.matches_tag(acbd)) {
-        bgmmc.C_strides[1] = bgmmc.C_strides[2];
-    }
-
     // BF32 'Hint' Heuristic:
     // Under the following conditions, F32 through AVX512_CORE performs better
     // than using BF32 arithmetic.

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1872,8 +1872,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.C_strides[d] = bgmmc.c_dt_sz * dst_d.blocking_desc().strides[dim];
     }
 
-    // We need to correct A_strides if batched dimensions are merged in M and
-    // A layout is formally transposed but could be treated as plain.
+    // We need to adjust A_strides if the batched dimensions are merged into M
+    // and A layout can be treated as plain.
     bgmmc.adjust_a_strides = merge_batch_dims_into_M && bgmmc.treat_A_as_plain;
     if (bgmmc.adjust_a_strides) bgmmc.A_strides[1] = bgmmc.A_strides[2];
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1873,11 +1873,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     }
 
     // We need to correct A_strides if batched dimensions are merged in M and
-    // A layout is formally transposed but could be treated as plain
-    // For 4D tensors, only apply adjustment for treat_A_as_plain, not for acbd tag
-    const bool adjust_for_acbd = src_d.matches_tag(acbd) && bgmmc.ndims == 3;
-    bgmmc.adjust_a_strides = merge_batch_dims_into_M
-            && (adjust_for_acbd || bgmmc.treat_A_as_plain);
+    // A layout is formally transposed but could be treated as plain.
+    bgmmc.adjust_a_strides = merge_batch_dims_into_M && bgmmc.treat_A_as_plain;
     if (bgmmc.adjust_a_strides) bgmmc.A_strides[1] = bgmmc.A_strides[2];
 
     // We need to correct C_strides if batched dimensions are merged in M and

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
@@ -40,3 +40,7 @@
 # 4D matrix A with acbd-like layout (second dimension = 1) - regression test for segfault.
 --reset
 --dt=bf16:bf16:bf16 --stag=abcd,acbd --wtag=abdc --dtag=abcd 6x1x100x256:1x1x256x9_n"4d_matrix_a_acbd_layout"
+
+# Test LDA initialization when the batch dimension are merged into M.
+--reset
+--dt=bf16 --stag=abdc --wtag=abcd --dtag=abcd 64x4x1x256:1x1x256x32_n"merge_batch_dimensions_into_M"

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_f32
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_f32
@@ -21,10 +21,6 @@
 --reset
 --stag=acb --wtag=abc --dtag=abc 2x16x2048:2x2048x16_n"large_K_with_batch"
 
-# test correct LDA initialization, when batches are merged into M dimension
---reset
---stag=abcd --dtag=abcd 2x1x8x2:1x1x2x8_n"merge_batches_into_M"
-
 # test special tag that can be matched with adbc
 --reset
 --stag=dabc --wtag=abx --dtag=abx 1x2x2x32:2x2x32x7


### PR DESCRIPTION
The change in #5249 fixed enabling the merge of the batch dimension into M, which had previously been disabled due to an incorrect condition.

The incorrect condition was introduced in #4632 together with a new regression test case:
`--dt=bf16:bf16:bf16 --stag=abcd,acbd --wtag=abdc --dtag=abcd 6x1x100x256:1x1x256x9_n "4d_matrix_a_acbd_layout"`

The regression test uses `--stag=abcd,acbd`. Because of the incorrect condition, merging the batch dimension into M was disabled for both of these source tags. As a result, all downstream code paths that depend on the merge being performed were also disabled.

A long time ago, we introduced the following code:
```cpp
if (merge_batch_dims_into_M && dst_d.matches_tag(acbd)) {
    bgmmc.C_strides[1] = bgmmc.C_strides[2];
}
```
At the time, we apparently did not have any test cases that exercised this code path. Later, when the regression test described above was added, the incorrect condition introduced in #4632 still prevented batch-dimension merging for the relevant layouts. Consequently, this code path continued to remain untested because it was never reached.

After fixing the condition in #5249, batch-dimension merging started working again for those layouts. This exposed another incorrect condition in the code above: `dst_d.matches_tag(acbd)`. Because that condition evaluates to true for the affected layouts, we incorrectly applied the stride adjustment, resulting in a crash.

One possible fix would be to make the condition check whether the M and N dimensions of the destination layout are adjacent. However, `is_src_dst_layout_batch_fusable()` already filters out all layouts for which this adjustment would be relevant. As a result, the code above is effectively dead code. Therefore, the correct fix is to remove it entirely.

This PR contains the following changes:
* Removes dead code related to A stride adjustment. The adjustment is needed because, unlike C, A can be treated as a plain tensor.
* Removes dead code that adjusts C strides.
* Updates the regression test to test A stride adjustment when dimensions are merged into M. The test now uses bf16 because the merge optimization is currently disabled for the GEMV code path, which is only enabled for f32.
* Does minor renaming to improve consistency.

**Note**: The code still relies heavily on tag matching in many places and that mechanism does not always produce the correct result. Consequently, an incorrect decision can propagate into downstream logic and cause cascading correctness issues.
For that reason, it is not always possible to replace a tag-matching check with a stride-based check directly. Such a change may be locally correct but still introduce downstream regressions due to existing dependencies on the current behavior.