### PR TITLE
Enable assymetric heads for D_qk >= D_v for micro kernel sdpa

### DIFF
--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -188,26 +188,28 @@ inline void apply_dropout_s_tile(
 #endif
 
 #if USE_SYSTOLIC_UKERNEL
-DECLARE_2D_TILE(q_tile_type, uint, SUBGROUP_SIZE, D_MAX / 2, 1, 1, q_tile_sg_n)
+DECLARE_2D_TILE(
+        q_tile_type, uint, SUBGROUP_SIZE, D_MAX_KQ / 2, 1, 1, q_tile_sg_n)
 #else
-DECLARE_2D_TILE(q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n)
+DECLARE_2D_TILE(
+        q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX_KQ, 1, 1, q_tile_sg_n)
 #endif
 
 #if BLOCK_Q
 
 #if USE_SYSTOLIC_UKERNEL
 DECLARE_2D_TILE_BLOCK_OPS(
-        q_tile_type, uint, SUBGROUP_SIZE, D_MAX / 2, 1, 1, q_tile_sg_n)
+        q_tile_type, uint, SUBGROUP_SIZE, D_MAX_KQ / 2, 1, 1, q_tile_sg_n)
 #else
 DECLARE_2D_TILE_BLOCK_OPS(
-        q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n)
+        q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX_KQ, 1, 1, q_tile_sg_n)
 #endif
 
 #elif Q_ALIGN < 4
 
 #if USE_SYSTOLIC_UKERNEL
 DECLARE_2D_TILE_LOAD_PACKED_VEC(q_tile_type, QRY_DATA_T, VEC_TYPE2,
-        SUBGROUP_SIZE, D_MAX / 2, 1, 1, q_tile_sg_n)
+        SUBGROUP_SIZE, D_MAX_KQ / 2, 1, 1, q_tile_sg_n)
 #endif
 
 #endif
@@ -485,7 +487,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #else
         const global SCALE_DATA_T *scale_ptr,
 #endif
-        int d, int k, int q, const global KEY_ATTR_SCALES_DATA_T *K_scales,
+        int d_qk, int d_v, int k, int q,
+        const global KEY_ATTR_SCALES_DATA_T *K_scales,
         const global KEY_ATTR_ZP_DATA_T *K_zp,
         const global VAL_ATTR_SCALES_DATA_T *V_scales,
         const global VAL_ATTR_ZP_DATA_T *V_zp, const int attn_mask_type
@@ -555,11 +558,11 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 
 #if KEY_SCALES || KEY_ZERO_POINTS
     uint ldkq = KEY_D3;
-    uint num_key_groups = d / KEY_GROUP_SIZE;
+    uint num_key_groups = div_up(d_qk, KEY_GROUP_SIZE);
 #endif
 #if VAL_SCALES || VAL_ZERO_POINTS
-    uint ldvq = div_up(d, VAL_GROUP_SIZE);
-    uint num_val_groups = d / VAL_GROUP_SIZE;
+    uint ldvq = div_up(d_v, VAL_GROUP_SIZE);
+    uint num_val_groups = div_up(d_v, VAL_GROUP_SIZE);
 #endif
 
     /* Subgroup IDs for each GEMM */
@@ -570,7 +573,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     uint sg_j_vs = sg_ij / ugemm_vs_sg_per_wg_m;
 
     /* SLM allocations -- place in one array to work around compiler bug */
-#define Q_slm_size (D_MAX * ugemm_kq_wg_tile_n * sizeof(QRY_DATA_T))
+#define Q_slm_size (D_MAX_KQ * ugemm_kq_wg_tile_n * sizeof(QRY_DATA_T))
 #define S_slm_size \
     (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(QRY_DATA_T))
 #define S_sum_slm_size \
@@ -630,11 +633,11 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         q_tile_type Q_tile;
         uint q0_copy = q_tile_sg_n * sg_ij;
 
-        tile_load_src1(&Q_tile, Q, d, q_group_size, ldq, 0, wg_j0 + q0_copy);
+        tile_load_src1(&Q_tile, Q, d_qk, q_group_size, ldq, 0, wg_j0 + q0_copy);
 
         /* Store Q tile to SLM */
         tile_store_t_slm_src1(
-                &Q_tile, Q_slm, ugemm_kq_sg_tile_n, D_MAX, q0_copy, 0);
+                &Q_tile, Q_slm, ugemm_kq_sg_tile_n, D_MAX_KQ, q0_copy, 0);
 
 #if Q_ARRIVE_AWAIT_BARRIER
         intel_work_group_barrier_arrive(CLK_LOCAL_MEM_FENCE);
