### PR TITLE
Upstream spacemit ops

### DIFF
--- a/.github/.licenserc.yml
+++ b/.github/.licenserc.yml
@@ -12,7 +12,8 @@ header:
       |YANDEX LLC
       |ZTE Corporation
       |Institute of Software, Chinese Academy of Sciences
-      |openKylin community)\.?\s*)+
+      |openKylin community
+      |SpacemiT Corporation)\.?\s*)+
       ?(?:SPDX-License-Identifier: Apache-2\.0\s+)?Licensed under the Apache License, Version 2\.0 \(the .License.\);
       you may not use this file except in compliance with the License\.
       You may obtain a copy of the License at
@@ -44,7 +45,7 @@ header:
 
 # Clang tools configs
     - '**/.clang-*'
-  
+
 # benchdnn inputs
     - 'tests/benchdnn/inputs/**'
 
@@ -59,4 +60,3 @@ header:
     - '**/*.vcxproj*'
 
   license-location-threshold: 25
-  

--- a/.github/.licenserc.yml
+++ b/.github/.licenserc.yml
@@ -45,7 +45,7 @@ header:
 
 # Clang tools configs
     - '**/.clang-*'
-
+  
 # benchdnn inputs
     - 'tests/benchdnn/inputs/**'
 
@@ -60,3 +60,4 @@ header:
     - '**/*.vcxproj*'
 
   license-location-threshold: 25
+  

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +32,9 @@ using namespace Xbyak_riscv;
 #define F16_STRIDED_OFF(field) \
     static_cast<int32_t>(offsetof( \
             jit_rvv_softmax_f16_strided_kernel_t::call_params_t, field))
