### PR TITLE
common, benchdnn: updates required for future coverage

### DIFF
--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -428,8 +428,19 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
         if (!zp.has_default_values(DNNL_ARG_SRC)) {
             const int mask_src = zp.get_mask(DNNL_ARG_SRC);
 
-            VCHECK_MATMUL_UNIMPL(utils::one_of(mask_src, 0, src_qmask_K,
-                                         src_qmask_M + src_qmask_K),
+            VCHECK_MATMUL_UNIMPL(
+                    utils::one_of(mask_src, 0, src_qmask_K,
+                            src_qmask_M + src_qmask_K, full_tensor_mask),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+
+            // Only a unit batch dim is supported for `full_tensor_mask`, e.g.,
+            // 1xMxK:BxKxN
+            VCHECK_MATMUL_UNIMPL(
+                    IMPLICATION(mask_src == full_tensor_mask, ndims_src <= 3),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+            VCHECK_MATMUL_UNIMPL(
+                    IMPLICATION(mask_src == full_tensor_mask && ndims_src == 3,
+                            desc.src_desc.dims[0] == 1),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
 
             if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {

--- a/src/cpu/matmul/ref_matmul_int8.hpp
+++ b/src/cpu/matmul/ref_matmul_int8.hpp
@@ -96,7 +96,15 @@ struct ref_matmul_int8_t : public primitive_t {
             if (!zp.has_default_values(DNNL_ARG_SRC)) {
                 int mask_src = zp.get_mask(DNNL_ARG_SRC);
                 VDISPATCH_MATMUL(utils::one_of(mask_src, 0, src_qmask_K(),
-                                         src_qmask_M() + src_qmask_K()),
+                                         src_qmask_M() + src_qmask_K(),
+                                         full_tensor_mask()),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                VDISPATCH_MATMUL(IMPLICATION(mask_src == full_tensor_mask(),
+                                         ndims() <= 3),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                VDISPATCH_MATMUL(IMPLICATION(mask_src == full_tensor_mask()
+                                                 && ndims() == 3,
+                                         src_md()->dims[0] == 1),
                         VERBOSE_UNSUPPORTED_ZP_CFG);
 
                 if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {

--- a/tests/benchdnn/conv/conv_dw_fusion.cpp
+++ b/tests/benchdnn/conv/conv_dw_fusion.cpp
@@ -33,9 +33,9 @@
 namespace conv_dw_fusion {
 
 int fill_scales(int exec_arg, const attr_t &attr, int arg, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_fp, res_t *res) {
     if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
-    return fill_scales(attr, arg, mem_dt, mem_fp);
+    return fill_scales(attr, arg, mem_dt, mem_fp, res);
 }
 
 std::unique_ptr<prb_t> get_first_conv_prb(const prb_t *prb) {
@@ -223,7 +223,7 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
                 } else if (is_pre_dw_scales_arg && !is_post_dw_scales_arg) {
                     int local_exec_arg = exec_arg ^ DNNL_ARG_ATTR_SCALES;
                     SAFE(fill_scales(exec_arg, prb0->attr, local_exec_arg, mem,
-                                 ref_mem),
+                                 ref_mem, res),
                             WARN);
                     SAFE(mem_map0.at(exec_arg).reorder(mem), WARN);
                 }
@@ -273,7 +273,8 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
         mem_map[dw_wei_scale_arg] = dnn_mem_t(
                 wei_scale_md, get_test_engine(), /* prefill = */ true);
         SAFE(fill_scales(dw_wei_scale_arg, prb1->attr, DNNL_ARG_WEIGHTS,
-                     mem_map.at(dw_wei_scale_arg), mem_map1.at(wei_scale_arg)),
+                     mem_map.at(dw_wei_scale_arg), mem_map1.at(wei_scale_arg),
+                     res),
                 WARN);
     }
     if (!prb1->attr.scales.get(DNNL_ARG_DST).is_def()) {
@@ -284,7 +285,8 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
         mem_map[dw_dst_scale_arg] = dnn_mem_t(
                 dst_scale_md, get_test_engine(), /* prefill = */ true);
         SAFE(fill_scales(dw_dst_scale_arg, prb1->attr, DNNL_ARG_DST,
-                     mem_map.at(dw_dst_scale_arg), mem_map1.at(dst_scale_arg)),
+                     mem_map.at(dw_dst_scale_arg), mem_map1.at(dst_scale_arg),
+                     res),
                 WARN);
     }
 

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1980,7 +1980,8 @@ int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
         }
     } else if (is_scales_arg) {
         int local_exec_arg = exec_arg ^ DNNL_ARG_ATTR_SCALES;
-        TIME_FILL(SAFE(fill_scales(attr, local_exec_arg, mem, ref_mem), WARN));
+        TIME_FILL(SAFE(
+                fill_scales(attr, local_exec_arg, mem, ref_mem, res), WARN));
     } else if (is_zero_point_arg) {
         int local_exec_arg = exec_arg ^ DNNL_ARG_ATTR_ZERO_POINTS;
         TIME_FILL(SAFE(

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -898,6 +898,16 @@ void skip_unimplemented_binary_po(const attr_t &attr, res_t *res) {
             return;
         }
     }
+
+    std::vector<dnnl_data_type_t> dts;
+    for (int i = 0; i < po.len(); i++) {
+        const auto &e = po.entry[i];
+        if (!e.is_binary_kind()) continue;
+
+        dts.push_back(e.binary.src1_dt);
+        if (e.is_binary_kind_with_ternary_op()) dts.push_back(e.binary.src2_dt);
+    }
+    skip_unimplemented_data_type(dts, FLAG_INF, res);
 }
 
 void skip_unimplemented_prelu_po(

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -133,14 +133,14 @@ const fill_cfg_t &get_perf_fill_cfg(dnnl_data_type_t dt) {
 #undef CASE
 }
 
-int fill_scales(
-        const attr_t &attr, int arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_scales(const attr_t &attr, int arg, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto &e = attr.scales.get(arg);
-    return fill_scales(e, mem_dt, mem_fp);
+    return fill_scales(e, mem_dt, mem_fp, res);
 }
 
 int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
 
@@ -152,30 +152,11 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
         // TODO: replace reorder with `fill` that takes any pattern unlike
         // memset.
     } else {
-        /* Do fixed partitioning to have same filling for any number of threads */
-        static constexpr int64_t chunk_size = 64;
-        const int64_t n_chunks = div_up(nelems, chunk_size);
-        benchdnn_parallel_nd(n_chunks, [&](int64_t idx_chunk) {
-            int64_t idx_start = idx_chunk * chunk_size;
-            int64_t idx_end = MIN2(idx_start + chunk_size, nelems);
-            // Note: we use a different seed for each chunk to avoid
-            // repeating patterns. We could use discard(idx_start) too but
-            // it has a complexity in O(idx_start). We also add 1 to avoid
-            // seeding with 0.
-            std::minstd_rand int_seed(idx_start + 1);
-            int_seed.discard(1);
-
-            std::uniform_int_distribution<> gen(-2, 2);
-
-            for (int64_t idx = idx_start; idx < idx_end; ++idx) {
-                int pow2 = gen(int_seed);
-                int pow2_shift = 1 << std::abs(pow2);
-                const float gen_val
-                        = pow2 < 0 ? (1.f / pow2_shift) : pow2_shift;
-                const float val = gen_val;
-                mem_fp.set_f32_elem(idx, val);
-            }
-        });
+        // 1/16, 1/8 and 1/4 to properly work with grouped scaling.
+        // Full density as zero scales are prohibited.
+        static const std::vector<float> scales_set {0.0625f, 0.125f, 0.25f};
+        fill_cfg_t fill_cfg(scales_set, /* density = */ 1.f, "scales");
+        SAFE(fill_random_real(mem_dt, mem_fp, res, fill_cfg), WARN);
     }
 
     if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
@@ -232,8 +213,6 @@ int fill_random_real_dense(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
 
     BENCHDNN_PRINT(6, "%s\n", fill_cfg.print_verbose().c_str());
 
-    // This function doesn't handle the predefined set yet.
-    assert(fill_cfg.predefined_set_.empty());
     // This function doesn't handle density yet.
     assert(fill_cfg.density_ == 1.f);
 
@@ -264,12 +243,20 @@ int fill_random_real_dense(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
         std::minstd_rand int_seed(nelems + idx_start + 1);
         int_seed.discard(1);
 
-        std::uniform_real_distribution<> gen_real(
+        std::uniform_real_distribution<float> gen_real(
                 fill_cfg.range_min_val_, fill_cfg.range_max_val_);
-        std::uniform_int_distribution<> gen_int(
-                fill_cfg.range_min_val_, fill_cfg.range_max_val_);
+        // For `predefined_set_` use indices for uniform distribution.
+        std::uniform_int_distribution<> gen_int
+                = !fill_cfg.predefined_set_.empty()
+                ? std::uniform_int_distribution<>(0,
+                          static_cast<int>(fill_cfg.predefined_set_.size()) - 1)
+                : std::uniform_int_distribution<>(
+                          fill_cfg.range_min_val_, fill_cfg.range_max_val_);
 
         const auto get_val = [&]() {
+            if (!fill_cfg.predefined_set_.empty()) {
+                return fill_cfg.predefined_set_[gen_int(int_seed)];
+            }
             return fill_cfg.only_integer_
                     ? static_cast<float>(gen_int(int_seed))
                     : gen_real(int_seed);

--- a/tests/benchdnn/utils/fill.hpp
+++ b/tests/benchdnn/utils/fill.hpp
@@ -83,10 +83,10 @@ const fill_cfg_t &get_perf_fill_cfg(dnnl_data_type_t dt);
 
 int fill_dropout_mask(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp);
 
-int fill_scales(
-        const attr_t &attr, int arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp);
+int fill_scales(const attr_t &attr, int arg, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res);
 int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp);
+        dnn_mem_t &mem_fp, res_t *res);
 
 int fill_zero_points(
         const attr_t &attr, int arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp);


### PR DESCRIPTION
`fill_scales` are updated to use smaller values for filling as grouped quantization can have longer accumulation chain that stops fitting with current scales. It also updates the function definition to use a `fill_cfg_t` abstraction.

Data types for binary post-op weren't validated before (didn't have cases with inconsistent data types).

SRC zero-points get a minor allowance extension. It's done to support `per_tensor` policy as `per_ocic` policy will be sent to limbo soon. Doesn't change any functional coverage for the library.