### PR TITLE
[GPU] Fix device info serialization

### DIFF
--- a/src/common/serialization.hpp
+++ b/src/common/serialization.hpp
@@ -22,6 +22,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <vector>
 #include <type_traits>
 
@@ -112,6 +113,8 @@ struct serialization_stream_t {
         for (const typename T::value_type &d : v)
             append<typename T::value_type>(d);
     }
+
+    void append(const std::string &s) { append_array(s.size(), s.data()); }
 
     template <typename Arg1, typename Arg2, typename... Args>
     void append(const Arg1 &a1, const Arg2 &a2, const Args &...args) {
@@ -253,6 +256,14 @@ struct deserializer_t {
             pop(t);
             v.emplace_back(t);
         }
+    }
+
+    void pop(std::string &s) {
+        size_t size = 0;
+        pop(size);
+        s.resize(size);
+        sstream_.get(idx_, size, reinterpret_cast<uint8_t *>(&s[0]));
+        idx_ += size;
     }
 
     template <typename T,

--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -354,8 +354,7 @@ status_t device_info_t::init_attributes_common(impl::engine_t *engine) {
 status_t device_info_t::init_serialized_device_info(
         const std::vector<uint8_t> &cache_blob) {
     if (!cache_blob.empty()) {
-        serialized_device_info_.append_array(
-                cache_blob.size(), cache_blob.data());
+        serialized_device_info_ = serialization_stream_t::from_data(cache_blob);
         return status::success;
     }
 
@@ -370,7 +369,11 @@ status_t device_info_t::init_serialized_device_info(
     serialized_device_info_.append(max_subgroup_size_);
     serialized_device_info_.append(max_exec_size_);
     serialized_device_info_.append(max_wg_size_);
+    serialized_device_info_.append(memory_size_);
     serialized_device_info_.append(l3_cache_size_);
+    serialized_device_info_.append(max_kernel_param_size_);
+    serialized_device_info_.append(device_address_bits_);
+    serialized_device_info_.append(max_allocation_size_);
     serialized_device_info_.append(extensions_);
     serialized_device_info_.append(native_extensions_);
     serialized_device_info_.append(mayiuse_systolic_);
@@ -379,9 +382,7 @@ status_t device_info_t::init_serialized_device_info(
     serialized_device_info_.append(mayiuse_non_uniform_work_groups_);
     serialized_device_info_.append(is_efficient_64bit_);
 
-    const size_t name_size = name_.size();
-    serialized_device_info_.append(name_size);
-    serialized_device_info_.append_array(name_size, name_.data());
+    serialized_device_info_.append(name_);
 
     return status::success;
 }
@@ -390,44 +391,35 @@ status_t device_info_t::init_from_cache_blob(
         const std::vector<uint8_t> &cache_blob) {
     if (cache_blob.empty()) return status::invalid_arguments;
 
-    size_t pos = 0;
-#define DESERIALIZE(val, expected_type) \
-    static_assert(std::is_same<std::remove_reference<decltype(val)>::type, \
-                          expected_type>::value, \
-            #val " has incorrect type"); \
-    (val) = *reinterpret_cast<const expected_type *>(cache_blob.data() + pos); \
-    pos += sizeof(expected_type);
+    auto s = serialization_stream_t::from_data(cache_blob);
+    deserializer_t d(s);
 
-    DESERIALIZE(gpu_arch_, compute::gpu_arch_t);
-    DESERIALIZE(gpu_product_, compute::gpu_product_t);
-    DESERIALIZE(ip_version_, uint32_t);
-    DESERIALIZE(runtime_version_.major, int);
-    DESERIALIZE(runtime_version_.minor, int);
-    DESERIALIZE(runtime_version_.build, int);
-    DESERIALIZE(eu_count_, int32_t);
-    DESERIALIZE(max_eus_per_wg_, int32_t);
-    DESERIALIZE(max_subgroup_size_, int32_t);
-    DESERIALIZE(max_exec_size_, int);
-    DESERIALIZE(max_wg_size_, size_t);
-    DESERIALIZE(l3_cache_size_, size_t);
-    DESERIALIZE(extensions_, uint64_t);
-    DESERIALIZE(native_extensions_, uint64_t);
-    DESERIALIZE(mayiuse_systolic_, bool);
-    DESERIALIZE(mayiuse_ngen_kernels_, bool);
-    DESERIALIZE(mayiuse_system_memory_allocators_, bool);
-    DESERIALIZE(mayiuse_non_uniform_work_groups_, bool);
-    DESERIALIZE(is_efficient_64bit_, bool);
-#undef DESERIALIZE
+    d.pop(gpu_arch_);
+    d.pop(gpu_product_);
+    d.pop(ip_version_);
+    d.pop(runtime_version_.major);
+    d.pop(runtime_version_.minor);
+    d.pop(runtime_version_.build);
+    d.pop(eu_count_);
+    d.pop(max_eus_per_wg_);
+    d.pop(max_subgroup_size_);
+    d.pop(max_exec_size_);
+    d.pop(max_wg_size_);
+    d.pop(memory_size_);
+    d.pop(l3_cache_size_);
+    d.pop(max_kernel_param_size_);
+    d.pop(device_address_bits_);
+    d.pop(max_allocation_size_);
+    d.pop(extensions_);
+    d.pop(native_extensions_);
+    d.pop(mayiuse_systolic_);
+    d.pop(mayiuse_ngen_kernels_);
+    d.pop(mayiuse_system_memory_allocators_);
+    d.pop(mayiuse_non_uniform_work_groups_);
+    d.pop(is_efficient_64bit_);
 
-    // name_ is not trivially copyable type
-    const size_t name_size
-            = *reinterpret_cast<const size_t *>(cache_blob.data() + pos);
-    pos += sizeof(size_t);
-    name_ = std::string(
-            reinterpret_cast<const char *>(cache_blob.data() + pos), name_size);
-    pos += name_size;
-    assert(name_size == name_.size());
-    assert(pos == cache_blob.size());
+    d.pop(name_);
+    assert(d.empty());
 
     return status::success;
 }

--- a/src/gpu/intel/engine.cpp
+++ b/src/gpu/intel/engine.cpp
@@ -104,3 +104,11 @@ const char *dnnl_impl_gpu_intel_get_isa_name(dnnl::impl::engine_t *engine) {
     auto *device_info = intel_engine->device_info();
     return intel::compute::to_string(device_info->gpu_arch());
 }
+
+void dnnl_impl_gpu_intel_clear_device_info_cache() {
+    using namespace dnnl::impl;
+    using namespace dnnl::impl::gpu::intel;
+
+    utils::lock_write_t lock(device_info_cache_mutex());
+    device_info_cache().clear();
+}

--- a/src/gpu/intel/engine.hpp
+++ b/src/gpu/intel/engine.hpp
@@ -219,5 +219,6 @@ extern "C" bool DNNL_API dnnl_impl_gpu_intel_mayiuse_ngen_kernels(
         dnnl::impl::engine_t *engine);
 extern "C" DNNL_API const char *dnnl_impl_gpu_intel_get_isa_name(
         dnnl::impl::engine_t *engine);
+extern "C" void DNNL_API dnnl_impl_gpu_intel_clear_device_info_cache();
 
 #endif

--- a/tests/gtests/test_persistent_cache_api.cpp
+++ b/tests/gtests/test_persistent_cache_api.cpp
@@ -24,9 +24,26 @@
 #include "oneapi/dnnl/dnnl_ocl.hpp"
 #endif
 
+extern "C" void dnnl_impl_gpu_intel_clear_device_info_cache();
+
 namespace dnnl {
 
 class persistent_cache_api_test_t : public ::testing::Test {};
+
+void check_engine_usable(const engine &eng) {
+    memory::desc md({4, 4}, memory::data_type::f32, memory::format_tag::ab);
+    auto prim = matmul(matmul::primitive_desc {eng, md, md, md});
+
+    auto src = test::make_memory(md, eng);
+    auto wei = test::make_memory(md, eng);
+    auto dst = test::make_memory(md, eng);
+
+    stream strm(eng);
+    prim.execute(strm,
+            {{DNNL_ARG_SRC, src}, {DNNL_ARG_WEIGHTS, wei},
+                    {DNNL_ARG_DST, dst}});
+    strm.wait();
+}
 
 HANDLE_EXCEPTIONS_FOR_TEST(
         persistent_cache_api_test_t, TestPersistentCacheAPI) {
@@ -86,11 +103,17 @@ HANDLE_EXCEPTIONS_FOR_TEST(
     ASSERT_TRUE(!cache_blob.empty());
     ASSERT_TRUE(!cache_blob_id.empty());
 
+    // Force init_from_cache_blob, otherwise the device info is reused from the
+    // internal cache.
+    dnnl_impl_gpu_intel_clear_device_info_cache();
+
     auto eng = make_engine(
             get_device(test_engine), get_context(test_engine), cache_blob);
 
     ASSERT_EQ(get_engine_cache_blob(eng), cache_blob);
     ASSERT_EQ(get_engine_cache_blob_id(get_device(eng)), cache_blob_id);
+
+    check_engine_usable(eng);
 }
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
 HANDLE_EXCEPTIONS_FOR_TEST(
@@ -118,6 +141,10 @@ HANDLE_EXCEPTIONS_FOR_TEST(
     ASSERT_TRUE(!cache_blob.empty());
     ASSERT_TRUE(!cache_blob_id.empty());
 
+    // Force init_from_cache_blob, otherwise the device info is reused from the
+    // internal cache.
+    dnnl_impl_gpu_intel_clear_device_info_cache();
+
     auto eng = make_engine(get_driver(test_engine), get_device(test_engine),
             get_context(test_engine), cache_blob);
 
@@ -125,6 +152,8 @@ HANDLE_EXCEPTIONS_FOR_TEST(
     ASSERT_EQ(
             get_engine_cache_blob_id(get_driver(test_engine), get_device(eng)),
             cache_blob_id);
+
+    check_engine_usable(eng);
 }
 
 #endif


### PR DESCRIPTION
Spotted several issues. Cold-cache persistent engine creation has been broken for some time so I'm not sure if anyone is even using this feature.

Issues:

- `memory_size_` (and a few other fields) were not serialized/deserialized -> USM allocation didn't work in a deserialized engine
- Mismatch in `name_size`/`name_` derialization and serialization
- `test_persistent_cache_api` doesn't test deserialization as is due to the device info cache. The deserialization step is bypassed. Introduced `dnnl_impl_gpu_intel_clear_device_info_cache` to force init-from-blob creation