### PR TITLE
cpu: x64: binary: fix assertion on permuted src0 layout with broadcast

### DIFF
--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -192,8 +192,9 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     conf_.bcast_type = is_tensor_op() ? bcast_t::none
                                       : get_bcast_type(src1_md_, bcast_dims);
     // op_type only matters for broadcasted operation
-    assert(IMPLICATION(
-            conf_.bcast_type != bcast_t::none, conf_.op_type != op_t::none));
+    VDISPATCH_BINARY(IMPLICATION(conf_.bcast_type != bcast_t::none,
+                             conf_.op_type != op_t::none),
+            "unsupported src0 layout for broadcast operation");
     conf_.broadcast_src1_value = (conf_.op_type == op_t::n_c_spatial
                                          && conf_.bcast_type == bcast_t::per_c)
             || (utils::one_of(conf_.op_type, op_t::n_spatial_c, op_t::c_blocked)
@@ -479,7 +480,8 @@ bool jit_uni_binary_t::pd_t::is_applicable() {
 
     // only nspc and ncsp formats are supported for bcast
     if (src0_d.is_plain() && src1_d.is_plain())
-        return is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d);
+        return is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d)
+                && get_op_type(src0_d) != op_t::none;
 
     // blocked formats
     if (!conf_.is_i8) {

--- a/tests/benchdnn/inputs/binary/harness_binary_regression
+++ b/tests/benchdnn/inputs/binary/harness_binary_regression
@@ -13,3 +13,6 @@
 
 # Post-op with non-broadcast load
 --reset --alg=add --attr-post-ops=binary_div:f32:common 1x4:1x4
+
+# Permuted src0 tag (acbd) with scalar broadcast should not assert (MFDNN-14988)
+--reset --allow-enum-tags-only=0 --alg=mul --sdt=f32:f32 --ddt=f32 --stag=acbd:abcd --dtag=acbd 128x12x1x256:1x1x1x1


### PR DESCRIPTION
TL;DR: avoid assertion by fixing the logic responsible for selecting jit:uni

## Problem

When src0 uses a permuted plain format (e.g. `acbd`) and src1 is broadcast (e.g. scalar `1x1x1x1`), `get_op_type()` returns `op_t::none` because the strides do not match any recognized pattern. Meanwhile `is_format_non_blocked()` incorrectly accepts such layouts when a spatial dimension equals 1, causing `is_applicable()` to return `true` and the primitive to proceed to `init()` where an `assert` fires and aborts the process.

**Reproducer:**
```
benchdnn --binary --allow-enum-tags-only=0 --engine=cpu --alg=mul --sdt=f32:f32 --ddt=f32 --stag=acbd:abcd --dtag=acbd 128x12x1x256:1x1x1x1
```

## Root Cause

For `acbd` with shape `128x12x1x256`, logical strides are `[3072, 256, 3072, 1]`. `get_op_type()` fails to classify the layout:
- Not `c_blocked` (is_plain)
- Not `n_spatial_c` (`strides[1]=256 != 1`)
- Not `n_c_spatial` (`strides[1]=256 < strides[2]=3072`, because H and C axes are swapped)

`is_format_non_blocked()` still returns `true` because the lower-bound checks for `is_ncx` are accidentally satisfied when `H=1` (`dims[2]=1`, so `dims[2]*dims[3]=256`, which `strides[1]=256` barely meets). This causes `is_applicable()` to return `true` and let an unsupported case through to `init()`.

## Fix

**Layer 1** — reject unsupported format early in `is_applicable()`:
Add `get_op_type(src0_d) != op_t::none` guard in the plain-format broadcast path so the primitive correctly returns `unimplemented` and the reference implementation handles it.

**Layer 2** — replace `assert` with `VDISPATCH_BINARY` as a safety net, converting any missed path from an abort into a proper `status::unimplemented`.

## Testing

Regression test case added to `tests/benchdnn/inputs/binary/harness_binary_regression`.

Jira: MFDNN-14988