+#define F16_EXP_SUB_SUM_OFF(field) \
+    static_cast<int32_t>(offsetof( \
+            jit_rvv_softmax_f16_exp_sub_sum_kernel_t::call_params_t, field))
 
 namespace {
 
@@ -45,6 +49,12 @@ template <bool gather>
 void dispatch_f16_strided(
         const jit_rvv_softmax_f16_strided_kernel_t::call_params_t *p) {
     static const jit_rvv_softmax_f16_strided_kernel_t kernel(gather);
+    kernel(p);
+}
+
+void dispatch_f16_exp_sub_sum(
+        const jit_rvv_softmax_f16_exp_sub_sum_kernel_t::call_params_t *p) {
+    static const jit_rvv_softmax_f16_exp_sub_sum_kernel_t kernel;
     kernel(p);
 }
 
@@ -140,6 +150,13 @@ void jit_rvv_softmax_f16_scatter(const dnnl::impl::float16_t *src,
     const jit_rvv_softmax_f16_strided_kernel_t::call_params_t p {
             src, dst, len, stride_bytes};
     dispatch_f16_strided<false>(&p);
+}
+
+void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src,
+        float *tmp, dim_t len, float sub, float *sum) {
+    const jit_rvv_softmax_f16_exp_sub_sum_kernel_t::call_params_t p {
+            reinterpret_cast<const uint16_t *>(src), tmp, len, sub, sum};
+    dispatch_f16_exp_sub_sum(&p);
 }
 
 void jit_rvv_softmax_f16_affine_kernel_t::generate() {
@@ -245,6 +262,127 @@ void jit_rvv_softmax_f16_strided_kernel_t::generate() {
     j_(loop);
 
     L(done);
+    ret();
+#else
+    ret();
+#endif
+}
+
+jit_rvv_softmax_f16_exp_sub_sum_kernel_t::
+        jit_rvv_softmax_f16_exp_sub_sum_kernel_t()
+    : jit_generator_t("jit_rvv_softmax_f16_exp_sub_sum_kernel") {
+    create_kernel();
+}
+
+void jit_rvv_softmax_f16_exp_sub_sum_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_tmp = a2;
+    const Reg reg_len = a3;
+    const Reg reg_sum = a4;
+    const Reg reg_sub_tmp = t2;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+    const Reg reg_maxexp = t4;
+    const Reg reg_minexp = t5;
+    const Reg reg_imm = t6;
+
+    const FReg f_zero = ft0;
+    const FReg f_lower = ft1;
+    const FReg f_upper = ft2;
+    const FReg f_round = ft3;
+    const FReg f_log2_recip = ft4;
+    const FReg f_log2_high = ft5;
+    const FReg f_log2_low = ft6;
+    const FReg f_sub = fa0;
+    const FReg f_poly3 = ft7;
+    const FReg f_poly4 = ft8;
+    const FReg f_poly56 = ft9;
+    const FReg f_sum = ft10;
+
+    const VReg v_in16(0);
+    const VReg v_x(8);
+    const VReg v_bias(12);
+    const VReg v_poly(16);
+    const VReg v_tmpv(20);
+    const VReg v_acc(24);
+    const VReg v_red(28);
+
+    auto load_f32 = [&](const FReg &freg, float value) {
+        li(reg_imm, static_cast<int64_t>(utils::bit_cast<uint32_t>(value)));
+        fmv_w_x(freg, reg_imm);
+    };
+
+    ld(reg_src, reg_param, F16_EXP_SUB_SUM_OFF(src));
+    ld(reg_tmp, reg_param, F16_EXP_SUB_SUM_OFF(tmp));
+    ld(reg_len, reg_param, F16_EXP_SUB_SUM_OFF(len));
+    ld(reg_sum, reg_param, F16_EXP_SUB_SUM_OFF(sum));
+    lw(reg_sub_tmp, reg_param, F16_EXP_SUB_SUM_OFF(sub));
+    fmv_w_x(f_sub, reg_sub_tmp);
+
+    fmv_w_x(f_zero, x0);
+    load_f32(f_lower, -103.9720840454f);
+    load_f32(f_upper, 88.7762626647950f);
+    load_f32(f_round, 12582912.0f);
+    load_f32(f_log2_recip, 1.44269504088896341f);
+    load_f32(f_log2_high, -6.93145752e-1f);
+    load_f32(f_log2_low, -1.42860677e-6f);
+    load_f32(f_poly3, 0x1.555450p-3f);
+    load_f32(f_poly4, 0x1.fffff6p-2f);
+    load_f32(f_poly56, 0x1.000000p+0f);
+    li(reg_minexp, static_cast<int64_t>(0xC1000000u));
+    li(reg_maxexp, static_cast<int64_t>(0x3F800000u));
+
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4);
+    vfmv_v_f(v_acc, f_zero);
+
+    Label loop, finish;
+    L(loop);
+    beqz(reg_len, finish);
+
+    vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m2);
+    vle16_v(v_in16, reg_src);
+    slli(reg_bytes, reg_vl, 1);
+    add(reg_src, reg_src, reg_bytes);
+    vfwcvt_f_f_v(v_x, v_in16);
+
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
+    vfsub_vf(v_x, v_x, f_sub);
+    vfmv_v_f(v_bias, f_round);
+    vfmv_v_f(v_poly, f_poly3);
+    vfmax_vf(v_x, v_x, f_lower);
+    vfmin_vf(v_x, v_x, f_upper);
+    vfmacc_vf(v_bias, f_log2_recip, v_x);
+    vfsub_vf(v_tmpv, v_bias, f_round);
+    vfmacc_vf(v_x, f_log2_high, v_tmpv);
+    vfmacc_vf(v_x, f_log2_low, v_tmpv);
+    vfmv_v_f(v_tmpv, f_poly4);
+    vfmadd_vv(v_poly, v_x, v_tmpv);
+    vfmv_v_f(v_tmpv, f_poly56);
+    vfmadd_vv(v_poly, v_x, v_tmpv);
+    vsll_vi(v_bias, v_bias, 23);
+    vmin_vx(v_tmpv, v_bias, reg_maxexp);
+    vmax_vx(v_tmpv, v_tmpv, reg_minexp);
+    vsub_vv(v_bias, v_bias, v_tmpv);
+    vadd_vx(v_bias, v_bias, reg_maxexp);
+    vadd_vx(v_tmpv, v_tmpv, reg_maxexp);
+    vfmul_vv(v_x, v_x, v_bias);
+    vfmadd_vv(v_poly, v_x, v_bias);
+    vfmul_vv(v_poly, v_poly, v_tmpv);
+    vfadd_vv(v_acc, v_acc, v_poly);
+    vse32_v(v_poly, reg_tmp);
+    slli(reg_bytes, reg_vl, 2);
+    add(reg_tmp, reg_tmp, reg_bytes);
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(finish);
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4);
+    vfmv_v_f(v_red, f_zero);
+    vfredosum_vs(v_red, v_acc, v_red);
+    vfmv_f_s(f_sum, v_red);
+    fsw(f_sum, reg_sum, 0);
     ret();
 #else
     ret();

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -155,7 +155,7 @@ void jit_rvv_softmax_f16_scatter(const dnnl::impl::float16_t *src,
 void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src,
         float *tmp, dim_t len, float sub, float *sum) {
     const jit_rvv_softmax_f16_exp_sub_sum_kernel_t::call_params_t p {
-            reinterpret_cast<const uint16_t *>(src), tmp, len, sub, sum};
+            src, tmp, len, sub, sum};
     dispatch_f16_exp_sub_sum(&p);
 }
 

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,6 +17,8 @@
 
 #ifndef CPU_RV64_JIT_RVV_SOFTMAX_KERNEL_HPP
 #define CPU_RV64_JIT_RVV_SOFTMAX_KERNEL_HPP
