### PR TITLE
xe: gemm: minor fixes

### DIFF
--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -319,9 +319,9 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         arg_list.set(argn++, slm, nullptr);
     }
 
-    if (pd()->a_quant.zp_ndims > 0 || problem->aScale2D())
+    if (problem->aoPtrDims >= 1 || problem->aScale2D())
         arg_list.set(argn++, offset_aq);
-    if (pd()->b_quant.zp_ndims > 0 || problem->bScale2D())
+    if (problem->boPtrDims >= 1 || problem->bScale2D())
         arg_list.set(argn++, offset_bq);
 
     lws[0] *= nocopy_info()->subgroupSize;
@@ -629,8 +629,8 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
 
                 auto off_aq = off_aq0;
                 auto off_bq = off_bq0;
-                if (pd()->a_quant.zp_ndims >= 1 || a_scales) off_aq += Bm;
-                if (pd()->b_quant.zp_ndims >= 1 || b_scales) off_bq += Bn;
+                if (problem.aoPtrDims >= 1 || a_scales) off_aq += Bm;
+                if (problem.boPtrDims >= 1 || b_scales) off_bq += Bn;
 
                 auto off_co = off_co0;
                 switch (cmask & 3) {

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -871,28 +871,31 @@ dim_t pd_t::scale_stride(int idx, int arg) const {
     gpu_assert(utils::one_of(arg, DNNL_ARG_A, DNNL_ARG_B));
     const memory_desc_t *md_ptr
             = (arg == DNNL_ARG_A) ? &a_scale_md_ : &b_scale_md_;
-    gpu_assert(memory_desc_wrapper(md_ptr).is_plain())
-            << "Expected plain scale_md_";
-    if (md_ptr->dims[idx] == 1) return 0;
-    return md_ptr->format_desc.blocking.strides[idx];
+    const memory_desc_wrapper mdw(md_ptr);
+    if (mdw.is_host_scalar_desc()) return 0;
+    gpu_assert(mdw.is_plain()) << "Expected plain scale_md_";
+    if (mdw.dims()[idx] == 1) return 0;
+    return mdw.strides()[idx];
 }
 
 dim_t pd_t::zp_stride(int idx, int arg) const {
     gpu_assert(utils::one_of(arg, DNNL_ARG_A, DNNL_ARG_B));
     const memory_desc_t *md_ptr = (arg == DNNL_ARG_A) ? &a_zp_md_ : &b_zp_md_;
-    gpu_assert(memory_desc_wrapper(md_ptr).is_plain())
-            << "Expected plain zp_md_";
-    if (md_ptr->dims[idx] == 1) return 0;
-    return md_ptr->format_desc.blocking.strides[idx];
+    const memory_desc_wrapper mdw(md_ptr);
+    if (mdw.is_host_scalar_desc()) return 0;
+    gpu_assert(mdw.is_plain()) << "Expected plain zp_md_";
+    if (mdw.dims()[idx] == 1) return 0;
+    return mdw.strides()[idx];
 }
 
 dim_t pd_t::gs_stride(int idx, int arg) const {
     gpu_assert(utils::one_of(arg, DNNL_ARG_A, DNNL_ARG_B));
     const memory_desc_t *md_ptr = (arg == DNNL_ARG_A) ? &a_gs_md_ : &b_gs_md_;
-    gpu_assert(memory_desc_wrapper(md_ptr).is_plain())
-            << "Expected plain gs_md_";
-    if (md_ptr->dims[idx] == 1) return 0;
-    return md_ptr->format_desc.blocking.strides[idx];
+    const memory_desc_wrapper mdw(md_ptr);
+    if (mdw.is_host_scalar_desc()) return 0;
+    gpu_assert(mdw.is_plain()) << "Expected plain gs_md_";
+    if (mdw.dims()[idx] == 1) return 0;
+    return mdw.strides()[idx];
 }
 
 } // namespace jit

--- a/src/gpu/intel/include/types_specific.h
+++ b/src/gpu/intel/include/types_specific.h
@@ -580,27 +580,27 @@
 #elif DST_DT_U4
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
 #define TO_DST(x) into_u4(convert_float(x))
-#define DST_DATA_FMAX 15.0
-#define DST_DATA_FMIN 0.0
+#define DST_DATA_FMAX 15.0f
+#define DST_DATA_FMIN 0.0f
 #define DST_DATA_FLOW DST_DATA_FMIN
 #elif DST_DT_S4
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
 #define TO_DST(x) into_s4(convert_float(x))
-#define DST_DATA_FMAX 7.0
-#define DST_DATA_FMIN 1
-#define DST_DATA_FLOW -8.0
+#define DST_DATA_FMAX 7.0f
+#define DST_DATA_FMIN 1f
+#define DST_DATA_FLOW -8.0f
 #elif DST_DT_F4_E2M1
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
 #define TO_DST(x) into_f4_e2m1(convert_float(x))
-#define DST_DATA_FMAX 6.0
-#define DST_DATA_FMIN 1.0
-#define DST_DATA_FLOW -6.0
+#define DST_DATA_FMAX 6.0f
+#define DST_DATA_FMIN 1.0f
+#define DST_DATA_FLOW -6.0f
 #elif DST_DT_F4_E3M0
 #define SET_DOUBLE_HALF_BYTE(x, y, z) set_double_half_byte(x, y, z)
 #define TO_DST(x) into_f4_e3m0(convert_float(x))
-#define DST_DATA_FMAX 16.0
-#define DST_DATA_FMIN 0.25
-#define DST_DATA_FLOW -16.0
+#define DST_DATA_FMAX 16.0f
+#define DST_DATA_FMIN 0.25f
+#define DST_DATA_FLOW -16.0f
 #elif DST_DT_U8
 #define TO_DST(x) convert_uchar_sat_rte(x)
 #define TO_DST2(x) convert_uchar2_sat_rte(x)


### PR DESCRIPTION
Fixes:
1. a mismatch between the kernel interface arguments and launch arguments.
2. a missing check for host scalar scale/zp strides (or lack thereof).
3. missing data type specifiers for data used in dynamic scale calculations.

Found in #5317.