### PR TITLE
cpu: rv64: add f16 RVV layernorm kernel

### DIFF
--- a/src/cpu/rv64/jit_rvv_layernorm_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_layernorm_kernel.cpp
@@ -203,7 +203,6 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
     ld(reg_len, reg_param, GET_FUSED_OFF(len));
     fcvt_s_l(f_len, reg_len);
     fdiv_s(f_var, f_var_sum, f_len);
-    fmax_s(f_var, f_var, f_zero);
 
     ld(reg_mean_ptr, reg_param, GET_FUSED_OFF(mean));
     beqz(reg_mean_ptr, store_var);
@@ -675,7 +674,6 @@ void jit_rvv_layernorm_f16_fused_kernel_t::generate() {
     vfredosum_vs(v_sumsq, v_sumsq, v_sum);
     vfmv_f_s(f_var_sum, v_sumsq);
     fdiv_s(f_var, f_var_sum, f_len);
-    fmax_s(f_var, f_var, f_zero);
     ld(reg_ptr, reg_param, GET_F16_OFF(variance));
     beqz(reg_ptr, skip_var);
     fsw(f_var, reg_ptr, 0);

--- a/src/cpu/rv64/jit_rvv_layernorm_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_layernorm_kernel.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -558,6 +559,192 @@ void jit_rvv_layernorm_data_kernel_t::generate() {
 
 #undef GET_FUSED_OFF
 #undef GET_DATA_OFF
+
+#define GET_F16_OFF(field) \
+    static_cast<int32_t>(offsetof( \
+            jit_rvv_layernorm_f16_fused_kernel_t::call_params_t, field))
+
+jit_rvv_layernorm_f16_fused_kernel_t::jit_rvv_layernorm_f16_fused_kernel_t(
+        bool with_scale, bool with_shift, bool weights_f16)
+    : jit_generator_t("jit_rvv_layernorm_f16_fused_kernel")
+    , with_scale_(with_scale)
+    , with_shift_(with_shift)
+    , weights_f16_(weights_f16) {
+    create_kernel();
+}
+
+void jit_rvv_layernorm_f16_fused_kernel_t::generate() {
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_dst = a2;
+    const Reg reg_scale = a3;
+    const Reg reg_shift = a4;
+    const Reg reg_len = a5;
+    const Reg reg_t1 = a6; // remaining element count
+    const Reg reg_ptr = a7; // mean/variance pointer scratch
+    const Reg reg_vl = t0; // current vsetvli element count
+    const Reg reg_tmp = t1;
+    const Reg reg_tmp2 = t2;
+
+    const FReg f_zero = ft0;
+    const FReg f_mean = ft1; // mean (also holds Sx before divide)
+    const FReg f_var_sum = ft2;
+    const FReg f_len = ft3;
+    const FReg f_inv = ft4; // 1/sqrt(var+eps), f32
+    const FReg f_var = ft5;
+    const FReg f_eps = ft6;
+    const FReg d_b = ft8;
+    const FReg d_eps = ft9;
+    const FReg d_one = ft10;
+
+    const VReg v_sum(0); // m8: Sx accumulator
+    const VReg v_sumsq(8); // m8: variance accumulator
+    const VReg v_work(16); // m8: widened x / compute register
+    const VReg v_ld(24); // m4: f16 load temp
+    const VReg v_gamma(24); // m8: widened/loaded gamma
+    const VReg v_gld(8); // m4: gamma f16 load temp
+    const VReg v_beta(8); // m8: widened/loaded beta
+    const VReg v_bld(4); // m4: beta f16 load temp
+
+    fmv_w_x(f_zero, x0);
+
+    Label sum_loop, sum_done, var_loop, var_done, skip_mean, skip_var;
+    Label out_loop, out_done;
+
+    // ---- pass 1: accumulate Sx in f32 ----
+    ld(reg_src, reg_param, GET_F16_OFF(src));
+    ld(reg_t1, reg_param, GET_F16_OFF(len));
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vmv_v_x(v_sum, x0);
+    vmv_v_x(v_work, x0);
+
+    L(sum_loop);
+    beqz(reg_t1, sum_done);
+    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4);
+    sub(reg_t1, reg_t1, reg_vl);
+    vle16_v(v_ld, reg_src);
+    slli(reg_tmp, reg_vl, 1);
+    add(reg_src, reg_src, reg_tmp);
+    vfwcvt_f_f_v(v_work, v_ld); // f16 -> f32, first reg_vl elems
+    vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8);
+    vfadd_vv(v_sum, v_sum, v_work);
+    vmv_v_x(v_work, x0); // keep tail zero for next widen
+    j_(sum_loop);
+    L(sum_done);
+
+    // ---- finish mean ----
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vmv_v_v(v_work, v_sum);
+    vmv_v_x(v_sum, x0); // reuse as reduction init (elem0 = 0)
+    vfredosum_vs(v_work, v_work, v_sum);
+    vfmv_f_s(f_mean, v_work); // Sx
+
+    ld(reg_len, reg_param, GET_F16_OFF(len));
+    fcvt_s_l(f_len, reg_len);
+    fdiv_s(f_mean, f_mean, f_len); // mean
+
+    ld(reg_ptr, reg_param, GET_F16_OFF(mean));
+    beqz(reg_ptr, skip_mean);
+    fsw(f_mean, reg_ptr, 0);
+    L(skip_mean);
+
+    // ---- pass 2: accumulate variance as sum((x - mean)^2) ----
+    ld(reg_src, reg_param, GET_F16_OFF(src));
+    ld(reg_t1, reg_param, GET_F16_OFF(len));
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vmv_v_x(v_sumsq, x0);
+    vmv_v_x(v_work, x0);
+
+    L(var_loop);
+    beqz(reg_t1, var_done);
+    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4);
+    sub(reg_t1, reg_t1, reg_vl);
+    vle16_v(v_ld, reg_src);
+    slli(reg_tmp, reg_vl, 1);
+    add(reg_src, reg_src, reg_tmp);
+    vfwcvt_f_f_v(v_work, v_ld); // f16 -> f32
+    vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8);
+    vfsub_vf(v_work, v_work, f_mean);
+    vfmacc_vv(v_sumsq, v_work, v_work);
+    vmv_v_x(v_work, x0); // keep tail zero for next widen
+    j_(var_loop);
+    L(var_done);
+
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vmv_v_x(v_sum, x0); // reuse as reduction init
+    vfredosum_vs(v_sumsq, v_sumsq, v_sum);
+    vfmv_f_s(f_var_sum, v_sumsq);
+    fdiv_s(f_var, f_var_sum, f_len);
+    fmax_s(f_var, f_var, f_zero);
+    ld(reg_ptr, reg_param, GET_F16_OFF(variance));
+    beqz(reg_ptr, skip_var);
+    fsw(f_var, reg_ptr, 0);
+    L(skip_var);
+
+    flw(f_eps, reg_param, GET_F16_OFF(eps));
+    fcvt_d_s(d_b, f_var);
+    fcvt_d_s(d_eps, f_eps);
+    fadd_d(d_b, d_b, d_eps); // var + eps (f64)
+    fsqrt_d(d_b, d_b);
+    li(reg_tmp, 1);
+    fcvt_d_w(d_one, reg_tmp);
+    fdiv_d(d_b, d_one, d_b); // 1/sqrt
+    fcvt_s_d(f_inv, d_b); // inv (f32)
+
+    // ---- pass 3: normalize + affine, write f16 ----
+    ld(reg_src, reg_param, GET_F16_OFF(src));
+    ld(reg_dst, reg_param, GET_F16_OFF(dst));
+    if (with_scale_) ld(reg_scale, reg_param, GET_F16_OFF(scale));
+    if (with_shift_) ld(reg_shift, reg_param, GET_F16_OFF(shift));
+    ld(reg_t1, reg_param, GET_F16_OFF(len));
+
+    L(out_loop);
+    beqz(reg_t1, out_done);
+    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4);
+    sub(reg_t1, reg_t1, reg_vl);
+
+    vle16_v(v_ld, reg_src);
+    vfwcvt_f_f_v(v_work, v_ld); // x -> f32
+
+    if (weights_f16_) {
+        if (with_scale_) {
+            vle16_v(v_gld, reg_scale);
+            vfwcvt_f_f_v(v_gamma, v_gld); // gamma -> f32 (v24 m8)
+        }
+        if (with_shift_) {
+            vle16_v(v_bld, reg_shift);
+            vfwcvt_f_f_v(v_beta, v_bld); // beta -> f32 (v8 m8)
+        }
+    } else if (with_scale_ || with_shift_) {
+        vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8);
+        if (with_scale_) vle32_v(v_gamma, reg_scale);
+        if (with_shift_) vle32_v(v_beta, reg_shift);
+    }
+
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vfsub_vf(v_work, v_work, f_mean); // x - mean
+    vfmul_vf(v_work, v_work, f_inv); // * inv
+    if (with_scale_) vfmul_vv(v_work, v_work, v_gamma);
+    if (with_shift_) vfadd_vv(v_work, v_work, v_beta);
+
+    vsetvli(reg_tmp, reg_vl, SEW::e16, LMUL::m4);
+    vfncvt_f_f_w(v_ld, v_work); // f32 -> f16
+    vse16_v(v_ld, reg_dst);
+
+    slli(reg_tmp, reg_vl, 1);
+    add(reg_src, reg_src, reg_tmp);
+    add(reg_dst, reg_dst, reg_tmp);
+    if (with_scale_ || with_shift_) {
+        slli(reg_tmp2, reg_vl, weights_f16_ ? 1 : 2);
+        if (with_scale_) add(reg_scale, reg_scale, reg_tmp2);
+        if (with_shift_) add(reg_shift, reg_shift, reg_tmp2);
+    }
+    j_(out_loop);
+    L(out_done);
+    ret();
+}
+
+#undef GET_F16_OFF
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_rvv_layernorm_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_layernorm_kernel.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,6 +79,36 @@ protected:
 private:
     const bool with_scale_;
     const bool with_shift_;
