### PR TITLE
common: sdpa: fix non-sdpa build

### DIFF
--- a/src/common/impl_registration.hpp
+++ b/src/common/impl_registration.hpp
@@ -184,7 +184,7 @@
 #define REG_SDPA_P(...) __VA_ARGS__
 #else
 #define REG_SDPA_P(...) \
-    { nullptr }
+    {}
 #endif
 
 #if BUILD_PRIMITIVE_ALL || BUILD_SHUFFLE


### PR DESCRIPTION
In commit https://github.com/uxlfoundation/oneDNN/commit/53cd04f2098c5e7d1db5ccee3fd1c92e554232ac `gpu_sdpa_list.cpp` was rewritten to add backward pass support, switching to `const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> impl_list_map = REG_SDPA_P({...})`.

`impl_registration.hpp` was not updated: `{ nullptr }` is now wrong for `std::map`. It tries to initialize a map from a single `nullptr` value, which doesn't compile:
```
src/common/impl_registration.hpp:187:15: error: no matching function for call to ‘std::map<dnnl::impl::pk_impl_key_t, std::vector<dnnl::impl::impl_list_item_t> >::map(<brace-enclosed initializer list>)’
  187 |     { nullptr }
      |               ^
src/gpu/gpu_sdpa_list.cpp:35:23: note: in expansion of macro ‘REG_SDPA_P’
   35 |         impl_list_map REG_SDPA_P({
      |                       ^~~~~~~~~~
```