### PR TITLE
build: add ittnotify include path regardless of feature flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,10 +24,8 @@ file(GLOB HEADERS_SUBDIR
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/oneapi/dnnl/*.hpp
     )
 
-if(DNNL_ENABLE_JIT_PROFILING OR DNNL_ENABLE_ITT_TASKS)
-    set(ITTNOTIFY_ROOT "${PROJECT_SOURCE_DIR}/third_party/ittnotify")
-    include_directories_with_host_compiler(${ITTNOTIFY_ROOT})
-endif()
+set(ITTNOTIFY_ROOT "${PROJECT_SOURCE_DIR}/third_party/ittnotify")
+include_directories_with_host_compiler(${ITTNOTIFY_ROOT})
 if(DNNL_GPU_VENDOR STREQUAL "INTEL" AND DNNL_GPU_RUNTIME MATCHES "^(OCL|SYCL|DPCPP)$")
     include_directories_with_host_compiler(${PROJECT_SOURCE_DIR}/third_party/mdapi)
 endif()


### PR DESCRIPTION
# Description

This patch invariably adds the include path of the ittnotify to the build system regardless of the previous flags that guarded against it to correct a bug on RISC-V system under certain build options.

## Reason for this patch

The `src/common/ittnotify.hpp` file unconditionally includes `ittnotify/ittnotify.h`. After the third_party restructuring on PR #5241, a bug was introduced to RISC-V systems when `DNNL_ENABLE_JIT_PROFILING` and `DNNL_ENABLE_ITT_TASKS` are both explicitly disabled during the build.

## Reproducing the bug

To reproduce the issue, build oneDNN for RV64 systems with the following flags:

-DDNNL_TARGET_ARCH='RV64' -DDNNL_ENABLE_JIT_PROFILING=OFF -DDNNL_ENABLE_ITT_TASKS=OFF

The build will fail when compiling the `src/common/ittnotify.cpp` source.

## Rationale

Despite the include directory always being visible, the relevant flags still work on guarding against unwanted behavior. While it would be possible to add guards to the ittynotify.cpp, it would be necessary to add guard to the types defined on ittnotify. The selected fix applies changes only to CMake and reproduces the semantics before PR #5241; having this include path available for this specific module.