### PR TITLE
cpu: rv64: add f32 and f16 rvv reduction kernel

### DIFF
--- a/src/cpu/cpu_reduction_list.cpp
+++ b/src/cpu/cpu_reduction_list.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
+* Copyright 2026 SpacemiT Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,6 +22,9 @@
 #if DNNL_X64
 #include "cpu/x64/jit_uni_reduction.hpp"
 using namespace dnnl::impl::cpu::x64;
+#elif DNNL_RV64
+#include "cpu/rv64/jit_uni_reduction.hpp"
+using namespace dnnl::impl::cpu::rv64;
 #endif
 
 namespace dnnl {
@@ -33,6 +37,7 @@ using namespace dnnl::impl::data_type;
 // clang-format off
 constexpr impl_list_item_t impl_list[] = REG_REDUCTION_P({
     CPU_INSTANCE_X64(jit_uni_reduction_t)
+    CPU_INSTANCE_RV64(jit_uni_reduction_t)
     CPU_INSTANCE(ref_reduction_t)
     /* eol */
     nullptr,

--- a/src/cpu/rv64/jit_uni_reduction.cpp
+++ b/src/cpu/rv64/jit_uni_reduction.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+* Copyright 2026 SpacemiT Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/rv64/jit_uni_reduction.hpp"
+#include "common/compiler_workarounds.hpp"
+#include "common/dnnl_thread.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+status_t jit_uni_reduction_t::init(engine_t *engine) {
+    UNUSED(engine);
+    kernel_.reset(new jit_uni_reduction_kernel_t(pd()->get_conf()));
+    CHECK(kernel_->create_kernel());
+    return status::success;
+}
+
+status_t jit_uni_reduction_t::execute(const exec_ctx_t &ctx) const {
+    const auto src = CTX_IN_MEM(const uint8_t *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(uint8_t *, DNNL_ARG_DST);
+
+    const auto &conf = pd()->get_conf();
+    const dim_t idle_size = conf.idle_size;
+    const dim_t reduce_size = conf.reduce_size;
+    const size_t src_dt_size = conf.src_dt_size;
+    const size_t dst_dt_size = conf.dst_dt_size;
+
+    parallel_nd(idle_size, [= COMPAT_THIS_CAPTURE](dim_t i) {
+        const dim_t src_off = i * reduce_size * src_dt_size;
+        const dim_t dst_off = i * dst_dt_size;
+
+        jit_uni_reduction_args_t args;
+        args.src = src + src_off;
+        args.dst = dst + dst_off;
+        args.reduce_size = reduce_size;
+        (*kernel_)(&args);
+    });
+
+    return status::success;
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_uni_reduction.hpp
+++ b/src/cpu/rv64/jit_uni_reduction.hpp
@@ -1,0 +1,149 @@
+/*******************************************************************************
+* Copyright 2026 SpacemiT Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_UNI_REDUCTION_HPP
+#define CPU_RV64_JIT_UNI_REDUCTION_HPP
+
+#include <memory>
+
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/cpu_reduction_pd.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
+#include "cpu/rv64/jit_uni_reduction_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_uni_reduction_t : public primitive_t {
+    struct pd_t : public cpu_reduction_pd_t {
+        using cpu_reduction_pd_t::cpu_reduction_pd_t;
+
+        DECLARE_COMMON_PD_T("jit:uni", jit_uni_reduction_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            using namespace format_tag;
+
+            VDISPATCH_REDUCTION(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_REDUCTION(
+                    !has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+
+            conf_.src_type = src_md()->data_type;
+            conf_.dst_type = dst_md()->data_type;
+            conf_.src_dt_size = types::data_type_size(conf_.src_type);
+            conf_.dst_dt_size = types::data_type_size(conf_.dst_type);
+            conf_.alg = desc()->alg_kind;
+
+            VDISPATCH_REDUCTION(
+                    is_supported_alg(conf_.alg), VERBOSE_BAD_ALGORITHM);
+            VDISPATCH_REDUCTION(
+                    is_supported_dt_pair(conf_.src_type, conf_.dst_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_REDUCTION(
+                    IMPLICATION(conf_.src_type == f16 || conf_.dst_type == f16,
+                            mayiuse(zvfh)),
+                    VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_REDUCTION(set_default_params() == status::success,
+                    VERBOSE_UNSUPPORTED_TAG);
+            VDISPATCH_REDUCTION(
+                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+            VDISPATCH_REDUCTION(
+                    impl::is_dense_format_kind({src_md(), dst_md()}),
+                    VERBOSE_UNSUPPORTED_SPARSE_CFG);
+
+            const memory_desc_wrapper src_mdw(src_md());
+            const memory_desc_wrapper dst_mdw(dst_md());
+
+            const format_tag_t src_tag = memory_desc_matches_one_of_tag(
+                    *src_md(), x, nc, ncw, nchw, ncdhw);
+            const format_tag_t dst_tag = memory_desc_matches_one_of_tag(
+                    *dst_md(), x, nc, ncw, nchw, ncdhw);
+            VDISPATCH_REDUCTION(
+                    src_tag != format_tag::undef && src_tag == dst_tag,
+                    VERBOSE_UNSUPPORTED_TAG);
+
+            const int ndims = src_mdw.ndims();
+            const auto &src_dims = src_mdw.dims();
+            const auto &dst_dims = dst_mdw.dims();
+
+            int reduced_ndims = 0;
+            conf_.idle_size = dst_mdw.nelems();
+            conf_.reduce_size = 1;
+            for (int d = ndims - 1; d >= 0; --d) {
+                if (src_dims[d] != dst_dims[d]) {
+                    VDISPATCH_REDUCTION(
+                            dst_dims[d] == 1, VERBOSE_UNSUPPORTED_TAG);
+                    ++reduced_ndims;
+                    conf_.reduce_size *= src_dims[d];
+                } else {
+                    break;
+                }
+            }
+
+            VDISPATCH_REDUCTION(reduced_ndims != 0,
+                    "dimensionality reduction not possible");
+            VDISPATCH_REDUCTION(
+                    conf_.reduce_size > 0, VERBOSE_EMPTY_TENSOR, "");
+
+            for (int d = 0; d < ndims - reduced_ndims; ++d) {
+                VDISPATCH_REDUCTION(
+                        src_dims[d] == dst_dims[d], VERBOSE_UNSUPPORTED_TAG);
+            }
+
+            return status::success;
+        }
+
+        const jit_reduction_conf_t &get_conf() const { return conf_; }
+
+    private:
+        static bool is_supported_dt_pair(
+                data_type_t src_type, data_type_t dst_type) {
+            using namespace data_type;
+            return utils::one_of(src_type, f32, f16)
+                    && utils::one_of(dst_type, f32, f16);
+        }
+
+        static bool is_supported_alg(alg_kind_t alg) {
+            using namespace alg_kind;
+            return utils::one_of(alg, reduction_sum, reduction_mean,
+                    reduction_max, reduction_min);
+        }
+
+        jit_reduction_conf_t conf_ = {};
+    };
+
+    jit_uni_reduction_t(const pd_t *apd) : primitive_t(apd) {}
+    ~jit_uni_reduction_t() override = default;
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_uni_reduction_kernel_t> kernel_;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_reduction_kernel.cpp
@@ -266,13 +266,9 @@ void jit_uni_reduction_kernel_t::emit_finalize_f16_widen_sum_or_mean() {
         emit_mean_scale_if_needed();
         fsw(f_tmp, reg_dst, 0);
     } else {
-        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m4, VTA::tu, VMA::mu);
-        vfncvt_f_f_w(v_data, v_red);
-        vfmv_f_s(f_tmp, v_data);
-        fcvt_s_h(Reg(f_tmp.getIdx()), Reg(f_tmp.getIdx()));
+        vfmv_f_s(f_tmp, v_red);
         emit_mean_scale_if_needed();
-        fcvt_h_s(Reg(f_tmp.getIdx()), Reg(f_tmp.getIdx()));
-        fsh(f_tmp, reg_dst, 0);
+        emit_store_scalar(scalar_kind_t::f32);
     }
 }
 

--- a/src/cpu/rv64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_reduction_kernel.cpp
@@ -1,0 +1,313 @@
+/*******************************************************************************
+* Copyright 2026 SpacemiT Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <limits>
+
+#include "common/bit_cast.hpp"
+
+#include "cpu/rv64/jit_uni_reduction_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+#define GET_OFF(field) offsetof(jit_uni_reduction_args_t, field)
+
+namespace {
+
+const Reg reg_param = a0;
+const Reg reg_src = a1;
+const Reg reg_dst = a2;
+const Reg reg_n = a3;
+const Reg reg_tmp = t0;
+
+const VReg v_data = VReg(0);
+const VReg v_acc = VReg(8);
+const VReg v_red = VReg(16);
+
+const FReg f_init = fa0;
+const FReg f_tmp = ft0;
+const FReg f_scale = ft1;
+
+constexpr uint16_t f16_lowest = 0xfbff;
+constexpr uint16_t f16_max = 0x7bff;
+
+} // namespace
+
+jit_uni_reduction_kernel_t::jit_uni_reduction_kernel_t(
+        const jit_reduction_conf_t &conf)
+    : jit_generator_t("jit_uni_reduction_kernel"), conf_(conf) {}
+
+void jit_uni_reduction_kernel_t::load_f32_const(
+        const Xbyak_riscv::FReg &freg, float value) {
+    li(reg_tmp, static_cast<int32_t>(utils::bit_cast<uint32_t>(value)));
+    fmv_w_x(freg, reg_tmp);
+}
+
+void jit_uni_reduction_kernel_t::load_f16_const(
+        const Xbyak_riscv::FReg &freg, uint16_t raw_value) {
+    li(reg_tmp, raw_value);
+    fmv_h_x(freg, reg_tmp);
+}
+
+void jit_uni_reduction_kernel_t::advance_src(int shift) {
+    slli(reg_tmp, reg_tmp, shift);
+    add(reg_src, reg_src, reg_tmp);
+}
+
+void jit_uni_reduction_kernel_t::load_params() {
+    ld(reg_src, reg_param, GET_OFF(src));
+    ld(reg_dst, reg_param, GET_OFF(dst));
+    ld(reg_n, reg_param, GET_OFF(reduce_size));
+}
+
+jit_uni_reduction_kernel_t::src_kind_t
+jit_uni_reduction_kernel_t::src_kind() const {
+    using namespace data_type;
+    if (conf_.src_type == f32) return src_kind_t::f32;
+    if (conf_.src_type == f16) return src_kind_t::f16;
+    assert(!"unsupported reduction source data type");
+    return src_kind_t::f32;
+}
+
+jit_uni_reduction_kernel_t::scalar_kind_t
+jit_uni_reduction_kernel_t::dst_kind() const {
+    using namespace data_type;
+    if (conf_.dst_type == f32) return scalar_kind_t::f32;
+    if (conf_.dst_type == f16) return scalar_kind_t::f16;
+    assert(!"unsupported reduction destination data type");
+    return scalar_kind_t::f32;
+}
+
+jit_uni_reduction_kernel_t::reduce_op_t
+jit_uni_reduction_kernel_t::reduce_op() const {
+    using namespace alg_kind;
+    switch (conf_.alg) {
+        case reduction_max: return reduce_op_t::max;
+        case reduction_min: return reduce_op_t::min;
+        case reduction_sum: return reduce_op_t::sum;
+        case reduction_mean: return reduce_op_t::mean;
+        default: assert(!"unsupported reduction alg");
+    }
+    return reduce_op_t::sum;
+}
+
+jit_uni_reduction_kernel_t::acc_kind_t jit_uni_reduction_kernel_t::acc_kind(
+        src_kind_t src_kind) const {
+    return src_kind == src_kind_t::f16 && !is_f16_widen_acc() ? acc_kind_t::f16
+                                                              : acc_kind_t::f32;
+}
+
+bool jit_uni_reduction_kernel_t::is_f16_widen_acc() const {
+    const reduce_op_t op = reduce_op();
+    return op == reduce_op_t::sum || op == reduce_op_t::mean;
+}
+
+void jit_uni_reduction_kernel_t::emit_store_scalar(scalar_kind_t scalar_kind) {
+    const scalar_kind_t dst_kind = this->dst_kind();
+    if (scalar_kind == scalar_kind_t::f32) {
+        if (dst_kind == scalar_kind_t::f32) {
+            fsw(f_tmp, reg_dst, 0);
+        } else {
+            fcvt_h_s(Reg(f_tmp.getIdx()), Reg(f_tmp.getIdx()));
+            fsh(f_tmp, reg_dst, 0);
+        }
+    } else {
+        if (dst_kind == scalar_kind_t::f32) {
+            fcvt_s_h(Reg(f_tmp.getIdx()), Reg(f_tmp.getIdx()));
+            fsw(f_tmp, reg_dst, 0);
+        } else {
+            fsh(f_tmp, reg_dst, 0);
+        }
+    }
+}
+
+void jit_uni_reduction_kernel_t::emit_init(src_kind_t src_kind) {
+    const reduce_op_t op = reduce_op();
+
+    if (src_kind == src_kind_t::f16 && !is_f16_widen_acc()) {
+        if (op == reduce_op_t::max)
+            load_f16_const(f_init, f16_lowest);
+        else if (op == reduce_op_t::min)
+            load_f16_const(f_init, f16_max);
+        else
+            assert(!"unsupported f16 non-widen reduction alg");
+    } else {
+        if (op == reduce_op_t::max)
+            load_f32_const(f_init, -std::numeric_limits<float>::infinity());
+        else if (op == reduce_op_t::min)
+            load_f32_const(f_init, std::numeric_limits<float>::infinity());
+        else
+            load_f32_const(f_init, 0.0f);
+    }
+
+    if (op == reduce_op_t::mean)
+        load_f32_const(f_scale, 1.0f / static_cast<float>(conf_.reduce_size));
+
+    const acc_kind_t acc = acc_kind(src_kind);
+    if (acc == acc_kind_t::f32)
+        vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::tu, VMA::mu);
+    else
+        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m8, VTA::tu, VMA::mu);
+
+    if (op == reduce_op_t::sum
+            || (src_kind == src_kind_t::f16 && is_f16_widen_acc())) {
+        vfmv_v_f(v_acc, f_init);
+        vfmv_v_f(v_red, f_init);
+    } else {
+        vfmv_v_f(v_red, f_init);
+        vfmv_v_f(v_acc, f_init);
+    }
+}
+
+void jit_uni_reduction_kernel_t::emit_update_acc(src_kind_t src_kind) {
+    const reduce_op_t op = reduce_op();
+    switch (op) {
+        case reduce_op_t::max: vfmax_vv(v_acc, v_data, v_acc); break;
+        case reduce_op_t::min: vfmin_vv(v_acc, v_data, v_acc); break;
+        case reduce_op_t::sum:
+        case reduce_op_t::mean:
+            if (src_kind == src_kind_t::f16)
+                vfwadd_wv(v_acc, v_acc, v_data);
+            else
+                vfadd_vv(v_acc, v_data, v_acc);
+            break;
+        default: assert(!"unsupported reduction alg");
+    }
+}
+
+void jit_uni_reduction_kernel_t::emit_loop(src_kind_t src_kind) {
+    Label loop;
+
+    L(loop);
+    if (src_kind == src_kind_t::f32) {
+        vsetvli(reg_tmp, reg_n, SEW::e32, LMUL::m8, VTA::tu, VMA::mu);
+        sub(reg_n, reg_n, reg_tmp);
+        vle32_v(v_data, reg_src);
+        advance_src(2);
+    } else {
+        if (is_f16_widen_acc())
+            vsetvli(reg_tmp, reg_n, SEW::e16, LMUL::m4, VTA::tu, VMA::mu);
+        else
+            vsetvli(reg_tmp, reg_n, SEW::e16, LMUL::m8, VTA::tu, VMA::mu);
+        sub(reg_n, reg_n, reg_tmp);
+        vle16_v(v_data, reg_src);
+        advance_src(1);
+    }
+    emit_update_acc(src_kind);
+    bnez(reg_n, loop);
+}
+
+void jit_uni_reduction_kernel_t::emit_horizontal_reduce(src_kind_t src_kind) {
+    const reduce_op_t op = reduce_op();
+    const acc_kind_t acc = acc_kind(src_kind);
+
+    if (acc == acc_kind_t::f32) {
+        vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::tu, VMA::mu);
+        if (op == reduce_op_t::max)
+            vfredmax_vs(v_red, v_acc, v_red);
+        else if (op == reduce_op_t::min)
+            vfredmin_vs(v_red, v_acc, v_red);
+        else if (op == reduce_op_t::mean && src_kind == src_kind_t::f32)
+            vfredusum_vs(v_red, v_acc, v_red);
+        else
+            vfredosum_vs(v_red, v_acc, v_red);
+    } else {
+        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m8, VTA::tu, VMA::mu);
+        if (op == reduce_op_t::max)
+            vfredmax_vs(v_red, v_acc, v_red);
+        else if (op == reduce_op_t::min)
+            vfredmin_vs(v_red, v_acc, v_red);
+        else
+            assert(!"unsupported f16 non-widen reduction alg");
+    }
+}
+
+void jit_uni_reduction_kernel_t::emit_mean_scale_if_needed() {
+    if (reduce_op() == reduce_op_t::mean) fmul_s(f_tmp, f_tmp, f_scale);
+}
+
+void jit_uni_reduction_kernel_t::emit_finalize_f16_minmax() {
+    emit_horizontal_reduce(src_kind_t::f16);
+    vfmv_f_s(f_tmp, v_red);
+    emit_store_scalar(scalar_kind_t::f16);
+}
+
+void jit_uni_reduction_kernel_t::emit_finalize_f16_widen_sum_or_mean() {
+    emit_horizontal_reduce(src_kind_t::f16);
+    if (reduce_op() == reduce_op_t::sum) {
+        if (dst_kind() == scalar_kind_t::f32) {
+            vfmv_f_s(f_tmp, v_red);
+            fsw(f_tmp, reg_dst, 0);
+        } else {
+            vsetvli(reg_tmp, x0, SEW::e16, LMUL::m4, VTA::tu, VMA::mu);
+            vfncvt_f_f_w(v_data, v_red);
+            vfmv_f_s(f_tmp, v_data);
+            fsh(f_tmp, reg_dst, 0);
+        }
+    } else if (dst_kind() == scalar_kind_t::f32) {
+        vfmv_f_s(f_tmp, v_red);
+        emit_mean_scale_if_needed();
+        fsw(f_tmp, reg_dst, 0);
+    } else {
+        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m4, VTA::tu, VMA::mu);
+        vfncvt_f_f_w(v_data, v_red);
+        vfmv_f_s(f_tmp, v_data);
+        fcvt_s_h(Reg(f_tmp.getIdx()), Reg(f_tmp.getIdx()));
+        emit_mean_scale_if_needed();
+        fcvt_h_s(Reg(f_tmp.getIdx()), Reg(f_tmp.getIdx()));
+        fsh(f_tmp, reg_dst, 0);
+    }
+}
+
+void jit_uni_reduction_kernel_t::emit_finalize(src_kind_t src_kind) {
+    if (src_kind == src_kind_t::f16) {
+        if (is_f16_widen_acc())
+            emit_finalize_f16_widen_sum_or_mean();
+        else
+            emit_finalize_f16_minmax();
+        return;
+    }
+
+    emit_horizontal_reduce(src_kind_t::f32);
+    vfmv_f_s(f_tmp, v_red);
+    emit_mean_scale_if_needed();
+    emit_store_scalar(scalar_kind_t::f32);
+}
+
+void jit_uni_reduction_kernel_t::emit_reduce(src_kind_t src_kind) {
+    emit_init(src_kind);
+    emit_loop(src_kind);
+    emit_finalize(src_kind);
+}
+
+void jit_uni_reduction_kernel_t::generate() {
+    load_params();
+
+    emit_reduce(src_kind());
+
+    ret();
+}
+
+#undef GET_OFF
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_reduction_kernel.cpp
@@ -162,9 +162,9 @@ void jit_uni_reduction_kernel_t::emit_init(src_kind_t src_kind) {
 
     const acc_kind_t acc = acc_kind(src_kind);
     if (acc == acc_kind_t::f32)
-        vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::tu, VMA::mu);
+        vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
     else
-        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m8, VTA::tu, VMA::mu);
+        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m8, VTA::ta, VMA::ma);
 
     if (op == reduce_op_t::sum
             || (src_kind == src_kind_t::f16 && is_f16_widen_acc())) {
@@ -197,15 +197,15 @@ void jit_uni_reduction_kernel_t::emit_loop(src_kind_t src_kind) {
 
     L(loop);
     if (src_kind == src_kind_t::f32) {
-        vsetvli(reg_tmp, reg_n, SEW::e32, LMUL::m8, VTA::tu, VMA::mu);
+        vsetvli(reg_tmp, reg_n, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
         sub(reg_n, reg_n, reg_tmp);
         vle32_v(v_data, reg_src);
         advance_src(2);
     } else {
         if (is_f16_widen_acc())
-            vsetvli(reg_tmp, reg_n, SEW::e16, LMUL::m4, VTA::tu, VMA::mu);
+            vsetvli(reg_tmp, reg_n, SEW::e16, LMUL::m4, VTA::ta, VMA::ma);
         else
-            vsetvli(reg_tmp, reg_n, SEW::e16, LMUL::m8, VTA::tu, VMA::mu);
+            vsetvli(reg_tmp, reg_n, SEW::e16, LMUL::m8, VTA::ta, VMA::ma);
         sub(reg_n, reg_n, reg_tmp);
         vle16_v(v_data, reg_src);
         advance_src(1);
@@ -219,7 +219,7 @@ void jit_uni_reduction_kernel_t::emit_horizontal_reduce(src_kind_t src_kind) {
     const acc_kind_t acc = acc_kind(src_kind);
 
     if (acc == acc_kind_t::f32) {
-        vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::tu, VMA::mu);
+        vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
         if (op == reduce_op_t::max)
             vfredmax_vs(v_red, v_acc, v_red);
         else if (op == reduce_op_t::min)
@@ -229,7 +229,7 @@ void jit_uni_reduction_kernel_t::emit_horizontal_reduce(src_kind_t src_kind) {
         else
             vfredosum_vs(v_red, v_acc, v_red);
     } else {
-        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m8, VTA::tu, VMA::mu);
+        vsetvli(reg_tmp, x0, SEW::e16, LMUL::m8, VTA::ta, VMA::ma);
         if (op == reduce_op_t::max)
             vfredmax_vs(v_red, v_acc, v_red);
         else if (op == reduce_op_t::min)
@@ -256,7 +256,7 @@ void jit_uni_reduction_kernel_t::emit_finalize_f16_widen_sum_or_mean() {
             vfmv_f_s(f_tmp, v_red);
             fsw(f_tmp, reg_dst, 0);
         } else {
-            vsetvli(reg_tmp, x0, SEW::e16, LMUL::m4, VTA::tu, VMA::mu);
+            vsetvli(reg_tmp, x0, SEW::e16, LMUL::m4, VTA::ta, VMA::ma);
             vfncvt_f_f_w(v_data, v_red);
             vfmv_f_s(f_tmp, v_data);
             fsh(f_tmp, reg_dst, 0);

--- a/src/cpu/rv64/jit_uni_reduction_kernel.hpp
+++ b/src/cpu/rv64/jit_uni_reduction_kernel.hpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+* Copyright 2026 SpacemiT Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_UNI_REDUCTION_KERNEL_HPP
+#define CPU_RV64_JIT_UNI_REDUCTION_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/rv64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_reduction_conf_t {
+    data_type_t src_type;
+    data_type_t dst_type;
+    alg_kind_t alg;
+    size_t src_dt_size;
+    size_t dst_dt_size;
+    dim_t idle_size;
+    dim_t reduce_size;
+};
+
+struct jit_uni_reduction_args_t {
+    const void *src;
+    void *dst;
+    dim_t reduce_size;
+};
+
+struct jit_uni_reduction_kernel_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_reduction_kernel)
+
+    explicit jit_uni_reduction_kernel_t(const jit_reduction_conf_t &conf);
+    ~jit_uni_reduction_kernel_t() override = default;
+
+private:
+    void generate() override;
+
+    void load_params();
+    void load_f32_const(const Xbyak_riscv::FReg &freg, float value);
+    void load_f16_const(const Xbyak_riscv::FReg &freg, uint16_t raw_value);
+    void advance_src(int shift);
+
+    enum class src_kind_t { f32, f16 };
+    enum class acc_kind_t { f32, f16 };
+    enum class scalar_kind_t { f32, f16 };
+    enum class reduce_op_t { max, min, sum, mean };
+
+    src_kind_t src_kind() const;
+    scalar_kind_t dst_kind() const;
+    reduce_op_t reduce_op() const;
+    acc_kind_t acc_kind(src_kind_t src_kind) const;
+    bool is_f16_widen_acc() const;
+
+    void emit_reduce(src_kind_t src_kind);
+    void emit_init(src_kind_t src_kind);
+    void emit_loop(src_kind_t src_kind);
+    void emit_finalize(src_kind_t src_kind);
+
+    void emit_update_acc(src_kind_t src_kind);
+    void emit_horizontal_reduce(src_kind_t src_kind);
+    void emit_mean_scale_if_needed();
+    void emit_store_scalar(scalar_kind_t scalar_kind);
+
+    void emit_finalize_f16_minmax();
+    void emit_finalize_f16_widen_sum_or_mean();
+
+    const jit_reduction_conf_t conf_;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
# Description

This PR adds an RV64 RVV JIT implementation for the CPU reduction primitive.

The new primitive covers dense plain suffix reductions for:

- algorithms: `sum`, `mean`, `max`, and `min`
- data types: `f32` and `f16` source/destination combinations
- layouts: `x`, `nc`, `ncw`, `nchw`, and `ncdhw`
- default attributes only

The implementation follows the x64-style split between the primitive dispatch layer and the JIT kernel layer. The dispatch layer validates supported cases, computes `idle_size` and contiguous suffix `reduce_size`, and falls unsupported cases back to the reference implementation. The kernel layer emits RVV reduction loops for f32 and f16, including f16 widening accumulation for sum/mean and f16 store conversion paths. Meanwhile, the file structure design refers to #5305 .

# Performance

Performance was measured with f16 reduction benchdnn cases. The baseline is `ref:any` ; the new results are `jit:uni` .
Times below use `min_time`(ms) from benchdnn. Benchmarks were run on Spacemit X100 (K3).

| Tag | Problem | Alg | Ref time | JIT time | Speedup |
| --- | --- | --- | ---: | ---: | ---: |
| x | `65536:1` | sum | 3.0718 | 0.0098 | 314.6x |
| x | `65536:1` | mean | 3.0715 | 0.0095 | 322.6x |
| x | `65536:1` | max | 3.1013 | 0.0088 | 352.9x |
| x | `65536:1` | min | 3.1311 | 0.0085 | 366.4x |
| nc | `1024x512:1024x1` | sum | 3.2302 | 0.0325 | 99.5x |
| nc | `1024x512:1024x1` | mean | 3.2378 | 0.0327 | 99.0x |
| nc | `1024x512:1024x1` | max | 3.2463 | 0.0229 | 141.5x |
| nc | `1024x512:1024x1` | min | 3.4109 | 0.0229 | 148.6x |
| nchw | `8x64x56x56:8x64x1x1` | sum | 11.9241 | 0.0515 | 231.5x |
| nchw | `8x64x56x56:8x64x1x1` | mean | 11.9258 | 0.0508 | 234.8x |
| nchw | `8x64x56x56:8x64x1x1` | max | 11.9270 | 0.0486 | 245.5x |
| nchw | `8x64x56x56:8x64x1x1` | min | 11.9836 | 0.0491 | 244.2x |
| ncdhw | `4x64x8x28x28:4x64x1x1x1` | sum | 14.6941 | 0.0496 | 296.5x |
| ncdhw | `4x64x8x28x28:4x64x1x1x1` | mean | 14.6770 | 0.0498 | 294.7x |
| ncdhw | `4x64x8x28x28:4x64x1x1x1` | max | 14.6968 | 0.0486 | 302.5x |
| ncdhw | `4x64x8x28x28:4x64x1x1x1` | min | 14.6006 | 0.0483 | 302.0x |

Geometric mean speedup across these 16 cases is approximately **232x** by `min_time` and **209x** by `avg_time`.


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?


