### PR TITLE
[cpu][matmul] int8 enable grouped scales

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -471,7 +471,10 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     brg->with_src_scales = !src_scales.has_default_values();
     brg->with_wei_scales
             = !brg->skip_wei_scales && !wei_scales.has_default_values();
-    if (brg->with_wei_scales) {
+
+    bool wei_scales_are_set = brg->is_single_wei_scale
+            || brg->is_per_n_wei_scales || brg->is_per_k_wei_scales;
+    if (brg->with_wei_scales && !wei_scales_are_set) {
         // Note. the current version supports only two different wei scales
         // types:
         //     1) common (mask = 0)
@@ -483,7 +486,11 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         // So if wei_scales.get_mask() > 0 (not common) it's assumed here that
         // scale type is per_n_dim_scale and driver which calls brgemm kernel
         // checked that mask has correct value for this case
-        brg->is_oc_scale = wei_scales.get_mask() > 0;
+
+        const auto &wei_scales_mask = wei_scales.get_mask();
+        brg->is_single_wei_scale = wei_scales_mask == 0;
+        brg->is_per_n_wei_scales = wei_scales_mask > 0;
+        brg->is_per_k_wei_scales = false;
         brg->dt_wei_scales = wei_scales.get_data_type();
     }
 
@@ -811,7 +818,9 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(zp_type_c);
 
     CMP_BRGEMM_FIELD(skip_wei_scales);
-    CMP_BRGEMM_FIELD(is_oc_scale);
+    CMP_BRGEMM_FIELD(is_single_wei_scale);
+    CMP_BRGEMM_FIELD(is_per_n_wei_scales);
+    CMP_BRGEMM_FIELD(is_per_k_wei_scales);
     CMP_BRGEMM_FIELD(with_src_scales);
     CMP_BRGEMM_FIELD(with_wei_scales);
     CMP_BRGEMM_FIELD(with_dst_scales);

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -499,7 +499,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     const bool scales_ok = attr->scales_.has_default_values({DNNL_ARG_SRC,
                                    DNNL_ARG_WEIGHTS, DNNL_ARG_DST})
             && IMPLICATION(!src_scales.has_default_values(),
-                    src_scales.get_mask() == 0)
+                    src_scales.get_mask() == 0 || brg->is_per_k_src_scales)
             && IMPLICATION(!dst_scales.has_default_values(),
                     dst_scales.get_mask() == 0);
     if (!scales_ok) return status::unimplemented;
@@ -822,6 +822,9 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(is_per_n_wei_scales);
     CMP_BRGEMM_FIELD(is_per_k_wei_scales);
     CMP_BRGEMM_FIELD(with_src_scales);
