### PR TITLE
cpu: rv64: brgemm: add f16 JIT kernel

### DIFF
--- a/src/cpu/rv64/brgemm/brgemm.cpp
+++ b/src/cpu/rv64/brgemm/brgemm.cpp
@@ -38,8 +38,13 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
     if (!brg) return status::invalid_arguments;
     if (M <= 0 || K <= 0) return status::invalid_arguments;
 
-    // Only f32 → f32 supported in the MVP.
-    if (!everyone_is(data_type::f32, dt_a, dt_b)) return status::unimplemented;
+    // Supported:
+    //   f32  × f32  → f32  (always)
+    //   f16  × f16  → f32  (Zvfh widening FMA)
+    const bool is_f32 = everyone_is(data_type::f32, dt_a, dt_b);
+    const bool is_f16
+            = everyone_is(data_type::f16, dt_a, dt_b) && mayiuse(zvfh);
+    if (!is_f32 && !is_f16) return status::unimplemented;
 
     *brg = utils::zero<brgemm_desc_t>();
 
@@ -61,7 +66,7 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->typesize_A = static_cast<int>(types::data_type_size(dt_a));
     brg->typesize_B = static_cast<int>(types::data_type_size(dt_b));
     brg->typesize_C = static_cast<int>(types::data_type_size(brg->dt_c));
