### PR TITLE
Fix brgemm conv guard and int8/f32 desc_set_postops rules

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -364,10 +364,10 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     // check that combination of data types is allowed
     if ((brg->dt_a == data_type::u8 && brg->dt_b == data_type::s8)
             && (!one_of(dt_d, data_type::u8, data_type::s8, data_type::s32,
-                    data_type::f32, data_type::f16, data_type::bf16))
-            && (!one_of(dt_bias, data_type::undef, data_type::u8, data_type::s8,
-                    data_type::s32, data_type::f32, data_type::f16,
-                    data_type::bf16)))
+                        data_type::f32, data_type::f16, data_type::bf16)
+                    || !one_of(dt_bias, data_type::undef, data_type::u8,
+                            data_type::s8, data_type::s32, data_type::f32,
+                            data_type::f16, data_type::bf16)))
         return status::unimplemented;
     if ((brg->dt_a == data_type::bf16 && brg->dt_b == data_type::bf16)
             && (!one_of(dt_d, data_type::bf16, data_type::f32))
@@ -375,8 +375,9 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
                     data_type::f32)))
         return status::unimplemented;
     if ((brg->dt_a == data_type::f32 && brg->dt_b == data_type::f32)
-            && (!one_of(dt_d, data_type::f32))
-            && (!one_of(dt_bias, data_type::undef, data_type::f32, dt_d)))
+            && (!one_of(dt_d, data_type::f32)
+                    || !one_of(
+                            dt_bias, data_type::undef, data_type::f32, dt_d)))
         return status::unimplemented;
     if (!IMPLICATION(brg->is_bf16,
                 one_of(dt_d, data_type::f32, data_type::bf16, data_type::f16,

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -593,7 +593,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
             is_bf32, is_tf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
-    ur = brg.bd_block * (is_amx(isa) ? brg.bd_block2 : 1);
+    ur = brg.bd_block * (brg.bd_block2 > 0 ? brg.bd_block2 : 1);
     if (ur == 0) return status::invalid_arguments;
     ur_block = brg.bd_block;
     if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -668,7 +668,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     brgattr.max_bottom_vpad = max_vpad;
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
-    ur = brg.bd_block * (is_amx(isa) ? brg.bd_block2 : 1);
+    ur = brg.bd_block * (brg.bd_block2 > 0 ? brg.bd_block2 : 1);
     ur_block = brg.bd_block;
     adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
     if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {


### PR DESCRIPTION
This is a fix for [MFDNN-15156](https://jira.devtools.intel.com/browse/MFDNN-15156) - "Convolution/Deconvolution failures: NUMERICAL/SEGFAULT"
This PR addresses data type validation and blocking factor calculation in BRGEMM:
* Refactored the logic in `brgemm_desc_set_postops` (in `brgemm.cpp`) to correctly validate allowed combinations of accumulator and bias data types for different input types, preventing unimplemented or unsupported configurations from proceeding.
* Updated the calculation of `ur` in both `jit_brgemm_conv_bwd_utils.cpp` and `jit_brgemm_conv_utils.cpp` to use `brg.bd_block2 > 0 ? brg.bd_block2 : 1` instead of relying solely on the AMX ISA, ensuring correct unrolling factor even when `bd_block2` is zero.