### PR TITLE
cpu: rv64: tune RVV f32 GEMM micro-kernel

### DIFF
--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
@@ -17,6 +17,10 @@
 #include "cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp"
 #include "common/verbose.hpp"
 
+#include <array>
+#include <memory>
+#include <mutex>
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -261,32 +265,38 @@ void jit_rvv_gemm_kernel_t::generate() {
 namespace {
 
 template <bool isTransA, bool isTransB>
+struct jit_rvv_gemm_kernel_storage_t {
+    std::array<std::unique_ptr<jit_rvv_gemm_kernel_t>, 8> nb;
+    std::array<std::unique_ptr<jit_rvv_gemm_kernel_t>, 8> b;
+    jit_rvv_gemm_kernel_table_t table;
+};
+
+template <bool isTransA, bool isTransB>
+jit_rvv_gemm_kernel_storage_t<isTransA, isTransB> &
+get_jit_rvv_gemm_kernel_storage() {
+    static jit_rvv_gemm_kernel_storage_t<isTransA, isTransB> storage;
+    static std::once_flag initialized;
+
+    std::call_once(initialized, [] {
+        for (dim_t n_cols = 1; n_cols <= 7; n_cols++) {
+            storage.nb[n_cols].reset(new jit_rvv_gemm_kernel_t(
+                    n_cols, isTransA, isTransB, false));
+            storage.b[n_cols].reset(new jit_rvv_gemm_kernel_t(
+                    n_cols, isTransA, isTransB, true));
+            storage.table.nb[n_cols] = storage.nb[n_cols].get();
+            storage.table.b[n_cols] = storage.b[n_cols].get();
+        }
+    });
+
+    return storage;
+}
+
+template <bool isTransA, bool isTransB>
 void jit_rvv_gemm_kernel_dispatch(const float *A, const float *B, float *C,
         dim_t lda, dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta,
         dim_t m, dim_t n_cols, const float *bias) {
-    // Kernels without fused bias (same code size as upstream)
-    static jit_rvv_gemm_kernel_t nb1(1, isTransA, isTransB, false);
-    static jit_rvv_gemm_kernel_t nb2(2, isTransA, isTransB, false);
-    static jit_rvv_gemm_kernel_t nb3(3, isTransA, isTransB, false);
-    static jit_rvv_gemm_kernel_t nb4(4, isTransA, isTransB, false);
-    static jit_rvv_gemm_kernel_t nb5(5, isTransA, isTransB, false);
-    static jit_rvv_gemm_kernel_t nb6(6, isTransA, isTransB, false);
-    static jit_rvv_gemm_kernel_t nb7(7, isTransA, isTransB, false);
-
-    static jit_rvv_gemm_kernel_t *arr_nb[]
-            = {nullptr, &nb1, &nb2, &nb3, &nb4, &nb5, &nb6, &nb7};
-
-    // Kernels with fused bias
-    static jit_rvv_gemm_kernel_t b1(1, isTransA, isTransB, true);
-    static jit_rvv_gemm_kernel_t b2(2, isTransA, isTransB, true);
-    static jit_rvv_gemm_kernel_t b3(3, isTransA, isTransB, true);
-    static jit_rvv_gemm_kernel_t b4(4, isTransA, isTransB, true);
-    static jit_rvv_gemm_kernel_t b5(5, isTransA, isTransB, true);
-    static jit_rvv_gemm_kernel_t b6(6, isTransA, isTransB, true);
-    static jit_rvv_gemm_kernel_t b7(7, isTransA, isTransB, true);
-
-    static jit_rvv_gemm_kernel_t *arr_b[]
-            = {nullptr, &b1, &b2, &b3, &b4, &b5, &b6, &b7};
+    const auto &table
+            = get_jit_rvv_gemm_kernel_storage<isTransA, isTransB>().table;
 
     static bool verbose_printed = false;
     if (!verbose_printed) {
@@ -308,11 +318,25 @@ void jit_rvv_gemm_kernel_dispatch(const float *A, const float *B, float *C,
     p.beta = beta;
     p.bias = bias;
 
-    jit_rvv_gemm_kernel_t **arr = bias ? arr_b : arr_nb;
-    (*arr[n_cols])(&p);
+    const jit_rvv_gemm_kernel_t *kernel
+            = bias ? table.b[n_cols] : table.nb[n_cols];
+    (*kernel)(&p);
 }
 
 } // namespace
+
+const jit_rvv_gemm_kernel_table_t &get_jit_rvv_gemm_kernel_table(
+        bool isTransA, bool isTransB) {
+    if (!isTransA && !isTransB) {
+        return get_jit_rvv_gemm_kernel_storage<false, false>().table;
+    } else if (isTransA && !isTransB) {
+        return get_jit_rvv_gemm_kernel_storage<true, false>().table;
+    } else if (!isTransA && isTransB) {
+        return get_jit_rvv_gemm_kernel_storage<false, true>().table;
+    } else {
+        return get_jit_rvv_gemm_kernel_storage<true, true>().table;
+    }
+}
 
 void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
         dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m,

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
@@ -56,7 +56,6 @@ void jit_rvv_gemm_kernel_t::generate() {
     const Reg reg_beta_bits = t5;
 
     const Reg reg_k = a4; // current k counter
-    const Reg reg_K_main = a5; // (K / 4) * 4
     const Reg reg_B0_ptr = a6; // running pointer into B
     const Reg reg_tmp0 = a7;
     const FReg freg_alpha = fa0;
@@ -65,7 +64,9 @@ void jit_rvv_gemm_kernel_t::generate() {
 
     const VReg v_c[7] = {
             VReg(0), VReg(4), VReg(8), VReg(12), VReg(16), VReg(20), VReg(24)};
-    const VReg v_a(28);
+    const VReg v_a0(24);
+    const VReg v_a1(28);
+    const VReg v_tmp = v_a0;
 
     // Layout of call_params_t:
     //   0  : const float *A
@@ -107,42 +108,73 @@ void jit_rvv_gemm_kernel_t::generate() {
     for (dim_t c = 0; c < n_cols_; c++)
         vmv_v_i(v_c[c], 0);
 
-    mv(reg_K_main, reg_K);
-    srli(reg_tmp3, reg_K_main, 2);
-    slli(reg_K_main, reg_tmp3, 2);
-
-    auto emit_k_step = [&]() {
+    auto emit_load_a = [&](const VReg &v_a) {
         if (isTransA_) {
             vlse32_v(v_a, reg_A_ptr, reg_lda_bytes);
         } else {
             vle32_v(v_a, reg_A_ptr);
         }
+    };
 
+    auto emit_load_b_to = [&](const FReg *freg_dst) {
         if (isTransB_) {
             for (dim_t c = 0; c < n_cols_; c++) {
-                flw(freg_b[c], reg_B0_ptr, static_cast<int32_t>(c * 4));
+                flw(freg_dst[c], reg_B0_ptr, static_cast<int32_t>(c * 4));
             }
         } else {
-            flw(freg_b[0], reg_B0_ptr, 0);
+            flw(freg_dst[0], reg_B0_ptr, 0);
             if (n_cols_ > 1) {
                 add(reg_tmp0, reg_B0_ptr, reg_ldb_bytes);
-                flw(freg_b[1], reg_tmp0, 0);
+                flw(freg_dst[1], reg_tmp0, 0);
                 for (dim_t c = 2; c < n_cols_; c++) {
                     add(reg_tmp0, reg_tmp0, reg_ldb_bytes);
-                    flw(freg_b[c], reg_tmp0, 0);
+                    flw(freg_dst[c], reg_tmp0, 0);
                 }
             }
         }
+    };
 
+    auto emit_load_b = [&]() { emit_load_b_to(freg_b); };
+
+    auto emit_compute_from = [&](const FReg *freg_src, const VReg &v_a) {
         for (dim_t c = 0; c < n_cols_; c++)
-            vfmacc_vf(v_c[c], freg_b[c], v_a);
+            vfmacc_vf(v_c[c], freg_src[c], v_a);
+    };
 
+    auto emit_compute
+            = [&](const VReg &v_a) { emit_compute_from(freg_b, v_a); };
+
+    auto emit_load_b_scattered_compute = [&](const VReg &v_a) {
+        if (isTransB_) {
+            emit_load_b();
+            emit_compute(v_a);
+        } else {
+            flw(freg_b[0], reg_B0_ptr, 0);
+            if (n_cols_ == 1) {
+                vfmacc_vf(v_c[0], freg_b[0], v_a);
+            } else {
+                add(reg_tmp0, reg_B0_ptr, reg_ldb_bytes);
+                flw(freg_b[1], reg_tmp0, 0);
+                vfmacc_vf(v_c[0], freg_b[0], v_a);
+                for (dim_t c = 2; c < n_cols_; c++) {
+                    add(reg_tmp0, reg_tmp0, reg_ldb_bytes);
+                    flw(freg_b[c], reg_tmp0, 0);
+                    vfmacc_vf(v_c[c - 1], freg_b[c - 1], v_a);
+                }
+                vfmacc_vf(v_c[n_cols_ - 1], freg_b[n_cols_ - 1], v_a);
+            }
+        }
+    };
+
+    auto emit_advance_a = [&]() {
         if (isTransA_) {
             addi(reg_A_ptr, reg_A_ptr, 4);
         } else {
             add(reg_A_ptr, reg_A_ptr, reg_lda_bytes);
         }
+    };
 
+    auto emit_advance_b = [&]() {
         if (isTransB_) {
             add(reg_B0_ptr, reg_B0_ptr, reg_ldb_bytes);
         } else {
@@ -152,32 +184,84 @@ void jit_rvv_gemm_kernel_t::generate() {
 
     mv(reg_k, x0);
 
-    Label label_k_main_loop, label_k_main_end;
-    Label label_k_tail_loop, label_k_tail_end;
+    if (!isTransB_) {
+        Label label_k_done;
+        Label label_loop_a0, label_loop_a1;
+        Label label_drain_a0, label_drain_a1;
 
-    L(label_k_main_loop);
-    bge(reg_k, reg_K_main, label_k_main_end);
+        bge(reg_k, reg_K, label_k_done);
 
-    emit_k_step();
-    emit_k_step();
-    emit_k_step();
-    emit_k_step();
+        emit_load_a(v_a0);
+        addi(reg_k, reg_k, 1);
+        bge(reg_k, reg_K, label_drain_a0);
 
-    addi(reg_k, reg_k, 4);
-    j_(label_k_main_loop);
+        L(label_loop_a0);
+        emit_advance_a();
+        emit_load_a(v_a1);
+        emit_load_b_scattered_compute(v_a0);
+        emit_advance_b();
+        addi(reg_k, reg_k, 1);
+        bge(reg_k, reg_K, label_drain_a1);
 
-    L(label_k_main_end);
+        L(label_loop_a1);
+        emit_advance_a();
+        emit_load_a(v_a0);
+        emit_load_b_scattered_compute(v_a1);
+        emit_advance_b();
+        addi(reg_k, reg_k, 1);
+        bge(reg_k, reg_K, label_drain_a0);
+        j_(label_loop_a0);
 
-    // Tail K loop for K % 4
-    L(label_k_tail_loop);
-    bge(reg_k, reg_K, label_k_tail_end);
+        L(label_drain_a0);
+        emit_load_b_scattered_compute(v_a0);
+        j_(label_k_done);
 
-    emit_k_step();
+        L(label_drain_a1);
+        emit_load_b_scattered_compute(v_a1);
+        j_(label_k_done);
 
-    addi(reg_k, reg_k, 1);
-    j_(label_k_tail_loop);
+        L(label_k_done);
+    } else {
+        Label label_k_done;
+        Label label_loop_a0, label_loop_a1;
+        Label label_drain_a0, label_drain_a1;
 
-    L(label_k_tail_end);
+        bge(reg_k, reg_K, label_k_done);
+
+        emit_load_a(v_a0);
+        emit_load_b();
+        addi(reg_k, reg_k, 1);
+        bge(reg_k, reg_K, label_drain_a0);
+
+        L(label_loop_a0);
+        emit_advance_a();
+        emit_advance_b();
+        emit_load_a(v_a1);
+        emit_compute(v_a0);
+        emit_load_b();
+        addi(reg_k, reg_k, 1);
+        bge(reg_k, reg_K, label_drain_a1);
+
+        L(label_loop_a1);
+        emit_advance_a();
+        emit_advance_b();
+        emit_load_a(v_a0);
+        emit_compute(v_a1);
+        emit_load_b();
+        addi(reg_k, reg_k, 1);
+        bge(reg_k, reg_K, label_drain_a0);
+        j_(label_loop_a0);
+
+        L(label_drain_a0);
+        emit_compute(v_a0);
+        j_(label_k_done);
+
+        L(label_drain_a1);
+        emit_compute(v_a1);
+        j_(label_k_done);
+
+        L(label_k_done);
+    }
 
     if (has_bias_) {
         // C-update with fused bias: result = alpha*acc + beta*C + bias
@@ -195,25 +279,25 @@ void jit_rvv_gemm_kernel_t::generate() {
 
             beq(reg_beta_bits, x0, label_beta_zero);
 
-            vle32_v(v_a, reg_tmp3);
-            vfmul_vf(v_a, v_a, freg_beta);
+            vle32_v(v_tmp, reg_tmp3);
+            vfmul_vf(v_tmp, v_tmp, freg_beta);
             vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
-            vfadd_vv(v_a, v_a, v_c[col_idx]);
+            vfadd_vv(v_tmp, v_tmp, v_c[col_idx]);
 
             beq(reg_bias_ptr, x0, label_skip_bias);
             vle32_v(v_c[col_idx], reg_bias_ptr);
-            vfadd_vv(v_a, v_a, v_c[col_idx]);
+            vfadd_vv(v_tmp, v_tmp, v_c[col_idx]);
             L(label_skip_bias);
 
-            vse32_v(v_a, reg_tmp3);
+            vse32_v(v_tmp, reg_tmp3);
             j_(label_done);
 
             L(label_beta_zero);
             vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
 
             beq(reg_bias_ptr, x0, label_c_store);
-            vle32_v(v_a, reg_bias_ptr);
-            vfadd_vv(v_c[col_idx], v_c[col_idx], v_a);
+            vle32_v(v_tmp, reg_bias_ptr);
+            vfadd_vv(v_c[col_idx], v_c[col_idx], v_tmp);
 
             L(label_c_store);
             vse32_v(v_c[col_idx], reg_tmp3);
@@ -238,11 +322,11 @@ void jit_rvv_gemm_kernel_t::generate() {
 
             beq(reg_beta_bits, x0, label_beta_zero);
 
-            vle32_v(v_a, reg_tmp3);
-            vfmul_vf(v_a, v_a, freg_beta);
+            vle32_v(v_tmp, reg_tmp3);
+            vfmul_vf(v_tmp, v_tmp, freg_beta);
             vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
-            vfadd_vv(v_a, v_a, v_c[col_idx]);
-            vse32_v(v_a, reg_tmp3);
+            vfadd_vv(v_tmp, v_tmp, v_c[col_idx]);
+            vse32_v(v_tmp, reg_tmp3);
             j_(label_done);
 
             L(label_beta_zero);
@@ -278,7 +362,7 @@ get_jit_rvv_gemm_kernel_storage() {
     static std::once_flag initialized;
 
     std::call_once(initialized, [] {
-        for (dim_t n_cols = 1; n_cols <= 7; n_cols++) {
+        for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
             storage.nb[n_cols].reset(new jit_rvv_gemm_kernel_t(
                     n_cols, isTransA, isTransB, false));
             storage.b[n_cols].reset(new jit_rvv_gemm_kernel_t(
@@ -289,38 +373,6 @@ get_jit_rvv_gemm_kernel_storage() {
     });
 
     return storage;
-}
-
-template <bool isTransA, bool isTransB>
-void jit_rvv_gemm_kernel_dispatch(const float *A, const float *B, float *C,
-        dim_t lda, dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta,
-        dim_t m, dim_t n_cols, const float *bias) {
-    const auto &table
-            = get_jit_rvv_gemm_kernel_storage<isTransA, isTransB>().table;
-
-    static bool verbose_printed = false;
-    if (!verbose_printed) {
-        VINFO(primitive, create, dispatch, rvv_gemm_jit,
-                "JIT gemm kernel taking over: m=%d, n=%d", (int)m, (int)n_cols);
-        verbose_printed = true;
-    }
-
-    jit_rvv_gemm_kernel_t::call_params_t p;
-    p.A = A;
-    p.B = B;
-    p.C = C;
-    p.lda = lda;
-    p.ldb = ldb;
-    p.ldc = ldc;
-    p.K = K;
-    p.m = m;
-    p.alpha = alpha;
-    p.beta = beta;
-    p.bias = bias;
-
-    const jit_rvv_gemm_kernel_t *kernel
-            = bias ? table.b[n_cols] : table.nb[n_cols];
-    (*kernel)(&p);
 }
 
 } // namespace
@@ -335,24 +387,6 @@ const jit_rvv_gemm_kernel_table_t &get_jit_rvv_gemm_kernel_table(
         return get_jit_rvv_gemm_kernel_storage<false, true>().table;
     } else {
         return get_jit_rvv_gemm_kernel_storage<true, true>().table;
-    }
-}
-
-void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
-        dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m,
-        dim_t n_cols, bool isTransA, bool isTransB, const float *bias) {
-    if (!isTransA && !isTransB) {
-        jit_rvv_gemm_kernel_dispatch<false, false>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
-    } else if (isTransA && !isTransB) {
-        jit_rvv_gemm_kernel_dispatch<true, false>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
-    } else if (!isTransA && isTransB) {
-        jit_rvv_gemm_kernel_dispatch<false, true>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
-    } else {
-        jit_rvv_gemm_kernel_dispatch<true, true>(
-                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols, bias);
     }
 }
 

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
@@ -35,23 +35,24 @@ namespace gemm_utils {
 //
 // Design choices:
 //   - LMUL is fixed to m4 (4 vector registers per group)
-//   - n_cols is fixed at JIT compile time (1..7), determining the number
+//   - n_cols is fixed at JIT compile time (1..6), determining the number
 //     of accumulator register groups emitted
 //   - m (tile height) is a runtime parameter; the JIT code uses vsetvli
 //     to set VL accordingly, so any m <= VLEN/32*4 is supported
 //   - isTransA/isTransB determine A/B memory access patterns
 //
-// Vector register layout (LMUL=m4, 8 groups of 4 regs):
+// Vector register layout (LMUL=m4):
 //   v0..v3   : accumulator c0 (column 0)
 //   v4..v7   : accumulator c1 (column 1)
 //   v8..v11  : accumulator c2 (column 2)
 //   v12..v15 : accumulator c3 (column 3)
 //   v16..v19 : accumulator c4 (column 4)
 //   v20..v23 : accumulator c5 (column 5)
-//   v24..v27 : accumulator c6 (column 6)
-//   v28..v31 : temporary for A loads and C update
+//   v24..v27 : A double-buffer 0 (also reused as C-update temporary)
+//   v28..v31 : A double-buffer 1
 //
-// When n_cols < 7, only the first n_cols accumulator groups are used.
+// The kernel uses n_cols in 1..6 with two LMUL=m4 A buffers to overlap
+// vle32.v on A with vfmacc.vf across consecutive K iterations.
 struct jit_rvv_gemm_kernel_t : public jit_generator_t {
     struct call_params_t {
         const float *A;
@@ -69,7 +70,7 @@ struct jit_rvv_gemm_kernel_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_kernel_t)
 
-    // Construct a JIT kernel for a specific n_cols (1..7), transpose modes,
+    // Construct a JIT kernel for a specific n_cols (1..6), transpose modes,
     // and optional fused-bias support.
     jit_rvv_gemm_kernel_t(
             dim_t n_cols, bool isTransA, bool isTransB, bool has_bias);

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
@@ -19,6 +19,8 @@
 
 #include "cpu/rv64/jit_generator.hpp"
 
+#include <array>
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -85,6 +87,14 @@ private:
     bool isTransB_;
     bool has_bias_;
 };
+
+struct jit_rvv_gemm_kernel_table_t {
+    std::array<const jit_rvv_gemm_kernel_t *, 8> nb {};
+    std::array<const jit_rvv_gemm_kernel_t *, 8> b {};
+};
+
+const jit_rvv_gemm_kernel_table_t &get_jit_rvv_gemm_kernel_table(
+        bool isTransA, bool isTransB);
 
 } // namespace gemm_utils
 } // namespace rv64

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
@@ -59,16 +59,39 @@ template <bool isTransA, bool isTransB>
 void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
         const dim_t lda, const float *B, const dim_t ldb, float *C,
         const dim_t ldc, const float alpha, const float beta, float *ws,
-        bool do_copy, int ithr, const float *bias) {
+        bool do_copy, int ithr, const float *bias, const dim_t m_unroll,
+        const jit_rvv_gemm_kernel_table_t &trans_a_table,
+        const jit_rvv_gemm_kernel_table_t &nontrans_a_table) {
     MAYBE_UNUSED(ithr);
 
     const dim_t n_unroll = gemm_f32_traits::get_n_unroll_factor();
-    const dim_t m_unroll = gemm_f32_traits::get_m_unroll_factor();
 
     const dim_t Nu = rnd_dn(N, n_unroll);
     const dim_t Mu = rnd_dn(M, m_unroll);
     const dim_t n_tail = N - Nu;
     const dim_t m_tail = M - Mu;
+
+    auto call_kernel
+            = [&](const jit_rvv_gemm_kernel_table_t &kernel_table,
+                      const float *a, const float *b, float *c, dim_t lda_eff,
+                      dim_t tile_m, dim_t tile_n, const float *bias_tile) {
+        jit_rvv_gemm_kernel_t::call_params_t p;
+        p.A = a;
+        p.B = b;
+        p.C = c;
+        p.lda = lda_eff;
+        p.ldb = ldb;
+        p.ldc = ldc;
+        p.K = K;
+        p.m = tile_m;
+        p.alpha = alpha;
+        p.beta = beta;
+        p.bias = bias_tile;
+
+        const jit_rvv_gemm_kernel_t *kernel
+                = bias_tile ? kernel_table.b[tile_n] : kernel_table.nb[tile_n];
+        (*kernel)(&p);
+    };
 
     auto invoke_kernel
             = [&](const float *a_orig, const float *b, float *c, dim_t tile_m,
@@ -88,8 +111,10 @@ void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
             trans_a_eff = isTransA;
         }
 
-        jit_rvv_gemm_kernel(a_eff, b, c, lda_eff, ldb, ldc, K, alpha, beta,
-                tile_m, tile_n, trans_a_eff, isTransB, bias_tile);
+        const auto &kernel_table
+                = trans_a_eff ? trans_a_table : nontrans_a_table;
+        call_kernel(
+                kernel_table, a_eff, b, c, lda_eff, tile_m, tile_n, bias_tile);
     };
 
     for (dim_t i = 0; i < Mu; i += m_unroll) {
@@ -114,15 +139,18 @@ void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
 
         for (dim_t j = 0; j < Nu; j += n_unroll) {
             const float *b = isTransB ? &B[j] : &B[j * ldb];
-            jit_rvv_gemm_kernel(a_tail, b, &C[Mu + j * ldc], lda, ldb, ldc, K,
-                    alpha, beta, m_tail, n_unroll, isTransA, isTransB,
-                    bias_tile);
+            const auto &kernel_table
+                    = isTransA ? trans_a_table : nontrans_a_table;
+            call_kernel(kernel_table, a_tail, b, &C[Mu + j * ldc], lda, m_tail,
+                    n_unroll, bias_tile);
         }
 
         if (n_tail > 0) {
             const float *b = isTransB ? &B[Nu] : &B[Nu * ldb];
-            jit_rvv_gemm_kernel(a_tail, b, &C[Mu + Nu * ldc], lda, ldb, ldc, K,
-                    alpha, beta, m_tail, n_tail, isTransA, isTransB, bias_tile);
+            const auto &kernel_table
+                    = isTransA ? trans_a_table : nontrans_a_table;
+            call_kernel(kernel_table, a_tail, b, &C[Mu + Nu * ldc], lda, m_tail,
+                    n_tail, bias_tile);
         }
     }
 }
@@ -131,7 +159,9 @@ template <bool isTransA, bool isTransB>
 void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
         const float *A, const dim_t lda, const float *B, const dim_t ldb,
         const float beta, float *C, const dim_t ldc, bool do_copy, float *ws,
-        int ithr, const float *bias) {
+        int ithr, const float *bias, const dim_t m_unroll,
+        const jit_rvv_gemm_kernel_table_t &trans_a_table,
+        const jit_rvv_gemm_kernel_table_t &nontrans_a_table) {
 
     constexpr dim_t BM = gemm_traits_t<float, isTransA, isTransB>::BM;
     constexpr dim_t BN = gemm_traits_t<float, isTransA, isTransB>::BN;
@@ -174,11 +204,12 @@ void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
                     const float *bias_block = bias ? bias + Bm : nullptr;
                     block_ker<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
                             ldb, curC, ldc, alpha, beta, ws, do_copy, ithr,
-                            bias_block);
+                            bias_block, m_unroll, trans_a_table,
+                            nontrans_a_table);
                 } else {
                     block_ker<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
                             ldb, curC, ldc, alpha, 1.0f, ws, do_copy, ithr,
-                            nullptr);
+                            nullptr, m_unroll, trans_a_table, nontrans_a_table);
                 }
             }
         }
@@ -228,13 +259,18 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
     bool do_copy = (NB / gemm_f32_traits::get_n_unroll_factor() > 3);
     const int nthr_mn = nthr_m * nthr_n;
     const int nthr_to_use = nthr_mn * nthr_k;
-    const size_t ws_elems_per_thr = K * gemm_f32_traits::get_m_unroll_factor();
+    const dim_t m_unroll = gemm_f32_traits::get_m_unroll_factor();
+    const size_t ws_elems_per_thr = K * m_unroll;
     const size_t ws_size_per_thr
             = rnd_up(ws_elems_per_thr * sizeof(float), PAGE_4K);
     if (do_copy) {
         ws_buffers = (float *)malloc(nthr_to_use * ws_size_per_thr, PAGE_4K);
         if (!ws_buffers) do_copy = false;
     }
+
+    const auto &trans_a_table = get_jit_rvv_gemm_kernel_table(true, isTransB);
+    const auto &nontrans_a_table
+            = get_jit_rvv_gemm_kernel_table(false, isTransB);
 
     auto get_thr_block = [&](dim_t &from, dim_t &to, dim_t &myN, dim_t NB,
                                  dim_t N, int ithr) {
@@ -289,18 +325,22 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
             if (!isTransA) {
                 if (!isTransB) {
                     gemm_ithr<false, false>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr<false, true>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, trans_a_table, nontrans_a_table);
                 }
             } else {
                 if (!isTransB) {
                     gemm_ithr<true, false>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr<true, true>(myM, myN, myK, alpha, myA, lda, myB,
-                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias);
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, trans_a_table, nontrans_a_table);
                 }
             }
         }

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
@@ -26,6 +26,9 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 namespace gemm_utils {
+
+std::atomic<dim_t> rvv_gemm_f32_m_unroll {0};
+
 #define BM_NOCOPY_RVV 64
 #define BN_NOCOPY_RVV 48
 #define BK_NOCOPY_RVV 384

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -20,6 +20,7 @@
 
 #include "common/c_types_map.hpp"
 
+#include <atomic>
 #include <cstddef>
 
 #include "xbyak_riscv/xbyak_riscv_util.hpp"
@@ -29,6 +30,8 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 namespace gemm_utils {
+
+extern std::atomic<dim_t> rvv_gemm_f32_m_unroll;
 
 template <typename T, bool isTransA, bool isTransB>
 struct gemm_traits_t {};
@@ -49,10 +52,12 @@ struct gemm_utils_traits<float> {
     // m = VLEN / 32 * LMUL, where LMUL = 4 for f32
     // VLEN=128 -> m=16, VLEN=256 -> m=32, VLEN=512 -> m=64
     static dim_t get_m_unroll_factor() {
-        static const dim_t m = []() -> dim_t {
+        dim_t m = rvv_gemm_f32_m_unroll.load(std::memory_order_relaxed);
+        if (m == 0) {
             const uint32_t vlen = Xbyak_riscv::CPU::getInstance().getVlen();
-            return static_cast<dim_t>(vlen / 32 * 4);
-        }();
+            m = static_cast<dim_t>(vlen / 32 * 4);
+            rvv_gemm_f32_m_unroll.store(m, std::memory_order_relaxed);
+        }
         return m;
     }
 

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -61,8 +61,8 @@ struct gemm_utils_traits<float> {
         return m;
     }
 
-    // Fixed n = 7 for the mx7 micro-kernel
-    static constexpr dim_t get_n_unroll_factor() { return 7; }
+    // Fixed n = 6 for the double-buffered mx6 micro-kernel.
+    static constexpr dim_t get_n_unroll_factor() { return 6; }
 };
 
 // Sum the m*n values from p_src into p_dst, assuming the two-dimensional
@@ -83,13 +83,6 @@ void calc_nthr_nocopy_rvv(dim_t m, dim_t n, dim_t k, int nthrs, int *nthrs_m,
 
 void partition_unit_diff(
         int ithr, int nthr, dim_t n, dim_t *t_offset, dim_t *t_block);
-
-// RVV JIT micro-kernel for f32 GEMM.
-// Computes an m x n tile of C = alpha * A * B + beta * C.
-// n_cols must be 1..7, m can be any value (handled by vsetvl).
-void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
-        dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m,
-        dim_t n_cols, bool isTransA, bool isTransB, const float *bias);
 
 } // namespace gemm_utils
 } // namespace rv64


### PR DESCRIPTION
# Description

This PR tunes the RV64 RVV f32 GEMM micro-kernel. The series targets three issues observed when a single LLM-style GEMM (e.g. an `lm_head` projection) is decomposed into many micro-kernel invocations on a wide-vector RVV core.

## Motivation

### 1) Per-call dispatch overhead

`jit_rvv_gemm_kernel_dispatch` currently carries 14 function-local `static` JIT kernel objects (7 `n_cols` × {with, without bias}) plus several `static` arrays. For each of these the compiler has to emit the [Itanium / RV64 ABI thread-safe-init guard](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#once-ctor):

```
lb    <guard byte>
fence rw, rw
beq   <guard non-zero>, init_block
```

`fence rw, rw` is a full memory barrier. With seven such guards back-to-back at the head of every micro-kernel invocation, the frontend stalls before any FMA can issue, and this is amplified when a GEMM is shredded into many small kernel calls.

The fix mirrors what the AArch64 / x86 backends already do for JIT kernel reuse: a templated `jit_rvv_gemm_kernel_storage_t<isTransA, isTransB>` holds a process-wide pointer table built once via `std::call_once`, and the dispatcher just reads `kernel_table.{nb,b}[n_cols]`. The runtime `isTransA / has_bias` guards are also lifted out of the inner loop so the gemm body issues a single indirect call instead of a chain of branches. `get_m_unroll_factor()` (also called per-tile) is moved from a function-local static to a `std::atomic<dim_t>` cache for the same reason.

### 2) A-side: vector load-to-use stall in the K loop

The original `mx7` micro-kernel uses `v0..v27` as 7 accumulator groups and `v28..v31` as the only LMUL=4 A buffer, so each K step looks like:

```
vle32.v   v28, (A)              # LMUL=4 load
vfmacc.vf v_c0, fa2, v28
vfmacc.vf v_c1, fa3, v28
... up to 7 columns ...
```

`vfmacc` cannot issue until `v28` is in the register file, and the issue queue has nothing else from this iteration to overlap with — a load-to-use stall every K step.

This PR gives up one accumulator column (mx7 → mx6) so that `v24..v27` / `v28..v31` form a two-stage A double buffer, and rewrites the K loop as:

```
prologue: load A[k]   into v_a0
loop_a0:  load A[k+1] into v_a1; FMA on v_a0; advance pointers
loop_a1:  load A[k+2] into v_a0; FMA on v_a1; advance pointers
drain:    FMA on the remaining A buffer
```

`vfmacc` of iteration `k` now issues against the A buffer that was loaded in iteration `k-1`, so the LMUL=4 vector load latency is hidden as long as there is one more K step. The `vsetvli` at kernel entry passes `vta=ta, vma=ma` since the rewritten kernel never depends on tail / masked-off lane preservation.

### 3) B-side: scalar load-to-use stall and bank conflicts

For non-transB the kernel reads B as scalar `flw` per column, then multiplies into the corresponding `v_c[c]`:

```
flw       fa2, 0*ldb(B0)
flw       fa3, 1*ldb(B0)
... up to n_cols flw ...
vfmacc.vf v_c[0], fa2, v_a
vfmacc.vf v_c[1], fa3, v_a
...
```

This pattern hits two issues on a typical in-order RVV core: back-to-back `flw` to addresses that differ by `ldb` bytes can collide on the same memory bank and serialize via retry, and the `vfmacc.vf` consumer waits on its scalar operand `freg_b[c]` to retire before the FMA can issue.

The K loop in this PR therefore interleaves scalar load and FMA so that `flw freg_b[c+1]` issues one step ahead of the `vfmacc.vf` that consumes `freg_b[c]`, and uses an incremental `add reg_tmp0, reg_tmp0, reg_ldb_bytes` for each address so that successive `flw`s land on different banks. See `emit_load_b_scattered_compute` in `jit_rvv_gemm_kernel.cpp`.

Pre-transposing B into a row-major panel before the kernel was also evaluated. It is **not** included in this PR — it is harder to make into a pure win once block-level transpose / pack overhead is accounted for, and at the call sites that matter B is already laid out as expected.

## Reproduction

Built with clang for `riscv64-unknown-linux-gnu` against `-march=rv64gcv_zvfh`, run under `qemu-riscv64` (user-mode):

```
benchdnn --matmul --mode=C \
   1x1:1x1 1x16:16x1 1x32:32x16 8x16:16x32 16x16:16x16 32x16:16x32 \
   1x64:64x1 1x7:7x1 1x7:7x6 1x7:7x12 3x7:7x1 3x7:7x4 3x7:7x12 \
   16x7:7x1 16x7:7x6 16x7:7x12 31x13:13x7 31x2:2x7 \
   17x6:6x1 17x6:6x2 17x6:6x4 17x6:6x5 17x6:6x6 17x6:6x7 \
   32x6:6x64 64x6:6x64 64x12:12x64 65x13:13x63

benchdnn --matmul --mode=C \
   --stag={ab,ba} --wtag={ab,ba}              16x7:7x12 31x13:13x7 64x6:6x64 \
   --bia-dt=f32 --bia_mask=2 --stag={ab,ba} --wtag={ab,ba} \
                                              16x7:7x12 31x13:13x7 64x6:6x64
```

All cases PASS; the ones exercising the new path report implementation `RISCV64GCV` in the summary, and transposed / bias layouts fall back to the `gemm:jit:f32` reference and also pass.

On an out-of-order RVV core with VLEN=128, this series measured a ~22% speedup over the baseline implementation.

Fixes # (n/a — no GitHub issue tracked)

## Disclosure

Implementation and commit drafting were assisted by an AI coding assistant (Anthropic Claude). Microarchitectural analysis, design decisions, and verification were reviewed by the author. No proprietary information about any specific RVV implementation is included; the analysis above describes generic in-order RVV behaviour.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

> On an out-of-order RVV core with VLEN=128, this series measured a ~22% speedup over the baseline. Absolute numbers depend on VLEN and the specific RVV core; maintainers with access to another RVV target are welcome to run a `--mode=P` sweep, and I'm happy to add numbers for a specific public platform if it helps reviewing.

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

> Not applicable: this is a tuning / refactor PR for an existing implementation, not a new feature. Behaviour-level coverage is provided by the existing benchdnn matmul / gemm tests.

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

> Not applicable: no functional bug is being fixed. The reproduction command above documents how to verify behaviour is preserved.

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?

> Not applicable.
