### PR TITLE
graph: backend: dnnl: fix nthr in decomp kernels under threadpool rt

### DIFF
--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -31,7 +31,6 @@
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
 #include "cpu/cpu_stream.hpp"
-#include "oneapi/dnnl/dnnl_threadpool.h"
 #endif
 
 namespace dnnl {
@@ -164,10 +163,6 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
                     const_cast<stream_t *>(g_stream));
-    tp_stream->before_exec_hook();
-    int thread_num = 1;
-    dnnl_threadpool_interop_get_max_concurrency(&thread_num);
-    mqa_cfg_.nthr = thread_num;
 #endif
 
     // each thread's own local resource
@@ -275,9 +270,9 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
         threadpool_utils::activate_threadpool(tp);
 #endif
     };
-    // TODO: remove this when primitive new API ready
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
-    omp_set_num_threads(mqa_cfg_.nthr);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    tp_stream->before_exec_hook();
 #endif
 
     parallel_nd_ext(mqa_cfg_.nthr, MBO, MBI, loop);

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -55,6 +55,9 @@ bool mqa_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
             static_cast<long int>(wei1_user_dims[0]),
             static_cast<long int>(wei2_user_dims[0]));
 
+    // Initialize nthr with max threads num
+    nthr = dnnl_get_max_threads();
+
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
 // RATIO is an empirical value used to determine the numerical relationship
 // between batch_size, num_head and thread number to determine whether to use
@@ -67,8 +70,6 @@ bool mqa_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
 // TODO: Refine the inequation based on the relationship of cache size and mqa
 // memory footprint requirements.
 #define RATIO 2
-    // Initialize nthr with current threads num
-    nthr = dnnl_get_current_num_threads();
     VCHECK_MQA_DECOMP(batch_size * num_head > RATIO * nthr, false,
             "doesn't meet condition for decompose:"
             "batch size * num_head should be larger than ratio * nthr, but got "
@@ -76,6 +77,7 @@ bool mqa_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
             static_cast<long int>(batch_size), static_cast<long int>(num_head),
             RATIO, nthr);
 #endif
+
     return true;
 }
 
@@ -330,6 +332,10 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
 
     // memory planing for buffer sharing
     memory_planning(mqa_registry);
+    // TODO: remove this when primitive new API ready
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(nthr);
+#endif
     return status::success;
 }
 

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
@@ -76,7 +76,7 @@ public:
     memory::dim batch_size, num_head, seq_len, size_per_head;
 
     // Thread nums during the workflow
-    int nthr;
+    int nthr = 0;
 
     // Used to record the exact input offset of the MQA subgraph
     // [mm1_src, mm1_wei, mm1_add, mm2_src]

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -31,7 +31,6 @@
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
 #include "cpu/cpu_stream.hpp"
-#include "oneapi/dnnl/dnnl_threadpool.h"
 #endif
 
 namespace dnnl {
@@ -169,11 +168,6 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
                     const_cast<stream_t *>(g_stream));
-    tp_stream->before_exec_hook();
-    int thread_num = 1;
-    dnnl_threadpool_interop_get_max_concurrency(&thread_num);
-    sdp_cfg_.nthr = thread_num;
-    tp_stream->after_exec_hook();
 #endif
 
     thread_local_cache_t<sdp_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -91,6 +91,9 @@ bool sdp_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
             "value:%s",
             dnnl_dt2str(ltw(inputs[graph_inport[mm1_wei]]).data_type()),
             dnnl_dt2str(ltw(inputs[graph_inport[mm2_wei]]).data_type()));
+
+    // Initialize nthr with max threads num
+    nthr = dnnl_get_max_threads();
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
 // RATIO is an empirical value used to determine the numerical relationship
 // between batch_size, num_head_q and thread number to determine whether to use
@@ -103,8 +106,6 @@ bool sdp_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
 // TODO: Refine the inequation based on the relationship of cache size and sdp
 // memory footprint requirements.
 #define RATIO 2
-    // Initialize nthr with current threads num
-    nthr = dnnl_get_current_num_threads();
     VCHECK_SDP_DECOMP(batch_size * num_head_q > RATIO * nthr, false,
             "Doesn't meet condition for decompose: Batch size * num_head_q "
             "should be larger than ratio * nthr, but got batch_size %ld, "

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -83,7 +83,7 @@ public:
             post_add_strides;
 
     // Thread nums during the workflow
-    int nthr;
+    int nthr = 0;
 
     // Used to record the exact input offset in subgraph
     // [mm1_src,mm1_wei,mm2_wei,mm1_scale,mm1_soft_capping,mm1_add,select_condition,select_other_input]


### PR DESCRIPTION
Properly get the number of thread (`nthr`) under threadpool runtime, which is needed to estimate the scratchpad size for decomposition kernels.

Previously, `nthr` was queried during execution time and used for internal scratchpad allocation and parallel-for.
Now with the fix, `nthr` is queried during compilation time and used for scratchpad size estimation. It's stored and used for parallel-for during execution time.