### PR TITLE
[GPU] gemm fixes

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -274,6 +274,7 @@ void CopyPlan::transform()
 
     legalizeRegions();
     legalizeNegation();
+    legalizeSIMD();
     optimizeSaturate();
 
     sort(SortType::SourceOrder);


### PR DESCRIPTION
addresses [MFDNN-15071](https://jira.devtools.intel.com/browse/MFDNN-15071),

~~1) Transpose strategy had incorrect layout when applying slm. Cblock size in layout was causing zero-points to be applied incorrectly as k dimension in layout was too big.~~     
fixed by 2)
2) On xehpg, there is a simd limitation that should be observed in the optimizeConcatenate routine in the copy planner.
~~3) For large buffers, surface access is automatically converted to stateless. However, stateless access does not allow out of bounds reads. If the strategy assumed padded access (pab), then explicity enable double masking when conversion to stateless access happens.~~    
will be addressed in separate PR.
~~4) Pre-existing logic was incorrectly reporting a non-transpose layout as transpose.~~     
invalid test case - has already been removed from testing.
~~5) Need A/B groupSums should only be true when the user requests and passes in additional buffers to the kernel for the group sums.~~  
addressed in https://github.com/uxlfoundation/oneDNN/pull/5356