### PR TITLE
cpu: rv64: switch the RV64 backend to runtime ISA dispatch

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -102,10 +102,11 @@ onednn_option(ARCH_OPT_FLAGS "HostOpts"
     - For GNU* Compiler Collection and Clang, the default option is `-msse4.1` which
       behaves similarly to the description above.
 
-    - For Clang and GCC compilers on RISC-V architecture this option accepts `-march=<ISA-string>` flag
-      to control whether or not oneDNN should be compiled with RVV Intrinsics. Use this option with
-      `-march=rv64gc` or `-march=rv64gcv` value to compile oneDNN with and without RVV Intrinsics respectively.
-      If the option is not provided, CMake will decide based on the active toolchain and compiler flags.
+    - For Clang and GCC compilers on RISC-V architecture this option accepts the
+      `-march=<ISA-string>` flag. The RV64 backend emits vector kernels at runtime
+      and does not use this option to include or exclude JIT sources. The default
+      is the portable `-march=rv64gc` baseline; an explicit value such as
+      `-march=rv64gcv` allows the compiler to generate code for that target ISA.
 
     - For all other cases there are no special optimizations flags.
 

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -120,89 +120,20 @@ if(DNNL_WITH_SYCL)
 endif()
 
 if (DNNL_TARGET_ARCH STREQUAL "RV64")
-    # Check if the RVV Intrinsics can be compiled with the current toolchain and flags
-    set(ARCH_SIMD_TEST_FLAGS "-march=rv64gcv")
-    set(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
-    set(CMAKE_REQUIRED_FLAGS "${ARCH_SIMD_TEST_FLAGS}")
-    include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles("#if !defined(__riscv) || !defined(__riscv_v)
-                               #error \"RISC-V or vector extension(RVV) is not supported by the compiler\"
-                               #endif
-
-                               #if defined(__riscv_v_intrinsic) && __riscv_v_intrinsic < 12000
-                               #error \"RISC-V intrinsics v0.12 or higher is required\"
-                               #endif
-
-                               #include <riscv_vector.h>
-                               int main() {
-                                return 0;
-                               };"
-                               CAN_COMPILE_RVV_INTRINSICS
-    )
-    
-    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_SAVE})
-    # Set CAN_COMPILE_RVV_INTRINSICS to TRUE / FALSE instead of 1 / "" (Undefined)
-    if (CAN_COMPILE_RVV_INTRINSICS)
-        # RVV is supported, now check for Zvfh (which depends on V)
-        set(ARCH_SIMD_TEST_FLAGS "-march=rv64gcv_zvfh")
-        set(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
-        set(CMAKE_REQUIRED_FLAGS "${ARCH_SIMD_TEST_FLAGS}")
-        check_cxx_source_compiles("#include <riscv_vector.h>
-                                   #ifndef __riscv_zvfh
-                                   #error \"Zvfh extension is not supported by the compiler\"
-                                   #endif   
-                                   int main() {
-                                    vfloat16m1_t a;
-                                    return 0; 
-                                   };"
-                                   CAN_COMPILE_ZVFH_INTRINSICS
-        )
-        set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_SAVE})
-
-        set(CAN_COMPILE_RVV_INTRINSICS TRUE)
-
-        # If explicitly passed DNNL_ARCH_OPT_FLAGS without V or Zvfh in the -march 
-        # string, disable their code paths even if the toolchain supports them.
-        if (DEFINED DNNL_ARCH_OPT_FLAGS AND DNNL_ARCH_OPT_FLAGS MATCHES "-march=")
-            string(FIND "${DNNL_ARCH_OPT_FLAGS}" "gcv" _dnnl_rv64_v_pos)
-            string(FIND "${DNNL_ARCH_OPT_FLAGS}" "zvfh" _dnnl_rv64_zvfh_pos)
-            if (_dnnl_rv64_v_pos EQUAL -1)
-                set(CAN_COMPILE_RVV_INTRINSICS FALSE)
-                set(CAN_COMPILE_ZVFH_INTRINSICS FALSE)
-            elseif (_dnnl_rv64_zvfh_pos EQUAL -1)
-                set(CAN_COMPILE_ZVFH_INTRINSICS FALSE)
-            endif()
-        endif()
-
-        if (CAN_COMPILE_ZVFH_INTRINSICS)
-            set(RV64_MARCH_FLAG "-march=rv64gcv_zvfh")
-        elseif (CAN_COMPILE_RVV_INTRINSICS)
-            set(RV64_MARCH_FLAG "-march=rv64gcv")
-        else()
-            set(RV64_MARCH_FLAG "-march=rv64gc")
-        endif()
+    # The RV64 backend is pure JIT: all vector kernels are emitted at runtime
+    # (Xbyak_riscv) and selected through mayiuse() CPU detection (V / Zvfh /
+    # Zvfbfwma), independent of the compiler's -march. The library is therefore
+    # built for the rv64gc baseline so a single binary runs on both V-capable and
+    # non-V RV64GC hardware; the JIT supplies the vector code paths when the CPU
+    # reports them. Pass DNNL_ARCH_OPT_FLAGS="-march=<isa>" to override (e.g.
+    # -march=rv64gcv to let the compiler auto-vectorize the reference/driver code
+    # on a V-only deployment).
+    set(RV64_MARCH_FLAG "-march=rv64gc")
+    if(DNNL_ARCH_OPT_FLAGS STREQUAL "HostOpts")
+        message(STATUS "Using default RV64 march flag: ${RV64_MARCH_FLAG} (portable baseline; JIT selects V/Zvfh at runtime; override with -DDNNL_ARCH_OPT_FLAGS=\"-march=...\")")
     else()