+    CMP_BRGEMM_FIELD(is_per_k_src_scales);
+    CMP_BRGEMM_FIELD(src_scale_m_stride);
+    CMP_BRGEMM_FIELD(dt_src_scales);
     CMP_BRGEMM_FIELD(with_wei_scales);
     CMP_BRGEMM_FIELD(with_dst_scales);
     CMP_BRGEMM_FIELD(dt_wei_scales);

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -303,11 +303,12 @@ struct brgemm_desc_t {
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_c = brgemm_broadcast_t::none;
 
-    // `skip_wei_scales` is controlled by the implementation and not by kernel
-    // API.
     bool skip_wei_scales = false;
-    int is_oc_scale = 0;
+    int is_single_wei_scale = 0;
+    int is_per_n_wei_scales = 0;
+    int is_per_k_wei_scales = 0;
     bool with_src_scales = false;
+    bool has_per_k_scales() const { return is_per_k_wei_scales; }
     bool with_wei_scales = false;
     // `dst_scales` passed as a bare pointer making kernel change multiplication
     // to division was proved to be significantly slower, both for pure divps
@@ -461,6 +462,17 @@ struct brgemm_desc_t {
         const bool has_tail_acc = is_bdb_tail && gemv_tail > 0;
         const dim_t full_accs = is_bdb_tail ? gemv_bdb_tail() : gemv_bd_block();
         return full_accs + has_tail_acc;
+    }
+
+    // Determines if the accumulator dt is integer.
+    //
+    // When the per-k scales are present, need to accumulate
+    // in f32 due to precision loss.
+    bool is_integer_acc() const { return is_int8 && !has_per_k_scales(); }
+
+    // Determines if the DQ2PS conversion is needed for the accumulator.
+    bool do_dq2ps_cvt() const {
+        return is_integer_acc() && (alpha != 1.f || beta != 1.f);
     }
 
     // return 'true' when FP8 MAC is not natively supported by the CPU ISA
@@ -690,33 +702,33 @@ struct brgemm_dynamic_values_t {
 };
 
 struct brgemm_kernel_params_t {
-    const void *ptr_A;
-    const void *ptr_B;
-    const brgemm_batch_element_t *batch;
-    void *ptr_C;
+    const void *ptr_A = nullptr;
+    const void *ptr_B = nullptr;
+    const brgemm_batch_element_t *batch = nullptr;
+    void *ptr_C = nullptr;
 
-    const void *ptr_bias;
-    void *ptr_D;
+    const void *ptr_bias = nullptr;
+    void *ptr_D = nullptr;
 
     const void *ptr_src_scales = nullptr;
     const void *ptr_wei_scales = nullptr;
     const void *ptr_dst_scales = nullptr;
-    void *ptr_buf;
+    void *ptr_buf = nullptr;
 
-    size_t do_post_ops;
-    size_t do_apply_comp;
-    size_t BS;
+    size_t do_post_ops = 0;
+    size_t do_apply_comp = 0;
+    size_t BS = 0;
 
     /*
      * ptr to table of void * elements that are pointers to post_op binary
      * src1 tensors
      */
-    const void *post_ops_binary_rhs_arg_vec;
-    size_t oc_logical_off;
-    size_t first_mb_matrix_addr_off;
-    size_t dst_row_logical_off;
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    size_t oc_logical_off = 0;
+    size_t first_mb_matrix_addr_off = 0;
+    size_t dst_row_logical_off = 0;
 
-    const char *data_C_ptr_;
+    const char *data_C_ptr_ = nullptr;
 
     const void *a_zp_compensations = nullptr;
     const void *b_zp_compensations = nullptr;
@@ -807,7 +819,7 @@ private:
 
 /// @param bias Vector of bias (vector length is N)
 /// @param scales - Vector of scale factor values which represents combination
-///     scale factors for matrixes A and B. If brgemm_desc_t::is_oc_scale = true
+///     scale factors for matrixes A and B. If brgemm_desc_t::is_per_n_scale = true
 ///     vector length is N otherwise it must be broadcasted to vector of simd
 ///     width length
 /// @param binary_post_ops_rhs - Ptr to table of pointers to tensors used as rhs

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -308,7 +308,14 @@ struct brgemm_desc_t {
     int is_per_n_wei_scales = 0;
     int is_per_k_wei_scales = 0;
     bool with_src_scales = false;
-    bool has_per_k_scales() const { return is_per_k_wei_scales; }
+    int is_per_k_src_scales = 0;
+    dim_t src_scale_m_stride = 0;
+    data_type_t dt_src_scales = data_type::undef;
+
+    bool has_per_k_scales() const {
+        return is_per_k_wei_scales || is_per_k_src_scales;
+    }
+
     bool with_wei_scales = false;
     // `dst_scales` passed as a bare pointer making kernel change multiplication
     // to division was proved to be significantly slower, both for pure divps

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -398,8 +398,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     if (brg.with_wei_scales) {
         reg_aux_wei_scales.restore();
-        const bool is_single_scale = !brg.is_oc_scale;
-        if (!is_single_scale) {
+        if (!brg.is_single_wei_scale) {
             assert(brg.dt_wei_scales == data_type::f32);
             lea(reg_aux_wei_scales,
                     ptr[reg_aux_wei_scales + reg_aux_N * sizeof(float)]);
@@ -420,7 +419,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
             const Vmm vmm_wei_scales = vmm_tmp(0);
             const auto addr
                     = ptr[reg_aux_wei_scales + wei_scales_offset(n, v_i)];
-            if (is_single_scale) {
+            if (brg.is_single_wei_scale) {
                 if (has_ptr_b_support) {
                     // No need to check for mask support separately, as masks
                     // are supported with the same isa that introduced address

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -403,7 +403,8 @@ private:
         return brg.typesize_bias * (n * n_block1() + v * simd_w_);
     }
     int wei_scales_offset(int n, int v) {
-        return sizeof(float) * brg.is_oc_scale * (n * n_block1() + v * simd_w_);
+        return sizeof(float) * brg.is_per_n_wei_scales
+                * (n * n_block1() + v * simd_w_);
     }
     size_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -577,7 +577,8 @@ private:
         const bool need_to_apply_post_ops
                 = are_post_ops_applicable_ && apply_post_ops;
         const auto store_by_vectors = need_to_apply_alpha_beta_
-                || need_to_apply_post_ops || brg.brgattr.bd_mask_level;
+                || need_to_apply_post_ops || brg.brgattr.bd_mask_level
+                || brg.has_per_k_scales();
         return store_by_vectors;
     }
     bool actual_ils(bool apply_post_ops, bool skip_accumulation = false) const {
@@ -829,7 +830,7 @@ dim_t jit_brgemm_amx_uker_base_t::bias_offset(int ldb) const noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::scales_offset(int ldb) const noexcept {
-    return brg.is_oc_scale * ldb * ld_block_scales_size_;
+    return brg.is_per_n_wei_scales * ldb * ld_block_scales_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(int ldb) const noexcept {
@@ -975,8 +976,9 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     const bool apply_beta = brg.beta != 0.f;
     if (!apply_alpha && !apply_beta) return;
 
-    const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
-    const bool use_vadd_for_beta = brg.beta == 1.f && !dq2ps_required;
+    // When K-scales (wei or src) are applied, accumulator is already
+    // converted to float (dq2ps + scales before alpha_beta), C stores floats.
+    const bool use_vadd_for_beta = brg.beta == 1.f && !brg.do_dq2ps_cvt();
 
     if (apply_beta && !use_vadd_for_beta) {
         mov(reg_tmp_gpr, float2int(static_cast<float>(brg.beta)));
@@ -988,12 +990,12 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
         vmovq(Xmm(zmm_alpha.getIdx()), reg_tmp_gpr);
         vbroadcastss(zmm_alpha, Xmm(zmm_alpha.getIdx()));
     }
-    if (dq2ps_required) vcvtdq2ps(zmm, zmm);
+    if (brg.do_dq2ps_cvt()) vcvtdq2ps(zmm, zmm);
     if (apply_alpha) vmulps(zmm, zmm, zmm_alpha);
     if (apply_beta) {
         if (use_vadd_for_beta) {
             auto zmm_masked = zmm | k_mask | T_z;
-            if (brg.is_int8)
+            if (brg.is_integer_acc())
                 vpaddd(zmm_masked, zmm, addr);
             else
                 vaddps(zmm_masked, zmm, addr);
@@ -1131,8 +1133,43 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         brgemm_iteration_t &bi) {
-    if (!bi.apply_postops) return;
+
     const auto ldi = bi.ldi;
+
+    // Load wei_scales for per K-block application (is_per_k_wei_scales).
+    // This must happen for both apply_postops and non-apply_postops paths.
+    if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
+        mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+            auto scales_ptr = EVEX_compress_addr(
+                    reg_scales, scales_offset(ldi->pos(ldb)));
+            auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
+            if (brg.is_single_wei_scale) {
+                // Broadcast a single scale value — handle non-f32 types.
+                switch (brg.dt_wei_scales) {
+                    case data_type::f32:
+                        vbroadcastss(zmm_scales(ldb), scales_ptr);
+                        break;
+                    case data_type::bf16:
+                        vpbroadcastw(zmm_scales(ldb), scales_ptr);
+                        vpslld(zmm_scales(ldb), zmm_scales(ldb), 16);
+                        break;
+                    case data_type::f16:
+                        vpbroadcastw(zmm_scales(ldb), scales_ptr);
+                        vcvtph2ps(zmm_scales(ldb),
+                                Xbyak::Ymm(zmm_scales(ldb).getIdx()));
+                        break;
+                    default: vbroadcastss(zmm_scales(ldb), scales_ptr); break;
+                }
+            } else {
+                // Load a vector of scale values with proper type conversion.
+                cvt2ps(brg.dt_wei_scales, zmm_scales(ldb), scales_ptr, true,
+                        false, k_mask);
+            }
+        }
+    }
+
+    if (!bi.apply_postops) return;
 
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
@@ -1156,18 +1193,17 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
     }
 
-    if (brg.with_wei_scales) {
+    if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
-            const bool is_single_scale = !brg.is_oc_scale;
 
             const auto zmm_scale = zmm_scales(ldb);
             const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
 
-            if (is_single_scale) {
+            if (brg.is_single_wei_scale) {
                 if (brg.with_src_scales) {
                     // Single value is not anticipated to be of any other type
                     // when both scales are defined.
@@ -1457,6 +1493,18 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
             vmovups(vreg_acc, ptr[reg_buf + buf_offset + wsp_offset]);
         }
 
+        // For K-scales (wei and/or src), convert int32->float and apply
+        // the current K-group's scales BEFORE alpha_beta accumulation.
+        if (brg.has_per_k_scales() && !bi.skip_accumulation) {
+            vcvtdq2ps(zmm, zmm);
+
+            if (brg.is_per_k_wei_scales) {
+                const Xbyak::Zmm scaled_zmm
+                        = vmm_mask(zmm, true, false, k_mask);
+                vmulps(scaled_zmm, scaled_zmm, zmm_scales(ldb));
+            }
+        }
+
         if (need_to_apply_alpha_beta_ || bi.skip_accumulation) {
             const auto c_offset = C_offset(bi, bdb, bd, bi.ldi->pos(ldb));
             const auto ptr_C
@@ -1467,7 +1515,8 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
         if (!bi.apply_postops) continue;
 
-        if (dq2ps_required) vcvtdq2ps(zmm, zmm);
+        // When K-scales (wei or src) are used, dq2ps already applied above.
+        if (dq2ps_required && !brg.has_per_k_scales()) vcvtdq2ps(zmm, zmm);
 
         if (brg.req_comp_pads_with_bcast)
             apply_comp_pad_to_vector(bi, bdb, bd, ldb, zmm.getIdx());
@@ -1503,7 +1552,11 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         }
     }
 
-    if (brg.with_src_scales || brg.with_wei_scales) {
+    // When K-scales (wei) are used, they were already applied
+    // per K-block above. Only apply the remaining scales (non-K) in postops.
+    const bool apply_scales_in_postops = brg.with_src_scales
+            || (brg.with_wei_scales && !brg.is_per_k_wei_scales);
+    if (apply_scales_in_postops) {
         for (auto bd = bd_start; bd < bd_finish; bd++) {
             if (!is_out_bd(bi.bdi, bdb, bd)) continue;
 
@@ -2944,7 +2997,7 @@ void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
                 = brg.alpha != 1.0f || brg.beta != 0.f;
         const bool beta_uses_vadd = brg.beta == 1.f
                 && IMPLICATION(brg.is_int8, brg.alpha == 1.0f);
-        dt_requires_saturation_ = brg.is_int8
+        dt_requires_saturation_ = brg.is_int8 && !brg.has_per_k_scales()
                 && !IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd);
     }
     use_sat_cvt_ = dt_requires_saturation_

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -190,6 +190,7 @@ private:
     const reg64_savable_t reg_zp_a_values {regscratchpad_, rbx, r18};
     const reg64_savable_t reg_zp_comp_b {regscratchpad_, rbx, r19};
     const reg64_savable_t reg_zp_c_values {regscratchpad_, rbx, r20};
+    const reg64_savable_t reg_src_scales_per_k {regscratchpad_, rbx, r21};
     const reg64_t reg_ptr_sum_zp = rbx;
     const reg64_t reg_converted_stride = rsi;
     const reg64_t reg_zp_comp_pad_a = rsi;
@@ -935,6 +936,11 @@ void jit_brgemm_amx_uker_base_t::read_params() {
         mov(reg_zp_c_values, ptr[param1 + GET_OFF(c_zp_values)]);
         reg_zp_c_values.save();
     }
+
+    if (brg.is_per_k_src_scales) {
+        mov(reg_src_scales_per_k, ptr[param1 + GET_OFF(ptr_src_scales)]);
+        reg_src_scales_per_k.save();
+    }
 }
 
 void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
@@ -1182,14 +1188,31 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
     }
 
-    if (brg.with_src_scales) {
+    if (brg.with_src_scales && !brg.is_per_k_src_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
-            vbroadcastss(zmm_scales(ldb) | k_mask | T_z, scales_ptr);
+            const auto zmm_scale = zmm_scales(ldb);
+            const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
+            switch (brg.dt_src_scales) {
+                case data_type::f32:
+                    vbroadcastss(zmm_scale_masked, scales_ptr);
+                    break;
+                case data_type::bf16:
+                    vpbroadcastw(zmm_scale, scales_ptr);
+                    uni_vpslld(zmm_scale_masked, zmm_scale, 16);
+                    break;
+                case data_type::f16:
+                    vpbroadcastw(zmm_scale, scales_ptr);
+                    vcvtph2psx(
+                            Xmm(zmm_scale.getIdx()), Xmm(zmm_scale.getIdx()));
+                    vbroadcastss(zmm_scale_masked, Xmm(zmm_scale.getIdx()));
+                    break;
+                default: assert(!"unsupported src_scales data type");
+            }
         }
     }
 
@@ -1204,7 +1227,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
             const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
 
             if (brg.is_single_wei_scale) {
-                if (brg.with_src_scales) {
+                if (brg.with_src_scales && !brg.is_per_k_src_scales) {
                     // Single value is not anticipated to be of any other type
                     // when both scales are defined.
                     assert(brg.dt_wei_scales == data_type::f32);
@@ -1249,7 +1272,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 default: assert(!"unsupported wei_scales data type");
             }
 
-            if (brg.with_src_scales) {
+            if (brg.with_src_scales && !brg.is_per_k_src_scales) {
                 // Src scales are set, need to multiply by their value.
                 vmulps(zmm_scale_masked, zmm_scale, zmm_wei_scale);
             } else {
@@ -1258,7 +1281,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
             }
         }
     }
-}
+    }
 
 void jit_brgemm_amx_uker_base_t::uni_prefetch(
         const Address &addr, brgemm_kernel_prefetching_t pft, bool for_write) {
@@ -1498,10 +1521,34 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         if (brg.has_per_k_scales() && !bi.skip_accumulation) {
             vcvtdq2ps(zmm, zmm);
 
+            const Xbyak::Zmm scaled_zmm = vmm_mask(zmm, true, false, k_mask);
+            // Apply K-wei_scales if present (pre-loaded per-ldb vector).
             if (brg.is_per_k_wei_scales) {
-                const Xbyak::Zmm scaled_zmm
-                        = vmm_mask(zmm, true, false, k_mask);
                 vmulps(scaled_zmm, scaled_zmm, zmm_scales(ldb));
+            }
+            // Apply K-src_scales per-bd: each M-row has its own scalar.
+            if (brg.is_per_k_src_scales) {
+                reg_src_scales_per_k.restore();
+                const auto out_bd = get_out_bd(bi.bdi, bdb, bd);
+                const auto src_sc_offset = out_bd * brg.src_scale_m_stride;
+                const auto src_sc_ptr = EVEX_compress_addr(
+                        reg_src_scales_per_k, src_sc_offset);
+                const auto zmm_src_sc = zmm_tmp_1();
+                switch (brg.dt_src_scales) {
+                    case data_type::f32:
+                        vbroadcastss(zmm_src_sc, src_sc_ptr);
+                        break;
+                    case data_type::bf16:
+                        vpbroadcastw(zmm_src_sc, src_sc_ptr);
+                        vpslld(zmm_src_sc, zmm_src_sc, 16);
+                        break;
+                    case data_type::f16:
+                        vpbroadcastw(zmm_src_sc, src_sc_ptr);
+                        vcvtph2ps(zmm_src_sc, Xbyak::Ymm(zmm_src_sc.getIdx()));
+                        break;
+                    default: assert(!"unsupported src_scales data type");
+                }
+                vmulps(scaled_zmm, scaled_zmm, zmm_src_sc);
             }
         }
 
@@ -1554,8 +1601,12 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
     // When K-scales (wei) are used, they were already applied
     // per K-block above. Only apply the remaining scales (non-K) in postops.
-    const bool apply_scales_in_postops = brg.with_src_scales
-            || (brg.with_wei_scales && !brg.is_per_k_wei_scales);
+    const bool src_scales_in_postops
+            = brg.with_src_scales && !brg.is_per_k_src_scales;
+    const bool wei_scales_in_postops
+            = brg.with_wei_scales && !brg.is_per_k_wei_scales;
+    const bool apply_scales_in_postops
+            = src_scales_in_postops || wei_scales_in_postops;
     if (apply_scales_in_postops) {
         for (auto bd = bd_start; bd < bd_finish; bd++) {
             if (!is_out_bd(bi.bdi, bdb, bd)) continue;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -418,10 +418,11 @@ private:
     void apply_compensation(dim_t bd_block, dim_t ld_block, bool is_ld_tail);
     void apply_alpha_beta(
             dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
+    void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail,
+            bool dq2ps_required, bool &dq2ps_cvt_done);
+    void apply_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail);
     void apply_post_ops(dim_t bd_block, dim_t ld_block2,
             dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
-    void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool dq2ps_required,
-            bool dq2ps_cvt_done, bool is_ld_tail);
     void gemv_apply_bias(dim_t bd_block, bool is_bdb_tail);
     void gemv_apply_wei_scales(dim_t bd_block, bool is_bdb_tail);
 
@@ -440,6 +441,8 @@ private:
             matrix_kind_t mk);
     void maybe_tileloadd_nt(matrix_kind_t matrix_kind, dim_t idx, dim_t offset,
             bool is_rd_tail, bool is_tail, bool last_bdb);
+    void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
+            const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
     void gemm_microkernel(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
             bool is_rd_tail, bool is_ld_tail, dim_t vpad,
@@ -694,7 +697,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
                 * types::data_type_size(brg.dt_wei_scales);
 
     const dim_t ld_offset = is_tail ? brg.ldb_tail : ld * brg.ld_block;
-    return ld_offset * brg.is_oc_scale
+    return ld_offset * brg.is_per_n_wei_scales
             * types::data_type_size(brg.dt_wei_scales);
 }
 
@@ -1299,7 +1302,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
  *
  * Unlike bias, weight scales have two scale modes:
  *   - common: one scalar scale for the whole operation
- *   - per-N (`is_oc_scale`): one scale value per element along N
+ *   - per-N (`is_per_n_wei_scales`): one scale value per element along N
  *
  * In GEMV, per-N scales collapse to a single scalar only when `y` is treated
  * as a column vector.
@@ -1339,7 +1342,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
     reg_aux_wei_scales.restore();
 
     // Per-N scales collapse to a single scalar unless `y` is treated as a row.
-    const bool is_single_scale = !brg.is_oc_scale || !brg.treat_y_as_row;
+    const bool is_single_scale = brg.is_single_wei_scale || !brg.treat_y_as_row;
     const Vmm vmm_wei_scales = vmm_tmp(0);
 
     if (is_single_scale) {
@@ -1371,70 +1374,9 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
-        bool dq2ps_required, bool dq2ps_cvt_done, bool is_ld_tail) {
-
-    auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
-
-    reg_aux_wei_scales.restore();
-
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
-        const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(ld)];
-        const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-        const bool is_single_scale = !brg.is_oc_scale;
-
-        const Vmm vmm_wei_scales = vmm_tmp(0);
-        const Vmm vmm_wei_scales_masked
-                = vmm_mask(vmm_wei_scales, is_tail, false, k_mask);
-        if (is_single_scale) {
-            switch (brg.dt_wei_scales) {
-                case data_type::f32: vbroadcastss(vmm_wei_scales, addr); break;
-                case data_type::bf16:
-                    vpbroadcastw(vmm_wei_scales, addr);
-                    uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
-                    break;
-                case data_type::f16:
-                    vpbroadcastw(vmm_wei_scales, addr);
-                    vcvtph2ps(Xmm(vmm_wei_scales.getIdx()),
-                            Xmm(vmm_wei_scales.getIdx()));
-                    vbroadcastss(vmm_wei_scales, Xmm(vmm_wei_scales.getIdx()));
-                    break;
-                default: assert(!"unsupported wei_scales data type");
-            }
-        } else {
-            if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
-                switch (brg.dt_wei_scales) {
-                    case data_type::f32:
-                        uni_vmovups(vmm_wei_scales_masked, addr);
-                        break;
-                    case data_type::bf16:
-                        uni_vpmovzxwd(vmm_wei_scales_masked, addr);
-                        uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
-                        break;
-                    case data_type::f16:
-                        vcvtph2ps(vmm_wei_scales_masked, addr);
-                        break;
-                    default: assert(!"unsupported wei_scales data type");
-                }
-            } else {
-                assert(brg.dt_wei_scales == data_type::f32);
-                vmaskmovps(vmm_wei_scales, vmm_tail_mask(), addr);
-            }
-        }
-
-        for (dim_t bd = 0; bd < bd_block; bd++) {
-            auto vmm = accm(ld_block2, bd, ld);
-            if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
-            uni_vmulps(vmm, vmm, vmm_wei_scales);
-        }
-    }
-}
-
-template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
         dim_t bd_block, dim_t ld_block2, bool is_ld_tail, bool is_bdb_tail) {
     const bool apply_alpha = brg.alpha != 1.f;
-    const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
 
     auto vmm_alpha = vmm_tmp(0);
     if (apply_alpha) {
@@ -1446,12 +1388,12 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
     for_(dim_t bd = 0; bd < bd_block; bd++)
     for (dim_t ld = 0; ld < ld_block2; ld++) {
         auto vmm = accm(ld_block2, bd, ld);
-        if (dq2ps_required) uni_vcvtdq2ps(vmm, vmm);
+        if (brg.do_dq2ps_cvt()) uni_vcvtdq2ps(vmm, vmm);
         if (apply_alpha) uni_vmulps(vmm, vmm, vmm_alpha);
     }
 
     if (brg.beta == 0.f) return;
-    const bool use_vadd_for_beta = brg.beta == 1.f && !dq2ps_required;
+    const bool use_vadd_for_beta = brg.beta == 1.f && !brg.do_dq2ps_cvt();
     const bool need_init_beta_vmm = brg.beta != 1.f;
     auto vmm_prev_dst = vmm_tmp(0);
     if (need_init_beta_vmm) {
@@ -1482,21 +1424,19 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
                 } else {
                     uni_vaddss(Xmm(vmm.getIdx()), Xmm(vmm.getIdx()), ptr_C);
                 }
+            } else if (IMPLICATION(is_tail,
+                               is_superset(brg.isa_impl, avx512_core))) {
+                auto vmm_masked = vmm_mask(vmm, is_tail, false, k_mask);
+                if (brg.is_integer_acc())
+                    uni_vpaddd(vmm_masked, vmm, ptr_C);
+                else
+                    uni_vaddps(vmm_masked, vmm, ptr_C);
             } else {
-                if (IMPLICATION(
-                            is_tail, is_superset(brg.isa_impl, avx512_core))) {
-                    auto vmm_masked = vmm_mask(vmm, is_tail, false, k_mask);
-                    if (brg.is_int8)
-                        uni_vpaddd(vmm_masked, vmm, ptr_C);
-                    else
-                        uni_vaddps(vmm_masked, vmm, ptr_C);
-                } else {
-                    vmaskmovps(vmm_prev_dst, vmm_tail_mask(), ptr_C);
-                    if (brg.is_int8)
-                        uni_vpaddd(vmm, vmm, vmm_prev_dst);
-                    else
-                        uni_vaddps(vmm, vmm, vmm_prev_dst);
-                }
+                vmaskmovps(vmm_prev_dst, vmm_tail_mask(), ptr_C);
+                if (brg.is_integer_acc())
+                    uni_vpaddd(vmm, vmm, vmm_prev_dst);
+                else
+                    uni_vaddps(vmm, vmm, vmm_prev_dst);
             }
         } else {
             assert(!brg.is_gemv && "int8 data type is not supported for gemv");
@@ -1659,6 +1599,117 @@ void jit_brgemm_kernel_t<Wmm>::reduce_gemv_accumulators(dim_t bd_block) {
     }
 }
 
+/** Loads scales to a given vmm, applying masking if needed.
+* Used in multiple places for loading scales for variety of supported data types.
+* @param type_in data type of the scales to be loaded.
+* @param vmm_scales vmm register to load the scales to.
+* @param op an operand to load the scales from, must point to memory.
+* @param is_ld_tail tail flag used for applying tail mask
+* @param is_single_scale single scale flag, broadcasting if it's true.
+*/
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::load_scales_to_vmm(const data_type_t type_in,
+        const Vmm &vmm_scales, const Xbyak::Operand &op, bool is_ld_tail,
+        bool is_single_scale) {
+    const auto k_mask = is_ld_tail ? ld_tail_mask : ld_full_mask;
+    if (is_single_scale) {
+        switch (type_in) {
+            case data_type::f32: vbroadcastss(vmm_scales, op); break;
+            case data_type::bf16:
+                vpbroadcastw(vmm_scales, op);
+                uni_vpslld(vmm_scales, vmm_scales, 16);
+                break;
+            case data_type::f16:
+                vpbroadcastw(vmm_scales, op);
+                vcvtph2ps(Xmm(vmm_scales.getIdx()), Xmm(vmm_scales.getIdx()));
+                vbroadcastss(vmm_scales, Xmm(vmm_scales.getIdx()));
+                break;
+            default: assert(!"unsupported scales data type");
+        }
+    } else {
+        if (IMPLICATION(is_ld_tail, isa_has_masks(brg.isa_impl))) {
+            const Vmm vmm_scales_masked
+                    = vmm_mask(vmm_scales, is_ld_tail, false, k_mask);
+            const auto addr = op.getAddress();
+            switch (type_in) {
+                case data_type::f32:
+                    if (brg.is_gemv) {
+                        if (!brg.treat_y_as_row)
+                            uni_vmovss(vmm_scales_masked, addr);
+                    } else {
+                        uni_vmovups(vmm_scales_masked, addr);
+                    }
+                    break;
+                case data_type::bf16:
+                    uni_vpmovzxwd(vmm_scales_masked, addr);
+                    uni_vpslld(vmm_scales, vmm_scales, 16);
+                    break;
+                case data_type::f16: vcvtph2ps(vmm_scales_masked, addr); break;
+                default: assert(!"unsupported scales data type");
+            }
+        } else {
+            assert(one_of(
+                    type_in, data_type::f32, data_type::bf16, data_type::f16));
+            const dim_t tail_size = brg.is_gemv
+                    ? (brg.gemv_acc_is_vector()
+                                      ? nstl::max<dim_t>(1, brg.gemv_tail)
+                                      : 1)
+                    : brg.ldb_tail;
+            load_data(type_in, vmm_scales, op.getAddress(), tail_size);
+        }
+    }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
+        bool is_ld_tail, bool dq2ps_required, bool &dq2ps_cvt_done) {
+    reg_aux_wei_scales.restore();
+    for (dim_t ld = 0; ld < ld_block2; ld++) {
+        const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(ld)];
+        const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+
+        const Vmm vmm_wei_scales = vmm_tmp(0);
+        load_scales_to_vmm(brg.dt_wei_scales, vmm_wei_scales, addr, is_tail,
+                brg.is_single_wei_scale);
+
+        for (dim_t bd = 0; bd < bd_block; bd++) {
+            auto vmm = accm(ld_block2, bd, ld);
+            if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
+
+            if (brg.is_gemv) {
+                if (!brg.treat_y_as_row) {
+                    uni_vmulss(Xmm(vmm.getIdx()), Xmm(vmm.getIdx()),
+                            vmm_wei_scales);
+                } else {
+                    auto addr_bd
+                            = ptr[reg_aux_wei_scales + wei_scales_offset(bd)];
+                    uni_vmovss(Xmm(vmm_wei_scales.getIdx()), addr_bd);
+                    uni_vmulss(Xmm(vmm.getIdx()), Xmm(vmm.getIdx()),
+                            vmm_wei_scales);
+                }
+            } else {
+                uni_vmulps(vmm, vmm, vmm_wei_scales);
+            }
+        }
+    }
+    dq2ps_cvt_done = true;
+}
+
+// Sibling stage to post-ops; called every brgemm K-call when per-K scales
+// are active. Driver shifts scale pointers per call. Leaves accumulator as
+// f32 so apply_alpha_beta uses vaddps against f32 buffer C.
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::apply_scales(
+        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+    assert(brg.has_per_k_scales());
+    const bool dq2ps_required = brg.is_int8;
+    bool dq2ps_cvt_done = false;
+
+    if (brg.is_per_k_wei_scales)
+        apply_wei_scales(bd_block, ld_block2, is_ld_tail, dq2ps_required,
+                dq2ps_cvt_done);
+}
+
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         dim_t ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail,
@@ -1670,14 +1721,16 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     const bool beta_uses_vadd
             = brg.beta == 1.f && IMPLICATION(brg.is_int8, brg.alpha == 1.0f);
     const bool dq2ps_required = brg.is_int8
-            && IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd);
+            && IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd)
+            && !brg.has_per_k_scales();
     const bool has_ptr_b_support = is_superset(brg.isa_impl, avx512_core);
 
     // This flag tracks whether the conversion has happened, since it must be
     // done only once despite all scales and bias applications requiring it.
     // TODO: perform conversion in a dedicated loop if it is required as it is
     // done in brgemm_post_ops kernel?
-    bool dq2ps_cvt_done = false;
+    // Pre-set when apply_scales() already did the int->f32 conversion.
+    bool dq2ps_cvt_done = brg.has_per_k_scales();
 
     if (brg.with_src_scales) {
         reg_src_scales.restoreTo(reg_aux_src_scales);
@@ -1699,11 +1752,10 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         dq2ps_cvt_done = true;
     }
 
-    if (brg.with_wei_scales) {
+    if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         if (!brg.is_gemv) {
-            apply_wei_scales(bd_block, ld_block2, dq2ps_required,
-                    dq2ps_cvt_done, is_ld_tail);
-            dq2ps_cvt_done = true;
+            apply_wei_scales(bd_block, ld_block2, is_ld_tail, dq2ps_required,
+                    dq2ps_cvt_done);
         } else {
             gemv_apply_wei_scales(bd_block, is_bdb_tail);
         }
@@ -2276,6 +2328,9 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
             L_aligned(label_store_without_comp);
         }
 
+        if (brg.has_per_k_scales())
+            apply_scales(bd_block, ld_block2, is_ld_tail);
+
         if (need_to_apply_alpha_beta)
             apply_alpha_beta(bd_block, ld_block2, is_ld_tail, is_bdb_tail);
 
@@ -2426,7 +2481,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
                                : brg.get_B_tensor(idx, is_tail);
     auto t1 = Tmm(tmm_idx);
 
-    auto reg_base = is_A ? reg_aux_A : reg_aux_B;
+    auto &reg_base = is_A ? reg_aux_A : reg_aux_B;
 
     auto reg_stride = is_A ? reg_stride_lda : reg_stride_ldb;
     bool try_load_nt = brg.innermost_loop

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -420,6 +420,8 @@ private:
             dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
     void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail,
             bool dq2ps_required, bool &dq2ps_cvt_done);
+    void apply_src_scales_per_k(dim_t bd_block, dim_t ld_block2,
+            bool dq2ps_required, bool &dq2ps_cvt_done);
     void apply_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail);
     void apply_post_ops(dim_t bd_block, dim_t ld_block2,
             dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
@@ -694,6 +696,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
         dim_t ld, bool is_tail) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return ld * (brg.bd_block / brg.gemv_bd_block())
+                * brg.is_per_n_wei_scales
                 * types::data_type_size(brg.dt_wei_scales);
 
     const dim_t ld_offset = is_tail ? brg.ldb_tail : ld * brg.ld_block;
@@ -1695,6 +1698,25 @@ void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
     dq2ps_cvt_done = true;
 }
 
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(dim_t bd_block,
+        dim_t ld_block2, bool dq2ps_required, bool &dq2ps_cvt_done) {
+    reg_src_scales.restoreTo(reg_aux_src_scales);
+    const auto vmm_src_sc = vmm_tmp(0);
+    for (dim_t bd = 0; bd < bd_block; bd++) {
+        const auto src_sc_addr
+                = ptr[reg_aux_src_scales + bd * brg.src_scale_m_stride];
+        load_scales_to_vmm(brg.dt_src_scales, vmm_src_sc, src_sc_addr,
+                /*is_ld_tail=*/false, /*is_single_scale=*/true);
+        for (dim_t ld = 0; ld < ld_block2; ld++) {
+            auto vmm = accm(ld_block2, bd, ld);
+            if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
+            uni_vmulps(vmm, vmm, vmm_src_sc);
+        }
+    }
+    dq2ps_cvt_done = true;
+}
+
 // Sibling stage to post-ops; called every brgemm K-call when per-K scales
 // are active. Driver shifts scale pointers per call. Leaves accumulator as
 // f32 so apply_alpha_beta uses vaddps against f32 buffer C.
