### PR TITLE
brgemm matmul: conditional use of destination type for bf16/f16 intermediate accumulation

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -751,7 +751,9 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
 
     const auto Ac = typesize_A * rd_block;
 
-    const auto Br = (brg.typesize_C != 0) ? Ac / brg.typesize_C : 0;
+    // AMX TMUL always writes 4-byte tile elements regardless of logical
+    // dt_c; use the fixed accumulator-tile element size for the palette.
+    const auto Br = Ac / brgemm_desc_t::amx_c_tile_elem_size;
 
     if (brg.get_num_A_tiles() + brg.get_num_B_tiles() + brg.get_num_C_tiles()
             > brgemm_desc_t::AMX_TILES_NUM) {
@@ -789,7 +791,7 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
             const bool is_ld_tail
                     = (brg.ldb_tail && n == (brg.get_ld_block2() - 1));
             const auto Cc = (is_ld_tail ? brg.ldb_tail : brg.ld_block)
-                    * brg.typesize_C;
+                    * brgemm_desc_t::amx_c_tile_elem_size;
             const auto C_tensor
                     = brg.get_C_tensor(m, n, is_bd_tail, is_ld_tail);
             tc_configure_tile(buff, C_tensor, Cr, Cc);

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -220,6 +220,10 @@ struct DNNL_API brgemm_attr_t {
     // and there is no unrolling by batchsize in kernel
     bool var_bs {false};
     bool postops_only {false};
+    // Force the kernel to populate the C buffer (reg_C) on non-postops
+    // calls, even when dt_c == dt_d and no post-ops. Set when an external
+    // C buffer must be filled (e.g. cross-K partial reduction in dst dtype).
+    bool use_intermediate_c_buffer {false};
     // Hint for bs_group value in brgemm_desc_t
     int hint_bs_group {0};
 
@@ -399,6 +403,8 @@ struct brgemm_desc_t {
     static constexpr int MAX_VPAD = 100;
     static constexpr int AMX_TILES_NUM = 8;
     static constexpr int tilesize = 1024;
+    // AMX accumulator tile element size (always f32, 4 bytes, independent of dt_c)
+    static constexpr int amx_c_tile_elem_size = static_cast<int>(sizeof(float));
 
     void set_attr(const primitive_attr_t *ppdattr);
     void set_dst_md(const memory_desc_t *pdst_md);
@@ -653,7 +659,8 @@ struct brgemm_desc_t {
                 brgemm_broadcast_t::none, zp_type_a, zp_type_b, zp_type_c);
         return dt_c != dt_d || with_eltwise || with_binary || with_bias
                 || with_sum || req_s8s8_compensation || has_zero_points
-                || with_src_scales || with_wei_scales || with_dst_scales;
+                || with_src_scales || with_wei_scales || with_dst_scales
+                || brgattr.use_intermediate_c_buffer;
     }
 
     bool can_dispatch_uker() const noexcept {

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -504,8 +504,8 @@ private:
 
     void process_output_range(brgemm_iteration_t &bi, int bd_start,
             int bd_finish, int bdb, int ldb);
-    void store_vector_without_post_ops(
-            int idx, const Address &addr, bool is_ld_tail);
+    void store_vector_without_post_ops(int idx, const Address &addr,
+            bool is_ld_tail, data_type_t dst_dt = data_type::f32);
     void store_vector(brgemm_iteration_t &bi, int bdb, int bd, int ldb);
     void apply_comp_pad_to_vector(brgemm_iteration_t &bi, int bdb, int inp_bd,
             int ldb, const int idx);
@@ -578,9 +578,15 @@ private:
     bool get_store_by_vectors(bool apply_post_ops) const {
         const bool need_to_apply_post_ops
                 = are_post_ops_applicable_ && apply_post_ops;
+        // Tile-direct-store fast-path dumps raw accumulator dtype; for
+        // narrow dt_c (bf16/f16) we must go through the per-vector store
+        // path that downconverts via store_vector_without_post_ops.
+        const bool c_dt_needs_cvt
+                = !utils::one_of(brg.dt_c, data_type::f32, data_type::s32);
         const auto store_by_vectors = need_to_apply_alpha_beta_
                 || need_to_apply_post_ops || brg.brgattr.bd_mask_level
-                || brg.has_per_k_scales() || brg.with_per_mn_compensation;
+                || brg.has_per_k_scales() || brg.with_per_mn_compensation
+                || c_dt_needs_cvt;
         return store_by_vectors;
     }
     bool actual_ils(bool apply_post_ops, bool skip_accumulation = false) const {
@@ -1005,9 +1011,15 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     const bool apply_beta = brg.beta != 0.f;
     if (!apply_alpha && !apply_beta) return;
 
+    // vaddps/vpaddd beta=1 fast-path reads the C buffer as raw accumulator
+    // dtype; only valid when dt_c matches it. For narrow dt_c (bf16/f16/f8)
+    // fall through to cvt2ps + vfmadd231ps so previous-dst is upconverted.
+    const bool c_dt_matches_acc
+            = utils::one_of(brg.dt_c, data_type::f32, data_type::s32);
     // When K-scales (wei or src) are applied, accumulator is already
     // converted to float (dq2ps + scales before alpha_beta), C stores floats.
-    const bool use_vadd_for_beta = brg.beta == 1.f && !brg.do_dq2ps_cvt();
+    const bool use_vadd_for_beta
+            = brg.beta == 1.f && !brg.do_dq2ps_cvt() && c_dt_matches_acc;
 
     if (apply_beta && !use_vadd_for_beta) {
         mov(reg_tmp_gpr, float2int(static_cast<float>(brg.beta)));
@@ -1766,10 +1778,23 @@ void jit_brgemm_amx_uker_base_t::store_vector_with_post_ops(
 }
 
 void jit_brgemm_amx_uker_base_t::store_vector_without_post_ops(
-        int idx, const Address &addr, bool is_ld_tail) {
+        int idx, const Address &addr, bool is_ld_tail, data_type_t dst_dt) {
     auto zmm = Zmm(idx);
 
     maybe_saturation(zmm);
+
+    // Downconvert f32 accumulator before the masked store for bf16/f16 dst.
+    if (dst_dt == data_type::bf16 || dst_dt == data_type::f16) {
+        auto k_mask = is_ld_tail ? ld_tail_mask : ld_full_mask;
+        auto ymm = Xbyak::Ymm(idx);
+        const Xbyak::Ymm r_ymm = vmm_mask(ymm, true, true, k_mask);
+        if (dst_dt == data_type::bf16)
+            vcvtneps2bf16(ymm, zmm);
+        else
+            vcvtps2ph(ymm, zmm, _op_mxcsr);
+        vmovdqu16(addr, r_ymm);
+        return;
+    }
 
     if (is_ld_tail)
         vmovups(addr | ld_tail_mask | T_z, zmm);
@@ -1794,11 +1819,15 @@ void jit_brgemm_amx_uker_base_t::store_vector(
         auto ptr_D = EVEX_compress_addr_safe(reg_D, d_offset, reg_tmp_gpr);
         store_vector_with_post_ops(vreg_acc.getIdx(), ptr_D, is_ld_tail);
     } else if (are_post_ops_applicable_) {
+        // Intermediate C-buffer store; dtype may be narrower than the
+        // accumulator (e.g. bf16/f16) under dst-dtype C-buffer mode.
         auto ptr_C = EVEX_compress_addr_safe(reg_C, c_offset, reg_tmp_gpr);
-        store_vector_without_post_ops(vreg_acc.getIdx(), ptr_C, is_ld_tail);
+        store_vector_without_post_ops(
+                vreg_acc.getIdx(), ptr_C, is_ld_tail, brg.dt_c);
     } else {
         auto ptr_D = EVEX_compress_addr_safe(reg_D, d_offset, reg_tmp_gpr);
-        store_vector_without_post_ops(vreg_acc.getIdx(), ptr_D, is_ld_tail);
+        store_vector_without_post_ops(
+                vreg_acc.getIdx(), ptr_D, is_ld_tail, brg.dt_d);
     }
 }
 
@@ -3167,7 +3196,10 @@ void jit_brgemm_amx_uker_base_t::generate() {
 
     ld_block_B_size_ = static_cast<dim_t>(brg.typesize_B)
             * ((brg.brgattr.LDB2 != 0) ? brg.brgattr.LDB2 : brg.ld_block);
-    ld_block_C_size_ = static_cast<dim_t>(brg.typesize_C) * brg.ld_block;
+    // tilestored stride for the f32 AMX accumulator tile (4-byte elements,
+    // independent of logical dt_c).
+    ld_block_C_size_ = static_cast<dim_t>(brgemm_desc_t::amx_c_tile_elem_size)
+            * brg.ld_block;
     ld_block_D_size_ = static_cast<dim_t>(brg.typesize_D) * brg.ld_block;
     ld_block_bias_size_ = static_cast<dim_t>(brg.typesize_bias) * brg.ld_block;
     if (brg.with_wei_scales) {

--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -301,9 +301,169 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
     }
 };
 
+/* xf16 (bf16/f16) reducer: upconvert -> f32 add -> downconvert. 2-byte
+ * elements; requires AVX-512 (vpmovzxwd/vcvtph2ps/vmovdqu16); bf16
+ * downconvert needs AVX512_BF16 (vcvtneps2bf16). */
+template <impl::data_type_t data_type, cpu_isa_t isa>
+struct reducer_2d_driver_xf16_t : public reducer_2d_driver_t<data_type> {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(reducer_2d_driver_xf16_t)
+
+    using data_t = typename prec_traits_t<data_type>::type;
+
+    void operator()(
+            data_t *dst, const data_t *srcs, size_t ny, size_t nx) override {
+        jit_generator_t::operator()(dst, srcs, ny, nx);
+    }
+
+    static constexpr int typesize = 2; // bf16/f16
+    static constexpr int simd_w = 16; // f32 lane count per zmm
+    static constexpr int simd_bytes = simd_w * typesize; // 32 bytes per vec
+
+    Xbyak::Reg64 reg_dst = abi_param1;
+    Xbyak::Reg64 reg_src = abi_param2;
+    Xbyak::Reg64 reg_ny = abi_param3;
+    Xbyak::Reg64 reg_nx = abi_param4;
+
+    Xbyak::Reg64 reg_x = this->rax;
+    Xbyak::Reg64 reg_long_offt = this->r11;
+    Xbyak::Reg64 reg_tmp = this->r10;
+
+    Xbyak::Opmask k_tail_mask = Xbyak::Opmask(1);
+
+    reducer_2d_driver_xf16_t(int n_src, size_t src_ld, size_t src_step,
+            size_t dst_step, bool nullify_dst)
+        : reducer_2d_driver_t<data_type>(
+                  n_src, src_ld, src_step, dst_step, nullify_dst, jit_name()) {}
+
+    void upcvt_ymm_to_zmm(const Xbyak::Zmm &z, const Xbyak::Ymm &y) {
+        if (data_type == data_type::bf16) {
+            this->vpmovzxwd(z, y);
+            this->vpslld(z, z, 16);
+        } else { // f16
+            this->vcvtph2ps(z, y);
+        }
+    }
+    void downcvt_zmm_to_ymm(const Xbyak::Ymm &y, const Xbyak::Zmm &z) {
+        if (data_type == data_type::bf16) {
+            this->vcvtneps2bf16(y, z);
+        } else { // f16
+            // 0x04 = round to current MXCSR setting (matches _op_mxcsr).
+            this->vcvtps2ph(y, z, 0x04);
+        }
+    }
+
+    // One iteration over `simd_w` (=16) elements: load dst, accumulate all
+    // srcs (already upconverted), downconvert, store.
+    void process_vec(bool with_tail_mask) {
+        using namespace Xbyak;
+        Zmm z_acc(0);
+        Zmm z_tmp(1);
+        Ymm y_acc(0);
+        Ymm y_tmp(1);
+
+        auto maybe_mask = [&](const Ymm &y, bool zeroing) {
+            if (!with_tail_mask) return y;
+            return zeroing ? Ymm(y | k_tail_mask | this->T_z) // load: {z}
+                           : Ymm(y | k_tail_mask); // store: merge
+        };
+
+        if (this->nullify_dst_) {
+            this->uni_vpxor(z_acc, z_acc, z_acc);
+        } else {
+            this->vmovdqu16(maybe_mask(y_acc, true), this->ptr[reg_dst]);
+            upcvt_ymm_to_zmm(z_acc, y_acc);
+        }
+        for (int src_id = 0; src_id < this->n_src_; ++src_id) {
+            const size_t off
+                    = (size_t)src_id * this->src_ld_ * (size_t)typesize;
+            if (off > (size_t)INT_MAX) {
+                this->mov(reg_long_offt, off);
+                this->vmovdqu16(maybe_mask(y_tmp, true),
+                        this->ptr[reg_src + reg_long_offt]);
+            } else {
+                this->vmovdqu16(
+                        maybe_mask(y_tmp, true), this->ptr[reg_src + (int)off]);
+            }
+            upcvt_ymm_to_zmm(z_tmp, y_tmp);
+            this->vaddps(z_acc, z_acc, z_tmp);
+        }
+        downcvt_zmm_to_ymm(y_acc, z_acc);
+        this->vmovdqu16(this->ptr[reg_dst], maybe_mask(y_acc, false));
+    }
+
+    void loop_x() {
+        Xbyak::Label loop_vec, loop_vec_end, tail_chk, tail_done;
+
+        this->mov(reg_x, reg_nx);
+
+        this->L(loop_vec);
+        this->cmp(reg_x, simd_bytes);
+        this->jl(loop_vec_end, this->T_NEAR);
+        process_vec(/*with_tail_mask=*/false);
+        this->add(reg_src, simd_bytes);
+        this->add(reg_dst, simd_bytes);
+        this->sub(reg_x, simd_bytes);
+        this->jmp(loop_vec, this->T_NEAR);
+
+        this->L(loop_vec_end);
+
+        // Tail in bytes: 0..(simd_bytes - typesize). Elements count = x/2.
+        this->cmp(reg_x, 0);
+        this->jle(tail_done, this->T_NEAR);
+
+        // Build a k-mask for (x / 2) elements: mask = (1u << (x / 2)) - 1.
+        this->mov(reg_tmp.cvt32(), 1);
+        this->mov(this->rcx, reg_x);
+        this->shr(this->rcx, 1); // bytes -> elements
+        this->shl(reg_tmp.cvt32(), this->cl);
+        this->sub(reg_tmp.cvt32(), 1);
+        this->kmovw(k_tail_mask, reg_tmp.cvt32());
+        process_vec(/*with_tail_mask=*/true);
+        this->add(reg_src, reg_x);
+        this->add(reg_dst, reg_x);
+
+        this->L(tail_done);
+
+        // restore address registers to row-start
+        this->sub(reg_src, reg_nx);
+        this->sub(reg_dst, reg_nx);
+    }
+
+    void generate() override {
+        static_assert(isa == avx512_core, "xf16 reducer requires avx512");
+
+        this->preamble();
+        // nx came in as element count; convert to bytes (typesize=2).
+        this->shl(reg_nx, 1);
+
+        Xbyak::Label ny_loop;
+        this->L(ny_loop);
+
+        loop_x();
+
+        this->add(reg_dst, this->dst_step_ * (size_t)typesize);
+        this->add(reg_src, this->src_step_ * (size_t)typesize);
+
+        this->dec(reg_ny);
+        this->jnz(ny_loop, this->T_NEAR);
+
+        this->postamble();
+    }
+};
+
 template <impl::data_type_t data_type>
 inline reducer_2d_driver_t<data_type> *create_reduce_2d_drv(int n_src,
         size_t src_ld, size_t src_step, size_t dst_step, bool nullify_dst) {
+    if (utils::one_of(data_type, data_type::bf16, data_type::f16)) {
+        // bf16 downconvert needs AVX512_BF16 (vcvtneps2bf16). f16 needs
+        // F16C/AVX512F. Caller is expected to only request these types
+        // when the matmul ISA already implies AMX_BF16/AMX_FP16.
+        if (mayiuse(avx512_core))
+            return new reducer_2d_driver_xf16_t<data_type, avx512_core>(
+                    n_src, src_ld, src_step, dst_step, nullify_dst);
+        assert(!"xf16 reducer requires avx512_core");
+        return nullptr;
+    }
     if (mayiuse(avx512_core))
         return new reducer_2d_driver_f_s_32_t<data_type, avx512_core>(
                 n_src, src_ld, src_step, dst_step, nullify_dst);
@@ -589,6 +749,8 @@ void cpu_accumulator_1d_t<data_type>::accumulate(
 
 template struct cpu_accumulator_1d_t<data_type::f32>;
 template struct cpu_accumulator_1d_t<data_type::s32>;
+template struct cpu_accumulator_1d_t<data_type::bf16>;
+template struct cpu_accumulator_1d_t<data_type::f16>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -81,6 +81,25 @@ bool matmul_amx_blocking_params_t::is_buffer_c_required() const {
             && (K > k_chunk_elems_ || K % k_blk_ > 0));
 }
 
+dim_t matmul_amx_blocking_params_t::effective_c_buf_dt_sz(
+        int nthr_k_cand) const {
+    if (!is_c_buf_dst_dt) return acc_dt_sz;
+    // Bypass (nthr_k<=1) has no scratch C buffer -> return 0 for footprint.
+    // D RMW traffic is modeled in bw() separately to avoid perturbing
+    // N_blk selection for single-K-chunk shapes.
+    if (nthr_k_cand <= 1 && !with_sum) return 0;
+    return c_dt_sz;
+}
+
+// The narrow-dt (bf16/f16) C discount only applies where the C buffer
+// actually disappears: nthr_k<=1 with several K-chunks. Elsewhere the
+// saving is dwarfed by the reduction and the M/N parallelism given up,
+// and letting it skew the score can cost an order of magnitude.
+bool matmul_amx_blocking_params_t::narrow_c_scoring_active() const {
+    const bool multiple_k_chunks = k_chunk_elems_ > 0 && K > k_chunk_elems_;
+    return is_c_buf_dst_dt && nthr_k_ <= 1 && multiple_k_chunks;
+}
+
 size_t matmul_amx_blocking_params_t::L2_threshold() {
     return 3 * platform::get_per_core_cache_size(2) / 4;
 }
@@ -420,7 +439,8 @@ void matmul_amx_blocking_params_macro_t::calculate_layer_sizes(
     if (is_horizontal) {
         // Amount of C/D bytes that are written per core
         size_t strip_dst_size = m_decomposition * n_per_thread
-                * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
+                * ((nthr_k_ == 1 || narrow_c_scoring_active()) ? c_dt_sz
+                                                               : acc_dt_sz);
         // Amount of compute
         layer_perf_characteristics.num_tmuls_per_strip = m_decomposition
                 * k_per_thread * n_per_thread / (m_tmul * k_tmul * n_tmul);
@@ -461,7 +481,8 @@ void matmul_amx_blocking_params_macro_t::calculate_layer_sizes(
     } else {
         // Amount of C/D bytes that are written per core
         size_t strip_dst_size = n_decomposition * m_per_thread
-                * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
+                * ((nthr_k_ == 1 || narrow_c_scoring_active()) ? c_dt_sz
+                                                               : acc_dt_sz);
         // Amount of compute
         layer_perf_characteristics.num_tmuls_per_strip = n_decomposition
                 * k_per_thread * m_per_thread / (m_tmul * k_tmul * n_tmul);
@@ -523,21 +544,43 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
             * div_up(n_decomposition, 16) * 64;
     float c_post_write_hit = c_post_write_total - c_post_write_miss;
 
-    float c_post_read_c_tmp = c_elem_per_strip * acc_dt_sz;
+    float c_post_read_c_tmp = c_elem_per_strip
+            * (narrow_c_scoring_active() ? c_dt_sz : acc_dt_sz);
 
     float c_tmp_l1_cycles;
     if (k_blk_ == K) {
+        // tile stores into wsp (hot in l1)
         c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
-                / bw_interpolator.l1_load_hit_bw;
+                / bw_interpolator.l1_store_hit_bw;
     } else {
-        // TODO: modify wrt wsp
-        c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
-                / bw_interpolator.l1_store_miss_bw;
+        if (narrow_c_scoring_active()) {
+            // tile stores into wsp (hot in l1)
+            c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+                    / bw_interpolator.l1_store_hit_bw;
+            // load from wsp to zmm
+            c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+                    / bw_interpolator.l1_load_hit_bw;
+
+            assert(k_chunk_size_ > 0);
+            // load previous partial results that are stored in c_dt_sz
+            c_tmp_l1_cycles += c_dt_sz * c_elem_per_strip * (k_chunk_size_ - 1)
+                    / bw_interpolator.l1_load_miss_bw;
+            // store new partial results in c_dt_sz
+            c_tmp_l1_cycles += c_dt_sz * c_elem_per_strip * (k_chunk_size_ - 1)
+                    / bw_interpolator.l1_store_hit_bw;
+        } else {
+            // tile loads from previous partial results
+            c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+                    / bw_interpolator.l1_load_miss_bw;
+            // tile stores of new partial results
+            c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+                    / bw_interpolator.l1_store_hit_bw;
+        }
     }
 
     float c_l1_cycles = c_post_write_miss / bw_interpolator.l1_store_miss_bw
             + c_post_write_hit / bw_interpolator.l1_store_hit_bw
-            + c_post_read_c_tmp / bw_interpolator.l1_store_hit_bw
+            + c_post_read_c_tmp / bw_interpolator.l1_load_hit_bw
             + c_tmp_l1_cycles;
 
     float l1_cycles = temporal_matrix_l1_miss / bw_interpolator.l1_load_miss_bw
@@ -605,11 +648,16 @@ float matmul_amx_blocking_params_macro_t::calculate_reduction_cycles(
         bw_map_t &bw_interpolator) const {
     // Calculate reduction cycles
     float reduction_cycles;
-    size_t c_size_per_core = m_per_thread * n_per_thread * acc_dt_sz;
+    // Score the reduction as plain f32 accumulation: the narrower partials do
+    // not make a K-split cheap enough to justify the M/N parallelism it costs.
+    const dim_t reduction_c_dt_sz = narrow_c_scoring_active()
+            ? effective_c_buf_dt_sz(nthr_k_)
+            : acc_dt_sz;
+    size_t c_size_per_core = m_per_thread * n_per_thread * reduction_c_dt_sz;
 
     if (nthr_k_ != 1) {
         if (c_size_per_core * 2 < L2_threshold() && batch == 1) {
-            float reduction_read_bytes = (M * rnd_up(N, 16) * acc_dt_sz)
+            float reduction_read_bytes = (M * rnd_up(N, 16) * reduction_c_dt_sz)
                     * ((nthr_k_ - 1)) / (nthr_m_ * nthr_n_);
             float reduction_read_cycles;
             if (layer_perf_characteristics.a_size
@@ -803,26 +851,32 @@ size_t matmul_amx_blocking_params_macro_t::l2_matrix_usage(size_t k_chunk_size,
         size_t m_or_n_blk, size_t k_blk, bool is_horizontal,
         bool force_transform_matrix_to_l2) const {
     int decomposition = is_horizontal ? m_decomposition : n_decomposition;
-    size_t l1_matrix_size = 2 * decomposition
-            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * gemm_dt_sz; // 2 for prefetch
-    size_t l2_matrix_size = m_or_n_blk
-            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * gemm_dt_sz;
+    const dim_t k_iter_elems
+            = nstl::min((dim_t)(k_blk * k_chunk_size), (dim_t)k_per_thread);
+    size_t l1_matrix_size
+            = 2 * decomposition * k_iter_elems * gemm_dt_sz; // 2 for prefetch
+    size_t l2_matrix_size = m_or_n_blk * k_iter_elems * gemm_dt_sz;
     if (force_transform_matrix_to_l2) {
         /* L2 matrix orig size */
         l2_matrix_size += m_or_n_blk * k_blk * k_chunk_size
                 * (is_horizontal ? b_dt_sz : a_dt_sz);
     }
     // Calculate C post size (output buffer)
-    size_t c_post_size;
-    if (is_horizontal) {
-        c_post_size = 2 * m_decomposition * rnd_up(m_or_n_blk * c_dt_sz, 64);
-    } else {
-        c_post_size = 2 * rnd_up(n_decomposition * c_dt_sz, 64) * m_or_n_blk;
+    size_t c_post_size = 0;
+    if (nthr_k_ == 1 || (acc_dt == dst_dt)) {
+        // With is_c_buf_dst_dt the final dst buffer holds the intermediate
+        // results; with reduction on top of it a similarly sized buffer is
+        // used instead.
+        if (is_horizontal) {
+            c_post_size
+                    = 2 * m_decomposition * rnd_up(m_or_n_blk * c_dt_sz, 64);
+        } else {
+            c_post_size
+                    = 2 * rnd_up(n_decomposition * c_dt_sz, 64) * m_or_n_blk;
+        }
     }
     // Calculate C tmp size (partial results buffer)
-    size_t c_tmp_size;
+    int c_tmp_size;
     if (k_blk == (size_t)K || (acc_dt == dst_dt && nthr_k_ == 1)) {
         c_tmp_size = 2 * m_decomposition * n_decomposition * acc_dt_sz;
     } else {
@@ -835,32 +889,40 @@ size_t matmul_amx_blocking_params_macro_t::l2_matrix_usage(size_t k_chunk_size,
 size_t matmul_amx_blocking_params_macro_t::l2_matrix_and_c_usage(
         size_t k_chunk_size, size_t m_or_n_blk, size_t k_blk,
         bool is_horizontal) const {
+    // NOTE: this, l2_matrix_usage() and bw() run during candidate generation
+    // with trial k_blk/k_chunk, so they always price C as f32: keying them on
+    // is_c_buf_dst_dt would make relaxed enumerate a different candidate set.
     size_t per_thread_for_l1_matrix
             = is_horizontal ? m_per_thread : n_per_thread;
-    size_t l1_matrix_size = 2 * per_thread_for_l1_matrix
-            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+    const dim_t k_iter_elems
+            = nstl::min((dim_t)(k_blk * k_chunk_size), (dim_t)k_per_thread);
+    size_t l1_matrix_size = 2 * per_thread_for_l1_matrix * k_iter_elems
             * gemm_dt_sz; // 2x factor to make sure C is fresher than A,B in LRU
-    size_t l2_matrix_size = 2 * m_or_n_blk
-            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+    size_t l2_matrix_size = 2 * m_or_n_blk * k_iter_elems
             * gemm_dt_sz; // 2x factor to make sure C is fresher than A,B in LRU
-    size_t c_size
-            = per_thread_for_l1_matrix * m_or_n_blk * acc_dt_sz; // Keep C in L2
+    int c_size = per_thread_for_l1_matrix * m_or_n_blk * acc_dt_sz; // C in L2
     return l1_matrix_size + l2_matrix_size + c_size;
 }
 
 int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
         size_t k_blk, size_t n_blk, bool is_horizontal) const {
-    int a_bw = m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * gemm_dt_sz;
-    int b_bw = n_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * gemm_dt_sz;
+    const dim_t k_iter_elems
+            = nstl::min((dim_t)(k_blk * k_chunk_size), (dim_t)k_per_thread);
+    int a_bw = m_blk * k_iter_elems * gemm_dt_sz;
+    int b_bw = n_blk * k_iter_elems * gemm_dt_sz;
     int c_bw;
 
-    if ((l2_matrix_and_c_usage(k_chunk_size, is_horizontal ? n_blk : m_blk,
-                 k_blk, is_horizontal)
-                        < L2_threshold()
-                || (dim_t)nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-                        == K)
+    // is_c_buf_dst_dt bypass: D RMW'd per K-chunk (vs f32-scratch). CRUCIAL: RMW cost only
+    // when K>1 chunk; single K-chunk has c_bw=0 for wide-N parallelism on small shapes.
+    const bool single_k_chunk = k_iter_elems == K;
+    const bool c_bypass_to_dst
+            = is_c_buf_dst_dt && nthr_k_ <= 1 && !with_sum && !single_k_chunk;
+
+    if (!c_bypass_to_dst
+            && (l2_matrix_and_c_usage(k_chunk_size,
+                        is_horizontal ? n_blk : m_blk, k_blk, is_horizontal)
+                            < L2_threshold()
+                    || single_k_chunk)
             && nthr_k_ == 1) {
         c_bw = 0;
     } else {
@@ -871,8 +933,9 @@ int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
 
 int matmul_amx_blocking_params_macro_t::compute(
         size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk) const {
-    return m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * n_blk;
+    const dim_t k_iter_elems
+            = nstl::min((dim_t)(k_blk * k_chunk_size), (dim_t)k_per_thread);
+    return m_blk * k_iter_elems * n_blk;
 }
 
 float matmul_amx_blocking_params_macro_t::ratio(size_t m_blk,
@@ -1565,8 +1628,9 @@ size_t matmul_amx_blocking_params_micro_t::calculate_chunk_memory_size() {
     const size_t B_buf_sz
             = use_buffer_b ? tr_b_dt_sz * n_blk_ * k_chunk_elems_ : 0;
     const size_t C_chunk_sz = c_dt_sz * m_chunk_elems_ * n_chunk_elems_;
-    const size_t C_buf_sz
-            = need_buf_c_ ? acc_dt_sz * m_chunk_elems_ * n_chunk_elems_ : 0;
+    const size_t C_buf_sz = need_buf_c_
+            ? effective_c_buf_dt_sz(nthr_k_) * m_chunk_elems_ * n_chunk_elems_
+            : 0;
     return A_chunk_sz + A_buf_sz + B_chunk_sz + B_buf_sz + C_chunk_sz
             + C_buf_sz;
 }

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -17,7 +17,6 @@
 #ifndef CPU_X64_MATMUL_AMX_BLOCKING_HEURISTICS_HPP
 #define CPU_X64_MATMUL_AMX_BLOCKING_HEURISTICS_HPP
 
-#include "common/math_utils.hpp"
 #include "cpu/x64/matmul/brgemm_matmul_utils.hpp"
 
 namespace dnnl {
@@ -138,6 +137,10 @@ public:
 protected:
     virtual float calculate_blocking_scores() const = 0;
     virtual dim_t get_actual_lda() const;
+    // Size of one C buffer element as seen by the scratchpad footprint.
+    dim_t effective_c_buf_dt_sz(int nthr_k_cand) const;
+    // Whether scoring may price C in dst dt instead of the accumulator dt.
+    bool narrow_c_scoring_active() const;
 
     // Num threads for parallelism wrt K dimension
     size_t nthr_m_ {0}, nthr_n_ {0}, nthr_k_ {0}, nthr_b_ {0};

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -471,9 +471,24 @@ status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, bgmmc_.bia_dt));
 
+        // is_c_buf_dst_dt path: keep partial K-chunk accumulation in dst dtype.
+        // nthr_k<=1 bypasses the C buffer (accumulate into D, beta=1);
+        // nthr_k>1 keeps a C buffer in dst dtype and reduces across K-threads.
+        // Either way set dt_c=dst_dt to activate the kernel's narrow-dt_c
+        // store/beta paths (see jit_brgemm_amx_uker.cpp).
+        if (bgmmc_.is_c_buf_dst_dt) {
+            brg.dt_c = brg.dt_d;
+            brg.typesize_C = types::data_type_size(brg.dt_c);
+        }
+
         brgemm_attr_t brgattr;
         brgattr.generate_skip_accumulation
                 = bgmmc_.post_ops_applicable && bgmmc_.nthr_k > 1;
+        // With dst-dtype C buffer (nthr_k>1), force intermediate-C-buffer
+        // store path even if dt_c==dt_d. Otherwise per-K-thread brgemm
+        // writes to reg_D, overrunning dst and racing across K-threads.
+        brgattr.use_intermediate_c_buffer
+                = bgmmc_.is_c_buf_dst_dt && bgmmc_.use_buffer_c;
         brgattr.mem_advice = bgmmc_.mem_advice;
         brgattr.max_bs = bs;
         brgattr.hint_prefetchw = bgmmc_.hint_prefetchw;
@@ -508,6 +523,11 @@ status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
 
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
         CHECK(brgemm_desc_finalize(&brg));
+
+        // Narrow dt_c is implemented by the AMX uker only, so every kernel in
+        // the set has to actually dispatch to it. Checked after the attributes
+        // are applied because that is what can_dispatch_uker() reads.
+        assert(IMPLICATION(bgmmc_.is_c_buf_dst_dt, brg.can_dispatch_uker()));
 
         bgmmc_.wsp_tile_per_thr_bytes = nstl::max(
                 brg.get_wsp_buffer_size(), bgmmc_.wsp_tile_per_thr_bytes);
@@ -573,14 +593,28 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
     if (bgmmc.use_buffer_a || bgmmc.use_buffer_a_tail_only)
         CHECK(create_brgemm_matmul_copy_a(copy_A_kernel_, &bgmmc));
 
-    if (pd()->with_reduce() || (bgmmc.nthr_k > 1 && bgmmc.acc_dt == f32)) {
+    // C-buffer dtype for cross-K reduction: by default this is acc_dt
+    // (f32 / s32). When relaxed accumulation is enabled and nthr_k > 1
+    // the per-thread brgemm writes bf16/f16 into the C buffer, so the
+    // reducer must work on bf16/f16 too.
+    const bool c_buf_is_dst_dt = bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k > 1;
+    if (pd()->with_reduce()
+            || (bgmmc.nthr_k > 1 && bgmmc.acc_dt == f32 && !c_buf_is_dst_dt)) {
         CHECK(safe_ptr_assign(
                 acc_ker_f32_, new cpu_accumulator_1d_t<data_type::f32>()));
         CHECK(acc_ker_f32_->create_kernel());
-    } else if (bgmmc.nthr_k > 1 && bgmmc.acc_dt == s32) {
+    } else if (bgmmc.nthr_k > 1 && bgmmc.acc_dt == s32 && !c_buf_is_dst_dt) {
         CHECK(safe_ptr_assign(
                 acc_ker_s32_, new cpu_accumulator_1d_t<data_type::s32>()));
         CHECK(acc_ker_s32_->create_kernel());
+    } else if (c_buf_is_dst_dt && bgmmc.dst_dt == data_type::bf16) {
+        CHECK(safe_ptr_assign(
+                acc_ker_bf16_, new cpu_accumulator_1d_t<data_type::bf16>()));
+        CHECK(acc_ker_bf16_->create_kernel());
+    } else if (c_buf_is_dst_dt && bgmmc.dst_dt == data_type::f16) {
+        CHECK(safe_ptr_assign(
+                acc_ker_f16_, new cpu_accumulator_1d_t<data_type::f16>()));
+        CHECK(acc_ker_f16_->create_kernel());
     }
 
     if (bgmmc.packed_sparse_weights) {
@@ -1363,7 +1397,11 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                 char *buf_reduced_base
                         = brgmm_ctx.get_buf_C_par_reduction_ptr(0, mb, nb);
 
-                const size_t m_offset = brgmm_ctx.get_LDC() * bgmmc.acc_dt_sz;
+                const bool c_buf_is_dst_dt
+                        = bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k > 1;
+                const dim_t c_buf_dt_sz
+                        = c_buf_is_dst_dt ? bgmmc.c_dt_sz : bgmmc.acc_dt_sz;
+                const size_t m_offset = brgmm_ctx.get_LDC() * c_buf_dt_sz;
                 for (int r = 1; r < num_reduction_buffers; r++) {
                     const char *buf_to_reduce_base
                             = brgmm_ctx.get_buf_C_par_reduction_ptr(r, mb, nb);
@@ -1622,10 +1660,18 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::accumulate(
         char *result_ptr, const char *reduce_ptr, size_t size) const {
-    if (pd()->get_brgemm_matmul_conf().acc_dt == f32)
+    const auto &bgmmc = pd()->get_brgemm_matmul_conf();
+    const bool c_buf_is_dst_dt = bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k > 1;
+    if (c_buf_is_dst_dt && bgmmc.dst_dt == data_type::bf16)
+        acc_ker_bf16_->accumulate(
+                (bfloat16_t *)result_ptr, (const bfloat16_t *)reduce_ptr, size);
+    else if (c_buf_is_dst_dt && bgmmc.dst_dt == data_type::f16)
+        acc_ker_f16_->accumulate(
+                (float16_t *)result_ptr, (const float16_t *)reduce_ptr, size);
+    else if (bgmmc.acc_dt == f32)
         acc_ker_f32_->accumulate(
                 (float *)result_ptr, (const float *)reduce_ptr, size);
-    else if (pd()->get_brgemm_matmul_conf().acc_dt == s32)
+    else if (bgmmc.acc_dt == s32)
         acc_ker_s32_->accumulate(
                 (int32_t *)result_ptr, (const int32_t *)reduce_ptr, size);
     else
@@ -2255,8 +2301,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             return get_data_C_ptr(0, m, n);
 
         int k_buf_idx = ithr_k - (!bgmmc_.post_ops_applicable ? 1 : 0);
+        const dim_t c_buf_dt_sz = (bgmmc_.is_c_buf_dst_dt && bgmmc_.nthr_k > 1)
+                ? bgmmc_.c_dt_sz
+                : bgmmc_.acc_dt_sz;
         return buf_C_ptr_ + k_buf_idx * bgmmc_.buffer_c_per_thread_sz
-                + get_data_C_off(0, m, n) * bgmmc_.acc_dt_sz / bgmmc_.c_dt_sz;
+                + get_data_C_off(0, m, n) * c_buf_dt_sz / bgmmc_.c_dt_sz;
     }
 
     dim_t get_data_B_off_within_block(dim_t k, dim_t n) const {

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -127,6 +127,8 @@ private:
     std::unique_ptr<jit_brgemm_matmul_copy_a_t> copy_A_kernel_;
     std::unique_ptr<cpu_accumulator_1d_t<data_type::f32>> acc_ker_f32_;
     std::unique_ptr<cpu_accumulator_1d_t<data_type::s32>> acc_ker_s32_;
+    std::unique_ptr<cpu_accumulator_1d_t<data_type::bf16>> acc_ker_bf16_;
+    std::unique_ptr<cpu_accumulator_1d_t<data_type::f16>> acc_ker_f16_;
     std::unique_ptr<jit_avx512_sparse_decompress_kernel_t>
             sparse_decompress_kernel_;
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2286,6 +2286,27 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             bgmmc.postops_inst_count = 0;
         }
 
+    // Use dst dtype (bf16/f16) for K-chunk accumulation when relaxed
+    // accumulation mode is enabled. nthr_k<=1 bypasses C buffer (beta=1 into D).
+    // Set before blocking heuristic so AMX blocking accounts for narrow C.
+    // use_buffer_c is decided inside heuristic, so not in predicate here.
+    {
+        const bool is_relaxed_acc = utils::one_of(attr.acc_mode_,
+                accumulation_mode::relaxed, accumulation_mode::any);
+        const bool dst_dt_eligible
+                = utils::one_of(bgmmc.dst_dt, data_type::bf16, data_type::f16);
+        // Only the AMX uker has the narrow-dt store/beta=1 paths.
+        const bool isa_eligible = is_superset(bgmmc.isa, avx512_core_amx);
+        // Narrow dt_c is an AMX uker feature, but runtime M falls back to a
+        // non-AMX ISA for the smallest M tail and runtime N leaves LDC/LDD as
+        // runtime values; either way can_dispatch_uker() picks the generic
+        // kernel.
+        const bool all_kernels_are_amx_uker = !bgmmc.is_runtime_M
+                && !bgmmc.is_runtime_N && !bgmmc.is_runtime_K;
+        bgmmc.is_c_buf_dst_dt = is_relaxed_acc && dst_dt_eligible
+                && isa_eligible && all_kernels_are_amx_uker;
+    }
+
     // Heuristic tries to optimize the following parameters:
     // - M_blk, M_Chunk
     // - N_blk, N_Chunk
@@ -2303,8 +2324,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     // Per-K (grouped) scales/ZP applied at kernel time (i.e. not folded into
     // buffer B) require each brgemm call to cover at most a single K-group
     // of every active per-K axis.
+    dim_t k_group = 0;
     if (!bgmmc.is_runtime_K) {
-        dim_t k_group = 0;
         auto fold_group = [&](bool active, dim_t g) {
             if (!active || g <= 0) return;
             k_group = (k_group == 0) ? g : math::gcd(k_group, g);
@@ -2318,22 +2339,61 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         fold_group(bgmmc.is_wei_zp_per_k && !wei_zp_folded_into_buffer_b,
                 bgmmc.wei_zp_k_gsize);
         fold_group(bgmmc.is_src_zp_per_k, bgmmc.src_zp_k_gsize);
-        if (k_group > 0) {
-            const dim_t prev_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
-            if (bgmmc.K_blk > k_group) {
-                bgmmc.K_blk = rnd_up(nstl::min(bgmmc.K, k_group),
-                        bgmmc.required_k_granularity);
-                bgmmc.brgemm_batch_size = 1;
-            } else {
-                const dim_t max_bs = nstl::max<dim_t>(1, k_group / bgmmc.K_blk);
-                if (bgmmc.brgemm_batch_size > max_bs)
-                    bgmmc.brgemm_batch_size = max_bs;
-            }
+    }
 
-            const dim_t new_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
-            if ((new_chunk_K < prev_chunk_K && new_chunk_K < bgmmc.K)
-                    || get_actual_ldd() != bgmmc.N) {
-                bgmmc.use_buffer_c = true;
+    bool per_k_requires_buffer_c = false;
+    auto apply_per_k_constraints = [&]() {
+        per_k_requires_buffer_c = false;
+        if (k_group <= 0) return;
+
+        const dim_t prev_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
+        if (bgmmc.K_blk > k_group) {
+            bgmmc.K_blk = rnd_up(
+                    nstl::min(bgmmc.K, k_group), bgmmc.required_k_granularity);
+            bgmmc.brgemm_batch_size = 1;
+        } else {
+            const dim_t max_bs = nstl::max<dim_t>(1, k_group / bgmmc.K_blk);
+            if (bgmmc.brgemm_batch_size > max_bs)
+                bgmmc.brgemm_batch_size = max_bs;
+        }
+
+        const dim_t new_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
+        per_k_requires_buffer_c
+                = (new_chunk_K < prev_chunk_K && new_chunk_K < bgmmc.K)
+                || get_actual_ldd() != bgmmc.N;
+        if (per_k_requires_buffer_c) bgmmc.use_buffer_c = true;
+    };
+
+    apply_per_k_constraints();
+
+    // is_c_buf_dst_dt bypass viability: nthr_k<=1 accumulates into narrow-dt
+    // D with recurring RMW per K-chunk. Only viable when panel reuse is
+    // high enough to hide RMW. For low reuse, f32-buffer path is faster.
+    if (bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k <= 1 && !bgmmc.with_sum) {
+        const dim_t panel_reuse
+                = nstl::max(bgmmc.M_chunk_size, bgmmc.N_chunk_size);
+        const dim_t bypass_k_chunk_elems
+                = static_cast<dim_t>(bgmmc.K_blk) * bgmmc.K_chunk_size;
+        const bool multiple_k_chunks
+                = bypass_k_chunk_elems > 0 && bgmmc.K > bypass_k_chunk_elems;
+        // `panel_reuse` is how often a loaded panel is reused within a
+        // chunk, i.e. how much compute can hide the narrow-D RMW the bypass
+        // repeats per K-chunk. Below this cut-off the RMW stays exposed.
+        const dim_t min_panel_reuse_for_bypass = 16;
+        if (multiple_k_chunks && panel_reuse < min_panel_reuse_for_bypass) {
+            bgmmc.is_c_buf_dst_dt = false;
+            VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
+                    VERBOSE_BLOCKING_FAIL, "");
+            apply_per_k_constraints();
+            // f32-buffer path wins only if it halves K-chunk granularity.
+            // Otherwise extra f32 buffer overhead outweighs saved D-RMW.
+            const dim_t f32_k_chunk_elems
+                    = static_cast<dim_t>(bgmmc.K_blk) * bgmmc.K_chunk_size;
+            if (f32_k_chunk_elems * 2 > bypass_k_chunk_elems) {
+                bgmmc.is_c_buf_dst_dt = true;
+                VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
+                        VERBOSE_BLOCKING_FAIL, "");
+                apply_per_k_constraints();
             }
         }
     }
@@ -2377,6 +2437,10 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                           && bgmmc.N_blk != bgmmc.N),
             "The first coordinate of every N_blk that is larger than LDB "
             "needs to be divisible by LDB");
+
+    if (bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k <= 1 && !bgmmc.with_sum
+            && !per_k_requires_buffer_c)
+        bgmmc.use_buffer_c = false;
 
     if (bgmmc.is_gemv && bgmmc.gemv_swap_a_b) {
         bgmmc.LDC = bgmmc.LDD = 1;
@@ -2625,14 +2689,23 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.brgemm_batch_tail_size
             = last_chunck_batch_size % bgmmc.brgemm_batch_size;
 
+    // Per-element size of the brgemm C buffer: with the dst-dtype opt-in and a
+    // real C buffer (nthr_k > 1) the kernel writes c_dt_sz elements instead of
+    // acc_dt_sz accumulators. Matching reducer picked in brgemm_matmul_t::init.
+    const dim_t c_buf_dt_sz
+            = (bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k > 1 && bgmmc.use_buffer_c)
+            ? bgmmc.c_dt_sz
+            : bgmmc.acc_dt_sz;
+
+    const dim_t c_buf_rows = bgmmc.gemv_swap_a_b ? bgmmc.N : bgmmc.M;
+    const dim_t c_buf_rows_blk
+            = bgmmc.gemv_swap_a_b ? bgmmc.N_blk : bgmmc.M_blk;
+
     if (!bgmmc.is_runtime_N && bgmmc.is_amx && bgmmc.nthr_k == 1) {
-        bgmmc.buffer_c_chunk_sz = rnd_up(bgmmc.N_blk, bgmmc.LDC) * bgmmc.M_blk
-                * bgmmc.acc_dt_sz;
+        bgmmc.buffer_c_chunk_sz
+                = rnd_up(bgmmc.N_blk, bgmmc.LDC) * bgmmc.M_blk * c_buf_dt_sz;
     } else {
-        const dim_t c_buf_rows = bgmmc.gemv_swap_a_b ? bgmmc.N : bgmmc.M;
-        const dim_t c_buf_rows_blk
-                = bgmmc.gemv_swap_a_b ? bgmmc.N_blk : bgmmc.M_blk;
-        bgmmc.buffer_c_chunk_sz = bgmmc.acc_dt_sz
+        bgmmc.buffer_c_chunk_sz = c_buf_dt_sz
                 * (bgmmc.is_runtime_N ? bgmmc.N_blk : bgmmc.LDC)
                 * (bgmmc.nthr_k > 1 ? c_buf_rows : c_buf_rows_blk);
     }

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1488,164 +1488,328 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     return best_imbalance;
 }
 
-status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
-        const brgemm_matmul_conf_utils_t &bm_conf_utils) {
+// Pick an AMX M block that uses most of a tile. Prefer M blocks that fill at
+// least 13 of the 16 tile rows, scaled by 2..4, and divide M evenly. Falls
+// back to the largest such block capped by M.
+dim_t pick_amx_m_blk(dim_t M) {
+    constexpr dim_t tile_rows_min = 13;
+    constexpr dim_t tile_rows_max = 16;
+    constexpr dim_t scale_rows_min = 2;
+    constexpr dim_t scale_rows_max = 4;
+
+    for_(dim_t r = tile_rows_max; r >= tile_rows_min; r--)
+    for (dim_t s = scale_rows_max; s >= scale_rows_min; s--) {
+        const dim_t m_blk = s * r;
+        if (M % m_blk == 0) return m_blk;
+    }
+
+    const dim_t max_M = scale_rows_max * tile_rows_max;
+    return nstl::min(M, max_M);
+}
+
+// Compute the per-K (grouped) scales/ZP granularity. When such quantization
+// parameters are applied at kernel time (i.e. not folded into buffer B), each
+// brgemm call must cover at most a single K-group of every active per-K axis.
+// Returns the gcd of all active per-K group sizes, or 0 when none apply.
+dim_t compute_k_group(const brgemm_matmul_conf_t &bgmmc) {
+    if (bgmmc.is_runtime_K) return 0;
+
+    dim_t k_group = 0;
+    auto fold_group = [&](bool active, dim_t g) {
+        if (!active || g <= 0) return;
+        k_group = (k_group == 0) ? g : math::gcd(k_group, g);
+    };
+    fold_group(bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b,
+            bgmmc.wei_scales_k_gsize);
+    fold_group(bgmmc.is_src_scale_per_k, bgmmc.src_scales_k_gsize);
+
+    const bool wei_zp_folded_into_buffer_b = bgmmc.with_wei_decompression
+            && !bgmmc.with_int8_grouped_quantization;
+    fold_group(bgmmc.is_wei_zp_per_k && !wei_zp_folded_into_buffer_b,
+            bgmmc.wei_zp_k_gsize);
+    fold_group(bgmmc.is_src_zp_per_k, bgmmc.src_zp_k_gsize);
+    return k_group;
+}
+
+// Reset the blocking state so a (re-)run of a blocking search starts from a
+// well-defined configuration.
+void reset_blocking_state(brgemm_matmul_conf_t &bgmmc) {
     bgmmc.N_blk = bgmmc.wei_n_blk;
     if (!bgmmc.is_runtime_N) bgmmc.N_blk = nstl::min(bgmmc.N_blk, bgmmc.N);
 
     bgmmc.M_chunk_size = bgmmc.N_chunk_size = bgmmc.K_chunk_size = 1;
+}
 
-    bool prefer_copy_a
-            = one_of(true, bm_conf_utils.is_f32() && bgmmc.isa == avx2,
-                      bm_conf_utils.is_bf16(),
-                      bm_conf_utils.is_bf16_with_int_wei(),
-                      (bgmmc.is_amx
-                              && (bm_conf_utils.is_f16()
-                                      || bm_conf_utils.is_f16_with_int_wei()
-                                      || bm_conf_utils.is_bf16_fp8()
-                                      || bm_conf_utils.is_f16_fp8())))
+// Clamp the K blocking so that a single brgemm call never spans more than one
+// per-K quantization group (see `compute_k_group()`).
+// Returns true when the resulting blocking forces a C buffer.
+bool apply_per_k_constraints(
+        brgemm_matmul_conf_t &bgmmc, dim_t k_group, dim_t actual_ldd) {
+    if (k_group <= 0) return false;
+
+    const dim_t prev_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
+    if (bgmmc.K_blk > k_group) {
+        bgmmc.K_blk = rnd_up(
+                nstl::min(bgmmc.K, k_group), bgmmc.required_k_granularity);
+        bgmmc.brgemm_batch_size = 1;
+    } else {
+        const dim_t max_bs = nstl::max<dim_t>(1, k_group / bgmmc.K_blk);
+        if (bgmmc.brgemm_batch_size > max_bs) bgmmc.brgemm_batch_size = max_bs;
+    }
+
+    const dim_t new_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
+    const bool per_k_requires_buffer_c
+            = (new_chunk_K < prev_chunk_K && new_chunk_K < bgmmc.K)
+            || actual_ldd != bgmmc.N;
+    if (per_k_requires_buffer_c) bgmmc.use_buffer_c = true;
+    return per_k_requires_buffer_c;
+}
+
+// Decide whether copying A into a buffer is preferable for the given data type
+// and shape.
+bool prefer_copy_a_heuristic(const brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils) {
+    const bool dt_prefers_copy_a = one_of(true,
+            bm_conf_utils.is_f32() && bgmmc.isa == avx2,
+            bm_conf_utils.is_bf16(), bm_conf_utils.is_bf16_with_int_wei(),
+            (bgmmc.is_amx
+                    && (bm_conf_utils.is_f16()
+                            || bm_conf_utils.is_f16_with_int_wei()
+                            || bm_conf_utils.is_bf16_fp8()
+                            || bm_conf_utils.is_f16_fp8())));
+    bool prefer_copy_a = dt_prefers_copy_a
             && (bgmmc.isa != avx2_vnni_2) // no perf study yet.
             && bgmmc.lda_big_pow2() && bgmmc.M >= 1024 && !bgmmc.is_gemv;
 
     // Avoid copying A for small N gives better performance.
     // TODO: Expand for other precisions and cases.
-
     if (bgmmc.is_amx && bm_conf_utils.is_int8())
         prefer_copy_a &= bgmmc.N >= 256;
 
-    if (bgmmc.is_amx) {
-        if (matmul_amx_blocking_params_macro_t::is_supported(
-                    bgmmc, bm_conf_utils)) {
-            //grid heuristic is possible best blocking is set
-            matmul_amx_blocking_params_macro_t best_blocking(bgmmc);
-            matmul_amx_blocking_params_macro_t::find_best_blocking(
-                    bgmmc, bm_conf_utils, best_blocking);
+    return prefer_copy_a;
+}
 
-            if (best_blocking.get_blocking_scores() != 0.0f) {
-                best_blocking.update_configuration(bgmmc);
-                return status::success;
-            }
-        }
-        bgmmc.use_buffer_a |= prefer_copy_a;
+// Run one AMX blocking search (macro grid heuristic first, micro heuristic as
+// a fallback) and apply the per-K constraints to the resulting blocking.
+status_t compute_amx_blocking_candidate(brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils, bool prefer_copy_a,
+        dim_t k_group, dim_t actual_ldd, bool &per_k_requires_buffer_c) {
+    reset_blocking_state(bgmmc);
 
-        // Configure matrix sizes
-        if (bgmmc.is_runtime_M) {
-            bgmmc.M_blk = 64; // use fixed block size for runtime M case
-        } else {
-            auto get_block_candidate = [&]() -> dim_t {
-                // for AMX prefer block sizes which utilize at least 13 tile
-                // rows
-                const dim_t tile_rows_min = 13;
-                const dim_t tile_rows_max = 16;
-                const dim_t scale_rows_min = 2;
-                const dim_t scale_rows_max = 4;
-
-                for_(dim_t r = tile_rows_max; r >= tile_rows_min; r--)
-                for (dim_t s = scale_rows_max; s >= scale_rows_min; s--) {
-                    const dim_t m_blk = s * r;
-                    if (bgmmc.M % m_blk == 0) return m_blk;
-                }
-
-                const dim_t max_M = scale_rows_max * tile_rows_max;
-                return nstl::min(bgmmc.M, max_M);
-            };
-            bgmmc.M_blk = get_block_candidate();
-        }
-
-        // AMX BRGEMM kernel requires (K_brgemm % 64 == 0 || K_brgemm < 64)
-        // for K_brgemm reduction value to avoid AMX tiles re-configuration.
-        // To satisfy this condition K_tail value is fixed to K % wei_k_blk here.
-
-        const bool fixed_K_tail_size
-                = bgmmc.K % bgmmc.wei_k_blk > 0 && bgmmc.K > bgmmc.wei_k_blk;
-        bgmmc.K_blk = bgmmc.K < bgmmc.wei_k_blk
-                ? rnd_up(bgmmc.K, bgmmc.required_k_granularity)
-                : fixed_K_tail_size ? bgmmc.wei_k_blk
-                                    : bgmmc.K;
-        bgmmc.brgemm_batch_size
-                = nstl::max(bgmmc.K / bgmmc.K_blk, static_cast<dim_t>(1));
-
-        matmul_amx_blocking_params_micro_t best_blocking(bgmmc);
-
-        matmul_amx_blocking_params_micro_t::find_best_blocking(
+    if (matmul_amx_blocking_params_macro_t::is_supported(
+                bgmmc, bm_conf_utils)) {
+        //grid heuristic is possible best blocking is set
+        matmul_amx_blocking_params_macro_t best_blocking(bgmmc);
+        matmul_amx_blocking_params_macro_t::find_best_blocking(
                 bgmmc, bm_conf_utils, best_blocking);
 
-        VCONDCHECK_BG(best_blocking.get_blocking_scores() != 0.0f,
-                VERBOSE_BLOCKING_FAIL, "");
+        if (best_blocking.get_blocking_scores() != 0.0f) {
+            best_blocking.update_configuration(bgmmc);
+            per_k_requires_buffer_c
+                    = apply_per_k_constraints(bgmmc, k_group, actual_ldd);
+            return status::success;
+        }
+    }
+    bgmmc.use_buffer_a |= prefer_copy_a;
 
-        best_blocking.update_configuration(bgmmc);
-
-    } else if (is_superset(bm_conf_utils.get_isa(), avx512_core)) {
-        // TODO:
-        // *) adjust K_BLK using 'rnd_up(bgmmc.K, bgmmc.required_k_granularity)'
-        //    for non-f32 datatypes.
-        // *) optimize param search complexity
-
-        // Approach for selecting ideal 'blocking parameters':
-        // M_blk:
-        // - main param for having parallel_work optimally distributed.
-        // - 'br_block' is a BRGeMM uKernel parameter derived from 'M_Blk',
-        // however, there is no measured performance impact from small
-        // variations in 'br_block' size.
-        //
-        // M_Chunks:
-        // - no noticeable performance impact i.e. 'M_blk = M_Chunks * M_Blk';
-        // with M_Chunks > 1', brgemm has the same performance results. Instead,
-        // choose a larger 'M_blk'.
-        //
-        // N_blk:
-        // - ideally 64 (from 'get_default_n_block()').
-        // - can be reduced to 32 to improve performance for some shapes, as
-        //  well as increasing parallelization search space.
-        //
-        // N_Chunks:
-        // - No different as long as thread/work balance is the same.
-        // - Note: for A_Transposed cases using A_buffer (i.e. bwd-w): select
-        // a higher count to increase performance -better for transposed data
-        // reuse.
-        //
-        // K_blk:
-        // - block size variation '512 <= K_blk < 1024' has negligible
-        // performance difference. However, Some cases benefit from higher
-        // block size.
-        // - can parallelize if not enough work; notice: requires reduction!
-        //
-        // Batch_Size:
-        // - unused.
-        bgmmc.use_buffer_a |= prefer_copy_a;
-        const matmul_avx512_blocking_params_t::matmul_params_t matmul(
-                bgmmc.M, bgmmc.N, bgmmc.K, bgmmc.batch);
-
-        matmul_avx512_blocking_params_t best_blocking(matmul, bgmmc.nthr);
-
-        const float best_imbalance = compute_blocking_heuristic_avx512(
-                bgmmc, bm_conf_utils, matmul, best_blocking);
-
-        VCONDCHECK_BG(best_imbalance != 1.f, VERBOSE_BLOCKING_FAIL, "")
-
-        best_blocking.update_configuration(bgmmc);
+    // Configure matrix sizes
+    if (bgmmc.is_runtime_M) {
+        bgmmc.M_blk = 64; // use fixed block size for runtime M case
     } else {
-        bgmmc.use_buffer_a |= prefer_copy_a;
-        VCONDCHECK_BG(is_superset(bm_conf_utils.get_isa(), avx2),
-                VERBOSE_UNSUPPORTED_ISA)
-        const bool is_f32 = bm_conf_utils.is_f32() && bgmmc.isa == avx2;
-
-        const matmul_avx512_blocking_params_t::matmul_params_t matmul(
-                bgmmc.M, bgmmc.N, bgmmc.K, bgmmc.batch);
-
-        matmul_avx512_blocking_params_t best_blocking(matmul, bgmmc.nthr);
-
-        const float best_imbalance = is_f32
-                ? compute_blocking_heuristic_avx2_f32(
-                          bgmmc, bm_conf_utils, matmul, best_blocking)
-                : compute_blocking_heuristic_avx2(
-                          bgmmc, bm_conf_utils, matmul, best_blocking);
-
-        VCONDCHECK_BG(best_imbalance != 1.f, VERBOSE_BLOCKING_FAIL, "")
-
-        best_blocking.update_configuration(bgmmc);
+        bgmmc.M_blk = pick_amx_m_blk(bgmmc.M);
     }
 
+    // AMX BRGEMM kernel requires
+    // (K_brgemm % 64 == 0 || K_brgemm < 64) for K_brgemm reduction
+    // value to avoid AMX tiles re-configuration. To satisfy this
+    // condition K_tail value is fixed to K % wei_k_blk here.
+    const bool fixed_K_tail_size
+            = bgmmc.K % bgmmc.wei_k_blk > 0 && bgmmc.K > bgmmc.wei_k_blk;
+    bgmmc.K_blk = bgmmc.K < bgmmc.wei_k_blk
+            ? rnd_up(bgmmc.K, bgmmc.required_k_granularity)
+            : fixed_K_tail_size ? bgmmc.wei_k_blk
+                                : bgmmc.K;
+    bgmmc.brgemm_batch_size
+            = nstl::max(bgmmc.K / bgmmc.K_blk, static_cast<dim_t>(1));
+
+    matmul_amx_blocking_params_micro_t best_blocking(bgmmc);
+
+    matmul_amx_blocking_params_micro_t::find_best_blocking(
+            bgmmc, bm_conf_utils, best_blocking);
+
+    VCONDCHECK_BG(best_blocking.get_blocking_scores() != 0.0f,
+            VERBOSE_BLOCKING_FAIL, "");
+
+    best_blocking.update_configuration(bgmmc);
+    per_k_requires_buffer_c
+            = apply_per_k_constraints(bgmmc, k_group, actual_ldd);
+    return status::success;
+}
+
+// Decide whether the is_c_buf_dst_dt bypass (nthr_k<=1 accumulating into
+// narrow-dt D with a recurring per-K-chunk read-modify-write) is worth
+// keeping, re-running the blocking search as the flag changes:
+//   1. High panel reuse (or single K-chunk): keep the bypass as-is.
+//   2. Low reuse: the D-RMW cannot be hidden, so adopt the f32 buffer.
+//   3. Unless that f32 path does not halve K-chunk granularity: revert.
+status_t reevaluate_narrow_c_bypass(brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils, bool prefer_copy_a,
+        dim_t k_group, dim_t actual_ldd, bool &per_k_requires_buffer_c) {
+    const dim_t panel_reuse = nstl::max(bgmmc.M_chunk_size, bgmmc.N_chunk_size);
+    const dim_t bypass_k_chunk_elems
+            = static_cast<dim_t>(bgmmc.K_blk) * bgmmc.K_chunk_size;
+    const bool multiple_k_chunks
+            = bypass_k_chunk_elems > 0 && bgmmc.K > bypass_k_chunk_elems;
+    // `panel_reuse` is how often a loaded panel is reused within a chunk,
+    // i.e. how much compute can hide the narrow-D RMW the bypass repeats per
+    // K-chunk. Below this cut-off the RMW stays exposed.
+    constexpr dim_t min_panel_reuse_for_bypass = 16;
+    if (!multiple_k_chunks || panel_reuse >= min_panel_reuse_for_bypass)
+        return status::success;
+
+    bgmmc.is_c_buf_dst_dt = false;
+    CHECK(compute_amx_blocking_candidate(bgmmc, bm_conf_utils, prefer_copy_a,
+            k_group, actual_ldd, per_k_requires_buffer_c));
+
+    // f32-buffer path wins only if it at least halves K-chunk granularity.
+    // Otherwise extra f32 buffer overhead outweighs saved D-RMW.
+    constexpr dim_t min_k_chunk_shrink_factor = 2;
+    const dim_t f32_k_chunk_elems
+            = static_cast<dim_t>(bgmmc.K_blk) * bgmmc.K_chunk_size;
+    if (f32_k_chunk_elems * min_k_chunk_shrink_factor > bypass_k_chunk_elems) {
+        bgmmc.is_c_buf_dst_dt = true;
+        CHECK(compute_amx_blocking_candidate(bgmmc, bm_conf_utils,
+                prefer_copy_a, k_group, actual_ldd, per_k_requires_buffer_c));
+    }
+    return status::success;
+}
+
+status_t compute_blocking_heuristic_amx(brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils,
+        const primitive_attr_t &attr, bool prefer_copy_a, dim_t k_group,
+        dim_t actual_ldd) {
+    // Only the AMX uker has the narrow-dt store/beta=1 paths this function
+    // relies on, so the caller must have dispatched on `is_amx`.
+    assert(bgmmc.is_amx);
+
+    // Use dst dtype (bf16/f16) for K-chunk accumulation under relaxed
+    // accumulation; nthr_k<=1 then bypasses the C buffer (beta=1 into D).
+    // Not write-once: the bypass-viability retry below may toggle it.
+    const bool is_relaxed_acc = utils::one_of(
+            attr.acc_mode_, accumulation_mode::relaxed, accumulation_mode::any);
+    const bool dst_dt_eligible
+            = utils::one_of(bgmmc.dst_dt, data_type::bf16, data_type::f16);
+    // Narrow dt_c is an AMX uker feature, but runtime M falls back to a
+    // non-AMX ISA for the smallest M tail and runtime N leaves LDC/LDD as
+    // runtime values; either way can_dispatch_uker() picks the generic kernel.
+    const bool all_kernels_are_amx_uker
+            = !bgmmc.is_runtime_M && !bgmmc.is_runtime_N && !bgmmc.is_runtime_K;
+    bgmmc.is_c_buf_dst_dt
+            = is_relaxed_acc && dst_dt_eligible && all_kernels_are_amx_uker;
+
+    // Must be re-evaluated after each blocking search: both `is_c_buf_dst_dt`
+    // and `nthr_k` may change while the bypass viability is reconsidered.
+    auto can_bypass_c_buffer = [&]() {
+        return bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k <= 1 && !bgmmc.with_sum;
+    };
+
+    bool per_k_requires_buffer_c = false;
+    CHECK(compute_amx_blocking_candidate(bgmmc, bm_conf_utils, prefer_copy_a,
+            k_group, actual_ldd, per_k_requires_buffer_c));
+
+    if (can_bypass_c_buffer())
+        CHECK(reevaluate_narrow_c_bypass(bgmmc, bm_conf_utils, prefer_copy_a,
+                k_group, actual_ldd, per_k_requires_buffer_c));
+
+    if (can_bypass_c_buffer() && !per_k_requires_buffer_c)
+        bgmmc.use_buffer_c = false;
+
+    return status::success;
+}
+
+status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils,
+        const memory_desc_wrapper &dst_d, const primitive_attr_t &attr) {
+    const dim_t actual_ldd = dst_d.ndims() == 2 && bgmmc.M == 1
+            ? bgmmc.N
+            : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
+    // Loop-invariant across every blocking candidate, so set it once here.
+    bgmmc.LDD = actual_ldd;
+
+    // Per-K (grouped) scales/ZP applied at kernel time (i.e. not folded into
+    // buffer B) require each brgemm call to cover at most a single K-group
+    // of every active per-K axis.
+    const dim_t k_group = compute_k_group(bgmmc);
+
+    const bool prefer_copy_a = prefer_copy_a_heuristic(bgmmc, bm_conf_utils);
+
+    if (bgmmc.is_amx)
+        return compute_blocking_heuristic_amx(
+                bgmmc, bm_conf_utils, attr, prefer_copy_a, k_group, actual_ldd);
+
+    bgmmc.is_c_buf_dst_dt = false;
+    reset_blocking_state(bgmmc);
+
+    const bool is_avx512 = is_superset(bm_conf_utils.get_isa(), avx512_core);
+    VCONDCHECK_BG(is_avx512 || is_superset(bm_conf_utils.get_isa(), avx2),
+            VERBOSE_UNSUPPORTED_ISA)
+
+    bgmmc.use_buffer_a |= prefer_copy_a;
+
+    const matmul_avx512_blocking_params_t::matmul_params_t matmul(
+            bgmmc.M, bgmmc.N, bgmmc.K, bgmmc.batch);
+    matmul_avx512_blocking_params_t best_blocking(matmul, bgmmc.nthr);
+
+    // TODO:
+    // *) adjust K_BLK using 'rnd_up(bgmmc.K, bgmmc.required_k_granularity)'
+    //    for non-f32 datatypes.
+    // *) optimize param search complexity
+
+    // Approach for selecting ideal 'blocking parameters' (avx512 path):
+    // M_blk:
+    // - main param for having parallel_work optimally distributed.
+    // - 'br_block' is a BRGeMM uKernel parameter derived from 'M_Blk',
+    // however, there is no measured performance impact from small
+    // variations in 'br_block' size.
+    //
+    // M_Chunks:
+    // - no noticeable performance impact i.e. 'M_blk = M_Chunks * M_Blk';
+    // with M_Chunks > 1', brgemm has the same performance results. Instead,
+    // choose a larger 'M_blk'.
+    //
+    // N_blk:
+    // - ideally 64 (from 'get_default_n_block()').
+    // - can be reduced to 32 to improve performance for some shapes, as
+    //  well as increasing parallelization search space.
+    //
+    // N_Chunks:
+    // - No different as long as thread/work balance is the same.
+    // - Note: for A_Transposed cases using A_buffer (i.e. bwd-w): select
+    // a higher count to increase performance -better for transposed data
+    // reuse.
+    //
+    // K_blk:
+    // - block size variation '512 <= K_blk < 1024' has negligible
+    // performance difference. However, Some cases benefit from higher
+    // block size.
+    // - can parallelize if not enough work; notice: requires reduction!
+    //
+    // Batch_Size:
+    // - unused.
+    const bool is_avx2_f32 = bm_conf_utils.is_f32() && bgmmc.isa == avx2;
+    const float best_imbalance = is_avx512
+            ? compute_blocking_heuristic_avx512(
+                      bgmmc, bm_conf_utils, matmul, best_blocking)
+            : is_avx2_f32 ? compute_blocking_heuristic_avx2_f32(
+                                    bgmmc, bm_conf_utils, matmul, best_blocking)
+                          : compute_blocking_heuristic_avx2(bgmmc,
+                                    bm_conf_utils, matmul, best_blocking);
+
+    VCONDCHECK_BG(best_imbalance != 1.f, VERBOSE_BLOCKING_FAIL, "")
+
+    best_blocking.update_configuration(bgmmc);
+
+    apply_per_k_constraints(bgmmc, k_group, actual_ldd);
     return status::success;
 }
 
@@ -2286,117 +2450,13 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             bgmmc.postops_inst_count = 0;
         }
 
-    // Use dst dtype (bf16/f16) for K-chunk accumulation when relaxed
-    // accumulation mode is enabled. nthr_k<=1 bypasses C buffer (beta=1 into D).
-    // Set before blocking heuristic so AMX blocking accounts for narrow C.
-    // use_buffer_c is decided inside heuristic, so not in predicate here.
-    {
-        const bool is_relaxed_acc = utils::one_of(attr.acc_mode_,
-                accumulation_mode::relaxed, accumulation_mode::any);
-        const bool dst_dt_eligible
-                = utils::one_of(bgmmc.dst_dt, data_type::bf16, data_type::f16);
-        // Only the AMX uker has the narrow-dt store/beta=1 paths.
-        const bool isa_eligible = is_superset(bgmmc.isa, avx512_core_amx);
-        // Narrow dt_c is an AMX uker feature, but runtime M falls back to a
-        // non-AMX ISA for the smallest M tail and runtime N leaves LDC/LDD as
-        // runtime values; either way can_dispatch_uker() picks the generic
-        // kernel.
-        const bool all_kernels_are_amx_uker = !bgmmc.is_runtime_M
-                && !bgmmc.is_runtime_N && !bgmmc.is_runtime_K;
-        bgmmc.is_c_buf_dst_dt = is_relaxed_acc && dst_dt_eligible
-                && isa_eligible && all_kernels_are_amx_uker;
-    }
-
     // Heuristic tries to optimize the following parameters:
     // - M_blk, M_Chunk
     // - N_blk, N_Chunk
     // - K_blk, batch_size
     // - nthr_K
-    VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
+    VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils, dst_d, attr),
             VERBOSE_BLOCKING_FAIL, "");
-
-    auto get_actual_ldd = [&]() {
-        return dst_d.ndims() == 2 && bgmmc.M == 1
-                ? bgmmc.N
-                : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
-    };
-
-    // Per-K (grouped) scales/ZP applied at kernel time (i.e. not folded into
-    // buffer B) require each brgemm call to cover at most a single K-group
-    // of every active per-K axis.
-    dim_t k_group = 0;
-    if (!bgmmc.is_runtime_K) {
-        auto fold_group = [&](bool active, dim_t g) {
-            if (!active || g <= 0) return;
-            k_group = (k_group == 0) ? g : math::gcd(k_group, g);
-        };
-        fold_group(bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b,
-                bgmmc.wei_scales_k_gsize);
-        fold_group(bgmmc.is_src_scale_per_k, bgmmc.src_scales_k_gsize);
-
-        const bool wei_zp_folded_into_buffer_b = bgmmc.with_wei_decompression
-                && !bgmmc.with_int8_grouped_quantization;
-        fold_group(bgmmc.is_wei_zp_per_k && !wei_zp_folded_into_buffer_b,
-                bgmmc.wei_zp_k_gsize);
-        fold_group(bgmmc.is_src_zp_per_k, bgmmc.src_zp_k_gsize);
-    }
-
-    bool per_k_requires_buffer_c = false;
-    auto apply_per_k_constraints = [&]() {
-        per_k_requires_buffer_c = false;
-        if (k_group <= 0) return;
-
-        const dim_t prev_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
-        if (bgmmc.K_blk > k_group) {
-            bgmmc.K_blk = rnd_up(
-                    nstl::min(bgmmc.K, k_group), bgmmc.required_k_granularity);
-            bgmmc.brgemm_batch_size = 1;
-        } else {
-            const dim_t max_bs = nstl::max<dim_t>(1, k_group / bgmmc.K_blk);
-            if (bgmmc.brgemm_batch_size > max_bs)
-                bgmmc.brgemm_batch_size = max_bs;
-        }
-
-        const dim_t new_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
-        per_k_requires_buffer_c
-                = (new_chunk_K < prev_chunk_K && new_chunk_K < bgmmc.K)
-                || get_actual_ldd() != bgmmc.N;
-        if (per_k_requires_buffer_c) bgmmc.use_buffer_c = true;
-    };
-
-    apply_per_k_constraints();
-
-    // is_c_buf_dst_dt bypass viability: nthr_k<=1 accumulates into narrow-dt
-    // D with recurring RMW per K-chunk. Only viable when panel reuse is
-    // high enough to hide RMW. For low reuse, f32-buffer path is faster.
-    if (bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k <= 1 && !bgmmc.with_sum) {
-        const dim_t panel_reuse
-                = nstl::max(bgmmc.M_chunk_size, bgmmc.N_chunk_size);
-        const dim_t bypass_k_chunk_elems
-                = static_cast<dim_t>(bgmmc.K_blk) * bgmmc.K_chunk_size;
-        const bool multiple_k_chunks
-                = bypass_k_chunk_elems > 0 && bgmmc.K > bypass_k_chunk_elems;
-        // `panel_reuse` is how often a loaded panel is reused within a
-        // chunk, i.e. how much compute can hide the narrow-D RMW the bypass
-        // repeats per K-chunk. Below this cut-off the RMW stays exposed.
-        const dim_t min_panel_reuse_for_bypass = 16;
-        if (multiple_k_chunks && panel_reuse < min_panel_reuse_for_bypass) {
-            bgmmc.is_c_buf_dst_dt = false;
-            VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
-                    VERBOSE_BLOCKING_FAIL, "");
-            apply_per_k_constraints();
-            // f32-buffer path wins only if it halves K-chunk granularity.
-            // Otherwise extra f32 buffer overhead outweighs saved D-RMW.
-            const dim_t f32_k_chunk_elems
-                    = static_cast<dim_t>(bgmmc.K_blk) * bgmmc.K_chunk_size;
-            if (f32_k_chunk_elems * 2 > bypass_k_chunk_elems) {
-                bgmmc.is_c_buf_dst_dt = true;
-                VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
-                        VERBOSE_BLOCKING_FAIL, "");
-                apply_per_k_constraints();
-            }
-        }
-    }
 
     if (bgmmc.wei_n_blk > bgmmc.N_blk && bgmmc.N != bgmmc.N_blk) {
         assert(!bgmmc.is_runtime_N
@@ -2438,14 +2498,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             "The first coordinate of every N_blk that is larger than LDB "
             "needs to be divisible by LDB");
 
-    if (bgmmc.is_c_buf_dst_dt && bgmmc.nthr_k <= 1 && !bgmmc.with_sum
-            && !per_k_requires_buffer_c)
-        bgmmc.use_buffer_c = false;
-
     if (bgmmc.is_gemv && bgmmc.gemv_swap_a_b) {
         bgmmc.LDC = bgmmc.LDD = 1;
     } else {
-        bgmmc.LDD = get_actual_ldd();
         bgmmc.LDC = bgmmc.use_buffer_c && bgmmc.nthr_k <= 1
                 ? (bgmmc.is_amx ? nstl::min((dim_t)32, bgmmc.N_blk)
                                 : bgmmc.N_blk)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -151,6 +151,9 @@ struct brgemm_matmul_conf_t {
     bool use_buffer_a_tail_only;
     bool use_buffer_b;
     bool use_buffer_c;
+    // Keep the intermediate C buffer in dst dtype (bf16/f16) when relaxed
+    // accumulation mode is enabled. AMX-only; gated on use_buffer_c and bf16/f16 dst.
+    bool is_c_buf_dst_dt = false;
     bool use_buffer_reduce;
 
     brgemm_matmul_bcast_desc_t bcast_A_desc;


### PR DESCRIPTION
**Summary**

This PR introduces support for using bf16/f16 data types for the C buffer (accumulation buffer) in AMX-based matrix multiplication operations, controlled by the accumulation_mode attribute. This optimization enables direct writes to destination memory, eliminating or reducing scratch buffer overhead depending on the K-blocking strategy.

**Motivation**

Traditional AMX matmul implementations use f32 scratch buffers for intermediate accumulation results. By using narrow data types (bf16/f16) matching the destination type, we unlock significant optimizations across different execution scenarios:

*1. Single-threaded K, single K-chunk (nthr_k == 1, K fits in one chunk):*
Eliminates accumulation buffers entirely - direct write to destination
Zero L2 residency cost for partial results
Zero RMW bandwidth overhead
Preserves wide-N parallelism on small shapes
Best case scenario

*2. Single-threaded K, multiple K-chunks (nthr_k == 1, K split across chunks):*
No separate accumulation buffer - uses destination D as accumulator
RMW to destination per K-chunk (read D, accumulate, write D back)
Saves buffer allocation vs f32 scratch
Per-chunk RMW cost amortizes over larger k_blk, favoring fewer K-chunks

*3. K-parallel execution (nthr_k > 1):*
Requires separate partial buffers per K-thread for parallel accumulation
Reduces memory traffic by ~50% (2 bytes vs 4 bytes per element)
Smaller L2 footprint for resident partial results
Final reduction combines partial results into destination requiring a more complex computation sequence.

Performance results on SPR (48 cores) for bf16 matmuls.
Top/Base: Comparison of regular f32 accumulation to verify that there are no regressions.
Relaxed/Strict: Comparison of low-precision accumulation versus f32 accumulation.
As expected, the improvement is observed for large K, where this dimension is split and intermediate accumulation is actually used.
<img width="420" height="271" alt="image" src="https://github.com/user-attachments/assets/466887a4-d165-45ee-a72e-44f436466446" />


