### PR TITLE
[GPU] Fix microkernel issues found with Xe3p

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/microkernel/elf.hpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/elf.hpp
@@ -69,6 +69,7 @@ struct SectionHeader {
         StringTable = 3,
         Note = 7,
         Relocation = 9,
+        ZebinSpirv = 0xFF000009,
         ZeInfo = 0xFF000011
     } type;
     uint64_t flags;

--- a/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
@@ -177,6 +177,27 @@ void fuse(std::vector<uint8_t> &binary,
     }
 }
 
+// Drop the zebin SPIR-V section (ZebinSpirv -> Null) so the runtime can't
+// rebuild the program from stale IR and lose the spliced-in microkernels.
+static void stripIntermediateRepresentation(std::vector<uint8_t> &binary) {
+    auto base = binary.data();
+    auto bytes = binary.size();
+    auto fheaderPtr = reinterpret_cast<FileHeader *>(base);
+
+    bool ok = bytes >= sizeof(FileHeader) && fheaderPtr->magic == ELFMagic
+            && fheaderPtr->elfClass == ELFClass64
+            && fheaderPtr->sectionHeaderSize == sizeof(SectionHeader)
+            && bytes >= fheaderPtr->sectionTableOff
+                            + sizeof(SectionHeader) * fheaderPtr->sectionCount;
+    if (!ok) return;
+
+    auto *sheaders = reinterpret_cast<SectionHeader *>(
+            base + fheaderPtr->sectionTableOff);
+    for (int s = 0; s < fheaderPtr->sectionCount; s++)
+        if (sheaders[s].type == SectionHeader::ZebinSpirv)
+            sheaders[s].type = SectionHeader::Null;
+}
+
 void fuse(std::vector<uint8_t> &binary, const char *source) {
     std::vector<uint8_t> microkernel;
     const auto sigilLen = strlen(sigilBinary);
@@ -198,6 +219,7 @@ void fuse(std::vector<uint8_t> &binary, const char *source) {
         }
         fuse(binary, microkernel, id);
     }
+    stripIntermediateRepresentation(binary);
 }
 
 static void fixupJumpTargets(uint8_t *start, size_t len, ptrdiff_t adjust) {


### PR DESCRIPTION
PR includes:

- SPIR-V code stripping for fused kernels. This is to make microkernels compatible with `RebuildPrecompiledKernels`
    - See driver code [here](https://github.com/intel/compute-runtime/blob/ee2aca6b4db56c2e54a3584e0354c4d937c08182/opencl/source/program/program.cpp#L296)
    - This option guides the driver to recompile a kernel based on the SPIR-V IR which results in microkernel loss

Fixes MFDNN-14968