### PR TITLE
Add proper guards for ITT API headers

### DIFF
--- a/src/common/dnnl_thread.hpp
+++ b/src/common/dnnl_thread.hpp
@@ -44,6 +44,7 @@
 // due to linker optimizations. The newer compiler and C++ standard, the less
 // binary size will be achieved.
 
+// This header needs a guard around ittnotify.hpp as it's used by gtests
 #if defined(DNNL_ENABLE_ITT_TASKS)
 #include "common/ittnotify.hpp"
 #endif

--- a/src/common/dnnl_thread.hpp
+++ b/src/common/dnnl_thread.hpp
@@ -44,10 +44,7 @@
 // due to linker optimizations. The newer compiler and C++ standard, the less
 // binary size will be achieved.
 
-// This header needs a guard around ittnotify.hpp as it's used by gtests
-#if defined(DNNL_ENABLE_ITT_TASKS)
 #include "common/ittnotify.hpp"
-#endif
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ
 #define DNNL_THR_SYNC 1
@@ -275,13 +272,11 @@ static inline void parallel(int nthr, const std::function<void(int, int)> &f) {
         f(i, nthr);
     }
 #else
-#if defined(DNNL_ENABLE_ITT_TASKS)
     auto task_primitive_kind = itt::primitive_task_get_current_kind();
     auto task_primitive_info = itt::primitive_task_get_current_info();
     auto task_primitive_log_kind = itt::primitive_task_get_current_log_kind();
     auto task_primitive_itt_id = itt::primitive_task_get_itt_id();
     bool itt_enable = itt::get_itt(itt::__itt_task_level_high);
-#endif
 #if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
     // Tasks must be always submitted to a threadpool, it will handle them
     // properly.
@@ -296,23 +291,18 @@ static inline void parallel(int nthr, const std::function<void(int, int)> &f) {
         int nthr_ = omp_get_num_threads();
         int ithr_ = omp_get_thread_num();
         assert(nthr_ == nthr);
-#if defined(DNNL_ENABLE_ITT_TASKS)
         if (ithr_ && itt_enable) {
             itt::primitive_task_start(
                     task_primitive_kind, task_primitive_log_kind);
             itt::primitive_add_metadata_and_id(task_primitive_info,
                     task_primitive_log_kind, task_primitive_itt_id);
         }
-#endif
         f(ithr_, nthr_);
-#if defined(DNNL_ENABLE_ITT_TASKS)
         if (ithr_ && itt_enable)
             itt::primitive_task_end(task_primitive_log_kind);
-#endif
     }
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB
     tbb::parallel_for(0, nthr, [&](int ithr) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
         bool mark_task = itt::primitive_task_get_current_kind()
                 == primitive_kind::undefined;
         if (mark_task && itt_enable) {
@@ -321,12 +311,9 @@ static inline void parallel(int nthr, const std::function<void(int, int)> &f) {
             itt::primitive_add_metadata_and_id(task_primitive_info,
                     task_primitive_log_kind, task_primitive_itt_id);
         }
-#endif
         f(ithr, nthr);
-#if defined(DNNL_ENABLE_ITT_TASKS)
         if (mark_task && itt_enable)
             itt::primitive_task_end(task_primitive_log_kind);
-#endif
     }, tbb::static_partitioner());
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
     using namespace dnnl::impl::threadpool_utils;
