### PR TITLE
[GPU][Xe3P] enforce xe3p+ prefetch count limitations

### DIFF
--- a/src/gpu/intel/gemm/jit/dsl/utils/block_2d_utils.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/utils/block_2d_utils.hpp
@@ -86,10 +86,18 @@ inline bool block_2d_pitch_ok(
     return true;
 }
 
-inline int block_2d_max_count(
+inline std::vector<int> block_2d_counts(ngen::HW hw, bool is_prefetch,
         bool is_store, bool is_transpose, int block_width, int type_size) {
-    if (is_store || is_transpose) return 1;
-    return 64 / (block_width * type_size);
+    if (is_store || is_transpose) return {1};
+    std::vector<int> res;
+    bool allow_256b = (hw >= ngen::HW::Xe3p) && is_prefetch;
+    for (auto i : {4, 2, 1}) {
+        int nbytes = block_width * type_size * i;
+        if (nbytes <= 64) res.push_back(i);
+        if (allow_256b && nbytes == 256) res.push_back(i);
+    }
+    if (res.empty()) gpu_error_not_expected();
+    return res;
 }
 
 } // namespace dsl

--- a/src/gpu/intel/jit/ir/block_2d_utils.hpp
+++ b/src/gpu/intel/jit/ir/block_2d_utils.hpp
@@ -91,13 +91,19 @@ inline bool block_2d_pitch_ok(
     return true;
 }
 
-inline int block_2d_max_count(ngen::HW hw, bool is_prefetch, bool is_store,
-        bool is_transpose, int block_width, int type_size) {
-    if (is_store || is_transpose) return 1;
-    if (hw == ngen::HW::Xe3p && is_prefetch) {
-        return 256 / (block_width * type_size);
+// Returns all valid counts for given parameters in descending size.
+inline std::vector<int> block_2d_counts(ngen::HW hw, bool is_prefetch,
+        bool is_store, bool is_transpose, int block_width, int type_size) {
+    if (is_store || is_transpose) return {1};
+    std::vector<int> res;
+    bool allow_256b = (hw >= ngen::HW::Xe3p) && is_prefetch;
+    for (auto i : {4, 2, 1}) {
+        int nbytes = block_width * type_size * i;
+        if (nbytes <= 64) res.push_back(i);
+        if (allow_256b && nbytes == 256) res.push_back(i);
     }
-    return 64 / (block_width * type_size);
+    if (res.empty()) gpu_error_not_expected();
+    return res;
 }
 
 } // namespace jit

--- a/src/gpu/intel/jit/ir/send_builder.cpp
+++ b/src/gpu/intel/jit/ir/send_builder.cpp
@@ -466,14 +466,14 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
     bool transpose = hint.transpose;
 
     // Try to reduce the number of messages by increasing count per message.
-    int try_count = count * 2;
-    int max_count = block_2d_max_count(ir_ctx_->hw(), is_prefetch, is_store,
-            transpose, width, mem_type_.size());
-    while (try_count <= max_count) {
-        if (b0.size % (try_count * width) != 0) break;
-        count = try_count;
-        try_count *= 2;
-    }
+    // Select the highest valid count.
+    std::vector<int> counts = block_2d_counts(ir_ctx_->hw(), is_prefetch,
+            is_store, transpose, width, mem_type_.size());
+    for (auto i : counts)
+        if (b0.size % (i * width) == 0) {
+            count = i;
+            break;
+        }
 
     int W = surface_width;
     int H = surface_height;
@@ -665,9 +665,9 @@ bool access_builder_t::fixup_send_2d_params(const dsl::type_t &send_type,
     int factor = 64 / surface_width_size;
     if (h % factor != 0) return false;
 
-    int max_count = block_2d_max_count(ir_ctx_->hw(),
+    int max_count = block_2d_counts(ir_ctx_->hw(),
             send_op_ == send_op_t::prefetch, send_op_ == send_op_t::store,
-            transpose, w, send_type.size());
+            transpose, w, send_type.size())[0];
 
     if (factor > max_count) return false;
 

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -664,8 +664,8 @@ struct send_2d_params_t {
 
     bool is_prefetch() const { return send_op == send_op_t::prefetch; }
 
-    int max_count(const dsl::hw_t &hw) const {
-        return block_2d_max_count(hw.ngen_hw(), is_prefetch(), is_store(),
+    std::vector<int> get_counts(const dsl::hw_t &hw) const {
+        return block_2d_counts(hw.ngen_hw(), is_prefetch(), is_store(),
                 transpose, w, type.size());
     }
 
@@ -673,11 +673,13 @@ struct send_2d_params_t {
     // message.
     void try_promote_count(const dsl::hw_t &hw) {
         if (vnni_factor != 1) return;
-        while (c * 2 <= max_count(hw)) {
-            if (w_rcount % 2 != 0) break;
-            c *= 2;
-            w_rcount /= 2;
-        }
+        std::vector<int> counts = get_counts(hw);
+        for (auto i : counts)
+            if (w_rcount % i == 0) {
+                c = i;
+                w_rcount /= i;
+                break;
+            }
     }
 
     bool apply_vnni_factor(int factor, const dsl::hw_t &hw) {
@@ -695,9 +697,9 @@ struct send_2d_params_t {
         if (H % factor != 0)
             return fail_2d("Can't apply VNNI factor: invalid surface height.");
         if (c != 1) return fail_2d("Can't apply VNNI factor: invalid count.");
-        if (factor > max_count(hw))
+        if (factor > get_counts(hw)[0])
             return fail_2d(
-                    "Can't apply VNNI factor: factor exceeds max_count(hw).");
+                    "Can't apply VNNI factor: factor exceeds max_count.");
         W *= factor;
         H /= factor;
         P *= factor;

--- a/src/gpu/intel/jit/ir/v2/send.hpp
+++ b/src/gpu/intel/jit/ir/v2/send.hpp
@@ -511,13 +511,14 @@ struct send_2d_desc_t {
     // Reduce the number of messages by increasing count per
     // message.
     void try_promote_count() {
-        int max_count = block_2d_max_count(hw, op == send_op_t::prefetch,
+        std::vector<int> counts = block_2d_counts(hw, op == send_op_t::prefetch,
                 op == send_op_t::store, transpose, w, type.size());
-        while (c * 2 <= max_count) {
-            if (w_rcount % 2 != 0) break;
-            c *= 2;
-            w_rcount /= 2;
-        }
+        for (auto i : counts)
+            if (w_rcount % i == 0) {
+                c = i;
+                w_rcount /= i;
+                break;
+            }
     }
 
     bool is_supported(const v2::view_t &view, const prover_t &prover) const {


### PR DESCRIPTION
# Description

Xe3P+ spec requires count (array length) to be either 1 or max value depending on other send params for prefetch messages. Enforce this requirement to resolve errors in simulation. 

Fixes [MFDNN-14822](https://jira.devtools.intel.com/browse/MFDNN-14822)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
