### PR TITLE
xe: gemm: fixup bdpas scale arg layout

### DIFF
--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -329,9 +329,6 @@ status_t gen_desc_t::finalize(const char *tags) {
             return status::unimplemented;
     }
 
-    // TODO: Fix kChain handling with BDPAS.
-    if (problem_.preferBDPAS()) { strategy_.kChain = 1; }
-
     // If the M/N group size is equal to M or N, align up to a multiple of unroll size
     // XXX: Increase group size to a large value before aligning to increase reusability
     // TODO: Refactor M/N groups/thread setting to preserve MN group count.

--- a/src/gpu/intel/gemm/jit/generator/pieces/compute_utils.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/compute_utils.hpp
@@ -54,6 +54,16 @@ static inline SystolicParams systolicParams(GEMMProblem problem)
     return params;
 }
 
+// Number of consecutive K-elements sharing a single scale value in BDPAS.
+// 32 for fp4/fp8, 16 for fp16.
+static inline int bdpasBlockK(const GEMMProblem &problem)
+{
+    return std::min(systolicParams(problem).ksys, 32);
+}
+
+// Number of M/N scale entries packed into one BDPAS scale arg tile.
+static constexpr int bdpasTileMN = 32;
+
 // Return # of outer products performed at once.
 static inline int minOuterProductCount(const GEMMProblem &problem, const GEMMStrategy &strategy)
 {

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -485,9 +485,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                         if (problem.aqGroupM > 1 || problem.bqGroupN > 1) stub();
 
                         int xqGroupK = isA ? problem.aqGroupK : problem.bqGroupK;
-                        int kxq = isA ? state.kaq : state.kbq;
-                        int kxq_load = xqGroupK * kxq;
-                        int k = (h % kxq_load) / xqGroupK;
+                        int k = h / xqGroupK;
 
                         int io0 = isA ? x : k;
                         int jo0 = isA ? k : x;
@@ -512,8 +510,8 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                         C = state.Cr_layout.find(i % Cr_unrollM, j % Cr_unrollN, state.Cr_regs, &nc, &C_block, cxCompC);
                     else
                         C = state.C_layout.find(i, j, state.C_regs[cBuffer], &nc, &C_block, cxCompC);
-                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true,  i, h + hh);
-                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, j, h + hh);
+                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true,  i, hha);
+                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, j, hhb);
                 } else if (state.systolicSumA) {
                     A = A_layout.find(x, hha, A_regs, &na, &A_block);
                     B = state.sysSumAll1s[0];
@@ -523,7 +521,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                         C = state.Asr_layout.find(x % Cr_unrollM, 0, state.Asr_regs, &nc, &C_block);
                     else
                         C = state.As_layout.find(x, 0, state.As_regs, &nc, &C_block);
-                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true, x, h + hh);
+                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true, x, hha);
                     BS = NullRegister().setType(Type::ngen_e8m0());
                 } else {
                     A = state.sysSumAll1s[0];
@@ -535,7 +533,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                     else
                         C = state.Bs_layout.find(0, x, state.Bs_regs, &nc, &C_block);
                     AS = NullRegister().setType(Type::ngen_e8m0());
-                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, h + hh, x);
+                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, hhb, x);
                 }
 
                 int nv = globalCM ? na : nb;

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -479,24 +479,20 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
 
                 const int cxCompA = -1, cxCompB = -1, cxCompC = -1, cBuffer = 0;
                 auto bdpasScaleArg = [&](const RegisterLayout Xr_scaleLayout, Type Tx_scaleOp,
-                                         GRFMultirange Xr_scaleRegs, bool isA, int x, int k) {
+                                         GRFMultirange Xr_scaleRegs, bool isA, int x, int h) {
                     RegData XS;
                     if (state.useBDPAS && !Xr_scaleLayout.empty()) {
-                        int neq;
-                        const RegisterBlock *qblock;
+                        if (problem.aqGroupM > 1 || problem.bqGroupN > 1) stub();
 
-                        int r, c, io0, jo0;
-                        r = Xr_scaleLayout.rows();
-                        c = Xr_scaleLayout.cols();
+                        int xqGroupK = isA ? problem.aqGroupK : problem.bqGroupK;
+                        int kxq = isA ? state.kaq : state.kbq;
+                        int kxq_load = xqGroupK * kxq;
+                        int k = (h % kxq_load) / xqGroupK;
 
-                        if (isA) {
-                            io0 = x;
-                            jo0 = (k / problem.aqGroupK) % c;
-                        } else {
-                            io0 = (k / problem.bqGroupK) % r;
-                            jo0 = x;
-                        }
-                        XS = Xr_scaleLayout.find(io0, jo0, Xr_scaleRegs, &neq, &qblock);
+                        int io0 = isA ? x : k;
+                        int jo0 = isA ? k : x;
+
+                        XS = Xr_scaleLayout.find(io0, jo0, Xr_scaleRegs);
                     } else
                         XS = NullRegister().setType(Type::ngen_e8m0());
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
@@ -44,6 +44,9 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
 
     if (!xo2D && !xoTo2D && !xs2D && !xg2D) return true;
 
+    if (state.useBDPAS && (xo2D || xoTo2D || xg2D))
+        stub("BDPAS with 2D offsets or group sums not supported");
+
     auto &X_strategy       = isA ? strategy.A             : strategy.B;
     auto &X_offsetStrategy = isA ? strategy.AO            : strategy.BO;
     auto &X_scaleStrategy  = isA ? strategy.A_scale       : strategy.B_scale;
@@ -104,6 +107,10 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
     int r, c, k, rNoSLM, cNoSLM;
     int tileR = 0, tileC = 0;
     bool remR = false, remC = false;
+
+    // K-elements processed per BDPAS pass.
+    int bBlockK = state.useBDPAS ? bdpasBlockK(problem) : 0;
+
     if (isA) {
         bool slmA = strategy.slmA;
         rNoSLM = strategy.unroll[LoopM];
@@ -117,7 +124,12 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
         rNoSLM = std::max(1, rNoSLM / xqGroupMN);
         cNoSLM = state.kaqLate = std::max(1, cNoSLM % xqGroupK == 0 ? cNoSLM /  xqGroupK: 1);
         remR = (strategy.remHandling[LoopM] != RemainderHandling::Ignore);
-        if (xqGroupMN <= 1 && xqGroupK > 1) tileC = 1;
+        if (state.useBDPAS) {
+            tileR = bdpasTileMN;
+            tileC = (xqGroupK > bBlockK) ? 1 : state.kaq;
+        } else if (xqGroupMN <= 1 && xqGroupK > 1) {
+            tileC = 1;
+        }
         if (xqGroupMN > 1 && (xqGroupMN % strategy.unroll[LoopM] && strategy.unroll[LoopM] % xqGroupMN))
             stub("Tile size not compatible with group size in m dimension");
     } else {
@@ -133,7 +145,12 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
         cNoSLM = std::max(1, cNoSLM / xqGroupMN);
         rNoSLM = state.kbqLate = std::max(1, rNoSLM % xqGroupK == 0 ?  rNoSLM / xqGroupK : 1);
         remC = (strategy.remHandling[LoopN] != RemainderHandling::Ignore);
-        if (xqGroupMN <= 1 && xqGroupK > 1) tileR = 1;
+        if (state.useBDPAS) {
+            tileR = (xqGroupK > bBlockK) ? 1 : state.kbq;
+            tileC = bdpasTileMN;
+        } else if (xqGroupMN <= 1 && xqGroupK > 1) {
+            tileR = 1;
+        }
         if (xqGroupMN > 1 && (xqGroupMN % strategy.unroll[LoopN] && strategy.unroll[LoopN] % xqGroupMN))
             stub("Tile size not compatible with group size in n dimension");
     }
@@ -148,7 +165,7 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
         remR = remC = false;
     }
 
