### PR TITLE
ocl, ze: remove error messages for destroy calls from a wrapper

### DIFF
--- a/src/gpu/intel/ze/device_info.cpp
+++ b/src/gpu/intel/ze/device_info.cpp
@@ -31,7 +31,7 @@ status_t device_info_t::init_device_name(impl::engine_t *engine) {
     ze_device_properties_t device_properties = {};
     device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
 
-    CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
+    ZE_CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
     name_ = std::string(device_properties.name);
 
     return status::success;
@@ -54,7 +54,7 @@ status_t device_info_t::init_runtime_version(impl::engine_t *engine) {
     ze_driver_properties_t driver_properties = {};
     driver_properties.stype = ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES;
 
-    CHECK(xpu::ze::zeDriverGetProperties(driver, &driver_properties));
+    ZE_CHECK(xpu::ze::zeDriverGetProperties(driver, &driver_properties));
 
     // Note: for some reason this returns a different value for a minor version
     // when compared to internal API to get a version string. For a version
@@ -101,7 +101,7 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
     device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     device_properties.pNext = &eu_count_ext;
 
-    CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
+    ZE_CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
 
     eu_count_ = eu_count_ext.numTotalEUs;
 
@@ -109,13 +109,13 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
     device_compute_properties.stype
             = ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;
 
-    CHECK(xpu::ze::zeDeviceGetComputeProperties(
+    ZE_CHECK(xpu::ze::zeDeviceGetComputeProperties(
             device, &device_compute_properties));
 
     max_wg_size_ = device_compute_properties.maxTotalGroupSize;
 
     uint32_t device_cache_properties_count = 0;
-    CHECK(xpu::ze::zeDeviceGetCacheProperties(
+    ZE_CHECK(xpu::ze::zeDeviceGetCacheProperties(
             device, &device_cache_properties_count, nullptr));
 
     std::vector<ze_device_cache_properties_t> device_cache_properties(
@@ -124,7 +124,7 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
         p.stype = ZE_STRUCTURE_TYPE_DEVICE_CACHE_PROPERTIES;
     }
 
-    CHECK(xpu::ze::zeDeviceGetCacheProperties(device,
+    ZE_CHECK(xpu::ze::zeDeviceGetCacheProperties(device,
             &device_cache_properties_count, device_cache_properties.data()));
     for (uint32_t i = 0; i < device_cache_properties_count; i++) {
         if (device_cache_properties[i].flags == 0) {
@@ -135,14 +135,15 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
 
     ze_device_module_properties_t device_module_props = {};
     device_module_props.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
-    CHECK(xpu::ze::zeDeviceGetModuleProperties(device, &device_module_props));
+    ZE_CHECK(
+            xpu::ze::zeDeviceGetModuleProperties(device, &device_module_props));
     max_kernel_param_size_ = device_module_props.maxArgumentsSize;
 
     ze_device_memory_access_properties_t device_memory_access_properties = {};
     device_memory_access_properties.stype
             = ZE_STRUCTURE_TYPE_DEVICE_MEMORY_ACCESS_PROPERTIES;
 
-    CHECK(xpu::ze::zeDeviceGetMemoryAccessProperties(
+    ZE_CHECK(xpu::ze::zeDeviceGetMemoryAccessProperties(
             device, &device_memory_access_properties));
     mayiuse_system_memory_allocators_
             = device_memory_access_properties.sharedSystemAllocCapabilities;

--- a/src/gpu/intel/ze/kernel.cpp
+++ b/src/gpu/intel/ze/kernel.cpp
@@ -68,8 +68,9 @@ status_t kernel_t::check_alignment(
 
 status_t kernel_t::set_arg(
         int arg_index, size_t arg_size, const void *arg_value) const {
-    return xpu::ze::zeKernelSetArgumentValue(
-            kernel_, arg_index, arg_size, arg_value);
+    ZE_CHECK(xpu::ze::zeKernelSetArgumentValue(
+            kernel_, arg_index, arg_size, arg_value));
+    return status::success;
 }
 
 status_t kernel_t::parallel_for(impl::stream_t &stream,
@@ -157,7 +158,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
                 return status::invalid_arguments;
         }
     } else {
-        CHECK(xpu::ze::zeKernelSuggestGroupSize(kernel_, global_size[0],
+        ZE_CHECK(xpu::ze::zeKernelSuggestGroupSize(kernel_, global_size[0],
                 global_size[1], global_size[2], &group_size[0], &group_size[1],
                 &group_size[2]));
     }
@@ -169,7 +170,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
         }
     }
 
-    CHECK(xpu::ze::zeKernelSetGroupSize(
+    ZE_CHECK(xpu::ze::zeKernelSetGroupSize(
             kernel_, group_size[0], group_size[1], group_size[2]));
     ze_group_count_t group_count = {global_size[0] / group_size[0],
             global_size[1] / group_size[1], global_size[2] / group_size[2]};
@@ -177,8 +178,8 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
     const auto &ze_deps = xpu::ze::event_t::from(deps);
     ze_event_handle_t out_event = ze_stream->create_event();
 
-    CHECK(xpu::ze::zeCommandListAppendLaunchKernel(ze_stream->list(), kernel_,
-            &group_count, out_event, ze_deps.size(), ze_deps.data()));
+    ZE_CHECK(xpu::ze::zeCommandListAppendLaunchKernel(ze_stream->list(),
+            kernel_, &group_count, out_event, ze_deps.size(), ze_deps.data()));
 
     if (out_event) xpu::ze::event_t::from(out_dep).append(out_event);
     if (stream.is_profiling_enabled()) {

--- a/src/gpu/intel/ze/stream.cpp
+++ b/src/gpu/intel/ze/stream.cpp
@@ -47,7 +47,7 @@ status_t stream_t::init() {
     if (is_profiling_enabled()) {
         ze_device_properties_t device_properties {};
         device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2;
-        CHECK(xpu::ze::zeDeviceGetProperties(
+        ZE_CHECK(xpu::ze::zeDeviceGetProperties(
                 utils::downcast<engine_t *>(engine())->device(),
                 &device_properties));
 

--- a/src/gpu/intel/ze/utils.cpp
+++ b/src/gpu/intel/ze/utils.cpp
@@ -42,7 +42,7 @@ status_t get_ze_device_enabled_systolic_intel(
     deviceModProps.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
     deviceModProps.pNext = &deviceModPropsExt;
 
-    CHECK(xpu::ze::zeDeviceGetModuleProperties(device, &deviceModProps));
+    ZE_CHECK(xpu::ze::zeDeviceGetModuleProperties(device, &deviceModProps));
     mayiuse_systolic
             = deviceModPropsExt.flags & ZE_INTEL_DEVICE_MODULE_EXP_FLAG_DPAS;
     return status::success;
@@ -59,7 +59,7 @@ status_t get_ze_device_enabled_native_float_atomics(
     deviceProps.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
     deviceProps.pNext = &fltAtom;
 
-    CHECK(xpu::ze::zeDeviceGetModuleProperties(device, &deviceProps));
+    ZE_CHECK(xpu::ze::zeDeviceGetModuleProperties(device, &deviceProps));
 
     ze_device_fp_atomic_ext_flags_t atomic_load_store
             = ZE_DEVICE_FP_ATOMIC_EXT_FLAG_GLOBAL_LOAD_STORE
@@ -106,7 +106,7 @@ status_t get_device_ip(ze_device_handle_t device, uint32_t &ip_version) {
     deviceProps.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     deviceProps.pNext = &devicePropsIP;
 
-    CHECK(xpu::ze::zeDeviceGetProperties(device, &deviceProps));
+    ZE_CHECK(xpu::ze::zeDeviceGetProperties(device, &deviceProps));
     ip_version = devicePropsIP.ipVersion;
     return status::success;
 }
@@ -128,9 +128,8 @@ status_t compile_ocl_module(ze_module_handle_t *module_ptr,
     ze_module_handle_t module_handle;
     // TODO: enable debug capabilities.
     // ze_module_build_log_handle_t module_build_log_handle;
-    auto st = xpu::ze::zeModuleCreate(context, device, &module_desc,
-            &module_handle, /* &module_build_log_handle */ nullptr);
-    if (st != status::success) return st;
+    ZE_CHECK(xpu::ze::zeModuleCreate(context, device, &module_desc,
+            &module_handle, /* &module_build_log_handle */ nullptr));
 
     *module_ptr = module_handle;
 
@@ -150,9 +149,8 @@ status_t compile_native_module(ze_module_handle_t *module_ptr,
     ze_module_handle_t module_handle;
     // TODO: enable under debug capabilities.
     // ze_module_build_log_handle_t module_build_log_handle;
-    auto st = xpu::ze::zeModuleCreate(context, device, &module_desc,
-            &module_handle, /* &module_build_log_handle */ nullptr);
-    if (st != status::success) return st;
+    ZE_CHECK(xpu::ze::zeModuleCreate(context, device, &module_desc,
+            &module_handle, /* &module_build_log_handle */ nullptr));
 
     *module_ptr = module_handle;
     return status::success;
@@ -205,7 +203,7 @@ status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
 
 status_t get_binary_size(
         ze_module_handle_t module_handle, size_t *binary_size) {
-    CHECK(xpu::ze::zeModuleGetNativeBinary(
+    ZE_CHECK(xpu::ze::zeModuleGetNativeBinary(
             module_handle, binary_size, nullptr));
     return status::success;
 }
@@ -216,7 +214,7 @@ status_t get_module_binary(
     CHECK(get_binary_size(module_handle, &module_binary_size));
 
     binary.resize(module_binary_size);
-    CHECK(xpu::ze::zeModuleGetNativeBinary(
+    ZE_CHECK(xpu::ze::zeModuleGetNativeBinary(
             module_handle, &module_binary_size, binary.data()));
 
     return status::success;
@@ -224,10 +222,11 @@ status_t get_module_binary(
 
 status_t get_kernel_binary(ze_kernel_handle_t kernel, xpu::binary_t &binary) {
     size_t binary_size = 0;
-    CHECK(xpu::ze::zeKernelGetBinaryExp(kernel, &binary_size, nullptr));
+    ZE_CHECK(xpu::ze::zeKernelGetBinaryExp(kernel, &binary_size, nullptr));
 
     binary.resize(binary_size);
-    CHECK(xpu::ze::zeKernelGetBinaryExp(kernel, &binary_size, binary.data()));
+    ZE_CHECK(
+            xpu::ze::zeKernelGetBinaryExp(kernel, &binary_size, binary.data()));
 
     return status::success;
 }
@@ -275,7 +274,8 @@ status_t create_kernels(ze_device_handle_t device, ze_context_handle_t context,
 
             uint32_t count = 1;
             const char *name = nullptr;
-            CHECK(xpu::ze::zeModuleGetKernelNames(*module_ptr, &count, &name));
+            ZE_CHECK(xpu::ze::zeModuleGetKernelNames(
+                    *module_ptr, &count, &name));
 
             kernel_name = std::string(name);
             assert(!kernel_name.empty());
@@ -286,7 +286,7 @@ status_t create_kernels(ze_device_handle_t device, ze_context_handle_t context,
         kernel_desc.pKernelName = kernel_name.c_str();
 
         ze_kernel_handle_t kernel;
-        CHECK(xpu::ze::zeKernelCreate(*module_ptr, &kernel_desc, &kernel));
+        ZE_CHECK(xpu::ze::zeKernelCreate(*module_ptr, &kernel_desc, &kernel));
 
         kernels[i] = kernel;
     }

--- a/src/xpu/ocl/utils.hpp
+++ b/src/xpu/ocl/utils.hpp
@@ -46,9 +46,8 @@ const char *convert_cl_int_to_str(cl_int cl_status);
 
 #define MAYBE_REPORT_OCL_ERROR(s) \
     do { \
-        VERROR(primitive, ocl, "errcode %d,%s,%s:%d", int(s), \
-                dnnl::impl::xpu::ocl::convert_cl_int_to_str(s), __FILENAME__, \
-                __LINE__); \
+        VERROR(primitive, ocl, "errcode %d,%s", int(s), \
+                dnnl::impl::xpu::ocl::convert_cl_int_to_str(s)); \
     } while (0)
 
 #define OCL_CHECK_V(x) \
@@ -186,7 +185,10 @@ struct ref_traits<cl_context> {
         UNUSED_OCL_RESULT(xpu::ocl::clRetainContext(t));
     }
     static void release(cl_context t) {
-        UNUSED_OCL_RESULT(xpu::ocl::clReleaseContext(t));
+        auto cl_st = xpu::ocl::clReleaseContext(t);
+        if (cl_st != CL_SUCCESS && cl_st != CL_INVALID_OPERATION) {
+            UNUSED_OCL_RESULT(cl_st);
+        }
     }
 };
 
@@ -210,13 +212,27 @@ struct ref_traits<cl_program> {
     }
 };
 
+// Kernels are part of the global static kernel cache object. It gets destroyed
+// at static objects destruction point of program destruction. This moment
+// happens after `atexit` system call, when OpenCL 3.1+ library will be
+// unloaded. The unloaded library means there are no OpenCL resources that can
+// be used for proper kernels destruction leading to reporting errors from this
+// wrapper. This error reports specific `CL_INVALID_OPERATION` error code.
+// Don't print an error message for this and successful codes.
+//
+// Note: since engine object is a singleton in benchdnn, objects retained during
+// engine construction shouldn't report `CL_INVALID_OPERATION` error message,
+// too. Such objects are a context and a device.
 template <>
 struct ref_traits<cl_kernel> {
     static void retain(cl_kernel t) {
         UNUSED_OCL_RESULT(xpu::ocl::clRetainKernel(t));
     }
     static void release(cl_kernel t) {
-        UNUSED_OCL_RESULT(xpu::ocl::clReleaseKernel(t));
+        auto cl_st = xpu::ocl::clReleaseKernel(t);
+        if (cl_st != CL_SUCCESS && cl_st != CL_INVALID_OPERATION) {
+            UNUSED_OCL_RESULT(cl_st);
+        }
     }
 };
 
@@ -256,7 +272,10 @@ struct ref_traits<cl_device_id> {
         UNUSED_OCL_RESULT(xpu::ocl::clRetainDevice(t));
     }
     static void release(cl_device_id t) {
-        UNUSED_OCL_RESULT(xpu::ocl::clReleaseDevice(t));
+        auto cl_st = xpu::ocl::clReleaseDevice(t);
+        if (cl_st != CL_SUCCESS && cl_st != CL_INVALID_OPERATION) {
+            UNUSED_OCL_RESULT(cl_st);
+        }
     }
 };
 

--- a/src/xpu/ze/capi/engine.cpp
+++ b/src/xpu/ze/capi/engine.cpp
@@ -126,13 +126,13 @@ status_t dnnl_ze_interop_engine_get_cache_blob_id(ze_driver_handle_t driver,
     // Get device name.
     ze_device_properties_t device_properties = {};
     device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
-    CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
+    ZE_CHECK(xpu::ze::zeDeviceGetProperties(device, &device_properties));
     auto device_name = std::string(device_properties.name);
 
     // Get driver version size.
     // Note: copied from engine_impl. See a comment there.
     ze_result_t (*pfnGetDriverVersionFn)(ze_driver_handle_t, char *, size_t *);
-    CHECK(xpu::ze::zeDriverGetExtensionFunctionAddress(driver,
+    ZE_CHECK(xpu::ze::zeDriverGetExtensionFunctionAddress(driver,
             "zeIntelGetDriverVersionString", (void **)&pfnGetDriverVersionFn));
 
     size_t driver_version_len = 0;

--- a/src/xpu/ze/engine_factory.cpp
+++ b/src/xpu/ze/engine_factory.cpp
@@ -32,18 +32,18 @@ engine_factory_t::engine_factory_t(engine_kind_t engine_kind) {
 
 size_t engine_factory_t::count() const {
     uint32_t driver_count = 0;
-    status_t status = status::success;
+    ze_result_t ze_status = ZE_RESULT_SUCCESS;
 
-    status = ze::zeDriverGet(&driver_count, nullptr);
-    if (status != status::success || driver_count == 0) return 0;
+    ze_status = ze::zeDriverGet(&driver_count, nullptr);
+    if (ze_status != ZE_RESULT_SUCCESS || driver_count == 0) return 0;
 
     std::vector<ze_driver_handle_t> drivers(driver_count);
-    status = ze::zeDriverGet(&driver_count, drivers.data());
-    if (status != status::success) return 0;
+    ze_status = ze::zeDriverGet(&driver_count, drivers.data());
+    if (ze_status != ZE_RESULT_SUCCESS) return 0;
 
     uint32_t device_count = 0;
-    status = ze::zeDeviceGet(drivers[0], &device_count, nullptr);
-    if (status != status::success) return 0;
+    ze_status = ze::zeDeviceGet(drivers[0], &device_count, nullptr);
+    if (ze_status != ZE_RESULT_SUCCESS) return 0;
 
     return device_count;
 }
@@ -54,22 +54,22 @@ status_t engine_factory_t::engine_create(
     ze_device_handle_t device = nullptr;
 
     uint32_t driver_count = 0;
-    CHECK(ze::zeDriverGet(&driver_count, nullptr));
+    ZE_CHECK(ze::zeDriverGet(&driver_count, nullptr));
     VERROR_ENGINE(driver_count > 0, status::invalid_arguments,
             "no drivers to query devices were found");
 
     std::vector<ze_driver_handle_t> drivers(driver_count);
-    CHECK(ze::zeDriverGet(&driver_count, drivers.data()));
+    ZE_CHECK(ze::zeDriverGet(&driver_count, drivers.data()));
     driver = drivers[0];
 
     uint32_t device_count = 0;
-    CHECK(ze::zeDeviceGet(driver, &device_count, nullptr));
+    ZE_CHECK(ze::zeDeviceGet(driver, &device_count, nullptr));
     VERROR_ENGINE(index < device_count, status::invalid_arguments,
             "asked for device %zu but only %u devices are found", index,
             device_count);
 
     std::vector<ze_device_handle_t> devices(device_count);
-    CHECK(ze::zeDeviceGet(driver, &device_count, devices.data()));
+    ZE_CHECK(ze::zeDeviceGet(driver, &device_count, devices.data()));
     device = devices[index];
 
     return engine_create(engine, driver, device, nullptr, index);

--- a/src/xpu/ze/engine_impl.cpp
+++ b/src/xpu/ze/engine_impl.cpp
@@ -38,7 +38,8 @@ status_t engine_impl_t::init() {
         context_desc.pNext = nullptr;
         context_desc.flags = 0;
 
-        CHECK(ze::zeContextCreate(driver_, &context_desc, &context_.unwrap()));
+        ZE_CHECK(ze::zeContextCreate(
+                driver_, &context_desc, &context_.unwrap()));
     }
 
     cl_int err;
@@ -62,7 +63,7 @@ status_t engine_impl_t::init() {
     ze_device_properties_t device_properties = {};
     device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     device_properties.pNext = nullptr;
-    CHECK(ze::zeDeviceGetProperties(device_, &device_properties));
+    ZE_CHECK(ze::zeDeviceGetProperties(device_, &device_properties));
     name_ = device_properties.name;
 
     // Note: the method below is undocumented. Implementation is sneak peeked
@@ -74,7 +75,7 @@ status_t engine_impl_t::init() {
     // src/gpu/intel/ze/devince_info.cpp, but it reports different numbers.
     // TODO: figure it out.
     ze_result_t (*pfnGetDriverVersionFn)(ze_driver_handle_t, char *, size_t *);
-    CHECK(ze::zeDriverGetExtensionFunctionAddress(driver_,
+    ZE_CHECK(ze::zeDriverGetExtensionFunctionAddress(driver_,
             "zeIntelGetDriverVersionString", (void **)&pfnGetDriverVersionFn));
 
     size_t driver_version_len = 0;

--- a/src/xpu/ze/stream_impl.cpp
+++ b/src/xpu/ze/stream_impl.cpp
@@ -35,10 +35,10 @@ status_t stream_impl_t::init(
         command_queue_desc.mode = ZE_COMMAND_QUEUE_MODE_DEFAULT;
         command_queue_desc.priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL;
 
-        CHECK(ze::zeCommandListCreateImmediate(
+        ZE_CHECK(ze::zeCommandListCreateImmediate(
                 context, device, &command_queue_desc, &list_.unwrap()));
     } else {
-        CHECK(ze::zeCommandListGetContextHandle(list_, &context));
+        ZE_CHECK(ze::zeCommandListGetContextHandle(list_, &context));
     }
 
     if ((flags() & stream_flags::out_of_order) && is_profiling_enabled()) {
@@ -57,7 +57,7 @@ status_t stream_impl_t::init(
         // validation or a single model profiling.
         event_pool_desc.count = 16 * 1024;
 
-        CHECK(ze::zeEventPoolCreate(
+        ZE_CHECK(ze::zeEventPoolCreate(
                 context, &event_pool_desc, 0, nullptr, &event_pool_.unwrap()));
     }
 
@@ -101,8 +101,8 @@ ze_event_handle_t stream_impl_t::create_event() {
     event_desc.wait = ZE_EVENT_SCOPE_FLAG_HOST;
 
     ze_event_handle_t event;
-    auto st = ze::zeEventCreate(event_pool_, &event_desc, &event);
-    if (st != status::success) return nullptr;
+    auto ze_status = ze::zeEventCreate(event_pool_, &event_desc, &event);
+    if (ze_status != ZE_RESULT_SUCCESS) return nullptr;
 
     events_.emplace_back(event);
 
@@ -110,13 +110,13 @@ ze_event_handle_t stream_impl_t::create_event() {
 }
 
 status_t stream_impl_t::wait() {
-    CHECK(ze::zeCommandListHostSynchronize(list_, UINT64_MAX));
+    ZE_CHECK(ze::zeCommandListHostSynchronize(list_, UINT64_MAX));
 
     return status::success;
 }
 
 status_t stream_impl_t::barrier() {
-    CHECK(ze::zeCommandListAppendBarrier(list_, nullptr, 0, nullptr));
+    ZE_CHECK(ze::zeCommandListAppendBarrier(list_, nullptr, 0, nullptr));
 
     return status::success;
 }

--- a/src/xpu/ze/stream_profiler.hpp
+++ b/src/xpu/ze/stream_profiler.hpp
@@ -89,7 +89,7 @@ public:
                     = *utils::downcast<ze::event_t *>(ev.event.get());
 
             ze_kernel_timestamp_result_t kernel_timestamp_result;
-            CHECK(ze::zeEventQueryKernelTimestamp(
+            ZE_CHECK(ze::zeEventQueryKernelTimestamp(
                     ze_event[0], &kernel_timestamp_result));
 
             entry_t entry(kernel_timestamp_result, max_timestamp_value_,

--- a/src/xpu/ze/utils.cpp
+++ b/src/xpu/ze/utils.cpp
@@ -21,14 +21,14 @@ namespace impl {
 namespace xpu {
 namespace ze {
 
-status_t ze_initialize() {
+ze_result_t ze_initialize() {
     static std::once_flag flag;
-    static status_t status = status::success;
+    static ze_result_t ze_status = ZE_RESULT_SUCCESS;
     std::call_once(flag, [&] {
         auto _init_drivers
                 = find_ze_symbol<decltype(&::zeInitDrivers)>("zeInitDrivers");
         if (!_init_drivers) {
-            status = status::runtime_error;
+            ze_status = ZE_RESULT_ERROR_UNINITIALIZED;
             return;
         }
 
@@ -37,13 +37,10 @@ status_t ze_initialize() {
         desc.stype = ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC;
         desc.pNext = nullptr;
         desc.flags = ZE_INIT_DRIVER_TYPE_FLAG_GPU;
-        if (_init_drivers(&driver_count, nullptr, &desc) != ZE_RESULT_SUCCESS) {
-            status = status::runtime_error;
-            return;
-        }
+        ze_status = _init_drivers(&driver_count, nullptr, &desc);
     });
 
-    return status;
+    return ze_status;
 }
 
 xpu::device_uuid_t get_device_uuid(ze_device_handle_t device) {
@@ -54,9 +51,9 @@ xpu::device_uuid_t get_device_uuid(ze_device_handle_t device) {
     device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     device_properties.pNext = nullptr;
 
-    auto status = ze::zeDeviceGetProperties(device, &device_properties);
-    MAYBE_UNUSED(status);
-    assert(status == status::success);
+    auto ze_status = ze::zeDeviceGetProperties(device, &device_properties);
+    MAYBE_UNUSED(ze_status);
+    assert(ze_status == ZE_RESULT_SUCCESS);
 
     const auto &device_id = device_properties.uuid.id;
 
@@ -71,17 +68,17 @@ xpu::device_uuid_t get_device_uuid(ze_device_handle_t device) {
 
 status_t get_device_index(size_t *index, ze_device_handle_t device) {
     uint32_t driver_count = 0;
-    CHECK(ze::zeDriverGet(&driver_count, nullptr));
+    ZE_CHECK(ze::zeDriverGet(&driver_count, nullptr));
     if (driver_count <= 0) return status::invalid_arguments;
 
     std::vector<ze_driver_handle_t> drivers(driver_count);
-    CHECK(ze::zeDriverGet(&driver_count, drivers.data()));
+    ZE_CHECK(ze::zeDriverGet(&driver_count, drivers.data()));
 
     uint32_t device_count = 0;
-    CHECK(ze::zeDeviceGet(drivers[0], &device_count, nullptr));
+    ZE_CHECK(ze::zeDeviceGet(drivers[0], &device_count, nullptr));
 
     std::vector<ze_device_handle_t> devices(device_count);
-    CHECK(ze::zeDeviceGet(drivers[0], &device_count, devices.data()));
+    ZE_CHECK(ze::zeDeviceGet(drivers[0], &device_count, devices.data()));
 
     for (size_t i = 0; i < device_count; i++) {
         if (device == devices[i]) {
@@ -129,7 +126,7 @@ status_t append_memory_copy(ze_command_list_handle_t list,
     std::lock_guard<std::mutex> guard(list_mutex);
 
     // This function is not thread-safe, guarding it with exclusive access.
-    CHECK(ze::zeCommandListAppendMemoryCopy(
+    ZE_CHECK(ze::zeCommandListAppendMemoryCopy(
             list, dst, src, size, out_event, num_deps_events, deps_events));
 
     return status::success;
@@ -142,7 +139,7 @@ status_t append_memory_fill(ze_command_list_handle_t list,
     std::lock_guard<std::mutex> guard(list_mutex);
 
     // This function is not thread-safe, guarding it with exclusive access.
-    CHECK(ze::zeCommandListAppendMemoryFill(list, dst, pattern, pattern_size,
+    ZE_CHECK(ze::zeCommandListAppendMemoryFill(list, dst, pattern, pattern_size,
             size, out_event, num_deps_events, deps_events));
 
     return status::success;

--- a/src/xpu/ze/utils.hpp
+++ b/src/xpu/ze/utils.hpp
@@ -85,17 +85,32 @@ static inline std::string to_string(ze_result_t r) {
 #undef ZE_STATUS_CASE
 }
 
+#define MAYBE_REPORT_ZE_ERROR(str) \
+    do { \
+        VERROR(primitive, level_zero, "errcode %s", str); \
+    } while (false)
+
 #define ZE_CHECK(f) \
     do { \
         ze_result_t res_ = (f); \
         if (res_ != ZE_RESULT_SUCCESS) { \
             std::string err_str_ = xpu::ze::to_string(res_); \
-            VERROR(common, level_zero, "errcode %s", err_str_.c_str()); \
+            MAYBE_REPORT_ZE_ERROR(err_str_.c_str()); \
             return status::runtime_error; \
         } \
     } while (false)
 
-status_t ze_initialize();
+#define ZE_CHECK_V(f) \
+    do { \
+        ze_result_t res_ = (f); \
+        if (res_ != ZE_RESULT_SUCCESS) { \
+            std::string err_str_ = xpu::ze::to_string(res_); \
+            MAYBE_REPORT_ZE_ERROR(err_str_.c_str()); \
+            return; \
+        } \
+    } while (false)
+
+ze_result_t ze_initialize();
 
 #if defined(_WIN32)
 #define ZE_LIB_NAME "ze_loader.dll"
@@ -111,12 +126,12 @@ F find_ze_symbol(const char *symbol) {
 
 #define INDIRECT_ZE_CALL(f) \
     template <typename... Args> \
-    status_t f(Args &&...args) { \
-        CHECK(ze_initialize()); \
+    ze_result_t f(Args &&...args) { \
+        ze_result_t init_res_ = ze_initialize(); \
+        if (init_res_ != ZE_RESULT_SUCCESS) return init_res_; \
         static auto f_ = find_ze_symbol<decltype(&::f)>(#f); \
-        if (!f_) return status::runtime_error; \
-        ZE_CHECK(f_(std::forward<Args>(args)...)); \
-        return status::success; \
+        if (!f_) return ZE_RESULT_ERROR_UNINITIALIZED; \
+        return (f_(std::forward<Args>(args)...)); \
     }
 INDIRECT_ZE_CALL(zeDriverGet)
 INDIRECT_ZE_CALL(zeDriverGetProperties)
@@ -173,44 +188,76 @@ struct destroy_traits;
 template <>
 struct destroy_traits<ze_command_list_handle_t> {
     static void destroy(ze_command_list_handle_t t) {
-        (void)xpu::ze::zeCommandListHostSynchronize(t, UINT64_MAX);
-        (void)xpu::ze::zeCommandListDestroy(t);
+        ZE_CHECK_V(xpu::ze::zeCommandListHostSynchronize(t, UINT64_MAX));
+        auto ze_res = xpu::ze::zeCommandListDestroy(t);
+        if (ze_res != ZE_RESULT_SUCCESS
+                && ze_res != ZE_RESULT_ERROR_UNINITIALIZED) {
+            ZE_CHECK_V(ze_res);
+        }
     }
 };
 
 template <>
 struct destroy_traits<ze_context_handle_t> {
     static void destroy(ze_context_handle_t t) {
-        (void)xpu::ze::zeContextDestroy(t);
+        auto ze_res = xpu::ze::zeContextDestroy(t);
+        if (ze_res != ZE_RESULT_SUCCESS
+                && ze_res != ZE_RESULT_ERROR_UNINITIALIZED) {
+            ZE_CHECK_V(ze_res);
+        }
     }
 };
 
 template <>
 struct destroy_traits<ze_event_handle_t> {
     static void destroy(ze_event_handle_t t) {
-        (void)xpu::ze::zeEventHostSynchronize(t, UINT64_MAX);
-        (void)xpu::ze::zeEventDestroy(t);
+        ZE_CHECK_V(xpu::ze::zeEventHostSynchronize(t, UINT64_MAX));
+        ZE_CHECK_V(xpu::ze::zeEventDestroy(t));
     }
 };
 
 template <>
 struct destroy_traits<ze_event_pool_handle_t> {
     static void destroy(ze_event_pool_handle_t t) {
-        (void)xpu::ze::zeEventPoolDestroy(t);
+        auto ze_res = xpu::ze::zeEventPoolDestroy(t);
+        if (ze_res != ZE_RESULT_SUCCESS
+                && ze_res != ZE_RESULT_ERROR_UNINITIALIZED) {
+            ZE_CHECK_V(ze_res);
+        }
     }
 };
 
+// Kernels are part of the global static kernel cache object. It gets destroyed
+// at static objects destruction point of program destruction. This moment
+// happens after `atexit` system call, when Level Zero library will be unloaded.
+// The unloaded library means there are no Level Zero resources that can be used
+// for proper kernels destruction leading to reporting errors from this
+// wrapper. This error reports specific `ZE_RESULT_ERROR_UNINITIALIZED` error
+// code. Don't print an error message for this and successful codes.
+//
+// Note: since engine object is a singleton in benchdnn, objects created during
+// engine construction shouldn't report `ZE_RESULT_ERROR_UNINITIALIZED` error
+// message, too. Such objects are a context, a list, an event pool and modules
+// associated with kernels.
 template <>
 struct destroy_traits<ze_kernel_handle_t> {
     static void destroy(ze_kernel_handle_t t) {
-        (void)xpu::ze::zeKernelDestroy(t);
+        auto ze_res = xpu::ze::zeKernelDestroy(t);
+        if (ze_res != ZE_RESULT_SUCCESS
+                && ze_res != ZE_RESULT_ERROR_UNINITIALIZED) {
+            ZE_CHECK_V(ze_res);
+        }
     }
 };
 
 template <>
 struct destroy_traits<ze_module_handle_t> {
     static void destroy(ze_module_handle_t t) {
-        (void)xpu::ze::zeModuleDestroy(t);
+        auto ze_res = xpu::ze::zeModuleDestroy(t);
+        if (ze_res != ZE_RESULT_SUCCESS
+                && ze_res != ZE_RESULT_ERROR_UNINITIALIZED) {
+            ZE_CHECK_V(ze_res);
+        }
     }
 };
 


### PR DESCRIPTION
https://jira.devtools.intel.com/browse/MFDNN-15099
https://jira.devtools.intel.com/browse/MFDNN-15133

For OpenCL v3.1 the library will de-initialize all its objects before global static objects when the application finishes.
This affects the way our primitive/kernel cache works and all calls to destroy objects become invalid and start spamming tons of messages.
It looks like there's nothing critical happening with not destroying those objects ahead of time. Thus, the decision is to simply ignore _the specific message_ when destroying objects that get populated in the cache, including objects the library manages itself.

The clean alternative to this approach is to reset cache by setting its capacity to 0 but this new requirement will transitively be put on ALL applications with oneDNN integration, which is a huge impact and doesn't seem like a user-friendly option.

Currently, Infra filters out these messages. Once this PR lands, those filters will be reverted, too. 

[Standalone CI](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f169cf35-7dce-f135-8d66-d4f5ef20c6a0) with filters disabled