@@ -1708,6 +1730,16 @@ void jit_brgemm_kernel_t<Wmm>::apply_scales(
     if (brg.is_per_k_wei_scales)
         apply_wei_scales(bd_block, ld_block2, is_ld_tail, dq2ps_required,
                 dq2ps_cvt_done);
+    if (brg.is_per_k_src_scales)
+        apply_src_scales_per_k(
+                bd_block, ld_block2, dq2ps_required, dq2ps_cvt_done);
+    if (dq2ps_required && !dq2ps_cvt_done) {
+        for_(dim_t ld = 0; ld < ld_block2; ld++)
+        for (dim_t bd = 0; bd < bd_block; bd++) {
+            auto vmm = accm(ld_block2, bd, ld);
+            uni_vcvtdq2ps(vmm, vmm);
+        }
+    }
 }
 
 template <typename Wmm>
@@ -1723,7 +1755,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     const bool dq2ps_required = brg.is_int8
             && IMPLICATION(alpha_or_beta_applicable, beta_uses_vadd)
             && !brg.has_per_k_scales();
-    const bool has_ptr_b_support = is_superset(brg.isa_impl, avx512_core);
+    const bool has_ptr_b_support = is_superset(brg.isa_impl, avx512_core)
+            && brg.dt_src_scales == data_type::f32;
 
     // This flag tracks whether the conversion has happened, since it must be
     // done only once despite all scales and bias applications requiring it.
