### PR TITLE
cpu: rv64: remove unused f32 path in ip

### DIFF
--- a/src/cpu/rv64/rvv_gemm_inner_product.hpp
+++ b/src/cpu/rv64/rvv_gemm_inner_product.hpp
@@ -27,6 +27,8 @@
 #include "cpu/cpu_inner_product_pd.hpp"
 #include "cpu/platform.hpp"
 
+#include "cpu/rv64/cpu_isa_traits.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -47,6 +49,10 @@ struct rvv_gemm_inner_product_fwd_t : public primitive_t {
             const auto wei_type = weights_md(0)->data_type;
             const auto dst_type = dst_md(0)->data_type;
             const auto bia_type = weights_md(1)->data_type;
+
+            // V is not part of the RV64 baseline; the JIT GEMM kernel emits
+            // vector instructions, so gate on runtime ISA detection.
+            VDISPATCH_INNER_PRODUCT(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
 
             VDISPATCH_INNER_PRODUCT(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_INNER_PRODUCT(

--- a/src/cpu/rv64/rvv_inner_product.cpp
+++ b/src/cpu/rv64/rvv_inner_product.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  ******************************************************************************/
 
-#include <riscv_vector.h>
+#include <cmath>
 
 #include "cpu/rv64/jit_rvv_inner_product_kernel.hpp"
 #include "cpu/rv64/rvv_inner_product.hpp"
@@ -48,26 +48,6 @@ dim_t get_ip_weights_off(const memory_desc_wrapper &mdw, int ndims, dim_t oc,
     }
 }
 
-float compute_ip_rvv_fwd_f32_f32(
-        const void *src, const void *weights, const dim_t len) {
-    const float *x = reinterpret_cast<const float *>(src);
-    const float *w = reinterpret_cast<const float *>(weights);
-
-    float acc_scalar = 0.0f;
-    for (dim_t i = 0; i < len;) {
-        size_t vl = __riscv_vsetvl_e32m1(static_cast<size_t>(len - i));
-        vfloat32m1_t vx = __riscv_vle32_v_f32m1(x + i, vl);
-        vfloat32m1_t vw = __riscv_vle32_v_f32m1(w + i, vl);
-        vfloat32m1_t vprod = __riscv_vfmul_vv_f32m1(vx, vw, vl);
-        vfloat32m1_t vzero = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-        vfloat32m1_t vred = __riscv_vfredusum_vs_f32m1_f32m1(vprod, vzero, vl);
-        float partial = __riscv_vfmv_f_s_f32m1_f32(vred);
-        acc_scalar += partial;
-        i += static_cast<dim_t>(vl);
-    }
-    return acc_scalar;
-}
-
 float compute_ip_rvv_fwd_s8_s8(
         const void *src, const void *weights, const dim_t len) {
     return jit_rvv_inner_product_fwd_s8_s8(src, weights, len);
@@ -82,11 +62,6 @@ float compute_ip_rvv_fwd(const void *src_base, const void *wei_base,
         const dim_t len, const data_type_t src_dt, const data_type_t wei_dt) {
     float acc = 0.0f;
     switch (src_dt) {
-        case data_type::f32:
-            if (wei_dt == data_type::f32) {
-                acc = compute_ip_rvv_fwd_f32_f32(src_base, wei_base, len);
-            }
-            break;
         case data_type::s8:
             if (wei_dt == data_type::s8) {
                 acc = compute_ip_rvv_fwd_s8_s8(src_base, wei_base, len);

--- a/src/cpu/rv64/rvv_inner_product.hpp
+++ b/src/cpu/rv64/rvv_inner_product.hpp
@@ -27,6 +27,8 @@
 #include "cpu/cpu_inner_product_pd.hpp"
 #include "cpu/platform.hpp"
 
+#include "cpu/rv64/cpu_isa_traits.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -36,10 +38,14 @@ struct rvv_inner_product_fwd_t : public primitive_t {
     struct pd_t : public cpu_inner_product_fwd_pd_t {
         using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T_("RISCV64GCV", rvv_inner_product_fwd_t);
+        DECLARE_COMMON_PD_T("jit:rvv", rvv_inner_product_fwd_t);
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
+
+            // V is not part of the RV64 baseline and the JIT kernel emits vector
+            // instructions, so gate on runtime ISA detection.
+            VDISPATCH_INNER_PRODUCT(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
 
             const auto src_type = src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;
@@ -53,9 +59,6 @@ struct rvv_inner_product_fwd_t : public primitive_t {
             VDISPATCH_INNER_PRODUCT(
                     check_types(src_type, wei_type, dst_type, bia_type),
                     VERBOSE_UNSUPPORTED_DT);
-#if !(defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1)
-            VDISPATCH_INNER_PRODUCT(false, VERBOSE_UNSUPPORTED_ISA);
-#endif
 
             using smask_t = primitive_attr_t::skip_mask_t;
             VDISPATCH_INNER_PRODUCT(attr()->has_default_values(smask_t::none),
@@ -99,8 +102,10 @@ struct rvv_inner_product_fwd_t : public primitive_t {
                 const data_type_t &bia_type) const {
             using namespace data_type;
             const bool dst_ok = utils::one_of(dst_type, f32, s32, s8, u8);
-            const bool src_wei_ok = (src_type == f32 && wei_type == f32)
-                    || (src_type == s8 && wei_type == s8)
+            // This implementation is registered only for the int8 (xi8:s8)
+            // dispatch list; f32 inner product is served by the gemm/brgemm
+            // implementations. Gate to exactly what the JIT kernel implements.
+            const bool src_wei_ok = (src_type == s8 && wei_type == s8)
                     || (src_type == u8 && wei_type == s8);
             const bool bia_ok = IMPLICATION(
                     with_bias(), utils::one_of(bia_type, f32, src_type));


### PR DESCRIPTION
## Summary

Completes the RV64 inner-product migration away from RVV C intrinsics and tidies up the
int8 implementation's dispatch gating and naming:

- Remove the last RVV intrinsic in the RV64 backend — a **dead `f32` path** in
  `rvv_inner_product.cpp`. After this PR and #5363 merged,  no file under `src/cpu/rv64/` includes
  `<riscv_vector.h>`; the backend is intrinsic-free.
- Tighten the int8 PD dtype gate to exactly what the kernel implements (`s8`/`u8`).
- Add the missing runtime `mayiuse(v)` ISA gate to the int8 and gemm inner-product PDs,
  and drop a vestigial compile-time guard.
- Rename the (now pure-JIT) int8 implementation `RISCV64GCV` → `jit:rvv`.

No functional change for any live path: the int8 `s8`/`u8` kernels are untouched, and
`f32` inner product was already served by the gemm/brgemm implementations.

## Follow-ups (not in this change)

- After this PR and #5363 merged, remove CMake remnants, macro definitions, and the like, and truly transition rv64 from compile-time feature detection to runtime dispatch.
