### PR TITLE
cpu: x64: take jit kernel params by const pointer

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -756,7 +756,7 @@ struct brgemm_kernel_t {
     brgemm_kernel_t() = default;
     virtual ~brgemm_kernel_t() = default;
     virtual status_t create_kernel() = 0;
-    virtual void operator()(brgemm_kernel_params_t *) const = 0;
+    virtual void operator()(const brgemm_kernel_params_t *) const = 0;
     virtual const jit_generator_t *get_jit_generator() const = 0;
     virtual const brgemm_desc_t &get_brg() const = 0;
 };
@@ -773,7 +773,7 @@ struct brgemm_kernel_common_t : public brgemm_kernel_t {
     ~brgemm_kernel_common_t() override;
 
     status_t create_kernel() override;
-    void operator()(brgemm_kernel_params_t *) const override;
+    void operator()(const brgemm_kernel_params_t *) const override;
     const jit_generator_t *get_jit_generator() const override;
     const brgemm_desc_t &get_brg() const override {
         return ((jit_base_brgemm_kernel_t *)brgemm_kernel_)->get_brg();
@@ -790,7 +790,7 @@ struct brgemm_amx_uker_t : public brgemm_kernel_t {
     ~brgemm_amx_uker_t() override;
 
     status_t create_kernel() override;
-    void operator()(brgemm_kernel_params_t *) const override;
+    void operator()(const brgemm_kernel_params_t *) const override;
     const jit_generator_t *get_jit_generator() const override;
     const brgemm_desc_t &get_brg() const override {
         return ((jit_base_brgemm_kernel_t *)brgemm_kernel_)->get_brg();
@@ -808,7 +808,7 @@ struct brdgmm_kernel_t : public brgemm_kernel_t {
     ~brdgmm_kernel_t() override;
 
     status_t create_kernel() override;
-    void operator()(brgemm_kernel_params_t *) const override;
+    void operator()(const brgemm_kernel_params_t *) const override;
     const jit_generator_t *get_jit_generator() const override;
     const brgemm_desc_t &get_brg() const override {
         return ((jit_base_brgemm_kernel_t *)brgemm_kernel_)->get_brg();

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -1511,7 +1511,8 @@ status_t brdgmm_kernel_t<Wmm>::create_kernel() {
 }
 
 template <typename Wmm>
-void brdgmm_kernel_t<Wmm>::operator()(brgemm_kernel_params_t *params) const {
+void brdgmm_kernel_t<Wmm>::operator()(
+        const brgemm_kernel_params_t *params) const {
     (*brgemm_kernel_)(params);
 }
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -3108,7 +3108,7 @@ status_t brgemm_amx_uker_t::create_kernel() {
     return brgemm_kernel_->create_kernel();
 }
 
-void brgemm_amx_uker_t::operator()(brgemm_kernel_params_t *params) const {
+void brgemm_amx_uker_t::operator()(const brgemm_kernel_params_t *params) const {
     (*brgemm_kernel_)(params);
 }
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -3820,7 +3820,7 @@ status_t brgemm_kernel_common_t<Wmm>::create_kernel() {
 
 template <typename Wmm>
 void brgemm_kernel_common_t<Wmm>::operator()(
-        brgemm_kernel_params_t *params) const {
+        const brgemm_kernel_params_t *params) const {
     (*brgemm_kernel_)(params);
 }
 

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -215,7 +215,7 @@ struct jit_avx512_common_conv_fwd_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    void operator()(jit_conv_args_t *p) const { (*kernel_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*kernel_)(p); }
 
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 

--- a/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
@@ -252,7 +252,7 @@ struct jit_avx512_core_add_cvt_ps_to_bf16_t : public jit_generator_t {
         postamble();
     }
 
-    void operator()(bf16_support::jit_call_t *params) const {
+    void operator()(const bf16_support::jit_call_t *params) const {
         jit_generator_t::operator()(params);
         msan_unpoison(params->out, params->nelems * sizeof(bfloat16_t));
     }
@@ -379,7 +379,7 @@ struct jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t : public jit_generator_t {
             dw(dst_prm_array[i]);
     }
 
-    void operator()(bf16_support::jit_call_t *params) const {
+    void operator()(const bf16_support::jit_call_t *params) const {
         jit_generator_t::operator()(params);
         msan_unpoison(params->out, params->nelems * sizeof(bfloat16_t));
     }

--- a/src/cpu/x64/jit_avx512_core_fp16cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_fp16cvt.hpp
@@ -55,7 +55,7 @@ struct jit_avx512_core_fp16_add_cvt_ps_to_f16_t : public jit_generator_t {
 
     void generate() override;
 
-    void operator()(f16_support::jit_call_t *params) const {
+    void operator()(const f16_support::jit_call_t *params) const {
         jit_generator_t::operator()(params);
         msan_unpoison(params->out, params->nelems * sizeof(float16_t));
     }

--- a/src/cpu/x64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.hpp
@@ -146,7 +146,8 @@ struct jit_brgemm_kernel_post_ops_base_t {
 
     virtual status_t generate_kernel() = 0;
 
-    virtual void operator()(brgemm_kernel_post_ops_args_t *args) const = 0;
+    virtual void operator()(const brgemm_kernel_post_ops_args_t *args) const
+            = 0;
 
     virtual int get_bcast_dim() const = 0;
 };
@@ -170,7 +171,7 @@ struct jit_brgemm_kernel_post_ops_t : public jit_brgemm_kernel_post_ops_base_t,
     status_t generate_kernel() override {
         return jit_generator_t::create_kernel();
     }
-    void operator()(brgemm_kernel_post_ops_args_t *args) const override {
+    void operator()(const brgemm_kernel_post_ops_args_t *args) const override {
         return jit_generator_t::operator()(args);
     }
 

--- a/src/cpu/x64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.cpp
@@ -43,7 +43,9 @@ struct jit_brgemm_trans_m_k_f32_t : public jit_brgemm_trans_src_t,
         , jit_generator_t(jit_name())
         , transpose_size(isa_max_vlen(conf_->isa) / typesize) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -477,7 +479,9 @@ struct jit_brgemm_trans_m_k_bf16_t : public jit_brgemm_trans_src_t,
     jit_brgemm_trans_m_k_bf16_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_src_t(conf), jit_generator_t(jit_name()) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -843,7 +847,9 @@ struct jit_brgemm_trans_m_k_f16_t : public jit_brgemm_trans_src_t,
     jit_brgemm_trans_m_k_f16_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_src_t(conf), jit_generator_t(jit_name()) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -1336,7 +1342,9 @@ struct jit_trans_to_vnni_t : public jit_brgemm_trans_to_vnni_t,
         : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform)
         , jit_generator_t(jit_name()) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -1656,7 +1664,9 @@ struct jit_copy_f32_t : public jit_brgemm_trans_to_vnni_t,
         , num_regs(isa_num_vregs(conf->isa))
         , col_shift(static_cast<dim_t>(column_step) * typesize_data) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -1872,7 +1882,9 @@ struct jit_copy_f16_t : public jit_brgemm_trans_to_vnni_t,
         col_shift_out = column_step * typesize_out;
     }
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -2145,7 +2157,9 @@ struct jit_brgemm_trans_wei_f32_t : public jit_brgemm_trans_wei_t,
         , jit_generator_t(jit_name())
         , transpose_size(conf->simd_w) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -2442,7 +2456,9 @@ struct jit_brgemm_trans_wei_bf16_t : public jit_brgemm_trans_wei_t,
     jit_brgemm_trans_wei_bf16_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_wei_t(conf), jit_generator_t(jit_name()) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -2657,7 +2673,9 @@ struct jit_brgemm_trans_wei_f16_t : public jit_brgemm_trans_wei_t,
     jit_brgemm_trans_wei_f16_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_wei_t(conf), jit_generator_t(jit_name()) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -2937,7 +2955,9 @@ struct jit_amx_ip_trans_diff_wei_to_vnni_t : public jit_amx_ip_trans_diff_wei_t,
         : jit_amx_ip_trans_diff_wei_t(jbgp, ext_ic_block, ext_oc_block)
         , jit_generator_t(jit_name()) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }

--- a/src/cpu/x64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.hpp
@@ -34,7 +34,7 @@ struct jit_brgemm_trans_src_t {
         dim_t current_M, current_K;
     };
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
     jit_brgemm_trans_src_t(const jit_brgemm_primitive_conf_t *conf)
@@ -55,7 +55,7 @@ struct jit_brgemm_copy_to_coarse_t : public jit_generator_t {
         dim_t last_row_blk;
     };
 
-    void operator()(ctx_t *ctx) { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) { jit_generator_t::operator()(ctx); }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -150,7 +150,7 @@ struct jit_brgemm_trans_to_vnni_t {
         matrix_C,
     };
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
     jit_brgemm_trans_to_vnni_t(const jit_brgemm_primitive_conf_t *conf,
@@ -172,7 +172,7 @@ struct jit_brgemm_trans_wei_t {
         dim_t current_N, current_K;
     };
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
     jit_brgemm_trans_wei_t(const jit_brgemm_primitive_conf_t *conf)
@@ -234,7 +234,7 @@ struct jit_amx_ip_trans_diff_wei_t {
         size_t last_ic_block;
     };
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
     jit_amx_ip_trans_diff_wei_t(const jit_brgemm_primitive_conf_t *jbgp,

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -45,7 +45,9 @@ struct jit_trans_iw_ic_t : public jit_trans_src_t, public jit_generator_t {
         , is_layout_nxc(utils::one_of(conf_->src_tag, format_tag::ndhwc,
                   format_tag::nhwc, format_tag::nwc)) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
 
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
@@ -698,7 +700,9 @@ struct jit_trans_ow_oc_t : public jit_trans_dst_t, public jit_generator_t {
                           ? 2
                           : data_type_vnni_granularity(conf->dst_dt)) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
 
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();

--- a/src/cpu/x64/jit_transpose_utils.hpp
+++ b/src/cpu/x64/jit_transpose_utils.hpp
@@ -34,7 +34,7 @@ struct jit_trans_src_t {
         int ch_work;
     };
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
     jit_trans_src_t(const jit_conv_conf_t *conf) : conf_(conf) {}
@@ -63,7 +63,7 @@ struct jit_trans_dst_t {
     jit_trans_dst_t(const jit_conv_conf_t *conf) : conf_(conf) {}
     virtual ~jit_trans_dst_t() = default;
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
     const jit_conv_conf_t *conf_;
 };

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -47,7 +47,7 @@ struct binary_kernel_t : public jit_generator_t {
             bool tail_kernel = false);
     ~binary_kernel_t() override = default;
 
-    void operator()(jit_uni_binary_args_t *p) {
+    void operator()(const jit_uni_binary_args_t *p) {
         jit_generator_t::operator()(p);
     }
 

--- a/src/cpu/x64/jit_uni_convert_xf16.hpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.hpp
@@ -145,7 +145,7 @@ struct jit_cvt_ps_to_xf16_t {
         kernel_->create_kernel();
     }
 
-    void operator()(cvt_xf16_support::jit_call_t *params) const {
+    void operator()(const cvt_xf16_support::jit_call_t *params) const {
         (*kernel_)(params);
         msan_unpoison(params->out,
                 (nelems_ ? nelems_ : params->nelems) * sizeof(float16_t));

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -49,7 +49,7 @@ struct jit_uni_eltwise_kernel_t : public jit_generator_t {
             const eltwise_pd_t *pd, const char *name, cpu_isa_t isa)
         : jit_generator_t(name, isa), pd_(pd) {}
 
-    void operator()(jit_args_t *p) { jit_generator_t::operator()(p); }
+    void operator()(const jit_args_t *p) { jit_generator_t::operator()(p); }
 
 protected:
     const eltwise_pd_t *pd_;

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -44,7 +44,9 @@ struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
             const eltwise_pd_t *pd, const cpu_isa_t isa, const char *name)
         : jit_generator_t(name, isa), pd_(pd) {}
 
-    void operator()(jit_args_int8_t *p) { jit_generator_t::operator()(p); }
+    void operator()(const jit_args_int8_t *p) {
+        jit_generator_t::operator()(p);
+    }
 
 protected:
     data_type_t data_type() const { return pd_->src_md()->data_type; }

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -64,7 +64,9 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
                           : avx512_core_dot_product_ ? 27
                                                      : 29) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -557,7 +559,9 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
                   && conf_->orig_src_dt == data_type::f16
                   && conf_->src_dt == data_type::f32) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -1580,7 +1584,9 @@ struct jit_brgemm_matmul_copy_a_transposed_int8_impl_t
         , last_m_block_tail_(conf_->M_tail % columns_step_)
         , do_compute_compensation_(conf_->has_zero_point_b) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -2838,7 +2844,9 @@ struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
                           : avx512_core_dot_product_ ? 23
                                                      : 25) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -3668,7 +3676,9 @@ struct jit_brgemm_matmul_copy_b_bf16_t
                   conf_->is_wei_zp_per_k || conf_->is_wei_scale_per_k)
         , elems_per_byte(is_src_int4 ? 2 : 1) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -4211,7 +4221,9 @@ struct jit_brgemm_matmul_copy_b_f32_t
         , src_stride_(conf_->copy_B_wei_stride)
         , tr_src_stride_(conf_->LDB * typesize_out_) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -4517,7 +4529,9 @@ struct jit_brgemm_matmul_copy_b_transposed_t
         , src_elems_per_byte_(is_src_int4_ ? 2 : 1)
         , is_dynamic_N_(conf->is_runtime_N) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }
@@ -5580,7 +5594,9 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
         , is_wei_grouped_over_k_(
                   conf_->is_wei_zp_per_k || conf_->is_wei_scale_per_k) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    void operator()(const ctx_t *ctx) override {
+        jit_generator_t::operator()(ctx);
+    }
     status_t create_kernel() override {
         return jit_generator_t::create_kernel();
     }

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
@@ -43,7 +43,7 @@ struct jit_brgemm_matmul_copy_b_t {
         dim_t dynamic_src_stride = 0;
     };
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
     jit_brgemm_matmul_copy_b_t(const brgemm_matmul_conf_t *conf)
@@ -68,7 +68,7 @@ struct jit_brgemm_matmul_copy_a_t {
         dim_t dynamic_src_ld = 0;
     };
 
-    virtual void operator()(ctx_t *ctx) = 0;
+    virtual void operator()(const ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
     jit_brgemm_matmul_copy_a_t(const brgemm_matmul_conf_t *conf)

--- a/src/cpu/x64/prelu/jit_prelu_reduction_kernel.hpp
+++ b/src/cpu/x64/prelu/jit_prelu_reduction_kernel.hpp
@@ -45,7 +45,7 @@ public:
     size_t simd_w() const;
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_prelu_reduction_kernel_t)
 
-    void operator()(jit_prelu_reduction_kernel_t::call_params_t *params) {
+    void operator()(const jit_prelu_reduction_kernel_t::call_params_t *params) {
         jit_generator_t::operator()(params);
     }
 

--- a/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.hpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.hpp
@@ -43,7 +43,7 @@ public:
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_prelu_backward_kernel_t)
 
-    void operator()(jit_prelu_backward_kernel_t::call_params_t *params) {
+    void operator()(const jit_prelu_backward_kernel_t::call_params_t *params) {
         jit_generator_t::operator()(params);
     }
 

--- a/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.hpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.hpp
@@ -40,7 +40,7 @@ public:
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_prelu_forward_kernel_t)
 
-    void operator()(jit_prelu_forward_kernel_t::call_params_t *params) {
+    void operator()(const jit_prelu_forward_kernel_t::call_params_t *params) {
         jit_generator_t::operator()(params);
     }
 

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
@@ -39,7 +39,8 @@ public:
         void *dst = nullptr;
     };
 
-    void operator()(jit_diff_weights_peephole_t::call_params_t *params) const {
+    void operator()(
+            const jit_diff_weights_peephole_t::call_params_t *params) const {
         jit_generator_t::operator()(params);
     }
 

--- a/src/cpu/x64/rnn/jit_gates_reduction.hpp
+++ b/src/cpu/x64/rnn/jit_gates_reduction.hpp
@@ -48,7 +48,7 @@ public:
         void *dst = nullptr;
     };
 
-    void operator()(jit_gates_reduction_t::call_params_t *params) const {
+    void operator()(const jit_gates_reduction_t::call_params_t *params) const {
         jit_generator_t::operator()(params);
     }
 


### PR DESCRIPTION
This PR refactors the JIT kernel call operators to accept parameters as const pointers. All x64 call operators in the library are now consistent.