@@ -1732,11 +1765,13 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     // Pre-set when apply_scales() already did the int->f32 conversion.
     bool dq2ps_cvt_done = brg.has_per_k_scales();
 
-    if (brg.with_src_scales) {
+    if (brg.with_src_scales && !brg.is_per_k_src_scales) {
         reg_src_scales.restoreTo(reg_aux_src_scales);
         auto vmm_src_scales = vmm_tmp(0);
         if (!has_ptr_b_support)
-            vbroadcastss(vmm_src_scales, ptr[reg_aux_src_scales]);
+            load_scales_to_vmm(brg.dt_src_scales, vmm_src_scales,
+                    ptr[reg_aux_src_scales],
+                    /*is_ld_tail=*/false, /*is_single_scale=*/true);
 
         for_(dim_t ld = 0; ld < ld_block2; ld++)
         for (dim_t bd = 0; bd < bd_block; bd++) {
@@ -3292,6 +3327,15 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
             add(reg_D, bdb_D_offset(bd_block2));
         }
         add(reg_a_offset, bdb_A_offset(bd_block2));
+
+        if (brg.is_per_k_src_scales) {
+            const auto adj_bd_block = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
+            const auto src_scales_stack_ptr
+                    = reg_src_scales.getStoragePtr().getRegExp();
+            const auto src_scales_offset
+                    = adj_bd_block * bd_block2 * brg.src_scale_m_stride;
+            add(dword[src_scales_stack_ptr], src_scales_offset);
+        }
 
         if (brg.is_gemv && brg.treat_y_as_row) {
             if (brg.with_bias) {

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -822,9 +822,10 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
             const auto addr = ptr[aux_reg_wei_scales
-                    + brg_.is_oc_scale * sizeof(float) * (n * brg_.ld_block)];
+                    + brg_.is_per_n_wei_scales * sizeof(float)
+                            * (n * brg_.ld_block)];
             const bool is_tail = tail > 0;
-            const bool is_single_scale = !brg_.is_oc_scale;
+            const bool is_single_scale = brg_.is_single_wei_scale;
 
             const auto vmm = vector(m, n);
             const auto vmm_wei_scales = vmm_tmp(0);
@@ -1060,7 +1061,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * sizeof(float) * oc_l_offset);
+                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
         }
     }
     if (nb2_tail > 0) {
@@ -1088,7 +1089,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * sizeof(float) * oc_l_offset);
+                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
         }
     }
     if (nb_tail > 0) {
@@ -1114,7 +1115,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_oc_scale * bia_typesize_ * (nb_tail));
+                        brg_.is_per_n_wei_scales * bia_typesize_ * (nb_tail));
         }
         add(aux_reg_out, out_typesize_ * (nb_tail));
     }

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -405,6 +405,15 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             brg.is_per_k_wei_scales = bgmmc_.is_wei_scale_per_k;
             brg.dt_wei_scales = bgmmc_.wei_scales_dt;
         }