+
+#include <cstdint>
 
 #include "common/c_types_map.hpp"
 #include "common/float16.hpp"
@@ -94,6 +97,27 @@ private:
     bool gather_;
 };
 
+struct jit_rvv_softmax_f16_exp_sub_sum_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const uint16_t *src;
+        float *tmp;
+        dim_t len;
+        float sub;
+        float *sum;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_softmax_f16_exp_sub_sum_kernel_t)
+
+    jit_rvv_softmax_f16_exp_sub_sum_kernel_t();
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+};
+
 void jit_rvv_softmax_f16_affine_from_f16(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, float sub, float mul);
 
@@ -105,6 +129,9 @@ void jit_rvv_softmax_f16_gather(const dnnl::impl::float16_t *src,
 
 void jit_rvv_softmax_f16_scatter(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, dim_t stride_bytes);
+
+void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src, float *tmp,
+        dim_t len, float sub, float *sum);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
@@ -18,8 +18,6 @@
 #ifndef CPU_RV64_JIT_RVV_SOFTMAX_KERNEL_HPP
 #define CPU_RV64_JIT_RVV_SOFTMAX_KERNEL_HPP
 
-#include <cstdint>
-
 #include "common/c_types_map.hpp"
 #include "common/float16.hpp"
 #include "cpu/rv64/jit_generator.hpp"
