### PR TITLE
common: gated_mlp: enable binary post-ops in gmlp

### DIFF
--- a/src/common/gated_mlp_pd.hpp
+++ b/src/common/gated_mlp_pd.hpp
@@ -76,7 +76,7 @@ struct gated_mlp_pd_t : public primitive_desc_t {
 
     int n_outputs() const override { return 1; }
     int n_inputs() const override {
-        return int(all_idxs().size()) - n_outputs();
+        return int(all_idxs().size()) - n_outputs() + n_binary_po_inputs();
     }
     const op_desc_t *op_desc() const override {
         return reinterpret_cast<const op_desc_t *>(this->desc());


### PR DESCRIPTION
This PR is a part of [MFDNN-14598](https://jira.devtools.intel.com/browse/MFDNN-14598) and the third prerequisite of https://github.com/uxlfoundation/oneDNN/pull/4951.

It tells the library that the primitive can, in fact, run with Binary post-ops.
The rest of the post-ops code has already been merged: #5221.