-        # RVV is not supported, so Zvfh is also not supported
-        set(CAN_COMPILE_RVV_INTRINSICS FALSE)
-        set(CAN_COMPILE_ZVFH_INTRINSICS FALSE)
-        set(RV64_MARCH_FLAG "-march=rv64gc")
+        message(STATUS "Using RV64 arch opt flags from DNNL_ARCH_OPT_FLAGS: ${DNNL_ARCH_OPT_FLAGS}")
     endif()
-
-    set(DNNL_RISCV_USE_RVV_INTRINSICS ${CAN_COMPILE_RVV_INTRINSICS})
-    if (${DNNL_RISCV_USE_RVV_INTRINSICS})
-        add_definitions(-DDNNL_RISCV_USE_RVV_INTRINSICS)
-    endif()
-
-    set(DNNL_RISCV_USE_ZVFH_INTRINSICS ${CAN_COMPILE_ZVFH_INTRINSICS})
-    if (${DNNL_RISCV_USE_ZVFH_INTRINSICS})
-        add_definitions(-DDNNL_RISCV_USE_ZVFH_INTRINSICS)
-    endif()
-
-    message(STATUS "Can compile RVV Intrinsics: ${CAN_COMPILE_RVV_INTRINSICS}")
-    message(STATUS "Can compile Zvfh Intrinsics: ${CAN_COMPILE_ZVFH_INTRINSICS}")
-    message(STATUS "DNNL_RISCV_USE_RVV_INTRINSICS: ${DNNL_RISCV_USE_RVV_INTRINSICS}")
-    message(STATUS "DNNL_RISCV_USE_ZVFH_INTRINSICS: ${DNNL_RISCV_USE_ZVFH_INTRINSICS}")
-    message(STATUS "Using RV64 march flag: ${RV64_MARCH_FLAG}")
 endif()
 
 if(MSVC)

--- a/src/cpu/cpu_batch_normalization_list.cpp
+++ b/src/cpu/cpu_batch_normalization_list.cpp
@@ -32,10 +32,8 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/jit_uni_batch_normalization_s8.hpp"
 using namespace dnnl::impl::cpu::aarch64;
 #elif DNNL_RV64
-#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
 #include "cpu/rv64/rvv_batch_normalization.hpp"
 using namespace dnnl::impl::cpu::rv64;
-#endif
 #endif
 
 namespace dnnl {
@@ -59,7 +57,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_tbb_batch_normalization_fwd_t<sse41>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_fwd_t<sve>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_fwd_t<asimd>)
-            CPU_INSTANCE_RV64GCV(rvv_batch_normalization_fwd_t)
+            CPU_INSTANCE_RV64(rvv_batch_normalization_fwd_t)
             CPU_INSTANCE(ncsp_batch_normalization_fwd_t<f32>)
             CPU_INSTANCE(ncsp_batch_normalization_fwd_t<bf16>)
             CPU_INSTANCE(ncsp_batch_normalization_fwd_t<f16>)

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -74,13 +74,11 @@ using namespace dnnl::impl::cpu::x64;
 #endif
 using namespace dnnl::impl::cpu::aarch64;
 #elif DNNL_RV64
-#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
 #include "cpu/rv64/jit_rvv_1x1_convolution.hpp"
+#include "cpu/rv64/jit_uni_dwconv.hpp"
 #include "cpu/rv64/rvv_brgemm_conv.hpp"
 #include "cpu/rv64/rvv_gemm_convolution.hpp"
 #include "cpu/rv64/rvv_winograd_convolution.hpp"
-#endif // DNNL_RISCV_USE_RVV_INTRINSICS
-#include "cpu/rv64/jit_uni_dwconv.hpp"
 using namespace dnnl::impl::cpu::rv64;
 #endif
 
