### PR TITLE
graph: backend: dnnl: passes: fix strides for quant data

### DIFF
--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -228,6 +228,7 @@ status_t replace_quant_data_with_binary_post_op(
                     : graph::data_type::f32;
             const_data_dst_value->set_data_type(out_dtype);
             const_data_dst_value->set_layout_type(layout_type::strided);
+            const_data_dst_value->set_strides(get_dense_strides(new_shape));
             const_data_op->add_output(const_data_dst_value);
 
             // connect binary and constant data


### PR DESCRIPTION
Fix the strides of the logical tensors which are created to represent quantization scales and zps.

Take 4D input quantisation as example:
- Previously, a per-tensor scale -> logical tensor with shape (1, 1, 1, 1) and strides (0, 0, 0, 0).
- Now with the fix, a per-tensor scale -> logical tensor with shape (1, 1, 1, 1) and strides (1, 1, 1, 1).