### PR TITLE
xe: compute: restore str2gpu_arch function

### DIFF
--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -66,6 +66,20 @@ static inline const char *to_string(gpu_arch_t arch) {
 #undef CASE
 }
 
+static inline gpu_arch_t str2gpu_arch(const char *str) {
+#define CASE(_case) \
+    if (!strcmp(STRINGIFY(_case), str)) return gpu_arch_t::_case
+    CASE(xe_lp);
+    CASE(xe_hp);
+    CASE(xe_hpg);
+    CASE(xe_hpc);
+    CASE(xe2);
+    CASE(xe3);
+    CASE(xe3p);
+    return gpu_arch_t::unknown;
+#undef CASE
+}
+
 enum class device_ext_t : uint64_t {
     // clang-format off
     // OpenCL data types


### PR DESCRIPTION
Fixes a build error caused by merging #5272 (which removes this function from the library) shortly after #5122 (which uses the function).