### PR TITLE
cpu: rv64: brgemm: add bf16 JIT kernel

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -122,6 +122,8 @@ bool has_data_type_support(data_type_t data_type) {
 #endif
 #elif DNNL_AARCH64
             return aarch64::mayiuse_bf16();
+#elif DNNL_RV64
+            return rv64::mayiuse(rv64::zvfbfwma);
 #else
             return false;
 #endif

--- a/src/cpu/rv64/brgemm/brgemm.cpp
+++ b/src/cpu/rv64/brgemm/brgemm.cpp
@@ -40,11 +40,14 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
 
     // Supported:
     //   f32  × f32  → f32  (always)
+    //   bf16 × bf16 → f32  (Zvfbfwma widening FMA)
     //   f16  × f16  → f32  (Zvfh widening FMA)
     const bool is_f32 = everyone_is(data_type::f32, dt_a, dt_b);
+    const bool is_bf16
+            = everyone_is(data_type::bf16, dt_a, dt_b) && mayiuse(zvfbfwma);
     const bool is_f16
             = everyone_is(data_type::f16, dt_a, dt_b) && mayiuse(zvfh);
-    if (!is_f32 && !is_f16) return status::unimplemented;
+    if (!is_f32 && !is_bf16 && !is_f16) return status::unimplemented;
 
     *brg = utils::zero<brgemm_desc_t>();
 
@@ -94,11 +97,13 @@ status_t brgemm_kernel_create(
     if (!brg_kernel) return status::invalid_arguments;
     *brg_kernel = nullptr;
 
-    // Pick the per-dtype kernel class. f32 / f16 each live in their
-    // own class so the f32 JIT codegen stays untouched.
+    // Pick the per-dtype kernel class. f32 / bf16 / f16 each live in
+    // their own class so the f32 JIT codegen stays untouched.
     brgemm_kernel_t *kernel = nullptr;
     if (brg.is_f32) {
         kernel = new brgemm_kernel_common_t(brg);
+    } else if (brg.dt_a == data_type::bf16) {
+        kernel = new brgemm_kernel_bf16_t(brg);
     } else if (brg.dt_a == data_type::f16) {
         kernel = new brgemm_kernel_f16_t(brg);
     } else {

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -795,6 +795,398 @@ void brgemm_kernel_f16_t::operator()(brgemm_kernel_params_t *p) const {
     (*jit_kernel_)(p);
 }
 
+// =====================================================================
+// bf16 JIT kernel: bf16 x bf16 -> f32 via widening FMA (Zvfbfwma).
+// =====================================================================
+
+struct jit_brgemm_bf16_kernel_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_bf16_kernel_t)
+
+    jit_brgemm_bf16_kernel_t(const brgemm_desc_t &brg)
+        : jit_generator_t("rv64_brgemm_kernel_bf16_jit"), brg_(brg) {}
+
+    void operator()(brgemm_kernel_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+    const brgemm_desc_t &get_brg() const { return brg_; }
+
+protected:
+    void generate() override;
+
+private:
+    brgemm_desc_t brg_;
+};
+
+void jit_brgemm_bf16_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const dim_t LDA_bytes = brg_.LDA * brg_.typesize_A; // bf16 → ×2
+    const dim_t LDB_bytes = brg_.LDB * brg_.typesize_B; // bf16 → ×2
+    const dim_t LDC_bytes = brg_.LDC * brg_.typesize_C; // f32  → ×4
+    const dim_t N_stride_B = 4 * LDB_bytes;
+    const dim_t N_stride_C = 4 * LDC_bytes;
+
+    // Single-B-pointer optimization: same predicate as f32, but LDB_bytes
+    // is half the f32 value for the same LDB, so this is more often true.
+    const bool use_single_b = (3 * LDB_bytes <= 2047);
+
+    const Reg reg_param = a0;
+    const Reg reg_tmp0 = a0;
+
+    const Reg reg_A = a1;
+    const Reg reg_n = a2;
+    const Reg reg_C = a3;
+    const Reg reg_k = a4;
+    const Reg reg_K_main = a5;
+    const Reg reg_B0 = a6;
+    const Reg reg_B1 = a7;
+
+    const Reg reg_lda = t0;
+    const Reg reg_ldb = t1;
+    const Reg reg_ldc = t2;
+    const Reg reg_K_val = t3;
+    const Reg reg_N = t4;
+    const Reg reg_beta = t5;
+    const Reg reg_tmp1 = t6;
+
+    const Reg reg_A_base = s0;
+    const Reg reg_B_base = s1;
+    const Reg reg_B2 = s2;
+    const Reg reg_B3 = s3;
+    const Reg reg_bias = s4;
+    const Reg reg_M = s5; // M kept around for repeated vsetvli toggles
+
+    // B scalars are bf16; flh loads 16 bits NaN-boxed, vfwmaccbf16.vf
+    // reinterprets the low 16 bits as bf16.
+    const FReg freg_b0 = fa0;
+    const FReg freg_b1 = fa1;
+    const FReg freg_b2 = fa2;
+    const FReg freg_b3 = fa3;
+
+    // C at e32/m4 (f32 widening dest); A at e16/m2 (bf16 source).
+    // vd kept off v0 to avoid overlap with the mask register.
+    const VReg v_c0(4); // LMUL=m4: occupies v4-v7
+    const VReg v_c1(8); // v8-v11
+    const VReg v_c2(12); // v12-v15
+    const VReg v_c3(16); // v16-v19
+    const VReg v_a0(20); // EMUL=m2: occupies v20-v21
+    const VReg v_a1(24); // EMUL=m2: occupies v24-v25
+    const VReg v_tmp(28); // v28-v31
+
+    addi(sp, sp, -56);
+    sd(reg_A_base, sp, 0);
+    sd(reg_B_base, sp, 8);
+    sd(reg_B2, sp, 16);
+    sd(reg_B3, sp, 24);
+    sd(reg_bias, sp, 32);
+    sd(reg_M, sp, 40);
+
+    ld(reg_A_base, reg_param, 0);
+    ld(reg_B_base, reg_param, 8);
+    ld(reg_C, reg_param, 16);
+    ld(reg_N, reg_param, 24);
+    ld(reg_M, reg_param, 32); // keep M around for repeated vsetvli toggles
+    ld(reg_K_val, reg_param, 40);
+    lw(reg_beta, reg_param, 48);
+    ld(reg_bias, reg_param, 56);
+
+    // e32/m4 for C/bias; toggle to e16/m2 around the FMA loop because
+    // vfwmaccbf16.vf is defined at SEW=e16. LMUL=m2 chosen so VLMAX
+    // matches the outer e32/m4 setting and vl is preserved.
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+
+    li(reg_lda, LDA_bytes);
+    li(reg_ldb, LDB_bytes);
+    li(reg_ldc, LDC_bytes);
+
+    if (use_single_b) {
+        li(s2, N_stride_B);
+        li(s3, N_stride_C);
+    }
+
+    srli(reg_K_main, reg_K_val, 2);
+    slli(reg_K_main, reg_K_main, 2);
+
+    mv(reg_n, x0);
+
+    Label lbl_n_loop, lbl_n_tail, lbl_n_tail_loop, lbl_n_end;
+
+    L(lbl_n_loop);
+    addi(reg_tmp0, reg_n, 4);
+    blt(reg_N, reg_tmp0, lbl_n_tail);
+
+    mv(reg_A, reg_A_base);
+
+    mv(reg_B0, reg_B_base);
+    if (!use_single_b) {
+        add(reg_B1, reg_B_base, reg_ldb);
+        add(reg_B2, reg_B1, reg_ldb);
+        add(reg_B3, reg_B2, reg_ldb);
+    }
+
+    // Zero accumulators at e32 m4 (each m4 group is 4 phys regs).
+    vmv_v_i(v_c0, 0);
+    vmv_v_i(v_c1, 0);
+    vmv_v_i(v_c2, 0);
+    vmv_v_i(v_c3, 0);
+
+    // Switch to e16/m2 for the K loop (vfwmaccbf16.vf requires SEW=e16).
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+
+    mv(reg_k, x0);
+    Label lbl_k_main_end, lbl_k_tail, lbl_k_tail_end;
+
+    // Load 4 B scalars (bf16 via flh).
+    auto emit_b_load = [&]() {
+        flh(freg_b0, reg_B0, 0);
+        if (use_single_b) {
+            flh(freg_b1, reg_B0, LDB_bytes);
+            flh(freg_b2, reg_B0, 2 * LDB_bytes);
+            flh(freg_b3, reg_B0, 3 * LDB_bytes);
+        } else {
+            flh(freg_b1, reg_B1, 0);
+            flh(freg_b2, reg_B2, 0);
+            flh(freg_b3, reg_B3, 0);
+        }
+    };
+
+    // Advance B pointer(s) by one bf16 element (2 bytes).
+    auto emit_b_advance = [&]() {
+        addi(reg_B0, reg_B0, 2);
+        if (!use_single_b) {
+            addi(reg_B1, reg_B1, 2);
+            addi(reg_B2, reg_B2, 2);
+            addi(reg_B3, reg_B3, 2);
+        }
+    };
+
+    // Pipelined K step: prefetch next A (bf16, EMUL=m2) while issuing
+    // widening FMAs into f32 accumulators using the already-loaded v_cur.
+    auto emit_pipelined_step = [&](const VReg &v_next, const VReg &v_cur) {
+        vle16_v(v_next, reg_A);
+        add(reg_A, reg_A, reg_lda);
+        emit_b_load();
+        vfwmaccbf16_vf(v_c0, freg_b0, v_cur);
+        vfwmaccbf16_vf(v_c1, freg_b1, v_cur);
+        vfwmaccbf16_vf(v_c2, freg_b2, v_cur);
+        vfwmaccbf16_vf(v_c3, freg_b3, v_cur);
+        emit_b_advance();
+    };
+
+    // Drain step (final iteration): no A prefetch, avoids OOB read.
+    auto emit_drain_step = [&](const VReg &v_cur) {
+        emit_b_load();
+        vfwmaccbf16_vf(v_c0, freg_b0, v_cur);
+        vfwmaccbf16_vf(v_c1, freg_b1, v_cur);
+        vfwmaccbf16_vf(v_c2, freg_b2, v_cur);
+        vfwmaccbf16_vf(v_c3, freg_b3, v_cur);
+        emit_b_advance();
+    };
+
+    beq(reg_K_main, x0, lbl_k_tail);
+
+    addi(reg_tmp1, reg_K_main, -4);
+
+    vle16_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+
+    align(16);
+    {
+        Label lbl_pipe, lbl_pipe_end;
+        L(lbl_pipe);
+        bge(reg_k, reg_tmp1, lbl_pipe_end);
+
+        emit_pipelined_step(v_a1, v_a0);
+        emit_pipelined_step(v_a0, v_a1);
+        emit_pipelined_step(v_a1, v_a0);
+        emit_pipelined_step(v_a0, v_a1);
+
+        addi(reg_k, reg_k, 4);
+        j_(lbl_pipe);
+        L(lbl_pipe_end);
+    }
+
+    emit_pipelined_step(v_a1, v_a0);
+    emit_pipelined_step(v_a0, v_a1);
+    emit_pipelined_step(v_a1, v_a0);
+    emit_drain_step(v_a1);
+    addi(reg_k, reg_k, 4);
+
+    L(lbl_k_main_end);
+
+    L(lbl_k_tail);
+    bge(reg_k, reg_K_val, lbl_k_tail_end);
+
+    vle16_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+    emit_b_load();
+    vfwmaccbf16_vf(v_c0, freg_b0, v_a0);
+    vfwmaccbf16_vf(v_c1, freg_b1, v_a0);
+    vfwmaccbf16_vf(v_c2, freg_b2, v_a0);
+    vfwmaccbf16_vf(v_c3, freg_b3, v_a0);
+    emit_b_advance();
+    addi(reg_k, reg_k, 1);
+    j_(lbl_k_tail);
+
+    L(lbl_k_tail_end);
+
+    // Switch back to e32/m4 for bias add + C store (f32 ops on m4 accums).
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+
+    // Bias is f32 (same as f32 kernel) → vle32_v + vfadd_vv.
+    {
+        Label lbl_no_bias;
+        beq(reg_bias, x0, lbl_no_bias);
+        vle32_v(v_tmp, reg_bias);
+        vfadd_vv(v_c0, v_c0, v_tmp);
+        vfadd_vv(v_c1, v_c1, v_tmp);
+        vfadd_vv(v_c2, v_c2, v_tmp);
+        vfadd_vv(v_c3, v_c3, v_tmp);
+        L(lbl_no_bias);
+    }
+
+    // C is f32 → vle32_v / vse32_v.
+    {
+        mv(reg_tmp0, reg_C);
+        Label lbl_bz, lbl_store_done;
+        beq(reg_beta, x0, lbl_bz);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c1);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c2);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vfadd_vv(v_tmp, v_tmp, v_c3);
+        vse32_v(v_tmp, reg_tmp0);
+
+        j_(lbl_store_done);
+
+        L(lbl_bz);
+        vse32_v(v_c0, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c1, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c2, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c3, reg_tmp0);
+
+        L(lbl_store_done);
+    }
+
+    if (use_single_b) {
+        add(reg_B_base, reg_B_base, s2);
+        add(reg_C, reg_C, s3);
+    } else {
+        li(reg_tmp1, N_stride_B);
+        add(reg_B_base, reg_B_base, reg_tmp1);
+        li(reg_tmp1, N_stride_C);
+        add(reg_C, reg_C, reg_tmp1);
+    }
+
+    addi(reg_n, reg_n, 4);
+    j_(lbl_n_loop);
+
+    // ---- N tail: 1 column at a time ----
+    L(lbl_n_tail);
+
+    L(lbl_n_tail_loop);
+    bge(reg_n, reg_N, lbl_n_end);
+
+    mv(reg_A, reg_A_base);
+    mv(reg_B0, reg_B_base);
+
+    // Currently at e32/m4 (from previous N iteration tail / outer setup).
+    vmv_v_i(v_c0, 0);
+
+    // Switch to e16/m2 for single-column FMA loop.
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+
+    mv(reg_k, x0);
+    Label lbl_kt2, lbl_kt2_end;
+
+    L(lbl_kt2);
+    bge(reg_k, reg_K_val, lbl_kt2_end);
+
+    vle16_v(v_a0, reg_A);
+    flh(freg_b0, reg_B0, 0);
+    vfwmaccbf16_vf(v_c0, freg_b0, v_a0);
+    add(reg_A, reg_A, reg_lda);
+    addi(reg_B0, reg_B0, 2);
+    addi(reg_k, reg_k, 1);
+    j_(lbl_kt2);
+
+    L(lbl_kt2_end);
+
+    // Back to e32/m4 for bias + C store.
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+
+    {
+        Label lbl_no_bias2;
+        beq(reg_bias, x0, lbl_no_bias2);
+        vle32_v(v_tmp, reg_bias);
+        vfadd_vv(v_c0, v_c0, v_tmp);
+        L(lbl_no_bias2);
+    }
+
+    {
+        Label lbl_bz2, lbl_done2;
+        beq(reg_beta, x0, lbl_bz2);
+        vle32_v(v_tmp, reg_C);
+        vfadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_C);
+        j_(lbl_done2);
+        L(lbl_bz2);
+        vse32_v(v_c0, reg_C);
+        L(lbl_done2);
+    }
+
+    add(reg_B_base, reg_B_base, reg_ldb);
+    add(reg_C, reg_C, reg_ldc);
+
+    addi(reg_n, reg_n, 1);
+    j_(lbl_n_tail_loop);
+
+    L(lbl_n_end);
+
+    ld(reg_A_base, sp, 0);
+    ld(reg_B_base, sp, 8);
+    ld(reg_B2, sp, 16);
+    ld(reg_B3, sp, 24);
+    ld(reg_bias, sp, 32);
+    ld(reg_M, sp, 40);
+    addi(sp, sp, 56);
+    ret();
+#else
+    ret();
+#endif
+}
+
+brgemm_kernel_bf16_t::brgemm_kernel_bf16_t(const brgemm_desc_t &brg)
+    : brg_(brg), jit_kernel_(new jit_brgemm_bf16_kernel_t(brg)) {}
+
+brgemm_kernel_bf16_t::~brgemm_kernel_bf16_t() {
+    delete jit_kernel_;
+}
+
+status_t brgemm_kernel_bf16_t::create_kernel() {
+    return jit_kernel_->create_kernel();
+}
+
+void brgemm_kernel_bf16_t::operator()(brgemm_kernel_params_t *p) const {
+    (*jit_kernel_)(p);
+}
+
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
@@ -26,6 +26,7 @@ namespace cpu {
 namespace rv64 {
 
 struct jit_brgemm_kernel_t;
+struct jit_brgemm_bf16_kernel_t;
 struct jit_brgemm_f16_kernel_t;
 
 struct brgemm_kernel_common_t : public brgemm_kernel_t {
@@ -39,6 +40,19 @@ struct brgemm_kernel_common_t : public brgemm_kernel_t {
 private:
     brgemm_desc_t brg_;
     jit_brgemm_kernel_t *jit_kernel_ = nullptr;
+};
+
+struct brgemm_kernel_bf16_t : public brgemm_kernel_t {
+    brgemm_kernel_bf16_t(const brgemm_desc_t &brg);
+    ~brgemm_kernel_bf16_t() override;
+
+    status_t create_kernel() override;
+    void operator()(brgemm_kernel_params_t *) const override;
+    const brgemm_desc_t &get_brg() const override { return brg_; }
+
+private:
+    brgemm_desc_t brg_;
+    jit_brgemm_bf16_kernel_t *jit_kernel_ = nullptr;
 };
 
 struct brgemm_kernel_f16_t : public brgemm_kernel_t {

--- a/src/cpu/rv64/cpu_isa_traits.cpp
+++ b/src/cpu/rv64/cpu_isa_traits.cpp
@@ -18,10 +18,69 @@
 #include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/platform.hpp"
 
+#if defined(__linux__) && defined(__riscv) && (__riscv_xlen == 64)
+#include <csetjmp>
+#include <csignal>
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace rv64 {
+
+#if defined(__linux__) && defined(__riscv) && (__riscv_xlen == 64)
+
+namespace {
+
+// SIGILL-trap probe for Zvfbfwma. Linux HWPROBE may not surface the
+// extension yet on a given chip, so we try to execute one
+// vfwmaccbf16.vf in a sigaction-protected block. The probe runs once
+// from the Riscv64Cpu singleton.
+
+sigjmp_buf bf16_probe_jmp;
+
+void bf16_probe_sigill_handler(int) {
+    siglongjmp(bf16_probe_jmp, 1);
+}
+
+bool probe_zvfbfwma_impl() {
+    struct sigaction sa {};
+    sa.sa_handler = bf16_probe_sigill_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    struct sigaction old_sa {};
+    if (sigaction(SIGILL, &sa, &old_sa) != 0) return false;
+
+    bool ok = false;
+    if (sigsetjmp(bf16_probe_jmp, 1) == 0) {
+        // vsetivli zero, 4, e16, m1, ta, ma   (0xcc807057)
+        // vfwmaccbf16.vf v2, fa0, v6          (0xee655157)
+        // Raw bytes because older binutils may lack the mnemonics.
+        asm volatile(
+                ".4byte 0xcc807057\n"
+                ".4byte 0xee655157\n"
+                :
+                :
+                : "memory");
+        ok = true;
+    }
+    sigaction(SIGILL, &old_sa, nullptr);
+    return ok;
+}
+
+} // namespace
+
+bool probe_zvfbfwma() {
+    return probe_zvfbfwma_impl();
+}
+
+#else
+
+bool probe_zvfbfwma() {
+    return false;
+}
+
+#endif
 
 struct isa_info_t {
     isa_info_t(cpu_isa_t aisa) : isa(aisa) {}

--- a/src/cpu/rv64/cpu_isa_traits.hpp
+++ b/src/cpu/rv64/cpu_isa_traits.hpp
@@ -39,14 +39,18 @@ namespace rv64 {
 enum cpu_isa_bit_t : unsigned {
     v_bit = 1u << 0,
     zvfh_bit = 1u << 1,
+    zvfbfwma_bit = 1u << 2,
 };
 
 enum cpu_isa_t : unsigned {
     isa_undef = 0u,
     v = v_bit,
     zvfh = zvfh_bit | v,
+    zvfbfwma = zvfbfwma_bit | v,
     isa_all = ~0u,
 };
+
+bool probe_zvfbfwma();
 
 struct Riscv64Cpu {
 public:
@@ -57,11 +61,13 @@ public:
 
     bool get_has_v() const { return has_v; }
     bool get_has_zvfh() const { return has_zvfh; }
+    bool get_has_zvfbfwma() const { return has_zvfbfwma; }
     uint32_t get_vlen() const { return vlen; }
 
 private:
     bool has_v = false;
     bool has_zvfh = false;
+    bool has_zvfbfwma = false;
     uint32_t vlen = 0;
 
     Riscv64Cpu() {
@@ -73,8 +79,12 @@ private:
         if (has_v) {
             has_zvfh
                     = xbyak_cpu.hasExtension(Xbyak_riscv::RISCVExtension::Zvfh);
+            // HWPROBE / cpuinfo may not surface Zvfbfwma even on silicon
+            // that implements it (firmware / DT lag). Trap-probe instead.
+            has_zvfbfwma = probe_zvfbfwma();
         } else {
             has_zvfh = false;
+            has_zvfbfwma = false;
         }
     }
 };
@@ -86,6 +96,7 @@ inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
     switch (cpu_isa) {
         case v: return cpu.get_has_v();
         case zvfh: return cpu.get_has_v() && cpu.get_has_zvfh();
+        case zvfbfwma: return cpu.get_has_v() && cpu.get_has_zvfbfwma();
         case isa_undef: return true;
         case isa_all: return false;
     }
@@ -118,7 +129,8 @@ inline int get_vlen_implementation_id(int vlen) {
     ((isa) == isa_undef ? prefix STRINGIFY(any) : \
     ((isa) == v ? prefix STRINGIFY(rvv) : \
     ((isa) == zvfh ? prefix STRINGIFY(rvv_zvfh) : \
-    prefix suffix_if_any)))
+    ((isa) == zvfbfwma ? prefix STRINGIFY(rvv_zvfbfwma) : \
+    prefix suffix_if_any))))
 /* clang-format on */
 
 } // namespace rv64

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -55,7 +55,7 @@ struct jit_pack_a_tile_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_pack_a_tile_t)
 
-    // input_typesize: 4 for f32, 2 for f16.
+    // input_typesize: 4 for f32, 2 for bf16/f16.
     explicit jit_pack_a_tile_t(int input_typesize)
         : jit_generator_t("jit_pack_a_tile"), input_typesize_(input_typesize) {
         assert(input_typesize == 2 || input_typesize == 4);
@@ -303,12 +303,13 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
                     && !bias_mdw.has_runtime_dims_or_strides(),
             VERBOSE_UNSUPPORTED_TAG);
 
-    // Accepted: f32/f32/f32, f16/f16/f32 (Zvfh).
+    // Accepted: f32/f32/f32, bf16/bf16/f32 (Zvfbfwma), f16/f16/f32 (Zvfh).
     const auto src_dt = src_mdw.data_type();
     const auto wei_dt = wei_mdw.data_type();
     const bool same_in_dt = src_dt == wei_dt;
-    const bool in_dt_ok
-            = same_in_dt && (src_dt == f32 || (src_dt == f16 && mayiuse(zvfh)));
+    const bool in_dt_ok = same_in_dt
+            && (src_dt == f32 || (src_dt == bf16 && mayiuse(zvfbfwma))
+                    || (src_dt == f16 && mayiuse(zvfh)));
     const bool types_ok = in_dt_ok && dst_mdw.data_type() == f32
             && IMPLICATION(!bias_mdw.is_zero(), bias_mdw.data_type() == f32)
             && desc()->accum_data_type == f32;
@@ -392,12 +393,13 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     VDISPATCH_MATMUL(
             N_ >= 16, VERBOSE_IMPL_HEURISTIC_FAIL, "N too small for brgemm");
 
-    // f32 keeps the K/A_bytes thresholds; f16 only requires batch*M.
-    const bool is_low_prec = (src_dt == data_type::f16);
+    // f32 keeps the K/A_bytes thresholds; bf16/f16 only require batch*M.
+    const bool is_low_prec
+            = (src_dt == data_type::bf16 || src_dt == data_type::f16);
     if (is_low_prec) {
         VDISPATCH_MATMUL(K_ >= BRGEMM_BK && batch_ * M_ >= 128,
                 VERBOSE_IMPL_HEURISTIC_FAIL,
-                "shape too small for f16 brgemm matmul");
+                "shape too small for bf16/f16 brgemm matmul");
     } else {
         const dim_t A_bytes = N_ * K_ * (dim_t)input_typesize_;
         const auto L2_bytes = platform::get_per_core_cache_size(3);
@@ -416,7 +418,7 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     const dim_t LDC = N_;
     const dim_t N_brg = batch_ * M_;
 
-    cpu_isa_t brg_isa = src_dt == f16 ? zvfh : v;
+    cpu_isa_t brg_isa = src_dt == bf16 ? zvfbfwma : (src_dt == f16 ? zvfh : v);
 
     brgemm_desc_t brg_desc;
     CHECK(brgemm_desc_init(&brg_desc, brg_isa, brgemm_strd, src_dt, src_dt,
@@ -444,7 +446,7 @@ void rvv_brgemm_matmul_t::pd_t::init_scratchpad() {
 }
 
 status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
-    // Byte arithmetic so one code path handles f32/f16.
+    // Byte arithmetic so one code path handles f32/bf16/f16.
     auto src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);
     auto weights = CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS);
     auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);

--- a/src/cpu/rv64/rvv_brgemm_matmul.hpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.hpp
@@ -55,7 +55,7 @@ struct rvv_brgemm_matmul_t : public primitive_t {
         dim_t K_ = 0;
         dim_t batch_ = 0;
         bool weights_are_broadcast_ = false;
-        // Input element size in bytes (4=f32, 2=f16). dst is always f32.
+        // Input element size in bytes (4=f32, 2=bf16/f16). dst is always f32.
         int input_typesize_ = 4;
 
     private:


### PR DESCRIPTION
# Description

This PR adds a vectorized BF16 BRGEMM kernel for RISC-V (RV64) and wires it into the matmul primitive.

Before this PR, BF16 matmul on RV64 had no vectorized implementation in oneDNN — it fell to `gemm:jit:bf16` (CPU-agnostic scalar emulation).

The FP16 half of the original PR (#5293) is submitted separately to keep the review surface small; this PR is independent and can land on its own.

## Key Features

- BF16 brgemm JIT kernel using `vfwmaccbf16.vf` (Zvfbfwma widening FMA).
- F32 kernel unchanged — the bf16 class is appended below the existing f32 class, so the f32 codegen and its dispatch behavior cannot regress.
- Dtype-aware matmul wrapper (`rvv_brgemm_matmul_t`): type gate accepts bf16, `jit_pack_a_tile_t` parameterized by input typesize, byte-based pointer arithmetic in `execute()`, per-dtype dispatch heuristic.
- **Runtime detection of Zvfbfwma via a SIGILL trap probe.** `/proc/cpuinfo` and `riscv_hwprobe` do not yet surface Zvfbfwma on real silicon (the HWPROBE bit only landed in Linux 6.15, March 2025, and vendor BSPs lag), so a one-shot `sigaction(SIGILL)` + `sigsetjmp` block executes one `vfwmaccbf16.vf` and treats successful execution as proof of support. The result is cached in the `Riscv64Cpu` singleton; callers query the usual `mayiuse(zvfbfwma)`. No CMake flag is required.

## Dispatch Heuristic

brgemm:rvv claims a matmul shape when:
- f32: `K >= 4096 && A_bytes > L2 && batch*M >= 128` (unchanged from prior gate)
- bf16: `K >= BRGEMM_BK (=256) && batch*M >= 128` (the K and A_bytes thresholds protect against losing to a faster vectorized fallback; no such fallback exists for bf16 on RV64, so they are dropped)

`batch*M >= 128` is kept across all dtypes — it's an internal kernel constraint on the inner N-loop pipeline depth, not a comparison against another impl.


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

Measured on Spacemit X100.

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

| GPT-J op | Shape | dtype | brgemm:rvv (this PR) | Fallback impl | Speedup |
| :--- | :--- | :--- | :--- | :--- | :--- |
| gemm0 (square FC) | 32x32x4096:1x4096x4096 | bf16 | 1,681 ms (20.4 Gflops) | gemm:jit:bf16 407,100 ms (0.084 Gflops) | 242× |
| gemm3 (FFN up) | 32x32x4096:1x4096x16384 | bf16 | 7,061 ms (19.5 Gflops) | gemm:jit:bf16 1,658,190 ms (0.083 Gflops) | 234× |

> No vectorized bf16 matmul impl existed on RV64 prior to this PR; the comparison is vectorized brgemm vs the CPU-agnostic scalar GEMM emulation.

## Correctness
- `benchdnn --mode=C` PASSED for `--dt=bf16:bf16:f32` on the GPT-J prefill shapes — bit-correct against benchdnn's reference impl.
- `test_benchdnn_modeC_matmul_ci_cpu` PASSED — full matmul CI suite covering all registered shape/dtype/post-op combos.

## Non-Regression

The f32 brgemm kernel source is bit-identical to main — the bf16 kernel class is appended below the existing f32 class in `jit_brgemm_kernel.cpp`. The f32 dispatch heuristic is also unchanged; only the dtype gate now also admits bf16.