### PR TITLE
benchdnn: refactor engine_t and stream_t

### DIFF
--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1851,16 +1851,19 @@ static void maybe_print_cpu_engine_error_message() {
 
 engine_t::engine_t(dnnl_engine_kind_t engine_kind) {
     size_t idx = engine_kind == dnnl_cpu ? 0 : engine_index;
-    dnnl_engine_t engine = nullptr;
-    dnnl_status_t status = dnnl_engine_create(&engine, engine_kind, idx);
-    if (engine_kind == dnnl_cpu && status != dnnl_success)
-        maybe_print_cpu_engine_error_message();
+    try {
+        engine_ = dnnl::engine(
+                static_cast<dnnl::engine::kind>(engine_kind), idx);
+    } catch (const dnnl::error &e) {
+        if (engine_kind == dnnl_cpu) maybe_print_cpu_engine_error_message();
+        DNN_SAFE_V(e.status);
+    }
     if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
         if (has_bench_mode_bit(mode_bit_t::corr)) {
             BENCHDNN_PRINT(0, "%s\n",
                     "Error: the modifier to disable host memory usage "
                     "cannot be used for correctness testing.");
-            status = dnnl_invalid_arguments;
+            DNN_SAFE_V(dnnl_invalid_arguments);
         }
     }
     // Temporary workaround.
@@ -1869,9 +1872,6 @@ engine_t::engine_t(dnnl_engine_kind_t engine_kind) {
     if (has_bench_mode_bit(mode_bit_t::perf) && engine_kind == dnnl_gpu) {
         bench_mode_modifier |= mode_modifier_t::no_ref_memory;
     }
-    DNN_SAFE_V(status);
-    // Take ownership of the just created handle.
-    engine_.reset(engine);
 }
 
 engine_t::engine_t(dnnl_engine_t engine) : engine_(engine, /* weak = */ true) {}
@@ -1884,56 +1884,35 @@ engine_t::engine_t(const engine_t &other, bool recreate_on_copy) {
         return;
     }
 
-    dnnl_engine_kind_t engine_kind;
-    DNN_SAFE_V(dnnl_engine_get_kind(other.engine_.get(), &engine_kind));
-
-    dnnl_engine_t engine = nullptr;
-    if (engine_kind == dnnl_cpu) {
+    const auto engine_kind = other.engine_.get_kind();
+    if (engine_kind == dnnl::engine::kind::cpu) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-        void *dev;
-        void *ctx;
-        DNN_SAFE_V(
-                dnnl_sycl_interop_engine_get_device(other.engine_.get(), &dev));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_get_context(
-                other.engine_.get(), &ctx));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_create(&engine, dev, ctx));
+        engine_ = dnnl::sycl_interop::make_engine(
+                dnnl::sycl_interop::get_device(other.engine_),
+                dnnl::sycl_interop::get_context(other.engine_));
 #else
-        DNN_SAFE_V(dnnl_engine_create(&engine, dnnl_cpu, 0));
+        engine_ = dnnl::engine(dnnl::engine::kind::cpu, 0);
 #endif
-    } else if (engine_kind == dnnl_gpu) {
+    } else if (engine_kind == dnnl::engine::kind::gpu) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        cl_device_id dev;
-        cl_context ctx;
-        DNN_SAFE_V(dnnl_ocl_interop_get_device(other.engine_.get(), &dev));
-        DNN_SAFE_V(
-                dnnl_ocl_interop_engine_get_context(other.engine_.get(), &ctx));
-        DNN_SAFE_V(dnnl_ocl_interop_engine_create(&engine, dev, ctx));
+        engine_ = dnnl::ocl_interop::make_engine(
+                dnnl::ocl_interop::get_device(other.engine_),
+                dnnl::ocl_interop::get_context(other.engine_));
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-        void *dev;
-        void *ctx;
-        DNN_SAFE_V(
-                dnnl_sycl_interop_engine_get_device(other.engine_.get(), &dev));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_get_context(
-                other.engine_.get(), &ctx));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_create(&engine, dev, ctx));
+        engine_ = dnnl::sycl_interop::make_engine(
+                dnnl::sycl_interop::get_device(other.engine_),
+                dnnl::sycl_interop::get_context(other.engine_));
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
-        ze_driver_handle_t drv;
-        ze_device_handle_t dev;
-        ze_context_handle_t ctx;
-        DNN_SAFE_V(
-                dnnl_ze_interop_engine_get_driver(other.engine_.get(), &drv));
-        DNN_SAFE_V(
-                dnnl_ze_interop_engine_get_device(other.engine_.get(), &dev));
-        DNN_SAFE_V(
-                dnnl_ze_interop_engine_get_context(other.engine_.get(), &ctx));
-        DNN_SAFE_V(dnnl_ze_interop_engine_create(&engine, drv, dev, ctx));
+        engine_ = dnnl::ze_interop::make_engine(
+                dnnl::ze_interop::get_driver(other.engine_),
+                dnnl::ze_interop::get_device(other.engine_),
+                dnnl::ze_interop::get_context(other.engine_));
 #else
         assert(!"unsupported GPU runtime");
 #endif
     } else {
         assert(!"unsupported engine kind");
     }