+};
+
+struct jit_rvv_layernorm_f16_fused_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const void *src; // f16
+        void *dst; // f16
+        const void *scale; // gamma, f16 or f32 (per weights_f16_)
+        const void *shift; // beta,  f16 or f32 (per weights_f16_)
+        dim_t len;
+        float eps;
+        float *mean; // f32 out, nullptr to skip
+        float *variance; // f32 out, nullptr to skip
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_layernorm_f16_fused_kernel_t)
+
+    jit_rvv_layernorm_f16_fused_kernel_t(
+            bool with_scale, bool with_shift, bool weights_f16);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    const bool with_scale_;
+    const bool with_shift_;
+    const bool weights_f16_;
 };
 
 } // namespace rv64

--- a/src/cpu/rv64/rvv_layer_normalization.cpp
+++ b/src/cpu/rv64/rvv_layer_normalization.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025 Intel Corporation
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,23 +29,22 @@ namespace rv64 {
 
 rvv_layer_normalization_fwd_t::rvv_layer_normalization_fwd_t(const pd_t *apd)
     : primitive_t(apd) {
-    fused_kernel_.reset(new jit_rvv_layernorm_fused_kernel_t(
-            pd()->use_scale(), pd()->use_shift()));
-    data_kernel_.reset(new jit_rvv_layernorm_data_kernel_t(
-            pd()->use_scale(), pd()->use_shift()));
+    if (pd()->src_md()->data_type == data_type::f16) {
+        const bool weights_f16
+                = pd()->weights_md()->data_type == data_type::f16;
+        f16_fused_kernel_.reset(new jit_rvv_layernorm_f16_fused_kernel_t(
+                pd()->use_scale(), pd()->use_shift(), weights_f16));
+    } else {
+        fused_kernel_.reset(new jit_rvv_layernorm_fused_kernel_t(
+                pd()->use_scale(), pd()->use_shift()));
+        data_kernel_.reset(new jit_rvv_layernorm_data_kernel_t(
+                pd()->use_scale(), pd()->use_shift()));
+    }
 }
 
 status_t rvv_layer_normalization_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
     using namespace memory_tracking::names;
-    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
-    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
-    const float *scale = pd()->use_scale()
-            ? CTX_IN_MEM(const float *, DNNL_ARG_SCALE)
-            : nullptr;
-    const float *shift = pd()->use_shift()
-            ? CTX_IN_MEM(const float *, DNNL_ARG_SHIFT)
-            : nullptr;
 
     float *mean_ptr = nullptr;
     float *variance_ptr = nullptr;
@@ -67,6 +67,41 @@ status_t rvv_layer_normalization_fwd_t::execute_forward(
     const float eps = pd()->desc()->layer_norm_epsilon;
     const bool save_stats = pd()->is_training();
     const bool calculate_stats = !pd()->stats_are_src();
+
+    if (pd()->src_md()->data_type == data_type::f16) {
+        const auto *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+        auto *dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+        const void *scale = pd()->use_scale()
+                ? CTX_IN_MEM(const void *, DNNL_ARG_SCALE)
+                : nullptr;
+        const void *shift = pd()->use_shift()
+                ? CTX_IN_MEM(const void *, DNNL_ARG_SHIFT)
+                : nullptr;
+        const size_t dt_size = types::data_type_size(data_type::f16);
+
+        parallel_nd(N, [&](dim_t n) {
+            jit_rvv_layernorm_f16_fused_kernel_t::call_params_t p;
+            p.src = reinterpret_cast<const char *>(src) + n * C * dt_size;
+            p.dst = reinterpret_cast<char *>(dst) + n * C * dt_size;
+            p.scale = scale;
+            p.shift = shift;
+            p.len = C;
+            p.eps = eps;
+            p.mean = save_stats ? mean_ptr + n : nullptr;
+            p.variance = save_stats ? variance_ptr + n : nullptr;
+            (*f16_fused_kernel_)(&p);
+        });
+        return status::success;
+    }
+
+    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
+    const float *scale = pd()->use_scale()
+            ? CTX_IN_MEM(const float *, DNNL_ARG_SCALE)
+            : nullptr;
+    const float *shift = pd()->use_shift()
+            ? CTX_IN_MEM(const float *, DNNL_ARG_SHIFT)
+            : nullptr;
 
     if (!calculate_stats) {
         parallel_nd(N, [&](dim_t n) {

--- a/src/cpu/rv64/rvv_layer_normalization.hpp
+++ b/src/cpu/rv64/rvv_layer_normalization.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025 Intel Corporation
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,16 +49,28 @@ struct rvv_layer_normalization_fwd_t : public primitive_t {
             VDISPATCH_LNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_LNORM(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
 
-            VDISPATCH_LNORM(
-                    (src_md()->data_type == f32), VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_LNORM(
-                    (dst_md()->data_type == f32), VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_LNORM(utils::one_of(src_md()->data_type, f32, f16),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_LNORM((dst_md()->data_type == src_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_LNORM(
                     (stat_md()->data_type == f32), VERBOSE_UNSUPPORTED_DT);
 
-            VDISPATCH_LNORM((check_scale_shift_data_type()),
-                    VERBOSE_UNSUPPORTED_FEATURE,
-                    "unsupported scale or shift data type");
+            if (src_md()->data_type == f16) {
+                VDISPATCH_LNORM(platform::has_data_type_support(f16),
+                        VERBOSE_UNSUPPORTED_DT);
+                // f16 path computes statistics in a single fused pass; it does
+                // not support externally provided (global) mean/variance.
+                VDISPATCH_LNORM(!stats_are_src(), VERBOSE_UNSUPPORTED_FEATURE,
+                        "f16 does not support global stats");
+                VDISPATCH_LNORM((check_scale_shift_data_type({f32, f16})),
+                        VERBOSE_UNSUPPORTED_FEATURE,
+                        "unsupported scale or shift data type");
+            } else if (src_md()->data_type == f32) {
+                VDISPATCH_LNORM((check_scale_shift_data_type({f32})),
+                        VERBOSE_UNSUPPORTED_FEATURE,
+                        "unsupported scale or shift data type");
+            }
 
             VDISPATCH_LNORM(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
@@ -185,6 +198,7 @@ private:
     std::shared_ptr<primitive_t> reorder_;
     std::unique_ptr<jit_rvv_layernorm_fused_kernel_t> fused_kernel_;
     std::unique_ptr<jit_rvv_layernorm_data_kernel_t> data_kernel_;
+    std::unique_ptr<jit_rvv_layernorm_f16_fused_kernel_t> f16_fused_kernel_;
 };
 
 } // namespace rv64


### PR DESCRIPTION
# Description

This PR adds RV64 RVV JIT support for the f16 layer normalization forward inference path.

The implementation targets f16 source data with f16/f32 scale/shift data and channel-wise scale/shift (`flags=CH`). For supported RV64/RVV layer normalization cases, the primitive now uses the RVV JIT implementation (`jit_lnorm:rvv`) instead of falling back to the reference implementation (`ref:any`).

The change depends on the latest xbyak_riscv 1.10 version for the JIT code generation path.

Functional testing has passed. Compared to the reference implementation, the current version delivers a 48.30x average performance improvement by benchdnn `%0time` (`avg_time`) across the matched test cases, with representative cases reaching more than 100x speedup.

# Changes

- Added/enabled the RV64 RVV JIT f16 layer normalization forward implementation.
- Wired supported f16 forward inference cases to `jit_lnorm:rvv`.
- Supported f16 source and f16/f32 scale/shift data with channel-wise scale/shift (`flags=CH`).


# Testing

Validations and benchmarks  were run on Spacemit X100 (K3).

```bash
./benchdnn --lnorm --mode=C --dir=FWD_I --dt=f16 --ss_dt=f16 --flags=CH --batch=inputs/lnorm/option_set_all
./benchdnn --lnorm --mode=P --dir=FWD_I --dt=f16 --ss_dt=f16 --flags=CH --batch=inputs/lnorm/option_set_all
```

The reference result uses `ref:any`, and the optimized result uses `jit_lnorm:rvv`. All correctness cases passed.

Representative cases:

| Problem | `min_time` speedup | `avg_time` speedup |
| --- | ---: | ---: |
| `30x300` | 40.31x | 26.83x |
| `256x768` | 144.32x | 22.05x |
| `5120x1024` | 78.67x | 63.74x |
| `128x1x1024` | 144.91x | 86.86x |
| `128x40x1024` | 143.30x | 105.20x |
| `6x2x128x1024` | 189.83x | 156.69x |

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