+        if (bgmmc_.with_src_scales) {
+            brg.dt_src_scales = bgmmc_.src_scales_dt;
+            if (bgmmc_.is_src_scale_per_k) {
+                brg.is_per_k_src_scales = true;
+                const auto num_k_groups
+                        = utils::div_up(bgmmc_.K, bgmmc_.src_scales_k_gsize);
+                brg.src_scale_m_stride = num_k_groups * bgmmc_.src_scales_dt_sz;
+            }
+        }
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 
@@ -802,8 +811,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
                         scratch, &leading_dimensions);
                 return;
             }
-            const void *src_scales
-                    = nullptr; // Will be introduced on next commit
+            const void *src_scales = bgmmc.is_src_scale_per_k
+                    ? brgmm_ctx.get_src_scales_ptr(m, k)
+                    : nullptr;
             const void *wei_scales = bgmmc.is_wei_scale_per_k
                             && !bgmmc.apply_scales_in_buffer_b
                     ? brgmm_ctx.get_wei_scales_ptr(n, k, b_idx)
@@ -826,7 +836,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
         // Final K-block: apply scales, compensation and post-ops. Per-K scales
         // take precedence over the common ones.
-        const void *src_scales = brgmm_ctx.get_src_scales_ptr();
+        const void *src_scales = bgmmc.is_src_scale_per_k
+                ? brgmm_ctx.get_src_scales_ptr(m, k)
+                : brgmm_ctx.get_src_scales_ptr();
         const void *wei_scales
                 = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b
                 ? brgmm_ctx.get_wei_scales_ptr(n, k, b_idx)
