### PR TITLE
cpu: aarch64: respect acc_mode in indirect_gemm:acl conv (requires ACL bump)

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "acl": "v52.7.0",
+        "acl": "v53.1.0",
         "gcc": "13",
         "clang": "17",
         "onednn-base": "v3.11"

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ On a CPU based on Arm AArch64 architecture, oneDNN CPU engine can be built with
 machine learning applications and provides AArch64 optimized implementations
 of core functions. This functionality currently requires that ACL is downloaded
 and built separately. See [Build from Source] section of the Developer Guide for
-details. The minimum supported version of ACL is 52.7.0.
+details. The minimum supported version of ACL is 53.1.0.
 
 [Arm Compute Library (ACL)]: https://github.com/arm-software/ComputeLibrary
 

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -32,8 +32,8 @@ endif()
 find_package(ACL REQUIRED)
 
 # Required. The minimum compatible major-version as per Semantic Versioning.
-set(ACL_MIN_MAJOR_VERSION "52")
-set(ACL_MIN_MINOR_VERSION "7")
+set(ACL_MIN_MAJOR_VERSION "53")
+set(ACL_MIN_MINOR_VERSION "1")
 set(ACL_MIN_VERSION "${ACL_MIN_MAJOR_VERSION}.${ACL_MIN_MINOR_VERSION}")
 
 # Optional. Maximum known compatible version if any.

--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2025 Arm Ltd. and affiliates
+* Copyright 2020-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -277,6 +277,17 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
         if (weights_md.dims[I_dim] % block_by != 0)
             return status::unimplemented;
     }
+
+    // Accumulation is always in f32 unless we are explicitly allowed to
+    // accumulate in f16 for an f16:f16:f16 convolution
+    const bool is_f16_conv = everyone_is(
+            f16, src_d.data_type(), wei_d.data_type(), dst_d.data_type());
+
+    const bool is_lower_acc_allowed
+            = one_of(attr.acc_mode_, accumulation_mode::f16,
+                    accumulation_mode::any, accumulation_mode::relaxed);
+
+    acp.use_fp32_acc = !(is_f16_conv && is_lower_acc_allowed);
 
     CHECK(acl_utils::reorder_to_weight_format(acp.wei_tensor_info, weights_md,
             expected_weight_format, I_dim, O_dim, {W_dim, H_dim}, {}));

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2025 Arm Ltd. and affiliates
+* Copyright 2020-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -59,6 +59,9 @@ struct acl_conv_conf_t {
     arm_compute::WeightsInfo weights_info;
     // Note: this will default to not enabled, and will do nothing
     arm_compute::ActivationLayerInfo act_info;
+    // We may sometimes accumulate in a lower precision if the
+    // accumulation_mode, data_type, and kernel availability allow it
+    bool use_fp32_acc = true;
 };
 
 namespace acl_convolution_utils {

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -43,7 +43,8 @@ status_t acl_indirect_gemm_convolution_fwd_t::init(engine_t *engine) {
             acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
             &acp_.dst_tensor_info,
             arm_compute::Conv2dInfo(acp_.padstride_info, acp_.dilation_info,
-                    acp_.act_info, acp_.fast_math, 1, acp_.weights_info));
+                    acp_.act_info, acp_.fast_math, 1, acp_.weights_info,
+                    acp_.use_fp32_acc));
     acl_obj_->aux_mem_req = acl_obj_->conv.workspace();
     return status::success;
 }
@@ -73,19 +74,13 @@ status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init_conf() {
     int ic = src_md_.dims[1];
     if (acp_.fast_math && ic % block_by == 0) return status::unimplemented;
 
-    // clang-format off
     // NOTE: indirect convolution method supports only nhwc layout.
-    ACL_CHECK_VALID(Op::validate(
-        &acp_.src_tensor_info,
-        &acp_.wei_tensor_info,
-        acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
-        &acp_.dst_tensor_info,
-        arm_compute::Conv2dInfo(acp_.padstride_info,
-                                acp_.dilation_info,
-                                acp_.act_info,
-                                acp_.fast_math,
-                                1, acp_.weights_info)));
-    // clang-format on
+    ACL_CHECK_VALID(Op::validate(&acp_.src_tensor_info, &acp_.wei_tensor_info,
+            acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
+            &acp_.dst_tensor_info,
+            arm_compute::Conv2dInfo(acp_.padstride_info, acp_.dilation_info,
+                    acp_.act_info, acp_.fast_math, 1, acp_.weights_info,
+                    acp_.use_fp32_acc)));
 
     return status::success;
 }
@@ -115,7 +110,8 @@ status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init(engine_t *engine) {
             acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
             &acp_.dst_tensor_info,
             arm_compute::Conv2dInfo(acp_.padstride_info, acp_.dilation_info,
-                    acp_.act_info, acp_.fast_math, 1, acp_.weights_info));
+                    acp_.act_info, acp_.fast_math, 1, acp_.weights_info,
+                    acp_.use_fp32_acc));
 
     auto scratchpad = scratchpad_registry().registrar();
     return init_scratchpad(conv, scratchpad, indirect_conv_keys, engine,


### PR DESCRIPTION
# Description

Makes `indirect_gemm:acl` conv respect the accumulation mode. This requires an ACL bump to [`53.1.0`](https://github.com/ARM-software/ComputeLibrary/releases/tag/v53.1.0).

Fixes #5106

`strict` accumulation (the default, equivalent to `f32` accumulation) and `any` accumulation now dispatch to their relevant kernels:
```
$ ONEDNN_VERBOSE=profile_externals ./build/tests/benchdnn/benchdnn --conv --mode=R --summary=no-impl --attr-acc-mode=strict,any --dir=FWD_I --dt=f16 --stag=acdb --wtag=any --dtag=acdb mb1_ic1oc8_ih3oh3kh3sh1dh0ph1_iw2ow2kw3sw1dw0pw1 | grep 'exec:external'    
onednn_verbose,v1,primitive,exec:external,CpuGemmAssemblyWrapperKernel/sve_ffhybrid_fp16fp32fp16_mla_6x4VL,0.0129395
onednn_verbose,v1,primitive,exec:external,CpuGemmAssemblyWrapperKernel/sve_ffhybrid_fp16_mla_6x4VL,0.00610352
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?