-    brg->is_f32 = true;
+    brg->is_f32 = is_f32;
 
     if (strides) {
         brg->stride_a = strides->stride_a;
@@ -89,7 +94,16 @@ status_t brgemm_kernel_create(
     if (!brg_kernel) return status::invalid_arguments;
     *brg_kernel = nullptr;
 
-    auto *kernel = new brgemm_kernel_common_t(brg);
+    // Pick the per-dtype kernel class. f32 / f16 each live in their
+    // own class so the f32 JIT codegen stays untouched.
+    brgemm_kernel_t *kernel = nullptr;
+    if (brg.is_f32) {
+        kernel = new brgemm_kernel_common_t(brg);
+    } else if (brg.dt_a == data_type::f16) {
+        kernel = new brgemm_kernel_f16_t(brg);
+    } else {
+        return status::unimplemented;
+    }
     status_t st = kernel->create_kernel();
     if (st != status::success) {
         delete kernel;
@@ -108,10 +122,13 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, const void *ptr_A,
         const void *ptr_bias) {
 
     const auto &brg = brg_kernel->get_brg();
-    const int ts = brg.typesize_C; // sizeof(float) = 4
+    const int ts_a = brg.typesize_A;
+    const int ts_b = brg.typesize_B;
+    const int ts_c = brg.typesize_C;
+    const int ts_bias = static_cast<int>(sizeof(float)); // bias is f32
     const int bd = brg.bd_block;
     const dim_t K = brg.reduce_dim;
-    const dim_t LDA_bytes = brg.LDA * ts;
+    const dim_t LDA_bytes = brg.LDA * ts_a;
 
     const auto *A_base = reinterpret_cast<const char *>(ptr_A);
     const auto *B_base = reinterpret_cast<const char *>(ptr_B);
@@ -119,7 +136,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, const void *ptr_A,
     const auto *bias_base = reinterpret_cast<const char *>(ptr_bias);
 
     // K-blocking: split the reduction dimension into chunks of BK to keep
-    // the A working-set (bd_block × BK × 4 bytes) inside the L1D cache.
+    // the A working-set inside the L1D cache.
     const dim_t BK = BRGEMM_BK;
 
     for (dim_t kb = 0; kb < K; kb += BK) {
@@ -127,7 +144,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, const void *ptr_A,
         const float beta_kb = (kb == 0) ? beta : 1.0f;
 
         const char *A_kb = A_base + kb * LDA_bytes;
-        const char *B_kb = B_base + kb * ts;
+        const char *B_kb = B_base + kb * ts_b;
         const char *bias_kb = (kb == 0) ? bias_base : nullptr;
 
         brgemm_kernel_params_t p;
@@ -138,20 +155,21 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, const void *ptr_A,
 
         // Process full bd_block tiles.
         for (int m = 0; m < brg.bdb; m++) {
-            p.ptr_A = A_kb + static_cast<dim_t>(m) * bd * ts;
-            p.ptr_C = C_base + static_cast<dim_t>(m) * bd * ts;
-            p.ptr_bias = bias_kb ? bias_kb + static_cast<dim_t>(m) * bd * ts
-                                 : nullptr;
+            p.ptr_A = A_kb + static_cast<dim_t>(m) * bd * ts_a;
+            p.ptr_C = C_base + static_cast<dim_t>(m) * bd * ts_c;
+            p.ptr_bias = bias_kb
+                    ? bias_kb + static_cast<dim_t>(m) * bd * ts_bias
+                    : nullptr;
             p.M = bd;
             (*brg_kernel)(&p);
         }
 
         // Process M tail (if any).
         if (brg.bdb_tail > 0) {
-            p.ptr_A = A_kb + static_cast<dim_t>(brg.bdb) * bd * ts;
-            p.ptr_C = C_base + static_cast<dim_t>(brg.bdb) * bd * ts;
+            p.ptr_A = A_kb + static_cast<dim_t>(brg.bdb) * bd * ts_a;
+            p.ptr_C = C_base + static_cast<dim_t>(brg.bdb) * bd * ts_c;
             p.ptr_bias = bias_kb
-                    ? bias_kb + static_cast<dim_t>(brg.bdb) * bd * ts
+                    ? bias_kb + static_cast<dim_t>(brg.bdb) * bd * ts_bias
                     : nullptr;
             p.M = brg.bdb_tail;
             (*brg_kernel)(&p);

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -416,6 +416,383 @@ void brgemm_kernel_common_t::operator()(brgemm_kernel_params_t *p) const {
     (*jit_kernel_)(p);
 }
 
+// =====================================================================
+// f16 JIT kernel: f16 x f16 -> f32 via widening FMA (Zvfh).
+// =====================================================================
+
+struct jit_brgemm_f16_kernel_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_f16_kernel_t)
+
+    jit_brgemm_f16_kernel_t(const brgemm_desc_t &brg)
+        : jit_generator_t("rv64_brgemm_kernel_f16_jit"), brg_(brg) {}
+
+    void operator()(brgemm_kernel_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+    const brgemm_desc_t &get_brg() const { return brg_; }
+
+protected:
+    void generate() override;
+
+private:
+    brgemm_desc_t brg_;
+};
+
+void jit_brgemm_f16_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const dim_t LDA_bytes = brg_.LDA * brg_.typesize_A; // f16 → ×2
+    const dim_t LDB_bytes = brg_.LDB * brg_.typesize_B; // f16 → ×2
+    const dim_t LDC_bytes = brg_.LDC * brg_.typesize_C; // f32 → ×4
+    const dim_t N_stride_B = 4 * LDB_bytes;
+    const dim_t N_stride_C = 4 * LDC_bytes;
+
+    const bool use_single_b = (3 * LDB_bytes <= 2047);
+
+    const Reg reg_param = a0;
+    const Reg reg_tmp0 = a0;
+
+    const Reg reg_A = a1;
+    const Reg reg_n = a2;
+    const Reg reg_C = a3;
+    const Reg reg_k = a4;
+    const Reg reg_K_main = a5;
+    const Reg reg_B0 = a6;
+    const Reg reg_B1 = a7;
+
+    const Reg reg_lda = t0;
+    const Reg reg_ldb = t1;
+    const Reg reg_ldc = t2;
+    const Reg reg_K_val = t3;
+    const Reg reg_N = t4;
+    const Reg reg_beta = t5;
+    const Reg reg_tmp1 = t6;
+
+    const Reg reg_A_base = s0;
+    const Reg reg_B_base = s1;
+    const Reg reg_B2 = s2;
+    const Reg reg_B3 = s3;
+    const Reg reg_bias = s4;
+    const Reg reg_M = s5; // M saved for repeated vsetvli configs
+
+    const FReg freg_b0 = fa0;
+    const FReg freg_b1 = fa1;
+    const FReg freg_b2 = fa2;
+    const FReg freg_b3 = fa3;
+
+    const VReg v_c0(0);
+    const VReg v_c1(4);
+    const VReg v_c2(8);
+    const VReg v_c3(12);
+    const VReg v_a0(16); // EMUL=m2 at e16: occupies v16-v17
+    const VReg v_a1(20); // EMUL=m2 at e16: occupies v20-v21
+    const VReg v_tmp(24);
+
+    addi(sp, sp, -56);
+    sd(reg_A_base, sp, 0);
+    sd(reg_B_base, sp, 8);
+    sd(reg_B2, sp, 16);
+    sd(reg_B3, sp, 24);
+    sd(reg_bias, sp, 32);
+    sd(reg_M, sp, 40);
+
+    ld(reg_A_base, reg_param, 0);
+    ld(reg_B_base, reg_param, 8);
+    ld(reg_C, reg_param, 16);
+    ld(reg_N, reg_param, 24);
+    ld(reg_M, reg_param, 32); // keep M around to re-issue vsetvli
+    ld(reg_K_val, reg_param, 40);
+    lw(reg_beta, reg_param, 48);
+    ld(reg_bias, reg_param, 56);
+
+    // Initial vsetvli for C/bias work (e32 m4).
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+
+    li(reg_lda, LDA_bytes);
+    li(reg_ldb, LDB_bytes);
+    li(reg_ldc, LDC_bytes);
+
+    if (use_single_b) {
+        li(s2, N_stride_B);
+        li(s3, N_stride_C);
+    }
+
+    srli(reg_K_main, reg_K_val, 2);
+    slli(reg_K_main, reg_K_main, 2);
+
+    mv(reg_n, x0);
+
+    Label lbl_n_loop, lbl_n_tail, lbl_n_tail_loop, lbl_n_end;
+
+    L(lbl_n_loop);
+    addi(reg_tmp0, reg_n, 4);
+    blt(reg_N, reg_tmp0, lbl_n_tail);
+
+    mv(reg_A, reg_A_base);
+
+    mv(reg_B0, reg_B_base);
+    if (!use_single_b) {
+        add(reg_B1, reg_B_base, reg_ldb);
+        add(reg_B2, reg_B1, reg_ldb);
+        add(reg_B3, reg_B2, reg_ldb);
+    }
+
+    // Zero accumulators at e32 m4 (4 phys regs each).
+    vmv_v_i(v_c0, 0);
+    vmv_v_i(v_c1, 0);
+    vmv_v_i(v_c2, 0);
+    vmv_v_i(v_c3, 0);
+
+    // Switch to e16/m2 for the K loop. VLMAX matches → vl unchanged.
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+
+    mv(reg_k, x0);
+    Label lbl_k_main_end, lbl_k_tail, lbl_k_tail_end;
+
+    auto emit_b_load = [&]() {
+        flh(freg_b0, reg_B0, 0);
+        if (use_single_b) {
+            flh(freg_b1, reg_B0, LDB_bytes);
+            flh(freg_b2, reg_B0, 2 * LDB_bytes);
+            flh(freg_b3, reg_B0, 3 * LDB_bytes);
+        } else {
+            flh(freg_b1, reg_B1, 0);
+            flh(freg_b2, reg_B2, 0);
+            flh(freg_b3, reg_B3, 0);
+        }
+    };
+
+    auto emit_b_advance = [&]() {
+        addi(reg_B0, reg_B0, 2);
+        if (!use_single_b) {
+            addi(reg_B1, reg_B1, 2);
+            addi(reg_B2, reg_B2, 2);
+            addi(reg_B3, reg_B3, 2);
+        }
+    };
+
+    auto emit_pipelined_step = [&](const VReg &v_next, const VReg &v_cur) {
+        vle16_v(v_next, reg_A);
+        add(reg_A, reg_A, reg_lda);
+        emit_b_load();
+        vfwmacc_vf(v_c0, freg_b0, v_cur);
+        vfwmacc_vf(v_c1, freg_b1, v_cur);
+        vfwmacc_vf(v_c2, freg_b2, v_cur);
+        vfwmacc_vf(v_c3, freg_b3, v_cur);
+        emit_b_advance();
+    };
+
+    auto emit_drain_step = [&](const VReg &v_cur) {
+        emit_b_load();
+        vfwmacc_vf(v_c0, freg_b0, v_cur);
+        vfwmacc_vf(v_c1, freg_b1, v_cur);
+        vfwmacc_vf(v_c2, freg_b2, v_cur);
+        vfwmacc_vf(v_c3, freg_b3, v_cur);
+        emit_b_advance();
+    };
+
+    beq(reg_K_main, x0, lbl_k_tail);
+
+    addi(reg_tmp1, reg_K_main, -4);
+
+    vle16_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+
+    align(16);
+    {
+        Label lbl_pipe, lbl_pipe_end;
+        L(lbl_pipe);
+        bge(reg_k, reg_tmp1, lbl_pipe_end);
+
+        emit_pipelined_step(v_a1, v_a0);
+        emit_pipelined_step(v_a0, v_a1);
+        emit_pipelined_step(v_a1, v_a0);
+        emit_pipelined_step(v_a0, v_a1);
+
+        addi(reg_k, reg_k, 4);
+        j_(lbl_pipe);
+        L(lbl_pipe_end);
+    }
+
+    emit_pipelined_step(v_a1, v_a0);
+    emit_pipelined_step(v_a0, v_a1);
+    emit_pipelined_step(v_a1, v_a0);
+    emit_drain_step(v_a1);
+    addi(reg_k, reg_k, 4);
+
+    L(lbl_k_main_end);
+
+    L(lbl_k_tail);
+    bge(reg_k, reg_K_val, lbl_k_tail_end);
+
+    vle16_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+    emit_b_load();
+    vfwmacc_vf(v_c0, freg_b0, v_a0);
+    vfwmacc_vf(v_c1, freg_b1, v_a0);
+    vfwmacc_vf(v_c2, freg_b2, v_a0);
+    vfwmacc_vf(v_c3, freg_b3, v_a0);
+    emit_b_advance();
+    addi(reg_k, reg_k, 1);
+    j_(lbl_k_tail);
+
+    L(lbl_k_tail_end);
+
+    // Switch back to e32 m4 for bias add + C store (f32 ops).
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+
+    {
+        Label lbl_no_bias;
+        beq(reg_bias, x0, lbl_no_bias);
+        vle32_v(v_tmp, reg_bias);
+        vfadd_vv(v_c0, v_c0, v_tmp);
+        vfadd_vv(v_c1, v_c1, v_tmp);
+        vfadd_vv(v_c2, v_c2, v_tmp);
+        vfadd_vv(v_c3, v_c3, v_tmp);
+        L(lbl_no_bias);
+    }
+
+    {
+        mv(reg_tmp0, reg_C);
+        Label lbl_bz, lbl_store_done;
+        beq(reg_beta, x0, lbl_bz);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c1);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c2);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c3);
+        vse32_v(v_tmp, reg_tmp0);
+
+        j_(lbl_store_done);
+
+        L(lbl_bz);
+        vse32_v(v_c0, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c1, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c2, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c3, reg_tmp0);
+
+        L(lbl_store_done);
+    }
+
+    if (use_single_b) {
+        add(reg_B_base, reg_B_base, s2);
+        add(reg_C, reg_C, s3);
+    } else {
+        li(reg_tmp1, N_stride_B);
+        add(reg_B_base, reg_B_base, reg_tmp1);
+        li(reg_tmp1, N_stride_C);
+        add(reg_C, reg_C, reg_tmp1);
+    }
+
+    addi(reg_n, reg_n, 4);
+    j_(lbl_n_loop);
+
+    // ---- N tail: 1 column at a time ----
+    L(lbl_n_tail);
+
+    L(lbl_n_tail_loop);
+    bge(reg_n, reg_N, lbl_n_end);
+
+    mv(reg_A, reg_A_base);
+    mv(reg_B0, reg_B_base);
+
+    // We're at e32 m4 here (after the previous iter or initial setup).
+    vmv_v_i(v_c0, 0);
+
+    // Switch to e16 m2 for the single-column K loop.
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+
+    mv(reg_k, x0);
+    Label lbl_kt2, lbl_kt2_end;
+
+    L(lbl_kt2);
+    bge(reg_k, reg_K_val, lbl_kt2_end);
+
+    vle16_v(v_a0, reg_A);
+    flh(freg_b0, reg_B0, 0);
+    vfwmacc_vf(v_c0, freg_b0, v_a0);
+    add(reg_A, reg_A, reg_lda);
+    addi(reg_B0, reg_B0, 2);
+    addi(reg_k, reg_k, 1);
+    j_(lbl_kt2);
+
+    L(lbl_kt2_end);
+
+    // Back to e32 m4 for bias add + C store.
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+
+    {
+        Label lbl_no_bias2;
+        beq(reg_bias, x0, lbl_no_bias2);
+        vle32_v(v_tmp, reg_bias);
+        vfadd_vv(v_c0, v_c0, v_tmp);
+        L(lbl_no_bias2);
+    }
+
+    {
+        Label lbl_bz2, lbl_done2;
+        beq(reg_beta, x0, lbl_bz2);
+        vle32_v(v_tmp, reg_C);
+        vfadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_C);
+        j_(lbl_done2);
+        L(lbl_bz2);
+        vse32_v(v_c0, reg_C);
+        L(lbl_done2);
+    }
+
+    add(reg_B_base, reg_B_base, reg_ldb);
+    add(reg_C, reg_C, reg_ldc);
+
+    addi(reg_n, reg_n, 1);
+    j_(lbl_n_tail_loop);
+
+    L(lbl_n_end);
+
+    ld(reg_A_base, sp, 0);
+    ld(reg_B_base, sp, 8);
+    ld(reg_B2, sp, 16);
+    ld(reg_B3, sp, 24);
+    ld(reg_bias, sp, 32);
+    ld(reg_M, sp, 40);
+    addi(sp, sp, 56);
+    ret();
+#else
+    ret();
+#endif
+}
+
+brgemm_kernel_f16_t::brgemm_kernel_f16_t(const brgemm_desc_t &brg)
+    : brg_(brg), jit_kernel_(new jit_brgemm_f16_kernel_t(brg)) {}
+
+brgemm_kernel_f16_t::~brgemm_kernel_f16_t() {
+    delete jit_kernel_;
+}
+
+status_t brgemm_kernel_f16_t::create_kernel() {
+    return jit_kernel_->create_kernel();
+}
+
+void brgemm_kernel_f16_t::operator()(brgemm_kernel_params_t *p) const {
+    (*jit_kernel_)(p);
+}
+
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -488,7 +488,9 @@ void jit_brgemm_f16_kernel_t::generate() {
     const VReg v_a1(20); // EMUL=m2 at e16: occupies v20-v21
     const VReg v_tmp(24);
 
-    addi(sp, sp, -56);
+    // sp shrinks by 48 bytes: 6 callee-saved regs × 8 = 48,
+    // which keeps sp 16-byte aligned per the RISC-V LP64 ABI.
+    addi(sp, sp, -48);
     sd(reg_A_base, sp, 0);
     sd(reg_B_base, sp, 8);
     sd(reg_B2, sp, 16);
@@ -506,7 +508,7 @@ void jit_brgemm_f16_kernel_t::generate() {
     ld(reg_bias, reg_param, 56);
 
     // Initial vsetvli for C/bias work (e32 m4).
-    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     li(reg_lda, LDA_bytes);
     li(reg_ldb, LDB_bytes);
@@ -544,7 +546,7 @@ void jit_brgemm_f16_kernel_t::generate() {
     vmv_v_i(v_c3, 0);
 
     // Switch to e16/m2 for the K loop. VLMAX matches → vl unchanged.
-    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
 
     mv(reg_k, x0);
     Label lbl_k_main_end, lbl_k_tail, lbl_k_tail_end;
@@ -639,7 +641,7 @@ void jit_brgemm_f16_kernel_t::generate() {
     L(lbl_k_tail_end);
 
     // Switch back to e32 m4 for bias add + C store (f32 ops).
-    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     {
         Label lbl_no_bias;
@@ -716,7 +718,7 @@ void jit_brgemm_f16_kernel_t::generate() {
     vmv_v_i(v_c0, 0);
 
     // Switch to e16 m2 for the single-column K loop.
-    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
 
     mv(reg_k, x0);
     Label lbl_kt2, lbl_kt2_end;
@@ -735,7 +737,7 @@ void jit_brgemm_f16_kernel_t::generate() {
     L(lbl_kt2_end);
 
     // Back to e32 m4 for bias add + C store.
-    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     {
         Label lbl_no_bias2;
@@ -771,7 +773,7 @@ void jit_brgemm_f16_kernel_t::generate() {
     ld(reg_B3, sp, 24);
     ld(reg_bias, sp, 32);
     ld(reg_M, sp, 40);
-    addi(sp, sp, 56);
+    addi(sp, sp, 48);
     ret();
 #else
     ret();

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
@@ -26,6 +26,7 @@ namespace cpu {
 namespace rv64 {
 
 struct jit_brgemm_kernel_t;
+struct jit_brgemm_f16_kernel_t;
 
 struct brgemm_kernel_common_t : public brgemm_kernel_t {
     brgemm_kernel_common_t(const brgemm_desc_t &brg);
@@ -38,6 +39,19 @@ struct brgemm_kernel_common_t : public brgemm_kernel_t {
 private:
     brgemm_desc_t brg_;
     jit_brgemm_kernel_t *jit_kernel_ = nullptr;
+};
+
+struct brgemm_kernel_f16_t : public brgemm_kernel_t {
+    brgemm_kernel_f16_t(const brgemm_desc_t &brg);
+    ~brgemm_kernel_f16_t() override;
+
+    status_t create_kernel() override;
+    void operator()(brgemm_kernel_params_t *) const override;
+    const brgemm_desc_t &get_brg() const override { return brg_; }
+
+private:
+    brgemm_desc_t brg_;
+    jit_brgemm_f16_kernel_t *jit_kernel_ = nullptr;
 };
 
 } // namespace rv64

--- a/src/cpu/rv64/cpu_isa_traits.cpp
+++ b/src/cpu/rv64/cpu_isa_traits.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace rv64 {
 
 struct isa_info_t {
-    isa_info_t(cpu_isa_t aisa) : isa(aisa) {};
+    isa_info_t(cpu_isa_t aisa) : isa(aisa) {}
     cpu_isa_t isa;
 };
 

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -307,8 +307,8 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     const auto src_dt = src_mdw.data_type();
     const auto wei_dt = wei_mdw.data_type();
     const bool same_in_dt = src_dt == wei_dt;
-    const bool in_dt_ok = same_in_dt
-            && (src_dt == f32 || (src_dt == f16 && mayiuse(zvfh)));
+    const bool in_dt_ok
+            = same_in_dt && (src_dt == f32 || (src_dt == f16 && mayiuse(zvfh)));
     const bool types_ok = in_dt_ok && dst_mdw.data_type() == f32
             && IMPLICATION(!bias_mdw.is_zero(), bias_mdw.data_type() == f32)
             && desc()->accum_data_type == f32;

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -45,17 +45,20 @@ using namespace data_type;
 // ---------------------------------------------------------------------------
 struct jit_pack_a_tile_t : public jit_generator_t {
     struct call_params_t {
-        float *ws; // offset 0
-        const float *A; // offset 8
-        dim_t LDA_orig; // offset 16
-        dim_t bd; // offset 24
+        void *ws; // offset 0
+        const void *A; // offset 8
+        dim_t LDA_orig; // offset 16 — in elements (not bytes)
+        dim_t bd; // offset 24 — in elements
         dim_t valid_rows; // offset 32
         dim_t K_inner; // offset 40
     };
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_pack_a_tile_t)
 
-    jit_pack_a_tile_t() : jit_generator_t("jit_pack_a_tile") {
+    // input_typesize: 4 for f32, 2 for f16.
+    explicit jit_pack_a_tile_t(int input_typesize)
+        : jit_generator_t("jit_pack_a_tile"), input_typesize_(input_typesize) {
+        assert(input_typesize == 2 || input_typesize == 4);
         create_kernel();
     }
 
@@ -84,6 +87,8 @@ protected:
 
         const VReg v_tmp(0);
 
+        const int elem_shift = (input_typesize_ == 4) ? 2 : 1;
+
         // Load parameters
         ld(reg_ws, reg_param, 0);
         ld(reg_A, reg_param, 8);
@@ -92,9 +97,8 @@ protected:
         ld(reg_rows_remaining, reg_param, 32); // reuse as valid_rows temp
         ld(reg_K, reg_param, 40);
 
-        // Compute LDA_orig * sizeof(float) and bd * sizeof(float)
-        slli(reg_LDA, reg_LDA, 2);
-        slli(reg_bd, reg_bd, 2);
+        slli(reg_LDA, reg_LDA, elem_shift);
+        slli(reg_bd, reg_bd, elem_shift);
 
         // Save valid_rows for reuse in each k iteration
         const Reg reg_valid_rows = a6;
@@ -106,25 +110,28 @@ protected:
         L(k_loop);
         beq(reg_k, reg_K, k_done);
 
-        // src = A + k * LDA_bytes
         mul(reg_tmp, reg_k, reg_LDA);
         add(reg_src, reg_A, reg_tmp);
 
-        // dst = ws + k * bd_bytes
         mul(reg_tmp, reg_k, reg_bd);
         add(reg_dst, reg_ws, reg_tmp);
 
-        // Inner copy loop: copy valid_rows floats
         mv(reg_rows_remaining, reg_valid_rows);
         Label copy_loop, copy_done;
         L(copy_loop);
         beqz(reg_rows_remaining, copy_done);
 
-        vsetvli(reg_vl, reg_rows_remaining, SEW::e32, LMUL::m4);
-        vle32_v(v_tmp, reg_src);
-        vse32_v(v_tmp, reg_dst);
+        if (input_typesize_ == 4) {
+            vsetvli(reg_vl, reg_rows_remaining, SEW::e32, LMUL::m4);
+            vle32_v(v_tmp, reg_src);
+            vse32_v(v_tmp, reg_dst);
+        } else {
+            vsetvli(reg_vl, reg_rows_remaining, SEW::e16, LMUL::m4);
+            vle16_v(v_tmp, reg_src);
+            vse16_v(v_tmp, reg_dst);
+        }
 
-        slli(reg_bytes, reg_vl, 2);
+        slli(reg_bytes, reg_vl, elem_shift);
         add(reg_src, reg_src, reg_bytes);
         add(reg_dst, reg_dst, reg_bytes);
         sub(reg_rows_remaining, reg_rows_remaining, reg_vl);
@@ -141,6 +148,9 @@ protected:
         ret();
 #endif
     }
+
+private:
+    int input_typesize_;
 };
 
 // ---------------------------------------------------------------------------
@@ -293,11 +303,18 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
                     && !bias_mdw.has_runtime_dims_or_strides(),
             VERBOSE_UNSUPPORTED_TAG);
 
-    const bool types_ok = src_mdw.data_type() == f32
-            && wei_mdw.data_type() == f32 && dst_mdw.data_type() == f32
+    // Accepted: f32/f32/f32, f16/f16/f32 (Zvfh).
+    const auto src_dt = src_mdw.data_type();
+    const auto wei_dt = wei_mdw.data_type();
+    const bool same_in_dt = src_dt == wei_dt;
+    const bool in_dt_ok = same_in_dt
+            && (src_dt == f32 || (src_dt == f16 && mayiuse(zvfh)));
+    const bool types_ok = in_dt_ok && dst_mdw.data_type() == f32
             && IMPLICATION(!bias_mdw.is_zero(), bias_mdw.data_type() == f32)
             && desc()->accum_data_type == f32;
     VDISPATCH_MATMUL(types_ok, VERBOSE_UNSUPPORTED_DT);
+
+    input_typesize_ = static_cast<int>(types::data_type_size(src_dt));
 
     VDISPATCH_MATMUL(attr()->has_default_values(smask_t::post_ops, f32),
             VERBOSE_UNSUPPORTED_ATTR);
@@ -375,19 +392,19 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     VDISPATCH_MATMUL(
             N_ >= 16, VERBOSE_IMPL_HEURISTIC_FAIL, "N too small for brgemm");
 
-    // BRGEMM's copy_A packing reads A sequentially (stride bd_block) while
-    // GEMM reads A with stride N. When A exceeds L2 cache, sequential reads
-    // from DRAM are ~2x faster than strided reads. Two conditions ensure
-    // BRGEMM is beneficial:
-    // 1. K >= 4096: K-blocking amortizes packing overhead
-    // 2. A exceeds L2: N * K * 4 > L2_size
-    // 3. batch * M >= 128: BRGEMM kernel's N-loop needs enough iterations
-    //    to pipeline efficiently; fewer causes regression (benchmarked).
-    const dim_t A_bytes = N_ * K_ * (dim_t)sizeof(float);
-    const auto L2_bytes = platform::get_per_core_cache_size(3);
-    VDISPATCH_MATMUL(K_ >= 4096 && A_bytes > L2_bytes && batch_ * M_ >= 128,
-            VERBOSE_IMPL_HEURISTIC_FAIL,
-            "shape not beneficial for brgemm matmul");
+    // f32 keeps the K/A_bytes thresholds; f16 only requires batch*M.
+    const bool is_low_prec = (src_dt == data_type::f16);
+    if (is_low_prec) {
+        VDISPATCH_MATMUL(K_ >= BRGEMM_BK && batch_ * M_ >= 128,
+                VERBOSE_IMPL_HEURISTIC_FAIL,
+                "shape too small for f16 brgemm matmul");
+    } else {
+        const dim_t A_bytes = N_ * K_ * (dim_t)input_typesize_;
+        const auto L2_bytes = platform::get_per_core_cache_size(3);
+        VDISPATCH_MATMUL(K_ >= 4096 && A_bytes > L2_bytes && batch_ * M_ >= 128,
+                VERBOSE_IMPL_HEURISTIC_FAIL,
+                "shape not beneficial for f32 brgemm matmul");
+    }
 
     // Compute blocking parameters
     const int vlen_f32 = get_platform_vlen() / 32;
@@ -399,16 +416,18 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     const dim_t LDC = N_;
     const dim_t N_brg = batch_ * M_;
 
+    cpu_isa_t brg_isa = src_dt == f16 ? zvfh : v;
+
     brgemm_desc_t brg_desc;
-    CHECK(brgemm_desc_init(&brg_desc, v, brgemm_strd, f32, f32,
+    CHECK(brgemm_desc_init(&brg_desc, brg_isa, brgemm_strd, src_dt, src_dt,
             brgemm_col_major, 1.0f, 0.0f, LDA, LDB, LDC, M_brg, N_brg, K_brg));
 
     brgemm_kernel_t *kernel = nullptr;
     CHECK(brgemm_kernel_create(&kernel, brg_desc));
     brg_kernel_.reset(kernel);
 
-    // Create JIT kernels for pack_a_tile and bias+postops
-    pack_kernel_.reset(new jit_pack_a_tile_t());
+    // pack_a_tile is dtype-aware; bias+postops touch only the f32 dst.
+    pack_kernel_.reset(new jit_pack_a_tile_t(input_typesize_));
     bias_postops_kernel_.reset(new jit_bias_postops_row_t());
 
     init_scratchpad();
@@ -420,19 +439,21 @@ void rvv_brgemm_matmul_t::pd_t::init_scratchpad() {
     using namespace memory_tracking::names;
     const auto &brg = brg_kernel_->get_brg();
     auto scratchpad = scratchpad_registry().registrar();
-    scratchpad.template book<float>(
-            key_brgemm_primitive_buffer_a, brg.bd_block * K_);
+    const size_t ws_bytes = (size_t)brg.bd_block * K_ * input_typesize_;
+    scratchpad.template book<char>(key_brgemm_primitive_buffer_a, ws_bytes);
 }
 
 status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
-    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
-    auto weights = CTX_IN_MEM(const float *, DNNL_ARG_WEIGHTS);
+    // Byte arithmetic so one code path handles f32/f16.
+    auto src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS);
     auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
 
     const dim_t M = pd()->M_;
     const dim_t N = pd()->N_;
     const dim_t K = pd()->K_;
     const dim_t batch = pd()->batch_;
+    const int in_ts = pd()->input_typesize_;
 
     const auto &brg = pd()->brg_kernel_->get_brg();
     const int bd = brg.bd_block;
@@ -445,28 +466,19 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
     const auto *pack_kernel = pd()->pack_kernel_.get();
     const auto *bias_postops_kernel = pd()->bias_postops_kernel_.get();
 
-    // Packing workspace from scratchpad.
-    // Size: bd × K × sizeof(float). For bd=32, K=4096: 512KB.
-    // Pack once per M-tile, then call kernel per K-block with offset.
+    // Packing workspace from scratchpad. Packed once per M-tile, then the
+    // brgemm kernel is called per K-block with offset into the buffer.
     const dim_t BK = BRGEMM_BK;
     auto &grantor = ctx.get_scratchpad_grantor();
-    float *ws = grantor.template get<float>(
+    char *ws = grantor.template get<char>(
             memory_tracking::names::key_brgemm_primitive_buffer_a);
 
-    // Manual M-tile × K-block loop with copy_A packing.
-    //
-    // For each M-tile:
-    // 1. Pack the tile's full A data from col-major (LDA=N) into contiguous
-    //    layout (LDA=bd).
-    // 2. For each K-block, call the JIT kernel with ptr_A pointing into the
-    //    packed buffer at the correct K-block offset.
     const int num_tiles = bdb + (bdb_tail > 0 ? 1 : 0);
     for (int t = 0; t < num_tiles; t++) {
         const bool is_tail = (t == bdb);
         const int rows = is_tail ? bdb_tail : bd;
-        const float *A_tile = weights + t * bd;
+        const char *A_tile = weights + (dim_t)t * bd * in_ts;
 
-        // JIT pack_a_tile
         jit_pack_a_tile_t::call_params_t pack_p;
         pack_p.ws = ws;
         pack_p.A = A_tile;
@@ -481,9 +493,9 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
             const float beta_kb = (kb == 0) ? 0.0f : 1.0f;
 
             brgemm_kernel_params_t p;
-            p.ptr_A = ws + kb * bd;
-            p.ptr_B = src + kb;
-            p.ptr_C = dst + t * bd;
+            p.ptr_A = ws + kb * bd * in_ts;
+            p.ptr_B = src + kb * in_ts;
+            p.ptr_C = dst + t * bd; // dst stays f32
             p.N = total_N;
             p.M = rows;
             p.K = K_inner;

--- a/src/cpu/rv64/rvv_brgemm_matmul.hpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.hpp
@@ -55,6 +55,8 @@ struct rvv_brgemm_matmul_t : public primitive_t {
         dim_t K_ = 0;
         dim_t batch_ = 0;
         bool weights_are_broadcast_ = false;
+        // Input element size in bytes (4=f32, 2=f16). dst is always f32.
+        int input_typesize_ = 4;
 
     private:
         void init_scratchpad();


### PR DESCRIPTION
# Description

This PR adds a vectorized FP16 BRGEMM kernel for RISC-V (RV64) and wires it into the matmul primitive.
Before this PR, FP16 matmul on RV64 had no vectorized implementation in oneDNN — it fell to `ref:any` (triple-nested scalar reference, because no `gemm_f16_matmul_t` exists upstream).
The BF16 half of the original PR (#5293) is submitted separately to keep the review surface small; this PR is independent and can land on its own.

## Key Features

- FP16 brgemm JIT kernel using `vfwmacc.vf` at `SEW=e16` (Zvfh widening FMA).
- F32 kernel unchanged — the f16 class is appended below the existing f32 class, so the f32 codegen and its dispatch behavior cannot regress.
- Dtype-aware matmul wrapper (`rvv_brgemm_matmul_t`): type gate accepts f16, `jit_pack_a_tile_t` parameterized by input typesize, byte-based pointer arithmetic in `execute()`, per-dtype dispatch heuristic.
- Detection uses the existing `Zvfh` flag in `Riscv64Cpu` (read by `Xbyak_riscv::CPU::hasExtension(Zvfh)` from `/proc/cpuinfo` + `riscv_hwprobe`). Zvfh is reliably advertised by current kernels/BSPs, so no extra probing is needed.

## Dispatch Heuristic

brgemm:rvv claims a matmul shape when:
- f32: `K >= 4096 && A_bytes > L2 && batch*M >= 128` (unchanged from prior gate)
- f16: `K >= BRGEMM_BK (=256) && batch*M >= 128` (the K and A_bytes thresholds protect against losing to a faster vectorized fallback; no such fallback exists for f16 on RV64, so they are dropped)

`batch*M >= 128` is kept across all dtypes — it's an internal kernel constraint on the inner N-loop pipeline depth, not a comparison against another impl.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

Measured on Spacemit X100.

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

| GPT-J op | Shape | dtype | brgemm:rvv (this PR) | Fallback impl | Speedup |
| :--- | :--- | :--- | :--- | :--- | :--- |
| gemm0 (square FC) | 32x32x4096:1x4096x4096 | f16 | 1,682 ms (20.4 Gflops) | ref:any 4,702,560 ms (0.007 Gflops) | 2,796× |

> The FP16 speedup is dramatic because the fallback (`ref:any`) is the bare scalar reference — no vectorized f16 matmul impl existed on RV64 prior to this PR.

## Correctness
- `benchdnn --mode=C` PASSED for `--dt=f16:f16:f32` on the GPT-J prefill shapes — bit-correct against benchdnn's reference impl.
- `test_benchdnn_modeC_matmul_ci_cpu` PASSED — full matmul CI suite covering all registered shape/dtype/post-op combos.

## Non-Regression

The f32 brgemm kernel source is bit-identical to main — the f16 kernel class is appended below the existing f32 class in `jit_brgemm_kernel.cpp`. The f32 dispatch heuristic is also unchanged; only the dtype gate now also admits f16.