@@ -139,10 +137,10 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_fwd_t)
-            CPU_INSTANCE_RV64GCV(jit_rvv_1x1_convolution_fwd_t)
-            CPU_INSTANCE_RV64GCV(rvv_wino_convolution_fwd_t)
-            CPU_INSTANCE_RV64GCV(rvv_brgemm_convolution_fwd_t)
-            CPU_INSTANCE_RV64GCV(riscv_gemm_convolution_fwd_t)
+            CPU_INSTANCE_RV64(jit_rvv_1x1_convolution_fwd_t)
+            CPU_INSTANCE_RV64(rvv_wino_convolution_fwd_t)
+            CPU_INSTANCE_RV64(rvv_brgemm_convolution_fwd_t)
+            CPU_INSTANCE_RV64(riscv_gemm_convolution_fwd_t)
             CPU_INSTANCE(gemm_convolution_fwd_t)
             CPU_INSTANCE(ref_convolution_fwd_t)
             CPU_INSTANCE(ref_fused_convolution_fwd_t)

--- a/src/cpu/cpu_engine.hpp
+++ b/src/cpu/cpu_engine.hpp
@@ -45,13 +45,6 @@
 #define CPU_INSTANCE_AARCH64_ACL(...) \
     DNNL_AARCH64_ACL_ONLY(CPU_INSTANCE(__VA_ARGS__))
 #define CPU_INSTANCE_RV64(...) DNNL_RV64_ONLY(CPU_INSTANCE(__VA_ARGS__))
-// TODO: CPU_INSTANCE_RV64GCV[_ZVFH] gate registration on the build-time
-// RVV/Zvfh intrinsics flags (legacy build-time ISA identification). Once the
-// remaining intrinsic-based RV64 primitives are migrated to JIT and onto
-// CPU_INSTANCE_RV64 (runtime mayiuse dispatch), remove these two macros.
-#define CPU_INSTANCE_RV64GCV(...) DNNL_RV64GCV_ONLY(CPU_INSTANCE(__VA_ARGS__))
-#define CPU_INSTANCE_RV64GCV_ZVFH(...) \
-    DNNL_RV64GCV_ZVFH_ONLY(CPU_INSTANCE(__VA_ARGS__))
 #define CPU_INSTANCE_PPC64(...) DNNL_PPC64_ONLY(CPU_INSTANCE(__VA_ARGS__))
 
 #if DNNL_EXPERIMENTAL_GROUPED_MEMORY

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -33,12 +33,10 @@ using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::cpu::aarch64;
 #endif
 #elif DNNL_RV64
-#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
 #include "cpu/rv64/rvv_brgemm_inner_product.hpp"
 #include "cpu/rv64/rvv_gemm_inner_product.hpp"
 #include "cpu/rv64/rvv_inner_product.hpp"
 using namespace dnnl::impl::cpu::rv64;
-#endif
 #endif
 
 namespace dnnl {
@@ -58,8 +56,8 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2>)
             CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
-            CPU_INSTANCE_RV64GCV(rvv_brgemm_inner_product_fwd_t)
-            CPU_INSTANCE_RV64GCV(rvv_gemm_inner_product_fwd_t)
+            CPU_INSTANCE_RV64(rvv_brgemm_inner_product_fwd_t)
+            CPU_INSTANCE_RV64(rvv_gemm_inner_product_fwd_t)
             CPU_INSTANCE(gemm_inner_product_fwd_t<f32>)
             CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,
@@ -152,7 +150,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni>)
-            CPU_INSTANCE_RV64GCV(rvv_inner_product_fwd_t)
+            CPU_INSTANCE_RV64(rvv_inner_product_fwd_t)
             CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t)
             CPU_INSTANCE(ref_inner_product_int8_fwd_t)
             nullptr,

--- a/src/cpu/cpu_layer_normalization_list.cpp
+++ b/src/cpu/cpu_layer_normalization_list.cpp
@@ -27,10 +27,8 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/jit_uni_layer_normalization.hpp"
 using namespace dnnl::impl::cpu::aarch64;
 #elif DNNL_RV64
-#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
 #include "cpu/rv64/rvv_layer_normalization.hpp"
 using namespace dnnl::impl::cpu::rv64;
-#endif // DNNL_RISCV_USE_RVV_INTRINSICS
 #endif
 
 namespace dnnl {
@@ -48,7 +46,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_layer_normalization_fwd_t)
             CPU_INSTANCE_AARCH64(jit_uni_layer_normalization_fwd_t<sve>)
             CPU_INSTANCE_AARCH64(jit_uni_layer_normalization_fwd_t<asimd>)
