### PR TITLE
cpu: rv64: preserve NaNs in min/max, ReLU, clamp, and fused post-op paths

### DIFF
--- a/src/cpu/rv64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_binary_injector.cpp
@@ -97,16 +97,18 @@ void jit_uni_binary_injector_t<isa>::compute_body(const Vmm &dst) {
                 h_->vfdiv_vv(dst, dst, v_rhs_);
             break;
         case binary_max:
-            if (scalar)
-                h_->vfmax_vf(dst, dst, f_rhs_);
-            else
-                h_->vfmax_vv(dst, dst, v_rhs_);
+            if (scalar) h_->vfmv_v_f(v_rhs_, f_rhs_);
+            h_->vmflt_vv(VReg(0), dst, v_rhs_);
+            h_->vmerge_vvm(dst, dst, v_rhs_);
+            h_->vmfne_vv(VReg(0), v_rhs_, v_rhs_);
+            h_->vmerge_vvm(dst, dst, v_rhs_);
             break;
         case binary_min:
-            if (scalar)
-                h_->vfmin_vf(dst, dst, f_rhs_);
-            else
-                h_->vfmin_vv(dst, dst, v_rhs_);
+            if (scalar) h_->vfmv_v_f(v_rhs_, f_rhs_);
+            h_->vmflt_vv(VReg(0), v_rhs_, dst);
+            h_->vmerge_vvm(dst, dst, v_rhs_);
+            h_->vmfne_vv(VReg(0), v_rhs_, v_rhs_);
+            h_->vmerge_vvm(dst, dst, v_rhs_);
             break;
         default: assert(!"unsupported binary alg"); break;
     }

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
@@ -376,7 +376,7 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &v) {
             break;
         }
 
