### PR TITLE
[GPU] Fixup GEMM precompute handling

### DIFF
--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -334,14 +334,14 @@ status_t gen_desc_t::finalize(const char *tags) {
     // TODO: Refactor M/N groups/thread setting to preserve MN group count.
     constexpr int perMNGroupSize = 1 << 24;
     if (problem_.aqGroupM == m_
-            && ((!problem_.forceGroupSumsA && !problem_.preferBDPAS())
+            && ((!problem_.hasGroupSumsA && !problem_.preferBDPAS())
                     || m_ > 1)) {
         problem_.aqGroupM = std::max(problem_.aqGroupM, perMNGroupSize);
         problem_.aqGroupM
                 = utils::rnd_up(problem_.aqGroupM, strategy_.unroll[LoopM]);
     }
     if (problem_.bqGroupN == n_
-            && ((!problem_.forceGroupSumsB && !problem_.preferBDPAS())
+            && ((!problem_.hasGroupSumsB && !problem_.preferBDPAS())
                     || n_ > 1)) {
         problem_.bqGroupN = std::max(problem_.bqGroupN, perMNGroupSize);
         problem_.bqGroupN
@@ -459,7 +459,7 @@ gen_nocopy_desc_t::select_kernel(const compute::device_info_t &dev_info,
                      || problem.boPtrDims > -1)
                     && problem.aoPtrDims > -1 && problem.Ta_ext.isInt8()
                     && problem.Tb_ext.isInt8() && problem.Tc.isFP()
-                    && !problem.forceGroupSumsA && !problem.forceGroupSumsB),
+                    && !problem.hasGroupSumsA && !problem.hasGroupSumsB),
             [](Type dt) -> const char * {
         if (dt.isInt8()) return "[OH]";
         return nullptr;

--- a/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
@@ -190,8 +190,8 @@ struct GEMMProblem : public CommonProblem {
     BatchMode batch = BatchMode::None;              // Batch mode.
     int batchDims = 0;                              // # of batch dimensions (strided batch only).
     bool sumA = false, sumB = false;                // If true, calculate A row sums/B column sums and store in CO.
-    bool forceGroupSumsA = false;
-    bool forceGroupSumsB = false;
+    bool hasGroupSumsA = false;
+    bool hasGroupSumsB = false;
     bool bdpasEnabled = false;                             // bdpas enabled for problem.
     bool cMXScale = false;
     MatrixAddressing sroundSeed;
@@ -261,8 +261,8 @@ struct GEMMProblem : public CommonProblem {
     bool aOffset2D() const { return (aoPtrDims >= 2); }
     bool bOffset2D() const { return (boPtrDims >= 2); }
 
-    bool quantized2DA() const { return forceGroupSumsB || aOffset2D() || aScale2D(); }
-    bool quantized2DB() const { return forceGroupSumsA || bOffset2D() || bScale2D(); }
+    bool quantized2DA() const { return hasGroupSumsB || aOffset2D() || aScale2D(); }
+    bool quantized2DB() const { return hasGroupSumsA || bOffset2D() || bScale2D(); }
 
     bool earlyDequantizeA() const { return (aOffset == ABOffset::Calc && earlyDequantizableOffset(Ta_ext, Tao, Ta)) || (aScale2D() && (Ta_scale.isSubsetOf(Ta) || (Ta.isFP() && !Ta.isF4() && !Ta.isF8()))); }
     bool earlyDequantizeB() const { return (bOffset == ABOffset::Calc && earlyDequantizableOffset(Tb_ext, Tbo, Tb)) || (bScale2D() && (Tb_scale.isSubsetOf(Tb) || (Tb.isFP() && !Tb.isF4() && !Tb.isF8()))); }

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -788,8 +788,8 @@ status_t pd_t::init_GEMMProblem(
     problem.sumA = (reduce_ab == sum_ab::sum_b_col);
     problem.sumB = (reduce_ab == sum_ab::sum_a_row);
     if (swap_ab_) std::swap(problem.sumA, problem.sumB);
-    problem.forceGroupSumsA = a_quant.force_gs;
-    problem.forceGroupSumsB = b_quant.force_gs;
+    problem.hasGroupSumsA = a_quant.force_gs;
+    problem.hasGroupSumsB = b_quant.force_gs;
 
     problem.postOps.cStochasticRound = dst_sround;
 
@@ -797,6 +797,7 @@ status_t pd_t::init_GEMMProblem(
         problem.autoTypeConversions(has_systolic);
 
     if (problem.needsAGroupSums()) {
+        if (!problem.hasGroupSumsA) return status::unimplemented;
         data_type_t gs_dt = a_quant.gs_type == data_type::undef
                 ? data_type::s32
                 : a_quant.gs_type;
@@ -806,6 +807,7 @@ status_t pd_t::init_GEMMProblem(
         if (problem.aqGroupK == 0) problem.aqGroupK = problem.bqGroupK;
     }
     if (problem.needsBGroupSums()) {
+        if (!problem.hasGroupSumsB) return status::unimplemented;
         data_type_t gs_dt = b_quant.gs_type == data_type::undef
                 ? data_type::s32
                 : b_quant.gs_type;


### PR DESCRIPTION
# Description

Enforce the presence of `precomputed_reduction` when it is required by GEMM. Resolves some errors from synthetic cases with attributes that require `precomputed_reduction`. 

Fixes [MFDNN-14296](https://jira.devtools.intel.com/browse/MFDNN-14926)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?