### PR TITLE
cpu: platform: aarch64: fall back to guessed cache size when query returns 0

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -18,6 +18,8 @@
 
 #include <thread>
 
+#include "common/verbose.hpp"
+
 #include "cpu/platform.hpp"
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
@@ -287,11 +289,17 @@ unsigned get_per_core_cache_size(int level) {
         const auto &cache_level
                 = static_cast<Xbyak_aarch64::util::Arm64CacheLevel>(level);
 
-        const auto cache_sz = aarch64::cpu().getDataCacheSize(cache_level);
         const auto sharing
                 = aarch64::cpu().getCoresSharingDataCache(cache_level);
-        const auto sz = (cache_sz && sharing) ? cache_sz / sharing : 0;
-        return sz ? sz : guess(level);
+        const auto sz = sharing
+                ? aarch64::cpu().getDataCacheSize(cache_level) / sharing
+                : 0;
+        if (sz) return sz;
+        VWARN(common, common,
+                "unable to query L%d data cache size; falling back to a "
+                "guess, which may affect cache-based heuristics",
+                level);
+        return guess(level);
     } else {
         return guess(level);
     }

--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -287,10 +287,13 @@ unsigned get_per_core_cache_size(int level) {
         const auto &cache_level
                 = static_cast<Xbyak_aarch64::util::Arm64CacheLevel>(level);
 
-        return aarch64::cpu().getDataCacheSize(cache_level)
-                / aarch64::cpu().getCoresSharingDataCache(cache_level);
+        const auto cache_sz = aarch64::cpu().getDataCacheSize(cache_level);
+        const auto sharing
+                = aarch64::cpu().getCoresSharingDataCache(cache_level);
+        const auto sz = (cache_sz && sharing) ? cache_sz / sharing : 0;
+        return sz ? sz : guess(level);
     } else {
-        return 0;
+        return guess(level);
     }
 #else
     return guess(level);


### PR DESCRIPTION
get_per_core_cache_size() returns 0 when the per-level data cache size is unavailable (e.g. /sys exposes no L1d size, common on VMs and containers).

0 size breaks consumers: the reorder planner (prb_block_for_cache) then always forces inner blocking and emits a kernel that drops data for padded blocked weights, and simple_concat always takes its hand-vectorised copy path and overruns its destination buffer (SIGBUS in the int8 concat test).

Return the architectural guess() when the queried size is 0, and guard the divide-by-zero.

Fixes #5313