### PR TITLE
Rename isa_has_masks() -> isa_has_evex()

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -246,7 +246,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::cvt2ps(data_type_t type_in,
     const bool is_load_tail = op.isMEM() && mask_flag && tail_size > 0
             && (tail_size < static_cast<int>(
                         vreg_traits_t<Vmm>::vlen / sizeof(float)));
-    if (IMPLICATION(is_load_tail, isa_has_masks(brg.isa_impl))) {
+    if (IMPLICATION(is_load_tail, isa_has_evex(brg.isa_impl))) {
         const Vmm vmm = maybe_mask(vmm_in, is_load_tail, store);
         switch (type_in) {
             case data_type::f32:
@@ -432,7 +432,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
                     vmulps(vmm, vmm, vmm_wei_scales);
                 }
             } else {
-                if (IMPLICATION(mask_flag, isa_has_masks(brg.isa_impl))) {
+                if (IMPLICATION(mask_flag, isa_has_evex(brg.isa_impl))) {
                     const Vmm vmm_wei_scales_masked
                             = maybe_mask(vmm_wei_scales, mask_flag, false);
                     switch (brg.dt_wei_scales) {
@@ -573,7 +573,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
                 vmovdqu8(addr, r_xmm);
                 continue;
             }
-            if (IMPLICATION(mask_flag, isa_has_masks(brg.isa_impl))) {
+            if (IMPLICATION(mask_flag, isa_has_evex(brg.isa_impl))) {
                 switch (brg.dt_d) {
                     case data_type::f32:
                     case data_type::s32: vmovups(addr, r_vmm); break;
@@ -644,7 +644,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_without_post_ops(
                     use_sat_cvt);
         }
         const auto offset = C_offset(m, n, v_i);
-        if (IMPLICATION(mask_flag, isa_has_masks(brg.isa_impl))) {
+        if (IMPLICATION(mask_flag, isa_has_evex(brg.isa_impl))) {
             auto vmm_acc_masked = maybe_mask(vmm_acc, mask_flag, true);
             vmovups(ptr[reg_aux_C + offset], vmm_acc_masked);
         } else {
@@ -721,10 +721,10 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
             // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
             const bool is_tail
                     = n + 1 == n_blocks && has_n_tail && substep_simd < simd_w_;
-            const Vmm vmm_zp = isa_has_masks(brg.isa_impl)
+            const Vmm vmm_zp = isa_has_evex(brg.isa_impl)
                     ? maybe_mask(vmm_zp_comp(), is_tail, false)
                     : vmm_zp_comp();
-            if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
+            if (IMPLICATION(is_tail, isa_has_evex(brg.isa_impl))) {
                 vmovups(vmm_zp,
                         maybe_EVEX_compress_addr(reg_aux_zp_comp, offset));
                 if (is_src_zp_bcast_) {
@@ -797,7 +797,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_a(
     const bool mask_flag = substep_simd < simd_w_;
     const auto addr = ptr[reg_aux_A + A_offset(m_i, n_i)
             + is_tail_block * v_i * simd_w_ * brg.typesize_A];
-    if (IMPLICATION(mask_flag, isa_has_masks(brg.isa_impl))) {
+    if (IMPLICATION(mask_flag, isa_has_evex(brg.isa_impl))) {
         vmma = maybe_mask(vmma, mask_flag, false);
         if (brg.dt_a == data_type::f32) {
             vmovups(vmma, addr);
@@ -900,11 +900,11 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
             vpdpbusd(vmm_acc, vmm_shift(), vmmb, get_encoding());
             break;
         case compute_pad_kernel_t::zero_point_kernel: {
-            const Vmm vmm_zp = isa_has_masks(brg.isa_impl)
+            const Vmm vmm_zp = isa_has_evex(brg.isa_impl)
                     ? maybe_mask(vmm_zp_comp(), is_tail_block, false)
                     : vmm_zp_comp();
             const size_t offset = comp_offset(n);
-            if (IMPLICATION(is_tail_block, isa_has_masks(brg.isa_impl))) {
+            if (IMPLICATION(is_tail_block, isa_has_evex(brg.isa_impl))) {
                 if (is_src_zp_bcast_) {
                     if (is_superset(brg.isa_impl, avx512_core))
                         vpmulld(vmm_zp, vmmb,
@@ -1347,7 +1347,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
     const bool has_n_block2_tail = n_block2_tail() > 0;
     const bool need_separate_n_block1_tail_block = n_block1_tail() != 0
             && !has_n_block2_tail && nb_n_block2() > 1
-            && !isa_has_masks(brg.isa_impl);
+            && !isa_has_evex(brg.isa_impl);
     const int loop_n = nb_n_block2() - has_n_block2_tail
             - need_separate_n_block1_tail_block;
     const bool do_loop_n = loop_n > 1;
@@ -1367,7 +1367,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
         {
             if (do_loop_n) {
                 if (vlen_tail_in_loop) {
-                    assert(isa_has_masks(brg.isa_impl));
+                    assert(isa_has_evex(brg.isa_impl));
                     Label done_k_mask;
                     cmp(reg_aux_N, n_loop_work - n_loop_step);
                     jl(done_k_mask, T_NEAR);
@@ -1406,7 +1406,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
     auto m_loop = [&]() {
         Label m_loop_label;
         const int m_blocks = m_block2();
-        const bool reset_mask = isa_has_masks(brg.isa_impl)
+        const bool reset_mask = isa_has_evex(brg.isa_impl)
                 && n_block1_tail() != 0 && do_loop_n && !has_n_block2_tail;
 
         xor_(reg_aux_M, reg_aux_M);
@@ -1446,7 +1446,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::init_masks() {
-    if (!isa_has_masks(brg.isa_impl)) return;
+    if (!isa_has_evex(brg.isa_impl)) return;
 
     if (is_fast_vnni_int8()) {
         mov(reg_tmp, 0x8888444422221111);

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -324,7 +324,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::apply_post_ops(
         auto vmm_sum_zp = vmm_tmp(0);
         if (p_sum_zp_reg_set) {
             mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-            if (is_superset(brg.isa_impl, avx512_core)) {
+            if (isa_has_evex(brg.isa_impl)) {
                 vcvtdq2ps(vmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
             } else {
                 uni_vpbroadcastd(vmm_sum_zp, ptr[reg_ptr_sum_zp]);
@@ -346,7 +346,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::apply_post_ops(
             if (!p_sum_scale_reg_set)
                 vaddps(vmm, vmm_prev_dst);
             else {
-                if (is_superset(brg.isa_impl, avx512_core)) {
+                if (isa_has_evex(brg.isa_impl)) {
                     vfmadd231ps(vmm, vmm_prev_dst, ptr_b[reg_ptr_sum_scale]);
                 } else {
                     auto vmm_scale = vmm_bcast();
@@ -508,7 +508,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
     if (compute_dst_zp_) {
         auto vmm_dst_zp = vmm_tmp(0);
         reg_dst_zero_point.restore();
-        if (is_superset(brg.isa_impl, avx512_core)) {
+        if (isa_has_evex(brg.isa_impl)) {
             vcvtdq2ps(vmm_dst_zp,
                     EVEX_compress_addr(reg_dst_zero_point, 0, true));
         } else {
@@ -591,14 +591,14 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
                         vcvtps2ph(addr, r_vmm, _op_mxcsr);
                         break;
                     case data_type::s8:
-                        if (is_superset(brg.isa_impl, avx512_core))
+                        if (isa_has_evex(brg.isa_impl))
                             vpmovsdb(addr, r_vmm);
                         else
                             store_data(brg.dt_d, vmm, reg_aux_D, offset,
                                     substep_simd);
                         break;
                     case data_type::u8:
-                        if (is_superset(brg.isa_impl, avx512_core))
+                        if (isa_has_evex(brg.isa_impl))
                             vpmovusdb(addr, r_vmm);
                         else
                             store_data(brg.dt_d, vmm, reg_aux_D, offset,
@@ -728,7 +728,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
                 vmovups(vmm_zp,
                         maybe_EVEX_compress_addr(reg_aux_zp_comp, offset));
                 if (is_src_zp_bcast_) {
-                    if (is_superset(brg.isa_impl, avx512_core))
+                    if (isa_has_evex(brg.isa_impl))
                         vpmulld(vmm_zp, vmm_zp,
                                 maybe_EVEX_compress_addr(
                                         reg_aux_src_zp, 0, true));
@@ -906,7 +906,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
             const size_t offset = comp_offset(n);
             if (IMPLICATION(is_tail_block, isa_has_evex(brg.isa_impl))) {
                 if (is_src_zp_bcast_) {
-                    if (is_superset(brg.isa_impl, avx512_core))
+                    if (isa_has_evex(brg.isa_impl))
                         vpmulld(vmm_zp, vmmb,
                                 maybe_EVEX_compress_addr(
                                         reg_aux_src_zp, 0, true));

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -291,9 +291,8 @@ private:
     }
     inline bool grouped_bs() const { return grouped_bs(brg); }
     static bool is_fma_embd(const brgemm_desc_t &brg) {
-        return grouped_bs(brg)
-                ? false
-                : brg.is_f32 && is_superset(brg.isa_impl, avx512_core);
+        return grouped_bs(brg) ? false
+                               : brg.is_f32 && isa_has_evex(brg.isa_impl);
     }
     bool is_fma_embd() { return is_fma_embd(brg); }
     bool is_fast_vnni_int8() { return is_fast_vnni_int8(brg); }

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -785,7 +785,7 @@ void jit_brgemm_kernel_t<Wmm>::cvt2ps(data_type_t type_in, const Vmm vmm_in,
     Vmm vmm = vmm_in;
     const bool has_tail = op.isMEM()
             && tail_size != vreg_traits_t<Vmm>::vlen / sizeof(float);
-    if (IMPLICATION(has_tail, is_superset(brg.isa_impl, avx512_core))) {
+    if (IMPLICATION(has_tail, isa_has_evex(brg.isa_impl))) {
         vmm = vmm_mask(vmm_in, mask_flag, store, ktail_mask);
     } else {
         load_data(type_in, vmm_in, op.getAddress(), tail_size);
@@ -1311,7 +1311,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
 
         const auto addr = ptr[reg_aux_bias + bias_offset(bd)];
 
-        if (is_superset(brg.isa_impl, avx512_core)) {
+        if (isa_has_evex(brg.isa_impl)) {
             const bool use_partial_mask = !brg.gemv_acc_is_vector()
                     || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
             const auto k_mask
@@ -1429,7 +1429,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
 
         const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(bd)];
 
-        if (is_superset(brg.isa_impl, avx512_core)) {
+        if (isa_has_evex(brg.isa_impl)) {
             const bool use_partial_mask = !brg.gemv_acc_is_vector()
                     || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
             const auto k_mask
@@ -1572,7 +1572,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
                 if (brg.gemv_acc_is_vector()) {
                     if (!gemv_is_tail_acc(bd, bd_block, is_bdb_tail)) {
                         uni_vaddps(vmm, vmm, ptr_C);
-                    } else if (is_superset(brg.isa_impl, avx512_core)) {
+                    } else if (isa_has_evex(brg.isa_impl)) {
                         uni_vmovups(
                                 vmm_prev_dst | gemv_partial_mask | T_z, ptr_C);
                         uni_vaddps(vmm, vmm, vmm_prev_dst);
@@ -1584,8 +1584,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
                     uni_vaddss(Xmm(vmm.getIdx()), Xmm(vmm.getIdx()), ptr_C);
                 }
             } else {
-                if (IMPLICATION(
-                            is_tail, is_superset(brg.isa_impl, avx512_core))) {
+                if (IMPLICATION(is_tail, isa_has_evex(brg.isa_impl))) {
                     auto vmm_masked = vmm_mask(vmm, is_tail, false, k_mask);
                     if (brg.is_int8)
                         uni_vpaddd(vmm_masked, vmm, ptr_C);
@@ -1948,7 +1947,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
             prefetchw(addr);
 
         if (brg.is_gemv) {
-            if (is_superset(brg.isa_impl, avx512_core)) {
+            if (isa_has_evex(brg.isa_impl)) {
                 const bool use_partial_mask = !brg.gemv_acc_is_vector()
                         || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
                 const auto k_mask
@@ -1978,7 +1977,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                 }
             }
             // Non-gemv path.
-        } else if (is_superset(brg.isa_impl, avx512_core)) {
+        } else if (isa_has_evex(brg.isa_impl)) {
             const Vmm r_vmm = vmm_mask(vmm, is_tail, true, k_mask);
             const Vmm_lower_t r_ymm
                     = vmm_mask(vmm_lower, is_tail, true, k_mask);
@@ -2101,8 +2100,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_compensation(
                 if (IMPLICATION(!brg.req_comp_pads_with_bcast, bd == 0)) {
                     const auto comp_addr = ptr[reg_aux_compensation
                             + bd_compensation_offset(ld, bd)];
-                    if (IMPLICATION(is_tail,
-                                is_superset(brg.isa_impl, avx512_core))) {
+                    if (IMPLICATION(is_tail, isa_has_evex(brg.isa_impl))) {
                         auto vmm_comp_masked
                                 = vmm_mask(vmm_comp, is_tail, false, k_mask);
                         uni_vmovups(vmm_comp_masked, comp_addr);
@@ -2162,7 +2160,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
 
             auto vmm = accm(1, bd, 0);
 
-            if (is_superset(brg.isa_impl, avx512_core)) {
+            if (isa_has_evex(brg.isa_impl)) {
                 const bool use_partial_mask = !brg.gemv_acc_is_vector()
                         || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
                 const auto k_mask
@@ -2819,7 +2817,7 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
     for (dim_t ld = 0; ld < ld_block2; ++ld) {
         const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-        if (IMPLICATION(is_tail, is_superset(brg.isa_impl, avx512_core))) {
+        if (IMPLICATION(is_tail, isa_has_evex(brg.isa_impl))) {
             auto vmm_store = vmm_mask(load(), is_tail, false, ld_tail_mask);
             uni_vmovups(vmm_store, addr);
         } else {
@@ -3077,7 +3075,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 else
                     vpermw(vmm_load, f16_perm_odd_vreg(), vmm_load);
                 vcvtph2psx(vmm_load, Vmm_lower_t(vmm_load.getIdx()));
-            } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
+            } else if (is_ld_tail && !isa_has_evex(brg.isa_impl)) {
                 load_bytes(vmm_load, addr, ldb_B_offset(0, true));
                 vcvtph2ps(vmm_load, Xmm(vmm_load.getIdx()));
             } else {
@@ -3093,13 +3091,13 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 // Upconvert: load 16 bits and move them 16 bits left.
                 uni_vpmovzxwd(vmm_load, addr);
                 uni_vpslld(vmm_load, vmm_load, 16);
-            } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
+            } else if (is_ld_tail && !isa_has_evex(brg.isa_impl)) {
                 load_bytes(vmm_load, addr, ldb_B_offset(0, true));
             } else {
                 uni_vmovups(vmm_load, addr);
             }
         } else if (is_ld_tail) {
-            if (is_superset(brg.isa_impl, avx512_core)) {
+            if (isa_has_evex(brg.isa_impl)) {
                 uni_vmovups(vmm_load, addr);
             } else {
                 load_bytes(vmm_load, addr, ldb_B_offset(0, true));
@@ -3673,7 +3671,7 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
                              brg.req_s8s8_compensation)
             && IMPLICATION(!vpad_exist, brg.req_cal_comp_pads);
 
-    if (is_superset(brg.isa_impl, avx512_core)) {
+    if (isa_has_evex(brg.isa_impl)) {
         const auto full_mask = size_t {0xffffffffffffffff};
 
         if (!brg.is_gemv) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -763,14 +763,14 @@ template <typename Wmm>
 template <typename U>
 U jit_brgemm_kernel_t<Wmm>::vmm_mask(const U vmm_in, bool mask_flag, bool store,
         Xbyak::Opmask ktail_mask) const {
-    return mask_flag && isa_has_masks(brg.isa_impl)
+    return mask_flag && isa_has_evex(brg.isa_impl)
             ? (store ? vmm_in | ktail_mask : vmm_in | ktail_mask | T_z)
             : vmm_in;
 }
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_set_avx_mask(bool is_tail) {
-    if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) return;
+    if (IMPLICATION(is_tail, isa_has_evex(brg.isa_impl))) return;
     // Note: `is_tail` may be true even when `gemv_tail == 0`.
     // In this case, the block is a tail block, but there is no partial
     // accumulator (only full accumulators are present).
@@ -1499,7 +1499,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
                 default: assert(!"unsupported wei_scales data type");
             }
         } else {
-            if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
+            if (IMPLICATION(is_tail, isa_has_evex(brg.isa_impl))) {
                 switch (brg.dt_wei_scales) {
                     case data_type::f32:
                         uni_vmovups(vmm_wei_scales_masked, addr);
@@ -2053,7 +2053,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_compensation(
                 if (IMPLICATION(!brg.req_comp_pads_with_bcast, bd == 0)) {
                     const auto zp_comp_a_addr = ptr[reg_aux_zp_comp_a
                             + bd_zp_comp_a_offset(ld, bd)];
-                    if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
+                    if (IMPLICATION(is_tail, isa_has_evex(brg.isa_impl))) {
                         auto vmm_zp_comp_a_masked = vmm_mask(
                                 vmm_zp_comp_a, is_tail, false, k_mask);
                         uni_vmovups(vmm_zp_comp_a_masked, zp_comp_a_addr);
@@ -2191,7 +2191,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
                 prefetchw(addr_c);
             if (!is_tail)
                 uni_vmovups(addr_c, vmm);
-            else if (isa_has_masks(brg.isa_impl)) { // is_tail
+            else if (isa_has_evex(brg.isa_impl)) { // is_tail
                 uni_vmovups(addr_c | ld_tail_mask | T_z, vmm);
             } else {
                 vmaskmovps(addr_c, vmm_tail_mask(), vmm);
@@ -3738,7 +3738,7 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
     align(32);
 
     const dim_t simd = vreg_traits_t<Vmm>::vlen / sizeof(float);
-    if (!isa_has_masks(brg.isa_impl) && (brg.ldb_tail || brg.gemv_tail)) {
+    if (!isa_has_evex(brg.isa_impl) && (brg.ldb_tail || brg.gemv_tail)) {
         const dim_t tail_size = brg.is_gemv ? brg.gemv_tail : brg.ldb_tail;
         L(avx_tail_mask_);
         for (dim_t i = 0; i < tail_size; ++i)

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -1672,7 +1672,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                 if (p_sum_zp_reg_set) {
                     assert(!brg.is_gemv && "feature is not supported for gemv");
                     mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-                    if (is_superset(brg.isa_impl, avx512_core)) {
+                    if (isa_has_evex(brg.isa_impl)) {
                         vcvtdq2ps(vmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
                     } else {
                         uni_vpbroadcastd(vmm_sum_zp, ptr[reg_ptr_sum_zp]);
@@ -1681,7 +1681,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                 }
 
                 if (p_sum_scale_reg_set) {
-                    if (is_superset(brg.isa_impl, avx512_core)) {
+                    if (isa_has_evex(brg.isa_impl)) {
                         // embd bcast fma
                         mov(reg_ptr_sum_scale,
                                 reinterpret_cast<size_t>(p_sum_scale));
@@ -1719,7 +1719,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                     if (p_sum_zp_reg_set)
                         uni_vsubps(vmm_prev_dst, vmm_prev_dst, vmm_sum_zp);
                     if (p_sum_scale_reg_set) {
-                        if (is_superset(brg.isa_impl, avx512_core))
+                        if (isa_has_evex(brg.isa_impl))
                             uni_vfmadd231ps(vmm, vmm_prev_dst,
                                     ptr_b[reg_ptr_sum_scale]);
                         else
@@ -1872,7 +1872,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         reg_aux_zp_c_values.restore();
         auto vmm_zp_c = vmm_tmp(0);
         if (brg.zp_type_c == brgemm_broadcast_t::per_tensor) {
-            if (is_superset(brg.isa_impl, avx512_core)) {
+            if (isa_has_evex(brg.isa_impl)) {
                 uni_vcvtdq2ps(vmm_zp_c,
                         EVEX_compress_addr(reg_aux_zp_c_values, 0, true));
             } else {
@@ -1886,7 +1886,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
             if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
                 dim_t zp_c_off = zp_c_values_offset(ld);
-                if (is_superset(brg.isa_impl, avx512_core)) {
+                if (isa_has_evex(brg.isa_impl)) {
                     auto zp_c_addr
                             = EVEX_compress_addr(reg_aux_zp_c_values, zp_c_off);
                     cvt2ps(data_type::s32, vmm_zp_c, zp_c_addr, is_tail, false,
@@ -2077,7 +2077,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_compensation(
             dim_t zp_comp_b_off = zp_comp_b_offset(bd);
             for (dim_t ld = 0; ld < ld_block2; ld++) {
                 auto vmm = accm(ld_block2, bd, ld);
-                if (is_superset(brg.isa_impl, avx512_core)) {
+                if (isa_has_evex(brg.isa_impl)) {
                     const auto zp_comp_b_addr = EVEX_compress_addr(
                             reg_aux_zp_comp_b, zp_comp_b_off, true);
                     uni_vpaddd(vmm, vmm, zp_comp_b_addr);
@@ -2847,7 +2847,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
     const auto load_and_convert_to_f32
             = [this](const Vmm vmm, const Xbyak::Address addr,
                       const data_type_t dt, bool is_tail) {
-        if (is_superset(brg.isa_impl, avx512_core)) {
+        if (isa_has_evex(brg.isa_impl)) {
             assert(one_of(brg.dt_a, data_type::bf16, data_type::f16));
             assert(one_of(brg.dt_b, data_type::bf16, data_type::f16));
 
@@ -3170,7 +3170,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     if (prefetch_offset <= INT_MAX) {
                         prefetcht0(ptr[reg_aux_B + prefetch_offset]);
                     } else {
-                        if (is_superset(brg.isa_impl, avx512_core)) {
+                        if (isa_has_evex(brg.isa_impl)) {
                             prefetcht0(EVEX_compress_addr_safe(reg_aux_B,
                                     prefetch_offset, reg_tmp_microkernel));
                         } else {

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -510,7 +510,7 @@ inline bool isa_has_f16(cpu_isa_t isa) {
             || is_superset(isa, avx10_1_512_amx_fp16);
 }
 
-inline bool isa_has_masks(cpu_isa_t isa) {
+inline bool isa_has_evex(cpu_isa_t isa) {
     return is_superset(isa, avx512_core);
 }
 

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -2903,7 +2903,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
     const bool scalar_f32
             = rhs_addr.isBroadcast() && rhs_arg_data_type == data_type::f32;
     const bool with_tail_not_fusable_to_binary_op
-            = with_tail && !isa_has_masks(isa);
+            = with_tail && !isa_has_evex(isa);
     const bool process_rhs_arg_using_tmp_vmm
             = rhs_arg_data_type != data_type::f32 || (scalar_f32 && !is_avx512_)
             || with_tail_not_fusable_to_binary_op
@@ -2930,7 +2930,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
     } else {
         const auto lhs = dst;
         if (with_tail) {
-            assert(isa_has_masks(isa));
+            assert(isa_has_evex(isa));
             assert(rhs_arg_static_params_.is_opmask_set()
                     && "Opmask is not set for tail loading avx512");
             const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -2960,7 +2960,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary_with_ternary_op(
         // While a more direct implementation can be obtained by
         // blending the tensors, the current approach reserves
         // fewer registers for operation.
-        if (is_superset(isa, avx512_core)) {
+        if (isa_has_evex(isa)) {
             const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;
             push_opmask(host_, cmp_mask);
             push_vmm(host_, dst);
@@ -4046,7 +4046,7 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::execute_prelu(
         const Vmm &dst, const Xbyak::Operand &rhs) const {
     Vmm tmp_vmm = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
-    if (is_superset(isa, avx512_core)) {
+    if (isa_has_evex(isa)) {
         assert(rhs.isMEM());
         Vmm dst_vmm = Vmm(dst.getIdx());
         Xbyak::Opmask maybe_tail_kmask = Xbyak::Opmask(dst.getOpmaskIdx());

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -1927,7 +1927,7 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
 template <cpu_isa_t isa, typename Wmm>
 bool jit_uni_eltwise_injector_t<isa, Wmm>::need_mask_register(
         alg_kind_t alg, bool is_fwd, float alpha) {
-    if (is_superset(isa, avx512_core)) return false;
+    if (isa_has_evex(isa)) return false;
 
     using namespace alg_kind;
     if (is_fwd) {

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -84,7 +84,7 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
         }
     }
 
-    if (is_superset(isa, avx512_core) && is_eltwise && is_like_binary
+    if (isa_has_evex(isa) && is_eltwise && is_like_binary
             && binary_static_params.rhs_arg_static_params.tail_size)
         assert(eltwise_static_params.k_mask_
                 != binary_static_params.rhs_arg_static_params.tail_opmask &&

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -90,7 +90,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
 
             for (int w = ow_b; w < ow_e; w++) {
                 const auto offset = out_oc_offset(n, w);
-                auto zp_addr = is_superset(jcp_.isa, avx512_core)
+                auto zp_addr = isa_has_evex(jcp_.isa)
                         ? EVEX_compress_addr(reg_zp_comp_out, offset)
                         : ptr[reg_zp_comp_out + offset];
 
@@ -110,7 +110,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
 
             for (int w = ow_b; w < ow_e; w++) {
                 const auto offset = out_oc_offset(n, w);
-                auto cp_addr = is_superset(jcp_.isa, avx512_core)
+                auto cp_addr = isa_has_evex(jcp_.isa)
                         ? EVEX_compress_addr(reg_comp_out, offset)
                         : ptr[reg_comp_out + offset];
 
@@ -199,7 +199,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::compute(const int ic_step,
         for (int n = 0; n < n_block; ++n) {
             auto vmm = accum(n_block, m, n);
             const auto oc_offset = inp_ic_offset(m_block, ic, m, n);
-            auto addr = is_superset(jcp_.isa, avx512_core)
+            auto addr = isa_has_evex(jcp_.isa)
                     ? EVEX_compress_addr(reg_aux_in, oc_offset)
                     : ptr[reg_aux_in + oc_offset];
             if (jcp_.has_int8_vnni) {

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -73,7 +73,7 @@ template <typename Vmm>
 Vmm dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::vmm_mask(
         const Vmm vmm_in, bool mask_flag, bool store,
         Xbyak::Opmask ktail_mask) {
-    return mask_flag && isa_has_masks(brg_.isa_impl)
+    return mask_flag && isa_has_evex(brg_.isa_impl)
             ? (store ? vmm_in | ktail_mask : vmm_in | ktail_mask | T_z)
             : vmm_in;
 }
@@ -100,7 +100,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::accumulate_bias(
     } else {
         auto addr = ptr[aux_reg_ddst
                 + ddst_typesize_ * mult_ * idx * brg_.ld_block];
-        if (IMPLICATION(mask_flag, isa_has_masks(brg_.isa_impl)))
+        if (IMPLICATION(mask_flag, isa_has_evex(brg_.isa_impl)))
             vmovups(vddst_load, addr);
         else
             vmaskmovps(vddst_load, vmm_tail_mask, addr);
@@ -132,7 +132,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::accumulate_bias(
         vpmovzxwd(vddst_load, addr_ddst);
         vdpbf16ps(vbias_acc, vreg_unit, vddst);
     } else if (ddst_dt_ == data_type::f32) {
-        if (IMPLICATION(mask_flag, isa_has_masks(brg_.isa_impl)))
+        if (IMPLICATION(mask_flag, isa_has_evex(brg_.isa_impl)))
             vmovups(vddst_load, addr_ddst);
         else
             vmaskmovps(vddst_load, vmm_tail_mask, addr_ddst);
@@ -165,7 +165,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::store(
             }
             break;
         case data_type::f32:
-            if (IMPLICATION(mask_flag, isa_has_masks(brg_.isa_impl)))
+            if (IMPLICATION(mask_flag, isa_has_evex(brg_.isa_impl)))
                 vmovups(addr, vmm_mask(vbias, mask_flag, true, k_tail_mask));
             else
                 vmaskmovps(addr, vmm_tail_mask, vbias);
@@ -262,7 +262,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::loop_by_N(
     if (nb_tail > 0) {
         auto vbias = vmm_mask(get_bias_reg(n_), true, false, k_tail_mask);
         auto addr = ptr[reg_bias_acc + acc_typesize_ * n_ * brg_.ld_block];
-        if (isa_has_masks(brg_.isa_impl))
+        if (isa_has_evex(brg_.isa_impl))
             vmovups(vbias, addr);
         else
             vmaskmovps(vbias, vmm_tail_mask, addr);
@@ -303,7 +303,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::loop_by_N(
     if (nb_tail > 0) {
         auto addr = ptr[reg_bias_acc + acc_typesize_ * n_ * brg_.ld_block];
         auto vbias = get_bias_reg(n_);
-        if (isa_has_masks(brg_.isa_impl)) {
+        if (isa_has_evex(brg_.isa_impl)) {
             vbias = vmm_mask(vbias, true, true, k_tail_mask);
             vmovups(addr, vbias);
         } else {
@@ -336,13 +336,13 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::init_masks(
 
     if (reduce_kind_ == matmul_reduce_kind::src
             && utils::one_of(bia_dt_, data_type::f16, data_type::bf16)) {
-        assert(isa_has_masks(brg_.isa_impl));
+        assert(isa_has_evex(brg_.isa_impl));
         mov(reg_mask, 1);
         kmovq(k_store_mask, reg_mask);
     }
 
     if (tail_length == 0) return;
-    if (isa_has_masks(brg_.isa_impl)) {
+    if (isa_has_evex(brg_.isa_impl)) {
         const auto full_mask = size_t {0xffffffffffffffff};
         const auto tail_mask = size_t((1 << tail_length) - 1);
         mov(reg_mask, full_mask);
@@ -444,7 +444,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::generate() {
             dw(f16_prm_array[i]);
     }
 
-    if (!isa_has_masks(brg_.isa_impl) && tail > 0) {
+    if (!isa_has_evex(brg_.isa_impl) && tail > 0) {
         align(32);
         L(mask_label_);
         for (int i = 0; i < tail; ++i)
@@ -598,7 +598,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::cvt2ps(
             // no tail and full vmm must be processed.
             && tail_size > 0;
 
-    if (IMPLICATION(is_tail, isa_has_masks(brg_.isa_impl))) {
+    if (IMPLICATION(is_tail, isa_has_evex(brg_.isa_impl))) {
         const Vmm vmm = maybe_mask(vmm_in, is_tail, store, ktail_mask);
         switch (type_in) {
             case data_type::f32:
@@ -716,7 +716,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_comp(
             auto zp_comp_a_addr = is_superset(brg_.isa_impl, avx512_core)
                     ? EVEX_compress_addr(aux_reg_zp_a_comp, zp_comp_offset)
                     : ptr[aux_reg_zp_a_comp + zp_comp_offset];
-            if (IMPLICATION(has_tail, isa_has_masks(brg_.isa_impl))) {
+            if (IMPLICATION(has_tail, isa_has_evex(brg_.isa_impl))) {
                 auto vmm_zp_comp_a_masked
                         = maybe_mask(vmm_zp_comp_a, has_tail, false, k_mask);
                 vmovups(vmm_zp_comp_a_masked, zp_comp_a_addr);
@@ -741,7 +741,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_comp(
             auto comp_addr = is_superset(brg_.isa_impl, avx512_core)
                     ? EVEX_compress_addr(aux_reg_s8s8_comp, s8s8_comp_offset)
                     : ptr[aux_reg_s8s8_comp + s8s8_comp_offset];
-            if (IMPLICATION(tail > 0, isa_has_masks(brg_.isa_impl))) {
+            if (IMPLICATION(tail > 0, isa_has_evex(brg_.isa_impl))) {
                 auto vmm_comp_masked
                         = maybe_mask(vmm_comp, tail > 0, false, k_mask);
                 vmovups(vmm_comp_masked, comp_addr);
@@ -838,7 +838,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
                     vmulps(vmm, vmm, vmm_wei_scales);
                 }
             } else {
-                if (IMPLICATION(is_tail, isa_has_masks(brg_.isa_impl))) {
+                if (IMPLICATION(is_tail, isa_has_evex(brg_.isa_impl))) {
                     const auto vmm_m = maybe_mask(vmm, is_tail, false, k_mask);
                     const auto vmm_wei_scales_masked = maybe_mask(
                             vmm_wei_scales, is_tail, false, k_mask);
@@ -1142,7 +1142,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
     int mb = brg_.bcast_dim / m_block;
     int mb_tail = brg_.bcast_dim % m_block;
 
-    if (isa_has_masks(brg_.isa_impl)) {
+    if (isa_has_evex(brg_.isa_impl)) {
         const auto full_mask = size_t {0xffffffffffffffff};
         const auto tail_mask = size_t((1 << nb_tail) - 1);
 

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -640,7 +640,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         auto vmm_sum_zp = vmm_tmp(1);
         if (*p_sum_zp != 0) {
             mov(reg_ptr_sum_zp, (size_t)p_sum_zp);
-            if (is_superset(brg_.isa_impl, avx512_core)) {
+            if (isa_has_evex(brg_.isa_impl)) {
                 vcvtdq2ps(vmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
             } else {
                 vpbroadcastd(vmm_sum_zp, ptr[reg_ptr_sum_zp]);
@@ -661,7 +661,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
             if (*p_sum_scale == 1.f)
                 uni_vaddps(vmm, vmm, vmm_prev_dst);
             else {
-                if (is_superset(brg_.isa_impl, avx512_core)) {
+                if (isa_has_evex(brg_.isa_impl)) {
                     vfmadd231ps(vmm, vmm_prev_dst, ptr_b[reg_ptr_sum_scale]);
                 } else {
                     auto vmm_sum_scale = vmm_tmp(2);
@@ -713,7 +713,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_comp(
         for (int n = 0; n < n_block; n++) {
             const size_t zp_comp_offset
                     = sizeof(int32_t) * (n * brg_.ld_block + m * brg_.LDB);
-            auto zp_comp_a_addr = is_superset(brg_.isa_impl, avx512_core)
+            auto zp_comp_a_addr = isa_has_evex(brg_.isa_impl)
                     ? EVEX_compress_addr(aux_reg_zp_a_comp, zp_comp_offset)
                     : ptr[aux_reg_zp_a_comp + zp_comp_offset];
             if (IMPLICATION(has_tail, isa_has_evex(brg_.isa_impl))) {
@@ -738,7 +738,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_comp(
             const size_t s8s8_comp_offset
                     = sizeof(int32_t) * (n * brg_.ld_block + m * brg_.LDB);
 
-            auto comp_addr = is_superset(brg_.isa_impl, avx512_core)
+            auto comp_addr = isa_has_evex(brg_.isa_impl)
                     ? EVEX_compress_addr(aux_reg_s8s8_comp, s8s8_comp_offset)
                     : ptr[aux_reg_s8s8_comp + s8s8_comp_offset];
             if (IMPLICATION(tail > 0, isa_has_evex(brg_.isa_impl))) {
@@ -902,7 +902,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
         mov(aux_reg_zp_c_values, ptr[rsp + aux_reg_zp_c_values_offs_]);
         auto vmm_zp_c = vmm_tmp(0);
         if (brg_.zp_type_c == brgemm_broadcast_t::per_tensor) {
-            if (is_superset(brg_.isa_impl, avx512_core))
+            if (isa_has_evex(brg_.isa_impl))
                 vcvtdq2ps(vmm_zp_c,
                         EVEX_compress_addr(aux_reg_zp_c_values, 0, true));
             else {
@@ -913,7 +913,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
         for (int n = 0; n < n_block; n++) {
             if (brg_.zp_type_c == brgemm_broadcast_t::per_n) {
                 int zp_c_off = zp_c_values_offset(n);
-                auto zp_c_addr = is_superset(brg_.isa_impl, avx512_core)
+                auto zp_c_addr = isa_has_evex(brg_.isa_impl)
                         ? EVEX_compress_addr(aux_reg_zp_c_values, zp_c_off)
                         : ptr[aux_reg_zp_c_values + zp_c_off];
                 cvt2ps(data_type::s32, vmm_zp_c, zp_c_addr, tail, false,

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -964,7 +964,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
             continue;
         }
 
-        if (is_superset(brg_.isa_impl, avx512_core)) {
+        if (isa_has_evex(brg_.isa_impl)) {
             auto vmm_masked = maybe_mask(vmm, tail > 0, true, k_mask);
             Vmm_lower_t vmm_low = Vmm_lower_t(vmm.getIdx());
             Vmm_lower2_t vmm_low2 = Vmm_lower2_t(vmm_low.getIdx());

--- a/src/cpu/x64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.hpp
@@ -284,7 +284,7 @@ private:
     template <typename T>
     T maybe_mask(const T vmm_in, bool mask_flag, bool store,
             Xbyak::Opmask ktail_mask) {
-        assert(IMPLICATION(mask_flag, isa_has_masks(brg_.isa_impl)));
+        assert(IMPLICATION(mask_flag, isa_has_evex(brg_.isa_impl)));
         return mask_flag
                 ? (store ? vmm_in | ktail_mask : vmm_in | ktail_mask | T_z)
                 : vmm_in;

--- a/src/cpu/x64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.cpp
@@ -1707,7 +1707,7 @@ void jit_copy_f32_t::copy_block(int nrows, int ncolumns) {
         const dim_t offset = r * src_stride + cb * col_shift;
         const bool is_tail
                 = nc_tail > 0 && ncolumns - cb * column_step < column_step;
-        if (is_superset(conf_->isa, avx512_core)) {
+        if (isa_has_evex(conf_->isa)) {
             auto src_reg = get_zmm(r * cb);
             auto src_load = is_tail ? src_reg | mask_tail | T_z : src_reg;
             auto addr = EVEX_compress_addr_safe(reg_src, offset, reg_long_offt);
@@ -1724,7 +1724,7 @@ void jit_copy_f32_t::copy_block(int nrows, int ncolumns) {
 
     auto store = [&](int r, int cb) {
         const dim_t offset = r * tr_src_stride + cb * col_shift;
-        if (is_superset(conf_->isa, avx512_core)) {
+        if (isa_has_evex(conf_->isa)) {
             auto reg = get_zmm(r * cb);
             auto addr = EVEX_compress_addr_safe(
                     reg_tr_src, offset, reg_long_offt);
@@ -2331,7 +2331,7 @@ void jit_brgemm_trans_wei_f32_t::transpose_8x8() {
 
 void jit_brgemm_trans_wei_f32_t::init_masks() {
 
-    if (is_superset(conf_->isa, avx512_core)) {
+    if (isa_has_evex(conf_->isa)) {
         kmovw(k3333, 0x3333); // 0011001100110011
         kmovw(k5555, 0x5555); // 0101010101010101
         kmovw(kAAAA, 0xaaaa); // 1010101010101010

--- a/src/cpu/x64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.cpp
@@ -357,7 +357,7 @@ void jit_brgemm_trans_m_k_f32_t::transpose(int nrows, int ncolumns) {
 }
 
 void jit_brgemm_trans_m_k_f32_t::init_masks(int tail_length) {
-    if (isa_has_masks(conf_->isa)) {
+    if (isa_has_evex(conf_->isa)) {
         kmovw(k3333, 0x3333); // 0011001100110011
         kmovw(k5555, 0x5555); // 0101010101010101
         kmovw(kAAAA, 0xaaaa); // 1010101010101010
@@ -390,7 +390,7 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
 
     const int simd_tail = ic_tail; // last_os_block_tail % transpose_size;
     init_masks(simd_tail);
-    if (last_os_block_tail && !isa_has_masks(conf_->isa))
+    if (last_os_block_tail && !isa_has_evex(conf_->isa))
         uni_vxorps(xmm_zero, xmm_zero, xmm_zero);
 
     mov(reg_src_base, ptr[param1 + GET_OFF(src)]);
@@ -461,7 +461,7 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
     }
 
     postamble();
-    if (simd_tail > 0 && !isa_has_masks(conf_->isa)) {
+    if (simd_tail > 0 && !isa_has_evex(conf_->isa)) {
         align(32);
         L(mask_label_);
         for (int i = 0; i < simd_tail; ++i)
@@ -1749,7 +1749,7 @@ void jit_copy_f32_t::init_masks(int tail_length) {
         jit_generator_t::kmovd(k, regw_tmp);
     };
 
-    if (isa_has_masks(conf_->isa))
+    if (isa_has_evex(conf_->isa))
         kmovd(mask_tail, (1 << tail_length) - 1);
     else
         vmovups(ymm_tail_mask, ptr[rip + mask_label_]);
@@ -1821,7 +1821,7 @@ void jit_copy_f32_t::generate() {
 
     postamble();
 
-    if (simd_tail > 0 && !isa_has_masks(conf_->isa)) {
+    if (simd_tail > 0 && !isa_has_evex(conf_->isa)) {
         align(32);
         L(mask_label_);
         for (int i = 0; i < simd_tail; ++i)

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -685,7 +685,7 @@ protected:
                     // Subtract with mask to keep zeros in spots where there's
                     // no data. Otherwise, subtracting mean and accumulating
                     // towards variance will spoil the right answer.
-                    if (is_superset(isa, avx512_core)) {
+                    if (isa_has_evex(isa)) {
                         uni_vsubps(Vmm_src(ur) | tail_opmask, Vmm_src(ur),
                                 Vmm_mean(ur));
                     } else if (is_superset(isa, avx)) {

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -268,7 +268,7 @@ protected:
         if (!tail)
             uni_vsubps(x1, x1, x2);
         else {
-            if (is_superset(isa, avx512_core))
+            if (isa_has_evex(isa))
                 uni_vsubps(x1 | Opmask(tail_opmask_idx) | T_z, x1, x2);
             else if (is_superset(isa, sse41)) {
                 // We need to call tail version once, it's fine to use vmm_tmp

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -220,7 +220,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding_in_post_ops(
     const Vmm vmm_zeros(vmm_tmp_.getIdx());
 
     uni_vxorps(vmm_zeros, vmm_zeros, vmm_zeros);
-    if (is_superset(conf_.isa, avx512_core))
+    if (isa_has_evex(conf_.isa))
         vblendmps(vmm_data | k_tail_mask_, vmm_zeros, vmm_data);
     else {
         std::bitset<8> tail_mask((1 << tail_size_) - 1);

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -245,7 +245,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         const Ymm &ysrc = Ymm(vsrc.getIdx());
         const Ymm &ytmp = Ymm(vtmp.getIdx());
 
-        if (is_superset(isa, avx512_core)) {
+        if (isa_has_evex(isa)) {
             vshuff32x4(ztmp, zsrc, zsrc, 0x4E); // 256-bit shuffle
             perform_op(vsrc, vsrc, vtmp, op);
             vshuff32x4(ztmp, zsrc, zsrc, 0xB1); // 128/256-bit shuffle
@@ -343,7 +343,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     void uni_vaddps_maybe_tail(
             const Vmm &v1, const Vmm &v2, const Vmm &vtmp, const bool tail) {
         if (tail) {
-            if (is_superset(isa, avx512_core)) {
+            if (isa_has_evex(isa)) {
                 uni_vaddps(v1 | tail_opmask, v1, v2);
             } else {
                 uni_vpxor(vtmp, vtmp, vtmp);
@@ -357,7 +357,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     void uni_vmaxps_maybe_tail(
             const Vmm &v1, const Vmm &v2, const Vmm &vtmp, const bool tail) {
         if (tail) {
-            if (is_superset(isa, avx512_core)) {
+            if (isa_has_evex(isa)) {
                 uni_vmaxps(v1 | tail_opmask, v1, v2);
             } else if (is_superset(isa, avx)) {
                 uni_vblendvps(v2, vneg_flt_max, v2, tail_vmask);
@@ -381,8 +381,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         Vmm src_vmm = vmm;
 
         if (tail && axis_has_padding_) {
-            if (is_superset(isa, avx512_core)
-                    && utils::one_of(dt, f32, bf16, f16)) {
+            if (isa_has_evex(isa) && utils::one_of(dt, f32, bf16, f16)) {
                 src_vmm = vzero | tail_opmask;
                 uni_vxorps(vzero, vzero, vzero);
                 uni_vmovups(src_vmm, vmm);
@@ -1192,7 +1191,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     void uni_vaddps_maybe_tail(
             const Vmm &v1, const Vmm &v2, const Vmm &vtmp, const bool tail) {
         if (tail) {
-            if (is_superset(isa, avx512_core)) {
+            if (isa_has_evex(isa)) {
                 uni_vaddps(v1 | tail_opmask, v1, v2);
             } else {
                 uni_vpxor(vtmp, vtmp, vtmp);
@@ -1206,7 +1205,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     void uni_vmaxps_maybe_tail(
             const Vmm &v1, const Vmm &v2, const Vmm &vtmp, const bool tail) {
         if (tail) {
-            if (is_superset(isa, avx512_core)) {
+            if (isa_has_evex(isa)) {
                 uni_vmaxps(v1 | tail_opmask, v1, v2);
             } else if (is_superset(isa, avx)) {
                 uni_vblendvps(v2, vneg_flt_max, v2, tail_vmask);

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -2375,7 +2375,7 @@ protected:
         const auto unmask_tail
                 = one_of(conf_->wei_dt, data_type::bf16, data_type::f16)
                 && !conf_->transposed_B;
-        if (isa_has_masks(conf_->isa))
+        if (isa_has_evex(conf_->isa))
             return is_tail ? vmm | tail_mask | T_z
                     // bf16 and f16 requires masking for tail
                     // to avoid AVX512F issues with zeroing upper bits
@@ -2431,7 +2431,7 @@ protected:
         vpermd(reg, vmm_permd, reg);
         // Without masks int4 is going to use 2 tmp registers
         // To perform masks using VPAND operator
-        if (!isa_has_masks(conf_->isa)) {
+        if (!isa_has_evex(conf_->isa)) {
             // TODO: Unify register usage over kernels
             const auto mask_vmm = Vmm(conf_->transposed_B ? 13 : 0);
             const auto tmp_vmm = vmm_permd;
@@ -3731,7 +3731,7 @@ private:
     Vmm vmm_wei_scales = Vmm(4);
 
     void kmovx(Opmask k, unsigned w) {
-        if (!isa_has_masks(conf_->isa)) return;
+        if (!isa_has_evex(conf_->isa)) return;
         const auto regw_tmp = reg_tmp.cvt32();
         if (is_dynamic_N) {
             mov(reg_tmp, 1);
@@ -3794,7 +3794,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
                 = one_of(zp_dt, data_type::s4, data_type::u4) ? 2 : 1;
         const auto offset = n * zp_dt_sz / elems_per_byte;
         const auto addr = maybe_EVEX_compress_addr(reg_zp_ptr, offset);
-        if (is_tail && !isa_has_masks(conf_->isa)) {
+        if (is_tail && !isa_has_evex(conf_->isa)) {
             load_bytes(vmm_zp_b_shift, addr, columns_tail / elems_per_byte);
             load_value(vmm_zp_b_shift, vmm_zp_b_shift, vmm_permd, zp_dt);
         }
@@ -3813,7 +3813,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
         const auto scales_dt_sz = types::data_type_size(scales_dt);
         const auto offset = n * scales_dt_sz;
         const auto addr = maybe_EVEX_compress_addr(reg_wei_scales, offset);
-        if (is_tail && !isa_has_masks(conf_->isa)) {
+        if (is_tail && !isa_has_evex(conf_->isa)) {
             load_bytes(
                     vmm_wei_scales, addr, columns_tail * wei_scales_typesize);
             load_scale_value(vmm_wei_scales, vmm_wei_scales, scales_dt,
@@ -3833,7 +3833,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
         const auto reg_src_load
                 = is_dynamic_stride && k % 2 != 0 ? reg_src_load_1 : reg_src;
         auto load_addr = maybe_EVEX_compress_addr(reg_src_load, offset);
-        if (!isa_has_masks(conf_->isa)) {
+        if (!isa_has_evex(conf_->isa)) {
             if (is_tail)
                 load_bytes(src_load, load_addr,
                         columns_tail * tr_typesize / elems_per_byte);
@@ -3965,7 +3965,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::init_masks() {
         mov(reg_tmp, reinterpret_cast<size_t>(bf16_vnni_permute));
         vmovdqa64(vmm_permw, ptr[reg_tmp]);
 
-        if (isa_has_masks(conf_->isa)) {
+        if (isa_has_evex(conf_->isa)) {
             // 64-bit mask is also used when is_wei_[zp\scales]_per_k
             mov(reg_tmp, 0xAAAAAAAAAAAAAAAA);
             kmovq(kAAAA, reg_tmp);
@@ -4249,7 +4249,7 @@ private:
     Ymm ymm_tail_mask = ymm1;
 
     inline void kmovw(Opmask k, unsigned w) {
-        if (!isa_has_masks(conf_->isa)) return;
+        if (!isa_has_evex(conf_->isa)) return;
         mov(regw_tmp, w);
         jit_generator_t::kmovd(k, regw_tmp);
     }
@@ -4281,7 +4281,7 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const bool is_tail = ncolumns - n < simd_w_;
         auto addr = maybe_EVEX_compress_addr(reg_src,
                 (k * src_stride_ + n * typesize_in_) / src_elems_per_byte_);
-        if (is_tail && !isa_has_masks(conf_->isa)) {
+        if (is_tail && !isa_has_evex(conf_->isa)) {
             load_bytes(src_vmm, addr,
                     (ncolumns % simd_w_) * typesize_in_ / src_elems_per_byte_);
             load_value(src_vmm, src_vmm, vmm_permd, conf_->orig_wei_dt, false);
@@ -4305,7 +4305,7 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
                 = one_of(zp_dt, data_type::s4, data_type::u4) ? 2 : 1;
         const auto offset = n * zp_dt_sz / elems_per_byte;
         const auto addr = maybe_EVEX_compress_addr(reg_zp_ptr, offset);
-        if (is_tail && !isa_has_masks(conf_->isa)) {
+        if (is_tail && !isa_has_evex(conf_->isa)) {
             load_bytes(vmm_zp_b_shift, addr,
                     (ncolumns % simd_w_) * zp_dt_sz / elems_per_byte);
             load_value(vmm_zp_b_shift, vmm_zp_b_shift, vmm_permd, zp_dt, false);
@@ -4325,7 +4325,7 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const auto scales_dt_sz = types::data_type_size(scales_dt);
         const auto offset = n * scales_dt_sz;
         const auto addr = maybe_EVEX_compress_addr(reg_wei_scales, offset);
-        if (is_tail && !isa_has_masks(conf_->isa)) {
+        if (is_tail && !isa_has_evex(conf_->isa)) {
             load_bytes(
                     vmm_wei_scales, addr, (ncolumns % simd_w_) * scales_dt_sz);
             load_scale_value(vmm_wei_scales, vmm_wei_scales, scales_dt, false);
@@ -4335,7 +4335,7 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
 
     const int columns_tail = ncolumns % simd_w_;
     if (columns_tail < simd_w_) {
-        if (isa_has_masks(conf_->isa)) {
+        if (isa_has_evex(conf_->isa)) {
             const auto tail_mask = (1 << columns_tail) - 1;
             kmovw(kTail, tail_mask);
             if (is_src_int4_ || is_src_f4_) {
@@ -4741,7 +4741,7 @@ template <typename Vmm>
 void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::init_tail_mask(
         const int columns_tail, const bool use_int4_mask) {
     assert(IMPLICATION(use_int4_mask, is_src_int4_));
-    assert(isa_has_masks(conf_->isa));
+    assert(isa_has_evex(conf_->isa));
     if (columns_tail > 0) {
         const int dt_step = req_cvtps2xf16_ || use_fp16_instructions_
                         || use_bf16_instructions_

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -1382,7 +1382,7 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::init_masks() {
     alignas(64) static constexpr const uint16_t idx5[32]
             = {0, 16, 2, 18, 8, 24, 10, 26, 4, 20, 6, 22, 12, 28, 14, 30, 1, 17,
                     3, 19, 9, 25, 11, 27, 5, 21, 7, 23, 13, 29, 15, 31};
-    if (is_superset(conf_->isa, avx512_core)) {
+    if (isa_has_evex(conf_->isa)) {
         if (is_f32) {
             kmovw(k3333, 0x3333); // 0011001100110011
             kmovw(k5555, 0x5555); // 0101010101010101
@@ -5685,7 +5685,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::init_masks() {
     alignas(64) static constexpr const uint32_t bf16_vnni_permute[16]
             = {0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15};
 
-    if (is_superset(conf_->isa, avx512_core)) {
+    if (isa_has_evex(conf_->isa)) {
         kxnorw(kFFFF, kFFFF, kFFFF); // 1111 1111 1111 1111
 
         mov(reg_tmp, reinterpret_cast<size_t>(bf16_vnni_permute));

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -3931,7 +3931,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
         else
             uni_vxorps(src_vmm1, src_vmm1, src_vmm1);
 
-        if (is_superset(conf_->isa, avx512_core)) {
+        if (isa_has_evex(conf_->isa)) {
             const auto src_ymm1 = ymm(src_vmm1.getIdx());
             vinsertf64x4(src_zmm0, src_zmm0, src_ymm1, 1);
             vpermw(src_zmm0, vmm_permw, src_zmm0);

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -668,7 +668,7 @@ void jit_io_helper_t<Vmm>::load_f32(
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::load_s32(
         const Xbyak::Address &src_addr, const Vmm &dst_vmm, const bool tail) {
-    if (is_superset(isa_, avx512_core))
+    if (isa_has_evex(isa_))
         host_->uni_vcvtdq2ps(dst_vmm, src_addr);
     else {
         load_f32(src_addr, dst_vmm, tail);
@@ -992,7 +992,7 @@ void jit_io_helper_t<Vmm>::broadcast(
                         dst_vmm, host_->ptr_b[src_addr.getRegExp()]);
             break;
         case data_type::s32: {
-            if (is_superset(isa_, avx512_core)) {
+            if (isa_has_evex(isa_)) {
                 host_->uni_vcvtdq2ps(
                         dst_vmm, host_->ptr_b[src_addr.getRegExp()]);
             } else {

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -507,7 +507,7 @@ void jit_io_helper_t<Vmm>::prepare_tail_mask() {
 
     if (!tail_conf_->tail_size_) return;
 
-    if (is_superset(isa_, avx512_core))
+    if (isa_has_evex(isa_))
         prepare_opmask(tail_conf_->tail_size_, tail_conf_->reg_tmp_,
                 tail_conf_->tail_opmask_);
     else if (is_superset(isa_, sse41))
@@ -524,7 +524,7 @@ void jit_io_helper_t<Vmm>::prepare_full_mask() {
                 data_type::f8_e5m2))
         return;
 
-    if (is_superset(isa_, avx512_core))
+    if (isa_has_evex(isa_))
         prepare_opmask(gather_conf_->simd_w_, gather_conf_->reg_tmp_,
                 gather_conf_->full_opmask_);
     else if (is_superset(isa_, avx2))
@@ -658,7 +658,7 @@ void jit_io_helper_t<Vmm>::load_byte_by_byte(const Xbyak::Address &src_addr,
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::load_f32(
         const Xbyak::Address &src_addr, const Vmm &dst_vmm, const bool tail) {
-    if (tail && !is_superset(isa_, avx512_core))
+    if (tail && !isa_has_evex(isa_))
         host_->vmaskmovps(
                 dst_vmm, Vmm(tail_conf_->tail_vmm_mask_idx_), src_addr);
     else
@@ -837,7 +837,7 @@ void jit_io_helper_t<Vmm>::store_f32(
         const Vmm &src_vmm, const Xbyak::Address &dst_addr, const bool tail) {
     if (io_conf_.nt_stores_enabled_)
         host_->uni_vmovntps(dst_addr, src_vmm);
-    else if (!is_superset(isa_, avx512_core) && tail)
+    else if (!isa_has_evex(isa_) && tail)
         host_->vmaskmovps(
                 dst_addr, Vmm(tail_conf_->tail_vmm_mask_idx_), src_vmm);
     else


### PR DESCRIPTION
This PR does a minor renaming to make the call site semantically accurate while using a single function:

Before:
* `isa_has_masks(isa)` -> Opmask registers are available
* `is_superset(isa, avx512_core)`/`isa_has_masks(isa)` -> EVEX-only instructions can be used 

After:
* `isa_has_evex()` -> Opmask registers are available
* `isa_has_evex()` -> EVEX-only instructions can be used

