### PR TITLE
benchdnn: introduce base_prb_t

### DIFF
--- a/tests/benchdnn/binary/binary.hpp
+++ b/tests/benchdnn/binary/binary.hpp
@@ -26,6 +26,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace binary {
@@ -58,7 +59,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_vdims_t {
+struct prb_t : public prb_vdims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
@@ -74,47 +75,29 @@ struct prb_t : public prb_vdims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
+        , base_prb_t(FLAG_FWD, inplace, attr, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
         , strides(strides)
         , alg(alg)
-        , inplace(inplace)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir = FLAG_FWD; // Lack of prop_kind, always considered as forward.
     std::vector<dnnl_data_type_t> sdt;
     dnnl_data_type_t ddt;
     std::vector<std::string> stag;
     std::string dtag;
     vdims_t strides;
     alg_t alg;
-    bool inplace;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
 
     bool is_ternary_op() const { return alg == alg_t::SELECT; }
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/bnorm/bnorm.hpp
+++ b/tests/benchdnn/bnorm/bnorm.hpp
@@ -30,6 +30,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 #ifdef DNNL_EXPERIMENTAL
@@ -91,7 +92,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.strides[0], s.flags[0],
@@ -107,7 +108,7 @@ struct prb_t : public desc_t {
             bool inplace, const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, inplace, attr, impl_filter)
         , dt(dt)
         , tag(tag)
         , strides(strides)
@@ -115,16 +116,11 @@ struct prb_t : public desc_t {
         , check_alg(check_alg)
         , debug_check_ws(debug_check_ws)
         , user_mb(mb)
-        , inplace(inplace)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) this->mb = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     dnnl_data_type_t dt;
     std::string tag;
     vdims_t strides;
@@ -132,11 +128,7 @@ struct prb_t : public desc_t {
     check_alg_t check_alg;
     bool debug_check_ws;
     int64_t user_mb;
-    bool inplace;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     bool need_ws() const {
         return (flags & (FUSE_NORM_RELU | FUSE_NORM_ADD_RELU))
                 && !(dir & FLAG_INF);
@@ -150,18 +142,8 @@ struct prb_t : public desc_t {
     }
     bool fuse_add_relu() const { return flags & FUSE_NORM_ADD_RELU; }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct cfg_t {

--- a/tests/benchdnn/brgemm/brgemm.hpp
+++ b/tests/benchdnn/brgemm/brgemm.hpp
@@ -44,6 +44,7 @@
 #include "dnnl_common.hpp"
 #include "utils/cfg.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace brgemm {
@@ -71,7 +72,7 @@ struct settings_t : public base_settings_t {
     void reset() { *this = settings_t(perf_template); }
 };
 
-struct prb_t : public prb_vdims_t {
+struct prb_t : public prb_vdims_t, public base_prb_t {
     prb_t(const prb_vdims_t &prb_vdims, const std::vector<dnnl_data_type_t> &dt,
             const std::string &stag, const std::string &wtag,
             const std::string &dtag, const vdims_t &strides,
@@ -81,6 +82,7 @@ struct prb_t : public prb_vdims_t {
             const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
+        , base_prb_t(FWD_I, false, attr, impl_filter)
         , dt(dt)
         , stag(stag)
         , wtag(wtag)
@@ -93,10 +95,8 @@ struct prb_t : public prb_vdims_t {
         , batch_size(batch_size)
         , brgemm_attr(brgemm_attr)
         , batch_kind(batch_kind)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
 
         // Broadcast data types if needed
         if (dt.size() == 1) {
@@ -124,7 +124,6 @@ struct prb_t : public prb_vdims_t {
     int64_t m, n, k;
     // brgemm does not have any propagation kind. Treat as forward inference to
     // have correct check for data type support.
-    dir_t dir = FWD_I;
     std::vector<dnnl_data_type_t> dt;
     std::string stag, wtag, dtag;
     vdims_t strides;
@@ -134,11 +133,7 @@ struct prb_t : public prb_vdims_t {
     int64_t batch_size;
     std::string brgemm_attr;
     std::string batch_kind;
-
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     double ops;
 
     const dims_t &src_dims() const { return vdims[0]; }
@@ -195,19 +190,8 @@ struct prb_t : public prb_vdims_t {
         return false;
     }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 
     void check_block_size() const;
 };

--- a/tests/benchdnn/concat/concat.hpp
+++ b/tests/benchdnn/concat/concat.hpp
@@ -26,6 +26,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace concat {
@@ -54,7 +55,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_vdims_t {
+struct prb_t : public prb_vdims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
@@ -69,15 +70,14 @@ struct prb_t : public prb_vdims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
+        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
         , axis(axis)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         // If dst is omitted by `dtag = tag::undef`, omit `ddt` as well.
         if (dtag == tag::undef) this->ddt = dnnl_data_type_undef;
 
@@ -86,17 +86,11 @@ struct prb_t : public prb_vdims_t {
         dst_dims[axis] = axis_size();
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir = FLAG_FWD; // Lack of prop_kind, always considered as forward.
     dnnl_data_type_t sdt, ddt;
     std::vector<std::string> stag;
     std::string dtag;
     int axis;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     int64_t axis_size() const {
         int64_t as = 0;
         for (int i = 0; i < n_inputs(); ++i)
@@ -104,19 +98,8 @@ struct prb_t : public prb_vdims_t {
         return as;
     }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -29,6 +29,7 @@
 #include "dnnl_common.hpp"
 #include "utils/cfg.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace conv {
@@ -117,7 +118,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.bia_dt[0], s.stag[0], s.wtag[0],
@@ -134,7 +135,7 @@ struct prb_t : public desc_t {
             int64_t mb, const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , dt(dt)
         , bia_dt_(bia_dt)
         , stag(stag)
@@ -144,10 +145,8 @@ struct prb_t : public desc_t {
         , alg(alg)
         , user_mb(mb)
         , ops(0)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -159,8 +158,6 @@ struct prb_t : public desc_t {
         count_ops();
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     std::vector<dnnl_data_type_t> dt;
     dnnl_data_type_t bia_dt_; // `_` to avoid conflicting name with bia_dt().
     std::string stag, wtag, dtag;
@@ -168,11 +165,7 @@ struct prb_t : public desc_t {
     mutable alg_t alg; // `mutable` because of `AUTO`.
     int64_t user_mb;
     double ops;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     void count_ops();
     int64_t count_n_acc() const {
         return (dir & FLAG_FWD)    ? kd * kh * kw * ic / g
@@ -186,19 +179,8 @@ struct prb_t : public desc_t {
     dnnl_data_type_t dst_dt() const { return dt[2]; }
     dnnl_data_type_t get_dt(data_kind_t data_kind) const;
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/deconv/deconv.hpp
+++ b/tests/benchdnn/deconv/deconv.hpp
@@ -32,6 +32,7 @@
 #include "utils/cfg.hpp"
 #include "utils/compare.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace deconv {
@@ -118,7 +119,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.bia_dt[0], s.stag[0], s.wtag[0],
@@ -134,7 +135,7 @@ struct prb_t : public desc_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , dt(dt)
         , bia_dt_(bia_dt)
         , stag(stag)
@@ -143,10 +144,8 @@ struct prb_t : public desc_t {
         , alg(alg)
         , user_mb(mb)
         , ops(0)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -158,19 +157,13 @@ struct prb_t : public desc_t {
         count_ops();
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     std::vector<dnnl_data_type_t> dt;
     dnnl_data_type_t bia_dt_; // `_` to avoid conflicting name with bia_dt().
     std::string stag, wtag, dtag;
     alg_t alg;
     int64_t user_mb;
     double ops;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     void count_ops();
     int64_t count_n_acc() const {
         return (dir & FLAG_FWD)    ? kd * kh * kw * ic / g
@@ -184,19 +177,8 @@ struct prb_t : public desc_t {
     dnnl_data_type_t dst_dt() const { return dt[2]; }
     dnnl_data_type_t get_dt(data_kind_t data_kind) const;
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/eltwise/eltwise.hpp
+++ b/tests/benchdnn/eltwise/eltwise.hpp
@@ -26,6 +26,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace eltwise {
@@ -57,7 +58,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_dims_t {
+struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.dir[0], s.dt[0], s.tag[0], s.alg[0], s.alpha[0],
@@ -72,33 +73,24 @@ struct prb_t : public prb_dims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , dir(dir)
+        , base_prb_t(dir, inplace, attr, impl_filter)
         , dt(dt)
         , tag(tag)
         , alg(alg)
         , alpha(alpha)
         , beta(beta)
         , user_mb(mb)
-        , inplace(inplace)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) dims[0] = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     dnnl_data_type_t dt;
     std::string tag;
     alg_t alg;
     float alpha, beta;
     int64_t user_mb;
-    bool inplace;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     bool use_dst() const {
         return alg == alg_t::RELU_DST || alg == alg_t::TANH_DST
                 || alg == alg_t::ELU_DST || alg == alg_t::SQRT_DST
@@ -106,19 +98,8 @@ struct prb_t : public prb_dims_t {
                 || alg == alg_t::CLIP_V2_DST;
     }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/gnorm/gnorm.hpp
+++ b/tests/benchdnn/gnorm/gnorm.hpp
@@ -26,6 +26,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 #include "bnorm/bnorm.hpp"
@@ -76,7 +77,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.flags[0], s.check_alg,
@@ -92,17 +93,14 @@ struct prb_t : public desc_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, inplace, attr, impl_filter)
         , dt(dt)
         , tag(tag)
         , flags(flags)
         , check_alg(check_alg)
         , user_mb(mb)
-        , inplace(inplace)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
 
         if (mb) this->mb = mb;
 
@@ -113,35 +111,20 @@ struct prb_t : public desc_t {
     }
 
     std::string stat_tag;
-    dir_t dir;
     std::vector<dnnl_data_type_t> dt;
     std::vector<std::string> tag;
     flags_t flags;
     check_alg_t check_alg;
     int64_t user_mb;
-    bool inplace;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     bool use_stats() const { return flags & GLOB_STATS; }
     bool use_sc() const { return flags & USE_SCALE; }
     bool use_sh() const { return flags & USE_SHIFT; }
 
     int64_t get_c_start(int64_t _g) const { return _g * this->ic / this->g; }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct cfg_t {

--- a/tests/benchdnn/ip/ip.hpp
+++ b/tests/benchdnn/ip/ip.hpp
@@ -26,6 +26,7 @@
 #include "dnnl_common.hpp"
 #include "utils/cfg.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace ip {
@@ -68,7 +69,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.bia_dt[0], s.stag[0], s.wtag[0],
@@ -84,7 +85,7 @@ struct prb_t : public desc_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , dt(dt)
         , bia_dt_(bia_dt)
         , stag(stag)
@@ -92,10 +93,8 @@ struct prb_t : public desc_t {
         , dtag(dtag)
         , user_mb(mb)
         , ops(0)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -107,18 +106,12 @@ struct prb_t : public desc_t {
         count_ops();
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     std::vector<dnnl_data_type_t> dt;
     dnnl_data_type_t bia_dt_; // `_` to avoid conflicting name with bia_dt().
     std::string stag, wtag, dtag;
     int64_t user_mb;
     double ops;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     void count_ops() {
         if (ops > 0) return;
         ops = 2. * mb * ic * oc * id * ih * iw;
@@ -133,19 +126,8 @@ struct prb_t : public desc_t {
     dnnl_data_type_t dst_dt() const { return dt[2]; }
     dnnl_data_type_t get_dt(data_kind_t data_kind) const;
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/lnorm/lnorm.hpp
+++ b/tests/benchdnn/lnorm/lnorm.hpp
@@ -30,6 +30,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 #include "bnorm/bnorm.hpp"
@@ -76,7 +77,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_dims_t {
+struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.tag[0], s.stat_tag[0], s.ss_dt[0], s.dir[0],
@@ -93,18 +94,15 @@ struct prb_t : public prb_dims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
+        , base_prb_t(dir, inplace, attr, impl_filter)
         , check_alg(check_alg)
         , tag(tag)
         , stat_tag(stat_tag)
         , ss_dt(ss_dt)
-        , dir(dir)
         , dt(dt)
         , flags(flags)
-        , inplace(inplace)
-        , attr(attr)
         , ctx_init(ctx_init)
         , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter)
         , n(1)
         , c(dims[ndims - 1])
         , eps(eps) {
@@ -124,13 +122,9 @@ struct prb_t : public prb_dims_t {
     std::vector<std::string> tag;
     std::string stat_tag;
     dnnl_data_type_t ss_dt;
-    dir_t dir;
     std::vector<dnnl_data_type_t> dt;
     flags_t flags;
-    bool inplace;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
     int64_t n, c;
     float eps;
 
@@ -139,19 +133,8 @@ struct prb_t : public prb_dims_t {
     bool use_sh() const { return flags & USE_SHIFT; }
     bool skip_mean() const { return flags & USE_RMS_NORM; }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct cfg_t {

--- a/tests/benchdnn/lrn/lrn.hpp
+++ b/tests/benchdnn/lrn/lrn.hpp
@@ -29,6 +29,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace lrn {
@@ -71,7 +72,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.alg[0], s.mb[0],
@@ -85,42 +86,24 @@ struct prb_t : public desc_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , dt(dt)
         , tag(tag)
         , alg(alg)
         , user_mb(mb)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) this->mb = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     dnnl_data_type_t dt;
     std::string tag;
     alg_t alg;
     int64_t user_mb;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -30,6 +30,7 @@
 #include "dnnl_common.hpp"
 #include "utils/cfg.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace matmul {
@@ -65,7 +66,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_vdims_t {
+struct prb_t : public prb_vdims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.dt[0], s.stag[0], s.wtag[0], s.dtag[0],
@@ -84,6 +85,7 @@ struct prb_t : public prb_vdims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
+        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
         , dt(dt)
         , stag(stag)
         , wtag(wtag)
@@ -93,10 +95,8 @@ struct prb_t : public prb_vdims_t {
         , bia_mask(bia_mask)
         , rt_dims_masks(rt_dims_masks)
         , sparse_options(sparse_options)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
 
         // Broadcast data types if needed
         if (dt.size() == 1) {
@@ -124,7 +124,6 @@ struct prb_t : public prb_vdims_t {
     }
 
     int64_t m, n, k, mb;
-    dir_t dir = FLAG_FWD; // Lack of prop_kind, always considered as forward.
     std::vector<dnnl_data_type_t> dt;
     std::string stag, wtag, dtag;
     vdims_t strides;
@@ -132,12 +131,7 @@ struct prb_t : public prb_vdims_t {
     int bia_mask;
     std::vector<dims_mask_t> rt_dims_masks;
     sparse_options_t sparse_options;
-
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     double ops;
 
     const dims_t &src_dims() const { return vdims[0]; }
@@ -181,14 +175,10 @@ struct prb_t : public prb_vdims_t {
 
     // Used to construct memory desc when dimensions are runtime since such mds
     // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const;
-
-    const char *str() const { return repro.c_str(); }
+    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const override;
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 
     void init_dst_rt_dims_mask() {
         if (rt_dims_masks.size() > 2) return;

--- a/tests/benchdnn/pool/pool.hpp
+++ b/tests/benchdnn/pool/pool.hpp
@@ -29,6 +29,7 @@
 #include "dnnl_common.hpp"
 #include "utils/cfg.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace pool {
@@ -108,7 +109,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.alg[0], s.mb[0],
@@ -123,15 +124,13 @@ struct prb_t : public desc_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , dt(dt)
         , tag(tag)
         , alg(alg)
         , user_mb(mb)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -142,17 +141,11 @@ struct prb_t : public desc_t {
 
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     std::vector<dnnl_data_type_t> dt;
     std::string tag;
     alg_t alg;
     int64_t user_mb;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     int64_t kernel_size() const { return kd * kh * kw; }
     bool has_ker_in_pad() const {
         bool ker_in_pad_d = pd >= kd || pd_r >= kd;
@@ -165,19 +158,8 @@ struct prb_t : public desc_t {
     dnnl_data_type_t dst_dt() const { return dt[1]; }
     dnnl_data_type_t get_dt(data_kind_t data_kind) const;
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/prelu/prelu.hpp
+++ b/tests/benchdnn/prelu/prelu.hpp
@@ -24,6 +24,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace prelu {
@@ -50,7 +51,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_vdims_t {
+struct prb_t : public prb_vdims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.dir[0], s.sdt[0], s.stag[0],
@@ -65,13 +66,11 @@ struct prb_t : public prb_vdims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , sdt(sdt)
         , stag(stag)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         // Broadcast data types if needed
         if (sdt.size() == 1) {
             const auto val = sdt[0]; // Need a copy here.
@@ -80,28 +79,12 @@ struct prb_t : public prb_vdims_t {
 
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     std::vector<dnnl_data_type_t> sdt;
     std::vector<std::string> stag;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/reduction/reduction.hpp
+++ b/tests/benchdnn/reduction/reduction.hpp
@@ -23,6 +23,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace reduction {
@@ -79,7 +80,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_vdims_t {
+struct prb_t : public prb_vdims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0], s.alg[0],
@@ -94,6 +95,7 @@ struct prb_t : public prb_vdims_t {
             const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
+        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
@@ -101,36 +103,18 @@ struct prb_t : public prb_vdims_t {
         , alg(alg)
         , p(p)
         , eps(eps)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir = FLAG_FWD; // Lack of prop_kind, always considered as forward.
     dnnl_data_type_t sdt, ddt;
     std::string stag, dtag;
     alg_t alg;
     float p, eps;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/reorder/reorder.hpp
+++ b/tests/benchdnn/reorder/reorder.hpp
@@ -26,6 +26,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace reorder {
@@ -80,7 +81,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_dims_t {
+struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
@@ -98,6 +99,7 @@ struct prb_t : public prb_dims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
+        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
@@ -106,25 +108,17 @@ struct prb_t : public prb_dims_t {
         , oflag(oflag)
         , cross_engine(cross_engine)
         , runtime_dim_mask(runtime_dim_mask)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir = FLAG_FWD; // Lack of prop_kind, always considered as forward.
     dnnl_data_type_t sdt, ddt;
     std::string stag, dtag;
     vdims_t strides;
     std::vector<flag_t> oflag;
     cross_engine_t cross_engine;
     unsigned runtime_dim_mask;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
     bool is_reorder_with_compensation(flag_bit_t flag) const;
     dims_t get_compensation_dims(flag_bit_t flag) const;
     int get_compensation_mask(flag_bit_t flag) const;
@@ -132,14 +126,10 @@ struct prb_t : public prb_dims_t {
 
     // Used to construct memory desc when dimensions are runtime since such mds
     // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const;
-
-    const char *str() const { return repro.c_str(); }
+    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const override;
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 
     void get_compensation_parameters(
             dims_t &comp_dims, int &mask, flag_bit_t flag) const;

--- a/tests/benchdnn/resampling/resampling.hpp
+++ b/tests/benchdnn/resampling/resampling.hpp
@@ -28,6 +28,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace resampling {
@@ -82,7 +83,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.sdt[0], s.ddt[0], s.tag[0], s.alg[0],
@@ -96,43 +97,25 @@ struct prb_t : public desc_t {
             const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , tag(tag)
         , alg(alg)
         , user_mb(mb)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) this->mb = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     dnnl_data_type_t sdt, ddt;
     std::string tag;
     alg_t alg;
     int64_t user_mb;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -31,6 +31,7 @@
 #include "dnnl_debug.hpp"
 #include "utils/memory.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 #define AOC array_offset_calculator
@@ -277,7 +278,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public desc_t {
+struct prb_t : public desc_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, dt_conf_t::create(s.cfg[0], s.attributes.front()),
@@ -301,10 +302,10 @@ struct prb_t : public desc_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
+        , base_prb_t(prop, false, attr, impl_filter)
         , cfg(cfg)
         , tag(tag)
         , prop(prop2prop_kind(prop))
-        , dir(prop)
         , alg(alg)
         , with_peephole(with_peephole)
         , with_projection(with_projection)
@@ -320,10 +321,8 @@ struct prb_t : public desc_t {
         , user_mb(mb)
         , ops(0.0)
         , linear_cscale(0.0f)
-        , attr(attr)
         , ctx_init(ctx_init)
         , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter)
         , wei_nscales(0)
         , wei_scales_mask(0x0)
         , wei_proj_nscales(0)
@@ -506,19 +505,9 @@ struct prb_t : public desc_t {
         }
     }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
     const dt_conf_t &cfg;
     std::vector<std::string> tag;
     dnnl_prop_kind_t prop;
-    dir_t dir; // Same as `prop`, for compatibility. TODO: remove me;
     alg_t alg;
     bool with_peephole, with_projection;
     dnnl_rnn_direction_t direction;
@@ -533,10 +522,7 @@ struct prb_t : public desc_t {
     int64_t user_mb;
     double ops;
     float linear_cscale;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
 
     float data_scale, data_shift;
 
@@ -551,9 +537,7 @@ struct prb_t : public desc_t {
     float *linear_scales;
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 
     /* Todo: fused the two functions in set_shifts_scales */
     void set_qparams(float fp_min, float fp_max);

--- a/tests/benchdnn/sdpa/sdpa.hpp
+++ b/tests/benchdnn/sdpa/sdpa.hpp
@@ -25,6 +25,7 @@
 #include "dnnl_common.hpp"
 #include "utils/cfg.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 // C API for SDPA primitive creation (forward and backward overloads).
@@ -94,7 +95,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_vdims_t {
+struct prb_t : public prb_vdims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.dir[0], s.dt[0], s.qtag[0], s.ktag[0], s.vtag[0],
@@ -112,7 +113,7 @@ struct prb_t : public prb_vdims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , dt(dt)
         , qtag(qtag)
         , ktag(ktag)
@@ -121,10 +122,8 @@ struct prb_t : public prb_vdims_t {
         , mdt(mdt)
         , mask_type(mask_type)
         , scale_type(scale_type)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
 
         // Broadcast data types if needed: Q,K,V,DST
         if (this->dt.size() == 1) {
@@ -183,17 +182,13 @@ struct prb_t : public prb_vdims_t {
     }
 
     int64_t n_queries, head_size, n_keys, n_values, mb;
-    dir_t dir;
     std::vector<dnnl_data_type_t> dt;
     std::string qtag, ktag, vtag, dtag;
     dnnl_data_type_t mdt;
     mask_type_t mask_type;
     scale_type_t scale_type;
 
-    bool inplace = false;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
 
     double ops;
     dims_t dst_dims;
@@ -222,13 +217,10 @@ struct prb_t : public prb_vdims_t {
     dnnl_data_type_t get_dt(data_kind_t data_kind) const;
 
     // Required by init_memory_args template (for runtime dims support).
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const;
-
-    const char *str() const { return repro.c_str(); }
+    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const override;
 
 private:
-    std::string repro;
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/shuffle/shuffle.hpp
+++ b/tests/benchdnn/shuffle/shuffle.hpp
@@ -29,6 +29,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace shuffle {
@@ -58,7 +59,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_dims_t {
+struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.dir[0], s.dt[0], s.tag[0], s.axis[0], s.group[0],
@@ -72,41 +73,23 @@ struct prb_t : public prb_dims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , dir(dir)
+        , base_prb_t(dir, false, attr, impl_filter)
         , dt(dt)
         , tag(tag)
         , axis(axis)
         , group(group)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     dnnl_data_type_t dt;
     std::string tag;
     int axis;
     int64_t group;
-    bool inplace = false; // Lacks placement, always considered `false`.
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/softmax/softmax.hpp
+++ b/tests/benchdnn/softmax/softmax.hpp
@@ -26,6 +26,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace softmax {
@@ -71,7 +72,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_dims_t {
+struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.dir[0], s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
@@ -88,7 +89,7 @@ struct prb_t : public prb_dims_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , dir(dir)
+        , base_prb_t(dir, inplace, attr, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
@@ -97,40 +98,21 @@ struct prb_t : public prb_dims_t {
         , axis(axis)
         , has_stats(has_stats)
         , user_mb(mb)
-        , inplace(inplace)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
         if (mb) dims[0] = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-
-    dir_t dir;
     dnnl_data_type_t sdt, ddt;
     std::string stag, dtag;
     alg_t alg;
     int axis;
     bool has_stats;
     int64_t user_mb;
-    bool inplace;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
-
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
 
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/sum/sum.hpp
+++ b/tests/benchdnn/sum/sum.hpp
@@ -26,6 +26,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace sum {
@@ -55,7 +56,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_dims_t {
+struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
@@ -70,16 +71,14 @@ struct prb_t : public prb_dims_t {
             bool inplace, const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
+        , base_prb_t(FLAG_FWD, inplace, attr, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
         , input_scales(input_scales)
-        , inplace(inplace)
-        , attr(attr)
         , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , ctx_exe(ctx_exe) {
 
         broadcast_vector(this->stag, n_inputs());
 
@@ -92,32 +91,17 @@ struct prb_t : public prb_dims_t {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
 
-    dir_t dir = FLAG_FWD; // Lack of prop_kind, always considered as forward.
     std::vector<dnnl_data_type_t> sdt;
     dnnl_data_type_t ddt;
     std::vector<std::string> stag;
     std::string dtag;
     std::vector<float> input_scales;
-    bool inplace;
-    attr_t attr;
     thr_ctx_t ctx_init, ctx_exe;
-    impl_filter_t impl_filter;
 
     int n_inputs() const { return (int)sdt.size(); }
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {

--- a/tests/benchdnn/utils/prb.hpp
+++ b/tests/benchdnn/utils/prb.hpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef UTILS_PRB_HPP
+#define UTILS_PRB_HPP
+
+#include "dnn_types.hpp"
+#include "utils/impl_filter.hpp"
+#include "utils/res.hpp"
+#include "utils/wrapper.hpp"
+
+#include <cassert>
+#include <string>
+
+// A base class for all driver-specific `prb_t` problem descriptors. It holds
+// the members that are common across **every** driver and exposes a polymorphic
+// interface for all functions to rely on it.
+struct base_prb_t {
+    base_prb_t() = default;
+    base_prb_t(dir_t dir, bool inplace, const attr_t &attr,
+            const impl_filter_t &impl_filter)
+        : dir(dir), inplace(inplace), attr(attr), impl_filter(impl_filter) {}
+
+    virtual ~base_prb_t() = default;
+
+    dir_t dir = FLAG_FWD;
+    bool inplace = false;
+    attr_t attr;
+    impl_filter_t impl_filter;
+
+    // Use to construct memory descriptor when dimensions are runtime since such
+    // memory descriptors can't be used directly from a query call and memory
+    // objects can't be constructed from such descriptors.
+    // Drivers supporting runtime dimensions must override this call.
+    virtual benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
+        assert(!"No runtime dimensions support for this driver!");
+        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
+    }
+
+    const char *str() const { return repro.c_str(); }
+
+protected:
+    // Collects driver-specific reproducer information into a single line. Each
+    // driver provides its own implementation and must call it last in the ctor
+    // to assign the result to `repro`.
+    virtual std::string set_repro_line() = 0;
+
+    std::string repro;
+};
+
+#endif

--- a/tests/benchdnn/zeropad/zeropad.hpp
+++ b/tests/benchdnn/zeropad/zeropad.hpp
@@ -24,6 +24,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "utils/perf_report.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace zeropad {
@@ -49,7 +50,7 @@ struct settings_t : public base_settings_t {
     }
 };
 
-struct prb_t : public prb_dims_t {
+struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s) : prb_t(s.prb_dims, s.dt[0], s.tag[0]) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
@@ -57,26 +58,15 @@ struct prb_t : public prb_dims_t {
 
     prb_t(const prb_dims_t &prb_dims, dnnl_data_type_t dt,
             const std::string &tag)
-        : prb_dims_t(prb_dims), dt(dt), tag(tag) {
+        : prb_dims_t(prb_dims), base_prb_t(), dt(dt), tag(tag) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
 
     dnnl_data_type_t dt;
     std::string tag;
 
-    // Used to construct memory desc when dimensions are runtime since such mds
-    // can't be used directly from query and memory objects can't be constructed.
-    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const {
-        assert(!"No runtime dimensions support for this driver!");
-        return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
-    }
-
-    const char *str() const { return repro.c_str(); }
-
 private:
-    std::string repro;
-
-    std::string set_repro_line();
+    std::string set_repro_line() override;
 };
 
 struct perf_report_t : public base_perf_report_t {


### PR DESCRIPTION
This will serve as a future foundation for de-templating all currently templated on `prb_t` functions.

Currently, all functions that have dependency on `prb` (most of them are in dnnl_common.hpp), force a function signature to be templated on `prb_t` since each driver namespace has own copy. It also mandates each `prb_t` type has similar members the common space relies on and methods.

The coming refactor will approach dependency on prb in polymorphic way - `base_prb_t` class (introduced in this PR) will serve as a parent class for each `prb_t` and each `prb_t` class with downcast `base_prb_t` to its own type when access to unique members is required. This relies on the same approach as library does for `opdesc_t`.

The base type serves two purposes:
* Allows de-template all functions which in turn allows to move all function bodies to .cpp, which allows to reduce the amount of headers passed across all benchdnn and also detangle a long dependency on the library through test_thread.hpp (which will be refactored as well).
* Allows to enable driver's features at a single spot without massive code update (though some driver specific changes in constructors will still be needed).