@@ -2153,7 +2165,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 + n_blk_local * bgmmc_.s8s8_comp_n_str;
     }
 
-    const void *get_src_scales_ptr() const { return src_scales_; }
+    const void *get_src_scales_ptr(dim_t m = 0, dim_t k = 0) const {
+        if (!bgmmc_.is_src_scale_per_k) return src_scales_;
+
+        const auto &k_group_sz = bgmmc_.src_scales_k_gsize;
+        const auto k_idx = k / k_group_sz;
+        const auto num_k_groups = utils::div_up(bgmmc_.K, k_group_sz);
+        auto offset = (m * num_k_groups + k_idx) * bgmmc_.src_scales_dt_sz;
+        return ((const char *)src_scales_ + offset);
+    }
 
     // Returns a pointer to the weights scales for the correspondent block based
     // on @p n and @p k.

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -392,7 +392,19 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         auto LDD = bgmmc_.LDD;
         if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
             brg.skip_zp_b_compensation = true;
-        if (bgmmc_.apply_scales_in_buffer_b) brg.skip_wei_scales = true;
+        brg.skip_wei_scales = bgmmc_.apply_scales_in_buffer_b;
+        // Fill up the scales info in case it's computing in brgemm
+        if (!brg.skip_wei_scales && bgmmc_.with_wei_scales) {
+            brg.is_single_wei_scale = bgmmc_.is_wei_scale_common;
+            brg.is_per_n_wei_scales = bgmmc_.is_wei_scale_per_n;
+            // For grouped (per-K) wei scales: K_blk == group_size and
+            // brgemm_batch_size == 1, so each brgemm call covers exactly one
+            // K-group. The matmul driver shifts `ptr_wei_scales` to the
+            // current group's per-N vector before each call. Brgemm just
+            // applies it as per-N at C-accumulation time.
+            brg.is_per_k_wei_scales = bgmmc_.is_wei_scale_per_k;
+            brg.dt_wei_scales = bgmmc_.wei_scales_dt;
+        }
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 
@@ -763,51 +775,104 @@ void brgemm_matmul_t<isa>::compute_kernel(
     brgmm_ctx.maybe_backup_dst_values_to_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
 
+    auto is_brg_amx = [&](const int brg_idx) {
+        return is_superset(
+                pd()->get_brg_desc(brg_idx).isa_impl, avx512_core_amx);
+    };
+
+    // Execute the kernel for one K-block. Pure accumulation into C goes through
+    // the plain execute API. Accumulation-time scales / grouped s8s8
+    // compensation and the final-block epilogue go through the post-ops API.
+    // The `do_only_*` flags map to {do_post_ops, do_apply_comp} as {0,1} (comp
+    // only) and {1,1} (epilogue).
+    auto execute_brgemm = [&](const brgemm_kernel_t *kernel, const int brg_idx,
+                                  const int bs, const bool need_postops) {
+        const bool per_k_scales
+                = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b;
+        const auto k = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
+        const auto m = brgmm_ctx.get_M_idx(m_blk_idx, true);
+
+        if (!need_postops) {
+            // Intermediate K-block: plain accumulation unless per-K scales
+            // must be applied during accumulation.
+            if (!per_k_scales) {
+                void *scratch
+                        = is_brg_amx(brg_idx) ? (void *)wsp_tile : nullptr;
+                brgemm_kernel_execute(kernel, bs, addr_batch, (void *)ptr_C,
+                        scratch, &leading_dimensions);
+                return;
+            }
+            const void *src_scales
+                    = nullptr; // Will be introduced on next commit
+            const void *wei_scales = bgmmc.is_wei_scale_per_k
+                            && !bgmmc.apply_scales_in_buffer_b
+                    ? brgmm_ctx.get_wei_scales_ptr(n, k, b_idx)
+                    : nullptr;
+            void *scratch = is_brg_amx(brg_idx) ? (void *)wsp_tile : nullptr;
+            const brgemm_post_ops_data_t post_ops_data {/*bias=*/nullptr,
+                    /*binary_post_ops_rhs=*/nullptr, /*oc_logical_off=*/0,
+                    /*dst_row_logical_off=*/0, /*data_C_ptr_=*/nullptr,
+                    /*first_mb_matrix_addr_off=*/0,
+                    /*a_zp_compensations=*/nullptr,
+                    /*b_zp_compensations=*/nullptr, /*c_zp_values=*/nullptr,
+                    /*skip_accumulation=*/false, /*zp_a_val=*/1,
+                    /*do_only_comp=*/false,
+                    /*do_only_zp_a_val=*/true, src_scales, wei_scales,
+                    /*dst_scales=*/nullptr};
+            brgemm_kernel_execute_postops(kernel, bs, addr_batch, (void *)ptr_C,
+                    (void *)ptr_D, post_ops_data, scratch, &leading_dimensions);
+            return;
+        }
+
+        // Final K-block: apply scales, compensation and post-ops. Per-K scales
+        // take precedence over the common ones.
+        const void *src_scales = brgmm_ctx.get_src_scales_ptr();
+        const void *wei_scales
+                = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b
+                ? brgmm_ctx.get_wei_scales_ptr(n, k, b_idx)
+                : brgmm_ctx.get_wei_scales_ptr(n, 0, b_idx);
+        const void *dst_scales = brgmm_ctx.get_dst_scales_inv_ptr(ithr);
+        void *scratch = is_brg_amx(brg_idx)
+                ? (void *)wsp_tile
+                : (void *)brgmm_ctx.get_s8s8_comp_ptr(
+                          ithr, b_idx, n_blk_idx, k_blk_idx);
+
+        const size_t dst_row_logical_off = m;
+        const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
+                ? b_idx / bgmmc.batch_without_first_dim
+                : 0;
+        const size_t first_mb_matrix_addr_off
+                = batch_first_dim_idx * (M * N) + (dst_row_logical_off * N + n);
+
+        const brgemm_post_ops_data_t post_ops_data {
+                /*bias=*/static_cast<const void *>(ptr_bias),
+                /*binary_post_ops_rhs=*/post_ops_binary_rhs_arg_vec.data(),
+                /*oc_logical_off=*/static_cast<size_t>(n), dst_row_logical_off,
+                /*data_C_ptr_=*/brgmm_ctx.get_data_C_ptr(0, 0, 0),
+                first_mb_matrix_addr_off,
+                /*a_zp_compensations=*/static_cast<const void *>(zp_comp_a),
+                /*b_zp_compensations=*/static_cast<const void *>(zp_comp_b),
+                /*c_zp_values=*/brgmm_ctx.get_zp_c_ptr(),
+                /*skip_accumulation=*/false, /*zp_a_val=*/1,
+                /*do_only_comp=*/false, /*do_only_zp_a_val=*/false, src_scales,
+                wei_scales, dst_scales};
+
+        brgemm_kernel_execute_postops(kernel, bs, addr_batch, (void *)ptr_C,
+                (void *)ptr_D, post_ops_data, scratch, &leading_dimensions);
+    };
+
     if (gemm_batch > 0 && brg_ker_idx >= 0) {
-        const bool is_amx = is_superset(
-                pd()->get_brg_desc(brg_ker_idx).isa_impl, avx512_core_amx);
         const auto brg_kernel = brg_kernels_[brg_ker_idx].get();
         assert(brg_kernel != nullptr);
         brgemm_palettes_.maybe_tile_configure(
-                is_amx, prev_ker_idx, brg_ker_idx);
+                is_brg_amx(brg_ker_idx), prev_ker_idx, brg_ker_idx);
 
         brgmm_ctx.init_brgemm_batch_elements_values(ithr, 0, gemm_batch,
                 A_data_batch_ptr, B_data_batch_ptr, b_idx, m_blk_idx, k_blk_idx,
                 n_blk_idx);
-        if (post_ops_applicable && is_last_K_blk && !is_K_tail) {
-            void *scratch = is_amx
-                    ? static_cast<void *>(wsp_tile)
-                    : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                              ithr, b_idx, n_blk_idx));
-
-            const size_t dst_row_logical_off
-                    = brgmm_ctx.get_M_idx(m_blk_idx, true);
-            const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
-                    ? b_idx / bgmmc.batch_without_first_dim
-                    : 0;
-            const size_t first_mb_matrix_addr_off
-                    = batch_first_dim_idx * (M * N)
-                    + (dst_row_logical_off * N + n);
-            const char *dst_anchor_point = brgmm_ctx.get_data_C_ptr(0, 0, 0);
-            const brgemm_post_ops_data_t post_ops_data {
-                    static_cast<const void *>(ptr_bias),
-                    post_ops_binary_rhs_arg_vec.data(), static_cast<size_t>(n),
-                    dst_row_logical_off, dst_anchor_point,
-                    first_mb_matrix_addr_off,
-                    static_cast<const void *>(zp_comp_a),
-                    static_cast<const void *>(zp_comp_b),
-                    brgmm_ctx.get_zp_c_ptr(), false, 1, false, false,
-                    brgmm_ctx.get_src_scales_ptr(),
-                    brgmm_ctx.get_wei_scales_ptr(n),
-                    brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
-            brgemm_kernel_execute_postops(brg_kernel, gemm_batch, addr_batch,
-                    (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch,
-                    &leading_dimensions);
-        } else {
-            brgemm_kernel_execute(brg_kernel, gemm_batch, addr_batch,
-                    (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
-                    &leading_dimensions);
-        }
+        const bool need_postops
+                = post_ops_applicable && is_last_K_blk && !is_K_tail;
+        execute_brgemm(brg_kernel, brg_ker_idx, gemm_batch, need_postops);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail, /* do_K_tail */ false);
@@ -824,47 +889,12 @@ void brgemm_matmul_t<isa>::compute_kernel(
             assert(!"Requested brgemm kernel was not created.");
             return;
         }
-        const bool is_amx = is_superset(
-                pd()->get_brg_desc(brg_ker_idx).isa_impl, avx512_core_amx);
         brgemm_palettes_.maybe_tile_configure(
-                is_amx, prev_ker_idx, brg_ker_idx);
+                is_brg_amx(brg_ker_idx), prev_ker_idx, brg_ker_idx);
         const auto brg_kernel_k_tail = brg_kernels_[brg_ker_idx].get();
 
