### PR TITLE
cpu: platform: aarch64: use xbyak_aarch64 for f16 detection

### DIFF
--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2023, 2025, 2026 Arm Ltd. and affiliates
+* Copyright 2023, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -263,6 +263,11 @@ inline bool isa_has_s8s8(cpu_isa_t isa) {
 inline bool mayiuse_bf16() {
     using namespace Xbyak_aarch64::util;
     return cpu().isBf16Supported();
+}
+
+inline bool mayiuse_f16() {
+    using namespace Xbyak_aarch64::util;
+    return cpu().isF16Supported();
 }
 
 inline int isa_num_vregs(cpu_isa_t isa) {

--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -132,8 +132,8 @@ bool has_data_type_support(data_type_t data_type) {
 #if DNNL_X64
             return x64::mayiuse(x64::avx512_core_fp16)
                     || x64::mayiuse(x64::avx2_vnni_2);
-#elif defined(DNNL_AARCH64_USE_ACL)
-            return arm_compute::CPUInfo::get().has_fp16();
+#elif DNNL_AARCH64
+            return aarch64::mayiuse_f16();
 #elif DNNL_RV64
             return rv64::mayiuse(rv64::zvfh);
 #else


### PR DESCRIPTION
# Description
Switch to `xbyak_aarch64` for `fp16` platform support detection.

Underlying support was added here: https://github.com/fujitsu/xbyak_aarch64/pull/117

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?