### PR TITLE
xe: pool: remove workaround for compiler bug

### DIFF
--- a/src/gpu/intel/pool/xe.cpp
+++ b/src/gpu/intel/pool/xe.cpp
@@ -76,16 +76,6 @@ static status_t init_conf_common(
     dim_t c_padded = utils::rnd_up(conf.c_padded, conf.sub_group_size);
 
     if (c_block_size >= 16 && n_block_size >= 16) {
-        // Workaround: OCL compiler on XE3P incorrectly compiles
-        // read_vect_c_block when USE_MB_C_BLOCK and u8 data type.
-        auto is_xe3p = utils::downcast<intel::engine_t *>(engine)
-                               ->device_info()
-                               ->gpu_arch()
-                >= compute::gpu_arch_t::xe3p;
-        VDISPATCH_POOLING_IC(!(is_xe3p && src_mdw.data_type() == data_type::u8),
-                "%s," VERBOSE_IMPL_HEURISTIC_FAIL, pd->info(engine),
-                "workaround xe3p compiler bug: u8 with mb_c_block");
-
         c_padded = utils::rnd_up(conf.c_padded, c_block_size);
         conf.use_mb_c_block = true;
         conf.vect_dt_n = 8;


### PR DESCRIPTION
PR relates to https://jira.devtools.intel.com/browse/MFDNN-14808. Removes w/a because the bug was fixed in the latest driver. 