@@ -339,7 +326,6 @@ static inline void parallel(int nthr, const std::function<void(int, int)> &f) {
         threadpool_utils::activate_threadpool(tp);
     } else {
         tp->parallel_for(nthr, [=](int ithr, int nthr) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
             bool is_master = threadpool_utils::get_active_threadpool() == tp;
             if (!is_master && itt_enable) {
                 itt::primitive_task_start(
@@ -347,13 +333,10 @@ static inline void parallel(int nthr, const std::function<void(int, int)> &f) {
                 itt::primitive_add_metadata_and_id(task_primitive_info,
                         task_primitive_log_kind, task_primitive_itt_id);
             }
-#endif
             f(ithr, nthr);
-#if defined(DNNL_ENABLE_ITT_TASKS)
             if (!is_master && itt_enable) {
                 itt::primitive_task_end(task_primitive_log_kind);
             }
-#endif
         });
     }
 #endif

--- a/src/common/ittnotify.cpp
+++ b/src/common/ittnotify.cpp
@@ -17,18 +17,16 @@
 #include "ittnotify.hpp"
 #include "utils.hpp"
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
-#include "dnnl_debug.h"
-#include "ittnotify/ittnotify.h"
-#endif
-
 namespace dnnl {
 namespace impl {
 namespace itt {
 
+#if defined(DNNL_ENABLE_ITT_TASKS)
 static setting_t<int> itt_task_level {__itt_task_level_high};
+#endif
 
 bool get_itt(__itt_task_level level) {
+#if defined(DNNL_ENABLE_ITT_TASKS)
     if (!itt_task_level.initialized()) {
         // Assumes that all threads see the same environment
         static int val
@@ -36,15 +34,20 @@ bool get_itt(__itt_task_level level) {
         itt_task_level.set(val);
     }
     return level <= itt_task_level.get();
+#else
+    UNUSED(level);
+    return false;
+#endif
 }
 
+#if defined(DNNL_ENABLE_ITT_TASKS)
 __itt_id make_itt_id(const char *tname, double stamp) {
     return __itt_id_make(
             const_cast<char *>(tname), static_cast<uint64_t>(stamp));
 }
+#endif
 
 #if defined(DNNL_ENABLE_ITT_TASKS)
-
 namespace {
 
 thread_local primitive_kind_t thread_primitive_kind;
@@ -72,8 +75,10 @@ __itt_domain *itt_domain(const char *log_kind) {
 }
 
 } // namespace
+#endif
 
 void primitive_task_start(primitive_kind_t kind, const char *log_kind) {
+#if defined(DNNL_ENABLE_ITT_TASKS)
     if (kind == primitive_kind::undefined) return;
     __itt_domain *pd_domain = itt_domain(log_kind);
 #define CASE(x) \
@@ -115,10 +120,15 @@ void primitive_task_start(primitive_kind_t kind, const char *log_kind) {
     }
     thread_primitive_kind = kind;
     thread_primitive_log_kind = log_kind;
+#else
+    UNUSED(kind);
+    UNUSED(log_kind);
+#endif
 }
 
 void primitive_add_metadata_and_id(
-        const char *pd_info, const char *log_kind, __itt_id task_id) {
+        const char *pd_info, const char *log_kind, const __itt_id *task_id) {
+#if defined(DNNL_ENABLE_ITT_TASKS)
     // A separate method for adding metadata and IDs to the primitive ITT tasks
     // provide the option to skip this step during primitive operation to avoid
     // performance impact from construction of very large metadata strings.
@@ -130,27 +140,49 @@ void primitive_add_metadata_and_id(
 
     // While the task ID is unique for each instance of the primitive operation,
     // it is shared across multi-threaded executions of the same instance.
-    thread_primitive_task_id = task_id;
+    thread_primitive_task_id = *task_id;
     __itt_id_create(pd_domain, thread_primitive_task_id);
+#else
+    UNUSED(pd_info);
+    UNUSED(log_kind);
+    UNUSED(task_id);
+#endif
 }
 
 primitive_kind_t primitive_task_get_current_kind() {
+#if defined(DNNL_ENABLE_ITT_TASKS)
     return thread_primitive_kind;
+#else
+    return primitive_kind::undefined;
+#endif
 }
 
 const char *primitive_task_get_current_info() {
+#if defined(DNNL_ENABLE_ITT_TASKS)
     return thread_primitive_info;
+#else
+    return "";
+#endif
 }
 
 const char *primitive_task_get_current_log_kind() {
+#if defined(DNNL_ENABLE_ITT_TASKS)
     return thread_primitive_log_kind;
+#else
+    return "";
+#endif
 }
 
-__itt_id primitive_task_get_itt_id() {
-    return thread_primitive_task_id;
+const __itt_id *primitive_task_get_itt_id() {
+#if defined(DNNL_ENABLE_ITT_TASKS)
+    return &thread_primitive_task_id;
+#else
+    return nullptr;
+#endif
 }
 
 void primitive_task_end(const char *log_kind) {
+#if defined(DNNL_ENABLE_ITT_TASKS)
     if (thread_primitive_kind != primitive_kind::undefined) {
         __itt_task_end(itt_domain(log_kind));
         thread_primitive_kind = primitive_kind::undefined;
@@ -162,25 +194,10 @@ void primitive_task_end(const char *log_kind) {
         __itt_id_destroy(itt_domain(log_kind), thread_primitive_task_id);
         thread_primitive_task_id = __itt_null;
     }
-}
 #else
-void primitive_task_start(primitive_kind_t kind) {
-    UNUSED(kind);
-}
-primitive_kind_t primitive_task_get_current_kind() {
-    return primitive_kind::undefined;
-}
-const char *primitive_task_get_current_info() {
-    return "";
-}
-const char *primitive_task_get_current_log_kind() {
-    return "";
-}
-__itt_id primitive_task_get_itt_id() {
-    return __itt_null;
-}
-void primitive_task_end(const char *log_kind) {}
+    UNUSED(log_kind);
 #endif
+}
 
 } // namespace itt
 } // namespace impl

--- a/src/common/ittnotify.cpp
+++ b/src/common/ittnotify.cpp
@@ -23,10 +23,8 @@ namespace itt {
 
 #if defined(DNNL_ENABLE_ITT_TASKS)
 static setting_t<int> itt_task_level {__itt_task_level_high};
-#endif
 
 bool get_itt(__itt_task_level level) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     if (!itt_task_level.initialized()) {
         // Assumes that all threads see the same environment
         static int val
@@ -34,20 +32,13 @@ bool get_itt(__itt_task_level level) {
         itt_task_level.set(val);
     }
     return level <= itt_task_level.get();
-#else
-    UNUSED(level);
-    return false;
-#endif
 }
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
 __itt_id make_itt_id(const char *tname, double stamp) {
     return __itt_id_make(
             const_cast<char *>(tname), static_cast<uint64_t>(stamp));
 }
-#endif
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
 namespace {
 
 thread_local primitive_kind_t thread_primitive_kind;
@@ -75,10 +66,8 @@ __itt_domain *itt_domain(const char *log_kind) {
 }
 
 } // namespace
-#endif
 
 void primitive_task_start(primitive_kind_t kind, const char *log_kind) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     if (kind == primitive_kind::undefined) return;
     __itt_domain *pd_domain = itt_domain(log_kind);
 #define CASE(x) \
@@ -120,15 +109,10 @@ void primitive_task_start(primitive_kind_t kind, const char *log_kind) {
     }
     thread_primitive_kind = kind;
     thread_primitive_log_kind = log_kind;
-#else
-    UNUSED(kind);
-    UNUSED(log_kind);
-#endif
 }
 
 void primitive_add_metadata_and_id(
         const char *pd_info, const char *log_kind, const __itt_id *task_id) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     // A separate method for adding metadata and IDs to the primitive ITT tasks
     // provide the option to skip this step during primitive operation to avoid
     // performance impact from construction of very large metadata strings.
@@ -142,47 +126,25 @@ void primitive_add_metadata_and_id(
     // it is shared across multi-threaded executions of the same instance.
     thread_primitive_task_id = *task_id;
     __itt_id_create(pd_domain, thread_primitive_task_id);
-#else
-    UNUSED(pd_info);
-    UNUSED(log_kind);
-    UNUSED(task_id);
-#endif
 }
 
 primitive_kind_t primitive_task_get_current_kind() {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     return thread_primitive_kind;
-#else
-    return primitive_kind::undefined;
-#endif
 }
 
 const char *primitive_task_get_current_info() {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     return thread_primitive_info;
-#else
-    return "";
-#endif
 }
 
 const char *primitive_task_get_current_log_kind() {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     return thread_primitive_log_kind;
-#else
-    return "";
-#endif
 }
 
 const __itt_id *primitive_task_get_itt_id() {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     return &thread_primitive_task_id;
-#else
-    return nullptr;
-#endif
 }
 
 void primitive_task_end(const char *log_kind) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
     if (thread_primitive_kind != primitive_kind::undefined) {
         __itt_task_end(itt_domain(log_kind));
         thread_primitive_kind = primitive_kind::undefined;
@@ -194,10 +156,8 @@ void primitive_task_end(const char *log_kind) {
         __itt_id_destroy(itt_domain(log_kind), thread_primitive_task_id);
         thread_primitive_task_id = __itt_null;
     }
-#else
-    UNUSED(log_kind);
-#endif
 }
+#endif // defined(DNNL_ENABLE_ITT_TASKS)
 
 } // namespace itt
 } // namespace impl

--- a/src/common/ittnotify.hpp
+++ b/src/common/ittnotify.hpp
@@ -44,18 +44,77 @@ typedef enum { // NOLINT(modernize-use-using)
 struct itt_task_level_t {
     int level;
 };
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
+__itt_id make_itt_id(const char *tname, double stamp);
+#endif
+
+// Conditional definitions below are used since dnnl_thread.hpp is included in
+// test_thread.hpp and gets pulled into most (all) test sources, which are
+// built without DNNL_ENABLE_ITT_TASKS.
+// Strictly follow this style when adding new entry points.
+
 // Returns `true` if requested @p level is less or equal to default or specified
 // one by env variable.
+#if defined(DNNL_ENABLE_ITT_TASKS)
 bool get_itt(__itt_task_level level);
-__itt_id make_itt_id(const char *tname, double stamp);
+#else
+static inline bool get_itt(__itt_task_level) {
+    return bool();
+}
+#endif
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
 void primitive_task_start(primitive_kind_t kind, const char *log_kind);
+#else
+static inline void primitive_task_start(primitive_kind_t, const char *) {}
+#endif
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
 void primitive_add_metadata_and_id(
         const char *pd_info, const char *log_kind, const __itt_id *task_id);
+#else
+static inline void primitive_add_metadata_and_id(
+        const char *, const char *, const __itt_id *) {}
+#endif
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
 primitive_kind_t primitive_task_get_current_kind();
+#else
+static inline primitive_kind_t primitive_task_get_current_kind() {
+    return primitive_kind_t();
+}
+#endif
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
 void primitive_task_end(const char *log_kind);
+#else
+static inline void primitive_task_end(const char *) {}
+#endif
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
 const char *primitive_task_get_current_info();
+#else
+static inline const char *primitive_task_get_current_info() {
+    return nullptr;
+}
+#endif
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
 const char *primitive_task_get_current_log_kind();
+#else
+static inline const char *primitive_task_get_current_log_kind() {
+    return nullptr;
+}
+#endif
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
 const __itt_id *primitive_task_get_itt_id();
+#else
+static inline const __itt_id *primitive_task_get_itt_id() {
+    return nullptr;
+}
+#endif
 } // namespace itt
 } // namespace impl
 } // namespace dnnl

--- a/src/common/ittnotify.hpp
+++ b/src/common/ittnotify.hpp
@@ -19,7 +19,15 @@
 
 #include "c_types_map.hpp"
 #include "dnnl.h"
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
+#include "dnnl_debug.h"
 #include "ittnotify/ittnotify.h"
+#else
+// Forward declaration of the ITT id type defined in ittnotify/ittnotify.h.
+struct ___itt_id; // NOLINT
+typedef struct ___itt_id __itt_id; // NOLINT
+#endif
 
 namespace dnnl {
 namespace impl {
@@ -42,13 +50,14 @@ bool get_itt(__itt_task_level level);
 __itt_id make_itt_id(const char *tname, double stamp);
 void primitive_task_start(primitive_kind_t kind, const char *log_kind);
 void primitive_add_metadata_and_id(
-        const char *pd_info, const char *log_kind, __itt_id task_id);
+        const char *pd_info, const char *log_kind, const __itt_id *task_id);
 primitive_kind_t primitive_task_get_current_kind();
 void primitive_task_end(const char *log_kind);
 const char *primitive_task_get_current_info();
 const char *primitive_task_get_current_log_kind();
-__itt_id primitive_task_get_itt_id();
+const __itt_id *primitive_task_get_itt_id();
 } // namespace itt
 } // namespace impl
 } // namespace dnnl
