### PR TITLE
graph: backend: dnnl: user scratchpad for gmlp

### DIFF
--- a/src/graph/backend/dnnl/executables/gated_mlp.cpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.cpp
@@ -26,29 +26,54 @@ namespace dnnl_impl {
 gated_mlp_executable_t::gated_mlp_executable_t(std::shared_ptr<op_t> &op,
         const dnnl::engine &p_engine, pd_cache_t &pd_cache,
         const fpmath_t &fpmath, bool use_block_layout) {
+    auto desc = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
+
+    if (desc) {
+        // create primitive
+        dnnl_primitive_t prim = nullptr;
+        auto ret = dnnl_primitive_create(&prim, desc.get());
+        if (prim && ret == dnnl_success) { prim_.reset(prim); }
+    }
+}
+
+gated_mlp_executable_t::desc_t gated_mlp_executable_t::create_desc(
+        std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
+    UNUSED(use_block_layout);
+
+    // first look up the cache
+    if (pd_cache.find(op.get()) != pd_cache.end()) {
+        auto pd = graph::utils::any_cast<dnnl::primitive_desc_base>(
+                pd_cache.at(op.get()));
+        return {pd, true};
+    }
+
     auto src_md = make_dnnl_memory_desc(op->get_input_logical_tensor(0));
     auto wei0_md = make_dnnl_memory_desc(op->get_input_logical_tensor(1));
     auto wei1_md = make_dnnl_memory_desc(op->get_input_logical_tensor(2));
     auto wei2_md = make_dnnl_memory_desc(op->get_input_logical_tensor(3));
     auto dst_md = make_dnnl_memory_desc(op->get_output_logical_tensor(0));
 
-    dnnl_primitive_attr_t attr = nullptr;
+    dnnl::primitive_attr attr;
+    attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    attr.set_fpmath_mode(
+            static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
     auto act_algo = op->has_attr(op_attr::alg_kind)
             ? static_cast<dnnl::algorithm>(
                       op->get_attr<int64_t>(op_attr::alg_kind))
             : dnnl::algorithm::undef;
+
     dnnl_primitive_desc_t pd = nullptr;
-    // create primitive desc.
     auto ret = dnnl_gated_mlp_primitive_desc_create(&pd, p_engine.get(),
             src_md.get(), wei0_md.get(), wei1_md.get(), wei2_md.get(),
-            dst_md.get(), static_cast<dnnl_alg_kind_t>(act_algo), attr);
-    if (pd && ret == dnnl_success) {
-        pd_.reset(pd);
-        // create primitive
-        dnnl_primitive_t prim = nullptr;
-        ret = dnnl_primitive_create(&prim, pd_.get());
-        if (prim && ret == dnnl_success) { prim_.reset(prim); }
-    }
+            dst_md.get(), static_cast<dnnl_alg_kind_t>(act_algo), attr.get());
+
+    if (!pd || ret != dnnl_success) return {dnnl::primitive_desc_base(), false};
+
+    dnnl::primitive_desc_base apd(pd);
+    pd_cache.insert({op.get(), apd});
+
+    return {apd, false};
 }
 
 void gated_mlp_executable_t::execute(const stream &stream,

--- a/src/graph/backend/dnnl/executables/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.hpp
@@ -27,6 +27,8 @@ namespace dnnl_impl {
 
 struct gated_mlp_executable_t : public op_executable_t {
     DECLARE_ARG_INDICES_GETTER;
+    // As we don't have public gated mlp primitive desc, let's use the base.
+    DECLARE_DESC_CLASS_AND_CREATOR(dnnl::primitive_desc_base);
 
     gated_mlp_executable_t(std::shared_ptr<op_t> &op,
             const dnnl::engine &p_engine, pd_cache_t &pd_cache,
@@ -47,10 +49,9 @@ struct gated_mlp_executable_t : public op_executable_t {
             const std::vector<cl_event> &deps) const override;
 #endif
 
-    bool is_initialized() const override { return pd_ && prim_; }
+    bool is_initialized() const override { return bool(prim_); }
 
 private:
-    std::unique_ptr<dnnl_primitive_desc, pd_deleter_t> pd_;
     std::unique_ptr<dnnl_primitive, prim_deleter_t> prim_;
 };
 

--- a/src/graph/backend/dnnl/kernels/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp.hpp
@@ -53,7 +53,8 @@ public:
 
         status_t ret = status::unimplemented;
 
-        if (enable_ukernel) {
+        // TODO: quantized fused gated mlp is not supported yet.
+        if (enable_ukernel && !quantized) {
             kernel = std::make_shared<
                     gated_mlp_primitive_kernel_t<quantized>>();
             ret = kernel->compile_impl(part, engine, inputs, outputs);

--- a/src/graph/backend/dnnl/kernels/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp.hpp
@@ -71,11 +71,9 @@ public:
         return ret;
     }
 
-    // Use large partition kernel as defautl. Turn the env var to 0 to select
-    // gated_mlp primitive.
     bool force_primitive() const {
         const int force = graph::utils::getenv_int_internal(
-                "GRAPH_GATED_MLP_FORCE_PRIMITIVE", 1);
+                "GRAPH_GATED_MLP_FORCE_PRIMITIVE", 0);
         return force > 0;
     }
 

--- a/src/graph/backend/dnnl/layout_propagator.cpp
+++ b/src/graph/backend/dnnl/layout_propagator.cpp
@@ -2009,30 +2009,18 @@ status_t layout_propagator_for_gated_mlp(std::shared_ptr<op_t> &op,
         const dnnl::engine &p_engine, pd_cache_t &pd_cache,
         const fpmath_t &fpmath, bool use_block_layout,
         subgraph_rewriter_t &rewriter) {
-    UNUSED(p_engine);
-    UNUSED(pd_cache);
-    UNUSED(fpmath);
-    UNUSED(use_block_layout);
     UNUSED(rewriter);
+    const auto pd = gated_mlp_executable_t::create_desc(
+            op, p_engine, pd_cache, fpmath, use_block_layout);
+
+    if (!pd) return status::unimplemented;
 
     value_ptr dst_val = op->get_output_value(0);
-    const logical_tensor_t &dst_lt = dst_val->get_logical_tensor();
+    status_t status = fill_layout_info(dst_val, pd.dst_desc());
+    if (status != status::success) { return status; }
 
-    dnnl::memory::desc expected_md;
-    if (ltw(dst_lt).is_any()) {
-        const auto tag = get_ncx_format(ltw(dst_lt).ndims());
-        expected_md = {ltw(dst_lt).vdims(),
-                static_cast<dnnl::memory::data_type>(ltw(dst_lt).data_type()),
-                tag};
-    } else {
-        expected_md = make_dnnl_memory_desc(dst_lt);
-    }
-    status_t status = fill_layout_info(dst_val, expected_md);
-
-    // fill scratchpads dimensions and data type to scratchpad value_t
-    value_ptr scratchpad_val = op->get_output_value(1);
-    const memory::desc scratchpad_desc;
-    status = fill_layout_info(scratchpad_val, scratchpad_desc);
+    value_ptr spad_val = op->get_output_value(1);
+    status = fill_layout_info(spad_val, pd.scratchpad_desc());
     return status;
 }
 


### PR DESCRIPTION
1. Pass scratchpad and fpmath mode attributes to gmlp primitive creation.
2. Enable gmlp primitive by default.