@@ -672,7 +675,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         cooperative_prefetch_2d_k(
                 /* ptr */ K,
                 /* r */ k,
-                /* c */ d,
+                /* c */ d_qk,
                 /* rmax */ ugemm_kq_wg_tile_m,
                 /* cmax */ PREFETCH_D_MAX,
                 /* ld */ ldk,
@@ -687,7 +690,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                 /* r */ k,
                 /* c */ num_key_groups,
                 /* rmax */ ugemm_kq_wg_tile_m,
-                /* cmax */ D_MAX / KEY_GROUP_SIZE,
+                /* cmax */ D_MAX_KQ / KEY_GROUP_SIZE,
                 /* ld */ ldkq,
                 /* sg_id */ sg_ij,
                 /* n_sg */ sg_per_wg,
@@ -700,7 +703,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                 /* r */ k,
                 /* c */ num_key_groups,
                 /* rmax */ ugemm_kq_wg_tile_m,
-                /* cmax */ D_MAX / KEY_GROUP_SIZE,
+                /* cmax */ D_MAX_KQ / KEY_GROUP_SIZE,
                 /* ld */ ldkq,
                 /* sg_id */ sg_ij,
                 /* n_sg */ sg_per_wg,
@@ -814,8 +817,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         s_tile_type S_tile
 #endif
                 = ugemm_kq(AS_KEY_TILE_PTR(K), ldk, AS_QRY_SLM_TILE_PTR(Q_slm),
-                        D_MAX, k0end, ugemm_kq_wg_tile_n, d, k0, 0, 0, sg_i_kq,
-                        sg_j_kq, (local char *)ugemm_slm
+                        D_MAX_KQ, k0end, ugemm_kq_wg_tile_n, d_qk, k0, 0, 0,
+                        sg_i_kq, sg_j_kq, (local char *)ugemm_slm
 #if KEY_SCALES == QUANTIZE_2D
                         ,
                         AS_KEY_SCALES_PTR(K_scales)
@@ -888,9 +891,9 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         /* Prefetch V tile. */
         cooperative_prefetch_2d_maybe_rem(
                 /* ptr */ V,
-                /* r */ d,
+                /* r */ d_v,
                 /* c */ k0end - k0,
-                /* rmax */ PREFETCH_D_MAX,
+                /* rmax */ PREFETCH_V_MAX,
                 /* cmax */ ugemm_kq_wg_tile_m,
                 /* ld */ ldv,
                 /* sg_id */ sg_ij,
@@ -904,7 +907,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                 /* ptr */ V_scales,
                 /* r */ num_val_groups,
                 /* c */ k0end - k0,
-                /* rmax */ PREFETCH_D_MAX / VAL_GROUP_SIZE,
+                /* rmax */ PREFETCH_V_MAX / VAL_GROUP_SIZE,
                 /* cmax */ k_chunk,
                 /* ld */ ldvq,
                 /* sg_id */ sg_ij,
@@ -918,7 +921,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                 /* ptr */ V_zp,
                 /* r */ num_val_groups,
                 /* c */ k0end - k0,
-                /* rmax */ PREFETCH_D_MAX / VAL_GROUP_SIZE,
+                /* rmax */ PREFETCH_V_MAX / VAL_GROUP_SIZE,
                 /* cmax */ k_chunk,
                 /* ld */ ldvq,
                 /* sg_id */ sg_ij,
@@ -1027,9 +1030,9 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             cooperative_prefetch_2d_k(
                     /* ptr */ K_next,
                     /* r */ k0end - k0 - ugemm_kq_wg_tile_m,
-                    /* c */ d,
+                    /* c */ d_qk,
                     /* rmax */ ugemm_kq_wg_tile_m,
-                    /* cmax */ D_MAX,
+                    /* cmax */ D_MAX_KQ,
                     /* ld*/ ldk,
                     /* sg_id */ sg_ij,
                     /* n_sg */ sg_per_wg,
@@ -1043,7 +1046,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                     /* r */ k0end - k0 - ugemm_kq_wg_tile_m,
                     /* c */ num_key_groups,
                     /* rmax */ ugemm_kq_wg_tile_m,
-                    /* cmax */ D_MAX / KEY_GROUP_SIZE,
+                    /* cmax */ D_MAX_KQ / KEY_GROUP_SIZE,
                     /* ld */ ldkq,
                     /* sg_id */ sg_ij,
                     /* n_sg */ sg_per_wg,
@@ -1057,7 +1060,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                     /* r */ k0end - k0 - ugemm_kq_wg_tile_m,
                     /* c */ num_key_groups,
                     /* rmax */ ugemm_kq_wg_tile_m,
-                    /* cmax */ D_MAX / KEY_GROUP_SIZE,
+                    /* cmax */ D_MAX_KQ / KEY_GROUP_SIZE,
                     /* ld */ ldkq,
                     /* sg_id */ sg_ij,
                     /* n_sg */ sg_per_wg,
@@ -1088,7 +1091,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                     /* r */ k0end - k0 - ugemm_kq_wg_tile_m,
                     /* c */ q - wg_j0,
                     /* rmax */ ugemm_kq_wg_tile_m,
-                    /* cmax */ (ugemm_kq_wg_tile_n * PREFETCH_D_MAX) / D_MAX,
+                    /* cmax */ (ugemm_kq_wg_tile_n * PREFETCH_D_MAX) / D_MAX_KQ,
                     /* ld */ MSK_S2,
                     /* sg_id */ sg_ij,
                     /* n_sg */ sg_per_wg,
@@ -1112,7 +1115,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         a_tile_type A_tile1
 #endif
                 = ugemm_vs(AS_VAL_TILE_PTR(V), ldv, AS_QRY_SLM_TILE_PTR(S_slm),
-                        ugemm_kq_wg_tile_m, d, ugemm_kq_wg_tile_n, k_chunk, 0,
+                        ugemm_kq_wg_tile_m, d_v, ugemm_kq_wg_tile_n, k_chunk, 0,
                         0, 0, sg_i_vs, sg_j_vs, (local char *)ugemm_slm
 #if VAL_SCALES == QUANTIZE_2D
                         ,
@@ -1215,13 +1218,13 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     uint sg_j0_vs = sg_j_vs * ugemm_vs_sg_tile_n + wg_j0;
 
 #if BLOCK_2D_A
-    tile_store_block2d(A_tile_dst, (global DST_TILE_DATA_T *)A, d, q_group_size,
-            lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block2d(A_tile_dst, (global DST_TILE_DATA_T *)A, d_v,
+            q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #elif BLOCK_A
     tile_store_block_rem_q(A_tile_dst, (global DST_TILE_DATA_T *)A,
             q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #else
-    tile_store(A_tile_dst, (global DST_TILE_DATA_T *)A, d, q_group_size, lda,
+    tile_store(A_tile_dst, (global DST_TILE_DATA_T *)A, d_v, q_group_size, lda,
             sg_i0_vs, sg_j0_vs);
 #endif
 }

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -173,7 +173,10 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             || (vs_acc_dt() == data_type::f16);
     VDISPATCH_SDPA(IMPLICATION(is_f16_accumulate_gemm, !use_systolic_ukernel()),
             "f16 accumulate only available with FMA matmul."); //TODO: update once matmul primitive supports systolic f16 accumulate for testing
-    config = choose_config(arch_, d->head_size(), d->keys(), thin_q, quantized,
+    // Query using max(D_qk, D_v) so the selected config's tiles are large
+    // enough to hold both the QK and V head sizes when they differ.
+    const dim_t query_head_size = std::max(d->head_size(), d->values());
+    config = choose_config(arch_, query_head_size, d->keys(), thin_q, quantized,
             is_integrated, use_fma_config, is_f32, is_f16_accumulate_gemm);
 
     VDISPATCH_SDPA(config != nullptr,
@@ -206,12 +209,12 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             config->unroll_n_vs * config->wg_n_vs, config->unroll_n_kq,
             config->unroll_n_vs);
 
-    VDISPATCH_SDPA(config->unroll_m_vs * config->wg_m_vs >= d->head_size(),
+    VDISPATCH_SDPA(config->unroll_m_vs * config->wg_m_vs >= d->values(),
             "The vs matmul config work_group tile M(%d*%d=%d) axis must be "
-            "greater than or equal to head size(%ld)",
+            "greater than or equal to values size(%ld)",
             config->unroll_m_vs, config->wg_m_vs,
             config->unroll_m_vs * config->wg_m_vs,
-            static_cast<long int>(d->head_size()));
+            static_cast<long int>(d->values()));
 
     // serializable minimal set of configuration params for ukernels
     // will be used to generate shim ukernels in reusable kernel_ctx
@@ -359,8 +362,8 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     if (with_value_scales() && !vs_common_scales) {
         auto scale_dt = value_scales_dt();
         problem_vs.Ta_scale = convert_dnnl_to_kernel_type(scale_dt);
-        problem_vs.A_scale.setAlignment(uint8_t(d->head_size()
-                / value_group_size() * types::data_type_size(scale_dt)));
+        problem_vs.A_scale.setAlignment(uint8_t(d->values() / value_group_size()
+                * types::data_type_size(scale_dt)));
         problem_vs.A_scale.layout = MatrixLayout::N;
         const int matrix_scale = 2;
         problem_vs.asPtrDims = matrix_scale;
@@ -368,7 +371,7 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     if (with_value_zp()) {
         auto zp_dt = value_zp_dt();
         problem_vs.Tao = convert_dnnl_to_kernel_type(zp_dt);
-        problem_vs.AO.setAlignment(uint8_t(d->head_size() / value_group_size()
+        problem_vs.AO.setAlignment(uint8_t(d->values() / value_group_size()
                 * types::data_type_size(zp_dt)));
         problem_vs.AO.layout = MatrixLayout::N;
         problem_vs.aoPtrDims = vs_common_zp ? 0 : 2;
@@ -838,7 +841,6 @@ static void init_conf_common(conf_t &conf, pd_type *pd) {
     conf.with_causal_mask = pd->with_causal_mask();
 
     conf.subgroup_size = pd->sg_size();
-    conf.d_max = pd->d_max();
 
     bool d_full = (d->head_size() == pd->d_max());
     conf.d_full = d_full;
@@ -853,6 +855,8 @@ static void init_conf_common(conf_t &conf, pd_type *pd) {
 status_t micro_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
     using namespace micro;
     init_conf_common(conf, this);
+    conf.d_max_kq = d_max_kq();
+    conf.d_max_v = d_max_v();
 
     conf.require_stateless_addressing = has_large_buffers();
 
@@ -922,7 +926,7 @@ status_t micro_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
     int tile_v = vs_wg_tile_m;
 
     bool d_full = conf.d_full;
-    bool v_full = (desc()->head_size() == tile_v);
+    bool v_full = (desc()->values() == tile_v);
 
     auto Q = desc()->queries();
     const dim_t Q_per_kv_group = (Q == 1 ? Q * conf.kv_group_size : Q);
@@ -944,13 +948,15 @@ status_t micro_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
         conf.prefetch_k0 = true;
         conf.prefetch_k = true;
         conf.prefetch_v = true;
-        conf.prefetch_d_max = nstl::min(d_max(), 64);
+        conf.prefetch_d_max = nstl::min(d_max_kq(), 64);
+        conf.prefetch_v_max = nstl::min(d_max_v(), 64);
         bool no_rem = d_full && v_full && (desc()->keys() % tile_k == 0);
         conf.prefetch_remainder = !no_rem;
     } else {
         conf.prefetch_mask = conf.prefetch_k0 = conf.prefetch_k
                 = conf.prefetch_v = conf.prefetch_remainder = false;
         conf.prefetch_d_max = 0;
+        conf.prefetch_v_max = 0;
     }
 
     conf.q_arrive_await_barrier = (Q > 1);
@@ -968,6 +974,7 @@ status_t micro_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
 
 status_t micro_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
     init_conf_common(conf, this);
+    conf.d_max = d_max();
 
     conf.require_stateless_addressing = has_large_buffers();
     conf.with_dS = with_dS();
@@ -1117,7 +1124,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     kernel_ctx.define_int("WITH_CAUSAL_MASK", with_causal_mask);
 
     kernel_ctx.define_int("SUBGROUP_SIZE", subgroup_size);
-    kernel_ctx.define_int("D_MAX", d_max);
+    kernel_ctx.define_int("D_MAX_KQ", d_max_kq);
+    kernel_ctx.define_int("D_MAX_V", d_max_v);
 
     kernel_ctx.define_int("BLOCK_Q", block_q);
     kernel_ctx.define_int("BLOCK_A", block_a);
@@ -1129,6 +1137,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     kernel_ctx.define_int("PREFETCH_V", prefetch_v);
     kernel_ctx.define_int("PREFETCH_REMAINDER", prefetch_remainder);
     kernel_ctx.define_int("PREFETCH_D_MAX", prefetch_d_max);
+    kernel_ctx.define_int("PREFETCH_V_MAX", prefetch_v_max);
     kernel_ctx.define_int("REMAINDER_Q", remainder_q);
 
     kernel_ctx.define_int("Q_ARRIVE_AWAIT_BARRIER", q_arrive_await_barrier);
@@ -1604,7 +1613,8 @@ status_t micro_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     const int kv_group_size = pd()->conf.kv_group_size;
     const dim_t Q = pd()->desc()->queries();
     const dim_t K = pd()->desc()->keys();
-    const dim_t D = pd()->desc()->head_size();
+    const dim_t D_qk = pd()->desc()->head_size();
+    const dim_t D_v = pd()->desc()->values();
     const dim_t Q_per_kv_group = (Q == 1 ? Q * kv_group_size : Q);
 
     const fwd_config_t config = {conf.ukernel_config.unroll_m_kq,
@@ -1659,7 +1669,8 @@ status_t micro_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     } else {
         arg_list.append(scale);
     }
-    arg_list.append((int)D);
+    arg_list.append((int)D_qk);
+    arg_list.append((int)D_v);
     arg_list.append((int)K);
     arg_list.append((int)Q);
     arg_list.append(key_scales);

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -82,7 +82,7 @@ struct micro_fwd_params_t : trivially_serializable_t<micro_fwd_params_t> {
     bool invert_scale, with_attn_scale, with_host_scale, with_attn_mask,
             broadcast_mask_q, with_causal_mask;
     uint8_t padding1[2] = {0};
-    int subgroup_size, d_max;
+    int subgroup_size, d_max_kq, d_max_v;
 
     bool d_full, arch_gte_hpc;
     bool block_q, block_a, block_2d_a;
@@ -90,6 +90,7 @@ struct micro_fwd_params_t : trivially_serializable_t<micro_fwd_params_t> {
     bool remainder_q;
     uint8_t padding2[5] = {0};
     int prefetch_d_max;
+    int prefetch_v_max;
 
     bool softmax_inf_as_zero;
     bool q_arrive_await_barrier;
@@ -245,8 +246,6 @@ struct micro_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_SDPA(set_default_formats() == status::success,
                     VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_SDPA(desc()->values() == desc()->head_size(),
-                    "values does not match head size");
 
             if (utils::one_of(desc()->key_md()->data_type, u4, s4)) {
                 VDISPATCH_SDPA(desc()->keys() % 2 == 0,
@@ -270,6 +269,15 @@ struct micro_fwd_t : public primitive_t {
                     static_cast<long int>(desc()->qry_md()->dims[1]),
                     static_cast<long int>(desc()->key_md()->dims[1]),
                     static_cast<long int>(desc()->val_md()->dims[1]));
+
+            // Asymmetric heads are only supported when the QK head size is at
+            // least the V head size (d_qk >= d_v). The kernel config is chosen
+            // from d_qk, so its V-side tile can only hold d_v when d_v <= d_qk.
+            VDISPATCH_SDPA(desc()->head_size() >= desc()->values(),
+                    "the QK head size(%ld) must be greater than or equal to"
+                    " the V head size(%ld)",
+                    static_cast<long int>(desc()->head_size()),
+                    static_cast<long int>(desc()->values()));
 
             VDISPATCH_SDPA(utils::one_of(kq_acc_dt(), f16, f32),
                     "KQ accumulation data type should be f16 or f32");
@@ -362,13 +370,22 @@ struct micro_fwd_t : public primitive_t {
         int sg_size() const { return sg_size_; }
         bool use_systolic_ukernel() const { return use_systolic_ukernel_; }
 
-        // Block size for head_size, which must be hard-coded into the kernel.
-        int d_max() const {
+        // Block size for the Q/K head dim, baked into the kernel.
+        int d_max_kq() const {
             int head_size = into<int>(desc()->head_size());
             for (int i = 32; i <= 1024; i *= 2)
                 if (head_size <= i) return i;
             return head_size;
         }
+        // Block size for the V/output head dim, baked into the kernel.
+        int d_max_v() const {
+            int v_size = into<int>(desc()->values());
+            for (int i = 32; i <= 1024; i *= 2)
+                if (v_size <= i) return i;
+            return v_size;
+        }
+        // Alias kept for ukernel tileC/tileR sites that use the KQ dimension.
+        int d_max() const { return d_max_kq(); }
 
         compute::gpu_arch_t arch() const { return arch_; }
         micro_fwd_params_t conf;

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -214,6 +214,12 @@
 --reset --in-shapes=3:1x16x384x32,3:1x16x384x64,3:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
 --reset --in-shapes=24:1x16x384x32,24:1x16x384x64,24:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-bottom-right-implicit-causal-mask-f16-f32.json
 
+# d_qk > d_v (larger query/key head, smaller value head)
+--reset --in-shapes=0:1x16x384x128+1:1x16x384x128+8:1x16x384x32,0:1x16x384x128+1:1x16x384x128+8:1x16x384x64 --case=complex_fusion/mha/sdpa-plain-simplified-f32.json
+--reset --in-shapes=1:1x16x384x128+2:1x16x384x128+3:1x16x384x32,1:1x16x384x128+2:1x16x384x128+3:1x16x384x64 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+--reset --in-shapes=1:1x16x384x128+2:1x16x384x128+3:1x16x384x32,1:1x16x384x128+2:1x16x384x128+3:1x16x384x64 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
+--reset --in-shapes=0:1x16x384x128+1:1x16x384x128+24:1x16x384x32,0:1x16x384x128+1:1x16x384x128+24:1x16x384x64 --case=complex_fusion/mha/sdpa-plain-bottom-right-implicit-causal-mask-f16-f32.json
+
 # sdpa with packed qkv
 --reset --in-shapes=1:1x12x1024x64*2359296x64x2304x1+2:1x12x1024x64*2359296x64x2304x1+5:1x1x1x1024+3:1x12x1024x64*2359296x64x2304x1 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
 

--- a/tests/benchdnn/inputs/sdpa/shapes_asymmetric_heads
+++ b/tests/benchdnn/inputs/sdpa/shapes_asymmetric_heads
@@ -1,0 +1,21 @@
+# Asymmetric-head SDPA shapes: Q/K head size (d_qk) != V head size (d_v).
+# These exercise the GPU micro kernel path that decouples the QK and V head
+# sizes (cf. tests/gtests/internals/test_sdpa.cpp AsymmetricHeads suites).
+# Only d_qk > d_v is covered: the V-side tile of the config chosen for d_qk
+# must be able to hold d_v, so d_v <= d_qk on the supported configs.
+# Format: Q_dims:K_dims:V_dims  (batch x heads x seq x head_dim)
+#   Q = mb x H x S_q  x d_qk
+#   K = mb x H x d_qk x S_kv   (K stored transposed)
+#   V = mb x H x S_kv x d_v
+
+# 16 heads, seq=384, d_qk=64, d_v=32
+1x16x384x64:1x16x64x384:1x16x384x32
+
+# 16 heads, seq=384, d_qk=128, d_v=64
+1x16x384x128:1x16x128x384:1x16x384x64
+
+# 16 heads, seq=384, d_qk=128, d_v=32
+1x16x384x128:1x16x128x384:1x16x384x32
+
+# Batch > 1: 8 heads, seq=384, d_qk=128, d_v=64
+2x8x384x128:2x8x128x384:2x8x384x64

--- a/tests/benchdnn/inputs/sdpa/test_sdpa_gpu
+++ b/tests/benchdnn/inputs/sdpa/test_sdpa_gpu
@@ -53,5 +53,15 @@
 --mask=causal_top_left
 --batch=shapes_transformer_gpu
 
+# Asymmetric heads (d_qk > d_v)
+--reset
+--dt=f16,bf16
+--batch=shapes_asymmetric_heads
+
+--reset
+--dt=f16,bf16
+--mask=causal_top_left
+--batch=shapes_asymmetric_heads
+
 # CI tests
 --batch=test_sdpa_ci


### PR DESCRIPTION
# Description
 Fused micro kernel doesn't allow different head sizes of QK and V tensors. This PR focuses on enabling that as per this request here: https://jira.devtools.intel.com/browse/MFDNN-14385

N.B:  Will continue testing it with the tests present in Graph API and extend testing starting ww25.2

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