@@ -99,7 +97,7 @@ private:
 
 struct jit_rvv_softmax_f16_exp_sub_sum_kernel_t : public jit_generator_t {
     struct call_params_t {
-        const uint16_t *src;
+        const dnnl::impl::float16_t *src;
         float *tmp;
         dim_t len;
         float sub;
@@ -130,8 +128,8 @@ void jit_rvv_softmax_f16_gather(const dnnl::impl::float16_t *src,
 void jit_rvv_softmax_f16_scatter(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, dim_t stride_bytes);
 
-void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src, float *tmp,
-        dim_t len, float sub, float *sum);
+void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src,
+        float *tmp, dim_t len, float sub, float *sum);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/rvv_softmax.cpp
+++ b/src/cpu/rv64/rvv_softmax.cpp
@@ -1,5 +1,6 @@
 /******************************************************************************
 * Copyright 2025 ZTE Corporation
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -102,23 +103,27 @@ void compute_softmax_f16_rvv(const dnnl::impl::float16_t *src,
     }
 
     if (is_logsoftmax) {
+        float *tmp_dst = new float[len];
         float sum_exp = 0.f;
-        for (dim_t i = 0; i < len; ++i) {
-            sum_exp += expf((float)src[i] - max_val);
-        }
+
+        jit_rvv_softmax_f16_exp_sub_sum(src, tmp_dst, len, max_val, &sum_exp);
         const float log_sum = logf(sum_exp);
 
         const float sub = max_val + log_sum;
         jit_rvv_softmax_f16_affine_from_f16(src, dst, len, sub, 1.0f);
+        delete[] tmp_dst;
     } else {
         float *tmp_dst = new float[len];
         float sum_exp = 0.f;
         const bool all_minus_inf
                 = is_softmax_inf_as_zero && (max_val == -INFINITY);
-        for (dim_t i = 0; i < len; ++i) {
-            float e = all_minus_inf ? 0.f : expf((float)src[i] - max_val);
-            tmp_dst[i] = e;
-            sum_exp += e;
+
+        if (all_minus_inf) {
+            for (dim_t i = 0; i < len; ++i)
+                tmp_dst[i] = 0.f;
+        } else {
+            jit_rvv_softmax_f16_exp_sub_sum(
+                    src, tmp_dst, len, max_val, &sum_exp);
         }
         const float inv_sum = sum_exp ? (1.0f / sum_exp) : 1.0f;
 


### PR DESCRIPTION
# Description

This PR adds RV64 RVV JIT support for the f16 softmax forward path.

The change replaces the scalar f16 `expf(src - max)` accumulation loop with a new RVV JIT kernel, `jit_rvv_softmax_f16_exp_sub_sum_kernel_t`, which:
- loads f16 input and widens it to f32 for computation;
- computes `exp(src - max)` using the RVV polynomial exp approximation;
- stores the temporary f32 exponential values;
- reduces the vector result into `sum_exp`.

Both softmax and logsoftmax f16 paths use this helper. The existing f16 affine conversion path is kept for the final normalization/logsoftmax output step, and strided f16 layouts continue to use the existing gather/compute/scatter flow.

This improves the RV64 f16 softmax implementation by moving the expensive exponential stage from scalar code to RVV vector code while preserving f32 intermediate computation for numerical behavior. Functional testing has passed. The measured maximum accuracy test error is 0.0002, which is within the tolerance range for FP16 precision. Compared to the original implementation, the current version delivers more than a 2x average performance improvement.

# Changes

- Added `jit_rvv_softmax_f16_exp_sub_sum_kernel_t`.
- Added `jit_rvv_softmax_f16_exp_sub_sum()` wrapper.
- Wired the new kernel into f16 softmax and logsoftmax forward execution.
- Preserved the existing `softmax_accurate_inf_as_zero` handling for all-`-inf` inputs.
- Added SpacemiT copyright headers and license allowlist entry.


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance
      improvements?

Benchmarks were run on Spacemit X100 (K3). Reported values are benchdnn %0time (avg_time) in milliseconds.

### Baseline

The baseline is the latest upstream repository version before this change. In that baseline, RV64 already has an f16 softmax path, but the expensive `expf(src - max)` and `sum_exp` stage is still computed by a scalar loop after converting each f16 element to f32.

| Problem | Axis | Baseline time, ms | Current time, ms | Speedup |
| --- | --- | ---: | ---: | ---: |
| `1x128` | default | 0.006562 | 0.002810 | 2.34x |
| `1x1024` | default | 0.038426 | 0.007880 | 4.88x |
| `32x1000` | default | 0.876378 | 0.635224 | 1.38x |
| `64x1000` | default | 1.158360 | 0.679500 | 1.70x |
| `128x1000` | default | 1.761680 | 0.770100 | 2.29x |
| `32x4096` | default | 1.768840 | 0.773450 | 2.29x |
| `64x4096` | default | 2.927140 | 0.958871 | 3.05x |
| `8x64x14x14` | default | 1.641500 | 0.948384 | 1.73x |
| `16x64x14x14` | default | 2.675710 | 1.345320 | 1.99x |
| `2x256x14x14` | default | 1.598470 | 0.893807 | 1.79x |
| `4x256x7x7` | default | 1.106500 | 0.736306 | 1.50x |
| `8x14x14x64` | 3 | 1.549120 | 0.842290 | 1.84x |
