### PR TITLE
{CPU} x64: update brgemm conv guard for bd_block2 availability

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -593,7 +593,8 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
             is_bf32, is_tf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
-    ur = brg.bd_block * (brg.bd_block2 > 0 ? brg.bd_block2 : 1);
+    // AMX kernel may fall back to VMM, in which case bd_block2 == 0
+    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
     if (ur == 0) return status::invalid_arguments;
     ur_block = brg.bd_block;
     if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -668,7 +668,8 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     brgattr.max_bottom_vpad = max_vpad;
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
-    ur = brg.bd_block * (brg.bd_block2 > 0 ? brg.bd_block2 : 1);
+    // AMX kernel may fall back to VMM, in which case bd_block2 == 0
+    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
     ur_block = brg.bd_block;
     adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
     if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {


### PR DESCRIPTION
This pull request makes a minor update to the calculation of the `ur` variable in both `jit_brgemm_conv_bwd_utils.cpp` and `jit_brgemm_conv_utils.cpp`. The update ensures that when the AMX kernel falls back to VMM and `bd_block2` is zero, the calculation does not result in `ur` being zero, which could cause errors.
