### PR TITLE
benchdnn: sdpa: Use same softmax alg as reference path

### DIFF
--- a/tests/benchdnn/sdpa/sdpa.cpp
+++ b/tests/benchdnn/sdpa/sdpa.cpp
@@ -22,6 +22,10 @@
 
 #include "oneapi/dnnl/dnnl.h"
 
+// Internal alg_kind used by the GPU SDPA kernel. Must be removed once
+// softmax_accurate_inf_as_zero is promoted to a public value.
+#include "src/common/c_types_map.hpp"
+
 #include "utils/fill.hpp"
 #include "utils/memory.hpp"
 #include "utils/parallel.hpp"
@@ -77,7 +81,8 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
             default: return 0;
         }
     }(prb->mask_type);
-    dnnl_alg_kind_t softmax_alg = dnnl_softmax_accurate;
+    dnnl_alg_kind_t softmax_alg = static_cast<dnnl_alg_kind_t>(
+            dnnl::impl::alg_kind::softmax_accurate_inf_as_zero);
 
     // KV head count is always derived from the K tensor's head dimension.
     dnnl_dim_t kv_hn = prb->k_dims()[prb->ndims - 3];


### PR DESCRIPTION
# Description

This commit fixes an issue where different softmax algorithms were used in the reference implementation and the test itself. The reference implementation was using softmax_accurate_inf_as_zero where as the test was being passed softmax_accurate. I have update the tests to use softmax_accurate_inf_as_zero for now as this is normally what we want to use but we should address this issue by adding a new flag to the SDPA driver to select which one we need.