-        case eltwise_elu:
+        case eltwise_elu: {
             // x>0 ? x : alpha*(exp(x)-1). NaN takes the false branch and
             // remains NaN through exp/sub/mul.
             const Xbyak_riscv::VReg v_mask(0);
@@ -390,6 +390,7 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &v) {
             h_->vfmul_vf(v, v, f_aux0_); // alpha*(...)
             h_->vmerge_vvm(v, v, v_aux1_);
             break;
+        }
 
         case eltwise_swish:
             // x * sigmoid(alpha * x)

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
@@ -29,7 +29,7 @@ namespace eltwise_injector {
 bool is_alg_supported(alg_kind_t alg) {
     using namespace alg_kind;
     switch (alg) {
-        // arithmetic, table-free, mask-free
+        // arithmetic, table-free
         case eltwise_relu:
         case eltwise_square:
         case eltwise_abs:
@@ -351,11 +351,10 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &v) {
             // is tiny, yet it is built as 2*sigmoid(2x)-1 ~= 2*0.5 - 1, so the
             // exp polynomial's ~1e-7 absolute error becomes a large *relative*
             // error (catastrophic cancellation). Blend in the linear approx
-            // tanh(x) ~= x for small |x| (where the x^3/3 error is negligible),
-            // mask-free so the forward path never touches v0: result =
-            // t + w*(x - t), with w a clamped ramp 1->0 over T1<|x|<T2. Inside
-            // the ramp both x and t already match tanh to <2e-5, so the convex
-            // blend is accurate regardless of w.
+            // tanh(x) ~= x for small |x| (where the x^3/3 error is negligible):
+            // result = t + w*(x - t), with w a clamped ramp 1->0 over
+            // T1<|x|<T2. Inside the ramp both x and t already match tanh to
+            // <2e-5, so the convex blend is accurate regardless of w.
             constexpr float t1 = 0.002f, t2 = 0.008f; // blend band (in |x|)
             h_->vmv_v_v(v_aux1_, v); // save x
             load_f32_const(f_aux0_, 2.f);
@@ -383,6 +382,7 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &v) {
             h_->vmv_v_v(v_aux1_, v); // save x
             load_f32_const(f_aux0_, 0.f);
             h_->vmfgt_vf(v_mask, v_aux1_, f_aux0_);
+            h_->vfmerge_vfm(v, v, f_aux0_); // positive lanes use exp(0)
             exp_compute_vector(v); // exp(x)
             load_f32_const(f_aux0_, 1.f);
             h_->vfsub_vf(v, v, f_aux0_); // exp(...) - 1

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
@@ -59,13 +59,17 @@ void jit_uni_eltwise_injector_t<isa>::load_f32_const(const FReg &f, float val) {
     h_->fmv_w_x(f, gpr_aux0_);
 }
 
-// mask-free clamp(v, lo, hi) = min(max(v, lo), hi)
+// NaN-preserving clamp(v, lo, hi). Comparisons with NaN are false, so NaN lanes
+// keep their original value instead of being replaced by the clamp bound.
 template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_t<isa>::clamp(const Vmm &v, float lo, float hi) {
+    const Xbyak_riscv::VReg v_mask(0);
     load_f32_const(f_aux0_, lo);
-    h_->vfmax_vf(v, v, f_aux0_);
+    h_->vmflt_vf(v_mask, v, f_aux0_);
+    h_->vfmerge_vfm(v, v, f_aux0_);
     load_f32_const(f_aux1_, hi);
-    h_->vfmin_vf(v, v, f_aux1_);
+    h_->vmfgt_vf(v_mask, v, f_aux1_);
+    h_->vfmerge_vfm(v, v, f_aux1_);
 }
 
 // exp(x) via base-2 range reduction + degree-5 minimax polynomial (the classic
@@ -84,10 +88,7 @@ void jit_uni_eltwise_injector_t<isa>::exp_compute_vector(const Vmm &v) {
     // -126) come out as exactly 0: (n-1)+127 == 0 builds +0.0, not subnormal
     // 2^-127. This matches x64 (which masks the < ln(FLT_MIN) lanes to 0); the
     // error vs the true value (~1e-38) is negligible.
-    load_f32_const(f_aux0_, 88.72283905f); // MAXLOGF
-    h_->vfmin_vf(v, v, f_aux0_);
-    load_f32_const(f_aux0_, -87.33654475f); // MINLOGF
-    h_->vfmax_vf(v, v, f_aux0_);
+    clamp(v, -87.33654475f, 88.72283905f); // MINLOGF, MAXLOGF
 
     // n = round(x * log2e); z = (float)n
     load_f32_const(f_aux0_, 1.44269504088896341f); // log2e
@@ -272,22 +273,20 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &v) {
     switch (alg_) {
         case eltwise_relu:
             if (alpha_ == 0.f) {
-                // relu(x) = max(x, 0)
+                // relu(x) = x < 0 ? 0 : x. Keep NaN lanes unchanged.
+                const Xbyak_riscv::VReg v_mask(0);
                 load_f32_const(f_aux0_, 0.f);
-                h_->vfmax_vf(v, v, f_aux0_);
+                h_->vmflt_vf(v_mask, v, f_aux0_);
+                h_->vfmerge_vfm(v, v, f_aux0_);
             } else {
-                // leaky relu = x>0 ? x : alpha*x, computed mask-free as
-                //   max(x,0) + alpha*min(x,0).
-                // Correct for ANY alpha (the old max(x,alpha*x) only held for
-                // alpha<=1) and leaves v0 untouched, which the fused post-op
-                // path requires (v0 is the accumulator there, so a v0
-                // compare-mask is unavailable). Mirrors the elu identity below.
+                // leaky relu = x>0 ? x : alpha*x. NaN takes the false branch,
+                // but alpha*NaN is still NaN.
+                const Xbyak_riscv::VReg v_mask(0);
                 load_f32_const(f_aux0_, 0.f);
                 load_f32_const(f_aux1_, alpha_);
-                h_->vfmin_vf(v_aux0_, v, f_aux0_); // min(x,0)
-                h_->vfmul_vf(v_aux0_, v_aux0_, f_aux1_); // alpha*min(x,0)
-                h_->vfmax_vf(v, v, f_aux0_); // max(x,0)
-                h_->vfadd_vv(v, v, v_aux0_); // max(x,0) + alpha*min(x,0)
+                h_->vfmul_vf(v_aux0_, v, f_aux1_);
+                h_->vmfgt_vf(v_mask, v, f_aux0_);
+                h_->vmerge_vvm(v, v_aux0_, v);
             }
             break;
 
@@ -378,18 +377,18 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &v) {
         }
 
         case eltwise_elu:
-            // x>0 ? x : alpha*(exp(x)-1)
-            //   = max(x,0) + alpha*(exp(min(x,0)) - 1)   [mask-free]
+            // x>0 ? x : alpha*(exp(x)-1). NaN takes the false branch and
+            // remains NaN through exp/sub/mul.
+            const Xbyak_riscv::VReg v_mask(0);
+            h_->vmv_v_v(v_aux1_, v); // save x
             load_f32_const(f_aux0_, 0.f);
-            h_->vfmax_vf(v_aux1_, v, f_aux0_); // max(x,0)  (kept in aux1)
-            load_f32_const(f_aux0_, 0.f);
-            h_->vfmin_vf(v, v, f_aux0_); // min(x,0)
-            exp_compute_vector(v); // exp(min(x,0))
+            h_->vmfgt_vf(v_mask, v_aux1_, f_aux0_);
+            exp_compute_vector(v); // exp(x)
             load_f32_const(f_aux0_, 1.f);
             h_->vfsub_vf(v, v, f_aux0_); // exp(...) - 1
             load_f32_const(f_aux0_, alpha_);
             h_->vfmul_vf(v, v, f_aux0_); // alpha*(...)
-            h_->vfadd_vv(v, v, v_aux1_); // + max(x,0)
+            h_->vmerge_vvm(v, v, v_aux1_);
             break;
 
         case eltwise_swish:

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
@@ -388,6 +388,8 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &v) {
             h_->vfsub_vf(v, v, f_aux0_); // exp(...) - 1
             load_f32_const(f_aux0_, alpha_);
             h_->vfmul_vf(v, v, f_aux0_); // alpha*(...)
+            load_f32_const(f_aux0_, 0.f);
+            h_->vmfgt_vf(v_mask, v_aux1_, f_aux0_);
             h_->vmerge_vvm(v, v, v_aux1_);
             break;
         }

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.hpp
@@ -35,9 +35,8 @@ namespace eltwise_injector {
 // compute_vector(). The host kernel guarantees these registers are dead during
 // post-op application. RVV vector length is a run-time quantity, so the host
 // (which owns the vsetvli state and the accumulator allocation) supplies free
-// vector scratch rather than the injector spilling — this also keeps the v0
-// mask register untouched, which matters for kernels whose accumulators land on
-// v0 (e.g. the brgemm kernel).
+// vector scratch rather than the injector spilling. The injector may use v0 as
+// a mask register, so hosts must keep accumulator groups away from v0.
 struct static_params_t {
     static_params_t(const Xbyak_riscv::VReg &v_aux0,
             const Xbyak_riscv::VReg &v_aux1, const Xbyak_riscv::VReg &v_aux2,
@@ -53,14 +52,12 @@ struct static_params_t {
 
     // Up to three vector scratch groups (same LMUL as the host accumulator).
     // Forward arithmetic algorithms use at most v_aux0; exp/logistic use
-    // v_aux0 and v_aux2; tanh/elu/swish/gelu_tanh use all three. Backward
-    // derivatives may use v_aux0 and v_aux1 plus v0 as a mask.
+    // v_aux0 and v_aux2; tanh/elu/swish/gelu_tanh use all three. Forward and
+    // backward may use v0 as a mask.
     Xbyak_riscv::VReg v_aux0, v_aux1, v_aux2;
     Xbyak_riscv::FReg f_aux0, f_aux1; // two FP scratch regs for constants
     Xbyak_riscv::Reg gpr_aux0; // one GPR scratch for constant materialization
-    // Forward (d = alg(s)) or backward (ds = alg'(s)). Backward is used by the
-    // standalone eltwise primitive, where v0 is free and used as the mask
-    // register; the forward post-op path stays mask-free and leaves v0 alone.
+    // Forward (d = alg(s)) or backward (ds = alg'(s)).
     bool is_fwd;
 };
 
@@ -120,7 +117,7 @@ private:
     void compute_body(const Vmm &v);
     void compute_vector_bwd(const Vmm &v);
     void load_f32_const(const Xbyak_riscv::FReg &f, float val);
-    // mask-free clamp(v, lo, hi); reuses f_aux0_/f_aux1_.
+    // NaN-preserving clamp(v, lo, hi); reuses f_aux0_/f_aux1_ and v0.
     void clamp(const Vmm &v, float lo, float hi);
     // exp(v) in place: range-reduce + Horner poly + 2^n scale. Uses v_aux0
     // and v_aux2; leaves v_aux1 free for callers. Building block for the

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.hpp
@@ -61,9 +61,9 @@ struct static_params_t {
     bool is_fwd;
 };
 
-// Whether the JIT eltwise injector can emit this algorithm. Covers the
-// mask-free arithmetic forward algorithms plus the transcendentals built on the
-// inline-coefficient exp() primitive (exp/logistic/tanh/elu/swish/gelu_tanh).
+// Whether the JIT eltwise injector can emit this algorithm. Covers arithmetic
+// forward algorithms plus the transcendentals built on the inline-coefficient
+// exp() primitive (exp/logistic/tanh/elu/swish/gelu_tanh).
 // Algorithms still needing log/erf (mish, gelu_erf, soft_relu, pow) are not yet
 // supported and fall back to a reference impl (the consumer pd rejects them).
 bool is_alg_supported(alg_kind_t alg);

--- a/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
@@ -79,6 +79,7 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
     const FReg f_sv = fa2;
     const FReg f_zero = fa3;
 
+    const VReg v_mask(0);
     const VReg v_src(4);
     const VReg v_mean(8);
     const VReg v_sm(12);
@@ -115,7 +116,10 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
         vfmul_vf(v_src, v_src, f_sm);
         vfadd_vf(v_src, v_src, f_sv);
     }
-    if (with_relu_) vfmax_vf(v_src, v_src, f_zero);
+    if (with_relu_) {
+        vmflt_vf(v_mask, v_src, f_zero);
+        vfmerge_vfm(v_src, v_src, f_zero);
+    }
     vse32_v(v_src, reg_dst);
 
     slli(reg_bytes, reg_vl, 2);

--- a/src/cpu/rv64/jit_rvv_gemm_convolution_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_gemm_convolution_kernel.cpp
@@ -158,7 +158,7 @@ void jit_rvv_gemm_convolution_apply_scalar_bias_relu(
     for (dim_t i = 0; i < len; ++i) {
         float value = dst[i] + bias;
         if (relu_alpha == 0.0f)
-            value = value > 0.0f ? value : 0.0f;
+            value = value < 0.0f ? 0.0f : value;
         else if (value < 0.0f)
             value *= relu_alpha;
         dst[i] = value * scale;
@@ -209,7 +209,8 @@ void jit_rvv_gemm_convolution_post_kernel_t::generate() {
 
     if (with_relu_) {
         if (relu_alpha_zero_) {
-            vfmax_vf(v_dst, v_dst, f_zero);
+            vmflt_vf(v_mask, v_dst, f_zero);
+            vfmerge_vfm(v_dst, v_dst, f_zero);
         } else {
             vmflt_vf(v_mask, v_dst, f_zero);
             vfmul_vf(v_tmp, v_dst, f_alpha);

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -307,6 +307,7 @@ void jit_rvv_softmax_f16_exp_sub_sum_kernel_t::generate() {
     const VReg v_tmpv(20);
     const VReg v_acc(24);
     const VReg v_red(28);
+    const VReg v_mask(0);
 
     auto load_f32_bits = [&](const FReg &freg, uint32_t bits) {
         li(reg_imm, static_cast<int64_t>(bits));
@@ -350,8 +351,10 @@ void jit_rvv_softmax_f16_exp_sub_sum_kernel_t::generate() {
     vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
     vfsub_vf(v_x, v_x, f_sub);
     vfmv_v_f(v_bias, f_round);
-    vfmax_vf(v_x, v_x, f_lower);
-    vfmin_vf(v_x, v_x, f_upper);
+    vmflt_vf(v_mask, v_x, f_lower);
+    vfmerge_vfm(v_x, v_x, f_lower);
+    vmfgt_vf(v_mask, v_x, f_upper);
+    vfmerge_vfm(v_x, v_x, f_upper);
     vfmacc_vf(v_bias, f_log2_recip, v_x);
     vfsub_vf(v_tmpv, v_bias, f_round);
     vfmacc_vf(v_x, f_log2_high, v_tmpv);

--- a/src/cpu/rv64/jit_uni_binary.cpp
+++ b/src/cpu/rv64/jit_uni_binary.cpp
@@ -141,8 +141,20 @@ void emit_binary_loop(jit_generator_t *h, alg_kind_t alg, bool scalar_src1,
             case binary_sub: h->vfsub_vf(vd, vd, f); break;
             case binary_mul: h->vfmul_vf(vd, vd, f); break;
             case binary_div: h->vfdiv_vf(vd, vd, f); break;
-            case binary_max: h->vfmax_vf(vd, vd, f); break;
-            case binary_min: h->vfmin_vf(vd, vd, f); break;
+            case binary_max:
+                h->vfmv_v_f(vs1, f);
+                h->vmflt_vv(VReg(0), vd, vs1);
+                h->vmerge_vvm(vd, vd, vs1);
+                h->vmfne_vv(VReg(0), vs1, vs1);
+                h->vmerge_vvm(vd, vd, vs1);
+                break;
+            case binary_min:
+                h->vfmv_v_f(vs1, f);
+                h->vmflt_vv(VReg(0), vs1, vd);
+                h->vmerge_vvm(vd, vd, vs1);
+                h->vmfne_vv(VReg(0), vs1, vs1);
+                h->vmerge_vvm(vd, vd, vs1);
+                break;
             // Comparison: dst = (dst OP src1) ? 1 : 0 (vf form has gt/ge).
             case binary_ge:
                 h->vmfge_vf(VReg(0), vd, f);
@@ -177,8 +189,18 @@ void emit_binary_loop(jit_generator_t *h, alg_kind_t alg, bool scalar_src1,
             case binary_sub: h->vfsub_vv(vd, vd, v1); break;
             case binary_mul: h->vfmul_vv(vd, vd, v1); break;
             case binary_div: h->vfdiv_vv(vd, vd, v1); break;
-            case binary_max: h->vfmax_vv(vd, vd, v1); break;
-            case binary_min: h->vfmin_vv(vd, vd, v1); break;
+            case binary_max:
+                h->vmflt_vv(VReg(0), vd, v1);
+                h->vmerge_vvm(vd, vd, v1);
+                h->vmfne_vv(VReg(0), v1, v1);
+                h->vmerge_vvm(vd, vd, v1);
+                break;
+            case binary_min:
+                h->vmflt_vv(VReg(0), v1, vd);
+                h->vmerge_vvm(vd, vd, v1);
+                h->vmfne_vv(VReg(0), v1, v1);
+                h->vmerge_vvm(vd, vd, v1);
+                break;
             // Comparison: vmfgt/vmfge have no vv form, so swap operands
             // (dst > v1 == v1 < dst, dst >= v1 == v1 <= dst).
             case binary_ge:

--- a/src/cpu/rv64/jit_uni_binary.cpp
+++ b/src/cpu/rv64/jit_uni_binary.cpp
@@ -124,8 +124,8 @@ void emit_binary_loop(jit_generator_t *h, alg_kind_t alg, bool scalar_src1,
     }
 
     // Turn the comparison mask in v0 into a 0.0/1.0 result in vd (in the active
-    // f32 compute vtype). v0 is free here (the fwd eltwise post-op chain that
-    // runs afterwards is mask-free), as is fa5/fa6.
+    // f32 compute vtype). The data/aux groups stay away from v0 so later
+    // post-op injectors can also use it as a mask; fa5/fa6 are free here.
     auto cmp_to_01 = [&]() {
         const FReg f_zero = fa5, f_one = fa6;
         h->fmv_w_x(f_zero, x0); // 0.0

--- a/src/cpu/rv64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_pool_kernel.cpp
@@ -278,8 +278,6 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     if (is_max_pool_) {
         vmflt_vv(v_mask, v_acc, v_tmp);
         vmerge_vvm(v_acc, v_acc, v_tmp);
-        vmfne_vv(v_mask, v_tmp, v_tmp);
-        vmerge_vvm(v_acc, v_acc, v_tmp);
     } else {
         vfadd_vv(v_acc, v_acc, v_tmp);
     }
@@ -506,8 +504,6 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
     }
     if (is_max_pool_) {
         vmflt_vv(v_mask, v_acc, v_tmp);
-        vmerge_vvm(v_acc, v_acc, v_tmp);
-        vmfne_vv(v_mask, v_tmp, v_tmp);
         vmerge_vvm(v_acc, v_acc, v_tmp);
     } else {
         // f32m2 += widen(f16m1), evaluated under the e16 vtype.
@@ -753,8 +749,6 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
             if (j * sw <= p && p < j * sw + kw) {
                 if (is_max) {
                     vmflt_vv(v_mask, acc(j), v_tmp);
-                    vmerge_vvm(acc(j), acc(j), v_tmp);
-                    vmfne_vv(v_mask, v_tmp, v_tmp);
                     vmerge_vvm(acc(j), acc(j), v_tmp);
                 } else
                     vfadd_vv(acc(j), acc(j), v_tmp);

--- a/src/cpu/rv64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_pool_kernel.cpp
@@ -152,6 +152,7 @@ template <cpu_isa_t isa, data_type_t d_type>
 void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const Reg reg_param = a0;
+    const VReg v_mask(0);
     const VReg v_acc(4), v_tmp(8);
 
     // Classify a fused binary post-op (if any) to pick the rhs load form. The
@@ -275,7 +276,10 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
         L(src_ld_done);
     }
     if (is_max_pool_) {
-        vfmax_vv(v_acc, v_acc, v_tmp);
+        vmflt_vv(v_mask, v_acc, v_tmp);
+        vmerge_vvm(v_acc, v_acc, v_tmp);
+        vmfne_vv(v_mask, v_tmp, v_tmp);
+        vmerge_vvm(v_acc, v_acc, v_tmp);
     } else {
         vfadd_vv(v_acc, v_acc, v_tmp);
     }
@@ -386,6 +390,7 @@ template <cpu_isa_t isa, data_type_t d_type>
 void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const Reg reg_param = a0;
+    const VReg v_mask(0);
     // max: v_acc(f16m1)=v4, v_tmp(f16m1)=v8.
     // avg: v_acc(f32m2)=v4-v5, v_tmp(f16m1)=v8 (load buffer + narrowed result).
     const VReg v_acc(4), v_tmp(8);
@@ -500,7 +505,10 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
         L(src_ld_done);
     }
     if (is_max_pool_) {
-        vfmax_vv(v_acc, v_acc, v_tmp);
+        vmflt_vv(v_mask, v_acc, v_tmp);
+        vmerge_vvm(v_acc, v_acc, v_tmp);
+        vmfne_vv(v_mask, v_tmp, v_tmp);
+        vmerge_vvm(v_acc, v_acc, v_tmp);
     } else {
         // f32m2 += widen(f16m1), evaluated under the e16 vtype.
         vfwadd_wv(v_acc, v_acc, v_tmp);
@@ -637,6 +645,7 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
     };
 
     const bool is_max = jpp_.alg == alg_kind::pooling_max;
+    const VReg v_mask(0);
     const bool is_avg_exclude
             = jpp_.alg == alg_kind::pooling_avg_exclude_padding;
     const int kw = jpp_.kw;
@@ -742,9 +751,12 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
         vle32_v(v_tmp, t5);
         for (int j = 0; j < ur_w; j++) {
             if (j * sw <= p && p < j * sw + kw) {
-                if (is_max)
-                    vfmax_vv(acc(j), acc(j), v_tmp);
-                else
+                if (is_max) {
+                    vmflt_vv(v_mask, acc(j), v_tmp);
+                    vmerge_vvm(acc(j), acc(j), v_tmp);
+                    vmfne_vv(v_mask, v_tmp, v_tmp);
+                    vmerge_vvm(acc(j), acc(j), v_tmp);
+                } else
                     vfadd_vv(acc(j), acc(j), v_tmp);
             }
         }

--- a/src/cpu/rv64/jit_uni_pooling.cpp
+++ b/src/cpu/rv64/jit_uni_pooling.cpp
@@ -72,7 +72,7 @@ data_t empty_window_value(const jit_pool_conf_t &jpp) {
         float v = (float)nstl::numeric_limits<data_t>::lowest();
         if (jpp.with_relu) { // fused only for f32
             if (jpp.relu_alpha == 0.0f)
-                v = std::max(v, 0.0f);
+                v = v < 0.0f ? 0.0f : v;
             else if (v <= 0.0f)
                 v *= jpp.relu_alpha;
         }

--- a/src/cpu/rv64/jit_uni_postops_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_postops_kernel.cpp
@@ -68,10 +68,9 @@ struct jit_uni_postops_kernel_t::impl_t : public jit_generator_t {
         ld(reg_rhs, reg_param, GET_OFF(rhs));
         ld(reg_len, reg_param, GET_OFF(len));
 
-        // Accumulator group v0 (m4). No masks are used by the injectors, so v0
-        // is safe as the data register. Aux groups follow at the m4 stride;
-        // v20 is the per-element bias staging group.
-        const VReg v_data(0);
+        // Accumulator group v24 (m4). The injectors may use v0 as a mask
+        // register, so the data register group must not overlap it.
+        const VReg v_data(24);
         const VReg v_bias(20);
         const FReg f_bias = fa3;
         eltwise_injector::static_params_t esp(


### PR DESCRIPTION
## Description

This PR fixes NaN handling in RV64/RVV JIT paths that use min/max, clamp, ReLU, ELU, binary min/max, pooling max, and related fused post-op paths.

The previous implementation used RVV floating-point min/max instructions such as `vfmax` / `vfmin` for operations like ReLU, clamp, binary min/max, and max pooling. These instructions do not preserve the expected oneDNN reference behavior for NaN inputs in these paths. As a result, NaN lanes could be replaced by finite values such as `0` or by clamping bounds, and `exp(NaN)` could incorrectly become `inf` after the range clamp.

This PR changes the affected RV64 JIT code to use explicit compare + merge sequences so that comparisons involving NaN evaluate false and NaN lanes keep the expected NaN result.

## Problem

Several RV64 JIT paths mishandled NaN values. For example:

* ReLU with `alpha=0` returned `0` for NaN inputs.
* CLIP returned the lower bound for NaN inputs.
* ELU returned `0` for NaN inputs.
* EXP could return `inf` for NaN inputs because the input was clamped before polynomial evaluation.
* Binary min/max could return a finite operand instead of propagating NaN as expected by the reference result.
* Fused ReLU paths in batch normalization and convolution also replaced NaN with `0`.

This caused benchdnn mismatches on imported NaN test data.

## Root cause

The RV64 implementation relied on `vfmax` / `vfmin` or equivalent max/min-style logic for several operations. These instructions are not suitable when the desired behavior is to preserve NaN lanes according to the oneDNN reference result used by these tests.

For NaN inputs, floating-point comparisons are false. Therefore, using explicit compare + merge logic allows non-NaN lanes to be clamped or selected normally while preserving NaN lanes.

## Fix

This PR replaces the affected min/max-style implementations with NaN-preserving compare + merge sequences.

The main changes include:

* Make eltwise `clamp()` NaN-preserving.
* Make ReLU preserve NaN instead of replacing it with `0`.
* Make ELU preserve NaN through the selected branch.
* Make EXP use the NaN-preserving clamp helper before range reduction.
* Make binary min/max propagate NaN according to the expected result.
* Make RV64 batch normalization fused ReLU preserve NaN.
* Make RV64 GEMM convolution fused ReLU preserve NaN.
* Make max pooling use explicit compare + merge to match reference comparison-update semantics. Unlike binary min/max, max pooling does not force propagation of source NaNs; NaN inputs do not update the accumulator because the comparison is false.
* Update RV64 injector register assumptions because forward paths may now use `v0` as a mask register.

## Validation
Tha validation is on SpacemiT(R) k3 X100.

I ran the RV64 NaN regression script before and after the fix:

[rv64_clamp_nan_cases.sh](https://github.com/user-attachments/files/29178070/rv64_clamp_nan_cases.sh)

Before the fix, NaN results were replaced by finite values in multiple paths, for example:

* `RELU`: `exp: nan`, `got: 0`
* `CLIP`: `exp: nan`, `got: 0`
* `ELU`: `exp: nan`, `got: 0`
* `EXP`: `exp: nan`, `got: inf`
* `binary_max` / `binary_min`: some NaN cases returned finite values such as `0`, `1`, or `5`
* fused ReLU in bnorm/conv: `exp: nan`, `got: 0`

After the fix, these cases produce `got: nan`, matching the expected numerical result.

Some benchdnn cases still print `FAILED` even after the fix. This is expected for these imported NaN test cases because `NaN != NaN` by definition. The important part is that the output changed from finite incorrect values to `nan`.

<details>
<summary>Before fix log</summary>

<pre><code>bianbu@k3:~/oneDNN-test/build-weekly/build/tests/benchdnn$ ./rv64_clamp_nan_cases.sh

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_relu --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=RELU --alpha=0 8
[   0][DST][0] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=4e-06 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_relu --alg=relu --alpha=0 --beta=0 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_clip --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=CLIP --alpha=0 --beta=6 8
[   0][DST][0] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=4e-06 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (4 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_clip --alg=clip --alpha=0 --beta=6 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_elu --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=ELU --alpha=1 8
[   0][DST][0] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=4e-05 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_elu --alg=elu --alpha=1 --beta=0 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_exp --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=EXP 8
[   0][DST][0] exp_f32:         nan exp:         nan got:         inf diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         inf diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=4e-06 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:3.8147e-06 all_max_rdiff:6.98686e-08
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_exp --alg=exp --alpha=0 --beta=0 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_max --binary --alg=MAX --sdt=f32:f32 --ddt=f32 --stag=abx:abx --dtag=abx 8:8
[   0][DST][0] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[   1][DST][1] exp_f32:         nan exp:         nan got:           1 diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   6][DST][6] exp_f32:         nan exp:         nan got:           5 diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=1.19209e-07 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:4 total:8) (3 ms) __REPRO: --binary --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_max --stag=abx:abx --dtag=abx --alg=max 8:8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_min --binary --alg=MIN --sdt=f32:f32 --ddt=f32 --stag=abx:abx --dtag=abx 8:8
[   0][DST][0] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[   1][DST][1] exp_f32:         nan exp:         nan got:           1 diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   6][DST][6] exp_f32:         nan exp:         nan got:           5 diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=1.19209e-07 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:4 total:8) (2 ms) __REPRO: --binary --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_min --stag=abx:abx --dtag=abx --alg=min 8:8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_bnorm_relu --bnorm --dir=FWD_I --dt=f32 --tag=nchw --flags=GR mb1ic1_ih1iw8
[   0][DST][0:0:0:0] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[   4][DST][0:0:0:4] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=6e-07 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --bnorm --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_bnorm_relu --dir=FWD_I --tag=nchw --flags=GR mb1ic1ih1iw8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_conv_relu --conv --dir=FWD_D --dt=f32 --stag=ncw --wtag=oiw --dtag=ncw --attr-post-ops=relu mb1ic1_oc1_iw1ow1kw1sw1
[   0][DST][0:0:0] exp_f32:         nan exp:         nan got:           0 diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=0 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:1 total:1) (3 ms) __REPRO: --conv --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_conv_relu --dir=FWD_D --stag=ncw --wtag=oiw --dtag=ncw --attr-post-ops=relu mb1ic1iw1oc1ow1kw1pw0
</code></pre>

</details>

<details>
<summary>After fix log</summary>

<pre><code>bianbu@k3:~/oneDNN-test/fix/build/tests/benchdnn$ ./rv64_clamp_nan_cases.sh

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_relu --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=RELU --alpha=0 8
[   0][DST][0] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=4e-06 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_relu --alg=relu --alpha=0 --beta=0 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_clip --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=CLIP --alpha=0 --beta=6 8
[   0][DST][0] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=4e-06 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_clip --alg=clip --alpha=0 --beta=6 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_elu --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=ELU --alpha=1 8
[   0][DST][0] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=4e-05 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_elu --alg=elu --alpha=1 --beta=0 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_exp --eltwise --dir=FWD_D --dt=f32 --tag=abx --alg=EXP 8
0:PASSED (2 ms) __REPRO: --eltwise --buffer-prefix=/tmp/onednn_rv64_nan_c054f5_exp --alg=exp --alpha=0 --beta=0 8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_max --binary --alg=MAX --sdt=f32:f32 --ddt=f32 --stag=abx:abx --dtag=abx 8:8
[   0][DST][0] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   1][DST][1] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   6][DST][6] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=1.19209e-07 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:4 total:8) (5 ms) __REPRO: --binary --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_max --stag=abx:abx --dtag=abx --alg=max 8:8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_min --binary --alg=MIN --sdt=f32:f32 --ddt=f32 --stag=abx:abx --dtag=abx 8:8
[   0][DST][0] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   1][DST][1] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   4][DST][4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   6][DST][6] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=1.19209e-07 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:4 total:8) (5 ms) __REPRO: --binary --buffer-prefix=/tmp/onednn_rv64_nan_25f3a6_binary_min --stag=abx:abx --dtag=abx --alg=min 8:8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_bnorm_relu --bnorm --dir=FWD_I --dt=f32 --tag=nchw --flags=GR mb1ic1_ih1iw8
[   0][DST][0:0:0:0] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[   4][DST][0:0:0:4] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=6e-07 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:2 total:8) (2 ms) __REPRO: --bnorm --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_bnorm_relu --dir=FWD_I --tag=nchw --flags=GR mb1ic1ih1iw8

./benchdnn --engine=cpu --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_conv_relu --conv --dir=FWD_D --dt=f32 --stag=ncw --wtag=oiw --dtag=ncw --attr-post-ops=relu mb1ic1_oc1_iw1ow1kw1sw1
[   0][DST][0:0:0] exp_f32:         nan exp:         nan got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=0 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
Note: importing data from a file led to a correctness issue. It is impossible to tell if that was a real oneDNN bug or just benchdnn refusing to acknowledge a minuscule difference as a match. Take this 'FAILED' with a grain of salt, and proceed with extra caution.
0:FAILED (errors:1 total:1) (3 ms) __REPRO: --conv --buffer-prefix=/tmp/onednn_rv64_nan_1da5f7_conv_relu --dir=FWD_D --stag=ncw --wtag=oiw --dtag=ncw --attr-post-ops=relu mb1ic1iw1oc1ow1kw1pw0
</code></pre>

</details>
