### PR TITLE
cpu: aarch64: jit: use hardware sp for stack management

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
@@ -93,9 +93,9 @@ void jit_brdgmm_kernel_base_t::read_params() {
         add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_B), X_TMP_0);
         ldr(reg_aux1_B, ptr(X_DEFAULT_ADDR));
         if (brg.brgattr.max_bs > 1) {
-            add_imm(X_DEFAULT_ADDR, X_SP, reg_A_offs_, X_TMP_0); //rsp=X_SP
+            add_imm(X_DEFAULT_ADDR, sp, reg_A_offs_, X_TMP_0);
             str(reg_aux1_A, ptr(X_DEFAULT_ADDR));
-            add_imm(X_DEFAULT_ADDR, X_SP, reg_B_offs_, X_TMP_0);
+            add_imm(X_DEFAULT_ADDR, sp, reg_B_offs_, X_TMP_0);
             str(reg_aux1_B, ptr(X_DEFAULT_ADDR));
         }
     }
@@ -104,8 +104,7 @@ void jit_brdgmm_kernel_base_t::read_params() {
         add_imm(X_DEFAULT_ADDR, param1, GET_OFF(batch), X_TMP_0);
         ldr(reg_aux_batch_addr, ptr(X_DEFAULT_ADDR));
         if (brg.brgattr.max_bs > 1) {
-            add_imm(X_DEFAULT_ADDR, X_SP, reg_batch0_addr_offs_,
-                    X_TMP_0); //rsp=X_SP
+            add_imm(X_DEFAULT_ADDR, sp, reg_batch0_addr_offs_, X_TMP_0);
             str(reg_aux_batch_addr, ptr(X_DEFAULT_ADDR));
         }
     }
@@ -113,26 +112,26 @@ void jit_brdgmm_kernel_base_t::read_params() {
     if (brg.with_bias) {
         add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_bias), X_TMP_0);
         ldr(reg_tmp, ptr(X_DEFAULT_ADDR));
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_bias_offs_, X_TMP_0); //rsp=X_SP
+        add_imm(X_DEFAULT_ADDR, sp, reg_bias_offs_, X_TMP_0);
         str(reg_tmp, ptr(X_DEFAULT_ADDR));
     }
 
     if (brg.with_scales) {
         add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_scales), X_TMP_0);
         ldr(reg_tmp, ptr(X_DEFAULT_ADDR));
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_scales_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_scales_offs_, X_TMP_0);
         str(reg_tmp, ptr(X_DEFAULT_ADDR));
     }
 
     if (brg.with_dst_scales) {
         add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_dst_scales), X_TMP_0);
         ldr(reg_tmp, ptr(X_DEFAULT_ADDR));
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_dst_scales_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_dst_scales_offs_, X_TMP_0);
         str(reg_tmp, ptr(X_DEFAULT_ADDR));
     }
 
     if (brg.with_binary) {
-        add_imm(X_DEFAULT_ADDR, X_SP, abi_param1_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, abi_param1_offs_, X_TMP_0);
         str(param1, ptr(X_DEFAULT_ADDR));
     }
 }
@@ -150,14 +149,14 @@ void jit_brdgmm_kernel_base_t::load_accumulators(int m_blocks, int n_blocks) {
 void jit_brdgmm_kernel_base_t::restore_A_B_matrices() {
     if (brg.brgattr.max_bs > 1
             && (one_of(brg.type, brgemm_addr, brgemm_offs) || has_vpad())) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_batch0_addr_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_batch0_addr_offs_, X_TMP_0);
         ldr(reg_aux_batch_addr, ptr(X_DEFAULT_ADDR));
     }
 
     if (brg.type == brgemm_strd && brg.brgattr.max_bs > 1) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_A_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_A_offs_, X_TMP_0);
         ldr(reg_aux1_A, ptr(X_DEFAULT_ADDR));
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_B_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_B_offs_, X_TMP_0);
         ldr(reg_aux1_B, ptr(X_DEFAULT_ADDR));
     }
 }
@@ -267,7 +266,7 @@ void jit_brdgmm_kernel_base_t::apply_post_ops(
     }
 
     if (brg.with_binary) {
-        add_imm(X_DEFAULT_ADDR, X_SP, abi_param1_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, abi_param1_offs_, X_TMP_0);
         ldr(reg_binary_params, ptr(X_DEFAULT_ADDR));
 
         if (with_binary_non_scalar_bcast_) {
@@ -352,7 +351,7 @@ void jit_brdgmm_kernel_base_t::store_accumulators_apply_post_ops(
     const bool dq2ps_required = brg.is_int8;
     const int v_substep = vnni_substep();
     if (brg.with_scales) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_scales_offs_, X_TMP_0); //rsp=X_SP
+        add_imm(X_DEFAULT_ADDR, sp, reg_scales_offs_, X_TMP_0);
         ldr(reg_aux_scales, ptr(X_DEFAULT_ADDR));
         if (brg.is_oc_scale) {
             mov_imm(X_TMP_1, sizeof(float));
@@ -396,7 +395,7 @@ void jit_brdgmm_kernel_base_t::store_accumulators_apply_post_ops(
     }
 
     if (brg.with_bias) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_bias_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_bias_offs_, X_TMP_0);
         ldr(reg_aux_bias, ptr(X_DEFAULT_ADDR));
         mov_imm(X_TMP_1, brg.typesize_bias);
         mul(X_TMP_1, reg_aux_N, X_TMP_1);
@@ -425,7 +424,7 @@ void jit_brdgmm_kernel_base_t::store_accumulators_apply_post_ops(
     if (postops_injector_) apply_post_ops(m_blocks, n_blocks, has_n_tail);
 
     if (brg.with_dst_scales) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_dst_scales_offs_, X_TMP_0); //rsp=X_SP
+        add_imm(X_DEFAULT_ADDR, sp, reg_dst_scales_offs_, X_TMP_0);
         ldr(reg_aux_dst_scales, ptr(X_DEFAULT_ADDR));
         auto vmm_dst_scales = vmm_tmp(0);
         ld1rw(vmm_dst_scales.s, P_ALL_ONE / T_z, ptr(reg_aux_dst_scales));
@@ -933,14 +932,14 @@ void jit_brdgmm_kernel_base_t::init_masks() {
 void jit_brdgmm_kernel_base_t::generate() {
 
     preamble();
-    sub_imm(X_SP, X_SP, stack_space_needed_, X_TMP_0); //rsp=X_SP
+    sub_imm(sp, sp, utils::rnd_up(stack_space_needed_, 16), X_TMP_0);
 
     init_masks();
 
     read_params();
     compute_loop();
 
-    add_imm(X_SP, X_SP, stack_space_needed_, X_TMP_0);
+    add_imm(sp, sp, utils::rnd_up(stack_space_needed_, 16), X_TMP_0);
     postamble();
 
     if (brg.with_eltwise) postops_injector_->prepare_table();

--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
@@ -167,13 +167,13 @@ private:
         if ((ld_idx < idx) && (idx <= dsc_idx)) {
             is_push = false;
         } else {
-            str(z_tmp, ptr(X_SP, -1, Xbyak_aarch64::MUL_VL));
+            str(z_tmp, ptr(sp, -1, Xbyak_aarch64::MUL_VL));
             is_push = true;
         }
         return z_tmp;
     }
     void pop_z_tmp(Xbyak_aarch64::ZReg z_tmp) {
-        if (is_push) { ldr(z_tmp, ptr(X_SP, -1, Xbyak_aarch64::MUL_VL)); }
+        if (is_push) { ldr(z_tmp, ptr(sp, -1, Xbyak_aarch64::MUL_VL)); }
     }
 
     void init_masks();

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -582,51 +582,51 @@ void jit_brgemm_kernel_t::ldb_regs_shift(int ld_block2, bool is_tail) {
             X_TMP_0);
 
     if (brg.with_bias) {
-        LDR_IMM(reg_aux_bias, X_SP, reg_aux_bias_offs_);
+        LDR_IMM(reg_aux_bias, sp, reg_aux_bias_offs_);
         add_imm(reg_aux_bias, reg_aux_bias,
                 (is_tail) ? bias_offset(1, true) : bias_offset(ld_block2),
                 X_TMP_0);
-        STR_IMM(reg_aux_bias, X_SP, reg_aux_bias_offs_);
+        STR_IMM(reg_aux_bias, sp, reg_aux_bias_offs_);
     }
     if (brg.req_s8s8_compensation) {
-        LDR_IMM(reg_aux_compensation, X_SP, reg_aux_comp_offs_);
+        LDR_IMM(reg_aux_compensation, sp, reg_aux_comp_offs_);
         add_imm(reg_aux_compensation, reg_aux_compensation,
                 (is_tail) ? compensations_offset(1, true)
                           : compensations_offset(ld_block2),
                 X_TMP_0);
-        STR_IMM(reg_aux_compensation, X_SP, reg_aux_comp_offs_);
+        STR_IMM(reg_aux_compensation, sp, reg_aux_comp_offs_);
     }
     if (brg.with_scales) {
-        LDR_IMM(reg_aux_scales, X_SP, reg_aux_scales_offs_);
+        LDR_IMM(reg_aux_scales, sp, reg_aux_scales_offs_);
         add_imm(reg_aux_scales, reg_aux_scales,
                 (is_tail) ? scales_offset(1, true) : scales_offset(ld_block2),
                 X_TMP_0);
-        STR_IMM(reg_aux_scales, X_SP, reg_aux_scales_offs_);
+        STR_IMM(reg_aux_scales, sp, reg_aux_scales_offs_);
     }
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
-        LDR_IMM(reg_aux_zp_comp_a, X_SP, reg_aux_zp_comp_a_offs_);
+        LDR_IMM(reg_aux_zp_comp_a, sp, reg_aux_zp_comp_a_offs_);
         add_imm(reg_aux_zp_comp_a, reg_aux_zp_comp_a,
                 (is_tail) ? zp_comp_a_offset(1, true)
                           : zp_comp_a_offset(ld_block2),
                 X_TMP_0);
-        STR_IMM(reg_aux_zp_comp_a, X_SP, reg_aux_zp_comp_a_offs_);
+        STR_IMM(reg_aux_zp_comp_a, sp, reg_aux_zp_comp_a_offs_);
     }
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
-        LDR_IMM(reg_aux_zp_c_values, X_SP, reg_aux_zp_c_values_offs_);
+        LDR_IMM(reg_aux_zp_c_values, sp, reg_aux_zp_c_values_offs_);
         add_imm(reg_aux_zp_c_values, reg_aux_zp_c_values,
                 (is_tail) ? zp_c_values_offset(1, true)
                           : zp_c_values_offset(ld_block2),
                 X_TMP_0);
-        STR_IMM(reg_aux_zp_c_values, X_SP, reg_aux_zp_c_values_offs_);
+        STR_IMM(reg_aux_zp_c_values, sp, reg_aux_zp_c_values_offs_);
     }
 }
 
 void jit_brgemm_kernel_t::advance_bd_block2_post_op_regs(int bd_block2) {
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
-        LDR_IMM(reg_zp_comp_b, X_SP, reg_zp_comp_b_offs_);
+        LDR_IMM(reg_zp_comp_b, sp, reg_zp_comp_b_offs_);
         add_imm(reg_zp_comp_b, reg_zp_comp_b, bdb_zp_comp_b_offset(bd_block2),
                 X_TMP_0);
-        STR_IMM(reg_zp_comp_b, X_SP, reg_zp_comp_b_offs_);
+        STR_IMM(reg_zp_comp_b, sp, reg_zp_comp_b_offs_);
     }
 }
 
