### PR TITLE
x64: brgemm (de)conv: zero out_buffer for tail iw block with uneven spatial

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -929,6 +929,14 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
 
             for_(int id = id_begin; id < id_end; id++)
             for (int ih = ih_begin; ih < ih_end; ih++) {
+                // Zero out_buffer before processing the tail iw block to
+                // prevent stale scratchpad data from leaking into positions
+                // that may not be written (e.g., stride sectors with no
+                // valid kernel overlap).
+                if (jcp.exec_type == exec_trans && jcp.has_uneven_iw
+                        && iwb == jcp.nb_iw - 1 && out_buffer) {
+                    std::memset(out_buffer, 0, dst_dsz * jcp.out_buffer_size);
+                }
                 for (int occ = 0; occ < oc_chunks; occ++) {
                     btc.id = id;
                     btc.ih = ih;


### PR DESCRIPTION
Zero the entire out_buffer before processing each (id, ih) iteration of the tail block. Without it there were some correction errors appearing on clang19 with eigen threadpool.

Fixes [MFDNN-15198](https://jira.devtools.intel.com/browse/MFDNN-15198)

[Nightly](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f16aab6e-8619-f1eb-86c3-d4f5ef20c6a0)