### PR TITLE
[GPU] Disable zero-pool usage during SYCL graph recording

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -239,6 +239,7 @@ enum {
     key_gemm_blocked_a,
     key_gemm_blocked_b,
     key_gemm_accumulator,
+    key_gemm_zero_buffer,
     key_gemm_interleaved_lhs,
     key_gemm_mm_result_s32,
     key_gemm_mm_signed_a,

--- a/src/gpu/intel/compute/zero_pool.cpp
+++ b/src/gpu/intel/compute/zero_pool.cpp
@@ -149,12 +149,8 @@ status_t zero_pool_t::claim(intel::stream_t *stream, size_t len,
 
     if (!inited_) {
         // One-time zero initialization before first use.
-        // Use immediate mode to ensure zero initialization
-        //   occurs now and is not recorded.
-        CHECK(stream->enter_immediate_mode());
         CHECK(stream->fill(*mem_, 0, chunk_count_ * chunk_size_,
                 stream->ctx().get_deps(), stream->ctx().get_deps()));
-        CHECK(stream->exit_immediate_mode());
         inited_ = true;
     }
 

--- a/src/gpu/intel/compute/zero_pool.cpp
+++ b/src/gpu/intel/compute/zero_pool.cpp
@@ -19,10 +19,6 @@
 
 #include "gpu/intel/compute/zero_pool.hpp"
 
-#ifdef DNNL_WITH_SYCL
-#include "gpu/intel/sycl/stream.hpp"
-#endif
-
 namespace dnnl {
 namespace impl {
 namespace gpu {
@@ -30,20 +26,6 @@ namespace intel {
 
 static std::unordered_map<engine_id_t, zero_pool_t *> zero_pool_cache;
 static std::mutex zero_pool_cache_mutex;
-
-#ifdef DNNL_WITH_SYCL
-// Unfortunately, weak_ptrs cannot be hashed, so unordered_map not possible here.
-// SYCL is currently missing owner_less for command graphs, so define it ourselves.
-struct weak_graph_owner_less_t {
-    bool operator()(const sycl::stream_t::weak_graph_t &lhs,
-            const sycl::stream_t::weak_graph_t &rhs) const noexcept {
-        return lhs.owner_before(rhs);
-    }
-};
-static std::map<sycl::stream_t::weak_graph_t, zero_pool_t *,
-        weak_graph_owner_less_t>
-        recorded_zero_pool_cache;
-#endif
 
 struct cleanup_sentinel_t {
     cleanup_sentinel_t(bool *ptr) : ptr_(ptr) {}
@@ -64,38 +46,12 @@ static bool in_cleanup() {
     return destroyed;
 }
 
-status_t lookup_zero_pool(intel::engine_t *engine, intel::stream_t *stream,
-        size_t chunk_size, zero_pool_t **out_pool) {
+status_t lookup_zero_pool(
+        intel::engine_t *engine, size_t chunk_size, zero_pool_t **out_pool) {
     status_t status = status::success;
 
     (void)in_cleanup();
 
-#ifdef DNNL_WITH_SYCL
-    // If recording, get a per-graph zero pool.
-    const auto *sycl_stream
-            = utils::downcast<const gpu::intel::sycl::stream_t *>(stream);
-    if (sycl_stream && sycl_stream->recording()) {
-        {
-            std::lock_guard<std::mutex> lock(zero_pool_cache_mutex);
-            auto &pool = recorded_zero_pool_cache
-                    [sycl_stream->get_current_graph_weak()];
-            if (!pool) {
-                pool = new zero_pool_t(engine, chunk_size, true,
-                        stream->flags() & stream_flags::in_order);
-                status = pool->init();
-
-                // Short-term hack: intentionally leak pool as
-                //  we cannot know when graph is no longer in use.
-                pool->attach_client();
-            }
-            *out_pool = pool;
-        }
-        (*out_pool)->attach_client();
-        return status;
-    }
-#endif
-
-    // In regular mode, find a per-engine zero pool.
     auto engine_id = engine->engine_id();
 
     {
@@ -133,13 +89,8 @@ void release_zero_pool(zero_pool_t *pool) {
     }
 }
 
-zero_pool_t::zero_pool_t(intel::engine_t *engine, size_t chunk_size,
-        bool stream_private, bool in_order)
-    : engine_(engine)
-    , chunk_size_(chunk_size)
-    , chunk_count_(stream_private ? 1 : 16)
-    , stream_private_(stream_private)
-    , in_order_(in_order) {
+zero_pool_t::zero_pool_t(intel::engine_t *engine, size_t chunk_size)
+    : engine_(engine), chunk_size_(chunk_size), chunk_count_(16) {
 
     assert(chunk_count_ <= max_chunks);
 }
@@ -210,16 +161,13 @@ status_t zero_pool_t::claim(intel::stream_t *stream, size_t len,
     auto slot = next_slot_++;
     if (next_slot_ >= chunk_count_) next_slot_ = 0;
 
-    if (!stream_private_ && event_pending_[slot]) {
+    if (event_pending_[slot]) {
         // Rare case: another thread claimed this slot but has not yet registered a completion event for it.
         // No choice but to create a temporary allocation (or yield and wait for the completion event).
         return claim_unpooled(stream, len, out_mem);
     }
 
-    if (stream_private_) {
-        // Per-stream zero pool. No event synchronization needed.
-        if (!in_order_) CHECK(stream->barrier());
-    } else if (events_[slot]) {
+    if (events_[slot]) {
         // Slot is claimed and has an outstanding event. Wait on it and delete it.
         stream->ctx().append_deps(*events_[slot]);
         events_[slot].reset();
@@ -236,7 +184,7 @@ void zero_pool_t::async_release(int token, const xpu::event_t &ev) {
     if (token >= 0) {
         std::lock_guard<std::mutex> lock(mutex_);
         int slot = token;
-        if (!stream_private_) events_[slot] = ev.clone();
+        events_[slot] = ev.clone();
         event_pending_[slot] = false;
     }
 }

--- a/src/gpu/intel/compute/zero_pool.hpp
+++ b/src/gpu/intel/compute/zero_pool.hpp
@@ -72,6 +72,10 @@ status_t lookup_zero_pool(intel::engine_t *engine, intel::stream_t *stream,
         size_t chunk_size, zero_pool_t **out_pool);
 void release_zero_pool(zero_pool_t *pool);
 
+inline bool use_zero_pool() {
+    return true;
+}
+
 } // namespace intel
 } // namespace gpu
 } // namespace impl

--- a/src/gpu/intel/compute/zero_pool.hpp
+++ b/src/gpu/intel/compute/zero_pool.hpp
@@ -31,8 +31,7 @@ namespace intel {
 
 class zero_pool_t {
 public:
-    zero_pool_t(intel::engine_t *engine, size_t chunk_size,
-            bool stream_private = false, bool in_order = false);
+    zero_pool_t(intel::engine_t *engine, size_t chunk_size);
 
     status_t init();
 
@@ -54,8 +53,6 @@ private:
     std::unique_ptr<memory_storage_t> mem_;
     size_t chunk_size_ = 0;
     int chunk_count_ = 0;
-    bool stream_private_ = false;
-    bool in_order_ = false;
     int clients_ = 0;
     int next_slot_ = 0;
     bool inited_ = false;
@@ -68,8 +65,8 @@ private:
             std::unique_ptr<memory_storage_t> &out_mem);
 };
 
-status_t lookup_zero_pool(intel::engine_t *engine, intel::stream_t *stream,
-        size_t chunk_size, zero_pool_t **out_pool);
+status_t lookup_zero_pool(
+        intel::engine_t *engine, size_t chunk_size, zero_pool_t **out_pool);
 void release_zero_pool(zero_pool_t *pool);
 
 inline bool use_zero_pool() {

--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -51,14 +51,39 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         const memory_storage_t *b_scales, const memory_storage_t *c_scales,
         const memory_storage_t *ag, const memory_storage_t *bg,
         const memory_storage_t &co, int16_t co_host_scalar,
-        const memory_storage_t *c_temp, const memory_storage_t *sround_seed,
-        int po_count, const memory_storage_t **po_srcs, int64_t offset_a,
-        int64_t offset_b, int64_t offset_c, int64_t offset_aq,
-        int64_t offset_bq, int64_t offset_co, int64_t *offset_po_src,
-        int32_t lda, int32_t ldb, int32_t ldc, int32_t m, int32_t n, int32_t k,
-        int32_t k0, float alpha, float beta, int32_t cmask, bool last_k_block,
-        bool swap_ab, bool disable_hilbert) const {
+        const memory_storage_t *c_temp,
+        const memory_storage_t *zero_buf_scratchpad,
+        const memory_storage_t *sround_seed, int po_count,
+        const memory_storage_t **po_srcs, int64_t offset_a, int64_t offset_b,
+        int64_t offset_c, int64_t offset_aq, int64_t offset_bq,
+        int64_t offset_co, int64_t *offset_po_src, int32_t lda, int32_t ldb,
+        int32_t ldc, int32_t m, int32_t n, int32_t k, int32_t k0, float alpha,
+        float beta, int32_t cmask, bool last_k_block, bool swap_ab,
+        bool disable_hilbert) const {
     if (pd()->desc()->batch() == 0) return status::success;
+
+    std::unique_ptr<memory_storage_t> zeros;
+    const memory_storage_t *zero_buf = nullptr;
+    int zp_token = 0;
+    if (nocopy_info()->fusedBeta() || nocopy_info()->fusedPostOps()) {
+        if (zero_pool) {
+            CHECK(zero_pool->claim(
+                    compute_stream, zero_buffer_bytes_, zeros, &zp_token));
+            zero_buf = zeros.get();
+        } else {
+            zero_buf = zero_buf_scratchpad;
+            auto nelems = uint32_t(zero_buffer_bytes_ / sizeof(uint32_t));
+            compute::kernel_arg_list_t zero_arg_list;
+            zero_arg_list.set(0, *zero_buf);
+            zero_arg_list.set(1, nelems);
+            compute::range_t zero_gws = {size_t(nelems)};
+            compute::range_t zero_lws
+                    = {size_t(std::min(256, (int)utils::max_pow2_div(nelems)))};
+            auto zero_nd_range = compute::nd_range_t(zero_gws, zero_lws);
+            CHECK(parallel_for(
+                    ctx, zero_nd_range, zero_fill_kernel_, zero_arg_list));
+        }
+    }
 
     uint32_t flags = 0;
     bool k_parallel_fixed
@@ -163,12 +188,8 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
             arg_list.set(argn++, int32_t(pd()->ld_binary(i)));
     }
 
-    std::unique_ptr<memory_storage_t> zeros;
-    int zp_token = 0;
     if (nocopy_info()->fusedBeta() || nocopy_info()->fusedPostOps()) {
-        CHECK(zero_pool->claim(
-                compute_stream, zero_pool_bytes_, zeros, &zp_token));
-        arg_list.set(argn++, *zeros);
+        arg_list.set(argn++, *zero_buf);
     }
 
     if (pd()->batch_dims() >= 1) {
@@ -330,7 +351,8 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
     auto nd_range = compute::nd_range_t(gws, lws);
     auto status = parallel_for(ctx, nd_range, nocopy_kernel_, arg_list);
 
-    if (nocopy_info()->fusedBeta() || nocopy_info()->fusedPostOps())
+    if (zero_pool
+            && (nocopy_info()->fusedBeta() || nocopy_info()->fusedPostOps()))
         zero_pool->async_release(zp_token, compute_stream->ctx().get_deps());
 
     return status;
@@ -342,18 +364,12 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
     auto zero_pool = zero_pool_;
 
 #ifdef DNNL_WITH_SYCL
-    bool release_zp = false;
     const auto *sycl_stream
             = utils::downcast<const gpu::intel::sycl::stream_t *>(
                     compute_stream);
-
-    if (need_zero_pool() && sycl_stream->recording()) {
-        auto *intel_engine
-                = utils::downcast<intel::engine_t *>(compute_stream->engine());
-        CHECK(lookup_zero_pool(intel_engine, compute_stream,
-                zero_pool_chunk_size_, &zero_pool));
-        release_zp = true;
-    }
+    // The zero-pool global state management is not compatible with SYCL graph;
+    // fall back to the graph-safe zero-buffer scratchpad path.
+    if (sycl_stream->recording()) zero_pool = nullptr;
 #endif
 
     const auto d = pd()->desc();
@@ -414,6 +430,12 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
     if (nocopy_info()->needsTempC()) {
         c_temp = ctx.get_scratchpad_grantor().get_memory_storage(
                 memory_tracking::names::key_gemm_accumulator);
+    }
+
+    std::unique_ptr<memory_storage_t> zero_buf_scratchpad;
+    if (need_zero_buffer() && !zero_pool) {
+        zero_buf_scratchpad = ctx.get_scratchpad_grantor().get_memory_storage(
+                memory_tracking::names::key_gemm_zero_buffer);
     }
 
     const memory_storage_t *po_srcs[GEMM_MAX_PO];
@@ -597,10 +619,11 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                 && (k > k0 * pd()->kernel_desc()->aux_params()->wgK)) {
             status = launch_nocopy(ctx, compute_stream, zero_pool, a, b, c, ao,
                     bo, ao_host_scalar, bo_host_scalar, a_scales, b_scales,
-                    c_scales, ag, bg, *co, co_host_scalar, nullptr, sround_seed,
-                    po_count, po_srcs, off_a0, off_b0, off_c0, off_aq0, off_bq0,
-                    off_co0, po_offsets0, lda, ldb, ldc, m, n, 0, 1, 1.0f, beta,
-                    0, false, swap_ab, true);
+                    c_scales, ag, bg, *co, co_host_scalar, nullptr,
+                    zero_buf_scratchpad.get(), sround_seed, po_count, po_srcs,
+                    off_a0, off_b0, off_c0, off_aq0, off_bq0, off_co0,
+                    po_offsets0, lda, ldb, ldc, m, n, 0, 1, 1.0f, beta, 0,
+                    false, swap_ab, true);
             if (status) return status;
             beta = 1.0f;
         }
@@ -662,21 +685,17 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                 status = launch_nocopy(ctx, compute_stream, zero_pool, a, b, c,
                         ao, bo, ao_host_scalar, bo_host_scalar, a_scales,
                         b_scales, c_scales, ag, bg, *co, co_host_scalar,
-                        c_temp.get(), sround_seed, po_count, po_srcs, off_a_src,
-                        off_b_src, off_c, off_aq, off_bq, off_co, po_offsets,
-                        lda, ldb, ldc, into<int32_t>(size_m),
-                        into<int32_t>(size_n), into<int32_t>(size_k), k0, alpha,
-                        eff_beta, cmask, last_k_block, swap_ab,
-                        disable_hilbert);
+                        c_temp.get(), zero_buf_scratchpad.get(), sround_seed,
+                        po_count, po_srcs, off_a_src, off_b_src, off_c, off_aq,
+                        off_bq, off_co, po_offsets, lda, ldb, ldc,
+                        into<int32_t>(size_m), into<int32_t>(size_n),
+                        into<int32_t>(size_k), k0, alpha, eff_beta, cmask,
+                        last_k_block, swap_ab, disable_hilbert);
 
                 if (status) return status;
             }
         }
     }
-
-#ifdef DNNL_WITH_SYCL
-    if (release_zp) release_zero_pool(zero_pool);
-#endif
 
     return status::success;
 }

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -618,8 +618,8 @@ struct gen_t : public primitive_t {
                 zero_pool_chunk_size_ = zg_max * 2 * 2 * 64;
 
                 auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
-                CHECK(lookup_zero_pool(intel_engine, nullptr,
-                        zero_pool_chunk_size_, &zero_pool_));
+                CHECK(lookup_zero_pool(
+                        intel_engine, zero_pool_chunk_size_, &zero_pool_));
 
                 nocopy_kernel_.save_output_events();
             }

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -22,9 +22,11 @@
 #include <memory>
 
 #include "common/c_types_map.hpp"
+#include "common/serialization.hpp"
 #include "common/utils.hpp"
 #include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/compute/kernel.hpp"
+#include "gpu/intel/compute/kernel_ctx.hpp"
 #include "gpu/intel/compute/zero_pool.hpp"
 #include "gpu/intel/gemm/jit/gen_kernel.hpp"
 #include "gpu/intel/gemm/jit/pd.hpp"
@@ -36,6 +38,44 @@ namespace impl {
 namespace gpu {
 namespace intel {
 namespace gemm {
+
+// The zero-buffer scratchpad path is prepared when the zero pool is disabled,
+// or (under SYCL) as a fallback while recording a graph.
+inline bool prepare_zero_buffer_scratchpad() {
+#ifdef DNNL_WITH_SYCL
+    return true;
+#else
+    return !use_zero_pool();
+#endif
+}
+
+struct zero_fill_params_t
+    : public trivially_serializable_t<zero_fill_params_t> {
+    status_t create_generator(const intel::engine_t &engine,
+            compute::kernel_bundle_t &bundle) const {
+        return engine.create_kernel_bundle(
+                bundle, get_kernel_names(), get_kernel_ctx());
+    }
+
+    const std::vector<const char *> &get_kernel_names() const {
+        static const std::vector<const char *> names {"gemm_zero_fill"};
+        return names;
+    }
+
+    compute::kernel_ctx_t get_kernel_ctx() const {
+        compute::kernel_ctx_t kernel_ctx;
+        // Match the main kernel's options (GRF mode, thread arbitration) to
+        // avoid hardware state reconfiguration between back-to-back kernel
+        // dispatches.
+        if (grf_256) kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
+        if (no_subgroup_ifp) kernel_ctx.add_option("-cl-no-subgroup-ifp");
+        return kernel_ctx;
+    }
+
+    bool grf_256 = false;
+    bool no_subgroup_ifp = false;
+    uint8_t pad[6] = {};
+};
 
 struct gen_t : public primitive_t {
     struct pd_t : public jit::pd_t {
@@ -510,6 +550,16 @@ struct gen_t : public primitive_t {
                 scratchpad.book(memory_tracking::names::key_gemm_accumulator,
                         temp_c_elems, temp_c_sz, 64, 65536);
             }
+            if (prepare_zero_buffer_scratchpad()
+                    && (info->fusedBeta() || info->fusedPostOps())) {
+                auto scratchpad = scratchpad_registry().registrar();
+                int zg_cl = 0;
+                if (info->fusedBeta()) zg_cl++;
+                if (info->fusedPostOps()) zg_cl++;
+                size_t zero_buffer_bytes = max_k_sliced_groups() * 64 * zg_cl;
+                scratchpad.book(memory_tracking::names::key_gemm_zero_buffer,
+                        zero_buffer_bytes, 1, 64, 65536);
+            }
         }
 
         const jit::gen_nocopy_desc_t *kernel_desc() const {
@@ -556,21 +606,34 @@ struct gen_t : public primitive_t {
         scalar_type_ = kd->scalar_type();
         const auto *info = nocopy_info();
 
-        if (need_zero_pool()) {
+        if (need_zero_buffer()) {
             int zg_cl = 0;
             if (info->fusedBeta()) zg_cl++;
             if (info->fusedPostOps()) zg_cl++;
 
-            zero_pool_bytes_ = pd()->max_k_sliced_groups() * 64 * zg_cl;
+            zero_buffer_bytes_ = pd()->max_k_sliced_groups() * 64 * zg_cl;
 
-            auto zg_max = pd()->dev_info_->hw_threads();
-            zero_pool_chunk_size_ = zg_max * 2 * 2 * 64;
+            if (use_zero_pool()) {
+                auto zg_max = pd()->dev_info_->hw_threads();
+                zero_pool_chunk_size_ = zg_max * 2 * 2 * 64;
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
-            CHECK(lookup_zero_pool(
-                    intel_engine, nullptr, zero_pool_chunk_size_, &zero_pool_));
+                auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+                CHECK(lookup_zero_pool(intel_engine, nullptr,
+                        zero_pool_chunk_size_, &zero_pool_));
 
-            nocopy_kernel_.save_output_events();
+                nocopy_kernel_.save_output_events();
+            }
+            if (prepare_zero_buffer_scratchpad()) {
+                zero_fill_params_t params;
+                params.grf_256 = (info->grfCount == 256);
+                // IFP on (default) forces round-robin thread arbitration.
+                // Disable it on a clear mismatch with the main kernel to
+                // avoid a thread arbitration switch between dispatches.
+                params.no_subgroup_ifp = (kd->strategy()->arbitrationMode
+                        != ngen::ThreadArbitrationMode::RoundRobin);
+                CHECK(create_kernel(
+                        engine, zero_fill_kernel_, "gemm_zero_fill", params));
+            }
         }
 
         return status::success;
@@ -588,6 +651,7 @@ private:
             const memory_storage_t *c_scales, const memory_storage_t *ag,
             const memory_storage_t *bg, const memory_storage_t &co,
             int16_t co_host_scalar, const memory_storage_t *c_temp,
+            const memory_storage_t *zero_buf_scratchpad,
             const memory_storage_t *sround_seed, int po_count,
             const memory_storage_t **po_src, int64_t offset_a, int64_t offset_b,
             int64_t offset_c, int64_t offset_aq, int64_t offset_bq,
@@ -601,14 +665,15 @@ private:
         return pd()->kernel_desc()->driver_info();
     }
 
-    bool need_zero_pool() const {
+    bool need_zero_buffer() const {
         return nocopy_info()->fusedBeta() || nocopy_info()->fusedPostOps();
     }
 
     compute::kernel_t nocopy_kernel_;
+    compute::kernel_t zero_fill_kernel_;
     compute::scalar_type_t scalar_type_;
     zero_pool_t *zero_pool_ = nullptr;
-    size_t zero_pool_bytes_ = 0;
+    size_t zero_buffer_bytes_ = 0;
     size_t zero_pool_chunk_size_ = 0;
 };
 

--- a/src/gpu/intel/gemm/zero_fill.cl
+++ b/src/gpu/intel/gemm/zero_fill.cl
@@ -1,0 +1,20 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+__kernel void gemm_zero_fill(__global uint *buf, uint n) {
+    uint id = get_global_id(0);
+    buf[id] = 0;
+}

--- a/src/gpu/intel/stream.hpp
+++ b/src/gpu/intel/stream.hpp
@@ -31,8 +31,6 @@ public:
     status_t notify_profiling_complete() const override;
 
     virtual status_t barrier() = 0;
-    virtual status_t enter_immediate_mode() { return status::success; }
-    virtual status_t exit_immediate_mode() { return status::success; }
 
 protected:
     bool has_zero_pad_primitive() const { return engine()->kind() == dnnl_gpu; }

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -124,13 +124,6 @@ bool stream_t::recording() const {
             == syclex::queue_state::recording;
 }
 
-stream_t::weak_graph_t stream_t::get_current_graph_weak() const {
-    bool success;
-    stream_t::weak_graph_t result = get_graph(impl()->queue(), success);
-    if (!success) result.reset();
-    return result;
-}
-
 status_t stream_t::enter_immediate_mode() {
     std::lock_guard<std::mutex> lock(immediate_mode_mutex_);
     if (!immediate_mode_level_++) pause_recording();

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -96,75 +96,11 @@ void stream_t::after_exec_hook() {
     if (is_profiling_enabled()) profiler_->stop_profiling();
 }
 
-// The following code needs sycl::queue::ext_oneapi_get_graph(), but it may
-//  not be defined. Some SFINAE is needed to avoid compile errors in this case.
 namespace syclex = ::sycl::ext::oneapi::experimental;
-template <typename Q>
-static auto get_graph_internal(
-        const Q &q, bool &success, int) -> decltype(q.ext_oneapi_get_graph()) {
-    success = true;
-    return q.ext_oneapi_get_graph();
-}
-
-template <typename Q>
-static syclex::command_graph<syclex::graph_state::modifiable>
-get_graph_internal(const Q &q, bool &success, long) {
-    success = false;
-    return syclex::command_graph<syclex::graph_state::modifiable>(
-            q.get_context(), q.get_device());
-}
-
-static syclex::command_graph<syclex::graph_state::modifiable> get_graph(
-        const ::sycl::queue *q, bool &success) {
-    return get_graph_internal(*q, success, 0);
-}
 
 bool stream_t::recording() const {
     return impl()->queue()->ext_oneapi_get_state()
             == syclex::queue_state::recording;
-}
-
-status_t stream_t::enter_immediate_mode() {
-    std::lock_guard<std::mutex> lock(immediate_mode_mutex_);
-    if (!immediate_mode_level_++) pause_recording();
-    return status::success;
-}
-
-status_t stream_t::exit_immediate_mode() {
-    std::lock_guard<std::mutex> lock(immediate_mode_mutex_);
-    if (immediate_mode_level_ > 0) {
-        if (!--immediate_mode_level_) resume_recording();
-    } else {
-        assert(!"exit_immediate_mode called without enter");
-        return status::runtime_error;
-    }
-    return status::success;
-}
-
-status_t stream_t::pause_recording() {
-    using graph_t = syclex::command_graph<syclex::graph_state::modifiable>;
-    if (recording()) {
-        bool success;
-        assert(!paused_graph_);
-        paused_graph_.reset(new graph_t(get_graph(impl()->queue(), success)));
-        if (!success) return status::runtime_error;
-        paused_graph_->end_recording();
-        auto &cur_dep = xpu::sycl::event_t::from(ctx().get_deps());
-        paused_dep_ = xpu::sycl::event_t {};
-        std::swap(paused_dep_, cur_dep);
-    }
-    return status::success;
-}
-
-status_t stream_t::resume_recording() {
-    if (paused_graph_) {
-        paused_graph_->begin_recording(*impl()->queue());
-        paused_graph_.reset();
-        auto &cur_dep = xpu::sycl::event_t::from(ctx().get_deps());
-        std::swap(paused_dep_, cur_dep);
-        paused_dep_ = xpu::sycl::event_t {};
-    }
-    return status::success;
 }
 
 } // namespace sycl

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -112,10 +112,6 @@ struct stream_t : public gpu::intel::stream_t {
     }
 
     bool recording() const;
-    using weak_graph_t = ::sycl::ext::oneapi::weak_object<
-            ::sycl::ext::oneapi::experimental::command_graph<::sycl::ext::
-                            oneapi::experimental::graph_state::modifiable>>;
-    weak_graph_t get_current_graph_weak() const;
 
     status_t enter_immediate_mode() override;
     status_t exit_immediate_mode() override;

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -113,9 +113,6 @@ struct stream_t : public gpu::intel::stream_t {
 
     bool recording() const;
 
-    status_t enter_immediate_mode() override;
-    status_t exit_immediate_mode() override;
-
 protected:
     xpu::sycl::stream_impl_t *impl() const {
         return (xpu::sycl::stream_impl_t *)impl::stream_t::impl_.get();
@@ -126,16 +123,6 @@ protected:
 
 private:
     status_t init();
-
-    status_t pause_recording();
-    status_t resume_recording();
-
-    std::mutex immediate_mode_mutex_;
-    int immediate_mode_level_ = 0;
-    std::unique_ptr<::sycl::ext::oneapi::experimental::command_graph<
-            ::sycl::ext::oneapi::experimental::graph_state::modifiable>>
-            paused_graph_;
-    xpu::sycl::event_t paused_dep_;
 };
 
 } // namespace sycl


### PR DESCRIPTION
Jira: [MFDNN-15072](https://jira.devtools.intel.com/browse/MFDNN-15072)

Background: the native recording API introduced for SYCL graphs is incompatible with the existing zero-pool support in oneDNN. In particular, it relies on pause/continue which is unsupported in the native recording mode.

The PR disables the zero-pool when SYCL graph recording is used.

Changes:

- GPU JIT GEMM PD may request a scratchpad to use during execution as the zero-initialized buffer
    - Scratchpad is requested when a) the runtime is SYCL and b) the chosen kernel needs a zero-initialized buffer for counters
- The decision whether to use scratchpad is taken at execution, when a SYCL queue is available to query if it's the graph recording mode
    - If it's recording, JIT GEMM calls a custom OpenCL kernel to zero-initialize the scratchpad buffer and uses it for the kernel
    - If it's not recording, JIT GEMM uses the existing zero-pool flow
- Mitigations to minimize overhead from a standalone zero-init kernel
    - Switch to a custom OpenCL kernel. It's compiled with special flags to align with the JIT GEMM kernel. It performance noticeably better than `fill()` or `memset()`
    - Moved zero-initialization closer to the primitive execution entry - to minimize host induced latency (irrelevant during SYCL graph execution)

The "dual" approach of using/not using the scratchpad adds complexity but I chose it after weighing other alternatives:

- Disabling the zero-pool everywhere - exposes an additional risk of regressions
- Adding proper support for zero-pool handling during SYCL graph recording - another level of complexity
    - A potential solution would need the experimental L0 callback API, a managed global state and a number of future pitfalls to resolve until we get it right

Performance data:

- Using `compute_stream->fill()` instead of the custom kernel results in ~20% worse performance in geomean for 50 most affected cases on PVC
- See top 5 worst regressions by platform below (we test ~1700 KPIs per platform)

```
ocl-bmg              7.06%, 6.42%, 4.95%, 4.12%, 4.03%
ocl-bmg-g31          6.35%, 5.08%, 3.87%, 3.83%, 3.62%
ocl-dg2              3.60%, 3.11%, 3.08%, 2.71%, 2.63%
ocl-lnl             14.97%, 3.82%, 3.73%, 3.15%, 2.81%
sycl-ats-m1          3.06%, 2.89%, 2.56%, 2.07%, 2.01%
sycl-pvc            31.43%, 26.35%, 16.05%, 13.45%, 13.45%
win-ocl-icx-arl-h    4.00%, 3.32%, 3.30%, 3.17%, 3.16%
win-ocl-icx-bmg      7.77%, 5.35%, 4.63%, 4.51%, 4.51%
win-ocl-icx-lnl      3.21%, 3.14%, 3.08%, 3.07%, 2.74%
win-ocl-icx-ptl      4.52%, 3.22%, 3.08%, 3.02%, 2.97%
```