@@ -636,38 +636,38 @@ void jit_brgemm_kernel_t::copy_post_ops_stack_values_to_aux(bool is_reg_tail) {
         mov(reg_aux_D, reg_D);
         eor(reg_b_offset, reg_b_offset, reg_b_offset);
         if (brg.with_bias) {
-            LDR_IMM(reg_bias, X_SP, reg_bias_offs_);
-            STR_IMM(reg_bias, X_SP, reg_aux_bias_offs_);
+            LDR_IMM(reg_bias, sp, reg_bias_offs_);
+            STR_IMM(reg_bias, sp, reg_aux_bias_offs_);
         }
         if (brg.req_s8s8_compensation) {
-            LDR_IMM(reg_compensation, X_SP, reg_comp_offs_);
-            STR_IMM(reg_compensation, X_SP, reg_aux_comp_offs_);
+            LDR_IMM(reg_compensation, sp, reg_comp_offs_);
+            STR_IMM(reg_compensation, sp, reg_aux_comp_offs_);
         }
         if (brg.with_scales) {
-            LDR_IMM(reg_scales, X_SP, reg_scales_offs_);
-            STR_IMM(reg_scales, X_SP, reg_aux_scales_offs_);
+            LDR_IMM(reg_scales, sp, reg_scales_offs_);
+            STR_IMM(reg_scales, sp, reg_aux_scales_offs_);
         }
 
         if (brg.zp_type_a != brgemm_broadcast_t::none) {
-            LDR_IMM(reg_zp_comp_a, X_SP, reg_zp_comp_a_offs_);
-            STR_IMM(reg_zp_comp_a, X_SP, reg_aux_zp_comp_a_offs_);
+            LDR_IMM(reg_zp_comp_a, sp, reg_zp_comp_a_offs_);
+            STR_IMM(reg_zp_comp_a, sp, reg_aux_zp_comp_a_offs_);
         }
 
         if (brg.zp_type_c != brgemm_broadcast_t::none) {
-            LDR_IMM(reg_zp_c_values, X_SP, reg_zp_c_values_offs_);
-            STR_IMM(reg_zp_c_values, X_SP, reg_aux_zp_c_values_offs_);
+            LDR_IMM(reg_zp_c_values, sp, reg_zp_c_values_offs_);
+            STR_IMM(reg_zp_c_values, sp, reg_aux_zp_c_values_offs_);
         }
     }
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
-        LDR_IMM(reg_zp_comp_b, X_SP, reg_zp_comp_b_offs_);
-        STR_IMM(reg_zp_comp_b, X_SP, reg_aux_zp_comp_b_offs_);
+        LDR_IMM(reg_zp_comp_b, sp, reg_zp_comp_b_offs_);
+        STR_IMM(reg_zp_comp_b, sp, reg_aux_zp_comp_b_offs_);
     }
 }
 
 void jit_brgemm_kernel_t::read_params() {
     Label label_done;
 
-    if (brg.with_binary) { STR_IMM(param1, X_SP, abi_param1_offs_); }
+    if (brg.with_binary) { STR_IMM(param1, sp, abi_param1_offs_); }
 
     if (brg.type == brgemm_addr) {
         LDR_IMM(reg_addr_batch, param1, GET_OFF(batch));
@@ -682,10 +682,10 @@ void jit_brgemm_kernel_t::read_params() {
 
         if (brg.type == brgemm_offs) {
             LDR_IMM(reg_offs_batch, param1, GET_OFF(batch));
-            STR_IMM(reg_offs_batch, X_SP, origin_offs_batch_offs_);
+            STR_IMM(reg_offs_batch, sp, origin_offs_batch_offs_);
         } else {
             LDR_IMM(reg_strd_batch, param1, GET_OFF(batch));
-            STR_IMM(reg_strd_batch, X_SP, origin_strd_batch_offs_);
+            STR_IMM(reg_strd_batch, sp, origin_strd_batch_offs_);
         }
     }
 
@@ -699,49 +699,49 @@ void jit_brgemm_kernel_t::read_params() {
     // brg.req_s8s8_compensation case
     if (brg.req_s8s8_compensation) {
         ldr(reg_buf, ptr(param1, GET_OFF(ptr_buf)));
-        str(reg_buf, ptr(X_SP, reg_buf_offs_));
+        str(reg_buf, ptr(sp, reg_buf_offs_));
     }
 
     if (brg.with_bias) {
         ldr(reg_bias, ptr(param1, GET_OFF(ptr_bias)));
-        str(reg_bias, ptr(X_SP, reg_bias_offs_));
+        str(reg_bias, ptr(sp, reg_bias_offs_));
     }
     if (brg.with_scales) {
         ldr(reg_scales, ptr(param1, GET_OFF(ptr_scales)));
-        str(reg_scales, ptr(X_SP, reg_scales_offs_));
+        str(reg_scales, ptr(sp, reg_scales_offs_));
     }
 
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
         ldr(reg_zp_comp_a, ptr(param1, GET_OFF(a_zp_compensations)));
-        str(reg_zp_comp_a, ptr(X_SP, reg_zp_comp_a_offs_));
+        str(reg_zp_comp_a, ptr(sp, reg_zp_comp_a_offs_));
     }
 
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         ldr(reg_zp_comp_b, ptr(param1, GET_OFF(b_zp_compensations)));
-        str(reg_zp_comp_b, ptr(X_SP, reg_zp_comp_b_offs_));
+        str(reg_zp_comp_b, ptr(sp, reg_zp_comp_b_offs_));
     }
 
     if (brg.zp_type_c != brgemm_broadcast_t::none) {
         ldr(reg_zp_c_values, ptr(param1, GET_OFF(c_zp_values)));
-        str(reg_zp_c_values, ptr(X_SP, reg_zp_c_values_offs_));
+        str(reg_zp_c_values, ptr(sp, reg_zp_c_values_offs_));
     }
 
     if (brg.with_dst_scales) {
         ldr(reg_dst_scales, ptr(param1, GET_OFF(ptr_dst_scales)));
-        str(reg_dst_scales, ptr(X_SP, reg_dst_scales_offs_));
+        str(reg_dst_scales, ptr(sp, reg_dst_scales_offs_));
     }
 
     ldr(reg_do_post_ops, ptr(param1, GET_OFF(do_post_ops)));
-    str(reg_do_post_ops, ptr(X_SP, reg_do_post_ops_offs_));
+    str(reg_do_post_ops, ptr(sp, reg_do_post_ops_offs_));
 
     ldr(reg_skip_accm, ptr(param1, GET_OFF(skip_accm)));
-    str(reg_skip_accm, ptr(X_SP, reg_skip_accm_offs_));
+    str(reg_skip_accm, ptr(sp, reg_skip_accm_offs_));
 
     ldr(reg_zp_a_val, ptr(param1, GET_OFF(zp_a_val)));
-    str(reg_zp_a_val, ptr(X_SP, reg_zp_a_val_offs_));
+    str(reg_zp_a_val, ptr(sp, reg_zp_a_val_offs_));
 
     ldr(reg_do_comp, ptr(param1, GET_OFF(do_apply_comp)));
-    str(reg_do_comp, ptr(X_SP, reg_do_comp_offs_));
+    str(reg_do_comp, ptr(sp, reg_do_comp_offs_));
 }
 
 void jit_brgemm_kernel_t::zero_accumulators(int bd_block2, bool is_bdb_tail,
@@ -809,7 +809,7 @@ void jit_brgemm_kernel_t::apply_post_ops(
             register_guard(brg.with_binary, this, {param1});
     const auto guard_space = register_guard.stack_space_occupied();
     if (brg.with_binary) {
-        add_imm(X_DEFAULT_ADDR, X_SP, abi_param1_offs_ + guard_space, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, abi_param1_offs_ + guard_space, X_TMP_0);
         ldr(param1, ptr(X_DEFAULT_ADDR));
 
         if (with_binary_non_scalar_bcast_) {
@@ -912,7 +912,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
         // otherwise it would be a Kx1 case.
         if (brg.is_gemv && brg.is_oc_scale && brg.LDB != 1) {
             int offset = 0;
-            add_imm(X_DEFAULT_ADDR, X_SP, reg_aux_scales_offs_, X_TMP_0);
+            add_imm(X_DEFAULT_ADDR, sp, reg_aux_scales_offs_, X_TMP_0);
             ldr(reg_aux_scales, ptr(X_DEFAULT_ADDR));
             for (int ld = 0; ld < ld_block2; ld++) {
                 for (int bd = 0; bd < bd_block; bd++) {
@@ -932,12 +932,12 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
             }
 
             // update the scale pointer
-            LDR_IMM(reg_aux_scales, X_SP, reg_aux_scales_offs_);
+            LDR_IMM(reg_aux_scales, sp, reg_aux_scales_offs_);
             add_imm(reg_aux_scales, reg_aux_scales, offset + sizeof(float),
                     X_TMP_0);
-            STR_IMM(reg_aux_scales, X_SP, reg_scales_offs_);
+            STR_IMM(reg_aux_scales, sp, reg_scales_offs_);
         } else {
-            add_imm(X_DEFAULT_ADDR, X_SP, reg_aux_scales_offs_, X_TMP_0);
+            add_imm(X_DEFAULT_ADDR, sp, reg_aux_scales_offs_, X_TMP_0);
             ldr(reg_aux_scales, ptr(X_DEFAULT_ADDR));
             for (int ld = 0; ld < ld_block2; ld++) {
                 const auto addr = X_DEFAULT_ADDR;
@@ -972,7 +972,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
     }
 
     if (brg.with_bias) {
-        LDR_IMM(reg_aux_bias, X_SP, reg_aux_bias_offs_);
+        LDR_IMM(reg_aux_bias, sp, reg_aux_bias_offs_);
 
         auto x_addr = reg_aux_bias;
         auto zmm_bias = z_tmp_1();
@@ -1003,9 +1003,9 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
             }
 
             // update the bias pointer
-            LDR_IMM(reg_aux_bias, X_SP, reg_aux_bias_offs_);
+            LDR_IMM(reg_aux_bias, sp, reg_aux_bias_offs_);
             add_imm(reg_aux_bias, reg_aux_bias, offset + 4, X_TMP_0);
-            STR_IMM(reg_aux_bias, X_SP, reg_bias_offs_);
+            STR_IMM(reg_aux_bias, sp, reg_bias_offs_);
 
         } else {
             for_(int ld = 0; ld < ld_block2; ld++)
@@ -1032,7 +1032,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
         apply_post_ops(bd_block, ld_block2, ldb_and_bdb_offset, is_ld_tail);
 
     if (brg.with_dst_scales) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_dst_scales_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_dst_scales_offs_, X_TMP_0);
         ldr(reg_aux_dst_scales, ptr(X_DEFAULT_ADDR));
         auto vmm_dst_scales = z_tmp_1();
         ld1rw(vmm_dst_scales.s, P_ALL_ONE / T_z, ptr(reg_aux_dst_scales));
@@ -1046,7 +1046,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
     }
 
     if (brg.zp_type_c != brgemm_broadcast_t::none) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_aux_zp_c_values_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_aux_zp_c_values_offs_, X_TMP_0);
         ldr(reg_aux_zp_c_values, ptr(X_DEFAULT_ADDR));
         auto vmm_zp_c = z_tmp_1();
         if (brg.zp_type_c == brgemm_broadcast_t::per_tensor) {
@@ -1137,12 +1137,12 @@ void jit_brgemm_kernel_t::apply_compensation(
 
     if (!brg.req_cal_comp_pads && brg.zp_type_a != brgemm_broadcast_t::none) {
         auto vmm_zp_a_val = z_tmp_2();
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_zp_a_val_offs_, X_TMP_0);
-        add_imm(reg_zp_a_val, X_SP, reg_zp_a_val_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_zp_a_val_offs_, X_TMP_0);
+        add_imm(reg_zp_a_val, sp, reg_zp_a_val_offs_, X_TMP_0);
         ldr(W_TMP_0, ptr(reg_zp_a_val));
         dup(vmm_zp_a_val.s, W_TMP_0);
 
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_aux_zp_comp_a_offs_, X_TMP_1);
+        add_imm(X_DEFAULT_ADDR, sp, reg_aux_zp_comp_a_offs_, X_TMP_1);
         ldr(reg_aux_zp_comp_a, ptr(X_DEFAULT_ADDR));
         for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
@@ -1166,7 +1166,7 @@ void jit_brgemm_kernel_t::apply_compensation(
     }
 
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
-        add_imm(X_DEFAULT_ADDR, X_SP, reg_aux_zp_comp_b_offs_, X_TMP_0);
+        add_imm(X_DEFAULT_ADDR, sp, reg_aux_zp_comp_b_offs_, X_TMP_0);
         ldr(reg_aux_zp_comp_b, ptr(X_DEFAULT_ADDR));
         for (int bd = 0; bd < bd_block; bd++) {
             int zp_comp_b_off = zp_comp_b_offset(bd);
@@ -1179,7 +1179,7 @@ void jit_brgemm_kernel_t::apply_compensation(
     }
 
     if (!brg.req_cal_comp_pads && brg.req_s8s8_compensation) {
-        ldr(reg_aux_compensation, ptr(X_SP, reg_aux_comp_offs_));
+        ldr(reg_aux_compensation, ptr(sp, reg_aux_comp_offs_));
         for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm_comp = z_tmp_1();
             int comp_offset = compensations_offset(ld);
@@ -1272,7 +1272,7 @@ void jit_brgemm_kernel_t::store_accumulators(int bd_block2, bool is_bdb_tail,
 
     if (brg.is_int8 && (brg.req_s8s8_compensation || has_zero_points)) {
         Label label_store_without_comp;
-        ldr(reg_do_comp, ptr(X_SP, reg_do_comp_offs_));
+        ldr(reg_do_comp, ptr(sp, reg_do_comp_offs_));
         cmp_imm(reg_do_comp, 0, X_TMP_0);
         b(EQ, label_store_without_comp);
         apply_compensation(bd_block, ld_block2, is_ld_tail);
@@ -1286,7 +1286,7 @@ void jit_brgemm_kernel_t::store_accumulators(int bd_block2, bool is_bdb_tail,
     if (are_post_ops_applicable) {
         Label label_store_without_post_ops;
 
-        LDR_IMM(reg_do_post_ops, X_SP, reg_do_post_ops_offs_);
+        LDR_IMM(reg_do_post_ops, sp, reg_do_post_ops_offs_);
         cmp_imm(reg_do_post_ops, 0, X_TMP_0);
         b(EQ, label_store_without_post_ops);
         if (brg.is_gemv) { sum_into_one_lane(bd_block, ld_block2, is_ld_tail); }
@@ -1338,9 +1338,9 @@ void jit_brgemm_kernel_t::restore_A_B_matrices() {
 
         if (restore_reg_batch) {
             if (brg.type == brgemm_offs) {
-                ldr(reg_offs_batch, ptr(X_SP, origin_offs_batch_offs_));
+                ldr(reg_offs_batch, ptr(sp, origin_offs_batch_offs_));
             } else {
-                ldr(reg_offs_batch, ptr(X_SP, origin_strd_batch_offs_));
+                ldr(reg_offs_batch, ptr(sp, origin_strd_batch_offs_));
             }
         }
     }
@@ -1398,9 +1398,9 @@ void jit_brgemm_kernel_t::set_A_B_matrices() {
         mov_imm(reg_tmp_gpr, brg.stride_b);
         add(reg_aux1_B, reg_aux1_B, reg_tmp_gpr);
         if (vpad_exist) {
-            ldr(reg_strd_batch, ptr(X_SP, origin_strd_batch_offs_));
+            ldr(reg_strd_batch, ptr(sp, origin_strd_batch_offs_));
             mov_imm(reg_strd_batch, sizeof(brgemm_batch_element_t));
-            str(reg_strd_batch, ptr(X_SP, origin_strd_batch_offs_));
+            str(reg_strd_batch, ptr(sp, origin_strd_batch_offs_));
         }
     }
     add(reg_aux_A, reg_aux_A, reg_a_offset);
@@ -1500,13 +1500,13 @@ void jit_brgemm_kernel_t::compute_int8_compensation(int rd_loop, int bd_b,
     };
 
     if (n_bcast_1_load && brg.zp_type_a != brgemm_broadcast_t::none) {
-        str(reg_bdb_loop, ptr(X_SP, reg_bdb_loop_offs_));
+        str(reg_bdb_loop, ptr(sp, reg_bdb_loop_offs_));
         const auto reg32_scratch = WReg(reg_zp_a_input_shift.getIdx());
         mov_imm(reg32_scratch, 0x1010101);
         dup(z_one_bytes().s, reg32_scratch);
-        ldr(reg32_scratch, ptr(X_SP, reg_zp_a_val_offs_));
+        ldr(reg32_scratch, ptr(sp, reg_zp_a_val_offs_));
         dup(z_zp_a_shift().s, reg32_scratch);
-        ldr(reg_bdb_loop, ptr(X_SP, reg_bdb_loop_offs_));
+        ldr(reg_bdb_loop, ptr(sp, reg_bdb_loop_offs_));
     }
 
     for_(int rd = 0; rd < rd_loop; rd += brg.rd_step)
@@ -1892,25 +1892,23 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
                 skip_accumulation);
 
         if (is_ldb_loop_) {
-            STR_IMM(reg_D, X_SP, reg_D_offs_);
+            STR_IMM(reg_D, sp, reg_D_offs_);
         } else {
             mov(reg_ldb_loop, reg_D);
         }
-        if (brg.brgattr.max_bs > 1) {
-            STR_IMM(reg_aux_D, X_SP, reg_aux_D_offs_);
-        }
+        if (brg.brgattr.max_bs > 1) { STR_IMM(reg_aux_D, sp, reg_aux_D_offs_); }
 
         if (brg.alpha != 0.f && !skip_accumulation) {
             restore_A_B_matrices();
 
             if (brg.req_s8s8_compensation) { assert(!"unsupported\n"); }
             if (need_comp_pads && brg.zp_type_a != brgemm_broadcast_t::none) {
-                str(reg_bdb_loop, ptr(X_SP, reg_bdb_loop_offs_));
+                str(reg_bdb_loop, ptr(sp, reg_bdb_loop_offs_));
                 const auto reg32_scratch = WReg(reg_zp_a_input_shift.getIdx());
                 mov(z_one_bytes().b, 1);
-                ldr(reg32_scratch, ptr(X_SP, reg_zp_a_val_offs_));
+                ldr(reg32_scratch, ptr(sp, reg_zp_a_val_offs_));
                 dup(z_zp_a_shift().s, reg32_scratch);
-                ldr(reg_bdb_loop, ptr(X_SP, reg_bdb_loop_offs_));
+                ldr(reg_bdb_loop, ptr(sp, reg_bdb_loop_offs_));
             }
 
             if (brg.brgattr.max_bs > 1) { mov(reg_BS_loop, reg_BS); }
@@ -1931,7 +1929,7 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
                                 : ((brg.type == brgemm_offs) ? reg_offs_batch
                                                              : reg_strd_batch);
                         if (brg.type == brgemm_strd) {
-                            LDR_IMM(reg_strd_batch, X_SP,
+                            LDR_IMM(reg_strd_batch, sp,
                                     origin_strd_batch_offs_);
                         }
                         ldr(reg_aux_A_vpad,
@@ -1990,13 +1988,11 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
         }
 
         if (is_ldb_loop_) {
-            LDR_IMM(reg_D, X_SP, reg_D_offs_);
+            LDR_IMM(reg_D, sp, reg_D_offs_);
         } else {
             mov(reg_D, reg_ldb_loop);
         }
-        if (brg.brgattr.max_bs > 1) {
-            LDR_IMM(reg_aux_D, X_SP, reg_aux_D_offs_);
-        }
+        if (brg.brgattr.max_bs > 1) { LDR_IMM(reg_aux_D, sp, reg_aux_D_offs_); }
 
         store_accumulators(bd_block2, is_bdb_tail, ld_block2, is_ld_tail,
                 skip_accumulation);
@@ -2194,7 +2190,7 @@ void jit_brgemm_kernel_t::bdb_loop() {
 
     if (brg.brgattr.generate_skip_accumulation) {
         Label bdb_loop_skip_acc_label, bdb_loop_done_label;
-        LDR_IMM(reg_skip_accm, X_SP, reg_skip_accm_offs_);
+        LDR_IMM(reg_skip_accm, sp, reg_skip_accm_offs_);
         cmp_imm(reg_skip_accm, 0, X_TMP_0);
         b(NE, bdb_loop_skip_acc_label);
 
@@ -2220,6 +2216,8 @@ void jit_brgemm_kernel_t::generate() {
     size_t simd_w_ = simd_elems(data_type::f32, brg.isa_impl);
 
     preamble();
+    sub_imm(sp, sp, utils::rnd_up(stack_space_needed_, 16), X_TMP_0);
+
     // Can we remove this?
     if (simd_w_ != cpu_sveLen / sizeof(float)) {
         set_preg(P_ALL_ONE.b, simd_w_ * 4, X_TMP_0, X_TMP_1);
@@ -2231,9 +2229,6 @@ void jit_brgemm_kernel_t::generate() {
     mov(x1, x3);
     mov(x8, x4);
     mov(x9, x5);
-
-    sub_imm(X_SP, X_SP, stack_space_needed_,
-            X_TMP_0); //rsp=X_SP
 
     vpad_exist
             = (brg.brgattr.max_top_vpad > 0 || brg.brgattr.max_bottom_vpad > 0)
@@ -2250,8 +2245,7 @@ void jit_brgemm_kernel_t::generate() {
 
     bdb_loop();
 
-    add_imm(X_SP, X_SP, stack_space_needed_, X_TMP_0);
-
+    add_imm(sp, sp, utils::rnd_up(stack_space_needed_, 16), X_TMP_0);
     postamble();
 
     if (brg.with_eltwise) postops_injector_->prepare_table();

--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -41,17 +41,17 @@ register_preserve_guard_t<isa>::register_preserve_guard_t(jit_generator_t *host,
         uint32_t i = 0;
         for (; i < store_pairs; ++i)
             host_->stp(gpr_regs_[2 * i], gpr_regs_[2 * i + 1],
-                    pre_ptr(host_->X_SP, -16));
+                    pre_ptr(host_->sp, -16));
 
         if (has_lone_store) {
             // The hardware requires the stack pointer to be quad-word aligned
             // https://github.com/ARM-software/abi-aa/blob/e2534ac15f02fa2e03b7f336f069f7cf392257d9/aapcs64/aapcs64.rst?#645the-stack
-            host_->str(gpr_regs_[2 * i], pre_ptr(host_->X_SP, -16));
+            host_->str(gpr_regs_[2 * i], pre_ptr(host_->sp, -16));
         }
     }
 
     if (!vec_regs_.empty()) {
-        host_->sub(host_->X_SP, host_->X_SP, vmm_to_preserve_size_bytes_);
+        host_->sub(host_->sp, host_->sp, vmm_to_preserve_size_bytes_);
 
         uint32_t stack_offset = vmm_to_preserve_size_bytes_;
         for (const auto &vmm : vmm_to_preserve) {
@@ -61,17 +61,17 @@ register_preserve_guard_t<isa>::register_preserve_guard_t(jit_generator_t *host,
             if (vlen_bytes > 16) {
                 if (stack_offset % vlen_bytes == 0) {
                     host_->st1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
-                            ptr(host_->X_SP, stack_offset / vlen_bytes,
+                            ptr(host_->sp, stack_offset / vlen_bytes,
                                     Xbyak_aarch64::MUL_VL));
                 } else {
-                    host_->add_imm(host_->X_DEFAULT_ADDR, host_->X_SP,
+                    host_->add_imm(host_->X_DEFAULT_ADDR, host_->sp,
                             stack_offset, host_->X_TMP_0);
                     host_->st1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
                             ptr(host_->X_DEFAULT_ADDR));
                 }
             } else {
-                host_->str(Xbyak_aarch64::QReg(idx),
-                        ptr(host_->X_SP, stack_offset));
+                host_->str(
+                        Xbyak_aarch64::QReg(idx), ptr(host_->sp, stack_offset));
             }
         }
     }
@@ -89,17 +89,17 @@ register_preserve_guard_t<isa>::~register_preserve_guard_t() {
         if (vlen_bytes > 16) {
             if (tmp_stack_offset % vlen_bytes == 0) {
                 host_->ld1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
-                        ptr(host_->X_SP, tmp_stack_offset / vlen_bytes,
+                        ptr(host_->sp, tmp_stack_offset / vlen_bytes,
                                 Xbyak_aarch64::MUL_VL));
             } else {
-                host_->add_imm(host_->X_DEFAULT_ADDR, host_->X_SP,
+                host_->add_imm(host_->X_DEFAULT_ADDR, host_->sp,
                         tmp_stack_offset, host_->X_TMP_0);
                 host_->ld1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
-                        ptr(host_->X_SP, host_->X_DEFAULT_ADDR));
+                        ptr(host_->sp, host_->X_DEFAULT_ADDR));
             }
         } else {
-            host_->ldr(Xbyak_aarch64::QReg(idx),
-                    ptr(host_->X_SP, tmp_stack_offset));
+            host_->ldr(
+                    Xbyak_aarch64::QReg(idx), ptr(host_->sp, tmp_stack_offset));
         }
 
         tmp_stack_offset += vlen_bytes;
@@ -107,20 +107,19 @@ register_preserve_guard_t<isa>::~register_preserve_guard_t() {
     }
 
     if (vmm_to_preserve_size_bytes_)
-        host_->add_imm(host_->X_SP, host_->X_SP, vmm_to_preserve_size_bytes_,
+        host_->add_imm(host_->sp, host_->sp, vmm_to_preserve_size_bytes_,
                 host_->X_TMP_0);
 
     if (!gpr_regs_.empty()) {
         const bool has_lone_store = gpr_regs_.size() % 2;
 
         if (has_lone_store) {
-            host_->ldr(gpr_regs_.back(), post_ptr(host_->X_SP, 16));
+            host_->ldr(gpr_regs_.back(), post_ptr(host_->sp, 16));
             gpr_regs_.pop_back();
         }
 
         for (int i = gpr_regs_.size() - 1; i > 0; --i) {
-            host_->ldp(
-                    gpr_regs_[i - 1], gpr_regs_[i], post_ptr(host_->X_SP, 16));
+            host_->ldp(gpr_regs_[i - 1], gpr_regs_[i], post_ptr(host_->sp, 16));
         }
     }
 }

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -421,33 +421,38 @@ int jit_uni_binary_injector_t<isa>::adjust_temp_vmm_hint(
     return user_hint;
 }
 
+// All stack size calculations need to be rounded up to the nearest multiple
+// of 16 to satisfy architecture requirements
 template <typename Vmm>
 static void push_vmm(jit_generator_t *host, const Vmm &vmm) {
-    host->sub_imm(host->X_SP, host->X_SP, host->cpu_sveLen * 16, host->X_TMP_0);
-    host->uni_str(vmm, host->X_SP);
+    const int32_t stack_space_needed_bytes
+            = utils::rnd_up(vmm.getBit() / 8, 16);
+
+    host->sub_imm(host->sp, host->sp, stack_space_needed_bytes, host->X_TMP_0);
+    host->uni_str(vmm, host->sp);
 }
 
 template <typename Vmm>
 static void pop_vmm(jit_generator_t *host, const Vmm &vmm) {
-    host->uni_ldr(vmm, host->X_SP);
-    host->add_imm(host->X_SP, host->X_SP, host->cpu_sveLen * 16, host->X_TMP_0);
+    const int32_t stack_space_needed_bytes
+            = utils::rnd_up(vmm.getBit() / 8, 16);
+
+    host->uni_ldr(vmm, host->sp);
+    host->add_imm(host->sp, host->sp, stack_space_needed_bytes, host->X_TMP_0);
 }
 
 static void push_opmask(jit_generator_t *host, const Xbyak_aarch64::PReg &k) {
-    static constexpr int k_mask_size = 8;
-    host->sub_imm(host->X_SP, host->X_SP, k_mask_size, host->X_TMP_0);
-    host->str(k, Xbyak_aarch64::ptr(host->X_SP));
+    const int32_t stack_space_needed_bytes = utils::rnd_up(k.getBit() / 8, 16);
+
+    host->sub_imm(host->sp, host->sp, stack_space_needed_bytes, host->X_TMP_0);
+    host->str(k, Xbyak_aarch64::ptr(host->sp));
 }
 
 static void pop_opmask(jit_generator_t *host, const Xbyak_aarch64::PReg &k) {
-    static constexpr int k_mask_size = 8;
-    host->ldr(k, Xbyak_aarch64::ptr(host->X_SP));
-    host->add_imm(host->X_SP, host->X_SP, k_mask_size, host->X_TMP_0);
-}
+    const int32_t stack_space_needed_bytes = utils::rnd_up(k.getBit() / 8, 16);
 
-template <typename Vmm>
-static void restore_stack(jit_generator_t *host, const Vmm &vmm) {
-    host->add_imm(host->X_SP, host->X_SP, host->cpu_sveLen * 16, host->X_TMP_0);
+    host->ldr(k, Xbyak_aarch64::ptr(host->sp));
+    host->add_imm(host->sp, host->sp, stack_space_needed_bytes, host->X_TMP_0);
 }
 
 template <cpu_isa_t isa>
@@ -1997,10 +2002,10 @@ void jit_uni_binary_injector_t<asimd>::execute_binary(alg_kind_t binary_alg,
                 // Pick the SIMD vector register with index i to be the scratch register.
                 v_rhs = Xbyak_aarch64::VReg(i);
                 // Allocate space on stack
-                host_->sub(host_->X_SP, host_->X_SP, SIMD_SZ);
+                host_->sub(host_->sp, host_->sp, SIMD_SZ);
                 // Store the scratch register into the stack so it's safe to clobber it.
-                host_->str(Xbyak_aarch64::QReg(i),
-                        Xbyak_aarch64::ptr(host_->X_SP));
+                host_->str(
+                        Xbyak_aarch64::QReg(i), Xbyak_aarch64::ptr(host_->sp));
                 // Compute the effective address we want to load from.
                 Xbyak_aarch64::XReg x_addr = host_->addr_off(addr.base_,
                         addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
@@ -2068,9 +2073,9 @@ void jit_uni_binary_injector_t<asimd>::execute_binary(alg_kind_t binary_alg,
     if (isAddr) {
         // Restore the scratch register's initial content from the stack.
         host_->ldr(Xbyak_aarch64::QReg(v_rhs.getIdx()),
-                Xbyak_aarch64::ptr(host_->X_SP));
+                Xbyak_aarch64::ptr(host_->sp));
         // Free allocated stack space.
-        host_->add(host_->X_SP, host_->X_SP, SIMD_SZ);
+        host_->add(host_->sp, host_->sp, SIMD_SZ);
     }
 }
 
@@ -2090,9 +2095,9 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
                 // Pick the SVE vector register with index i to be the scratch register.
                 z_rhs = Vmm(i);
                 // Allocate 1 VL space on stack
-                host_->addvl(host_->X_SP, host_->X_SP, -1);
+                host_->addvl(host_->sp, host_->sp, -1);
                 // Store the scratch register into the stack so it's safe to clobber it.
-                host_->str(z_rhs, Xbyak_aarch64::ptr(host_->X_SP));
+                host_->str(z_rhs, Xbyak_aarch64::ptr(host_->sp));
                 // Compute the effective address we want to load from.
                 Xbyak_aarch64::XReg x_addr = host_->addr_off(addr.base_,
                         addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
@@ -2159,9 +2164,9 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
 
     if (isAddr) {
         // Restore the scratch register's initial content from the stack.
-        host_->ldr(z_rhs, Xbyak_aarch64::ptr(host_->X_SP));
+        host_->ldr(z_rhs, Xbyak_aarch64::ptr(host_->sp));
         // Free allocated stack space.
-        host_->addvl(host_->X_SP, host_->X_SP, 1);
+        host_->addvl(host_->sp, host_->sp, 1);
     }
 }
 

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -107,15 +107,16 @@ void jit_uni_eltwise_injector_t<isa>::injector_preamble(
     assert(preserved_gprs_count == aux_gprs_count());
 
     if (save_state_) {
-        const int reg_size = h->x0.getBit() / 8;
-        if (preserve_p_table_) h->str(x_table, pre_ptr(h->X_SP, -reg_size));
+        // TODO: use register_preserve_guard for better stack management
+        const int reg_size = utils::rnd_up(h->x0.getBit() / 8, 16);
+        if (preserve_p_table_) h->str(x_table, pre_ptr(h->sp, -reg_size));
         for (size_t i = 0; i < preserved_gprs_count; ++i)
-            h->str(XReg(preserved_gpr_idxs[i]), pre_ptr(h->X_SP, -reg_size));
+            h->str(XReg(preserved_gpr_idxs[i]), pre_ptr(h->sp, -reg_size));
 
         if (preserve_vmm_) {
             if (preserved_vecs_count)
-                h->sub_imm(h->X_SP, h->X_SP, preserved_vecs_count * vlen,
-                        h->X_TMP_0);
+                h->sub_imm(
+                        h->sp, h->sp, preserved_vecs_count * vlen, h->X_TMP_0);
             for (size_t i = 0; i < preserved_vecs_count; ++i)
                 store_preserved_vec(i, preserved_vec_idxs[i]);
         }
@@ -135,7 +136,7 @@ void jit_uni_eltwise_injector_t<isa>::injector_preamble_tail(
     const int idx_off = vecs_to_preserve - tail_vecs_to_preserve;
 
     if (save_state_) {
-        if (idx_off) h->add_imm(h->X_SP, h->X_SP, idx_off * vlen, h->X_TMP_0);
+        if (idx_off) h->add_imm(h->sp, h->sp, idx_off * vlen, h->X_TMP_0);
 
         for (size_t i = 0; i < tail_vecs_to_preserve; ++i)
             load_preserved_vec(i, preserved_vec_idxs[idx_off + i]);
@@ -148,7 +149,7 @@ void jit_uni_eltwise_injector_t<isa>::injector_preamble_tail(
         for (size_t i = 0; i < tail_vecs_to_preserve; ++i)
             store_preserved_vec(i, preserved_vec_idxs[idx_off + i]);
 
-        if (idx_off) h->sub_imm(h->X_SP, h->X_SP, idx_off * vlen, h->X_TMP_0);
+        if (idx_off) h->sub_imm(h->sp, h->sp, idx_off * vlen, h->X_TMP_0);
     }
 
     assign_regs();
@@ -158,7 +159,7 @@ void jit_uni_eltwise_injector_t<isa>::injector_preamble_tail(
 template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_t<isa>::injector_postamble() {
     using namespace Xbyak_aarch64::util;
-    const int reg_size = h->x0.getBit() / 8;
+    const int reg_size = utils::rnd_up(h->x0.getBit() / 8, 16);
     if (!save_state_) return;
 
     if (preserve_vmm_) {
@@ -166,13 +167,12 @@ void jit_uni_eltwise_injector_t<isa>::injector_postamble() {
             load_preserved_vec(i, preserved_vec_idxs[i]);
 
         if (preserved_vecs_count)
-            h->add_imm(
-                    h->X_SP, h->X_SP, preserved_vecs_count * vlen, h->X_TMP_0);
+            h->add_imm(h->sp, h->sp, preserved_vecs_count * vlen, h->X_TMP_0);
     }
 
     for (int i = aux_gprs_count() - 1; i >= 0; --i)
-        h->ldr(XReg(preserved_gpr_idxs[i]), post_ptr(h->X_SP, reg_size));
-    if (preserve_p_table_) h->ldr(x_table, post_ptr(h->X_SP, reg_size));
+        h->ldr(XReg(preserved_gpr_idxs[i]), post_ptr(h->sp, reg_size));
+    if (preserve_p_table_) h->ldr(x_table, post_ptr(h->sp, reg_size));
 }
 
 template <cpu_isa_t isa>
@@ -195,9 +195,9 @@ template <cpu_isa_t isa>
 inline void jit_uni_eltwise_injector_t<isa>::store_preserved_vec(
         size_t slot, size_t vmm_idx) {
     if (isa == asimd) {
-        h->str(QReg(vmm_idx), ptr(h->X_SP, static_cast<int32_t>(slot * vlen)));
+        h->str(QReg(vmm_idx), ptr(h->sp, static_cast<int32_t>(slot * vlen)));
     } else {
-        h->str(ZReg(vmm_idx), ptr(h->X_SP, slot, MUL_VL));
+        h->str(ZReg(vmm_idx), ptr(h->sp, slot, MUL_VL));
     }
 }
 
@@ -205,9 +205,9 @@ template <cpu_isa_t isa>
 inline void jit_uni_eltwise_injector_t<isa>::load_preserved_vec(
         size_t slot, size_t vmm_idx) {
     if (isa == asimd) {
-        h->ldr(QReg(vmm_idx), ptr(h->X_SP, static_cast<int32_t>(slot * vlen)));
+        h->ldr(QReg(vmm_idx), ptr(h->sp, static_cast<int32_t>(slot * vlen)));
     } else {
-        h->ldr(ZReg(vmm_idx), ptr(h->X_SP, slot, MUL_VL));
+        h->ldr(ZReg(vmm_idx), ptr(h->sp, slot, MUL_VL));
     }
 }
 
@@ -1235,16 +1235,16 @@ void jit_uni_eltwise_injector_t<isa>::gelu_tanh_compute_vector_bwd(
     h->fmul(vmm_aux2, vmm_aux2, vmm_aux0);
 
     // save G2 on stack as tanh uses all available registers
-    h->sub_imm(h->X_SP, h->X_SP, vlen, h->X_TMP_0);
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->sub_imm(h->sp, h->sp, vlen, h->X_TMP_0);
+    h->mov(h->X_TMP_0, h->sp);
     h->str(ZReg(IDX(vmm_aux2)), ptr(h->X_TMP_0));
 
     // T = tanh(G1(x))
     tanh_compute_vector_fwd(vmm_src);
 
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->mov(h->X_TMP_0, h->sp);
     h->ldr(ZReg(IDX(vmm_aux2)), ptr(h->X_TMP_0));
-    h->add_imm(h->X_SP, h->X_SP, vlen, h->X_TMP_0);
+    h->add_imm(h->sp, h->sp, vlen, h->X_TMP_0);
 
     // compute 0.5 * (1 + T) * (1 + G2 * (1 - T))
     // 1) R = G2 * (1 - T) = G2 - G2 * T
@@ -1373,18 +1373,18 @@ void jit_uni_eltwise_injector_t<isa>::swish_compute_vector_bwd(
     h->fmul(vmm_src, vmm_src, table_val(alpha, z_tmp));
 
     // Save R on stack for later usage
-    h->sub_imm(h->X_SP, h->X_SP, vlen, h->X_TMP_0);
+    h->sub_imm(h->sp, h->sp, vlen, h->X_TMP_0);
 
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->mov(h->X_TMP_0, h->sp);
     h->str(ZReg(IDX(vmm_src)), ptr(h->X_TMP_0));
 
     // Q = sigmoid(alpha * s)
     logistic_compute_vector_fwd(vmm_src);
 
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->mov(h->X_TMP_0, h->sp);
     h->ldr(ZReg(IDX(vmm_aux0)), ptr(h->X_TMP_0));
 
-    h->add_imm(h->X_SP, h->X_SP, vlen, h->X_TMP_0);
+    h->add_imm(h->sp, h->sp, vlen, h->X_TMP_0);
 
     // compute Q * (1 + R * (1 - Q))
     // T = R * (1 - Q) = R - R * Q
@@ -1430,8 +1430,8 @@ void jit_uni_eltwise_injector_t<isa>::gelu_erf_compute_vector_bwd(
     h->fmul(vmm_src, vmm_src, table_val(gelu_erf_one_over_sqrt_two, z_tmp));
 
     // Save R on stack for later usage
-    h->sub_imm(h->X_SP, h->X_SP, vlen, h->X_TMP_0);
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->sub_imm(h->sp, h->sp, vlen, h->X_TMP_0);
+    h->mov(h->X_TMP_0, h->sp);
     h->str(ZReg(IDX(vmm_src)), ptr(h->X_TMP_0));
 
     // Q = exp(-R*R)
@@ -1441,7 +1441,7 @@ void jit_uni_eltwise_injector_t<isa>::gelu_erf_compute_vector_bwd(
     exp_compute_vector_fwd(vmm_src);
 
     // T = R / sqrt(pi) * Q
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->mov(h->X_TMP_0, h->sp);
     h->ldr(ZReg(IDX(vmm_aux2)), ptr(h->X_TMP_0));
     h->fmul(vmm_aux2, vmm_aux2, table_val(gelu_erf_one_over_sqrt_pi, z_tmp));
     h->fmul(vmm_aux2, vmm_aux2, vmm_src);
@@ -1451,15 +1451,15 @@ void jit_uni_eltwise_injector_t<isa>::gelu_erf_compute_vector_bwd(
             ZRegD(IDX(table_val(sign_mask, z_tmp))));
 
     // get sign
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->mov(h->X_TMP_0, h->sp);
     h->ldr(ZReg(IDX(vmm_aux0)), ptr(h->X_TMP_0));
     h->and_(ZRegD(IDX(vmm_aux0)), ZRegD(IDX(vmm_aux0)),
             ZRegD(IDX(table_val(sign_mask, z_tmp))));
 
     // abs(x)
-    h->add_imm(h->X_TMP_0, h->X_SP, 0, h->X_TMP_1);
+    h->mov(h->X_TMP_0, h->sp);
     h->ldr(ZReg(IDX(vmm_aux1)), ptr(h->X_TMP_0));
-    h->add_imm(h->X_SP, h->X_SP, vlen, h->X_TMP_0);
+    h->add_imm(h->sp, h->sp, vlen, h->X_TMP_0);
 
     abs_compute_vector_fwd(ZReg(IDX(vmm_aux1)));
 

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -72,12 +72,12 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::store_accumulators(
     if (jcp_.src_zero_point) {
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
-            str(vmm_zp_shift, ptr(X_SP, -1, MUL_VL));
+            str(vmm_zp_shift, ptr(sp, -1, MUL_VL));
 
             auto vmm = accum(n_block, m, n);
             auto vmm_tmp = vmm_tmp_1();
             auto vmm_zp = vmm_zp_shift;
-            ldr(vmm_tmp, ptr(X_SP, -1, MUL_VL));
+            ldr(vmm_tmp, ptr(sp, -1, MUL_VL));
             add_imm(X_DEFAULT_ADDR, reg_zp_comp_out, out_oc_offset(n), X_TMP_0);
             ldr(vmm_zp, ptr(X_DEFAULT_ADDR));
 
@@ -85,19 +85,19 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::store_accumulators(
             add(vmm_tmp.s, vmm_tmp.s, vmm_zp.s);
             st1w(vmm_tmp.s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
 
-            ldr(vmm_zp_shift, ptr(X_SP, -1, MUL_VL));
+            ldr(vmm_zp_shift, ptr(sp, -1, MUL_VL));
         }
     }
 
     if (jcp_.s8s8_compensation_required) {
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
-            str(vmm_cp_shift, ptr(X_SP, -1, MUL_VL));
+            str(vmm_cp_shift, ptr(sp, -1, MUL_VL));
 
             auto vmm = accum(n_block, m, n);
             auto vmm_tmp = vmm_tmp_1();
             auto vmm_zp = vmm_cp_shift;
-            ldr(vmm_tmp, ptr(X_SP, -1, MUL_VL));
+            ldr(vmm_tmp, ptr(sp, -1, MUL_VL));
             add_imm(X_DEFAULT_ADDR, reg_comp_out, out_oc_offset(n), X_TMP_0);
             ldr(vmm_zp, ptr(X_DEFAULT_ADDR));
 
@@ -105,7 +105,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::store_accumulators(
             add(vmm_tmp.s, vmm_tmp.s, vmm_zp.s);
             st1w(vmm_tmp.s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
 
-            ldr(vmm_cp_shift, ptr(X_SP, -1, MUL_VL));
+            ldr(vmm_cp_shift, ptr(sp, -1, MUL_VL));
         }
     }
 }

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -339,10 +339,10 @@ private:
 
         if (brg.zp_type_a != brgemm_broadcast_t::none) {
             auto vmm_zp_a_val = vmm_tmp(1);
-            ldr(reg_zp_a_val, ptr(X_SP, reg_zp_a_val_offs_));
+            ldr(reg_zp_a_val, ptr(sp, reg_zp_a_val_offs_));
             dup(vmm_zp_a_val.s, WReg(reg_zp_a_val.getIdx()));
 
-            ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+            ldr(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
             for (int n = 0; n < n_block; n++) {
                 auto vmm_zp_comp_a = vmm_tmp(0);
                 const size_t zp_comp_offset
@@ -359,7 +359,7 @@ private:
         }
 
         if (brg.req_s8s8_compensation) {
-            ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+            ldr(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
             for (int n = 0; n < n_block; n++) {
                 auto vmm_comp = vmm_tmp(0);
                 const size_t s8s8_comp_offset
@@ -376,7 +376,7 @@ private:
     }
     void maybe_apply_comp(int m_block, int n_block, int tail = 0) {
         Label label_apply_without_comp;
-        ldr(reg_apply_comp, ptr(X_SP, reg_apply_comp_offs_));
+        ldr(reg_apply_comp, ptr(sp, reg_apply_comp_offs_));
         cmp(reg_apply_comp, 0);
         b(EQ, label_apply_without_comp);
         apply_comp(m_block, n_block, tail);
@@ -446,7 +446,7 @@ private:
         if (postops_injector_) inject_attr_postops(m_block, n_block, tail);
 
         if (brg.beta != 0 && brg.with_dst_scales) {
-            ldr(aux_reg_dst_scales, ptr(X_SP, reg_dst_scales_offs_));
+            ldr(aux_reg_dst_scales, ptr(sp, reg_dst_scales_offs_));
             auto vmm_tmp1 = vmm_tmp(1);
             ldr(vmm_tmp1, ptr(aux_reg_dst_scales));
 
@@ -459,7 +459,7 @@ private:
         }
 
         if (brg.beta != 0 && brg.zp_type_c != brgemm_broadcast_t::none) {
-            ldr(aux_reg_zp_c_values, ptr(X_SP, aux_reg_zp_c_values_offs_));
+            ldr(aux_reg_zp_c_values, ptr(sp, aux_reg_zp_c_values_offs_));
             auto vmm_zp_c = vmm_tmp(0);
             if (brg.zp_type_c == brgemm_broadcast_t::per_tensor) {
                 auto vmm_tmp1 = vmm_tmp(1);
@@ -547,16 +547,16 @@ private:
         if (brg.beta != 0) {
             if (jcp.with_bias) mov(aux_reg_bias, reg_bias);
             if (brg.zp_type_c != brgemm_broadcast_t::none) {
-                ldr(aux_reg_zp_c_values, ptr(X_SP, reg_zp_c_values_offs_));
-                str(aux_reg_zp_c_values, ptr(X_SP, aux_reg_zp_c_values_offs_));
+                ldr(aux_reg_zp_c_values, ptr(sp, reg_zp_c_values_offs_));
+                str(aux_reg_zp_c_values, ptr(sp, aux_reg_zp_c_values_offs_));
             }
             if (brg.zp_type_a != brgemm_broadcast_t::none) {
-                ldr(aux_reg_zp_a_comp, ptr(X_SP, reg_zp_a_comp_offs_));
-                str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                ldr(aux_reg_zp_a_comp, ptr(sp, reg_zp_a_comp_offs_));
+                str(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
             }
             if (brg.req_s8s8_compensation) {
-                ldr(aux_reg_s8s8_comp, ptr(X_SP, reg_s8s8_comp_offs_));
-                str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                ldr(aux_reg_s8s8_comp, ptr(sp, reg_s8s8_comp_offs_));
+                str(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
             }
             mov(aux_reg_scales, reg_scales);
         }
@@ -579,23 +579,23 @@ private:
                             bia_typesize_ * oc_l_offset, X_TMP_0);
                 if (brg.zp_type_c != brgemm_broadcast_t::none) {
                     ldr(aux_reg_zp_c_values,
-                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                            ptr(sp, aux_reg_zp_c_values_offs_));
                     add_imm(aux_reg_zp_c_values, aux_reg_zp_c_values,
                             zp_c_values_offset(n_block2_), X_TMP_0);
                     str(aux_reg_zp_c_values,
-                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                            ptr(sp, aux_reg_zp_c_values_offs_));
                 }
                 if (brg.zp_type_a != brgemm_broadcast_t::none) {
-                    ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    ldr(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
                     add_imm(aux_reg_zp_a_comp, aux_reg_zp_a_comp,
                             sizeof(int32_t) * oc_l_offset, X_TMP_0);
-                    str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    str(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
                 }
                 if (brg.req_s8s8_compensation) {
-                    ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    ldr(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
                     add_imm(aux_reg_s8s8_comp, aux_reg_s8s8_comp,
                             sizeof(int32_t) * oc_l_offset, X_TMP_0);
-                    str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    str(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
                 }
 
                 add_imm(aux_reg_scales, aux_reg_scales,
@@ -618,23 +618,23 @@ private:
                             bia_typesize_ * oc_l_offset, X_TMP_0);
                 if (brg.zp_type_c != brgemm_broadcast_t::none) {
                     ldr(aux_reg_zp_c_values,
-                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                            ptr(sp, aux_reg_zp_c_values_offs_));
                     add_imm(aux_reg_zp_c_values, aux_reg_zp_c_values,
                             zp_c_values_offset(nb2_tail), X_TMP_0);
                     str(aux_reg_zp_c_values,
-                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                            ptr(sp, aux_reg_zp_c_values_offs_));
                 }
                 if (brg.zp_type_a != brgemm_broadcast_t::none) {
-                    ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    ldr(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
                     add_imm(aux_reg_zp_a_comp, aux_reg_zp_a_comp,
                             sizeof(int32_t) * oc_l_offset, X_TMP_0);
-                    str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    str(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
                 }
                 if (brg.req_s8s8_compensation) {
-                    ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    ldr(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
                     add_imm(aux_reg_s8s8_comp, aux_reg_s8s8_comp,
                             sizeof(int32_t) * oc_l_offset, X_TMP_0);
-                    str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    str(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
                 }
 
                 add_imm(aux_reg_scales, aux_reg_scales,
@@ -654,23 +654,23 @@ private:
                             bia_typesize_ * (nb_tail), X_TMP_0);
                 if (brg.zp_type_c != brgemm_broadcast_t::none) {
                     ldr(aux_reg_zp_c_values,
-                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                            ptr(sp, aux_reg_zp_c_values_offs_));
                     add_imm(aux_reg_zp_c_values, aux_reg_zp_c_values,
                             zp_c_values_offset(1, nb_tail), X_TMP_0);
                     str(aux_reg_zp_c_values,
-                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                            ptr(sp, aux_reg_zp_c_values_offs_));
                 }
                 if (brg.zp_type_a != brgemm_broadcast_t::none) {
-                    ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    ldr(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
                     add_imm(aux_reg_zp_a_comp, aux_reg_zp_a_comp,
                             sizeof(int32_t) * nb_tail, X_TMP_0);
-                    str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    str(aux_reg_zp_a_comp, ptr(sp, aux_reg_zp_a_comp_offs_));
                 }
                 if (brg.req_s8s8_compensation) {
-                    ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    ldr(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
                     add_imm(aux_reg_s8s8_comp, aux_reg_s8s8_comp,
                             sizeof(int32_t) * nb_tail, X_TMP_0);
-                    str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    str(aux_reg_s8s8_comp, ptr(sp, aux_reg_s8s8_comp_offs_));
                 }
                 add_imm(aux_reg_scales, aux_reg_scales,
                         is_oc_scale_ * bia_typesize_ * (nb_tail), X_TMP_0);
@@ -687,6 +687,8 @@ private:
         size_t simd_w_ = simd_elems(data_type::f32, brg.isa_impl);
 
         preamble();
+        sub_imm(sp, sp, utils::rnd_up(stack_space_needed_, 16), X_TMP_0);
+
         if (simd_w_ != cpu_sveLen / sizeof(float)) {
             set_preg(P_ALL_ONE.b, simd_w_ * 4, X_TMP_0, X_TMP_1);
             set_preg(k_full_mask.b, simd_w_ * 4, X_TMP_0, X_TMP_1);
@@ -700,7 +702,7 @@ private:
         mov(x8, x4);
         mov(x9, x5);
 
-        mov(x4, X_SP);
+        mov(x4, sp);
         int nb = brg.load_dim / brg.ld_block;
         int nb_tail = brg.load_dim % brg.ld_block;
 
@@ -725,7 +727,7 @@ private:
             ldr(reg_scales, ptr(X_DEFAULT_ADDR));
             add_imm(X_DEFAULT_ADDR, param1, GET_OFF(apply_comp), X_TMP_0);
             ldr(reg_apply_comp, ptr(X_DEFAULT_ADDR));
-            str(reg_apply_comp, ptr(X_SP, reg_apply_comp_offs_));
+            str(reg_apply_comp, ptr(sp, reg_apply_comp_offs_));
 
             if (jcp.with_bias) {
                 add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_bias), X_TMP_0);
@@ -734,29 +736,29 @@ private:
             if (brg.zp_type_c != brgemm_broadcast_t::none) {
                 add_imm(X_DEFAULT_ADDR, param1, GET_OFF(c_zp_values), X_TMP_0);
                 ldr(reg_zp_c_values, ptr(X_DEFAULT_ADDR));
-                str(reg_zp_c_values, ptr(X_SP, reg_zp_c_values_offs_));
+                str(reg_zp_c_values, ptr(sp, reg_zp_c_values_offs_));
             }
             if (brg.zp_type_a != brgemm_broadcast_t::none) {
                 add_imm(X_DEFAULT_ADDR, param1, GET_OFF(a_zp_compensation),
                         X_TMP_0);
                 ldr(reg_zp_a_comp, ptr(X_DEFAULT_ADDR));
-                str(reg_zp_a_comp, ptr(X_SP, reg_zp_a_comp_offs_));
+                str(reg_zp_a_comp, ptr(sp, reg_zp_a_comp_offs_));
 
                 add_imm(X_DEFAULT_ADDR, param1, GET_OFF(a_comp_val), X_TMP_0);
                 ldr(reg_zp_a_val, ptr(X_DEFAULT_ADDR));
-                str(reg_zp_a_val, ptr(X_SP, reg_zp_a_val_offs_));
+                str(reg_zp_a_val, ptr(sp, reg_zp_a_val_offs_));
             }
             if (brg.req_s8s8_compensation) {
                 add_imm(X_DEFAULT_ADDR, param1, GET_OFF(s8s8_compensation),
                         X_TMP_0);
                 ldr(reg_s8s8_comp, ptr(X_DEFAULT_ADDR));
-                str(reg_s8s8_comp, ptr(X_SP, reg_s8s8_comp_offs_));
+                str(reg_s8s8_comp, ptr(sp, reg_s8s8_comp_offs_));
             }
             if (brg.with_dst_scales) {
                 add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_dst_scales),
                         X_TMP_0);
                 ldr(reg_dst_scales, ptr(X_DEFAULT_ADDR));
-                str(reg_dst_scales, ptr(X_SP, reg_dst_scales_offs_));
+                str(reg_dst_scales, ptr(sp, reg_dst_scales_offs_));
             }
         }
         add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_out), X_TMP_0);
@@ -787,8 +789,7 @@ private:
 
         if (mb_tail > 0) loop_by_N(mb_tail, nb2, nb2_tail, nb_tail);
 
-        add_imm(X_SP, X_SP, stack_space_needed_, X_TMP_0);
-
+        add_imm(sp, sp, utils::rnd_up(stack_space_needed_, 16), X_TMP_0);
         postamble();
 
         if (postops_injector_) postops_injector_->prepare_table();

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -172,7 +172,6 @@ public:
     const Xbyak_aarch64::XReg X_TMP_3 = x26;
     const Xbyak_aarch64::XReg X_TMP_4 = x27;
     const Xbyak_aarch64::XReg X_DEFAULT_ADDR = x28;
-    const Xbyak_aarch64::XReg X_SP = x21;
     const Xbyak_aarch64::PReg P_TMP = p7;
     const Xbyak_aarch64::PReg P_TMP_0 = p11;
     const Xbyak_aarch64::PReg P_TMP_1 = p12;
@@ -226,8 +225,6 @@ public:
             ptrue(P_NOT_256.b, Xbyak_aarch64::VL32);
             not_(P_NOT_256.b, P_ALL_ONE / Xbyak_aarch64::T_z, P_NOT_256.b);
         }
-
-        mov(X_SP, sp);
     }
 
     void postamble() {

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
@@ -76,7 +76,7 @@ void jit_sve_1x1_conv_kernel_t<isa>::bcast_loop(int load_loop_blk) {
     mov(aux1_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_output_data, reg_output_data);
-    ldr(reg_bcast_loop_iter, ptr(X_SP, reg_bcast_loop_work_offt));
+    ldr(reg_bcast_loop_iter, ptr(sp, reg_bcast_loop_work_offt));
 
     Label bcast_loop;
     Label bcast_loop_tail;
@@ -171,7 +171,7 @@ void jit_sve_1x1_conv_kernel_t<isa>::apply_postops(
             if (mask_flag) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
         });
 
-        ldr(abi_param1, ptr(X_SP, reg_abi_param1_backup));
+        ldr(abi_param1, ptr(sp, reg_abi_param1_backup));
 
         postops_injector_->compute_vector_range(vmm_idxs, rhs_arg_params);
     } else {
@@ -462,13 +462,13 @@ void jit_sve_1x1_conv_kernel_t<isa>::reduce_loop(
 template <cpu_isa_t isa>
 void jit_sve_1x1_conv_kernel_t<isa>::generate() {
     preamble();
+    sub_imm(sp, sp, utils::rnd_up(stack_space_needed, 16), X_TMP_0);
 
-    sub_imm(X_SP, X_SP, stack_space_needed, X_TMP_0);
     if (jcp.with_binary) {
         const auto zeroed_reg = x15;
         eor(zeroed_reg, zeroed_reg, zeroed_reg);
-        str(zeroed_reg, ptr(X_SP, reg_binary_post_op_acc_off));
-        str(param1, ptr(X_SP, reg_abi_param1_backup));
+        str(zeroed_reg, ptr(sp, reg_binary_post_op_acc_off));
+        str(param1, ptr(sp, reg_abi_param1_backup));
     }
 
     /* Pointers indicate weight, input, and output data */
@@ -482,7 +482,7 @@ void jit_sve_1x1_conv_kernel_t<isa>::generate() {
     /* Get workloads of each loop */
     ldr(reg_load_loop_work, ptr(abi_param1, GET_OFF(load_dim)));
     ldr(reg_bcast_loop_work, ptr(abi_param1, GET_OFF(bcast_dim)));
-    str(reg_bcast_loop_work, ptr(X_SP, reg_bcast_loop_work_offt));
+    str(reg_bcast_loop_work, ptr(sp, reg_bcast_loop_work_offt));
     ldr(reg_reduce_loop_work, ptr(abi_param1, GET_OFF(reduce_dim)));
 
     /* A flag for controlling reduce loop */
@@ -498,14 +498,14 @@ void jit_sve_1x1_conv_kernel_t<isa>::generate() {
     if (load_dim_tail) {
         const WReg w_tmp(reg_load_dim_tail_mask.getIdx());
         mov_imm(w_tmp, (1 << load_dim_tail) - 1);
-        st1w(zreg_tmp1.s, P_ALL_ONE / T_z, ptr(X_SP, -1, MUL_VL));
+        st1w(zreg_tmp1.s, P_ALL_ONE / T_z, ptr(sp, -1, MUL_VL));
         index(zreg_tmp.s, 0, 1);
         mov(zreg_tmp1.s, 1);
         lsl(zreg_tmp1.s, P_ALL_ONE / T_m, zreg_tmp.s);
         dup(zreg_tmp.s, w_tmp);
         and_(zreg_tmp.d, zreg_tmp.d, zreg_tmp1.d);
         cmpne(k_load_dim_tail_mask.s, P_ALL_ONE, zreg_tmp.s, 0);
-        ldr(zreg_tmp1, ptr(X_SP, -1, MUL_VL));
+        ldr(zreg_tmp1, ptr(sp, -1, MUL_VL));
     }
 
     auto load_loop_body = [=](int load_loop_blk) {
@@ -541,10 +541,10 @@ void jit_sve_1x1_conv_kernel_t<isa>::generate() {
                         reg_tmp_imm);
                 if (jcp.with_binary) {
                     const auto oc_off_oprnd = aux_reg_load_data;
-                    ldr(oc_off_oprnd, ptr(X_SP, reg_binary_post_op_acc_off));
+                    ldr(oc_off_oprnd, ptr(sp, reg_binary_post_op_acc_off));
                     add_vl_or_imm(oc_off_oprnd, oc_off_oprnd,
                             jcp.load_block * load_loop_blk, X_TMP_0);
-                    str(oc_off_oprnd, ptr(X_SP, reg_binary_post_op_acc_off));
+                    str(oc_off_oprnd, ptr(sp, reg_binary_post_op_acc_off));
                 }
                 break;
             case backward_data:
@@ -616,9 +616,9 @@ void jit_sve_1x1_conv_kernel_t<isa>::generate() {
     }
     L(load_loop_blk[num_ur_cases]);
 
-    add_imm(X_SP, X_SP, stack_space_needed, X_TMP_0);
-
+    add_imm(sp, sp, utils::rnd_up(stack_space_needed, 16), X_TMP_0);
     postamble();
+
     if (jcp.with_eltwise) postops_injector_->prepare_table();
 }
 

--- a/src/cpu/aarch64/jit_sve_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.cpp
@@ -3950,11 +3950,11 @@ void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_od_loop_partial() {
 
     mov(reg_input_d_org, reg_input_d);
     mov(reg_output_d_org, reg_output_d);
-    str(reg_d_index, pre_ptr(X_SP, -8));
+    str(reg_d_index, pre_ptr(sp, -16));
 
     compute_oh_loop_common();
 
-    ldr(reg_d_index, post_ptr(X_SP, 8));
+    ldr(reg_d_index, post_ptr(sp, 16));
     mov(reg_output_d, reg_output_d_org);
     mov(reg_input_d, reg_input_d_org);
 

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -382,11 +382,11 @@ void jit_uni_binary_kernel_t<isa>::compute_bcast(bool tail) {
 
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::push(const Xbyak_aarch64::XReg &reg) {
-    str(reg, pre_ptr(X_SP, -static_cast<int>(reg.getBit() / 8)));
+    str(reg, pre_ptr(sp, -16));
 }
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::pop(const Xbyak_aarch64::XReg &reg) {
-    ldr(reg, post_ptr(X_SP, (reg.getBit() / 8)));
+    ldr(reg, post_ptr(sp, 16));
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
@@ -611,16 +611,18 @@ template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::init_mask() {
     using namespace data_type;
 
-    sub(X_SP, X_SP, 8 * max_num_ll);
+    const auto stack_space_bytes = utils::rnd_up(8 * max_num_ll, 16);
+    sub_imm(sp, sp, stack_space_bytes, X_TMP_0);
 
     for (int ll = 0; ll < max_num_ll; ll++) {
         mov_imm(reg_mask, jpp.tail[ll]);
-        str(reg_mask, ptr(X_SP, 8 * ll));
+        str(reg_mask, ptr(sp, 8 * ll));
     }
     for (int ll = 0; ll < max_num_ll; ll++) {
-        ldr(PReg(mask(ll)), ptr(X_SP));
-        add(X_SP, X_SP, 8);
+        ldr(PReg(mask(ll)), ptr(sp, 8 * ll));
     }
+
+    add_imm(sp, sp, stack_space_bytes, X_TMP_0);
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -513,8 +513,7 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
     }
 
     if (jpp.simple_alg && jpp.ndims == 5) {
-        str(reg_input, pre_ptr(X_SP, -8));
-        str(reg_output, pre_ptr(X_SP, -8));
+        stp(reg_input, reg_output, pre_ptr(sp, -16));
 
         mov(aux_reg_input_d, reg_input);
         ldr(ki, ptr(reg_param, GET_OFF(kd_padding)));
@@ -573,8 +572,7 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
         subs(ki, ki, 1);
         cmp(ki, 0);
         b(GT, kd_label);
-        ldr(reg_output, post_ptr(X_SP, 8));
-        ldr(reg_input, post_ptr(X_SP, 8));
+        ldp(reg_input, reg_output, post_ptr(sp, 16));
     }
 
     if (!jpp.is_backward) {
@@ -634,9 +632,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     }
     if (jpp.is_training) dup(vmm_k_offset, reg_k_shift);
     if (jpp.ndims == 5) {
-        str(reg_input, pre_ptr(X_SP, -8));
+        stp(reg_input, reg_output, pre_ptr(sp, -16));
 
-        str(reg_output, pre_ptr(X_SP, -8));
         mov(aux_reg_input_d, reg_input);
         ldr(ki, ptr(reg_param, GET_OFF(kd_padding)));
         L(kd_label);
@@ -690,8 +687,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
         subs(ki, ki, 1);
         cmp(ki, 0);
         b(GT, kd_label);
-        ldr(reg_output, post_ptr(X_SP, 8));
-        ldr(reg_input, post_ptr(X_SP, 8));
+        ldp(reg_input, reg_output, post_ptr(sp, 16));
     }
 
     if (jpp.with_postops)
@@ -775,8 +771,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
     dup(vmm_k_offset, reg_k_shift);
 
     if (jpp.simple_alg && jpp.ndims == 5) {
-        str(reg_input, pre_ptr(X_SP, -8));
-        str(reg_output, pre_ptr(X_SP, -8));
+        stp(reg_input, reg_output, pre_ptr(sp, -16));
+
         mov(aux_reg_input_d, reg_input);
 
         ldr(ki, ptr(reg_param, GET_OFF(kd_padding)));
@@ -829,8 +825,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
         subs(ki, ki, 1);
         cmp(ki, 0);
         b(GT, kd_label);
-        ldr(reg_output, post_ptr(X_SP, 8));
-        ldr(reg_input, post_ptr(X_SP, 8));
+        ldp(reg_input, reg_output, post_ptr(sp, 16));
     }
 }
 

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -642,9 +642,9 @@ void jit_softmax_sve_t::backward() {
 
 void jit_softmax_sve_t::prepare_mask() {
     if (simd_w_ > cpu_isa_traits<sve_128>::vlen / sizeof(float)) {
-        sub_imm(X_SP, X_SP, 64 * 2, X_TMP_0);
-        str(p_shuff0, ptr(X_SP, 0, MUL_VL));
-        str(p_shuff1, ptr(X_SP, 1, MUL_VL));
+        sub_imm(sp, sp, 64 * 2, X_TMP_0);
+        str(p_shuff0, ptr(sp, 0, MUL_VL));
+        str(p_shuff1, ptr(sp, 1, MUL_VL));
         not_(P_TMP_1.b, P_ALL_ONE, P_ALL_ONE.b);
         trn1(p_shuff0.d, P_ALL_ONE.d, P_TMP_1.d);
         trn1(p_shuff0.d, p_shuff0.d, p_shuff0.d);
@@ -656,9 +656,11 @@ void jit_softmax_sve_t::prepare_mask() {
 }
 
 void jit_softmax_sve_t::restore_mask() {
-    ldr(p_shuff0, ptr(X_SP, 0, MUL_VL));
-    ldr(p_shuff1, ptr(X_SP, 1, MUL_VL));
-    add_imm(X_SP, X_SP, 64 * 2, X_TMP_0);
+    if (simd_w_ > cpu_isa_traits<sve_128>::vlen / sizeof(float)) {
+        ldr(p_shuff0, ptr(sp, 0, MUL_VL));
+        ldr(p_shuff1, ptr(sp, 1, MUL_VL));
+        add_imm(sp, sp, 64 * 2, X_TMP_0);
+    }
 }
 
 void jit_softmax_sve_t::generate() {

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2022-2025 Arm Ltd. and affiliates
+* Copyright 2022-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1610,7 +1610,7 @@ void jit_uni_reorder_kernel_f32_t::loop_end(Label &l, XReg reg_cnt, int len,
 
         // On the stack should be an information if node
         // was processed with tail or not.
-        ldr(X_TMP_0, post_ptr(X_SP, X_TMP_0.getBit() / 8));
+        ldr(X_TMP_0, post_ptr(sp, 16));
 
         cmp(X_TMP_0, with_tail_info_);
         b(NE, if_end);
@@ -1680,12 +1680,12 @@ void jit_uni_reorder_kernel_f32_t::create_loops(const simple_impl_desc_t &desc,
         Label loop, if_no_tail, if_end;
 
         if (curr_node_has_tail) {
-            const size_t reg_bytes = X_TMP_0.getBit() / 8;
+            const size_t reg_bytes = utils::rnd_up(X_TMP_0.getBit() / 8, 16);
             if (prb_.nodes[curr_node_id].is_parent_empty()) {
                 mov(reg_loop_cnt, tail_size);
                 // Put info that node is being processed with tail.
                 mov(X_TMP_0, with_tail_info_);
-                str(X_TMP_0, pre_ptr(X_SP, -static_cast<int>(reg_bytes)));
+                str(X_TMP_0, pre_ptr(sp, -static_cast<int>(reg_bytes)));
             } else {
                 ldr(X_TMP_0, ptr(data_chunk_addr(parent_node_id)));
                 check_if_this_is_last_chunk(X_TMP_0, parent_node_id);
@@ -1693,14 +1693,14 @@ void jit_uni_reorder_kernel_f32_t::create_loops(const simple_impl_desc_t &desc,
                 mov(reg_loop_cnt, tail_size);
                 // Put info that node is being processed with tail.
                 mov(X_TMP_0, with_tail_info_);
-                str(X_TMP_0, pre_ptr(X_SP, -static_cast<int>(reg_bytes)));
+                str(X_TMP_0, pre_ptr(sp, -static_cast<int>(reg_bytes)));
                 b(if_end);
 
                 L(if_no_tail);
                 mov(reg_loop_cnt, node_size);
                 // Put info that node is being processed without tail.
                 mov(X_TMP_0, without_tail_info_);
-                str(X_TMP_0, pre_ptr(X_SP, -static_cast<int>(reg_bytes)));
+                str(X_TMP_0, pre_ptr(sp, -static_cast<int>(reg_bytes)));
                 L(if_end);
             }
         }

--- a/src/cpu/aarch64/utils/jit_io_helper.cpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.cpp
@@ -438,7 +438,7 @@ static void load_bytes(jit_generator *host, const Xbyak_aarch64::VReg &vmm,
     if (load_size > 16) {
         host->str(host->z31,
                 Xbyak_aarch64::ptr(
-                        host->X_SP, -1, Xbyak_aarch64::MUL_VL));
+                        host->sp, -1, Xbyak_aarch64::MUL_VL));
         const Xbyak_aarch64::ZReg z_vmm(vmm.getIdx());
         const Xbyak_aarch64::ZReg z_tmp(host->z31.getIdx());
         host->ptrue(host->P_TMP.d, Xbyak_aarch64::VL2);
@@ -453,7 +453,7 @@ static void load_bytes(jit_generator *host, const Xbyak_aarch64::VReg &vmm,
         host->mov(z_vmm.s, host->P_NOT_256 / Xbyak_aarch64::T_m, 0);
         host->ldr(host->z31,
                 Xbyak_aarch64::ptr(
-                        host->X_SP, -1, Xbyak_aarch64::MUL_VL));
+                        host->sp, -1, Xbyak_aarch64::MUL_VL));
     }
 }
 
@@ -487,7 +487,7 @@ static void load_bytes_to_dword_extension(jit_generator *host,
     }
     host->str(host->z31,
             Xbyak_aarch64::ptr(
-                    host->X_SP, -1, Xbyak_aarch64::MUL_VL));
+                    host->sp, -1, Xbyak_aarch64::MUL_VL));
     // For load_size == 8/4, do load/extension in one go
     const Xbyak_aarch64::ZReg z_tmp(host->z31.getIdx());
     if (load_size == 8) {
@@ -528,7 +528,7 @@ static void load_bytes_to_dword_extension(jit_generator *host,
     }
     host->ldr(host->z31,
             Xbyak_aarch64::ptr(
-                    host->X_SP, -1, Xbyak_aarch64::MUL_VL));
+                    host->sp, -1, Xbyak_aarch64::MUL_VL));
 }
 template <typename Vmm>
 void load_data(jit_generator *host, data_type_t type_in, const Vmm &vmm,
@@ -767,9 +767,9 @@ int jit_io_helper_t<Xbyak_aarch64::VReg>::allocate_temp_register(
         // Look for a temporary vector register whose index isn’t the same as lhs.
         if (reg.getIdx() != i) {
             // Allocate space on stack
-            host_->sub(host_->X_SP, host_->X_SP, SIMD_SZ);
+            host_->sub(host_->sp, host_->sp, SIMD_SZ);
             // Store the scratch register into the stack so it's safe to clobber it.
-            host_->str(Xbyak_aarch64::QReg(i), Xbyak_aarch64::ptr(host_->X_SP));
+            host_->str(Xbyak_aarch64::QReg(i), Xbyak_aarch64::ptr(host_->sp));
             // The temporary register was found, therefore there is no need to keep searching.
             return i;
         }
@@ -784,9 +784,9 @@ void jit_io_helper_t<Xbyak_aarch64::VReg>::deallocate_temp_register(
     const int SIMD_SZ = 16; // SIMD register length in bytes
 
     // Restore the scratch register's initial content from the stack.
-    host_->ldr(Xbyak_aarch64::QReg(idx), Xbyak_aarch64::ptr(host_->X_SP));
+    host_->ldr(Xbyak_aarch64::QReg(idx), Xbyak_aarch64::ptr(host_->sp));
     // Free allocated stack space
-    host_->add(host_->X_SP, host_->X_SP, SIMD_SZ);
+    host_->add(host_->sp, host_->sp, SIMD_SZ);
 }
 
 template <>
@@ -870,14 +870,14 @@ void jit_io_helper_t<Vmm>::store_i8_sdb(Xbyak_aarch64::XReg addr,
         const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
     UNUSED(tail);
     host_->str(host_->z31,
-            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->sp, -1, Xbyak_aarch64::MUL_VL));
     const Xbyak_aarch64::ZReg z_tmp(host_->z31.getIdx());
     host_->mov(z_tmp.d, Xbyak_aarch64::ZRegD(src_vmm.getIdx()));
     host_->smin(z_tmp.s, 127);
     host_->smax(z_tmp.s, -128);
     host_->st1b(z_tmp.s, mask, Xbyak_aarch64::ptr(addr));
     host_->ldr(host_->z31,
-            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->sp, -1, Xbyak_aarch64::MUL_VL));
 }
 
 template <>
@@ -932,13 +932,13 @@ void jit_io_helper_t<Vmm>::store_i8_udb(Xbyak_aarch64::XReg addr,
         const Vmm &src_vmm, const bool tail, const Xbyak_aarch64::PReg &mask) {
     UNUSED(tail);
     host_->str(host_->z31,
-            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->sp, -1, Xbyak_aarch64::MUL_VL));
     const Xbyak_aarch64::ZReg z_tmp(host_->z31.getIdx());
     host_->mov(z_tmp.d, Xbyak_aarch64::ZRegD(src_vmm.getIdx()));
     host_->umin(z_tmp.s, 255);
     host_->st1b(z_tmp.s, mask, Xbyak_aarch64::ptr(addr));
     host_->ldr(host_->z31,
-            Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+            Xbyak_aarch64::ptr(host_->sp, -1, Xbyak_aarch64::MUL_VL));
 }
 
 template <typename Vmm>


### PR DESCRIPTION
# Description
Switches use of the arbitrary `X_SP` (i.e, `x21`) register over to the hardware stack pointer (i.e, `sp`, `x31`) for stack management. The main advantages are that the hardware `sp` is used by the kernel and other functions while our use of the `X_SP` register is invisible to them. This also frees up x21 for general-purpose use.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