-            CPU_INSTANCE_RV64GCV(rvv_layer_normalization_fwd_t)
+            CPU_INSTANCE_RV64(rvv_layer_normalization_fwd_t)
             CPU_INSTANCE(simple_layer_normalization_fwd_t)
             CPU_INSTANCE(ref_layer_normalization_fwd_t)
             nullptr,

--- a/src/cpu/cpu_softmax_list.cpp
+++ b/src/cpu/cpu_softmax_list.cpp
@@ -30,10 +30,8 @@ using namespace dnnl::impl::cpu::x64;
 #endif
 using namespace dnnl::impl::cpu::aarch64;
 #elif DNNL_RV64
-#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
 #include "cpu/rv64/rvv_softmax.hpp"
 using namespace dnnl::impl::cpu::rv64;
-#endif
 #endif
 
 namespace dnnl {
@@ -52,7 +50,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve>)
             CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<asimd>)
             CPU_INSTANCE_AARCH64_ACL(acl_softmax_fwd_t)
-            CPU_INSTANCE_RV64GCV(rvv_softmax_fwd_t)
+            CPU_INSTANCE_RV64(rvv_softmax_fwd_t)
             CPU_INSTANCE(ref_softmax_fwd_t)
             nullptr,
         }},

--- a/src/cpu/gemm/gemm.cpp
+++ b/src/cpu/gemm/gemm.cpp
@@ -48,10 +48,9 @@ using namespace dnnl::impl::cpu::ppc64;
 #elif DNNL_S390X
 #include "cpu/s390x/gemm.h"
 #elif DNNL_RV64
-#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
 using namespace dnnl::impl::cpu::rv64;
