### PR TITLE
[GPU] Xe3p 256 B prefetch + more

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
@@ -293,7 +293,7 @@ void Generator<hw>::setupAddr(Type T, const GRFRange &addr, const BO &ptr, const
             // Assemble some information.
             bool memCM = isColMajor(atype.layout);
             int bw, bh, bcount, multiX;
-            block.getBlock2DWH(bw, bh, bcount, atype, &multiX);
+            block.getBlock2DWH(bw, bh, bcount, atype, astrategy.prefetch, &multiX);
 
             auto iremR = params.remR, iremC = params.remC;
             if (!block.remainderR) iremR.invalidate();
@@ -526,7 +526,7 @@ void Generator<hw>::setupAddrRel(const GRFRange &addrDst, const GRFRange &addrSr
     }
 
     if (isBlock2D(astrategy.accessType))
-        updateBlock2DSizes(addrDst, blockDst, blockSrc, atype);
+        updateBlock2DSizes(addrDst, blockDst, blockSrc, atype, astrategy.prefetch);
 }
 
 static inline int findBaseBlock(const RegisterBlock &block, const RegisterLayout &layout, int start, int end,
@@ -805,7 +805,7 @@ void Generator<hw>::setAddrRemainder(Type T, const GRFRange &addr, const Registe
     auto &remW = memCM ? thisRemR : thisRemC;
     auto &remH = memCM ? thisRemC : thisRemR;
     int bw, bh, bcount, multiX;
-    block.getBlock2DWH(bw, bh, bcount, atype, &multiX);
+    block.getBlock2DWH(bw, bh, bcount, atype, astrategy.prefetch, &multiX);
 
     if (!block.remainderR)                   thisRemR.invalidate();
     if (!block.remainderC)                   thisRemC.invalidate();

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -2076,9 +2076,9 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
 
     // Free unneeded registers after address setup.
     if (!state.isNested) {
-        if (strategy.A.address2D && (!strategy.prefetchA || strategy.A_prefetch.address2D))
+        if (strategy.A.address2D && (!strategy.prefetchA || strategy.A_prefetch.address2D) && !strategy.l3PrefetchA)
             state.ra.safeRelease(state.inputs.lda);
-        if (strategy.B.address2D && (!strategy.prefetchB || strategy.B_prefetch.address2D))
+        if (strategy.B.address2D && (!strategy.prefetchB || strategy.B_prefetch.address2D) && !strategy.l3PrefetchB)
             state.ra.safeRelease(state.inputs.ldb);
         if (!strategy.C.address2D && (!strategy.prefetchC || !strategy.C_prefetch.address2D) && !keepIJ0(problem, strategy)) {
             state.ra.safeRelease(state.i0);

--- a/src/gpu/intel/gemm/jit/generator/pieces/l3_prefetch.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/l3_prefetch.cxx
@@ -36,13 +36,26 @@ void Generator<hw>::gemmInitL3Prefetch(bool nextWave, const GEMMProblem &problem
     bool doA = strategy.l3PrefetchA;
     bool doB = strategy.l3PrefetchB;
 
+    // L3 prefetch targets global memory. When SLM copies are active,
+    // problem.A/B have been replaced with SLM layouts; use the saved
+    // original global layouts instead. Check strategy.A/B.base rather
+    // than strategy.slmA/B, as the latter is true even before SLM setup
+    // has run (e.g. during warmup).
+    bool slmActiveA = (strategy.A.base.getModel() == AddressModel::ModelSLM);
+    bool slmActiveB = (strategy.B.base.getModel() == AddressModel::ModelSLM);
+    auto globalA = slmActiveA ? state.Ai : problem.A;
+    auto globalB = slmActiveB ? state.Bi : problem.B;
+
     auto &gidMN = state.groupIDMN;
     auto gcMN = state.inputs.groupCountMN;
     Subregister nextGroupID;
 
     if (nextWave) {
         nextGroupID = state.ra.alloc_sub<uint32_t>();
-        add(1, nextGroupID, gidMN, state.inputs.groupStride);
+        if (strategy.persistentLoop())
+            add(1, nextGroupID, gidMN, state.inputs.groupStride);
+        else
+            add(1, nextGroupID, gidMN, 1);
     } else
         nextGroupID = gidMN;
 
@@ -78,8 +91,8 @@ void Generator<hw>::gemmInitL3Prefetch(bool nextWave, const GEMMProblem &problem
     if (doA) mulConstant(1, nextI0, state.nextGroupIDM, strategy.wgTile(LoopM));
     if (doB) mulConstant(1, nextJ0, state.nextGroupIDN, strategy.wgTile(LoopN));
 
-    auto coopSplitA = naturalSplitA(problem.A.layout);
-    auto coopSplitB = naturalSplitB(problem.B.layout);
+    auto coopSplitA = naturalSplitA(globalA.layout);
+    auto coopSplitB = naturalSplitB(globalB.layout);
 
     auto effApL3 = state.inputs.A;
     auto effBpL3 = state.inputs.B;
@@ -95,28 +108,28 @@ void Generator<hw>::gemmInitL3Prefetch(bool nextWave, const GEMMProblem &problem
     int ma_prefetchL3, ka_prefetchL3;
     int kb_prefetchL3, nb_prefetchL3;
 
-    if (doA) coopSplit(true,  ma_prefetchL3, ka_prefetchL3, strategy.unroll[LoopM], strategy.ka_prefetchL3, strategy.wgTile(LoopM), coopSplitA, problem.A, strategy);
-    if (doB) coopSplit(false, kb_prefetchL3, nb_prefetchL3, strategy.kb_prefetchL3, strategy.unroll[LoopN], strategy.wgTile(LoopN), coopSplitB, problem.B, strategy);
+    if (doA) coopSplit(true,  ma_prefetchL3, ka_prefetchL3, strategy.unroll[LoopM], strategy.ka_prefetchL3, strategy.wgTile(LoopM), coopSplitA, globalA, strategy);
+    if (doB) coopSplit(false, kb_prefetchL3, nb_prefetchL3, strategy.kb_prefetchL3, strategy.unroll[LoopN], strategy.wgTile(LoopN), coopSplitB, globalB, strategy);
 
     std::swap(state.effCoopA, coopSplitA);  /* Temporarily override A/B splitting */
     std::swap(state.effCoopB, coopSplitB);
 
-    if (doA) gemmApplyWorkshareOffset(true,  effApL3, state.inputs.A, Apl3_params, problem.A, strategy.AB_prefetchL3, ma_prefetchL3, ka_prefetchL3, problem, strategy, state);
-    if (doB) gemmApplyWorkshareOffset(false, effBpL3, state.inputs.B, Bpl3_params, problem.B, strategy.AB_prefetchL3, kb_prefetchL3, nb_prefetchL3, problem, strategy, state);
+    if (doA) gemmApplyWorkshareOffset(true,  effApL3, state.inputs.A, Apl3_params, globalA, strategy.AB_prefetchL3, ma_prefetchL3, ka_prefetchL3, problem, strategy, state);
+    if (doB) gemmApplyWorkshareOffset(false, effBpL3, state.inputs.B, Bpl3_params, globalB, strategy.AB_prefetchL3, kb_prefetchL3, nb_prefetchL3, problem, strategy, state);
 
     std::swap(state.effCoopA, coopSplitA);
     std::swap(state.effCoopB, coopSplitB); /* ... and restore */
 
     if (!strategy.AB_prefetchL3.address2D) {
-        if (doA) gemmOffsetAm(nextI0, effApL3, problem.A, problem, strategy, state);
-        if (doB) gemmOffsetBn(nextJ0, effBpL3, problem.B, problem, strategy, state);
+        if (doA) gemmOffsetAm(nextI0, effApL3, globalA, problem, strategy, state);
+        if (doB) gemmOffsetBn(nextJ0, effBpL3, globalB, problem, strategy, state);
     }
 
     if (strategy.kParallelLocal) stub();
 
     if (doA && state.Apl3_layout.empty()) {
         state.flagL3PFA = state.raVFlag.alloc();
-        state.Apl3_layout = RegisterLayout(hw, Ta_ext, ma_prefetchL3, ka_prefetchL3, problem.A, strategy.AB_prefetchL3);
+        state.Apl3_layout = RegisterLayout(hw, Ta_ext, ma_prefetchL3, ka_prefetchL3, globalA, strategy.AB_prefetchL3);
         for (auto &block: state.Apl3_layout)
             block.flag[0] = state.flagL3PFA;
         allocAddrRegs(state.Apl3_addrs, state.Apl3_layout, state);
@@ -124,7 +137,7 @@ void Generator<hw>::gemmInitL3Prefetch(bool nextWave, const GEMMProblem &problem
 
     if (doB && state.Bpl3_layout.empty()) {
         state.flagL3PFB = state.raVFlag.alloc();
-        state.Bpl3_layout = RegisterLayout(hw, Tb_ext, kb_prefetchL3, nb_prefetchL3, problem.B, strategy.AB_prefetchL3);
+        state.Bpl3_layout = RegisterLayout(hw, Tb_ext, kb_prefetchL3, nb_prefetchL3, globalB, strategy.AB_prefetchL3);
         for (auto &block: state.Bpl3_layout)
             block.flag[0] = state.flagL3PFB;
         allocAddrRegs(state.Bpl3_addrs, state.Bpl3_layout, state);

--- a/src/gpu/intel/gemm/jit/generator/pieces/layout_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/layout_setup.cxx
@@ -81,7 +81,7 @@ void Generator<hw>::adjustSubblockAddrs(const RegisterLayout &sublayout, const v
             auto RegisterBlock::* nh = memCM ? &RegisterBlock::nc : &RegisterBlock::nr;
             bool remW = memCM ? subblock.remainderR : subblock.remainderC;
             bool remH = memCM ? subblock.remainderC : subblock.remainderR;
-            subblock.getBlock2DWH(bw, bh, bcount, atype);
+            subblock.getBlock2DWH(bw, bh, bcount, atype, astrategy.prefetch);
 
             if (!astrategy.address2D) {
                 if (subblock.*nw != block.*nw || subblock.count != block.count) {
@@ -96,17 +96,17 @@ void Generator<hw>::adjustSubblockAddrs(const RegisterLayout &sublayout, const v
                 }
             }
             if (subaddr.isValid())
-                updateBlock2DSizes(subaddr[0], subblock, block, atype);
+                updateBlock2DSizes(subaddr[0], subblock, block, atype, astrategy.prefetch);
         }
     }
 }
 
 // Update block 2D width/height/count parameters as needed after cloning an address register.
 template <HW hw>
-void Generator<hw>::updateBlock2DSizes(GRF addr, const RegisterBlock &dst, const RegisterBlock &src, const MatrixAddressing &atype)
+void Generator<hw>::updateBlock2DSizes(GRF addr, const RegisterBlock &dst, const RegisterBlock &src, const MatrixAddressing &atype, bool prefetch)
 {
     int bw, bh, bcount;
-    dst.getBlock2DWH(bw, bh, bcount, atype);
+    dst.getBlock2DWH(bw, bh, bcount, atype, prefetch);
 
     if (dst.nr != src.nr || dst.nc != src.nc || dst.count != src.count)
         mov(1, addr.ud(7), (bw - 1) | ((bh - 1) << 8) | ((bcount - 1) << 16));

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
@@ -121,7 +121,7 @@ void Generator<hw>::loadMatrixBlock(const Register &dest, const RegisterBlock &b
         case AccessType::Block2DTranspose:
         case AccessType::Block2DVNNI: {
             int w = 0, h = 0, count = 0;
-            block.getBlock2DWH(w, h, count, atype);
+            block.getBlock2DWH(w, h, count, atype, astrategy.prefetch);
             auto spec = block_2d(getDataSizeLSC(block.ebytes, false), w, h, count) | astrategy.cachingR;
             if (astrategy.accessType == AccessType::Block2DTranspose) spec |= transpose;
             if (astrategy.accessType == AccessType::Block2DVNNI)      spec |= vnni;
@@ -221,7 +221,7 @@ void Generator<hw>::storeMatrixBlock(const GRF &src, const RegisterBlock &block,
         case AccessType::Block2DTranspose:
         case AccessType::Block2DVNNI: {
             int w = 0, h = 0, count = 0;
-            block.getBlock2DWH(w, h, count, atype);
+            block.getBlock2DWH(w, h, count, atype, astrategy.prefetch);
             auto spec = block_2d(getDataSizeLSC(block.ebytes, false), w, h, count) | astrategy.cachingW;
             if (astrategy.accessType == AccessType::Block2DTranspose) spec |= transpose;
             if (astrategy.accessType == AccessType::Block2DVNNI)      spec |= vnni;

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
@@ -533,8 +533,13 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
     state.Bs_regs = state.ra.alloc_range(state.Bs_layout.regs());
 
     // Allocate registers for A/B prefetch.
-    state.Ap_regs = state.ra.alloc_range(state.Ap_layout.regs());
-    state.Bp_regs = state.ra.alloc_range(state.Bp_layout.regs());
+    auto needsPFRegs = [](const MatrixAddressingStrategy &as) {
+        return as.prefetch && !as.newDP;
+    };
+    if (state.Ap_layout.valid() && needsPFRegs(state.Ap_layout.addressingStrategy()))
+        state.Ap_regs = state.ra.alloc_range(state.Ap_layout.regs());
+    if (state.Bp_layout.valid() && needsPFRegs(state.Bp_layout.addressingStrategy()))
+        state.Bp_regs = state.ra.alloc_range(state.Bp_layout.regs());
 
     // Allocate registers for A/B quantization parameters.
     state.A_offsetRegs = state.ra.alloc_range(state.A_offsetLayout.regs());

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_layout.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_layout.cpp
@@ -647,7 +647,9 @@ RegisterBlock::RegisterBlock(HW hw_, Type T, int r, int c, const MatrixAddressin
                     maxYBlock = 8;
                 } else {
                     Tblock = Type::u32;
-                    maxW = 8;
+                    maxW = (hw == HW::Xe3p) ? 16 : 8;
+                    // 1-8, 16 supported on Xe3p
+                    if (maxXBlock < (maxW * Tblock) / T) maxW = 8;
                 }
                 maxXBlock = std::min(maxXBlock, (maxW * Tblock) / T);
             } else if (vnni) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_layout.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_layout.cpp
@@ -27,6 +27,10 @@ using namespace ngen;
 using namespace ngen::utils;
 using std::vector;
 
+namespace SendSpec {
+int MaxBlock2DWidthBytes(ngen::HW hw, bool prefetch) { return (hw == HW::Xe3p && prefetch) ? 256 : 64; }
+} // namespace SendSpec
+
 RegisterBlock::RegisterBlock(HW hw_, Type T, int r, int c, const MatrixAddressing &atype, const MatrixAddressingStrategy &astrategy,
                              bool remainderR_, bool remainderC_, bool writable_, RemainderOptions remOpts,
                              int maxRBlock, int maxCBlock)
@@ -610,7 +614,7 @@ RegisterBlock::RegisterBlock(HW hw_, Type T, int r, int c, const MatrixAddressin
         case AccessType::Block2DTranspose:
         case AccessType::Block2DVNNI: {
             // bytes * array length <= 8
-            // width * array length <= 64 bytes
+            // width * array length <= 64 bytes (or == 256 bytes on Xe3p)
             //  => width <= 1 GRF
             // height <= 32 (load) 8 (store)
             // array length = 1 for store, transpose
@@ -664,8 +668,13 @@ RegisterBlock::RegisterBlock(HW hw_, Type T, int r, int c, const MatrixAddressin
             auto X_logical = X;
             X = (X * T) / Tblock;
 
-            // Carve out a maximal allowed block size.
-            xblock = std::min(X, 64 / Tblock);
+            // Carve out a maximal allowed block size - up to 64 bytes, or exactly 256 byte prefetches
+            int maxBlockBytes = SendSpec::MaxBlock2DWidthBytes(hw, prefetch);
+            if (X * Tblock < maxBlockBytes) {
+                // Max-size prefetches only, or fall back to regular block size limitations
+                maxBlockBytes =  SendSpec::MaxBlock2DWidthBytes(hw, false);
+            }
+            xblock = std::min(X, maxBlockBytes / Tblock);
             xblock = std::max(xblock, 4 / Tblock);
             int yblockLimit = writable ? 8 : 32;
 
@@ -1080,7 +1089,7 @@ bool RegisterBlock::pseudoblockUseChannelScattered(const MatrixAddressing &atype
     return (astrategy.base.getModel() == ModelSLM) && (ebytes == 4) && !astrategy.atomic;
 }
 
-void RegisterBlock::getBlock2DWH(int &w, int &h, int &count, const MatrixAddressing &atype, int *outMultiX) const
+void RegisterBlock::getBlock2DWH(int &w, int &h, int &count, const MatrixAddressing &atype, bool prefetch, int *outMultiX) const
 {
     int multiX = 1;
     bool transpose = (isColMajor(atype.layout) != colMajor);
@@ -1088,7 +1097,12 @@ void RegisterBlock::getBlock2DWH(int &w, int &h, int &count, const MatrixAddress
     h = isColMajor(atype.layout) ? nc : nr;
     w = (w * extra) / (ebytes * 8);     /* extra: #bits in logical data type */
     if (isPacked(atype.layout)) {
-        int maxW = 64 / ebytes;
+        // prefetch: allow max-size or regular max width fallback
+        int maxWBytes = SendSpec::MaxBlock2DWidthBytes(hw, prefetch);
+        if (w * ebytes < maxWBytes) {
+            maxWBytes = SendSpec::MaxBlock2DWidthBytes(hw, false);
+        }
+        int maxW = maxWBytes / ebytes;
         multiX = div_up(w, maxW);
         w /= multiX;
         h *= multiX;

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_layout.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_layout.hpp
@@ -220,7 +220,7 @@ struct RegisterBlock {
     bool pseudoblockUseChannelScattered(const MatrixAddressing &atype, const MatrixAddressingStrategy &astrategy) const;
 
     // Get width/height/array size parameters for underlying 2D block load message.
-    void getBlock2DWH(int &w, int &h, int &count, const MatrixAddressing &atype, int *outMultiX = nullptr) const;
+    void getBlock2DWH(int &w, int &h, int &count, const MatrixAddressing &atype, bool prefetch, int *outMultiX = nullptr) const;
 
     // Count the number of address/header GRFs required by a RegisterBlock.
     int addrGRFs(const MatrixAddressing &atype, const MatrixAddressingStrategy &astrategy) const;

--- a/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
@@ -418,7 +418,7 @@ protected:
     bool tryAddRemainder(RegisterLayout &layout, bool remainderR, bool remainderC, RemainderOptions remOpts);
     void addRemainder(RegisterLayout &layout, bool remainderR, bool remainderC, RemainderOptions remOpts);
     void addRemainder(RegisterLayout &layout, std::vector<ngen::GRFRange> &addrs, const ngen::Subregister &ld, bool remainderR, bool remainderC, RemainderOptions remOpts, const CommonStrategy &strategy, CommonState &state, int dataRegs = -1);
-    void updateBlock2DSizes(ngen::GRF addr, const RegisterBlock &dst, const RegisterBlock &src, const MatrixAddressing &atype);
+    void updateBlock2DSizes(ngen::GRF addr, const RegisterBlock &dst, const RegisterBlock &src, const MatrixAddressing &atype, bool prefetch);
     void adjustSubblockAddrs(const RegisterLayout &sublayout, const std::vector<ngen::GRFRange> &subaddrs, const RegisterLayout &layout, const std::vector<ngen::GRFRange> &addrs, const CommonStrategy &strategy, const CommonState &state);
 
     // masks.cxx

--- a/src/gpu/intel/gemm/jit/include/gemmstone/strategy.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/strategy.hpp
@@ -356,7 +356,8 @@ struct GEMMStrategy : public GEMMStrategyPOD
     bool persistentLoop()     const { return persistent || kParallelVariable; }
 
     bool needsMNLocalIDs()    const { return xParallel || (slmBuffers > 0) || cooperativePF || kParallelLocal || persistentLoop()
-                                                       || namedBarriers[LoopM] || namedBarriers[LoopN] || (dpasw && !fixedSystolic); }
+                                                       || namedBarriers[LoopM] || namedBarriers[LoopN] || (dpasw && !fixedSystolic)
+                                                       || (l3PrefetchA || l3PrefetchB); }
     bool needsKLocalIDs()     const { return kParallelLocal || persistentLoop(); }
     bool needsKLoopBarrier()  const { return (barrierFreq > 0) || (slmBuffers > 0); }
     bool needsBarrier()       const { return needsKLoopBarrier() || xParallel || kParallelLocal || fuseBeta || fusePostOps; }


### PR DESCRIPTION
Addresses [MFDNN-14862](https://jira.devtools.intel.com/browse/MFDNN-14862), as well as some other various changes related to L3 prefetch.
- L3 prefetch was enabled (implicitly) only for persistent threaded kernels. Generalized to non-persistent-threading
- L3 prefetch uses the incorrect layout when SLM buffering is used, changed to always select the global memory layout
- lda/ldb inputs were incorrectly released when using L3 prefetches (used at the end of the k-loop for prefetching the next tile), fixed by keeping them in those cases.
- Added 256-byte prefetch support to gemmstone for Xe3p. Enabled only when prefetch size meets or exceeds 256 bytes (i.e. prefetch sizes are not increased to 256 bytes)
- Added 32-width transposed block 2D load support for Xe3p (described in spec)