### PR TITLE
doc: set ONEDNN_BUILD_DOC as OFF by default

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -189,7 +189,7 @@ option(DNNL_DEV_MODE "Enables internal tracing capabilities" OFF)
 # Documentation
 # -------------
 
-option(DNNL_BUILD_DOC "Enables building documentation" ${DNNL_IS_MAIN_PROJECT})
+option(DNNL_BUILD_DOC "Enables building documentation" OFF)
 
 set(ONEDNN_DOC_VERSIONS_JSON "" CACHE STRING "Location of JSON file for
     PyData Sphinx Theme version switcher. Must be a stable, persistent,

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -139,12 +139,10 @@ Graph API (enabled via `ONEDNN_BUILD_GRAPH`) is not compatible with
 
 | CMake Option             | Default | Supported values | Description                                                                                                        |
 |:-------------------------|:--------|:-----------------|:-------------------------------------------------------------------------------------------------------------------|
-| ONEDNN_BUILD_DOC         | **ON**  | OFF              | Controls building the documentation                                                                                |
+| ONEDNN_BUILD_DOC         | **OFF** | ON               | Controls building the documentation                                                                                |
 | ONEDNN_DOC_VERSIONS_JSON | \       | \<url\>          | Location of JSON file for [PyData Sphinx Theme version switcher]. Enables documentation version switcher when set. |
 
 [PyData Sphinx Theme version switcher]: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html
-
-@note `ONEDNN_BUILD_DOC` is disabled by default when oneDNN is built as a sub-project.
 
 ### Validation
 


### PR DESCRIPTION
Goal is to not build documentation by default

// https://github.com/intel-innersource/libraries.performance.math.onednn-infra/pull/1076 was merged and ensures that gh pushing won't be broken