-        if (post_ops_applicable) {
-            void *scratch = is_amx
-                    ? static_cast<void *>(wsp_tile)
-                    : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                              ithr, b_idx, n_blk_idx));
-
-            const size_t dst_row_logical_off
-                    = brgmm_ctx.get_M_idx(m_blk_idx, true);
-            const size_t batch_first_dim_idx = bgmmc.batch_ndims > 1
-                    ? b_idx / bgmmc.batch_without_first_dim
-                    : 0;
-            const size_t first_mb_matrix_addr_off
-                    = batch_first_dim_idx * (M * N)
-                    + (dst_row_logical_off * N + n);
-            const char *dst_anchor_point = brgmm_ctx.get_data_C_ptr(0, 0, 0);
-            const brgemm_post_ops_data_t post_ops_data {
-                    static_cast<const void *>(ptr_bias),
-                    post_ops_binary_rhs_arg_vec.data(), static_cast<size_t>(n),
-                    dst_row_logical_off, dst_anchor_point,
-                    first_mb_matrix_addr_off,
-                    static_cast<const void *>(zp_comp_a),
-                    static_cast<const void *>(zp_comp_b),
-                    brgmm_ctx.get_zp_c_ptr(), false, 1, false, false,
-                    brgmm_ctx.get_src_scales_ptr(),
-                    brgmm_ctx.get_wei_scales_ptr(n),
-                    brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
-
-            brgemm_kernel_execute_postops(brg_kernel_k_tail, 1, addr_batch,
-                    (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch,
-                    &leading_dimensions);
-        } else {
-            brgemm_kernel_execute(brg_kernel_k_tail, 1, addr_batch,
-                    (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
-                    &leading_dimensions);
-        }
+        execute_brgemm(
+                brg_kernel_k_tail, brg_ker_idx, /*bs=*/1, post_ops_applicable);
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
                 k_blk_idx, do_init, is_K_tail,
@@ -1195,7 +1225,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                             static_cast<const void *>(zp_comp_b),
                             brgmm_ctx.get_zp_c_ptr(), skip_accumulation, 1,
                             false, false, brgmm_ctx.get_src_scales_ptr(),
-                            brgmm_ctx.get_wei_scales_ptr(n),
+                            brgmm_ctx.get_wei_scales_ptr(n, 0, b),
                             brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
 
                     brgemm_kernel_execute_postops(brg_kernel, 0, nullptr,
@@ -1313,8 +1343,8 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
     int32_t neg_zp_a = brgmm_ctx.get_neg_zp_a();
     ctx.zp_a_neg_value_ptr = &neg_zp_a;
 
-    ctx.compensation_ptr
-            = (void *)brgmm_ctx.get_s8s8_comp_ptr(ithr, b_idx, n_blk_idx);
+    ctx.compensation_ptr = (void *)brgmm_ctx.get_s8s8_comp_ptr(
+            ithr, b_idx, n_blk_idx, k_blk_idx);
 
     ctx.dynamic_src_stride = brgmm_ctx.copy_B_wei_stride();
 
@@ -1334,7 +1364,7 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         ctx.current_K_iters = k_iters;
         ctx.current_K_pad = brgmm_ctx.get_current_K_pad(k_iters);
         ctx.src_scales_ptr = brgmm_ctx.get_src_scales_ptr();
-        ctx.wei_scales_ptr = brgmm_ctx.get_wei_scales_ptr(n, k);
+        ctx.wei_scales_ptr = brgmm_ctx.get_wei_scales_ptr(n, k, b_idx);
         ctx.zp_b_value_ptr = brgmm_ctx.get_wei_zp_ptr(n, k);
         if (bgmmc.blocked_B && !bgmmc.is_f16_with_int_wei
                 && isa == avx512_core_fp16) {
@@ -2110,7 +2140,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return bias_ptr_ + n * bgmmc_.bias_dt_sz;
     }
 
-    int32_t *get_s8s8_comp_ptr(int ithr, int b, int n_blk_idx) const {
+    int32_t *get_s8s8_comp_ptr(
+            int ithr, int b, int n_blk_idx, int k_blk_idx = 0) const {
         if (!bgmmc_.s8s8_compensation_required) return nullptr;
 
         const int n_blk_local = bgmmc_.use_buffer_b
@@ -2126,7 +2157,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Returns a pointer to the weights scales for the correspondent block based
     // on @p n and @p k.
-    const void *get_wei_scales_ptr(dim_t n, dim_t k = 0) const {
+    const void *get_wei_scales_ptr(dim_t n, dim_t k = 0, int b_idx = 0) const {
         if (bgmmc_.is_wei_scale_common) return wei_scales_;
         auto offset = n;
         if (bgmmc_.is_wei_scale_per_k) {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1667,6 +1667,13 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.is_runtime_N = is_runtime_value(bgmmc.N);
     bgmmc.is_runtime_K = is_runtime_value(bgmmc.K);
 
+    // Downgrade to per-N to avoid the expensive K-scales JIT path which
+    // is not needed for this case.
+    if (bgmmc.is_wei_scale_per_k && !bgmmc.is_runtime_K
+            && bgmmc.wei_scales_k_gsize >= bgmmc.K) {
+        bgmmc.is_wei_scale_per_k = false;
+    }
+
     bgmmc.is_gemv = is_gemv_applicable(
             bgmmc, bm_conf_utils, src_md, weights_md, dst_md, attr);
     VCONDCHECK_BG(IMPLICATION(bgmmc.is_gemv, isa == avx2),

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1580,6 +1580,28 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     bgmmc.with_src_scales = !src_scales.has_default_values();
     bgmmc.with_wei_scales = !wei_scales.has_default_values();
+    if (bgmmc.with_src_scales) {
+        const auto &src_scale_mask = src_scales.get_mask();
+        // src per-k grouped scales: mask has K bit set and groups are used
+        bgmmc.is_src_scale_per_k
+                = (src_scale_mask & (1 << (bgmmc.ndims - 1))) != 0
+                && !src_scales.has_default_groups();
+        // Publish the src scales dtype for ALL with_src_scales cases (not
+        // just per-K) so downstream kernels can dispatch the right load
+        // width. The common-scalar broadcast in jit_brgemm_amx_uker relies
+        // on `brg.dt_src_scales` to avoid an f32-sized load over a bf16/f16
+        // scalar buffer.
+        bgmmc.src_scales_dt = src_scales.get_data_type();
+        bgmmc.src_scales_dt_sz = types::data_type_size(bgmmc.src_scales_dt);
+        if (bgmmc.is_src_scale_per_k) {
+            bgmmc.src_scales_k_gsize = src_scales.get_group(1);
+        }
+        // Per-K src scales require driver-side K_blk alignment to the
+        // group size, which is wired in a later commit. Until then,
+        // gracefully fall back to ref.
+        VCONDCHECK_BG(
+                !bgmmc.is_src_scale_per_k, VERBOSE_UNSUPPORTED_SCALES_CFG);
+    }
     if (bgmmc.with_wei_scales) {
         const auto &wei_scale_mask = wei_scales.get_mask();
         bgmmc.is_wei_scale_common = wei_scale_mask == 0;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -264,6 +264,12 @@ struct brgemm_matmul_conf_t {
     dim_t wei_scales_k_gsize = 0;
     data_type_t wei_scales_dt = data_type::undef;
 
+    // Src scales per-K
+    bool is_src_scale_per_k = false;
+    dim_t src_scales_k_gsize = 0;
+    data_type_t src_scales_dt = data_type::undef;
+    size_t src_scales_dt_sz = 0;
+
     // Zero points
     bool has_zero_point_a;
     bool has_zero_point_b;


### PR DESCRIPTION
## Overview
Implements grouped scales support for `src` and `wei` in brgemm kernel and wires it with matmul primitive.
Scales are possible to reuse for other data types since it's imlemented in brgemm kernel.

This is first part of bigger feature [MFDNN-11991](https://jira.devtools.intel.com/browse/MFDNN-11991).


Supported ISAs: AVX512+, AVX2-VNNI-2. 