-    engine_.reset(engine);
 }
 
 dnnl_engine_kind_t engine_t::get_kind() const {
@@ -1941,7 +1920,7 @@ dnnl_engine_kind_t engine_t::get_kind() const {
     // `any` kind.
     if (engine_.get(/* allow_empty = */ true) == nullptr)
         return dnnl_any_engine;
-    return query_engine_kind(engine_.get());
+    return static_cast<dnnl_engine_kind_t>(engine_.get_kind());
 }
 
 stream_t::stream_t(const engine_t &engine, void *interop_obj) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -58,76 +58,6 @@
 extern "C" dnnl_status_t dnnl_impl_notify_profiling_complete(
         dnnl_stream_t stream);
 
-bool is_cpu(const dnnl_engine_t &engine) {
-    return query_engine_kind(engine) == dnnl_cpu;
-}
-
-bool is_gpu(const dnnl_engine_t &engine) {
-    return query_engine_kind(engine) == dnnl_gpu;
-}
-
-bool is_async(const dnnl_engine_t &engine) {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    if (is_cpu(engine))
-        return dnnl::testing::get_threadpool()->get_flags()
-                & dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS;
-#else
-    if (is_cpu(engine)) return DNNL_CPU_RUNTIME == DNNL_RUNTIME_DPCPP;
-#endif
-    // all supported GPU runtimes are async
-    return is_gpu(engine);
-}
-
-bool is_sycl_engine(const dnnl_engine_t &engine) {
-    if (is_cpu(engine)) return DNNL_CPU_RUNTIME == DNNL_RUNTIME_DPCPP;
-    if (is_gpu(engine)) return DNNL_GPU_RUNTIME == DNNL_RUNTIME_DPCPP;
-    return false;
-}
-
-bool is_opencl_engine(const dnnl_engine_t &engine) {
-    if (is_gpu(engine)) return DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL;
-    return false;
-}
-
-bool is_ze_engine(const dnnl_engine_t &engine) {
-    if (is_gpu(engine)) return DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE;
-    return false;
-}
-
-bool is_nvidia_gpu(const dnnl_engine_t &engine) {
-#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
-    if (!is_gpu(engine)) return false;
-    constexpr int nvidia_vendor_id = 0x10DE;
-    auto eng = dnnl::engine(engine, true);
-    auto device = dnnl::sycl_interop::get_device(eng);
-    const auto eng_vendor_id
-            = device.get_info<::sycl::info::device::vendor_id>();
-    return eng_vendor_id == nvidia_vendor_id;
-#endif
-    return false;
-}
-
-bool is_amd_gpu(const dnnl_engine_t &engine) {
-#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR == DNNL_VENDOR_AMD
-    if (!is_gpu(engine)) return false;
-    constexpr int amd_vendor_id = 0x1002;
-    auto eng = dnnl::engine(engine, true);
-    auto device = dnnl::sycl_interop::get_device(eng);
-    const auto eng_vendor_id
-            = device.get_info<::sycl::info::device::vendor_id>();
-    return eng_vendor_id == amd_vendor_id;
-#endif
-    return false;
-}
-
-bool is_generic_gpu(const dnnl_engine_t &engine) {
-#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR == DNNL_VENDOR_GENERIC
-    return is_gpu(engine);
-#endif
-
-    return false;
-}
-
 int check_pd_cache(const_dnnl_primitive_desc_t pd, res_t *res) {
     // Disable this check for threadpool. A threadpool is always defined in
     // validation infrastructure but creates primitives in a separate
@@ -1090,7 +1020,7 @@ int check_ref_impl_hit(res_t *res) {
     return OK;
 }
 
-bool is_f64_supported(const dnnl_engine_t &engine) {
+bool is_f64_supported(const engine_t &engine) {
     if (!is_gpu(engine)) return false;
     if (is_nvidia_gpu(engine) || is_amd_gpu(engine)) return false;
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_DPCPP

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1915,12 +1915,20 @@ engine_t::engine_t(const engine_t &other, bool recreate_on_copy) {
     }
 }
 
-dnnl_engine_kind_t engine_t::get_kind() const {
+dnnl::engine::kind engine_t::get_kind() const {
     // An empty engine (e.g., a host scalar memory carries no engine) returns
     // `any` kind.
     if (engine_.get(/* allow_empty = */ true) == nullptr)
-        return dnnl_any_engine;
-    return static_cast<dnnl_engine_kind_t>(engine_.get_kind());
+        return dnnl::engine::kind::any;
+    return engine_.get_kind();
+}
+
+bool engine_t::is_cpu() const {
+    return get_kind() == dnnl::engine::kind::cpu;
+}
+
+bool engine_t::is_gpu() const {
+    return get_kind() == dnnl::engine::kind::gpu;
 }
 
 stream_t::stream_t(const engine_t &engine, void *interop_obj) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -356,49 +356,6 @@ void args_t::replace(int arg, const dnn_mem_t *mem) {
     }
 }
 
-stream_staller_t::stream_staller_t(stream_t &stream) {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    auto eng = query_engine(stream);
-    auto eng_kind = query_engine_kind(eng);
-    if (eng_kind != dnnl_cpu) return;
-
-    void *tp_ptr;
-    dnnl_threadpool_interop_stream_get_threadpool(stream, &tp_ptr);
-    auto tp = static_cast<dnnl::threadpool_interop::threadpool_iface *>(tp_ptr);
-
-    // `tp` is not expected to be empty for CPU streams with threadpol runtime.
-    if (!tp) SAFE_V(FAIL);
-
-    // Only relevant for asynchronous threadpool, synchronous will
-    // deadlock.
-    if (tp->get_flags()
-            != dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS)
-        return;
-
-    // Each thread from the threadpool should get the task to be stalled.
-    const int num_tasks = tp->get_num_threads();
-
-    // The main thread must be let through, otherwise it deadlocks as
-    // task submission won't happen.
-    std::thread::id main_thr_id = std::this_thread::get_id();
-
-    // Shared future allows to pass all waiting threads at once inside the
-    // palallel call.
-    std::shared_future<void> fut(prom_.get_future());
-
-    tp->parallel_for(num_tasks, [=](int, int) {
-        std::thread::id id_thr = std::this_thread::get_id();
-        if (id_thr != main_thr_id) fut.wait();
-    });
-#endif
-}
-
-void stream_staller_t::release() {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    prom_.set_value();
-#endif
-}
-
 // Unmap before passing the memory to execute
 void execute_unmap_args(
         const args_t &args, std::vector<dnnl_exec_arg_t> &dnnl_args) {
@@ -1759,24 +1716,6 @@ execution_mode_t str2execution_mode(const char *str) {
     BENCHDNN_PRINT(0, "%s", "Error: execution mode value is not recognized.\n");
     SAFE_V(FAIL);
     return execution_mode_t::direct;
-}
-
-stream_t::stream_t(const engine_t &engine, void *interop_obj) {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    if (is_cpu(engine)) {
-        auto tp = static_cast<dnnl::threadpool_interop::threadpool_iface *>(
-                interop_obj);
-        if (tp == nullptr) tp = dnnl::testing::get_threadpool();
-        stream_ = dnnl::threadpool_interop::make_stream(engine, tp);
-        return;
-    }
-#endif
-
-    const bool use_profiling = has_bench_mode_bit(mode_bit_t::perf)
-            && is_gpu(engine) && !is_nvidia_gpu(engine) && !is_amd_gpu(engine);
-    const auto flags = static_cast<dnnl::stream::flags>(
-            stream_kind2stream_flags(stream_kind, use_profiling));
-    stream_ = dnnl::stream(engine, flags);
 }
 
 float reorder_rescale_factor() {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1849,9 +1849,10 @@ static void maybe_print_cpu_engine_error_message() {
 #endif
 }
 
-engine_t::engine_t(dnnl_engine_kind_t engine_kind) : is_owner_(true) {
+engine_t::engine_t(dnnl_engine_kind_t engine_kind) {
     size_t idx = engine_kind == dnnl_cpu ? 0 : engine_index;
-    dnnl_status_t status = dnnl_engine_create(&engine_, engine_kind, idx);
+    dnnl_engine_t engine = nullptr;
+    dnnl_status_t status = dnnl_engine_create(&engine, engine_kind, idx);
     if (engine_kind == dnnl_cpu && status != dnnl_success)
         maybe_print_cpu_engine_error_message();
     if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
@@ -1869,64 +1870,78 @@ engine_t::engine_t(dnnl_engine_kind_t engine_kind) : is_owner_(true) {
         bench_mode_modifier |= mode_modifier_t::no_ref_memory;
     }
     DNN_SAFE_V(status);
+    // Take ownership of the just created handle.
+    engine_.reset(engine);
 }
 
-engine_t::engine_t(dnnl_engine_t engine) : engine_(engine), is_owner_(false) {}
+engine_t::engine_t(dnnl_engine_t engine) : engine_(engine, /* weak = */ true) {}
 
-engine_t::engine_t(const engine_t &other) : is_owner_(other.is_owner_) {
-    if (!is_owner_) {
+engine_t::engine_t(const dnnl::engine &engine) : engine_(engine) {}
+
+engine_t::engine_t(const engine_t &other, bool recreate_on_copy) {
+    if (!recreate_on_copy) {
         engine_ = other.engine_;
         return;
     }
 
     dnnl_engine_kind_t engine_kind;
-    DNN_SAFE_V(dnnl_engine_get_kind(other.engine_, &engine_kind));
+    DNN_SAFE_V(dnnl_engine_get_kind(other.engine_.get(), &engine_kind));
 
+    dnnl_engine_t engine = nullptr;
     if (engine_kind == dnnl_cpu) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
         void *dev;
         void *ctx;
-        DNN_SAFE_V(dnnl_sycl_interop_engine_get_device(other.engine_, &dev));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_get_context(other.engine_, &ctx));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_create(&engine_, dev, ctx));
+        DNN_SAFE_V(
+                dnnl_sycl_interop_engine_get_device(other.engine_.get(), &dev));
+        DNN_SAFE_V(dnnl_sycl_interop_engine_get_context(
+                other.engine_.get(), &ctx));
+        DNN_SAFE_V(dnnl_sycl_interop_engine_create(&engine, dev, ctx));
 #else
-        DNN_SAFE_V(dnnl_engine_create(&engine_, dnnl_cpu, 0));
+        DNN_SAFE_V(dnnl_engine_create(&engine, dnnl_cpu, 0));
 #endif
     } else if (engine_kind == dnnl_gpu) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
         cl_device_id dev;
         cl_context ctx;
-        DNN_SAFE_V(dnnl_ocl_interop_get_device(other.engine_, &dev));
-        DNN_SAFE_V(dnnl_ocl_interop_engine_get_context(other.engine_, &ctx));
-        DNN_SAFE_V(dnnl_ocl_interop_engine_create(&engine_, dev, ctx));
+        DNN_SAFE_V(dnnl_ocl_interop_get_device(other.engine_.get(), &dev));
+        DNN_SAFE_V(
+                dnnl_ocl_interop_engine_get_context(other.engine_.get(), &ctx));
+        DNN_SAFE_V(dnnl_ocl_interop_engine_create(&engine, dev, ctx));
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
         void *dev;
         void *ctx;
-        DNN_SAFE_V(dnnl_sycl_interop_engine_get_device(other.engine_, &dev));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_get_context(other.engine_, &ctx));
-        DNN_SAFE_V(dnnl_sycl_interop_engine_create(&engine_, dev, ctx));
+        DNN_SAFE_V(
+                dnnl_sycl_interop_engine_get_device(other.engine_.get(), &dev));
+        DNN_SAFE_V(dnnl_sycl_interop_engine_get_context(
+                other.engine_.get(), &ctx));
+        DNN_SAFE_V(dnnl_sycl_interop_engine_create(&engine, dev, ctx));
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
         ze_driver_handle_t drv;
         ze_device_handle_t dev;
         ze_context_handle_t ctx;
-        DNN_SAFE_V(dnnl_ze_interop_engine_get_driver(other.engine_, &drv));
-        DNN_SAFE_V(dnnl_ze_interop_engine_get_device(other.engine_, &dev));
-        DNN_SAFE_V(dnnl_ze_interop_engine_get_context(other.engine_, &ctx));
-        DNN_SAFE_V(dnnl_ze_interop_engine_create(&engine_, drv, dev, ctx));
+        DNN_SAFE_V(
+                dnnl_ze_interop_engine_get_driver(other.engine_.get(), &drv));
+        DNN_SAFE_V(
+                dnnl_ze_interop_engine_get_device(other.engine_.get(), &dev));
+        DNN_SAFE_V(
+                dnnl_ze_interop_engine_get_context(other.engine_.get(), &ctx));
+        DNN_SAFE_V(dnnl_ze_interop_engine_create(&engine, drv, dev, ctx));
 #else
         assert(!"unsupported GPU runtime");
 #endif
     } else {
         assert(!"unsupported engine kind");
     }
-}
-
-engine_t::~engine_t() {
-    if (is_owner_) DNN_SAFE_V(dnnl_engine_destroy(engine_));
+    engine_.reset(engine);
 }
 
 dnnl_engine_kind_t engine_t::get_kind() const {
-    return query_engine_kind(engine_);
+    // An empty engine (e.g., a host scalar memory carries no engine) returns
+    // `any` kind.
+    if (engine_.get(/* allow_empty = */ true) == nullptr)
+        return dnnl_any_engine;
+    return query_engine_kind(engine_.get());
 }
 
 stream_t::stream_t(dnnl_engine_t engine, void *interop_obj) : is_owner_(true) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -344,10 +344,6 @@ int test_persistent_cache_api(
     return OK;
 }
 
-// Engine kind used to run oneDNN primitives for testing
-dnnl_engine_kind_t engine_tgt_kind = dnnl_cpu;
-// Engine index used to run oneDNN primitives for testing
-size_t engine_index = 0;
 // CPU ISA specific hints : none by default
 isa_hints_t hints {isa_hints_t::none};
 
@@ -1833,102 +1829,6 @@ execution_mode_t str2execution_mode(const char *str) {
     BENCHDNN_PRINT(0, "%s", "Error: execution mode value is not recognized.\n");
     SAFE_V(FAIL);
     return execution_mode_t::direct;
-}
-
-static void maybe_print_cpu_engine_error_message() {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-    fprintf(stderr,
-            "ERROR: can't create CPU engine. Possible reasons for this error:\n"
-            "- Incorrect SYCL_DEVICE_FILTER. The filter must be either unset "
-            "or include 'opencl:cpu' devices.\n"
-            "- Missing TBB library which is required for OpenCL CPU runtime. "
-            "Check that TBB library is available in the system.\n"
-            "- Missing OpenCL CPU runtime or other issues with OpenCL CPU "
-            "runtime. Check that output from `sycl-ls` or `clinfo -l` commands "
-            "include any CPU devices.\n");
-#endif
-}
-
-engine_t::engine_t(dnnl_engine_kind_t engine_kind) {
-    size_t idx = engine_kind == dnnl_cpu ? 0 : engine_index;
-    try {
-        engine_ = dnnl::engine(
-                static_cast<dnnl::engine::kind>(engine_kind), idx);
-    } catch (const dnnl::error &e) {
-        if (engine_kind == dnnl_cpu) maybe_print_cpu_engine_error_message();
-        DNN_SAFE_V(e.status);
-    }
-    if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
-        if (has_bench_mode_bit(mode_bit_t::corr)) {
-            BENCHDNN_PRINT(0, "%s\n",
-                    "Error: the modifier to disable host memory usage "
-                    "cannot be used for correctness testing.");
-            DNN_SAFE_V(dnnl_invalid_arguments);
-        }
-    }
-    // Temporary workaround.
-    // TODO: make mode-modifier=M by default for perf on GPU.
-    // TODO-TODO: make mode-modifier=M by default (including CPU).
-    if (has_bench_mode_bit(mode_bit_t::perf) && engine_kind == dnnl_gpu) {
-        bench_mode_modifier |= mode_modifier_t::no_ref_memory;
-    }
-}
-
-engine_t::engine_t(dnnl_engine_t engine) : engine_(engine, /* weak = */ true) {}
-
-engine_t::engine_t(const dnnl::engine &engine) : engine_(engine) {}
-
-engine_t::engine_t(const engine_t &other, bool recreate_on_copy) {
-    if (!recreate_on_copy) {
-        engine_ = other.engine_;
-        return;
-    }
-
-    const auto engine_kind = other.engine_.get_kind();
-    if (engine_kind == dnnl::engine::kind::cpu) {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-        engine_ = dnnl::sycl_interop::make_engine(
-                dnnl::sycl_interop::get_device(other.engine_),
-                dnnl::sycl_interop::get_context(other.engine_));
-#else
-        engine_ = dnnl::engine(dnnl::engine::kind::cpu, 0);
-#endif
-    } else if (engine_kind == dnnl::engine::kind::gpu) {
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        engine_ = dnnl::ocl_interop::make_engine(
-                dnnl::ocl_interop::get_device(other.engine_),
-                dnnl::ocl_interop::get_context(other.engine_));
-#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-        engine_ = dnnl::sycl_interop::make_engine(
-                dnnl::sycl_interop::get_device(other.engine_),
-                dnnl::sycl_interop::get_context(other.engine_));
-#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
-        engine_ = dnnl::ze_interop::make_engine(
-                dnnl::ze_interop::get_driver(other.engine_),
-                dnnl::ze_interop::get_device(other.engine_),
-                dnnl::ze_interop::get_context(other.engine_));
-#else
-        assert(!"unsupported GPU runtime");
-#endif
-    } else {
-        assert(!"unsupported engine kind");
-    }
-}
-
-dnnl::engine::kind engine_t::get_kind() const {
-    // An empty engine (e.g., a host scalar memory carries no engine) returns
-    // `any` kind.
-    if (engine_.get(/* allow_empty = */ true) == nullptr)
-        return dnnl::engine::kind::any;
-    return engine_.get_kind();
-}
-
-bool engine_t::is_cpu() const {
-    return get_kind() == dnnl::engine::kind::cpu;
-}
-
-bool engine_t::is_gpu() const {
-    return get_kind() == dnnl::engine::kind::gpu;
 }
 
 stream_t::stream_t(const engine_t &engine, void *interop_obj) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1944,13 +1944,15 @@ dnnl_engine_kind_t engine_t::get_kind() const {
     return query_engine_kind(engine_.get());
 }
 
-stream_t::stream_t(dnnl_engine_t engine, void *interop_obj) : is_owner_(true) {
+stream_t::stream_t(const engine_t &engine, void *interop_obj) {
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
     if (is_cpu(engine)) {
         auto tp = static_cast<dnnl::threadpool_interop::threadpool_iface *>(
                 interop_obj);
         if (tp == nullptr) tp = dnnl::testing::get_threadpool();
-        SAFE_V(dnnl_threadpool_interop_stream_create(&stream_, engine, tp));
+        dnnl_stream_t stream = nullptr;
+        SAFE_V(dnnl_threadpool_interop_stream_create(&stream, engine, tp));
+        stream_.reset(stream);
         return;
     }
 #endif
@@ -1959,21 +1961,9 @@ stream_t::stream_t(dnnl_engine_t engine, void *interop_obj) : is_owner_(true) {
             && is_gpu(engine) && !is_nvidia_gpu(engine) && !is_amd_gpu(engine);
     dnnl_stream_flags_t flags
             = stream_kind2stream_flags(stream_kind, use_profiling);
-    DNN_SAFE_V(dnnl_stream_create(&stream_, engine, flags));
-}
-
-stream_t::~stream_t() {
-    if (is_owner_) DNN_SAFE_V(dnnl_stream_destroy(stream_));
-}
-
-stream_t &stream_t::operator=(stream_t &&rhs) {
-    if (&rhs == this) return *this;
-
-    stream_ = rhs.stream_;
-    is_owner_ = rhs.is_owner_;
-
-    rhs.is_owner_ = false;
-    return *this;
+    dnnl_stream_t stream = nullptr;
+    DNN_SAFE_V(dnnl_stream_create(&stream, engine, flags));
+    stream_.reset(stream);
 }
 
 float reorder_rescale_factor() {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -37,7 +37,7 @@
 #endif
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-#include "oneapi/dnnl/dnnl_threadpool.h"
+#include "oneapi/dnnl/dnnl_threadpool.hpp"
 #endif
 
 // Uses only publicly available types.
@@ -1929,20 +1929,16 @@ stream_t::stream_t(const engine_t &engine, void *interop_obj) {
         auto tp = static_cast<dnnl::threadpool_interop::threadpool_iface *>(
                 interop_obj);
         if (tp == nullptr) tp = dnnl::testing::get_threadpool();
-        dnnl_stream_t stream = nullptr;
-        SAFE_V(dnnl_threadpool_interop_stream_create(&stream, engine, tp));
-        stream_.reset(stream);
+        stream_ = dnnl::threadpool_interop::make_stream(engine, tp);
         return;
     }
 #endif
 
     const bool use_profiling = has_bench_mode_bit(mode_bit_t::perf)
             && is_gpu(engine) && !is_nvidia_gpu(engine) && !is_amd_gpu(engine);
-    dnnl_stream_flags_t flags
-            = stream_kind2stream_flags(stream_kind, use_profiling);
-    dnnl_stream_t stream = nullptr;
-    DNN_SAFE_V(dnnl_stream_create(&stream, engine, flags));
-    stream_.reset(stream);
+    const auto flags = static_cast<dnnl::stream::flags>(
+            stream_kind2stream_flags(stream_kind, use_profiling));
+    stream_ = dnnl::stream(engine, flags);
 }
 
 float reorder_rescale_factor() {

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -108,9 +108,12 @@ struct engine_t {
     engine_t(const engine_t &other, bool recreate_on_copy = false);
     operator dnnl_engine_t() const { return engine_.get(); }
     operator const dnnl::engine &() const { return engine_; }
-    dnnl_engine_kind_t get_kind() const;
+
+    bool is_cpu() const;
+    bool is_gpu() const;
 
 private:
+    dnnl::engine::kind get_kind() const;
     engine_t &operator=(engine_t &other) = delete;
     dnnl::engine engine_;
 };
@@ -135,7 +138,8 @@ private:
 // Engine used to run oneDNN primitives for testing.
 inline const engine_t &get_test_engine() {
     static const engine_t instance(engine_tgt_kind);
-    assert(instance.get_kind() == engine_tgt_kind);
+    assert((engine_tgt_kind == dnnl_cpu && instance.is_cpu())
+            || (engine_tgt_kind == dnnl_gpu && instance.is_gpu()));
     return instance;
 }
 

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -116,16 +116,20 @@ private:
 };
 
 struct stream_t {
-    stream_t() : stream_(nullptr), is_owner_(false) {}
-    stream_t(dnnl_engine_t engine, void *interop_obj = nullptr);
-    ~stream_t();
-    operator dnnl_stream_t() const { return stream_; }
-    stream_t &operator=(stream_t &&rhs);
+    stream_t() = default;
+    stream_t(const engine_t &engine, void *interop_obj = nullptr);
+    operator dnnl_stream_t() const {
+        return stream_.get(/* allow_empty = */ true);
+    }
+    operator dnnl::stream &() { return stream_; }
+    // Wrapper over dnnl::stream::wait() to avoid explicit casts to dnnl::stream
+    // at graph driver call sites.
+    void wait() { stream_.wait(); }
+    stream_t &operator=(stream_t &&rhs) = default;
 
 private:
     BENCHDNN_DISALLOW_COPY_AND_ASSIGN(stream_t);
-    dnnl_stream_t stream_;
-    bool is_owner_;
+    dnnl::stream stream_;
 };
 
 // Engine used to run oneDNN primitives for testing.

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -18,7 +18,6 @@
 #define DNNL_COMMON_HPP
 
 #include <functional>
-#include <future> // for std::promise and std::future
 #include <stddef.h>
 #include <stdint.h>
 #include <vector>
@@ -38,6 +37,7 @@
 #include "utils/impl_filter.hpp"
 #include "utils/numeric.hpp"
 #include "utils/parallel.hpp"
+#include "utils/stream_kind.hpp"
 
 #include "tests/test_thread.hpp"
 
@@ -60,23 +60,6 @@ int check_primitive_cache(dnnl_primitive_t p, res_t *res);
 extern isa_hints_t hints;
 extern int default_num_streams;
 extern int num_streams;
-
-struct stream_t {
-    stream_t() = default;
-    stream_t(const engine_t &engine, void *interop_obj = nullptr);
-    operator dnnl_stream_t() const {
-        return stream_.get(/* allow_empty = */ true);
-    }
-    operator dnnl::stream &() { return stream_; }
-    // Wrapper over dnnl::stream::wait() to avoid explicit casts to dnnl::stream
-    // at graph driver call sites.
-    void wait() { stream_.wait(); }
-    stream_t &operator=(stream_t &&rhs) = default;
-
-private:
-    BENCHDNN_DISALLOW_COPY_AND_ASSIGN(stream_t);
-    dnnl::stream stream_;
-};
 
 bool is_f64_supported(const engine_t &engine = get_test_engine());
 
@@ -113,18 +96,6 @@ struct args_t {
 
 private:
     std::vector<std::pair<int, const dnn_mem_t *>> args_;
-};
-
-struct stream_staller_t {
-    // Enqueue tasks to stall a primitive execution tasks for asynchronous
-    // threadpool runtime. For rest runtimes does nothing.
-    stream_staller_t(stream_t &stream);
-
-    // A signal the submission has completed and ready for execution.
-    void release();
-
-private:
-    std::promise<void> prom_;
 };
 
 template <typename prb_t>

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -33,6 +33,7 @@
 #include "utils/compare.hpp"
 #include "utils/dims.hpp"
 #include "utils/dnnl_query.hpp"
+#include "utils/engine.hpp"
 #include "utils/fill.hpp"
 #include "utils/impl_filter.hpp"
 #include "utils/numeric.hpp"
@@ -41,41 +42,6 @@
 #include "tests/test_thread.hpp"
 
 #define for_ for
-
-#define DNN_SAFE(f, s) \
-    do { \
-        dnnl_status_t status__ = f; \
-        if (status__ != dnnl_success) { \
-            if ((s) == CRIT || (s) == WARN) { \
-                BENCHDNN_PRINT(0, \
-                        "Error: Function '%s' at (%s:%d) returned '%s'\n", \
-                        __FUNCTION__, __FILE__, __LINE__, \
-                        status2str(status__)); \
-                fflush(0); \
-                if ((s) == CRIT) exit(2); \
-            } \
-            return FAIL; \
-        } \
-    } while (0)
-
-#define DNN_SAFE_V(f) \
-    do { \
-        dnnl_status_t status__ = (f); \
-        if (status__ != dnnl_success) { \
-            BENCHDNN_PRINT(0, \
-                    "Error: Function '%s' at (%s:%d) returned '%s'\n", \
-                    __FUNCTION__, __FILE__, __LINE__, status2str(status__)); \
-            fflush(0); \
-            exit(2); \
-        } \
-    } while (0)
-
-// Unlike `DNN_SAFE` this one returns `dnnl_status_t`, not `OK/FAIL`.
-#define DNN_SAFE_STATUS(f) \
-    do { \
-        dnnl_status_t status__ = (f); \
-        if (status__ != dnnl_success) { return status__; } \
-    } while (0)
 
 #ifndef DNNL_EXPERIMENTAL_PROFILING
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL \
@@ -91,32 +57,9 @@ extern "C" dnnl_status_t dnnl_query_profiling_data(dnnl_stream_t stream,
 int check_pd_cache(const_dnnl_primitive_desc_t pd, res_t *res);
 int check_primitive_cache(dnnl_primitive_t p, res_t *res);
 
-extern dnnl_engine_kind_t engine_tgt_kind;
-extern size_t engine_index;
 extern isa_hints_t hints;
 extern int default_num_streams;
 extern int num_streams;
-
-struct engine_t {
-    engine_t(dnnl_engine_kind_t engine_kind);
-    engine_t(dnnl_engine_t engine);
-    engine_t(const dnnl::engine &engine);
-    // `recreate_on_copy=true` forces to construct a brand new engine_t object
-    // with underlying interop objects from `other`.
-    // When `recreate_on_copy=false`, copy follows a weak_ptr semantics that
-    // `dnnl::engine` provides.
-    engine_t(const engine_t &other, bool recreate_on_copy = false);
-    operator dnnl_engine_t() const { return engine_.get(); }
-    operator const dnnl::engine &() const { return engine_; }
-
-    bool is_cpu() const;
-    bool is_gpu() const;
-
-private:
-    dnnl::engine::kind get_kind() const;
-    engine_t &operator=(engine_t &other) = delete;
-    dnnl::engine engine_;
-};
 
 struct stream_t {
     stream_t() = default;

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -24,7 +24,7 @@
 #include <vector>
 #include <unordered_map>
 
-#include "oneapi/dnnl/dnnl.h"
+#include "oneapi/dnnl/dnnl.hpp"
 
 #include "common.hpp"
 #include "dnn_types.hpp"
@@ -100,15 +100,19 @@ extern int num_streams;
 struct engine_t {
     engine_t(dnnl_engine_kind_t engine_kind);
     engine_t(dnnl_engine_t engine);
-    engine_t(const engine_t &other);
-    ~engine_t();
-    operator dnnl_engine_t() const { return engine_; }
+    engine_t(const dnnl::engine &engine);
+    // `recreate_on_copy=true` forces to construct a brand new engine_t object
+    // with underlying interop objects from `other`.
+    // When `recreate_on_copy=false`, copy follows a weak_ptr semantics that
+    // `dnnl::engine` provides.
+    engine_t(const engine_t &other, bool recreate_on_copy = false);
+    operator dnnl_engine_t() const { return engine_.get(); }
+    operator const dnnl::engine &() const { return engine_; }
     dnnl_engine_kind_t get_kind() const;
 
 private:
     engine_t &operator=(engine_t &other) = delete;
-    dnnl_engine_t engine_;
-    bool is_owner_;
+    dnnl::engine engine_;
 };
 
 struct stream_t {
@@ -534,7 +538,7 @@ int init_prim(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &user_prim,
         // where CPU and GPU engines are re-created because this is a commonly
         // used scenario in the frameworks.
         // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-        engine_t engine(get_test_engine());
+        engine_t engine(get_test_engine(), /* recreate_on_copy = */ true);
 
         // The first primitive creation using a temporary engine.
         SAFE(create_primitive(primw, engine, init_pd_func, prb, res, dir, hint,

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -78,36 +78,7 @@ private:
     dnnl::stream stream_;
 };
 
-// Engine used to run oneDNN primitives for testing.
-inline const engine_t &get_test_engine() {
-    static const engine_t instance(engine_tgt_kind);
-    assert((engine_tgt_kind == dnnl_cpu && instance.is_cpu())
-            || (engine_tgt_kind == dnnl_gpu && instance.is_gpu()));
-    return instance;
-}
-
-// Engine used to run all reference native implementations and CPU
-// implementations used by `--fast-ref` option.
-inline const engine_t &get_cpu_engine() {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_NONE
-    // In case of lacking CPU engine, just re-use testing one.
-    return get_test_engine();
-#else
-    static const engine_t instance(dnnl_cpu);
-    return instance;
-#endif
-}
-
-bool is_cpu(const dnnl_engine_t &engine = get_test_engine());
-bool is_gpu(const dnnl_engine_t &engine = get_test_engine());
-bool is_async(const dnnl_engine_t &engine = get_test_engine());
-bool is_sycl_engine(const dnnl_engine_t &engine = get_test_engine());
-bool is_opencl_engine(const dnnl_engine_t &engine = get_test_engine());
-bool is_ze_engine(const dnnl_engine_t &engine = get_test_engine());
-bool is_nvidia_gpu(const dnnl_engine_t &engine = get_test_engine());
-bool is_f64_supported(const dnnl_engine_t &engine = get_test_engine());
-bool is_amd_gpu(const dnnl_engine_t &engine = get_test_engine());
-bool is_generic_gpu(const dnnl_engine_t &engine = get_test_engine());
+bool is_f64_supported(const engine_t &engine = get_test_engine());
 
 // Extended version of dnnl_sycl_interop_memory_kind_t enumeration.
 enum class memory_kind_ext_t {

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -643,7 +643,7 @@ std::string deserialized_graph_t::get_string() const {
 
 dnnl::graph::graph deserialized_graph_t::to_graph(
         const graph_fpmath_mode_t &fpmath_mode) const {
-    const auto &engine = get_graph_engine();
+    const dnnl::engine &engine = get_graph_engine();
     dnnl::graph::graph g(engine.get_kind());
     g.set_fpmath_mode(static_cast<dnnl::fpmath_mode>(
                               str2fpmath_mode(fpmath_mode.mode_.c_str())),

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -620,12 +620,7 @@ int doit(const prb_t *prb, res_t *res) {
 
     const dnnl::engine &eng = get_graph_engine();
 
-    const bool use_profiling = has_bench_mode_bit(mode_bit_t::perf)
-            && is_gpu(eng.get()) && !is_nvidia_gpu(eng.get())
-            && !is_amd_gpu(eng.get());
-    dnnl_stream_flags_t flags
-            = stream_kind2stream_flags(stream_kind, use_profiling);
-    cpp_stream_t strm {eng, static_cast<dnnl::stream::flags>(flags)};
+    stream_t strm {get_graph_engine()};
 
     // mark the output logical tensors of partition as ANY layout enabled
     std::unordered_set<size_t> id_to_set_any_layout;

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -435,8 +435,7 @@ int skip_unimplemented_ops(const dnnl::graph::partition &partition,
     static const std::vector<std::string> unimplemented_ops {"Pow"};
     // A list of ops that don't have DNNL backend support so far on GPU.
     static const std::vector<std::string> unimplemented_ops_gpu {};
-    const dnnl::engine &eng = get_graph_engine();
-    bool is_gpu = eng.get_kind() == dnnl::engine::kind::gpu;
+    const bool is_gpu = get_graph_engine().is_gpu();
     // For an unsupported partition, retrieve all operation IDs, find a
     // correspondent operation kind in a deserialized_graph_t and match it against
     // a list of known unsupported ops.
@@ -479,8 +478,7 @@ int skip_unimplemented_ops(const dnnl::graph::partition &partition,
 int skip_unimplemented_accumulation_mode(
         const dnnl::graph::partition &partition, const deserialized_graph_t &dg,
         res_t *res) {
-    const dnnl::engine &eng = get_graph_engine();
-    bool is_cpu = eng.get_kind() == dnnl::engine::kind::cpu;
+    const bool is_cpu = get_graph_engine().is_cpu();
     if (!is_cpu) return OK;
     const std::vector<size_t> &partition_op_ids = partition.get_ops();
     for (const size_t op_id : partition_op_ids) {

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -435,7 +435,7 @@ int skip_unimplemented_ops(const dnnl::graph::partition &partition,
     static const std::vector<std::string> unimplemented_ops {"Pow"};
     // A list of ops that don't have DNNL backend support so far on GPU.
     static const std::vector<std::string> unimplemented_ops_gpu {};
-    const auto &eng = get_graph_engine();
+    const dnnl::engine &eng = get_graph_engine();
     bool is_gpu = eng.get_kind() == dnnl::engine::kind::gpu;
     // For an unsupported partition, retrieve all operation IDs, find a
     // correspondent operation kind in a deserialized_graph_t and match it against
@@ -479,7 +479,7 @@ int skip_unimplemented_ops(const dnnl::graph::partition &partition,
 int skip_unimplemented_accumulation_mode(
         const dnnl::graph::partition &partition, const deserialized_graph_t &dg,
         res_t *res) {
-    const auto &eng = get_graph_engine();
+    const dnnl::engine &eng = get_graph_engine();
     bool is_cpu = eng.get_kind() == dnnl::engine::kind::cpu;
     if (!is_cpu) return OK;
     const std::vector<size_t> &partition_op_ids = partition.get_ops();
@@ -618,12 +618,11 @@ int doit(const prb_t *prb, res_t *res) {
     SAFE(skip_unimplemented_partitions(partitions, dg, prb, res), WARN);
     if (res->state == SKIPPED) return OK;
 
-    const auto &eng = get_graph_engine();
-    const dnnl::engine &dnnl_eng = static_cast<const dnnl::engine>(eng);
+    const dnnl::engine &eng = get_graph_engine();
 
     const bool use_profiling = has_bench_mode_bit(mode_bit_t::perf)
-            && is_gpu(dnnl_eng.get()) && !is_nvidia_gpu(dnnl_eng.get())
-            && !is_amd_gpu(dnnl_eng.get());
+            && is_gpu(eng.get()) && !is_nvidia_gpu(eng.get())
+            && !is_amd_gpu(eng.get());
     dnnl_stream_flags_t flags
             = stream_kind2stream_flags(stream_kind, use_profiling);
     cpp_stream_t strm {eng, static_cast<dnnl::stream::flags>(flags)};

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -82,15 +82,6 @@ void compiled_partition_executor(dnnl::graph::compiled_partition &cp,
     }
 }
 
-inline dnnl::stream::flags get_profiling_flags() {
-#ifdef DNNL_EXPERIMENTAL_PROFILING
-    return dnnl::stream::flags::profiling;
-#else
-    return static_cast<dnnl::stream::flags>(
-            dnnl::impl::stream_flags::profiling);
-#endif
-}
-
 inline int measure_perf_aggregate(timer::timer_t &t,
         std::vector<perf_function_t> &perf_func_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
@@ -99,10 +90,7 @@ inline int measure_perf_aggregate(timer::timer_t &t,
     const int max_batch_times = 4096;
     // Nvidia/AMD don't support profiling.
     const bool use_profiling = is_gpu() && !is_nvidia_gpu() && !is_amd_gpu();
-    const dnnl::stream::flags flags = use_profiling
-            ? dnnl::stream::flags::default_flags | get_profiling_flags()
-            : dnnl::stream::flags::default_flags;
-    cpp_stream_t stream {get_graph_engine(), flags};
+    stream_t stream {get_graph_engine()};
 
     // Warm-up run, this is not measured due to possibility the associated
     // kernel has not been built and skews the results.
@@ -120,7 +108,7 @@ inline int measure_perf_aggregate(timer::timer_t &t,
             = fix_times_per_prb ? fix_times_per_prb : min_times_per_prb;
 
     t.reset();
-    reset_gpu_profiling(((dnnl::stream)stream).get());
+    reset_gpu_profiling(stream);
 
     bool is_first_loop = true;
     size_t prim_num = 1;
@@ -138,10 +126,10 @@ inline int measure_perf_aggregate(timer::timer_t &t,
             std::vector<uint64_t> cycles;
             // Cannot determine the number of expected profiling entries
             // beforehand so pass -1.
-            SAFE(get_gpu_profiling_info(((dnnl::stream)stream).get(), nsecs,
-                         cycles, /*expected_num_entries=*/-1),
+            SAFE(get_gpu_profiling_info(
+                         stream, nsecs, cycles, /*expected_num_entries=*/-1),
                     CRIT);
-            reset_gpu_profiling(((dnnl::stream)stream).get());
+            reset_gpu_profiling(stream);
 
             // Profiling should have information to report, otherwise, stop.
             if (nsecs.empty()) {
@@ -188,11 +176,7 @@ inline int measure_perf_individual(timer::timer_t &t,
         const std::vector<std::vector<dnnl::graph::tensor>> &inputs_v,
         const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
         const std::vector<dnnl::graph::tensor> &scratchpads, res_t *res) {
-    const bool use_profiling = is_gpu() && !is_nvidia_gpu() && !is_amd_gpu();
-    const dnnl::stream::flags flags = use_profiling
-            ? dnnl::stream::flags::default_flags | get_profiling_flags()
-            : dnnl::stream::flags::default_flags;
-    cpp_stream_t stream {get_graph_engine(), flags};
+    stream_t stream {get_graph_engine()};
 
     t.reset();
     while (true) {
@@ -1258,20 +1242,6 @@ dnnl::graph::logical_tensor::layout_type str2layout(
         return dnnl::graph::logical_tensor::layout_type::undef;
 }
 
-cpp_stream_t::cpp_stream_t(
-        const dnnl::engine &eng, dnnl::stream::flags flags, void *interop_obj) {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    if (eng.get_kind() == dnnl::engine::kind::cpu) {
-        auto tp = static_cast<dnnl::threadpool_interop::threadpool_iface *>(
-                interop_obj);
-        if (tp == nullptr) tp = dnnl::testing::get_threadpool();
-        stream_ = dnnl::threadpool_interop::make_stream(eng, tp);
-        return;
-    }
-#endif
-    stream_ = dnnl::stream {eng, flags};
-}
-
 engine_t make_graph_engine(bool use_host) {
 
     dnnl::graph::allocator &alloc = get_graph_allocator(use_host);
@@ -1317,47 +1287,6 @@ dnnl_data_type_t convert_dt(const dnnl::graph::logical_tensor::data_type dt) {
         case graph_dt::undef:
         default: return dnnl_data_type_undef;
     }
-}
-
-stream_staller_t::stream_staller_t(graph::cpp_stream_t &stream) {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    const auto &eng = stream.get_engine();
-    auto eng_kind = eng.get_kind();
-    if (eng_kind != dnnl::engine::kind::cpu) return;
-
-    auto tp = dnnl::threadpool_interop::get_threadpool(stream);
-
-    // `tp` is not expected to be empty for CPU streams with threadpol runtime.
-    if (!tp) SAFE_V(FAIL);
-
-    // Only relevant for asynchronous threadpool, synchronous will
-    // deadlock.
-    if (tp->get_flags()
-            != dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS)
-        return;
-
-    // Each thread from the threadpool should get the task to be stalled.
-    const int num_tasks = tp->get_num_threads();
-
-    // The main thread must be let through, otherwise it deadlocks as
-    // task submission won't happen.
-    std::thread::id main_thr_id = std::this_thread::get_id();
-
-    // Shared future allows to pass all waiting threads at once inside the
-    // palallel call.
-    std::shared_future<void> fut(prom_.get_future());
-
-    tp->parallel_for(num_tasks, [=](int, int) {
-        std::thread::id id_thr = std::this_thread::get_id();
-        if (id_thr != main_thr_id) fut.wait();
-    });
-#endif
-}
-
-void stream_staller_t::release() {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    prom_.set_value();
-#endif
 }
 
 } // namespace graph

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -1272,24 +1272,25 @@ cpp_stream_t::cpp_stream_t(
     stream_ = dnnl::stream {eng, flags};
 }
 
-cpp_engine_t::cpp_engine_t(bool use_host) {
+engine_t make_graph_engine(bool use_host) {
 
     dnnl::graph::allocator &alloc = get_graph_allocator(use_host);
 
     if (use_host || is_cpu()) {
-        engine_ = make_engine_with_allocator(dnnl::engine::kind::cpu,
-                static_cast<size_t>(engine_index), alloc);
+        return engine_t(make_engine_with_allocator(dnnl::engine::kind::cpu,
+                static_cast<size_t>(engine_index), alloc));
     } else {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-        engine_ = make_engine_with_allocator(dnnl::engine::kind::gpu,
-                static_cast<size_t>(engine_index), alloc);
+        return engine_t(make_engine_with_allocator(dnnl::engine::kind::gpu,
+                static_cast<size_t>(engine_index), alloc));
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
         // needs to prepare ocl_malloc_wrapper and ocl_free_wrapper and call
         // make_engine_with_allocator instead.
-        engine_ = dnnl::engine(
-                dnnl::engine::kind::gpu, static_cast<size_t>(engine_index));
+        return engine_t(dnnl::engine(
+                dnnl::engine::kind::gpu, static_cast<size_t>(engine_index)));
 #else
         assert(!"unsupported gpu runtime");
+        return engine_t(dnnl::engine {});
 #endif
     }
 }

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -198,19 +198,6 @@ void change_format_to_ncx(First &first, Rest &...rest) {
     change_format_to_ncx(rest...);
 }
 
-struct cpp_stream_t {
-    cpp_stream_t(const dnnl::engine &eng,
-            dnnl::stream::flags flags = dnnl::stream::flags::default_flags,
-            void *interop_obj = nullptr);
-    void wait() { stream_.wait(); }
-    operator dnnl::stream &() { return stream_; }
-    dnnl::engine get_engine() const { return stream_.get_engine(); }
-
-private:
-    BENCHDNN_DISALLOW_COPY_AND_ASSIGN(cpp_stream_t);
-    dnnl::stream stream_;
-};
-
 // Creates the graph engine wrapped into the common `engine_t` abstraction. The
 // graph library requires an allocator attached to the engine to allocate memory
 // for constant cache and scratchpad, hence the engine is built via
@@ -259,18 +246,6 @@ struct graph_fpmath_mode_t {
     // Since fpmath_mode doesn't provide an "undef" value that would indicate
     // it was not set externally to the json case, need to maintain this flag.
     bool override_json_value_ = false;
-};
-
-struct stream_staller_t {
-    // Enqueue tasks to stall a primitive execution tasks for asynchronous
-    // threadpool runtime. For rest runtimes does nothing.
-    stream_staller_t(graph::cpp_stream_t &stream);
-
-    // A signal the submission has completed and ready for execution.
-    void release();
-
-private:
-    std::promise<void> prom_;
 };
 
 // RAII guard that temporarily overrides `execution_mode` and restores the
@@ -322,9 +297,8 @@ inline int validate_backend(const ::sycl::queue &queue, res_t *res) {
 // Record operations into a SYCL command graph and return the finalized
 // executable. `record_func` is called while the queue is in recording state.
 // Returns nullptr on failure (with res->state set to FAILED).
-inline std::unique_ptr<sycl_exec_graph_t> record_and_finalize(
-        cpp_stream_t &stream, ::sycl::queue &queue,
-        std::function<void()> &record_func, res_t *res) {
+inline std::unique_ptr<sycl_exec_graph_t> record_and_finalize(stream_t &stream,
+        ::sycl::queue &queue, std::function<void()> &record_func, res_t *res) {
     BENCHDNN_PRINT(
             2, "%s\n", "[INFO] Using experimental SYCL graph execution.");
 

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -211,33 +211,27 @@ private:
     dnnl::stream stream_;
 };
 
-// engine used for graph lib, graph lib engine needs allocator to allocate
-// memory for constant cache, scratchpad.
-struct cpp_engine_t {
-    cpp_engine_t(bool use_host);
-    dnnl::engine::kind get_kind() const { return engine_.get_kind(); }
-    operator dnnl::engine &() { return engine_; }
-    operator const dnnl::engine &() const { return engine_; }
+// Creates the graph engine wrapped into the common `engine_t` abstraction. The
+// graph library requires an allocator attached to the engine to allocate memory
+// for constant cache and scratchpad, hence the engine is built via
+// `make_engine_with_allocator` and adopted by `engine_t`.
+engine_t make_graph_engine(bool use_host);
 
-private:
-    BENCHDNN_DISALLOW_COPY_AND_ASSIGN(cpp_engine_t);
-    dnnl::engine engine_;
-};
-
-// engine used for graph lib, graph lib engine needs allocator to allocate
-// memory for constant cache, scratchpad.
-inline const cpp_engine_t &get_graph_engine() {
-    static const cpp_engine_t instance(/*use_host*/ false);
+// Engine used for the graph library. It wraps a `dnnl::engine` created with an
+// allocator (see `make_graph_engine`) into the common `engine_t` abstraction so
+// that the graph driver shares the same engine type as the rest of benchdnn
+// while still exposing the C++ engine interface required by the graph API.
+inline const engine_t &get_graph_engine() {
+    static const engine_t instance(make_graph_engine(/*use_host*/ false));
     return instance;
 }
 
-inline const cpp_engine_t &get_graph_host_engine() {
+inline const engine_t &get_graph_host_engine() {
     // return `get_graph_engine` for `is_cpu` to avoid different engine instances.
-    const dnnl::engine &g_eng
-            = get_graph_engine().operator const dnnl::engine &();
+    const dnnl::engine &g_eng = get_graph_engine();
     if (is_cpu(g_eng.get())) { return get_graph_engine(); }
 
-    static const cpp_engine_t instance(/*use_host*/ true);
+    static const engine_t instance(make_graph_engine(/*use_host*/ true));
     return instance;
 }
 

--- a/tests/benchdnn/utils/engine.cpp
+++ b/tests/benchdnn/utils/engine.cpp
@@ -29,10 +29,32 @@
 #include "oneapi/dnnl/dnnl_ze.hpp"
 #endif
 
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "oneapi/dnnl/dnnl_threadpool.hpp"
+#include "tests/test_thread.hpp"
+#endif
+
 // Engine kind used to run oneDNN primitives for testing
 dnnl_engine_kind_t engine_tgt_kind = dnnl_cpu;
 // Engine index used to run oneDNN primitives for testing
 size_t engine_index = 0;
+
+const engine_t &get_test_engine() {
+    static const engine_t instance(engine_tgt_kind);
+    assert((engine_tgt_kind == dnnl_cpu && instance.is_cpu())
+            || (engine_tgt_kind == dnnl_gpu && instance.is_gpu()));
+    return instance;
+}
+
+const engine_t &get_cpu_engine() {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_NONE
+    // In case of lacking CPU engine, just re-use testing one.
+    return get_test_engine();
+#else
+    static const engine_t instance(dnnl_cpu);
+    return instance;
+#endif
+}
 
 namespace {
 void maybe_print_cpu_engine_error_message() {
@@ -129,4 +151,74 @@ bool engine_t::is_cpu() const {
 
 bool engine_t::is_gpu() const {
     return get_kind() == dnnl::engine::kind::gpu;
+}
+
+bool is_cpu(const engine_t &engine) {
+    return engine.is_cpu();
+}
+
+bool is_gpu(const engine_t &engine) {
+    return engine.is_gpu();
+}
+
+bool is_async(const engine_t &engine) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    if (is_cpu(engine))
+        return dnnl::testing::get_threadpool()->get_flags()
+                & dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS;
+#else
+    if (is_cpu(engine)) return DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL;
+#endif
+    // all supported GPU runtimes are async
+    return is_gpu(engine);
+}
+
+bool is_sycl_engine(const engine_t &engine) {
+    if (is_cpu(engine)) return DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL;
+    if (is_gpu(engine)) return DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL;
+    return false;
+}
+
+bool is_opencl_engine(const engine_t &engine) {
+    if (is_gpu(engine)) return DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL;
+    return false;
+}
+
+bool is_ze_engine(const engine_t &engine) {
+    if (is_gpu(engine)) return DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE;
+    return false;
+}
+
+bool is_nvidia_gpu(const engine_t &engine) {
+#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
+    if (!is_gpu(engine)) return false;
+    constexpr int nvidia_vendor_id = 0x10DE;
+    auto eng = dnnl::engine(engine, true);
+    auto device = dnnl::sycl_interop::get_device(eng);
+    const auto eng_vendor_id
+            = device.get_info<::sycl::info::device::vendor_id>();
+    return eng_vendor_id == nvidia_vendor_id;
+#endif
+    return false;
+}
+
+bool is_amd_gpu(const engine_t &engine) {
+#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR == DNNL_VENDOR_AMD
+    if (!is_gpu(engine)) return false;
+    constexpr int amd_vendor_id = 0x1002;
+    auto eng = dnnl::engine(engine, true);
+    auto device = dnnl::sycl_interop::get_device(eng);
+    const auto eng_vendor_id
+            = device.get_info<::sycl::info::device::vendor_id>();
+    return eng_vendor_id == amd_vendor_id;
+#endif
+    return false;
+}
+
+bool is_generic_gpu(const engine_t &engine) {
+#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR == DNNL_VENDOR_GENERIC
+    return is_gpu(engine);
+#endif
+
+    return false;
 }

--- a/tests/benchdnn/utils/engine.cpp
+++ b/tests/benchdnn/utils/engine.cpp
@@ -1,0 +1,132 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "utils/engine.hpp"
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include "oneapi/dnnl/dnnl_ocl.hpp"
+#endif
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL \
+        || DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+#include "oneapi/dnnl/dnnl_sycl.hpp"
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
+#include "oneapi/dnnl/dnnl_ze.hpp"
+#endif
+
+// Engine kind used to run oneDNN primitives for testing
+dnnl_engine_kind_t engine_tgt_kind = dnnl_cpu;
+// Engine index used to run oneDNN primitives for testing
+size_t engine_index = 0;
+
+namespace {
+void maybe_print_cpu_engine_error_message() {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
+    fprintf(stderr,
+            "ERROR: can't create CPU engine. Possible reasons for this error:\n"
+            "- Incorrect SYCL_DEVICE_FILTER. The filter must be either unset "
+            "or include 'opencl:cpu' devices.\n"
+            "- Missing TBB library which is required for OpenCL CPU runtime. "
+            "Check that TBB library is available in the system.\n"
+            "- Missing OpenCL CPU runtime or other issues with OpenCL CPU "
+            "runtime. Check that output from `sycl-ls` or `clinfo -l` commands "
+            "include any CPU devices.\n");
+#endif
+}
+} // namespace
+
+engine_t::engine_t(dnnl_engine_kind_t engine_kind) {
+    size_t idx = engine_kind == dnnl_cpu ? 0 : engine_index;
+    try {
+        engine_ = dnnl::engine(
+                static_cast<dnnl::engine::kind>(engine_kind), idx);
+    } catch (const dnnl::error &e) {
+        if (engine_kind == dnnl_cpu) maybe_print_cpu_engine_error_message();
+        DNN_SAFE_V(e.status);
+    }
+    if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
+        if (has_bench_mode_bit(mode_bit_t::corr)) {
+            BENCHDNN_PRINT(0, "%s\n",
+                    "Error: the modifier to disable host memory usage "
+                    "cannot be used for correctness testing.");
+            DNN_SAFE_V(dnnl_invalid_arguments);
+        }
+    }
+    // Temporary workaround.
+    // TODO: make mode-modifier=M by default for perf on GPU.
+    // TODO-TODO: make mode-modifier=M by default (including CPU).
+    if (has_bench_mode_bit(mode_bit_t::perf) && engine_kind == dnnl_gpu) {
+        bench_mode_modifier |= mode_modifier_t::no_ref_memory;
+    }
+}
+
+engine_t::engine_t(dnnl_engine_t engine) : engine_(engine, /* weak = */ true) {}
+
+engine_t::engine_t(const dnnl::engine &engine) : engine_(engine) {}
+
+engine_t::engine_t(const engine_t &other, bool recreate_on_copy) {
+    if (!recreate_on_copy) {
+        engine_ = other.engine_;
+        return;
+    }
+
+    if (other.is_cpu()) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
+        engine_ = dnnl::sycl_interop::make_engine(
+                dnnl::sycl_interop::get_device(other.engine_),
+                dnnl::sycl_interop::get_context(other.engine_));
+#else
+        engine_ = dnnl::engine(dnnl::engine::kind::cpu, 0);
+#endif
+    } else if (other.is_gpu()) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+        engine_ = dnnl::ocl_interop::make_engine(
+                dnnl::ocl_interop::get_device(other.engine_),
+                dnnl::ocl_interop::get_context(other.engine_));
+#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+        engine_ = dnnl::sycl_interop::make_engine(
+                dnnl::sycl_interop::get_device(other.engine_),
+                dnnl::sycl_interop::get_context(other.engine_));
+#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
+        engine_ = dnnl::ze_interop::make_engine(
+                dnnl::ze_interop::get_driver(other.engine_),
+                dnnl::ze_interop::get_device(other.engine_),
+                dnnl::ze_interop::get_context(other.engine_));
+#else
+        assert(!"unsupported GPU runtime");
+#endif
+    } else {
+        assert(!"unsupported engine kind");
+    }
+}
+
+dnnl::engine::kind engine_t::get_kind() const {
+    // An empty engine (e.g., a host scalar memory carries no engine) returns
+    // `any` kind.
+    if (engine_.get(/* allow_empty = */ true) == nullptr)
+        return dnnl::engine::kind::any;
+    return engine_.get_kind();
+}
+
+bool engine_t::is_cpu() const {
+    return get_kind() == dnnl::engine::kind::cpu;
+}
+
+bool engine_t::is_gpu() const {
+    return get_kind() == dnnl::engine::kind::gpu;
+}

--- a/tests/benchdnn/utils/engine.hpp
+++ b/tests/benchdnn/utils/engine.hpp
@@ -81,4 +81,21 @@ private:
     dnnl::engine engine_;
 };
 
+// Engine used to run oneDNN primitives for testing.
+const engine_t &get_test_engine();
+
+// Engine used to run all reference native implementations and CPU
+// implementations used by `--fast-ref` option.
+const engine_t &get_cpu_engine();
+
+bool is_cpu(const engine_t &engine = get_test_engine());
+bool is_gpu(const engine_t &engine = get_test_engine());
+bool is_async(const engine_t &engine = get_test_engine());
+bool is_sycl_engine(const engine_t &engine = get_test_engine());
+bool is_opencl_engine(const engine_t &engine = get_test_engine());
+bool is_ze_engine(const engine_t &engine = get_test_engine());
+bool is_nvidia_gpu(const engine_t &engine = get_test_engine());
+bool is_amd_gpu(const engine_t &engine = get_test_engine());
+bool is_generic_gpu(const engine_t &engine = get_test_engine());
+
 #endif

--- a/tests/benchdnn/utils/engine.hpp
+++ b/tests/benchdnn/utils/engine.hpp
@@ -1,0 +1,84 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef UTILS_ENGINE_HPP
+#define UTILS_ENGINE_HPP
+
+#include "oneapi/dnnl/dnnl.hpp"
+
+#include "common.hpp"
+#include "dnnl_debug.hpp"
+
+#define DNN_SAFE(f, s) \
+    do { \
+        dnnl_status_t status__ = f; \
+        if (status__ != dnnl_success) { \
+            if ((s) == CRIT || (s) == WARN) { \
+                BENCHDNN_PRINT(0, \
+                        "Error: Function '%s' at (%s:%d) returned '%s'\n", \
+                        __FUNCTION__, __FILE__, __LINE__, \
+                        status2str(status__)); \
+                fflush(0); \
+                if ((s) == CRIT) exit(2); \
+            } \
+            return FAIL; \
+        } \
+    } while (0)
+
+#define DNN_SAFE_V(f) \
+    do { \
+        dnnl_status_t status__ = (f); \
+        if (status__ != dnnl_success) { \
+            BENCHDNN_PRINT(0, \
+                    "Error: Function '%s' at (%s:%d) returned '%s'\n", \
+                    __FUNCTION__, __FILE__, __LINE__, status2str(status__)); \
+            fflush(0); \
+            exit(2); \
+        } \
+    } while (0)
+
+// Unlike `DNN_SAFE` this one returns `dnnl_status_t`, not `OK/FAIL`.
+#define DNN_SAFE_STATUS(f) \
+    do { \
+        dnnl_status_t status__ = (f); \
+        if (status__ != dnnl_success) { return status__; } \
+    } while (0)
+
+extern dnnl_engine_kind_t engine_tgt_kind;
+extern size_t engine_index;
+
+struct engine_t {
+    engine_t(dnnl_engine_kind_t engine_kind);
+    engine_t(dnnl_engine_t engine);
+    engine_t(const dnnl::engine &engine);
+    // `recreate_on_copy=true` forces to construct a brand new engine_t object
+    // with underlying interop objects from `other`.
+    // When `recreate_on_copy=false`, copy follows a weak_ptr semantics that
+    // `dnnl::engine` provides.
+    engine_t(const engine_t &other, bool recreate_on_copy = false);
+    operator dnnl_engine_t() const { return engine_.get(); }
+    operator const dnnl::engine &() const { return engine_; }
+
+    bool is_cpu() const;
+    bool is_gpu() const;
+
+private:
+    dnnl::engine::kind get_kind() const;
+    engine_t &operator=(engine_t &other) = delete;
+    dnnl::engine engine_;
+};
+
+#endif

--- a/tests/benchdnn/utils/stream_kind.cpp
+++ b/tests/benchdnn/utils/stream_kind.cpp
@@ -16,6 +16,17 @@
 
 #include "utils/stream_kind.hpp"
 #include "common.hpp"
+#include "utils/bench_mode.hpp"
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "oneapi/dnnl/dnnl_threadpool.hpp"
+
+#include "utils/dnnl_query.hpp"
+
+#include "tests/test_thread.hpp"
+
+#include <thread>
+#endif
 
 stream_kind_t default_stream_kind {stream_kind_t::def};
 stream_kind_t stream_kind {default_stream_kind};
@@ -64,4 +75,63 @@ std::ostream &operator<<(std::ostream &s, stream_kind_t stream_kind) {
     if (stream_kind == stream_kind_t::out_of_order) s << "out_of_order";
 
     return s;
+}
+
+stream_t::stream_t(const engine_t &engine, void *interop_obj) {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    if (is_cpu(engine)) {
+        auto tp = static_cast<dnnl::threadpool_interop::threadpool_iface *>(
+                interop_obj);
+        if (tp == nullptr) tp = dnnl::testing::get_threadpool();
+        stream_ = dnnl::threadpool_interop::make_stream(engine, tp);
+        return;
+    }
+#endif
+
+    const bool use_profiling = has_bench_mode_bit(mode_bit_t::perf)
+            && is_gpu(engine) && !is_nvidia_gpu(engine) && !is_amd_gpu(engine);
+    const auto flags = static_cast<dnnl::stream::flags>(
+            stream_kind2stream_flags(stream_kind, use_profiling));
+    stream_ = dnnl::stream(engine, flags);
+}
+
+stream_staller_t::stream_staller_t(stream_t &stream) {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    auto eng = query_engine(stream);
+    auto eng_kind = query_engine_kind(eng);
+    if (eng_kind != dnnl_cpu) return;
+
+    auto tp = dnnl::threadpool_interop::get_threadpool(stream);
+
+    // `tp` is not expected to be empty for CPU streams with threadpol runtime.
+    if (!tp) SAFE_V(FAIL);
+
+    // Only relevant for asynchronous threadpool, synchronous will
+    // deadlock.
+    if (tp->get_flags()
+            != dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS)
+        return;
+
+    // Each thread from the threadpool should get the task to be stalled.
+    const int num_tasks = tp->get_num_threads();
+
+    // The main thread must be let through, otherwise it deadlocks as
+    // task submission won't happen.
+    std::thread::id main_thr_id = std::this_thread::get_id();
+
+    // Shared future allows to pass all waiting threads at once inside the
+    // palallel call.
+    std::shared_future<void> fut(prom_.get_future());
+
+    tp->parallel_for(num_tasks, [=](int, int) {
+        std::thread::id id_thr = std::this_thread::get_id();
+        if (id_thr != main_thr_id) fut.wait();
+    });
+#endif
+}
+
+void stream_staller_t::release() {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    prom_.set_value();
+#endif
 }

--- a/tests/benchdnn/utils/stream_kind.hpp
+++ b/tests/benchdnn/utils/stream_kind.hpp
@@ -17,9 +17,13 @@
 #ifndef UTILS_STREAM_KIND_HPP
 #define UTILS_STREAM_KIND_HPP
 
-#include <sstream>
+#include "oneapi/dnnl/dnnl.hpp"
 
-#include "oneapi/dnnl/dnnl_types.h"
+#include "common.hpp"
+#include "utils/engine.hpp"
+
+#include <future>
+#include <sstream>
 
 enum class stream_kind_t {
     // The library-defined stream kind.
@@ -37,5 +41,34 @@ dnnl_stream_flags_t stream_kind2stream_flags(
 stream_kind_t str2stream_kind(const char *str);
 
 std::ostream &operator<<(std::ostream &s, stream_kind_t stream_kind);
+
+struct stream_t {
+    stream_t() = default;
+    stream_t(const engine_t &engine, void *interop_obj = nullptr);
+    operator dnnl_stream_t() const {
+        return stream_.get(/* allow_empty = */ true);
+    }
+    operator dnnl::stream &() { return stream_; }
+    // Wrapper over dnnl::stream::wait() to avoid explicit casts to dnnl::stream
+    // at graph driver call sites.
+    void wait() { stream_.wait(); }
+    stream_t &operator=(stream_t &&rhs) = default;
+
+private:
+    BENCHDNN_DISALLOW_COPY_AND_ASSIGN(stream_t);
+    dnnl::stream stream_;
+};
+
+struct stream_staller_t {
+    // Enqueue tasks to stall a primitive execution tasks for asynchronous
+    // threadpool runtime. For rest runtimes does nothing.
+    stream_staller_t(stream_t &stream);
+
+    // A signal the submission has completed and ready for execution.
+    void release();
+
+private:
+    std::promise<void> prom_;
+};
 
 #endif

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -336,7 +336,7 @@ public:
         }
 
         barrier_init();
-        workers_.reset(new std::vector<worker_data>(num_threads_));
+        workers_.reset(new std::vector<worker_data_t>(num_threads_));
         for (int i = 0; i < num_threads_; i++) {
             auto wd = &workers_->at(i);
             wd->thread_id = i;
@@ -346,7 +346,7 @@ public:
         barrier_wait();
     }
 
-    virtual ~threadpool_t() {
+    ~threadpool_t() override {
         std::unique_lock<std::mutex> l(master_mutex_);
         barrier_init();
         task_submit(nullptr, 0);
@@ -355,13 +355,13 @@ public:
         barrier_wait();
     }
 
-    virtual int get_num_threads() const { return num_threads_; }
+    int get_num_threads() const override { return num_threads_; }
 
-    virtual bool get_in_parallel() const { return worker_self() != nullptr; }
+    bool get_in_parallel() const override { return worker_self() != nullptr; }
 
-    virtual uint64_t get_flags() const { return 0; }
+    uint64_t get_flags() const override { return 0; }
 
-    virtual void parallel_for(int n, const task_func &fn) {
+    void parallel_for(int n, const task_func &fn) override {
         if (worker_self() != nullptr)
             task_execute(0, 1, &fn, n);
         else {
@@ -379,27 +379,27 @@ private:
     std::mutex master_mutex_;
     std::mutex master_submit_mutex_;
 
-    struct worker_data {
+    struct worker_data_t {
         int thread_id;
         threadpool_t *tp;
         std::condition_variable cv;
         std::unique_ptr<std::thread> thread;
     };
-    std::unique_ptr<std::vector<worker_data>> workers_;
-    static thread_local worker_data *worker_self_;
-    worker_data *worker_self() const {
+    std::unique_ptr<std::vector<worker_data_t>> workers_;
+    static thread_local worker_data_t *worker_self_;
+    worker_data_t *worker_self() const {
         return worker_self_ != nullptr && worker_self_->tp == this
                 ? worker_self_
                 : nullptr;
     }
 
-    struct task_data {
+    struct task_data_t {
         std::atomic<int> go_flag;
         const task_func *fn;
         int n;
     };
     int master_sense_;
-    task_data tasks_[2];
+    task_data_t tasks_[2];
 
     dnnl::impl::counting_barrier_t barrier_;
 
@@ -432,7 +432,7 @@ private:
         }
     }
 
-    static void worker_loop(worker_data *wd) {
+    static void worker_loop(worker_data_t *wd) {
         worker_self_ = wd;
         int worker_sense = 0;
 
@@ -455,7 +455,7 @@ private:
     }
 };
 
-thread_local threadpool_t::worker_data *threadpool_t::worker_self_ = nullptr;
+thread_local threadpool_t::worker_data_t *threadpool_t::worker_self_ = nullptr;
 
 } // namespace testing
 } // namespace dnnl


### PR DESCRIPTION
This starts a series of refactor PRs that aim to remove code duplication between graph driver and rest infrastructure, improve code maintenance through clear module separation in benchdnn, and faster enabling of driver-specific features that require manual update each prb_t abstraction.

The series starts with merging `cpp_engine_t` with `engine_t` and `cpp_stream_t` with `stream_t`. This allows to merge stream_staller_t abstraction, and will allow to consolidate execution_mode logic with further native_graph mode enabling.

`engine_t` start using C++ dnnl::engine version.
The most significant change is constructors and copy constructor which now follow the `weak_ptr` semantics and provide an explicit bool flag for new engine copy to test primitive cache.

Related functions utilizing correspondent types were moved to dedicated files. The will be populated later as now everything sticks to dnnl_common.hpp.