+
 #endif

--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -19,9 +19,7 @@
 #include "c_types_map.hpp"
 #include "engine.hpp"
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
 #include "ittnotify.hpp"
-#endif
 
 #include "cache_hit_types.hpp"
 #include "primitive.hpp"
@@ -65,13 +63,11 @@ status_t primitive_create(primitive_iface_t **primitive_iface,
 
     std::pair<primitive_iface_t *, cache_state_t> p_iface;
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
     const bool enable_itt = itt::get_itt(itt::__itt_task_level_low);
     if (enable_itt) {
         itt::primitive_task_start(
                 primitive_desc_iface->impl()->kind(), VERBOSE_create);
     }
-#endif
 
     if (get_verbose(verbose_t::create_profile,
                 prim_kind2_comp_kind(primitive_desc_iface->impl()->kind()))) {
@@ -93,7 +89,6 @@ status_t primitive_create(primitive_iface_t **primitive_iface,
                 p_iface, cache_blob));
     }
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
     if (enable_itt) {
         // Before metadata is added to the ITT task, the `info()` string is
         // checked for initialization.
@@ -104,15 +99,16 @@ status_t primitive_create(primitive_iface_t **primitive_iface,
         const char *pd_info = p_iface.first->pd()->impl()->info(
                 primitive_desc_iface->engine(), false);
         if ((p_iface.second == cache_state_t::miss) || (pd_info && *pd_info)) {
-            auto task_id
+#if defined(DNNL_ENABLE_ITT_TASKS)
+            const __itt_id task_id
                     = itt::make_itt_id(p_iface.first->pd()->info(), get_msec());
             itt::primitive_add_metadata_and_id(
-                    p_iface.first->pd()->info(), VERBOSE_create, task_id);
+                    p_iface.first->pd()->info(), VERBOSE_create, &task_id);
+#endif
         }
 
         itt::primitive_task_end(VERBOSE_create);
     }