-    bool wantCM = isA ^ (xqGroupMN > 1);
+    bool wantCM = state.useBDPAS ? isA : isA ^ (xqGroupMN > 1);
     auto chooseAccess = [=](const MatrixAddressing &Xq) {
         return (wantCM == isColMajor(Xq.layout)) ? AccessType::Block : AccessType::Scattered;
     };
@@ -193,16 +210,17 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
     auto makeQRepack = [&, tileR, tileC](Type Txq, Type Txq_int, RegisterLayout &repack, const RegisterLayout &src,
                                          int m, int n, int cp, bool forceRepack) mutable {
         if (cp > 1 || (cColMajor && (cp != src[0].crosspack)) || Txq != Txq_int || forceRepack) {
-            bool allowPartialRegs = false;
-            // Native MXFP DPAS support
-            if (state.useBDPAS) {
-                allowPartialRegs = true;
-                cp = 1;
-                if (isA) {
-                    tileR = problem.aqGroupK;
-                } else {
-                    tileC = problem.bqGroupK;
-                }
+            // Each BDPAS pass reads scales from one half-GRF. When xqGroupK == bdpasBlockK,
+            // each group maps to one pass and scales pack naturally as [group0, group1].
+            // When xqGroupK > bdpasBlockK, both passes share the same group and scales
+            // must be duplicated to the upper half-GRF: [group0, group0].
+            bool allowPartialRegs = state.useBDPAS && xqGroupK == bBlockK;
+            if (state.useBDPAS && xqGroupK > bBlockK) {
+                // Do not support group sizes that aren't multiples of ksys - this case produces mixed
+                // [group0, group0] and [group0, group1] scales args, which is not currently supported.
+                int ksys = systolicParams(problem).ksys;
+                if (xqGroupK % ksys != 0)
+                    stub("BDPAS scale group straddling not supported");
             }
             repack = RegisterLayout(hw, Txq_int, m, n, wantCM, cp, tileR, tileC, allowPartialRegs);
         }
@@ -236,18 +254,16 @@ void Generator<hw>::gemmRepack2DQuantizationData(Type Ts, Type Td, const Registe
         for (int doffC = 0; doffC < layoutDst.cols(); doffC += layoutSrc.cols())
             copyRegisters(Ts, Td, layoutSrc, layoutDst, src, dst, doffR, doffC, false, strategy, state);
 
-    int r = layoutDst.rows();
-    int c = layoutDst.cols();
-    // FP4 bdpas with group > 32 requires duplicating scales into upper half of registers.
-    if(state.useBDPAS && r * c < minOuterProductCount(problem, strategy)){
-        int halfRegElems = elementsPerGRF(hw, Td) / 2;
-        if(r * c > halfRegElems) stub();
-        RegisterLayout offsetLayout(layoutDst);
-        for( auto &b : offsetLayout){
-            if(b.nr * b.nc > halfRegElems) stub();
-            b.offsetBytes += (b.nr * b.nc);
+    // BDPAS: duplicate scale data to the upper half of each GRF for the second pass.
+    // When xqGroupK > bBlockK, both passes within a bdpas share the same scale group,
+    // so the first half's data must be replicated to the second half.
+    if (state.useBDPAS) {
+        if (layoutDst[0].ld == elementsPerGRF(hw, Td)) {
+            auto upperLayout = layoutDst;
+            for (auto &block : upperLayout)
+                block.offsetBytes += bdpasTileMN;
+            copyRegisters(Td, Td, layoutDst, upperLayout, dst, dst, 0, 0, false, strategy, state);
         }
-        copyRegisters(Td, Td, layoutDst, offsetLayout, dst, dst, 0, 0, false, strategy, state); 
     }
 
     // Duplicate data in padded region. TODO: do this as part of the copy.

--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -926,7 +926,7 @@ static inline void encodeCommon12(Instruction12 &i, Opcode opcode, const Instruc
     i2.common.maskCtrl = mod.parts.maskCtrl;
     i2.common.atomicCtrl = mod.parts.threadCtrl;
     i2.commonXeHPC.dstExt = (dst.isIndirect() ? dst.getOffset() : dst.getByteOffset()) & 1;
-    if (opcode == Opcode::dpas)
+    if (opcode == Opcode::dpas || opcode == Opcode::bdpas)
         i2.common.accWrCtrl = mod.parts.accWrCtrl;   /* {Fwd} */
     i2.common.saturate = mod.parts.saturate;
     i.common = i2.common;


### PR DESCRIPTION
bdpas instructions expect the following layout for scale args (caveats below):
- 32 bytes reserved for M/N-varying scales
- 32 bytes reserved for the M/N-varying scales for the next k-group

The indexing and repacking subroutines get complicated when the problem's group size is a multiple of the bdpas native group size, causing incorrect results in various bdpas kernels (none of which are currently in the library). As a result of invalid indexing and invalid register layout creation in complex and subtle ways, some kernels fail correctness tests in the following ways:
- unrollM/unrollN get too large (e.g. 64x64)
- smaller M/N unroll sizes and group size > 32
- kChain > 1

This PR fixes each of these cases, allowing for kernels that make use of the 2xDPAS feature and get close to peak performance on CRI. Such kernels are not added in this PR, but it makes it possible to tune for them.

Caveats to my layout explanation:
- bdpas only operates on chunks of 16x8 tiles, so scales for 2-4 bdpas tiles can be interleaved in a single register - packing them into the 32 byte M/N-varying regions.
- Only fp4 uses the 2nd half of the register, since BDPAS operates on 32 bytes of k-elements per instruction (32 fp8 elements, or 64 fp4 elements).