### PR TITLE
xe3p: copy plan: force src/dst alignment in hf<->int conversion

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -2761,6 +2761,9 @@ void CopyPlan::legalizeRegions()
                 } else
                     canSwizzle = false;
             }
+
+            if (hfIntConvert)
+                canSwizzle = false;
         }
 
         if (!canSwizzle) {


### PR DESCRIPTION
Addresses [MFDNN-14985](https://jira.devtools.intel.com/browse/MFDNN-14985).