### PR TITLE
gpu: generic: sycl: enable profiling (second attempt)

### DIFF
--- a/src/gpu/generic/sycl/stream.cpp
+++ b/src/gpu/generic/sycl/stream.cpp
@@ -16,6 +16,8 @@
 
 #include "common/verbose.hpp"
 
+#include "xpu/sycl/stream_profiler.hpp"
+
 #include "gpu/generic/sycl/engine.hpp"
 #include "gpu/generic/sycl/stream.hpp"
 
@@ -30,28 +32,58 @@ status_t stream_t::init() {
             && (flags() & stream_flags::out_of_order) == 0)
         return status::invalid_arguments;
 
-    VCONDCHECK(primitive, create, check, stream,
-            is_profiling_enabled() == false, status::unimplemented,
-            VERBOSE_PROFILING_UNSUPPORTED);
+    if (is_profiling_enabled())
+        profiler_ = utils::make_unique<xpu::sycl::stream_profiler_t>(this);
 
     // If queue_ is not set then construct it
     auto &sycl_engine = *utils::downcast<generic::sycl::engine_t *>(engine());
+    auto &sycl_ctx = sycl_engine.context();
+    auto &sycl_dev = sycl_engine.device();
 
     if (!impl()->queue()) {
-        auto &sycl_ctx = sycl_engine.context();
-        auto &sycl_dev = sycl_engine.device();
         ::sycl::property_list prop_list;
-        if (flags() & stream_flags::in_order)
-            prop_list = {::sycl::property::queue::in_order {}};
+        if (is_profiling_enabled() && sycl_dev.is_gpu()) {
+            prop_list = (flags() & stream_flags::in_order)
+                    ? ::sycl::property_list {::sycl::property::queue::
+                                                     in_order {},
+                              ::sycl::property::queue::enable_profiling {}}
+                    : ::sycl::property_list {
+                              ::sycl::property::queue::enable_profiling {}};
+        } else {
+            prop_list = (flags() & stream_flags::in_order)
+                    ? ::sycl::property_list {::sycl::property::queue::
+                                      in_order {}}
+                    : ::sycl::property_list {};
+        }
         impl()->set_queue(::sycl::queue(sycl_ctx, sycl_dev, prop_list));
     } else {
+        // TODO: Compare device and context of the engine with those of the
+        // queue after SYCL adds support for device/context comparison.
+        //
+        // For now perform some simple checks.
         auto sycl_dev = queue().get_device();
         bool args_ok = engine()->kind() == engine_kind::gpu
                 && (sycl_dev.is_gpu() || sycl_dev.is_accelerator());
         if (!args_ok) return status::invalid_arguments;
     }
 
+    if (is_profiling_enabled() && sycl_dev.is_gpu() && !queue().is_in_order()) {
+        VERROR(common, dpcpp,
+                "DPC++ kernel profiling is not supported with out-of-order "
+                "queues");
+        return status::invalid_arguments;
+    }
+
     return status::success;
+}
+
+void stream_t::before_exec_hook() {
+    if (is_profiling_enabled()) profiler_->start_profiling();
+}
+
+void stream_t::after_exec_hook() {
+    sycl_ctx().set_deps(xpu::sycl::event_t());
+    if (is_profiling_enabled()) profiler_->stop_profiling();
 }
 
 } // namespace sycl

--- a/src/gpu/generic/sycl/stream.hpp
+++ b/src/gpu/generic/sycl/stream.hpp
@@ -53,16 +53,24 @@ public:
         return status::success;
     }
 
+    void before_exec_hook() override;
+    void after_exec_hook() override;
+
     status_t reset_profiling() override {
         if (!is_profiling_enabled()) return status::invalid_arguments;
-        profiler_->reset();
+        profiler().reset();
         return status::success;
     }
 
     status_t get_profiling_data(profiling_data_kind_t data_kind,
             int *num_entries, uint64_t *data) const override {
         if (!is_profiling_enabled()) return status::invalid_arguments;
-        return profiler_->get_info(data_kind, num_entries, data);
+        return profiler().get_info(data_kind, num_entries, data);
+    }
+
+    status_t notify_profiling_complete() const override {
+        if (!is_profiling_enabled()) return status::invalid_arguments;
+        return profiler().notify_profiling_complete();
     }
 
     ::sycl::queue &queue() const { return *impl()->queue(); }


### PR DESCRIPTION
Previously verified only `-DONEDNN_INTERNAL_ENABLE_GENERIC_SYCL_KERNELS=ON` build for Intel, didn't verify actual generic backend. With this patch set, both work properly.