### PR TITLE
Extend GEMV code path to support bf16 and f16 data types 

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -283,19 +283,24 @@ status_t brgemv_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_x, bool transA, float alpha, float beta, dim_t LDA,
         dim_t INCY, dim_t M, dim_t N, bool treat_y_as_row) {
+    using namespace data_type;
 
-    // Only f32 is supported for now.
-    if (!utils::everyone_is(data_type::f32, dt_a, dt_x))
+    // GEMV uses f32 accumulators with upconvert from the input dt; both
+    // operands must share the same dt.
+    if (!utils::one_of(dt_a, f32, bf16, f16) || dt_a != dt_x)
         return status::unimplemented;
 
     // The transA kernel requires the output to be contiguous.
     if (transA && INCY > 1) return status::unimplemented;
 
+    // Set `is_gemv` before `brgemm_desc_init` so the GEMV branch in
+    // `set_isa_impl` (and other downstream code) can take effect.
+    brg->is_gemv = true;
+
     CHECK(brgemm_desc_init(brg, isa, type, dt_a, dt_x, false, false,
             brgemm_row_major, alpha, beta, LDA, 1, INCY, M, 1, N, nullptr,
             false));
 
-    brg->is_gemv = true;
     // Initialize transA here because `brgemm_desc_init` would otherwise return
     // unimplemented since brgemm doesn't support this case and we don't pass
     // the `is_gemv` flag to `brgemm_desc_init`. This keeps the GEMV
@@ -347,15 +352,26 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     brg->is_runtime_ldd = is_runtime_value(LDD);
     const auto dt_d = dst_md->data_type;
 
-    // check that bias and output data type are supported by isa
-    if (!IMPLICATION(one_of(data_type::bf16, dt_bias, dt_d),
-                is_superset(brg->isa_impl, avx512_core)
-                        || is_superset(brg->isa_impl, avx2_vnni_2)))
-        return status::unimplemented;
-    if (!IMPLICATION(one_of(data_type::f16, dt_bias, dt_d),
-                is_superset(brg->isa_impl, avx512_core_fp16)
-                        || is_superset(brg->isa_impl, avx2_vnni_2)))
-        return status::unimplemented;
+    if (!brg->is_gemv) {
+        if (!IMPLICATION(one_of(data_type::bf16, dt_bias, dt_d),
+                    is_superset(brg->isa_impl, avx512_core)
+                            || is_superset(brg->isa_impl, avx2_vnni_2)))
+            return status::unimplemented;
+        if (!IMPLICATION(one_of(data_type::f16, dt_bias, dt_d),
+                    is_superset(brg->isa_impl, avx512_core_fp16)
+                            || is_superset(brg->isa_impl, avx2_vnni_2)))
+            return status::unimplemented;
+    } else {
+        // The GEMV code path requires avx512_core_bf16 for bf16 and avx512_core
+        // for f16.
+        if (!IMPLICATION(one_of(data_type::bf16, dt_bias, dt_d),
+                    is_superset(brg->isa_impl, avx512_core_bf16)))
+            return status::unimplemented;
+        if (!IMPLICATION(one_of(data_type::f16, dt_bias, dt_d),
+                    is_superset(brg->isa_impl, avx512_core)))
+            return status::unimplemented;
+    }
+
     if (!IMPLICATION(one_of(data_type::f8_e5m2, dt_bias, dt_d)
                         || one_of(data_type::f8_e4m3, dt_bias, dt_d),
                 utils::one_of(

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -463,6 +463,13 @@ struct brgemm_desc_t {
         return full_accs + has_tail_acc;
     }
 
+    // Returns true when GEMV can use native `vdpbf16ps` instead of
+    // bf16->f32 conversion + `vfmadd231ps`.
+    bool gemv_use_vdpbf16ps() const {
+        assert(is_gemv);
+        return !transA && is_bf16;
+    }
+
     // return 'true' when FP8 MAC is not natively supported by the CPU ISA
     bool is_fp8_via_convert() const {
         return is_fp8 && utils::one_of(isa_impl, avx10_1_512_amx_fp16, avx10_2);

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -470,6 +470,14 @@ struct brgemm_desc_t {
         return !transA && is_bf16;
     }
 
+    // Returns true if GEMV uses a single scale value.
+    bool gemv_single_wei_scale() const {
+        assert(is_gemv);
+        // Per-N scales collapse to a single scalar unless `y` is treated as a
+        // row.
+        return !is_oc_scale || !treat_y_as_row;
+    }
+
     // return 'true' when FP8 MAC is not natively supported by the CPU ISA
     bool is_fp8_via_convert() const {
         return is_fp8 && utils::one_of(isa_impl, avx10_1_512_amx_fp16, avx10_2);

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -810,7 +810,7 @@ status_t brgemm_blocking_vmm_gemv(brgemm_desc_t *brg) {
         brg->bdb = brg->bcast_dim / brg->bd_block;
         brg->bdb_tail = brg->bcast_dim % brg->bd_block;
 
-        brg->rd_block = simd_w;
+        brg->rd_block = brg->gemv_use_vdpbf16ps() ? 2 * simd_w : simd_w;
         brg->rdb = brg->reduce_dim / brg->rd_block;
         brg->rdb_tail = brg->reduce_dim % brg->rd_block;
 

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -125,6 +125,18 @@ void set_isa_impl(brgemm_desc_t *brg) {
                 one_of(brg->isa_user, isa_undef, isa);
     };
 
+    if (brg->is_gemv) {
+        if (everyone_is(data_type::f32, brg->dt_a, brg->dt_b)) {
+            brg->isa_impl = is_isa_ok(avx2) ? avx2 : isa_undef;
+        } else if (everyone_is(data_type::bf16, brg->dt_a, brg->dt_b)) {
+            brg->isa_impl = is_isa_ok(avx512_core_bf16) ? avx512_core_bf16
+                                                        : isa_undef;
+        } else if (everyone_is(data_type::f16, brg->dt_a, brg->dt_b)) {
+            brg->isa_impl = is_isa_ok(avx512_core) ? avx512_core : isa_undef;
+        }
+        return;
+    }
+
     if (brg->is_tf32) {
         brg->isa_impl = avx10_2_amx_2;
     } else if (brg->is_bf32) {
@@ -777,10 +789,10 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
  *
  */
 status_t brgemm_blocking_vmm_gemv(brgemm_desc_t *brg) {
-    const int simd_w = 8;
-
-    assert(utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2));
+    assert(utils::one_of(brg->isa_impl, avx2, avx512_core, avx512_core_bf16));
     assert(brg->load_dim == 1);
+
+    const int simd_w = is_superset(brg->isa_impl, avx512_core) ? 16 : 8;
 
     // Blocking parameters for the non-transposed case.
     if (!brg->transA) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -1398,11 +1398,9 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
 
     reg_aux_wei_scales.restore();
 
-    // Per-N scales collapse to a single scalar unless `y` is treated as a row.
-    const bool is_single_scale = !brg.is_oc_scale || !brg.treat_y_as_row;
     const Vmm vmm_wei_scales = vmm_tmp(0);
 
-    if (is_single_scale) {
+    if (brg.gemv_single_wei_scale()) {
         const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(0)];
 
         switch (brg.dt_wei_scales) {
@@ -1424,10 +1422,11 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
     for (dim_t bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
 
-        if (is_single_scale) {
+        if (brg.gemv_single_wei_scale()) {
             uni_vmulps(acc, acc, vmm_wei_scales);
             continue;
         }
+
         const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(bd)];
 
         if (is_superset(brg.isa_impl, avx512_core)) {
@@ -3458,7 +3457,7 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                 reg_bias.save();
             }
 
-            if (brg.with_wei_scales) {
+            if (brg.with_wei_scales && !brg.gemv_single_wei_scale()) {
                 reg_wei_scales.restore();
                 add(reg_wei_scales, wei_scales_offset(brg.gemv_bd_block()));
                 reg_wei_scales.save();

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2895,14 +2895,35 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
     if (!brg.transA) {
         maybe_set_avx_mask(is_rd_tail);
 
-        load_and_convert_to_f32(
-                gemv_load_b(), ptr[reg_aux_B], brg.dt_b, is_rd_tail);
+        const auto a_vmm = gemv_load_a();
+        const auto b_vmm = gemv_load_b();
+
+        const auto b_addr = ptr[reg_aux_B];
+
+        if (brg.gemv_use_vdpbf16ps()) {
+            if (is_rd_tail)
+                vmovdqu16(b_vmm | rd_tail_mask | T_z, b_addr);
+            else
+                uni_vmovups(b_vmm, b_addr);
+        } else {
+            load_and_convert_to_f32(b_vmm, b_addr, brg.dt_b, is_rd_tail);
+        }
 
         for (dim_t bd = 0; bd < bd_block; bd++) {
+            const auto acc = accm(1, bd, 0);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
-            load_and_convert_to_f32(
-                    gemv_load_a(), a_addr, brg.dt_a, is_rd_tail);
-            uni_vfmadd231ps(accm(1, bd, 0), gemv_load_a(), gemv_load_b());
+
+            if (brg.gemv_use_vdpbf16ps()) {
+                if (is_rd_tail) {
+                    vmovdqu16(a_vmm | rd_tail_mask | T_z, a_addr);
+                    vdpbf16ps(acc, b_vmm, a_vmm);
+                } else {
+                    vdpbf16ps(acc, b_vmm, a_addr);
+                }
+            } else {
+                load_and_convert_to_f32(a_vmm, a_addr, brg.dt_a, is_rd_tail);
+                uni_vfmadd231ps(acc, a_vmm, b_vmm);
+            }
         }
     } else {
         bcast_and_convert_to_f32(gemv_load_b(), ptr[reg_aux_B], brg.dt_b);

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -111,13 +111,14 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
             const dim_t tail_size = !brg.is_gemv
                     ? brg.ldb_tail
                     : (brg.gemv_acc_is_vector() ? brg.gemv_tail : 1);
+            const auto k_mask = !brg.is_gemv ? ld_tail_mask : gemv_partial_mask;
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
                     static_cast<size_t>(vmm_tmp(0).getIdx()), this->r14,
                     this->r15, this->r13, preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<size_t>(tail_size),
-                    ld_tail_mask, use_exact_tail_scalar_bcast};
+                    dst_md_wrapper, static_cast<size_t>(tail_size), k_mask,
+                    use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {this->param1,
                     binary_injector::get_all_strategies_supported_by_injector(),
@@ -261,10 +262,30 @@ private:
     bool with_binary_non_scalar_bcast_ = false;
     const int max_effective_vregs;
 
+    // Opmask(2) and Opmask(3) have slightly different semantics in the GEMM
+    // and GEMV code paths. This is why we have GEMV-specific aliases.
+    //
+    // GEMM:
+    //   ld_full_mask - all bits in the mask are set; used along the load
+    //                  dimension.
+    //   ld_tail_mask - only bits corresponding to the load dimension tail
+    //                  are set.
     Xbyak::Opmask ld_full_mask = Xbyak::Opmask(2);
     Xbyak::Opmask ld_tail_mask = Xbyak::Opmask(3);
+
+    // GEMV:
+    //   gemv_full_mask    - all bits in the mask are set; used along the
+    //                       broadcast dimension.
+    //   gemv_partial_mask - only bits corresponding to the broadcast-dimension
+    //                       tail are set when transA is true. When transA is
+    //                       false, only one bit is set because we store one
+    //                       element.
+    Xbyak::Opmask gemv_full_mask = Xbyak::Opmask(2);
+    Xbyak::Opmask gemv_partial_mask = Xbyak::Opmask(3);
+
     Xbyak::Opmask fp8_col_mask = Xbyak::Opmask(4);
     Xbyak::Opmask kmask_fp8_aux = Xbyak::Opmask(5);
+    // Used for both AMX GEMM and GEMV code paths.
     Xbyak::Opmask rd_tail_mask = Xbyak::Opmask(6);
 
     static int get_max_effective_vregs(const brgemm_desc_t &brg) {
@@ -1263,7 +1284,22 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
     const bool is_bias_scalar = !brg.treat_y_as_row;
     auto bias = vmm_tmp(0);
 
-    if (is_bias_scalar) vbroadcastss(bias, ptr[reg_aux_bias + bias_offset(0)]);
+    if (is_bias_scalar) {
+        const auto addr = ptr[reg_aux_bias + bias_offset(0)];
+        switch (brg.dt_bias) {
+            case data_type::f32: vbroadcastss(bias, addr); break;
+            case data_type::bf16:
+                vpbroadcastw(bias, addr);
+                uni_vpslld(bias, bias, 16);
+                break;
+            case data_type::f16:
+                vpbroadcastw(Xmm(bias.getIdx()), addr);
+                vcvtph2ps(Xmm(bias.getIdx()), Xmm(bias.getIdx()));
+                vbroadcastss(bias, Xmm(bias.getIdx()));
+                break;
+            default: assert(!"unsupported bias data type");
+        }
+    }
 
     for (dim_t bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
@@ -1275,17 +1311,41 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
 
         const auto addr = ptr[reg_aux_bias + bias_offset(bd)];
 
-        if (brg.gemv_acc_is_vector()) {
-            if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
-                vmaskmovps(bias, vmm_tail_mask(), addr);
-            else
-                uni_vmovups(bias, addr);
+        if (is_superset(brg.isa_impl, avx512_core)) {
+            const bool use_partial_mask = !brg.gemv_acc_is_vector()
+                    || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
+            const auto k_mask
+                    = use_partial_mask ? gemv_partial_mask : gemv_full_mask;
 
-            uni_vaddps(acc, acc, bias);
+            switch (brg.dt_bias) {
+                case data_type::f32:
+                    uni_vmovups(bias | k_mask | T_z, addr);
+                    break;
+                case data_type::bf16:
+                    uni_vpmovzxwd(bias | k_mask | T_z, addr);
+                    uni_vpslld(bias, bias, 16);
+                    break;
+                case data_type::f16:
+                    vcvtph2ps(bias | k_mask | T_z, addr);
+                    break;
+                default: assert(!"unsupported bias data type");
+            }
         } else {
-            uni_vmovss(Xmm(bias.getIdx()), addr);
-            uni_vaddss(Xmm(acc.getIdx()), Xmm(acc.getIdx()), bias);
+            if (brg.gemv_acc_is_vector()) {
+                if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
+                    vmaskmovps(bias, vmm_tail_mask(), addr);
+                else
+                    uni_vmovups(bias, addr);
+            } else {
+                uni_vmovss(Xmm(bias.getIdx()), addr);
+            }
         }
+
+        if (brg.gemv_acc_is_vector())
+            uni_vaddps(acc, acc, bias);
+        else
+            uni_vaddss(
+                    Xmm(acc.getIdx()), Xmm(acc.getIdx()), Xmm(bias.getIdx()));
     }
 }
 
@@ -1344,7 +1404,21 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
 
     if (is_single_scale) {
         const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(0)];
-        vbroadcastss(vmm_wei_scales, addr);
+
+        switch (brg.dt_wei_scales) {
+            case data_type::f32: vbroadcastss(vmm_wei_scales, addr); break;
+            case data_type::bf16:
+                vpbroadcastw(vmm_wei_scales, addr);
+                uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
+                break;
+            case data_type::f16:
+                vpbroadcastw(Xmm(vmm_wei_scales.getIdx()), addr);
+                vcvtph2ps(Xmm(vmm_wei_scales.getIdx()),
+                        Xmm(vmm_wei_scales.getIdx()));
+                vbroadcastss(vmm_wei_scales, Xmm(vmm_wei_scales.getIdx()));
+                break;
+            default: assert(!"unsupported wei scales data type");
+        }
     }
 
     for (dim_t bd = 0; bd < bd_block; bd++) {
@@ -1356,17 +1430,41 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
         }
         const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(bd)];
 
-        if (brg.gemv_acc_is_vector()) {
-            if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
-                vmaskmovps(vmm_wei_scales, vmm_tail_mask(), addr);
-            else
-                uni_vmovups(vmm_wei_scales, addr);
+        if (is_superset(brg.isa_impl, avx512_core)) {
+            const bool use_partial_mask = !brg.gemv_acc_is_vector()
+                    || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
+            const auto k_mask
+                    = use_partial_mask ? gemv_partial_mask : gemv_full_mask;
 
-            uni_vmulps(acc, acc, vmm_wei_scales);
+            switch (brg.dt_wei_scales) {
+                case data_type::f32:
+                    uni_vmovups(vmm_wei_scales | k_mask | T_z, addr);
+                    break;
+                case data_type::bf16:
+                    uni_vpmovzxwd(vmm_wei_scales | k_mask | T_z, addr);
+                    uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
+                    break;
+                case data_type::f16:
+                    vcvtph2ps(vmm_wei_scales | k_mask | T_z, addr);
+                    break;
+                default: assert(!"unsupported wei scales data type");
+            }
         } else {
-            uni_vmovss(vmm_wei_scales, addr);
-            uni_vmulss(Xmm(acc.getIdx()), Xmm(acc.getIdx()), vmm_wei_scales);
+            if (brg.gemv_acc_is_vector()) {
+                if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
+                    vmaskmovps(vmm_wei_scales, vmm_tail_mask(), addr);
+                else
+                    uni_vmovups(vmm_wei_scales, addr);
+            } else {
+                uni_vmovss(Xmm(vmm_wei_scales.getIdx()), addr);
+            }
         }
+
+        if (brg.gemv_acc_is_vector())
+            uni_vmulps(acc, acc, vmm_wei_scales);
+        else
+            uni_vmulss(Xmm(acc.getIdx()), Xmm(acc.getIdx()),
+                    Xmm(vmm_wei_scales.getIdx()));
     }
 }
 
@@ -1475,6 +1573,10 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
                 if (brg.gemv_acc_is_vector()) {
                     if (!gemv_is_tail_acc(bd, bd_block, is_bdb_tail)) {
                         uni_vaddps(vmm, vmm, ptr_C);
+                    } else if (is_superset(brg.isa_impl, avx512_core)) {
+                        uni_vmovups(
+                                vmm_prev_dst | gemv_partial_mask | T_z, ptr_C);
+                        uni_vaddps(vmm, vmm, vmm_prev_dst);
                     } else {
                         vmaskmovps(vmm_prev_dst, vmm_tail_mask(), ptr_C);
                         uni_vaddps(vmm, vmm, vmm_prev_dst);
@@ -1604,16 +1706,16 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                         cvt2ps(brg.sum_dt, vmm_prev_dst, addr, is_tail, false,
                                 k_mask, ld_size);
                     } else {
-                        const bool is_tail = brg.gemv_acc_is_vector()
-                                && gemv_is_tail_acc(bd, bd_end, is_bdb_tail);
+                        const bool use_partial_mask = !brg.gemv_acc_is_vector()
+                                || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
+                        const auto k_mask = use_partial_mask ? gemv_partial_mask
+                                                             : gemv_full_mask;
 
-                        const auto ignored_k_mask = ld_full_mask; // not used
-
-                        const dim_t elements_to_load = is_tail
-                                ? brg.gemv_tail
+                        const dim_t elements_to_load = use_partial_mask
+                                ? brg.gemv_acc_is_vector() ? brg.gemv_tail : 1
                                 : brg.bd_block / brg.gemv_bd_block();
-                        cvt2ps(brg.sum_dt, vmm_prev_dst, addr, is_tail, false,
-                                ignored_k_mask, elements_to_load);
+                        cvt2ps(brg.sum_dt, vmm_prev_dst, addr, use_partial_mask,
+                                false, k_mask, elements_to_load);
                     }
 
                     if (p_sum_zp_reg_set)
@@ -1845,7 +1947,39 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         if (brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
                 && !is_superset(brg.isa_impl, avx10_2))
             prefetchw(addr);
-        if (is_superset(brg.isa_impl, avx512_core)) {
+
+        if (brg.is_gemv) {
+            if (is_superset(brg.isa_impl, avx512_core)) {
+                const bool use_partial_mask = !brg.gemv_acc_is_vector()
+                        || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
+                const auto k_mask
+                        = use_partial_mask ? gemv_partial_mask : gemv_full_mask;
+
+                switch (brg.dt_d) {
+                    case data_type::f32: uni_vmovups(addr, vmm | k_mask); break;
+                    case data_type::bf16:
+                        vcvtneps2bf16(vmm_lower, vmm, get_encoding());
+                        vmovdqu16(addr, vmm_lower | k_mask);
+                        break;
+                    case data_type::f16:
+                        vcvtps2ph(vmm_lower, vmm, _op_mxcsr);
+                        vmovdqu16(addr, vmm_lower | k_mask);
+                        break;
+                    default: assert(!"unsupported gemv dst data type");
+                }
+            } else {
+                assert(brg.dt_d == data_type::f32);
+                if (brg.gemv_acc_is_vector()) {
+                    if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
+                        vmaskmovps(addr, vmm_tail_mask(), vmm);
+                    else
+                        uni_vmovups(addr, vmm);
+                } else {
+                    uni_vmovss(addr, vmm);
+                }
+            }
+            // Non-gemv path.
+        } else if (is_superset(brg.isa_impl, avx512_core)) {
             const Vmm r_vmm = vmm_mask(vmm, is_tail, true, k_mask);
             const Vmm_lower_t r_ymm
                     = vmm_mask(vmm_lower, is_tail, true, k_mask);
@@ -1886,23 +2020,12 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                 }
             }
         } else {
-            if (brg.is_gemv) {
-                if (brg.gemv_acc_is_vector()) {
-                    if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
-                        vmaskmovps(addr, vmm_tail_mask(), vmm);
-                    else
-                        uni_vmovups(addr, vmm);
-                } else {
-                    uni_vmovss(addr, vmm);
-                }
-            } else {
-                const dim_t ld_block = is_tail ? brg.ldb_tail : brg.ld_block;
-                if (is_tail && types::data_type_size(brg.dt_b) == sizeof(float))
-                    vmaskmovps(addr, vmm_tail_mask(), vmm);
-                else
-                    store_data(brg.dt_d, vmm, reg_aux_D, D_offset(bd, ld),
-                            ld_block);
-            }
+            const dim_t ld_block = is_tail ? brg.ldb_tail : brg.ld_block;
+            if (is_tail && types::data_type_size(brg.dt_b) == sizeof(float))
+                vmaskmovps(addr, vmm_tail_mask(), vmm);
+            else
+                store_data(
+                        brg.dt_d, vmm, reg_aux_D, D_offset(bd, ld), ld_block);
         }
         if (brg.is_runtime_ldd && bd_block > 1 && ld == ld_block2 - 1)
             reg_D_shift_bytes.addTo(reg_aux_D);
@@ -2031,18 +2154,31 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
 
     if (brg.is_gemv) {
         for (dim_t bd = 0; bd < bd_block; bd++) {
+            const bool need_prefetch
+                    = brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
+                    && !is_superset(brg.isa_impl, avx10_2);
+
             const auto addr_c = ptr[reg_aux_C + C_offset(bd, 0)];
-            if (brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
-                    && !is_superset(brg.isa_impl, avx10_2))
-                prefetchw(addr_c);
+            if (need_prefetch) prefetchw(addr_c);
+
             auto vmm = accm(1, bd, 0);
-            if (brg.gemv_acc_is_vector()) {
-                if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
-                    vmaskmovps(addr_c, vmm_tail_mask(), vmm);
-                else
-                    uni_vmovups(addr_c, vmm);
+
+            if (is_superset(brg.isa_impl, avx512_core)) {
+                const bool use_partial_mask = !brg.gemv_acc_is_vector()
+                        || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
+                const auto k_mask
+                        = use_partial_mask ? gemv_partial_mask : gemv_full_mask;
+                uni_vmovups(addr_c | k_mask, vmm);
             } else {
-                uni_vmovss(addr_c, Xmm(vmm.getIdx()));
+                assert(brg.dt_d == data_type::f32);
+                if (brg.gemv_acc_is_vector()) {
+                    if (gemv_is_tail_acc(bd, bd_block, is_bdb_tail))
+                        vmaskmovps(addr_c, vmm_tail_mask(), vmm);
+                    else
+                        uni_vmovups(addr_c, vmm);
+                } else {
+                    uni_vmovss(addr_c, Xmm(vmm.getIdx()));
+                }
             }
         }
     } else {
@@ -2262,7 +2398,6 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
         else
             bd_block = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
         assert(bd_block > 0);
-
         if (brg.is_gemv && !brg.gemv_acc_is_vector())
             reduce_gemv_accumulators(bd_block);
 
@@ -2712,39 +2847,72 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
 
     const dim_t bd_block = brg.gemv_num_acc_blocks(is_bdb_tail);
 
+    const auto load_and_convert_to_f32
+            = [this](const Vmm vmm, const Xbyak::Address addr,
+                      const data_type_t dt, bool is_tail) {
+        if (is_superset(brg.isa_impl, avx512_core)) {
+            assert(one_of(brg.dt_a, data_type::bf16, data_type::f16));
+            assert(one_of(brg.dt_b, data_type::bf16, data_type::f16));
+
+            const auto tail_mask
+                    = brg.transA ? gemv_partial_mask : rd_tail_mask;
+            const auto kmask = is_tail ? tail_mask : gemv_full_mask;
+
+            if (dt == data_type::bf16) {
+                uni_vpmovzxwd(vmm | kmask | T_z, addr);
+                uni_vpslld(vmm, vmm, 16);
+            } else if (dt == data_type::f16) {
+                vmovdqu16(Vmm_lower_t(vmm.getIdx()) | kmask | T_z, addr);
+                vcvtph2ps(vmm, Vmm_lower_t(vmm.getIdx()));
+            } else
+                assert(!"unsupported data type");
+        } else {
+            assert(brg.isa_impl == avx2);
+            if (is_tail)
+                vmaskmovps(vmm, vmm_tail_mask(), addr);
+            else
+                uni_vmovups(vmm, addr);
+        }
+    };
+
+    const auto bcast_and_convert_to_f32
+            = [this](const Vmm vmm, const Xbyak::Address addr,
+                      const data_type_t dt) {
+        if (dt == data_type::f32) {
+            vbroadcastss(vmm, addr);
+        } else if (dt == data_type::bf16) {
+            vpbroadcastw(vmm, addr);
+            uni_vpslld(vmm, vmm, 16);
+        } else if (dt == data_type::f16) {
+            vpbroadcastw(Xmm(vmm.getIdx()), addr);
+            vcvtph2ps(Xmm(vmm.getIdx()), Xmm(vmm.getIdx()));
+            vbroadcastss(vmm, Xmm(vmm.getIdx()));
+        } else {
+            assert(!"unsupported GEMV input data type");
+        }
+    };
+
     if (!brg.transA) {
         maybe_set_avx_mask(is_rd_tail);
 
-        if (is_rd_tail)
-            vmaskmovps(gemv_load_b(), vmm_tail_mask(), ptr[reg_aux_B]);
-        else
-            uni_vmovups(gemv_load_b(), ptr[reg_aux_B]);
+        load_and_convert_to_f32(
+                gemv_load_b(), ptr[reg_aux_B], brg.dt_b, is_rd_tail);
 
         for (dim_t bd = 0; bd < bd_block; bd++) {
-            auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
-
-            if (is_rd_tail)
-                vmaskmovps(gemv_load_a(), vmm_tail_mask(), a_addr);
-            else
-                uni_vmovups(gemv_load_a(), a_addr);
-
+            const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
+            load_and_convert_to_f32(
+                    gemv_load_a(), a_addr, brg.dt_a, is_rd_tail);
             uni_vfmadd231ps(accm(1, bd, 0), gemv_load_a(), gemv_load_b());
         }
     } else {
-        vbroadcastss(gemv_load_b(), ptr[reg_aux_B]);
-
+        bcast_and_convert_to_f32(gemv_load_b(), ptr[reg_aux_B], brg.dt_b);
         for (dim_t bd = 0; bd < bd_block; bd++) {
             const bool is_tail_acc
                     = gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
-
-            if (is_tail_acc) {
-                maybe_set_avx_mask(true);
-                vmaskmovps(gemv_load_a(), vmm_tail_mask(), a_addr);
-            } else {
-                uni_vmovups(gemv_load_a(), a_addr);
-            }
-
+            maybe_set_avx_mask(is_tail_acc);
+            load_and_convert_to_f32(
+                    gemv_load_a(), a_addr, brg.dt_a, is_tail_acc);
             uni_vfmadd231ps(accm(1, bd, 0), gemv_load_a(), gemv_load_b());
         }
     }
@@ -3463,13 +3631,32 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
 
     if (is_superset(brg.isa_impl, avx512_core)) {
         const auto full_mask = size_t {0xffffffffffffffff};
-        const auto tail_mask = size_t((1 << brg.ldb_tail) - 1);
-        reg64_t reg_mask = rax;
 
-        mov(reg_mask, full_mask);
-        kmovq(ld_full_mask, reg_mask);
-        mov(reg_mask, tail_mask);
-        kmovq(ld_tail_mask, reg_mask);
+        if (!brg.is_gemv) {
+            const auto tail_mask = size_t((1 << brg.ldb_tail) - 1);
+            reg64_t reg_mask = rax;
+
+            mov(reg_mask, full_mask);
+            kmovq(ld_full_mask, reg_mask);
+            mov(reg_mask, tail_mask);
+            kmovq(ld_tail_mask, reg_mask);
+        } else {
+            const auto partial_mask
+                    = brg.transA ? size_t((1 << brg.gemv_tail) - 1) : 1;
+            reg64_t reg_mask = rax;
+
+            mov(reg_mask, full_mask);
+            kmovq(gemv_full_mask, reg_mask);
+            mov(reg_mask, partial_mask);
+            kmovq(gemv_partial_mask, reg_mask);
+
+            // non-transA GEMV code path may require a mask for the reduce
+            // dimension.
+            if (!brg.transA && brg.gemv_tail > 0) {
+                mov(reg_mask, static_cast<size_t>((1 << brg.gemv_tail) - 1));
+                kmovq(rd_tail_mask, reg_mask);
+            }
+        }
     }
 
     if (brg.is_int8 && !brg.has_int8_vnni) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2893,12 +2893,20 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
     };
 
     if (!brg.transA) {
+        // GEMV is bandwidth-bound and the HW prefetcher doesn't keep enough
+        // loads in flight for these streams so SW-prefetch ahead of the load:
+        // the B vector once and each of the A rows. The distance is empirically
+        // tuned.
+        constexpr dim_t gemv_pf_dist = 512; // bytes = 8 cache lines
+
         maybe_set_avx_mask(is_rd_tail);
 
         const auto a_vmm = gemv_load_a();
         const auto b_vmm = gemv_load_b();
 
         const auto b_addr = ptr[reg_aux_B];
+
+        if (!is_rd_tail) prefetcht0(ptr[reg_aux_B + gemv_pf_dist]);
 
         if (brg.gemv_use_vdpbf16ps()) {
             if (is_rd_tail)
@@ -2912,6 +2920,9 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
         for (dim_t bd = 0; bd < bd_block; bd++) {
             const auto acc = accm(1, bd, 0);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
+
+            if (!is_rd_tail)
+                prefetcht0(ptr[reg_aux_A + A_offset(bd, 0) + gemv_pf_dist]);
 
             if (brg.gemv_use_vdpbf16ps()) {
                 if (is_rd_tail) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2937,11 +2937,24 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
             }
         }
     } else {
+        // Same idea as the non-transA path but here each A row is strided by
+        // LDA per reduce step so the prefetch distance is in reduce steps not
+        // bytes. Only enabled for the avx512 path (bf16/f16): it moves half the
+        // bytes of f32 so it's latency-bound (stalls on strided misses) and
+        // benefits from prefetch. f32/avx2 is already at the BW limit so leave
+        // it to the HW prefetcher.
+        constexpr dim_t gemv_pf_rd_steps_ahead = 8;
+        const bool do_pf = is_superset(brg.isa_impl, avx512_core);
+
         bcast_and_convert_to_f32(gemv_load_b(), ptr[reg_aux_B], brg.dt_b);
         for (dim_t bd = 0; bd < bd_block; bd++) {
             const bool is_tail_acc
                     = gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
+            if (do_pf) {
+                prefetcht0(ptr[reg_aux_A + A_offset(bd, 0)
+                        + gemv_pf_rd_steps_ahead * rdb_A_offset()]);
+            }
             maybe_set_avx_mask(is_tail_acc);
             load_and_convert_to_f32(
                     gemv_load_a(), a_addr, brg.dt_a, is_tail_acc);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1160,8 +1160,8 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
             float cur_imbalance = cur_params.get_imbalance();
 
             const int m_chunk_size = 1;
-            const auto m_chunks = div_up(bgmmc.M, m_blk * m_chunk_size);
-            const auto n_chunks = div_up(bgmmc.N, n_blk * n_chunk_size);
+            const auto m_chunks = div_up(matmul.M, m_blk * m_chunk_size);
+            const auto n_chunks = div_up(matmul.N, n_blk * n_chunk_size);
             const auto work_amount = bgmmc.batch * m_chunks * n_chunks;
 
             int nthr_bmn = nthr / nthr_k;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -564,20 +564,22 @@ bool is_gemv_applicable(const brgemm_matmul_conf_t &bgmmc,
     const auto gemv_strategy
             = bm_conf_utils.get_gemv_strategy(gemv_A_tag, gemv_B_tag);
 
-    const bool is_transA_strategy = utils::one_of(gemv_strategy,
-            gemv_strategy_t::n1_A_trans, gemv_strategy_t::m1_B_plain);
-    const bool is_swap_strategy = utils::one_of(gemv_strategy,
-            gemv_strategy_t::m1_B_plain, gemv_strategy_t::m1_B_trans);
-
-    // transA GEMV requires contiguous output (INCY == 1) for tensors with
-    // batch dimensions. Some batched layouts, e.g. `bac`, place the batch
-    // dimension between consecutive GEMV output elements and make INCY > 1.
-    const dim_t ndims = bgmmc.ndims;
-    if (is_transA_strategy && ndims > 2) {
-        const dim_t gemv_incy = is_swap_strategy
-                ? 1
-                : C_md.format_desc.blocking.strides[ndims - 2];
-        if (gemv_incy != 1) return false;
+    // The `n1_A_trans` strategy dispatches the transA BRGEMV kernel, which
+    // vector-stores `y` and therefore requires unit output stride (INCY == 1).
+    // The `m1_B_plain` strategy dispatches the same kernel but swaps A/B, which
+    // automatically forces INCY == 1, so it needs no check here.
+    if (gemv_strategy == gemv_strategy_t::n1_A_trans) {
+        // When the C format is `any` it's not yet initialized at this point, so
+        // we shouldn't read the strides. It will later be initialized with
+        // `plain_tensor_layout_tag`, where N == 1 makes the M axis unit-strided
+        // (INCY == 1), so the `any` case resolves to a contiguous layout by
+        // design and is therefore skipped.
+        //
+        // `dims_adjacent()` validates unit INCY for an explicit C, ignoring
+        // batch-dim permutations and handling unit dimensions safely.
+        if (C_md.format_kind != format_kind::any
+                && !dims_adjacent(C_md, bgmmc.ndims - 2, bgmmc.ndims - 1))
+            return false;
     }
 
     return true;
@@ -744,6 +746,11 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_tags(memory_desc_t &A_md,
         VCHECK_BG(memory_desc_init_by_tag(C_md, desired_C_tag),
                 VERBOSE_UNSUPPORTED_TAG);
         bgmmc.dst_tag = desired_C_tag;
+
+        // `is_gemv_applicable()` assumes that the `any` format tag resolves to
+        // `plain_tensor_layout_tag`.
+        assert(IMPLICATION(
+                bgmmc.is_gemv, bgmmc.dst_tag == plain_tensor_layout_tag));
     } else {
         const memory_desc_wrapper C_mdw(C_md);
         // If one of dims is `1` then `ba` is identical to `ab`.

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -390,14 +390,17 @@ int brgemm_matmul_conf_utils_t::get_default_n_block(
 */
 gemv_strategy_t brgemm_matmul_conf_utils_t::get_gemv_strategy(
         format_tag_t A_tag, format_tag_t B_tag) const {
-    if (bgmmc.M == 1 && B_tag == plain_tensor_layout_tag)
-        return gemv_strategy_t::m1_B_plain;
-    if (bgmmc.M == 1 && B_tag == transposed_tensor_layout_tag)
-        return gemv_strategy_t::m1_B_trans;
+    // Note: keep n1_A_plain ahead of the m1_B_* checks. It avoids swapping
+    // A and B (which would disable merging batch dims into M), so it is less
+    // restrictive and preferred for the M == 1 && N == 1 case.
     if (bgmmc.N == 1 && A_tag == plain_tensor_layout_tag)
         return gemv_strategy_t::n1_A_plain;
     if (bgmmc.N == 1 && A_tag == transposed_tensor_layout_tag)
         return gemv_strategy_t::n1_A_trans;
+    if (bgmmc.M == 1 && B_tag == plain_tensor_layout_tag)
+        return gemv_strategy_t::m1_B_plain;
+    if (bgmmc.M == 1 && B_tag == transposed_tensor_layout_tag)
+        return gemv_strategy_t::m1_B_trans;
 
     return gemv_strategy_t::none;
 }

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1354,12 +1354,12 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     size_t max_parallel = matmul.batch * n_chunks;
     const float req_additional_parallel = nthr / max_parallel;
     if (req_additional_parallel > 1) {
-        min_m_blk = saturate<dim_t>(
-                16, max_m_blk, matmul.M / req_additional_parallel);
+        min_m_blk = saturate<dim_t>(nstl::min((dim_t)16, max_m_blk), max_m_blk,
+                matmul.M / req_additional_parallel);
         max_parallel *= div_up(matmul.M, min_m_blk);
     } else if (bm_conf_utils.check_is_transposed(bgmmc.src_tag)
             && matmul.K >= 4096) {
-        min_m_blk = nstl::max((dim_t)16, matmul.M / 4);
+        min_m_blk = nstl::min(max_m_blk, nstl::max((dim_t)16, matmul.M / 4));
     }
 
     bool low_parallel_work = max_parallel % nthr != 0

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -999,6 +999,30 @@ struct matmul_avx512_blocking_params_t {
     }
 };
 
+// When it's the GEMV case and swapping A and B is required, we re-create
+// `matmul_params_t` with swapped M and N parameters. Otherwise, we use the
+// original object. We need this to ensure consistent blocking parameters for
+// the same GEMV code path across different scenarios (M=1 and N=1).
+matmul_avx512_blocking_params_t::matmul_params_t maybe_swap_mn_params(
+        const brgemm_matmul_conf_t &bgmmc,
+        const matmul_avx512_blocking_params_t::matmul_params_t &matmul) {
+    if (bgmmc.is_gemv && bgmmc.gemv_swap_a_b)
+        return matmul_avx512_blocking_params_t::matmul_params_t(
+                matmul.N, matmul.M, matmul.K, matmul.batch);
+    return matmul;
+}
+
+// The matmul driver expects blocking parameters that are consistent with
+// the original problem, therefore, we need to swap the M and N blocking
+// parameters to reverse the effect of `maybe_swap_mn_params`.
+void maybe_unswap_mn_blocking(const brgemm_matmul_conf_t &bgmmc,
+        matmul_avx512_blocking_params_t &best_blocking) {
+    if (!(bgmmc.is_gemv && bgmmc.gemv_swap_a_b)) return;
+    std::swap(best_blocking.m_chunks, best_blocking.n_chunks);
+    std::swap(best_blocking.m_blk, best_blocking.n_blk);
+    std::swap(best_blocking.m_tail, best_blocking.n_tail);
+}
+
 float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
         const matmul_avx512_blocking_params_t::matmul_params_t &matmul,
@@ -1227,17 +1251,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
         matmul_avx512_blocking_params_t &best_blocking) {
     float best_imbalance = 1.f; // reduce
 
-    // When it's the GEMV case and swapping A and B is required, we
-    // re-create `matmul_params_t` with swapped M and N parameters. Otherwise,
-    // we use the original object.
-    // We need this to ensure consistent blocking parameters for the same
-    // GEMV code path across different scenarios (M=1 and N=1).
-    const bool swap_m_n_blks = bgmmc.is_gemv && bgmmc.gemv_swap_a_b;
-    const auto &matmul = swap_m_n_blks
-            ? matmul_avx512_blocking_params_t::matmul_params_t(
-                      matmul_.N, matmul_.M, matmul_.K, matmul_.batch)
-            : matmul_;
-
+    const auto matmul = maybe_swap_mn_params(bgmmc, matmul_);
     const int nthr = bgmmc.nthr;
 
     dim_t max_m_blk = nstl::min((dim_t)256, matmul.M);
@@ -1293,14 +1307,8 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
         }
     }
 
-    // The matmul driver expects blocking parameters that are consistent with
-    // the original problem, therefore, we need to swap the M and N blocking
-    // parameters.
-    if (swap_m_n_blks) {
-        std::swap(best_blocking.m_chunks, best_blocking.n_chunks);
-        std::swap(best_blocking.m_blk, best_blocking.n_blk);
-        std::swap(best_blocking.m_tail, best_blocking.n_tail);
-    }
+    maybe_unswap_mn_blocking(bgmmc, best_blocking);
+
     return best_imbalance;
 }
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1091,6 +1091,49 @@ void compute_gemv_k_blocking(dim_t K, int &k_blk, int &batch_size) {
     batch_size = static_cast<int>(std::max<dim_t>(1, div_up(K, k_blk)));
 }
 
+// GEMV usually keeps nthr_k == 1 so the K-reduction stays in registers.
+//
+// For n1_A_trans/m1_B_plain, A is column-major (LDA == M). Each K-step accesses
+// A with a stride of M * dt bytes. If that stride is a power of two, accesses
+// repeatedly hit the same cache sets. Once the A footprint exceeds L2, this
+// causes conflict misses and the thread becomes latency-bound. Non-power-of-two
+// strides distribute accesses across cache sets and avoid this issue.
+//
+// Splitting K across threads increases memory-level parallelism and hides the
+// miss latency. The reduction overhead is negligible. However, this only helps
+// when M-parallelism is low. If there are already enough M-blocks to keep cores
+// busy, M-parallelism hides the stalls and K-splitting only adds overhead.
+//
+// Therefore, enable K-splitting only when:
+//  - the A stride (M * dt) is a power of two,
+//  - the A footprint exceeds L2, and
+//  - M-parallelism is too low to fully utilize the cores.
+//
+// div_up(M, min_m_blk) is an upper bound on M-parallelism because the tuner can
+// only select m_blk >= min_m_blk.
+bool is_gemv_k_split_needed(const brgemm_matmul_conf_t &bgmmc,
+        const matmul_avx512_blocking_params_t::matmul_params_t &matmul,
+        int min_m_blk, int nthr) {
+    if (!bgmmc.is_gemv
+            || !utils::one_of(bgmmc.gemv_strategy, gemv_strategy_t::n1_A_trans,
+                    gemv_strategy_t::m1_B_plain))
+        return false;
+
+    const dim_t src_dt_sz = bgmmc.gemv_swap_a_b ? bgmmc.b_dt_sz : bgmmc.a_dt_sz;
+    const size_t src_sz = matmul.M * matmul.K * src_dt_sz;
+    const size_t l2_size = platform::get_per_core_cache_size(2);
+    const dim_t max_m_blocks = div_up(matmul.M, min_m_blk);
+
+    // (a) A's column stride is a power of two.
+    const bool aliasing_stride = math::is_pow2(matmul.M * src_dt_sz);
+    // (b) The A footprint exceeds L2.
+    const bool src_exceeds_l2 = src_sz > l2_size;
+    // (c) There are too few M-blocks to keep cores busy.
+    const bool low_m_parallelism = max_m_blocks <= 2 * nthr;
+
+    return aliasing_stride && src_exceeds_l2 && low_m_parallelism;
+}
+
 float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
         const matmul_avx512_blocking_params_t::matmul_params_t &matmul_,
@@ -1207,6 +1250,17 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
             start_nthr_k = nthr_k;
             last_nthr_k = nthr_k;
         }
+    }
+
+    // Enable K-split only for the GEMV cache-aliasing case where M-parallelism
+    // is insufficient. (see `is_gemv_k_split_needed` for the rationale).
+    if (is_gemv_k_split_needed(bgmmc, matmul, min_m_blk, nthr)) {
+        const int max_gemv_nthr_k = 4;
+        const int gemv_nthr_k = std::min(nthr, max_gemv_nthr_k);
+        // Re-calculate k blocking.
+        compute_gemv_k_blocking(
+                div_up(matmul.K, gemv_nthr_k), k_blk, brgemm_bs);
+        start_nthr_k = last_nthr_k = gemv_nthr_k;
     }
 
     // Use large m-blocking if possible.

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1070,6 +1070,20 @@ void maybe_unswap_mn_blocking(const brgemm_matmul_conf_t &bgmmc,
     std::swap(best_blocking.m_tail, best_blocking.n_tail);
 }
 
+// GEMV is memory-bound so we want the largest possible K_blk because a small
+// K_blk splits K into many K_chunks that accumulate through the C buffer and
+// break A/B streaming. Using one large K_blk keeps the whole reduction in
+// registers.
+//
+// - K_blk is capped as a conservative bound on in-kernel (int32) offsets.
+// - batch_size is set so K_blk * batch_size covers K (K_chunks == 1) so the
+//   brgemm batch loop reduces all K-blocks in registers.
+void compute_gemv_k_blocking(dim_t K, int &k_blk, int &batch_size) {
+    constexpr dim_t max_gemv_k_blk = 16384;
+    k_blk = static_cast<int>(std::min<dim_t>(K, max_gemv_k_blk));
+    batch_size = static_cast<int>(std::max<dim_t>(1, div_up(K, k_blk)));
+}
+
 float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
         const matmul_avx512_blocking_params_t::matmul_params_t &matmul_,
@@ -1098,7 +1112,9 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
     const bool use_extended_k_blk = matmul.K > 1024
             && (!bm_conf_utils.check_is_transposed(bgmmc.src_tag));
     const dim_t default_k_blk = use_extended_k_blk ? 1024 : 512;
-    const int k_blk = static_cast<int>(nstl::min(matmul.K, default_k_blk));
+    int k_blk = static_cast<int>(nstl::min(matmul.K, default_k_blk));
+    int brgemm_bs = 1;
+    if (bgmmc.is_gemv) compute_gemv_k_blocking(matmul.K, k_blk, brgemm_bs);
     int start_nthr_k = 1;
     int last_nthr_k = 1;
 
@@ -1132,8 +1148,10 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
             }
         }
 
-        // Parallelize across K for shapes with big 'K' dimension
-        bool bwd_w_par_k_blk = bgmmc.batch == 1
+        // Parallelize across K for shapes with big 'K' dimension.
+        // Disabled for GEMV: it needs nthr_k == 1 to keep one continuous,
+        // in-register K-stream.
+        bool bwd_w_par_k_blk = !bgmmc.is_gemv && bgmmc.batch == 1
                 && bm_conf_utils.check_is_transposed(bgmmc.src_tag)
                 && !bm_conf_utils.is_int8()
                 && IMPLICATION(bm_conf_utils.is_bf16(), math::is_pow2(matmul.K))
@@ -1144,9 +1162,10 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         }
 
         // Enable k-partitioning for huge k and small m/n dimensions.
+        // Disabled for GEMV (same reason: keep nthr_k == 1).
         bool is_huge_k = matmul.K >= 20000;
         bool is_small_mn = matmul.M <= 512 && matmul.N <= 512;
-        bool use_k_partitioning = is_huge_k && is_small_mn;
+        bool use_k_partitioning = !bgmmc.is_gemv && is_huge_k && is_small_mn;
 
         // TODO: expand to other data types.
         use_k_partitioning = use_k_partitioning && bm_conf_utils.is_f32();
@@ -1204,7 +1223,7 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
                 --n_chunk_size)
         for (int m_blk = max_m_blk; m_blk >= min_m_blk; --m_blk) {
             cur_params.update_params(
-                    1, m_blk, n_chunk_size, n_blk, 1, k_blk, nthr_k);
+                    1, m_blk, n_chunk_size, n_blk, brgemm_bs, k_blk, nthr_k);
 
             float cur_imbalance = cur_params.get_imbalance();
 
@@ -1226,7 +1245,8 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         }
 
         if (!found_best_blocking) {
-            cur_params.update_params(1, min_m_blk, 1, n_blk, 1, k_blk, nthr_k);
+            cur_params.update_params(
+                    1, min_m_blk, 1, n_blk, brgemm_bs, k_blk, nthr_k);
 
             float cur_imbalance = cur_params.get_imbalance();
             if (cur_imbalance < best_imbalance) {
@@ -1317,7 +1337,9 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
             = static_cast<int>(nstl::min(max_n_chunks, n_chunks));
 
     constexpr dim_t default_k_blk = 1024;
-    const int k_blk = static_cast<int>(nstl::min(matmul.K, default_k_blk));
+    int k_blk = static_cast<int>(nstl::min(matmul.K, default_k_blk));
+    int brgemm_bs = 1;
+    if (bgmmc.is_gemv) compute_gemv_k_blocking(matmul.K, k_blk, brgemm_bs);
     const int start_nthr_k = 1;
 
     // for cases with low parallel work, reduce 'min_m_blk' to
@@ -1351,7 +1373,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     for (int m_blk = max_m_blk; m_blk >= min_m_blk; --m_blk) {
         matmul_avx512_blocking_params_t cur_params(matmul, nthr);
         cur_params.update_params(
-                1, m_blk, n_chunk_size, n_blk, 1, k_blk, nthr_k);
+                1, m_blk, n_chunk_size, n_blk, brgemm_bs, k_blk, nthr_k);
 
         float cur_imbalance = cur_params.get_imbalance();
         if (cur_imbalance < best_imbalance) {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -279,6 +279,27 @@ status_t check_isa_with_datatype(
     return ok ? status::success : status::unimplemented;
 }
 
+// The GEMV code path has requirements for (isa, dt) combinations that may
+// differ from what the general `check_isa_with_datatype` table allows.
+//
+// Whether the GEMV code path is applicable is not known when
+// `check_isa_with_datatype` is called. Therefore, both
+// `check_isa_with_datatype` and `gemv_check_isa_with_datatype` are called and
+// the final decision is made later, once GEMV applicability is known.
+status_t gemv_check_isa_with_datatype(
+        const cpu_isa_t isa, const brgemm_matmul_conf_utils_t &bm_conf_utils) {
+    // Valid GEMV (dt, isa) combinations:
+    // - f32  -> avx2
+    // - bf16 -> avx512_core_bf16
+    // - f16  -> avx512_core
+    // Any other data type or isa is unsupported.
+    const bool ok = (bm_conf_utils.is_f32() && isa == avx2)
+            || (bm_conf_utils.is_bf16() && isa == avx512_core_bf16)
+            || (bm_conf_utils.is_f16() && isa == avx512_core);
+
+    return ok ? status::success : status::unimplemented;
+}
+
 status_t check_datatype_cfg(const brgemm_matmul_conf_utils_t &bm_conf_utils) {
     const bool ok
             = one_of(true, bm_conf_utils.is_f32(), bm_conf_utils.is_bf16(),
@@ -510,8 +531,7 @@ format_tag_t brgemm_matmul_conf_utils_t::get_gemv_B_tag(
  * GEMV is applicable only when:
  *   - M == 1 or N == 1
  *   - reduction is not used
- *   - data type is f32
- *   - fpmath mode is strict
+ *   - data type is f32, bf16, or f16
  *   - A and B formats can be resolved to supported GEMV layouts
  *   - output layout satisfies GEMV requirements
  */
@@ -525,8 +545,16 @@ bool is_gemv_applicable(const brgemm_matmul_conf_t &bgmmc,
     // Reduction is not supported for GEMV code path.
     if (bgmmc.with_reduce) return false;
 
-    // BRGEMV currently supports only f32.
-    if (!bm_conf_utils.is_f32()) return false;
+    // GEMV applicability must ensure that at least one `brgemm_matmul_t<isa>`
+    // instantiation can execute the case because GEMM/GEMV dispatching logic
+    // relies on it. Here we require the platform to support the exact isa that
+    // `gemv_check_isa_with_datatype` mandates for the data type:
+    // f32 -> avx2, bf16 -> avx512_core_bf16, f16 -> avx512_core.
+    // This also rejects any data type not supported by the GEMV path.
+    const bool gemv_isa_dt_supported = (bm_conf_utils.is_f32() && mayiuse(avx2))
+            || (bm_conf_utils.is_bf16() && mayiuse(avx512_core_bf16))
+            || (bm_conf_utils.is_f16() && mayiuse(avx512_core));
+    if (!gemv_isa_dt_supported) return false;
 
     const format_tag_t gemv_A_tag = bm_conf_utils.get_gemv_A_tag(A_md);
     const format_tag_t gemv_B_tag = bm_conf_utils.get_gemv_B_tag(B_md);
@@ -1044,8 +1072,10 @@ void maybe_unswap_mn_blocking(const brgemm_matmul_conf_t &bgmmc,
 
 float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
-        const matmul_avx512_blocking_params_t::matmul_params_t &matmul,
+        const matmul_avx512_blocking_params_t::matmul_params_t &matmul_,
         matmul_avx512_blocking_params_t &best_blocking) {
+
+    const auto matmul = maybe_swap_mn_params(bgmmc, matmul_);
     const int nthr = bgmmc.nthr;
 
     const bool need_large_m_blk = bgmmc.ndims == 2 && bm_conf_utils.is_f32()
@@ -1205,6 +1235,9 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
             }
         }
     }
+
+    maybe_unswap_mn_blocking(bgmmc, best_blocking);
+
     return best_imbalance;
 }
 
@@ -1212,8 +1245,9 @@ float compute_blocking_heuristic_avx2(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
         const matmul_avx512_blocking_params_t::matmul_params_t &matmul,
         matmul_avx512_blocking_params_t &best_blocking) {
-    const int nthr = bgmmc.nthr;
+    assert(!bgmmc.is_gemv);
 
+    const int nthr = bgmmc.nthr;
     const int max_m_blk
             = static_cast<int>(nstl::min(/*64*/ (dim_t)256, matmul.M));
     int min_m_blk
@@ -1531,7 +1565,27 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             bias_md.format_kind == format_kind::any);
 
     VCHECK_BG(check_datatype_cfg(bm_conf_utils), VERBOSE_UNSUPPORTED_DT_CFG);
-    VCHECK_BG(check_isa_with_datatype(isa, bm_conf_utils),
+
+    // The GEMM and GEMV code paths have different (isa, dt) requirements.
+    // At this stage, we do not yet know whether the GEMV path applies to the
+    // current problem. Reorganizing this initialization to determine that here
+    // would introduce an undesirable dependency on the position of the
+    // `is_gemv_applicable()` call.
+    //
+    // To avoid this, we perform the checks independently using two functions:
+    //
+    // * check_isa_with_datatype()      — validates (isa, dt) for the GEMM path
+    // * gemv_check_isa_with_datatype() — validates (isa, dt) for the GEMV path
+    //
+    // We call both functions here and defer selecting the relevant result until
+    // after `is_gemv_applicable()` is evaluated.
+    const status_t check_isa_dt_st
+            = check_isa_with_datatype(isa, bm_conf_utils);
+    const status_t gemv_check_isa_dt_st
+            = gemv_check_isa_with_datatype(isa, bm_conf_utils);
+
+    VCONDCHECK_BG(
+            one_of(status::success, check_isa_dt_st, gemv_check_isa_dt_st),
             VERBOSE_ISA_DT_MISMATCH);
 
     bgmmc.is_amx = is_superset(isa, avx512_core_amx);
@@ -1696,8 +1750,26 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     bgmmc.is_gemv = is_gemv_applicable(
             bgmmc, bm_conf_utils, src_md, weights_md, dst_md, attr);
-    VCONDCHECK_BG(IMPLICATION(bgmmc.is_gemv, isa == avx2),
-            "Fall back to the AVX2 implementation for the GEMV code path");
+
+    // At this point, GEMV applicability is known so we decide how to interpret
+    // the (isa, dt) check statuses:
+    // - `check_isa_dt_st`         (GEMM path)
+    // - `gemv_check_isa_dt_st`    (GEMV path)
+    //
+    // If GEMV is applicable we use `gemv_check_isa_dt_st` to drive the
+    // instantiation search:
+    // - `status::success`:        this instantiation is valid
+    // - `status::unimplemented`:  this instantiation is not applicable
+    //
+    // This relies on the invariant that the GEMV path is applicable guarantees
+    // the existence of at least one valid instantiation for GEMV
+    // (`is_gemv_applicable` checks data type support independently of ida).
+    // Therefore, a failure here only means that the *current* instantiation is
+    // not the right one.
+    //
+    // If GEMV is not applicable we use `check_isa_dt_st`.
+    VCHECK_BG(bgmmc.is_gemv ? gemv_check_isa_dt_st : check_isa_dt_st,
+            VERBOSE_ISA_DT_MISMATCH);
 
     if (bgmmc.is_gemv) {
         bgmmc.gemv_strategy = bm_conf_utils.get_gemv_strategy(

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -393,6 +393,10 @@ gemv_strategy_t brgemm_matmul_conf_utils_t::get_gemv_strategy(
     // Note: keep n1_A_plain ahead of the m1_B_* checks. It avoids swapping
     // A and B (which would disable merging batch dims into M), so it is less
     // restrictive and preferred for the M == 1 && N == 1 case.
+    //
+    // Note: A_tag and B_tag are inferred from the strides. When the layout is
+    // ambiguous, we prefer the interpretation that dispatches the faster GEMV
+    // kernel (non-transA).
     if (bgmmc.N == 1 && A_tag == plain_tensor_layout_tag)
         return gemv_strategy_t::n1_A_plain;
     if (bgmmc.N == 1 && A_tag == transposed_tensor_layout_tag)
@@ -981,20 +985,32 @@ struct matmul_avx512_blocking_params_t {
             //   - m1_B_plain:  col-major view B   -> LDA = B_strides[1]
             //   - m1_B_trans:  row-major B        -> LDA = B_strides[0]
             //
+            // When the dimension whose stride is read is a unit dim, that
+            // stride is unreliable, so LDA falls back to the contiguous size
+            // of the other dim.
+            //
             // Strides are in bytes.
             assert(bgmmc.gemv_strategy != gemv_strategy_t::none);
+            const dim_t M = bgmmc.M;
+            const dim_t N = bgmmc.N;
+            const dim_t K = bgmmc.K;
+
             switch (bgmmc.gemv_strategy) {
                 case gemv_strategy_t::m1_B_plain:
-                    bgmmc.LDA = bgmmc.B_strides[1] / bgmmc.b_dt_sz;
+                    // K==1: stride of unit dim K is unreliable; use contiguous N.
+                    bgmmc.LDA = K == 1 ? N : bgmmc.B_strides[1] / bgmmc.b_dt_sz;
                     break;
                 case gemv_strategy_t::m1_B_trans:
-                    bgmmc.LDA = bgmmc.B_strides[0] / bgmmc.b_dt_sz;
+                    // N==1: stride of unit dim N is unreliable; use contiguous K.
+                    bgmmc.LDA = N == 1 ? K : bgmmc.B_strides[0] / bgmmc.b_dt_sz;
                     break;
                 case gemv_strategy_t::n1_A_plain:
-                    bgmmc.LDA = bgmmc.A_strides[1] / bgmmc.a_dt_sz;
+                    // M==1: stride of unit dim M is unreliable; use contiguous K.
+                    bgmmc.LDA = M == 1 ? K : bgmmc.A_strides[1] / bgmmc.a_dt_sz;
                     break;
                 case gemv_strategy_t::n1_A_trans:
-                    bgmmc.LDA = bgmmc.A_strides[0] / bgmmc.a_dt_sz;
+                    // K==1: stride of unit dim K is unreliable; use contiguous M.
+                    bgmmc.LDA = K == 1 ? M : bgmmc.A_strides[0] / bgmmc.a_dt_sz;
                     break;
                 default: assert(!"unknown gemv strategy");
             }

--- a/src/cpu/x64/utils/jit_regops.cpp
+++ b/src/cpu/x64/utils/jit_regops.cpp
@@ -26,11 +26,23 @@ namespace regops {
 
 void horizontal_add_ps(
         jit_generator_t *code, Xbyak::Xmm src, Xbyak::Xmm workspace) {
-    UNUSED(workspace);
-    if (code->is_valid_isa(avx)) {
+    // XMM indices 16-31 can only be encoded with EVEX. vhaddps/haddps have no
+    // EVEX form so for high registers we have to use an EVEX-encodable
+    // vshufps + vaddps reduction.
+    const bool requires_evex = src.getIdx() >= 16 || workspace.getIdx() >= 16;
+
+    if (requires_evex) {
+        assert(code->is_valid_isa(avx512_core));
+        code->vshufps(workspace, src, src, 0xB1); // [1,0,3,2]
+        code->vaddps(src, src, workspace);
+        code->vshufps(workspace, src, src, 0x4E); // [2,3,0,1]
+        code->vaddps(src, src, workspace);
+    } else if (code->is_valid_isa(avx)) {
+        UNUSED(workspace);
         code->vhaddps(src, src, src);
         code->vhaddps(src, src, src);
     } else {
+        UNUSED(workspace);
         code->haddps(src, src);
         code->haddps(src, src);
     }
@@ -41,9 +53,16 @@ void horizontal_add_ps(
     const Xbyak::Xmm xmm_ws {workspace.getIdx()};
     const Xbyak::Xmm xmm_src {src.getIdx()};
 
-    code->vextractf128(xmm_ws, src, 1);
+    // vextractf128 is VEX-only and cannot encode ymm16-31. Use the EVEX
+    // vextractf32x4 for high registers.
+    const bool requires_evex = src.getIdx() >= 16 || workspace.getIdx() >= 16;
+    if (requires_evex)
+        code->vextractf32x4(xmm_ws, src, 1);
+    else
+        code->vextractf128(xmm_ws, src, 1);
+
     code->vaddps(xmm_src, xmm_src, xmm_ws);
-    horizontal_add_ps(code, xmm_src);
+    horizontal_add_ps(code, xmm_src, xmm_ws);
 }
 
 void horizontal_add_ps(

--- a/src/cpu/x64/utils/jit_regops.hpp
+++ b/src/cpu/x64/utils/jit_regops.hpp
@@ -29,10 +29,10 @@ namespace regops {
  * Horizontally sums packed fp32 values in a 128-bit XMM register.
  * @param code JIT code generator instance.
  * @param src Source XMM register.i
- * @param workspace Optional dummy register (ignored).
+ * @param workspace Temporary XMM register.
  */
-void horizontal_add_ps(jit_generator_t *code, Xbyak::Xmm src,
-        Xbyak::Xmm workspace = Xbyak::Xmm {});
+void horizontal_add_ps(
+        jit_generator_t *code, Xbyak::Xmm src, Xbyak::Xmm workspace);
 
 /**
  * Horizontally sums packed fp32 values in a 256-bit YMM register,


### PR DESCRIPTION
This PR extends the GEMV code path to support bf16 and f16 data types (MFDNN-14404).

* All gemv strategies are extended
* f16 - requires `avx512_core`, implemented via upconversion on the fly (f16 -> f32)
* bf16 has two implementations and requires `avx512_core_bf16`:
  * via `vdpbf16ps`, when we dispatch non-transA gemv kernel, no conversion
  * via upconversion on the fly, when we dispatch transA  gemv kernel (bf16 -> f32)
* The support was not added for` avx2_vnni*` because there was no clear use case or motivation for it

* bias, scales, post-ops are supported

This PR also has a few small GEMV related fixes:
* 7cac1dad6d15470640ce0563fcbb80bc365d0789
* ce566bc42d3ab2e9bc9001c1495509300eed9ee2
* 2b29041bc09820ac24b6acf229e11077e057bf62
* 1be73bc23b52794feadf3e0eb9c5b7a03b239d1f
* 7a1c316258ca1b26f99d801c45edb356191ae34c

Performance pre-commit on GNR (this branch vs main from ww23.6):
<img width="307" height="556" alt="image" src="https://github.com/user-attachments/assets/d5217c0b-7bac-45be-b992-66f7dcfa0228" />

Since GEMV cases contribute only a small fraction of the total model execution time, their impact on end-to-end performance is limited (e.g., ~7% for RGAT RT, BF16). This is expected.