-#endif
 
     return safe_ptr_assign((*primitive_iface), p_iface.first);
 }
@@ -123,7 +119,6 @@ status_t primitive_execute(
     status_t status = success;
     auto pd = primitive_iface->pd();
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
     const bool enable_itt = itt::get_itt(itt::__itt_task_level_low);
     if (enable_itt) {
         itt::primitive_task_start(pd->impl()->kind(), VERBOSE_exec);
@@ -136,14 +131,15 @@ status_t primitive_execute(
         const auto *pd_info
                 = pd->impl()->info(primitive_iface->engine(), false);
         if (pd_info && *pd_info) {
+#if defined(DNNL_ENABLE_ITT_TASKS)
             // ITT task IDs are uniquely assigned using pd->info() and
             // timestamps - the timestamps helps distinguish between different
             // instances of the same configuration
-            auto task_id = itt::make_itt_id(pd_info, get_msec());
-            itt::primitive_add_metadata_and_id(pd_info, VERBOSE_exec, task_id);
+            const __itt_id task_id = itt::make_itt_id(pd_info, get_msec());
+            itt::primitive_add_metadata_and_id(pd_info, VERBOSE_exec, &task_id);
+#endif
         }
     }
-#endif
 
     if (get_verbose(verbose_t::exec_profile,
                 prim_kind2_comp_kind(pd->impl()->kind()))) {
@@ -189,9 +185,7 @@ status_t primitive_execute(
         status = stream->enqueue_primitive(primitive_iface, ctx);
     }
 
-#if defined(DNNL_ENABLE_ITT_TASKS)
     if (enable_itt) itt::primitive_task_end(VERBOSE_exec);
-#endif
 
     if (msan_enabled) unpoison_outputs(ctx.args());
 

--- a/tests/test_thread.hpp
+++ b/tests/test_thread.hpp
@@ -69,6 +69,8 @@ struct thr_ctx_t {
 // At the same time, the calls to dnnl::impl::parallel*() from within the
 // library continue using the library version of these functions.
 #define threadpool_utils testing_threadpool_utils
+// Prohibit ITT API instrumentation
+#undef DNNL_ENABLE_ITT_TASKS
 #include "src/common/dnnl_thread.hpp"
 #undef threadpool_utils
 


### PR DESCRIPTION
Before #5241 we unconditionally included ITT API headers in `common/ittnotify.hpp`. Introduced changes resulted in build failing when `DNNL_ENABLE_JIT_PROFILING=OFF` or `DNNL_ENABLE_ITT_TASKS=OFF`. This PR adds proper guards to avoid including ITT API headers when they are not needed.

Supersedes #5312
