### PR TITLE
Fixes for GPU reorder OpenCL build errors

### DIFF
--- a/src/gpu/intel/reorder/custom.cpp
+++ b/src/gpu/intel/reorder/custom.cpp
@@ -342,6 +342,12 @@ custom_kernel_t select_kernel(const conf_t &conf,
         return custom_kernel_t::none;
     }
 
+    // This kernel fails to compile with f8 data types
+    if (utils::one_of(src_mdw.data_type(), dnnl_f8_e4m3, dnnl_f8_e5m2)
+            || utils::one_of(dst_mdw.data_type(), dnnl_f8_e4m3, dnnl_f8_e5m2)) {
+        return custom_kernel_t::none;
+    }
+
     int mask = conf.src_quant.scale_mask() | conf.src_quant.zp_mask()
             | conf.dst_quant.scale_mask() | conf.dst_quant.zp_mask();
 

--- a/src/gpu/intel/reorder/generic.cl
+++ b/src/gpu/intel/reorder/generic.cl
@@ -133,7 +133,7 @@ __kernel void generic_reorder(__global SRC_DATA_T *restrict src,
         const int pad
                 = pad_d0 || pad_d1 || pad_d2 || pad_d3 || pad_d4 || pad_d5;
         if (!pad_sgid) {
-            SRC_DATA_T src_tmp = pad ? 0 : src[src_off];
+            SRC_DATA_T src_tmp = pad ? TO_SRC(0) : src[src_off];
             cache[cache_idx] = src_tmp;
         }
     }


### PR DESCRIPTION
This PR fixes two OpenCL build errors in reorder:
```
onednn_verbose,v1,common,error,ocl,Error during the build of OpenCL program. Build log:
9:6623:26: error: incompatible operand types ('int' and 'bf16')
SRC_DATA_T src_tmp = pad ? 0 : src[src_off];
                         ^ ~   ~~~~~~~~~~~~
,src/gpu/intel/ocl/engine.cpp:233
onednn_verbose,v1,primitive,error,ocl,errcode -11,CL_BUILD_PROGRAM_FAILURE,src/gpu/intel/ocl/engine.cpp:325
unknown file: Failure
C++ exception with description "could not create a primitive" thrown in the test body.
```

```
onednn_verbose,v1,common,error,ocl,Error during the build of OpenCL program. Build log:
4:7046:1: error: unknown type name 'f8_e4m38'; did you mean 'f8_e4m3'?
DST_DATA8_T dst_tmp;
^~~~~~~~~~~
f8_e4m3
4:4553:21: note: expanded from macro 'DST_DATA8_T'
#define DST_DATA8_T CONCAT2(DST_DATA_T, 8)
                    ^
4:172:23: note: expanded from macro 'CONCAT2'
#define CONCAT2(a, b) CONCAt2(a, b)
                      ^
4:171:23: note: expanded from macro 'CONCAt2'
#define CONCAt2(a, b) a##b
                      ^
<scratch space>:221:1: note: expanded from here
f8_e4m38
^
4:94:3: note: 'f8_e4m3' declared here
} f8_e4m3;
  ^
4:7050:1: error: assigning to '__private f8_e4m3' from incompatible type 'uchar8' (vector of 8 'uchar' values)
REORDER8(DEFAULT_ROUND, dst_tmp, src_tmp, src_scale, dst_scale,
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4:6412:6: note: expanded from macro 'REORDER8'
_dst = SRC_TO_DST8(_src); \
     ^ ~~~~~~~~~~~~~~~~~
4:7052:1: error: invalid reinterpretation: sizes of 'uchar8' (vector of 8 'uchar' values) and '__private f8_e4m3' must match
DST_BLOCK_WRITE8(&dst[d0], dst_tmp);
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4:6238:58: note: expanded from macro 'DST_BLOCK_WRITE8'
intel_sub_group_block_write_uc8((__global uchar *)(dst), as_uchar8(val))
                                                         ^~~~~~~~~~~~~~
./opencl-c-base.h:587:22: note: expanded from macro 'as_uchar8'
#define as_uchar8(x) __builtin_astype((x), uchar8)
                     ^                ~~~
,src/gpu/intel/ocl/engine.cpp:233
onednn_verbose,v1,primitive,error,ocl,errcode -11,CL_BUILD_PROGRAM_FAILURE,src/gpu/intel/ocl/engine.cpp:325
```