-#endif
 #endif
 
 namespace dnnl {
@@ -150,9 +149,13 @@ dnnl_status_t extended_sgemm(const char *transa, const char *transb,
     }
 #endif
 
-#if DNNL_RV64 && defined(DNNL_RISCV_USE_RVV_INTRINSICS)
-    return rvv_gemm_f32(
-            transa, transb, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, bias);
+#if DNNL_RV64
+    // Pure-JIT RVV f32 GEMM. The library is built for the rv64gc baseline, so
+    // gate on runtime V detection and fall through to the portable reference
+    // GEMM when the running CPU has no vector unit.
+    if (mayiuse(v))
+        return rvv_gemm_f32(transa, transb, M, N, K, alpha, A, lda, B, ldb,
+                beta, C, ldc, bias);
 #endif
 
     return ref_gemm<float>(

--- a/src/cpu/matmul/cpu_matmul_list.cpp
+++ b/src/cpu/matmul/cpu_matmul_list.cpp
@@ -45,13 +45,10 @@ using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::cpu::aarch64::matmul;
 using namespace dnnl::impl::cpu::aarch64;
 #elif DNNL_RV64
-#ifdef DNNL_RISCV_USE_RVV_INTRINSICS
 #include "cpu/rv64/rvv_brgemm_matmul.hpp"
 #include "cpu/rv64/rvv_matmul.hpp"
 using namespace dnnl::impl::cpu::rv64::matmul;
 using namespace dnnl::impl::cpu::rv64;
-#endif
-
 #endif
 
 namespace dnnl {
@@ -84,8 +81,8 @@ constexpr impl_list_item_t impl_list[] = REG_MATMUL_P({
         CPU_INSTANCE_AVX2(brgemm_matmul_t<avx2_vnni_2>)
         CPU_INSTANCE_AVX2(brgemm_matmul_t<avx2_vnni>)
         CPU_INSTANCE_AVX2(brgemm_matmul_t<avx2>)
-        CPU_INSTANCE_RV64GCV(rvv_brgemm_matmul_t)
-        CPU_INSTANCE_RV64GCV(rvv_matmul_t)
+        CPU_INSTANCE_RV64(rvv_brgemm_matmul_t)
+        CPU_INSTANCE_RV64(rvv_matmul_t)
         CPU_INSTANCE(gemm_f32_matmul_t)
         CPU_INSTANCE(gemm_bf16_matmul_t<f32>)
         CPU_INSTANCE(gemm_bf16_matmul_t<bf16>)

--- a/src/cpu/platform.hpp
+++ b/src/cpu/platform.hpp
@@ -86,25 +86,6 @@
 #define DNNL_AARCH64_ONLY(...) Z_CONDITIONAL_DO(DNNL_AARCH64, __VA_ARGS__)
 #define DNNL_RV64_ONLY(...) Z_CONDITIONAL_DO(DNNL_RV64, __VA_ARGS__)
 
-// Using RISC-V implementations optimized with RVV Intrinsics is optional for RISC-V builds
-// and can be enabled with DNNL_ARCH_OPT_FLAGS="-march=<ISA-string>" option, where <ISA-string>
-// contains V extension. If disabled, generic reference implementations will be used.
-// TODO: DNNL_RV64GCV_ONLY / DNNL_RV64GCV_ZVFH_ONLY back the legacy build-time
-// ISA macros CPU_INSTANCE_RV64GCV[_ZVFH]. Remove both once all RV64 primitives
-// are JIT and registered via DNNL_RV64_ONLY (runtime mayiuse dispatch).
-#if defined(DNNL_RV64) && defined(DNNL_RISCV_USE_RVV_INTRINSICS)
-#define DNNL_RV64GCV_ONLY(...) __VA_ARGS__
-#else
-#define DNNL_RV64GCV_ONLY(...)
-#endif
-
-// Zvfh intrinsics are enabled if V extension is enabled and Zvfh is supported by the toolchain.
-#if defined(DNNL_RV64) && defined(DNNL_RISCV_USE_ZVFH_INTRINSICS)
-#define DNNL_RV64GCV_ZVFH_ONLY(...) __VA_ARGS__
-#else
-#define DNNL_RV64GCV_ZVFH_ONLY(...)
-#endif
-
 // Negation of the helper macros above
 #define DNNL_NON_X64_ONLY(...) Z_CONDITIONAL_DO(Z_NOT(DNNL_X64), __VA_ARGS__)
 

--- a/src/cpu/rv64/CMakeLists.txt
+++ b/src/cpu/rv64/CMakeLists.txt
@@ -19,18 +19,9 @@ file(GLOB_RECURSE SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch]pp
 )
 
-if(NOT DNNL_RISCV_USE_RVV_INTRINSICS)
-    # Do not compile RISC-V implementations optimized with RVV intrinsics
-    list(FILTER SOURCES EXCLUDE REGEX "rvv_*")
-
-    # Registering a library w/o any sources leads to a CMake error.
-    # If required, create an empty source file to prevent it.
-    list(LENGTH SOURCES NUM_OF_SOURCES)
-    if(NUM_OF_SOURCES EQUAL 0)
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp "")
-        set(SOURCES ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp)
-    endif()
-endif()
+# The RV64 backend is pure JIT (Xbyak_riscv emits vector code at runtime), so
+# every source compiles for the rv64gc baseline regardless of the V extension.
+# There is no longer an intrinsic-only subset to exclude.
 
 # Build sources into an object library
 set(OBJ_LIB ${DNNL_LIBRARY_NAME}_cpu_riscv)

--- a/src/cpu/rv64/CMakeLists.txt
+++ b/src/cpu/rv64/CMakeLists.txt
@@ -19,10 +19,6 @@ file(GLOB_RECURSE SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch]pp
 )
 
-# The RV64 backend is pure JIT (Xbyak_riscv emits vector code at runtime), so
-# every source compiles for the rv64gc baseline regardless of the V extension.
-# There is no longer an intrinsic-only subset to exclude.
-
 # Build sources into an object library
 set(OBJ_LIB ${DNNL_LIBRARY_NAME}_cpu_riscv)
 add_library(${OBJ_LIB} OBJECT ${SOURCES})

--- a/src/cpu/rv64/rvv_batch_normalization.hpp
+++ b/src/cpu/rv64/rvv_batch_normalization.hpp
@@ -22,6 +22,7 @@
 
 #include "cpu/cpu_batch_normalization_pd.hpp"
 #include "cpu/platform.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -33,13 +34,16 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
         using cpu_batch_normalization_fwd_pd_t::
                 cpu_batch_normalization_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T_("RISCV64GCV", rvv_batch_normalization_fwd_t);
+        DECLARE_COMMON_PD_T_("jit:rvv", rvv_batch_normalization_fwd_t);
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
 
             using namespace data_type;
 
+            // Vector kernels are JIT-emitted; the rv64gc baseline build means a
+            // non-V CPU must defer to the next (reference) implementation.
+            VDISPATCH_BNORM(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_BNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
 
             const data_type_t dtsrc = src_md()->data_type;

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -179,6 +179,10 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     const auto src_dt = src_mdw.data_type();
     const auto wei_dt = wei_mdw.data_type();
     const bool same_in_dt = src_dt == wei_dt;
+    // Derive the kernel ISA from the input dtype now, before the dtype/ISA gate
+    // below, so a declined bf16/f16 PD reports brgemm:rvv_zvfbfwma / _zvfh in the
+    // dispatch log instead of the default brgemm:rvv.
+    isa_ = (src_dt == f16) ? zvfh : (src_dt == bf16) ? zvfbfwma : v;
     const bool in_dt_ok = same_in_dt
             && (src_dt == f32 || (src_dt == bf16 && mayiuse(zvfbfwma))
                     || (src_dt == f16 && mayiuse(zvfh)));

--- a/src/cpu/rv64/rvv_brgemm_matmul.hpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.hpp
@@ -28,6 +28,7 @@
 #include "cpu/matmul/cpu_matmul_pd.hpp"
 
 #include "cpu/rv64/brgemm/brgemm.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/jit_uni_postops_kernel.hpp"
 
 namespace dnnl {
@@ -42,7 +43,8 @@ struct rvv_brgemm_matmul_t : public primitive_t {
     struct pd_t : public ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
         using ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t::cpu_matmul_pd_t;
 
-        DECLARE_COMMON_PD_T("brgemm:rvv", rvv_brgemm_matmul_t);
+        DECLARE_COMMON_PD_T(
+                JIT_IMPL_NAME_HELPER("brgemm:", isa_, ""), rvv_brgemm_matmul_t);
 
         status_t init(engine_t *engine);
 
@@ -57,6 +59,9 @@ struct rvv_brgemm_matmul_t : public primitive_t {
         bool weights_are_broadcast_ = false;
         // Input element size in bytes (4=f32, 2=bf16/f16). dst is always f32.
         int input_typesize_ = 4;
+        // Kernel isa from the input dtype (f32->v / f16->zvfh / bf16->zvfbfwma);
+        // drives the impl name (brgemm:rvv / brgemm:rvv_zvfh / ..._zvfbfwma).
+        cpu_isa_t isa_ = v;
 
     private:
         void init_scratchpad();

--- a/src/cpu/rv64/rvv_gemm_convolution.hpp
+++ b/src/cpu/rv64/rvv_gemm_convolution.hpp
@@ -29,6 +29,7 @@
 #include "cpu/cpu_convolution_pd.hpp"
 #include "cpu/gemm/gemm.hpp"
 #include "cpu/primitive_attr_postops.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/jit_uni_postops_kernel.hpp"
 #include "cpu/rv64/rvv_gemm_convolution_utils.hpp"
 
@@ -47,6 +48,9 @@ struct riscv_gemm_convolution_fwd_t : public primitive_t {
         status_t init(engine_t *engine) {
             using namespace data_type;
 
+            // The GEMM path is JIT-emitted (rvv_gemm_f32); on the rv64gc
+            // baseline a non-V CPU must defer to the next implementation.
+            VDISPATCH_CONV(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
 
             if (with_bias()) {

--- a/src/cpu/rv64/rvv_gemm_inner_product.hpp
+++ b/src/cpu/rv64/rvv_gemm_inner_product.hpp
@@ -36,7 +36,7 @@ struct rvv_gemm_inner_product_fwd_t : public primitive_t {
     struct pd_t : public cpu_inner_product_fwd_pd_t {
         using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("RISCV64GCV:gemm", rvv_gemm_inner_product_fwd_t);
+        DECLARE_COMMON_PD_T("gemm:rvv", rvv_gemm_inner_product_fwd_t);
 
         status_t init(engine_t *engine) {
             UNUSED(engine);

--- a/src/cpu/rv64/rvv_layer_normalization.hpp
+++ b/src/cpu/rv64/rvv_layer_normalization.hpp
@@ -37,8 +37,12 @@ struct rvv_layer_normalization_fwd_t : public primitive_t {
         using cpu_layer_normalization_fwd_pd_t::
                 cpu_layer_normalization_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_lnorm:", v, ""),
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_lnorm:", isa_, ""),
                 rvv_layer_normalization_fwd_t);
+
+        // f16 runs the Zvfh path (vfwcvt/vfncvt); f32 stays on V. Drives the
+        // verbose impl name (jit_lnorm:rvv vs jit_lnorm:rvv_zvfh).
+        cpu_isa_t isa_ = v;
 
         status_t init(engine_t *engine) {
             using namespace data_type;
@@ -55,6 +59,12 @@ struct rvv_layer_normalization_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_LNORM(
                     (stat_md()->data_type == f32), VERBOSE_UNSUPPORTED_DT);
+
+            // Set the ISA that drives the impl name (jit_lnorm:rvv vs
+            // jit_lnorm:rvv_zvfh) once the dtype is validated and before any
+            // mayiuse()/has_data_type_support() rejection, so a declined f16 PD
+            // is not mislabeled jit_lnorm:rvv in the dispatch log.
+            isa_ = (src_md()->data_type == f16) ? zvfh : v;
 
             if (src_md()->data_type == f16) {
                 VDISPATCH_LNORM(platform::has_data_type_support(f16),

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -21,6 +21,7 @@
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
 #include "cpu/matmul/cpu_matmul_pd.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/jit_uni_postops_kernel.hpp"
 
 namespace dnnl {
@@ -33,13 +34,17 @@ struct rvv_matmul_t : public primitive_t {
     struct pd_t : public ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
         using ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t::cpu_matmul_pd_t;
 
-        DECLARE_COMMON_PD_T("RISCV64GCV", rvv_matmul_t)
+        DECLARE_COMMON_PD_T("jit:rvv", rvv_matmul_t)
 
         static constexpr data_type_t d_type = data_type::f32;
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
             using smask_t = primitive_attr_t::skip_mask_t;
+
+            // Vector kernels are JIT-emitted; the rv64gc baseline build means a
+            // non-V CPU must defer to the next (reference) implementation.
+            VDISPATCH_MATMUL(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
 
             const memory_desc_wrapper src_mdw(src_md(0));
             const memory_desc_wrapper weights_mdw(weights_md(0));

--- a/src/cpu/rv64/rvv_softmax.hpp
+++ b/src/cpu/rv64/rvv_softmax.hpp
@@ -42,10 +42,13 @@ struct rvv_softmax_conf_t {
 struct rvv_softmax_fwd_t : public primitive_t {
     struct pd_t : public cpu_softmax_fwd_pd_t {
         using cpu_softmax_fwd_pd_t::cpu_softmax_fwd_pd_t;
-        DECLARE_COMMON_PD_T("RISCV64GCV", rvv_softmax_fwd_t);
+        DECLARE_COMMON_PD_T(
+                JIT_IMPL_NAME_HELPER("jit:", isa_, ""), rvv_softmax_fwd_t);
 
         rvv_softmax_conf_t rsp_;
         bool use_jit_ = false;
+        // f32 uses isa v, f16 uses Zvfh (vfwcvt/vfncvt); drives the impl name.
+        cpu_isa_t isa_ = v;
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
@@ -72,6 +75,10 @@ struct rvv_softmax_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_SOFTMAX(src_md()->data_type == dst_md()->data_type,
                     VERBOSE_UNSUPPORTED_DT);
+            // f16 runs the Zvfh widening/narrowing path; f32 stays on V. Set the
+            // ISA that drives the impl name (jit:rvv vs jit:rvv_zvfh) before any
+            // mayiuse() rejection, so a declined f16 PD is not mislabeled jit:rvv.
+            isa_ = is_f16 ? zvfh : v;
             VDISPATCH_SOFTMAX(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
             if (is_f16) {
                 VDISPATCH_SOFTMAX(mayiuse(zvfh), VERBOSE_UNSUPPORTED_ISA);


### PR DESCRIPTION
## Summary

Now that every RV64 primitive is pure JIT, this PR removes the last remnants of
the intrinsic-era *build-time* ISA gating and turns the backend into genuine
**single-binary runtime dispatch**, mirroring the x64 model (baseline ISA at
compile time + JIT emitting the vector ISA at runtime after `mayiuse()`).

A single `-march=rv64gc` build now runs correctly on both V-capable and non-V
RV64GC hardware: the JIT emits V / Zvfh / Zvfbfwma code only when the running CPU
reports them, and each primitive declines (→ next implementation) when it does
not.

## Motivation

The backend no longer contains a single RVV intrinsic (no `riscv_vector.h`
include anywhere under `src/cpu/rv64`), yet it still carried the build-time
machinery from the intrinsic era:

- `cmake/platform.cmake` probed whether RVV/Zvfh **intrinsics** compile and set
  `DNNL_RISCV_USE_RVV_INTRINSICS` / `DNNL_RISCV_USE_ZVFH_INTRINSICS`.
- `src/cpu/rv64/CMakeLists.txt` excluded every `rvv_*` source when intrinsics
  were unavailable.
- `CPU_INSTANCE_RV64GCV[_ZVFH]` (and the `DNNL_RV64GCV_ONLY[_ZVFH]` macros)
  gated *registration* on those build-time flags, so a `rv64gc` build silently
  dropped all RVV primitives, and a `rv64gcv` build compiled V instructions into
  the reference/driver C++ (so the binary required V to even load).

These are now obsolete and actively misleading. The `TODO`s in
`src/cpu/platform.hpp` and `src/cpu/cpu_engine.hpp` already called for their
removal once all RV64 primitives became JIT.

## What changed

### Build system — one portable baseline
- `cmake/platform.cmake`: deleted the `riscv_vector.h` compile probe and the
  `DNNL_RISCV_USE_{RVV,ZVFH}_INTRINSICS` definitions; `RV64_MARCH_FLAG` is now
  always `-march=rv64gc`.
- `src/cpu/rv64/CMakeLists.txt`: removed the `rvv_*` source exclusion — all JIT
  sources always compile on the baseline.

### Dead macros removed
- `DNNL_RV64GCV_ONLY` / `DNNL_RV64GCV_ZVFH_ONLY` (`src/cpu/platform.hpp`).
- `CPU_INSTANCE_RV64GCV` / `CPU_INSTANCE_RV64GCV_ZVFH` (`src/cpu/cpu_engine.hpp`).
  The `_ZVFH` variants had zero uses.

### Registration → runtime dispatch
- All 12 `CPU_INSTANCE_RV64GCV(...)` registrations switched to
  `CPU_INSTANCE_RV64(...)` (softmax, convolution ×4, layer/batch norm,
  matmul ×2, inner product ×3).
- The 7 `#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)` include guards around the
  RV64 headers in the implementation lists are now always-on under `#elif
  DNNL_RV64`.
- `src/cpu/gemm/gemm.cpp`: `extended_sgemm`'s RV64 path now routes via a runtime
  `if (mayiuse(v)) return rvv_gemm_f32(...);` and falls through to the portable
  `ref_gemm` otherwise (previously a build-time `#if`, which would have dropped
  the JIT GEMM entirely on a baseline build).

### Correctness — missing runtime ISA gates
Three PDs reach V-emitting JIT but had no `mayiuse(v)` check; they were only safe
because `RV64GCV` hid them on non-V builds. With always-on registration they
would emit illegal instructions on a non-V CPU, so a gate was added to each:
- `rvv_matmul_t` (`src/cpu/rv64/rvv_matmul.hpp`)
- `riscv_gemm_convolution_fwd_t` (`src/cpu/rv64/rvv_gemm_convolution.hpp`)
- `rvv_batch_normalization_fwd_t` (`src/cpu/rv64/rvv_batch_normalization.hpp`)

### Verbose implementation names reflect the runtime ISA
The intrinsic-era `"RISCV64GCV"` / `"RISCV64GCV:gemm"` names were renamed, and the
single-class primitives that span f32/f16(/bf16) now derive the name from the
ISA actually selected (via `JIT_IMPL_NAME_HELPER` + a `cpu_isa_t isa_` set from
the data type in `init()`, the same pattern group normalization already uses):

| primitive | f32 | f16 (Zvfh) | bf16 (Zvfbfwma) |
|---|---|---|---|
| matmul (`rvv_matmul`) | `jit:rvv` | — (f32 only) | — |
| matmul (`rvv_brgemm_matmul`) | `brgemm:rvv` | `brgemm:rvv_zvfh` | `brgemm:rvv_zvfbfwma` |
| softmax | `jit:rvv` | `jit:rvv_zvfh` | — |
| layer norm | `jit_lnorm:rvv` | `jit_lnorm:rvv_zvfh` | — |
| inner product (gemm) | `gemm:rvv` | — (f32 only) | — |
| batch norm | `jit:rvv` | — (f32 only) | — |

Primitives that are f32-only (batch norm, plain matmul, gemm/brgemm inner
product, gemm/brgemm convolution) keep their static `…:rvv` name, which is
correct because no other ISA is ever used. Eltwise / pooling already encode the
ISA via their `<v>` / `<zvfh>` template parameter.

## Behavior change for downstream builds

The default RV64 compile target changes from `-march=rv64gcv[_zvfh]` to
`-march=rv64gc`. This is what makes the binary portable. To let the compiler
auto-vectorize the reference/driver C++ for a V-only deployment, pass
`-DDNNL_ARCH_OPT_FLAGS="-march=rv64gcv"` (or `..._zvfh`) as before; runtime JIT
dispatch is unaffected by that flag.

## Validation

Cross-compiled with `riscv64-linux-gnu-g++-14`, `-march=rv64gc`, `ONEDNN_WERROR=ON`,
Release. **Functional only**

- **Build:** clean, zero warnings under `-Werror`; the whole RV64 backend now
  compiles on the baseline.
- **V present (VLEN=128 and 256):** matmul, convolution (`gemm:rvv`,
  `jit_1x1:rvv`), inner product (`gemm:rvv` f32, `jit:rvv` int8), batch norm,
  softmax, layer norm all dispatch to their RV64 JIT impl with `failed:0`.
- **V absent — same `rv64gc` binary** (`QEMU_CPU=rv64,v=false`): every RV64 JIT
  impl cleanly declines and the reference takes over (`gemm:ref`,
  `ncsp_bnorm:any`, `ref:any`, `gemm_s8u8s32:ref`), `failed:0`, **no illegal
  instruction**.
- **Zvfh (QEMU 11.0.1, f16):** eltwise / pooling → `jit:rvv_zvfh`, softmax →
  `jit:rvv_zvfh`, layer norm → `jit_lnorm:rvv_zvfh`; with `zvfh` off the f16 path
  declines cleanly.
- **Zvfbfwma (QEMU 11.0.1, bf16):** brgemm matmul → `brgemm:rvv_zvfbfwma`
  (f16 → `brgemm:rvv_zvfh`), `failed:0`.