### PR TITLE
Fixes and improvements for generic SYCL kernels

### DIFF
--- a/cmake/SYCL.cmake
+++ b/cmake/SYCL.cmake
@@ -157,6 +157,10 @@ else()
     message(STATUS "DPC++ support is enabled (OpenCL and Level Zero)")
 endif()
 
+if(DNNL_INTERNAL_ENABLE_GENERIC_SYCL_KERNELS)
+    add_definitions(-DDNNL_ENABLE_SYCL_KERNELS)
+endif()
+
 # XXX: Suppress warning coming from SYCL headers:
 #   #pragma message("The Intel extensions have been moved into cl_ext.h.
 #   Please include cl_ext.h directly.")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -436,3 +436,7 @@ onednn_option(AMD_SYCL_KERNELS_TARGET_ARCH ""
     Warning: This option is temporary and will be removed as soon as the compiler
     stops to require specifying the target architecture. After removing the option
     the generic SYCL kernels will always be enabled for AMD vendor.") # internal
+
+onednn_option(INTERNAL_ENABLE_GENERIC_SYCL_KERNELS OFF
+    "Enables implementations with generic SYCL kernels when DNNL_GPU_VENDOR is
+    not GENERIC.")

--- a/src/gpu/generic/CMakeLists.txt
+++ b/src/gpu/generic/CMakeLists.txt
@@ -22,7 +22,8 @@ file(GLOB SOURCES
 # - Always enable generic SYCL kernels for generic vendor.
 # - Always enable generic SYCL kernels for NVIDIA vendor.
 # - Only enable the generic SYCL kernels for AMD vendor if target architecture has been specified.
-if(DNNL_SYCL_GENERIC OR DNNL_SYCL_CUDA OR DNNL_AMD_ENABLE_SYCL_KERNELS)
+if(DNNL_INTERNAL_ENABLE_GENERIC_SYCL_KERNELS OR DNNL_SYCL_GENERIC
+    OR DNNL_SYCL_CUDA OR DNNL_AMD_ENABLE_SYCL_KERNELS)
     add_subdirectory(sycl)
 endif()
 

--- a/src/gpu/generic/shuffle_by_reorder.hpp
+++ b/src/gpu/generic/shuffle_by_reorder.hpp
@@ -37,7 +37,7 @@ struct shuffle_by_reorder_t : public gpu::primitive_t {
     struct pd_t : public gpu_shuffle_pd_t {
         using gpu_shuffle_pd_t::gpu_shuffle_pd_t;
 
-        DECLARE_COMMON_PD_T("reorder:any", shuffle_by_reorder_t);
+        DECLARE_COMMON_PD_T("reorder-based:any", shuffle_by_reorder_t);
 
         status_t init(impl::engine_t *engine) {
             const auto &md_src = is_fwd() ? src_md() : diff_src_md();

--- a/src/gpu/generic/sycl/binary_kernels.hpp
+++ b/src/gpu/generic/sycl/binary_kernels.hpp
@@ -81,12 +81,7 @@ struct binary_kernel_vec_t {
             }
         }
 
-        const bool is_blocked_fmt = conf_.src0_md.inner_nblks() > 0
-                || conf_.src1_md.inner_nblks() > 0
-                || conf_.dst_md.inner_nblks() > 0;
-
-        if (!any_broadcast && !is_blocked_fmt
-                && conf_.post_ops.get_post_op() == 0
+        if (!any_broadcast && conf_.post_ops.get_post_op() == 0
                 && conf_.wk_size % vec_len == 0 && is_same_tag) {
             for (int vec_idx = item.get_global_id(0);
                     vec_idx < conf_.wk_size / vec_len;

--- a/src/gpu/generic/sycl/ref_batch_normalization.hpp
+++ b/src/gpu/generic/sycl/ref_batch_normalization.hpp
@@ -78,7 +78,8 @@ struct ref_batch_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
                     VERBOSE_UNSUPPORTED_DT);
 
             if (is_training() && (fuse_norm_relu() || fuse_norm_add_relu()))
-                init_default_ws(8);
+                CHECK(init_default_ws(8));
+
             return init_conf();
         }
         status_t init_conf();
@@ -145,9 +146,10 @@ struct ref_batch_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
                     VERBOSE_OUT_OF_RANGE_DIMS, "diff_src");
 
             if (fuse_norm_relu() || fuse_norm_add_relu()) {
-                init_default_ws(8);
+                CHECK(init_default_ws(8));
                 VDISPATCH_BNORM(compare_ws(hint_fwd_pd_), VERBOSE_WS_INIT);
             }
+
             return init_conf();
         }
 

--- a/src/gpu/generic/sycl/ref_batch_normalization.hpp
+++ b/src/gpu/generic/sycl/ref_batch_normalization.hpp
@@ -40,7 +40,7 @@ struct ref_batch_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_batch_normalization_fwd_pd_t {
         using gpu_batch_normalization_fwd_pd_t::
                 gpu_batch_normalization_fwd_pd_t;
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_batch_normalization_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_batch_normalization_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -104,7 +104,7 @@ struct ref_batch_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
         using gpu_batch_normalization_bwd_pd_t::
                 gpu_batch_normalization_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_batch_normalization_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_batch_normalization_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_binary.hpp
+++ b/src/gpu/generic/sycl/ref_binary.hpp
@@ -38,7 +38,7 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_binary_pd_t {
         using gpu_binary_pd_t::gpu_binary_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_binary_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_binary_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -80,7 +80,7 @@ struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public convolution_fwd_pd_t {
         using convolution_fwd_pd_t::convolution_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_convolution_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_convolution_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -160,7 +160,7 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public convolution_bwd_data_pd_t {
         using convolution_bwd_data_pd_t::convolution_bwd_data_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_convolution_bwd_data_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_convolution_bwd_data_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -241,7 +241,7 @@ struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public convolution_bwd_weights_pd_t {
         using convolution_bwd_weights_pd_t::convolution_bwd_weights_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_convolution_bwd_weights_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_convolution_bwd_weights_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_deconvolution.hpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.hpp
@@ -40,7 +40,7 @@ struct ref_deconvolution_bwd_weights_t
     struct pd_t : public deconvolution_bwd_weights_pd_t {
         using deconvolution_bwd_weights_pd_t::deconvolution_bwd_weights_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_deconvolution_bwd_weights_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_deconvolution_bwd_weights_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_eltwise.hpp
+++ b/src/gpu/generic/sycl/ref_eltwise.hpp
@@ -36,7 +36,7 @@ struct ref_sycl_eltwise_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_eltwise_fwd_pd_t {
         using gpu_eltwise_fwd_pd_t::gpu_eltwise_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_eltwise_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_eltwise_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
@@ -101,7 +101,7 @@ struct ref_sycl_eltwise_bwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_eltwise_bwd_pd_t {
         using gpu_eltwise_bwd_pd_t::gpu_eltwise_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_eltwise_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_eltwise_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_group_normalization.hpp
+++ b/src/gpu/generic/sycl/ref_group_normalization.hpp
@@ -33,8 +33,7 @@ struct ref_group_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
 
     struct pd_t : public group_normalization_fwd_pd_t {
         using group_normalization_fwd_pd_t::group_normalization_fwd_pd_t;
-        DECLARE_COMMON_PD_T(
-                "ref:sycl:group_normalization", ref_group_normalization_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_group_normalization_fwd_t);
 
         status_t init(impl::engine_t *engine);
 
@@ -58,8 +57,7 @@ struct ref_group_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
 
     struct pd_t : public group_normalization_bwd_pd_t {
         using group_normalization_bwd_pd_t ::group_normalization_bwd_pd_t;
-        DECLARE_COMMON_PD_T("ref:sycl:group_normalization_bwd",
-                ref_group_normalization_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_group_normalization_bwd_t);
 
         status_t init(impl::engine_t *engine);
 

--- a/src/gpu/generic/sycl/ref_inner_product.hpp
+++ b/src/gpu/generic/sycl/ref_inner_product.hpp
@@ -63,7 +63,7 @@ struct ref_inner_product_fwd_t : public gpu::generic::sycl::primitive_t {
         using gpu_inner_product_fwd_pd_t::gpu_inner_product_fwd_pd_t;
         using sm = primitive_attr_t::skip_mask_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_inner_product_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_inner_product_fwd_t);
 
         status_t init(impl::engine_t *engine);
 
@@ -97,7 +97,7 @@ struct ref_inner_product_bwd_data_t : public gpu::generic::sycl::primitive_t {
 
     struct pd_t : public gpu_inner_product_bwd_data_pd_t {
         using gpu_inner_product_bwd_data_pd_t::gpu_inner_product_bwd_data_pd_t;
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_inner_product_bwd_data_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_inner_product_bwd_data_t);
 
         status_t init(impl::engine_t *engine);
 
@@ -132,7 +132,7 @@ struct ref_inner_product_bwd_weights_t
     struct pd_t : public gpu_inner_product_bwd_weights_pd_t {
         using gpu_inner_product_bwd_weights_pd_t::
                 gpu_inner_product_bwd_weights_pd_t;
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_inner_product_bwd_weights_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_inner_product_bwd_weights_t);
 
         status_t init(impl::engine_t *engine);
 

--- a/src/gpu/generic/sycl/ref_layer_normalizations.hpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.hpp
@@ -40,7 +40,7 @@ struct ref_layer_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
         using gpu_layer_normalization_fwd_pd_t::
                 gpu_layer_normalization_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_layer_normalization_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_layer_normalization_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -113,7 +113,7 @@ struct ref_layer_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
         using gpu_layer_normalization_bwd_pd_t::
                 gpu_layer_normalization_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_layer_normalization_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_layer_normalization_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_lrn.hpp
+++ b/src/gpu/generic/sycl/ref_lrn.hpp
@@ -34,7 +34,7 @@ struct ref_sycl_lrn_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_lrn_fwd_pd_t {
         using gpu_lrn_fwd_pd_t::gpu_lrn_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_lrn_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_lrn_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace format_tag;
@@ -88,7 +88,7 @@ struct ref_sycl_lrn_bwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_lrn_bwd_pd_t {
         using gpu_lrn_bwd_pd_t::gpu_lrn_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_lrn_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_lrn_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace format_tag;

--- a/src/gpu/generic/sycl/ref_matmul.hpp
+++ b/src/gpu/generic/sycl/ref_matmul.hpp
@@ -38,7 +38,7 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_matmul_pd_t {
         using gpu_matmul_pd_t::gpu_matmul_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_matmul_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_matmul_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_pooling.hpp
+++ b/src/gpu/generic/sycl/ref_pooling.hpp
@@ -40,7 +40,7 @@ struct ref_pooling_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_pooling_fwd_pd_t {
         using gpu_pooling_fwd_pd_t::gpu_pooling_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_pooling_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_pooling_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -104,7 +104,7 @@ struct ref_pooling_bwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_pooling_bwd_pd_t {
         using gpu_pooling_bwd_pd_t::gpu_pooling_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_pooling_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_pooling_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_prelu.hpp
+++ b/src/gpu/generic/sycl/ref_prelu.hpp
@@ -42,7 +42,7 @@ struct ref_prelu_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_prelu_fwd_pd_t {
         using gpu_prelu_fwd_pd_t::gpu_prelu_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_prelu_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_prelu_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -99,7 +99,7 @@ struct ref_prelu_bwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_prelu_bwd_pd_t {
         using gpu_prelu_bwd_pd_t::gpu_prelu_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_prelu_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_prelu_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_reduction.hpp
+++ b/src/gpu/generic/sycl/ref_reduction.hpp
@@ -49,7 +49,7 @@ struct ref_reduction_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_reduction_pd_t {
         using gpu_reduction_pd_t::gpu_reduction_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_reduction_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_reduction_t);
 
         status_t init(impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;

--- a/src/gpu/generic/sycl/ref_reorder.hpp
+++ b/src/gpu/generic/sycl/ref_reorder.hpp
@@ -37,7 +37,7 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_reorder_pd_t {
         using gpu_reorder_pd_t::gpu_reorder_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_reorder_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_reorder_t);
 
         status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
                 impl::engine_t *dst_engine) {

--- a/src/gpu/generic/sycl/ref_resampling.hpp
+++ b/src/gpu/generic/sycl/ref_resampling.hpp
@@ -38,7 +38,7 @@ struct ref_resampling_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_resampling_fwd_pd_t {
         using gpu_resampling_fwd_pd_t::gpu_resampling_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_resampling_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_resampling_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace prop_kind;
@@ -89,7 +89,7 @@ struct ref_resampling_bwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_resampling_bwd_pd_t {
         using gpu_resampling_bwd_pd_t::gpu_resampling_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_resampling_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_resampling_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_shuffle.hpp
+++ b/src/gpu/generic/sycl/ref_shuffle.hpp
@@ -38,7 +38,7 @@ struct ref_shuffle_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_shuffle_pd_t {
         using gpu_shuffle_pd_t::gpu_shuffle_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_shuffle_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_shuffle_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace format_tag;

--- a/src/gpu/generic/sycl/ref_softmax.hpp
+++ b/src/gpu/generic/sycl/ref_softmax.hpp
@@ -34,7 +34,7 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_softmax_fwd_pd_t {
         using gpu_softmax_fwd_pd_t::gpu_softmax_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_softmax_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_softmax_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
@@ -100,7 +100,7 @@ struct ref_sycl_softmax_bwd_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_softmax_bwd_pd_t {
         using gpu_softmax_bwd_pd_t::gpu_softmax_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_softmax_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_softmax_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/ref_sum.hpp
+++ b/src/gpu/generic/sycl/ref_sum.hpp
@@ -37,7 +37,7 @@ struct ref_sum_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_sum_pd_t {
         using gpu_sum_pd_t::gpu_sum_pd_t;
 
-        DECLARE_SUM_PD_T("dpcpp:ref:any", ref_sum_t);
+        DECLARE_SUM_PD_T("sycl:ref:any", ref_sum_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace format_tag;

--- a/src/gpu/generic/sycl/ref_sum_many_inputs.hpp
+++ b/src/gpu/generic/sycl/ref_sum_many_inputs.hpp
@@ -37,7 +37,7 @@ struct ref_sum_many_inputs_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_sum_pd_t {
         using gpu_sum_pd_t::gpu_sum_pd_t;
 
-        DECLARE_SUM_PD_t("dpcpp:ref:sum_many_inputs", ref_sum_many_inputs_t);
+        DECLARE_SUM_PD_t("sycl:many_inputs:any", ref_sum_many_inputs_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/generic/sycl/reorder_kernels.hpp
+++ b/src/gpu/generic/sycl/reorder_kernels.hpp
@@ -81,10 +81,9 @@ struct reorder_kernel_t {
                 flattened_index < conf_.num_elements;
                 flattened_index += item.get_global_range(0)) {
 
-            to_tensor.get_logical_index(
-                    flattened_index, dst_padded_index, true);
+            to_tensor.get_logical_index(flattened_index, dst_padded_index);
 
-            float from_value = from_tensor.load_md(dst_padded_index, true);
+            float from_value = from_tensor.load_md(dst_padded_index);
             // apply src scale and zero points;
             // dequantized_x = scale * (quantized_x - zero_point);
             if (conf_.apply_src_zp) {
@@ -104,7 +103,7 @@ struct reorder_kernel_t {
                 from_value = from_value * src_scale;
             }
 
-            auto dst_idx = conf_.dst_md.off_v(dst_padded_index, true);
+            auto dst_idx = conf_.dst_md.off_v(dst_padded_index);
             from_value = conf_.post_ops.apply(from_value, dst_, dst_idx);
             // during quanization, apply scale first
             // quantized value = dequan_value / scale + zero_point;
@@ -124,7 +123,7 @@ struct reorder_kernel_t {
                 }
                 from_value = from_value + dst_zp;
             }
-            to_tensor.store_md(from_value, dst_padded_index, true);
+            to_tensor.store_md(from_value, dst_padded_index);
         }
     }
 

--- a/src/gpu/generic/sycl/rnn/ref_rnn.hpp
+++ b/src/gpu/generic/sycl/rnn/ref_rnn.hpp
@@ -176,7 +176,7 @@ struct ref_rnn_fwd_t : ref_rnn_common_base_t {
 
         pd_t(const pd_t &other) = default;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_rnn_fwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_rnn_fwd_t);
 
         status_t init(impl::engine_t *engine);
 
@@ -263,7 +263,7 @@ struct ref_rnn_bwd_t : ref_rnn_common_base_t {
 
         pd_t(const pd_t &other) = default;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_rnn_bwd_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", ref_rnn_bwd_t);
 
         status_t init(impl::engine_t *engine);
 

--- a/src/gpu/generic/sycl/simple_reduction.hpp
+++ b/src/gpu/generic/sycl/simple_reduction.hpp
@@ -39,7 +39,7 @@ struct simple_reduction_t : public gpu::generic::sycl::primitive_t {
     struct pd_t : public gpu_reduction_pd_t {
         using gpu_reduction_pd_t::gpu_reduction_pd_t;
 
-        DECLARE_COMMON_PD_T("dpcpp:ref:any", simple_reduction_t);
+        DECLARE_COMMON_PD_T("sycl:ref:any", simple_reduction_t);
 
         status_t init(impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;

--- a/src/gpu/generic/sycl/stream.hpp
+++ b/src/gpu/generic/sycl/stream.hpp
@@ -48,22 +48,34 @@ public:
         return status::success;
     }
 
-    ::sycl::queue &queue() const { return *impl()->queue(); }
-
     status_t wait() override {
         queue().wait_and_throw();
         return status::success;
     }
 
+    status_t reset_profiling() override {
+        if (!is_profiling_enabled()) return status::invalid_arguments;
+        profiler_->reset();
+        return status::success;
+    }
+
+    status_t get_profiling_data(profiling_data_kind_t data_kind,
+            int *num_entries, uint64_t *data) const override {
+        if (!is_profiling_enabled()) return status::invalid_arguments;
+        return profiler_->get_info(data_kind, num_entries, data);
+    }
+
+    ::sycl::queue &queue() const { return *impl()->queue(); }
+
     status_t copy(const memory_storage_t &src, const memory_storage_t &dst,
             size_t size, const xpu::event_t &deps,
             xpu::event_t &out_dep) override {
-        return impl()->copy(this, src, dst, size, deps, out_dep);
+        return impl()->copy(this, src, dst, size, deps, out_dep, &profiler());
     }
 
     status_t fill(const memory_storage_t &dst, uint8_t pattern, size_t size,
             const xpu::event_t &deps, xpu::event_t &out_dep) override {
-        return impl()->fill(dst, pattern, size, deps, out_dep);
+        return impl()->fill(dst, pattern, size, deps, out_dep, &profiler());
     }
 
     const xpu::sycl::context_t &sycl_ctx() const { return impl()->sycl_ctx(); }

--- a/src/gpu/generic/sycl/sycl_gpu_kernel.cpp
+++ b/src/gpu/generic/sycl/sycl_gpu_kernel.cpp
@@ -14,11 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "common/stream.hpp"
-
 #include "xpu/sycl/stream_impl.hpp"
 
 #include "gpu/generic/sycl/sycl_gpu_kernel.hpp"
+#include "gpu/gpu_stream.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -38,6 +37,13 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
         cgh.use_kernel_bundle(*kernel_bundle_);
         cgf(cgh);
     });
+
+    if (stream.is_profiling_enabled()) {
+        auto sycl_event = utils::make_unique<xpu::sycl::event_t>(
+                std::vector<::sycl::event> {event});
+        auto *gpu_stream = utils::downcast<gpu::stream_t *>(&stream);
+        gpu_stream->profiler().register_event(std::move(sycl_event));
+    }
 
     deps = {event};
     return status::success;

--- a/src/gpu/generic/sycl/sycl_io_helper.hpp
+++ b/src/gpu/generic/sycl/sycl_io_helper.hpp
@@ -238,8 +238,8 @@ struct memory_tensor_t {
         store_float_vec<width>(md_.data_type(), val, mem_.get_pointer(), idx);
     }
 
-    inline float load_md(const dims_t &pos, bool padded = false) const {
-        return load(md_.off_v(pos, padded));
+    inline float load_md(const dims_t &pos) const {
+        return load(md_.off_v(pos));
     }
 
     inline float load_md_bc(dims_t offsets) const {
@@ -250,14 +250,14 @@ struct memory_tensor_t {
         return load(md_.off_v(offsets_masked));
     }
 
-    inline void store_md(float val, const dims_t &pos, bool padded = false) {
-        store(val, md_.off_v(pos, padded));
+    inline void store_md(float val, const dims_t &pos) {
+        store(val, md_.off_v(pos));
     }
 
     // flattened_index must be less than nelems
-    inline void get_logical_index(dim_t flattened_index, dims_t &logical_index,
-            bool use_padded_dims = false) {
-        const auto &dims = use_padded_dims ? md_.padded_dims() : md_.dims();
+    inline void get_logical_index(
+            dim_t flattened_index, dims_t &logical_index) {
+        const auto &dims = md_.dims();
         auto ndims = md_.ndims();
         for (auto i = ndims - 1; i >= 0; i--) {
             logical_index[i] = flattened_index % dims[i];

--- a/src/gpu/generic/sycl/sycl_post_ops.hpp
+++ b/src/gpu/generic/sycl/sycl_post_ops.hpp
@@ -187,8 +187,11 @@ struct ref_prelu_op_t {
         using namespace format_tag;
         auto dat_tag = utils::pick(
                 ndims_ - 2, ab, acb, acdb, acdeb); // prelu post-op uses axb
-        memory_desc_init_by_tag(
+        auto status = memory_desc_init_by_tag(
                 prelu_desc, ndims_, prelu_dims, src_mdw.data_type(), dat_tag);
+        assert(status == status::success);
+        if (status != status::success) return;
+
         utils::array_copy(
                 strides_, prelu_desc.format_desc.blocking.strides, ndims_);
 

--- a/src/gpu/gpu_impl_list.hpp
+++ b/src/gpu/gpu_impl_list.hpp
@@ -74,7 +74,8 @@ namespace gpu {
 #if defined(DNNL_WITH_SYCL) \
         && ((DNNL_GPU_VENDOR == DNNL_VENDOR_GENERIC) \
                 || (DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA) \
-                || defined(DNNL_AMD_ENABLE_SYCL_KERNELS))
+                || defined(DNNL_AMD_ENABLE_SYCL_KERNELS) \
+                || defined(DNNL_ENABLE_SYCL_KERNELS))
 #define DNNL_GPU_GENERIC_SYCL_ONLY(...) __VA_ARGS__
 #define GENERIC_SYCL_KERNELS_ENABLED
 #else

--- a/src/gpu/intel/ip/ref.hpp
+++ b/src/gpu/intel/ip/ref.hpp
@@ -131,7 +131,7 @@ struct ref_bwd_data_t : public primitive_t {
     struct pd_t : public bwd_data_pd_t {
         using bwd_data_pd_t::bwd_data_pd_t;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_bwd_data_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_data_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -196,7 +196,7 @@ struct ref_bwd_weights_t : public primitive_t {
     struct pd_t : public bwd_weights_pd_t {
         using bwd_weights_pd_t::bwd_weights_pd_t;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_bwd_weights_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_weights_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/intel/lnorm/ref.hpp
+++ b/src/gpu/intel/lnorm/ref.hpp
@@ -34,7 +34,7 @@ struct ref_fwd_t : public primitive_t {
     struct pd_t : public fwd_pd_t {
         using fwd_pd_t::fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("lnorm_ref:any", ref_fwd_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -114,7 +114,7 @@ struct ref_bwd_t : public primitive_t {
     struct pd_t : public bwd_pd_t {
         using bwd_pd_t::bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("lnorm_ref:any", ref_bwd_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/intel/lrn/ref.hpp
+++ b/src/gpu/intel/lrn/ref.hpp
@@ -33,7 +33,7 @@ struct ref_fwd_t : public primitive_t {
     struct pd_t : public fwd_pd_t {
         using fwd_pd_t::fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_fwd_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -162,7 +162,7 @@ struct ref_bwd_t : public primitive_t {
     struct pd_t : public bwd_pd_t {
         using bwd_pd_t::bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_bwd_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/intel/ocl/stream.cpp
+++ b/src/gpu/intel/ocl/stream.cpp
@@ -123,13 +123,12 @@ void stream_t::after_exec_hook() {
 status_t stream_t::copy(const memory_storage_t &src,
         const memory_storage_t &dst, size_t size, const xpu::event_t &deps,
         xpu::event_t &out_dep) {
-    return impl()->copy(this, src, dst, size, deps, out_dep, profiler_.get());
+    return impl()->copy(this, src, dst, size, deps, out_dep, &profiler());
 }
 
 status_t stream_t::fill(const memory_storage_t &dst, uint8_t pattern,
         size_t size, const xpu::event_t &deps, xpu::event_t &out_dep) {
-    return impl()->fill(
-            this, dst, pattern, size, deps, out_dep, profiler_.get());
+    return impl()->fill(this, dst, pattern, size, deps, out_dep, &profiler());
 }
 
 status_t stream_t::barrier() {

--- a/src/gpu/intel/pool/ref.hpp
+++ b/src/gpu/intel/pool/ref.hpp
@@ -33,7 +33,7 @@ struct ref_fwd_t : public primitive_t {
     struct pd_t : public fwd_pd_t {
         using fwd_pd_t::fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("ocl:ref", ref_fwd_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/intel/reduction/jit.hpp
+++ b/src/gpu/intel/reduction/jit.hpp
@@ -42,7 +42,7 @@ struct gen_t : public primitive_t {
     struct pd_t : public reduction::pd_t {
         using reduction::pd_t::pd_t;
 
-        DECLARE_COMMON_PD_T("jit:ref", gen_t);
+        DECLARE_COMMON_PD_T("jit:xe", gen_t);
 
         status_t init(impl::engine_t *engine) {
             // Require the corresponding environment variable - skip this impl

--- a/src/gpu/intel/reduction/ref.hpp
+++ b/src/gpu/intel/reduction/ref.hpp
@@ -34,7 +34,7 @@ struct ref_t : public primitive_t {
     struct pd_t : public reduction::pd_t {
         using reduction::pd_t::pd_t;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
         status_t init(impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;

--- a/src/gpu/intel/resampling/ref.hpp
+++ b/src/gpu/intel/resampling/ref.hpp
@@ -31,7 +31,7 @@ struct ref_fwd_t : public primitive_t {
     struct pd_t : public fwd_pd_t {
         using fwd_pd_t::fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_fwd_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -87,7 +87,7 @@ struct ref_bwd_t : public primitive_t {
     struct pd_t : public bwd_pd_t {
         using bwd_pd_t::bwd_pd_t;
 
-        DECLARE_COMMON_PD_T("ref:any", ref_bwd_t);
+        DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -86,13 +86,12 @@ struct stream_t : public gpu::intel::stream_t {
     status_t copy(const memory_storage_t &src, const memory_storage_t &dst,
             size_t size, const xpu::event_t &deps,
             xpu::event_t &out_dep) override {
-        return impl()->copy(
-                this, src, dst, size, deps, out_dep, profiler_.get());
+        return impl()->copy(this, src, dst, size, deps, out_dep, &profiler());
     }
 
     status_t fill(const memory_storage_t &dst, uint8_t pattern, size_t size,
             const xpu::event_t &deps, xpu::event_t &out_dep) override {
-        return impl()->fill(dst, pattern, size, deps, out_dep, profiler_.get());
+        return impl()->fill(dst, pattern, size, deps, out_dep, &profiler());
     }
 
     status_t barrier() override { return impl()->barrier(); }

--- a/src/xpu/sycl/types.hpp
+++ b/src/xpu/sycl/types.hpp
@@ -118,9 +118,14 @@ using in_memory_arg_t = memory_arg_t<::sycl::access::mode::read>;
 using out_memory_arg_t = memory_arg_t<::sycl::access::mode::write>;
 using inout_memory_arg_t = memory_arg_t<::sycl::access::mode::read_write>;
 
-// TODO: this class mimics memory_desc_t and makes sure it can be passed
-// to SYCL kernels as a kernel argument. SYCL puts restrictions on kernel
-// arguments, e.g. those cannot contain unions.
+// This class keeps only essentials from original memory_desc_t as this class
+// is used inside conf classes which are passed to kernels as arguments
+// directly. There's a hard limit on arguments size and the less is used, the
+// more can be put into those conf classes.
+//
+// Note: if, for whatever reason, blocking descriptor will be needed, a new
+// abstraction should be introduced and used with those memory descriptors that
+// would utilize it.
 struct md_t {
     // There is a limitation on total size of kernel arguments hence using
     // reduced number of supported dimensions and int32_t for dimensions.
@@ -130,17 +135,10 @@ struct md_t {
     using dims32_t = dim32_t[max_dims];
 
     data_type_t data_type() const { return data_type_; }
-
     dim32_t ndims() const { return ndims_; }
-    dim32_t offset0() const { return offset0_; }
-    dim32_t inner_nblks() const { return inner_nblks_; }
 
     const dims32_t &dims() const { return dims_; }
-    const dims32_t &padded_dims() const { return padded_dims_; }
-    const dims32_t &padded_offsets() const { return padded_offsets_; }
     const dims32_t &strides() const { return strides_; }
-    const dims32_t &inner_blks() const { return inner_blks_; }
-    const dims32_t &inner_idxs() const { return inner_idxs_; }
 
     md_t() = default;
     md_t(const memory_desc_t *md) {
@@ -157,16 +155,9 @@ struct md_t {
     (lhs) = static_cast<dim32_t>(rhs)
 
         CHECK_AND_ASSIGN(ndims_, mdw.ndims());
-        CHECK_AND_ASSIGN(offset0_, mdw.offset0());
-        CHECK_AND_ASSIGN(inner_nblks_, blk.inner_nblks);
-
         for (int d = 0; d < mdw.ndims(); d++) {
             CHECK_AND_ASSIGN(dims_[d], mdw.dims()[d]);
-            CHECK_AND_ASSIGN(padded_dims_[d], mdw.padded_dims()[d]);
-            CHECK_AND_ASSIGN(padded_offsets_[d], mdw.padded_offsets()[d]);
             CHECK_AND_ASSIGN(strides_[d], blk.strides[d]);
-            CHECK_AND_ASSIGN(inner_blks_[d], blk.inner_blks[d]);
-            CHECK_AND_ASSIGN(inner_idxs_[d], blk.inner_idxs[d]);
         }
 #undef CHECK_AND_ASSIGN
     }
@@ -174,55 +165,29 @@ struct md_t {
     template <typename... Args>
     dim_t off(Args... args) const {
         dims_t pos = {args...};
-        return off_v(pos, false);
+        return off_v(pos);
     }
 
-    dim_t off_v(const dims_t pos, bool is_pos_padded = false) const {
-        dims_t pos_copy = {0};
-        for (int d = 0; d < ndims(); ++d)
-            pos_copy[d] = pos[d] + (is_pos_padded ? 0 : padded_offsets()[d]);
-        dim_t phys_offset = offset0();
-
-        if (inner_nblks() > 0) {
-            dim_t blk_stride = 1;
-            for (int iblk = inner_nblks() - 1; iblk >= 0; --iblk) {
-                const int d = inner_idxs()[iblk];
-
-                dim_t p;
-                if (pos_copy[d] <= INT32_MAX) {
-                    p = (int32_t)pos_copy[d] % (int32_t)inner_blks()[iblk];
-                    pos_copy[d] = (int32_t)pos_copy[d]
-                            / (int32_t)inner_blks()[iblk];
-                } else {
-                    p = pos_copy[d] % inner_blks()[iblk];
-                    pos_copy[d] /= inner_blks()[iblk];
-                }
-
-                phys_offset += p * blk_stride;
-
-                blk_stride *= inner_blks()[iblk];
-            }
-        }
-
+    dim_t off_v(const dims_t pos) const {
+        dim_t phys_offset = 0;
         for (int d = 0; d < ndims(); ++d) {
-            const dim_t p = pos_copy[d];
+            const dim_t p = pos[d];
             phys_offset += p * strides()[d];
         }
         return phys_offset;
     }
 
-    dim_t off_v_masked(
-            const dims_t pos, int mask, bool is_pos_padded = false) const {
+    dim_t off_v_masked(const dims_t pos, int mask) const {
         dims_t pos_masked;
         utils::copy_dims_with_mask(pos_masked, pos, ndims(), mask);
-        return off_v(pos_masked, is_pos_padded);
+        return off_v(pos_masked);
     }
 
-    dim_t off_l(dim_t l_offset, bool is_pos_padded = false) const {
+    dim_t off_l(dim_t l_offset) const {
         dims_t pos;
         for (int rd = 0; rd < ndims(); ++rd) {
             const int d = ndims() - 1 - rd;
-            const dim_t cur_dim = is_pos_padded ? padded_dims()[d] : dims()[d];
+            const dim_t cur_dim = dims()[d];
             if (l_offset <= INT32_MAX && cur_dim <= INT32_MAX) {
                 pos[d] = (int32_t)l_offset % (int32_t)cur_dim;
                 l_offset = (int32_t)l_offset / (int32_t)cur_dim;
@@ -231,23 +196,14 @@ struct md_t {
                 l_offset /= cur_dim;
             }
         }
-        return off_v(pos, is_pos_padded);
+        return off_v(pos);
     }
 
 private:
     data_type_t data_type_;
-
     dim32_t ndims_;
-
     dims32_t dims_;
-    dims32_t padded_dims_;
-    dims32_t padded_offsets_;
-    dim32_t offset0_;
-
     dims32_t strides_;
-    dim32_t inner_nblks_;
-    dims32_t inner_blks_;
-    dims32_t inner_idxs_;
 };
 
 struct bfloat16_t {

--- a/src/xpu/sycl/usm_memory_storage.hpp
+++ b/src/xpu/sycl/usm_memory_storage.hpp
@@ -80,7 +80,9 @@ public:
                 : nullptr;
         auto storage = utils::make_unique<usm_memory_storage_t>(engine());
         if (!storage) return nullptr;
-        storage->init(memory_flags_t::use_runtime_ptr, size, sub_ptr);
+        auto status
+                = storage->init(memory_flags_t::use_runtime_ptr, size, sub_ptr);
+        if (status != status::success) return nullptr;
         return storage;
     }
 


### PR DESCRIPTION
This PR intends to unblock the KernelFoundry team in their endeavor to benchmark their kernels against oneDNN.
They have a dedicated library that has a single entry into their kernels.
The idea is to patch generic SYCL implementations with a piece of code that would check whether a KernelFoundry kernel was requested (by searching for the library in runtime (preloaded with LD_PRELOAD), or by a dedicated env variable) and dispatch into that call with arguments from execute(...).

To have an ability for performance comparison out-of-the-box, the library should be built against ONEDNN_GPU_VENDOR=INTEL w/ generic SYCL kernels (which a new build option targets, otherwise, they are excluded by default).

Also, to compile and have an ability to skip undesired implementations some changes in names and proper checks are needed.

Lastly, matmul kernel arguments size exceeded reasonable amount for any problem which required a radical cut for `md_t` which didn't use any blocks in kernels.

I also copied SYCL profiling capabilities for generic backend to have apples-to-apples comparison.