### PR TITLE
graph: backend: dnnl: rework the internal allocator and constant buffer

### DIFF
--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -22,32 +22,21 @@
 #include <utility>
 #include <vector>
 
-#include "graph/interface/allocator.hpp"
-#include "graph/interface/backend.hpp"
-#include "graph/interface/shape_infer.hpp"
-
 #include "graph/utils/utils.hpp"
 
 #include "graph/backend/dnnl/common.hpp"
 #include "graph/backend/dnnl/dnnl_backend.hpp"
-#include "graph/backend/dnnl/scratchpad.hpp"
 
 #include "common/primitive_desc_iface.hpp"
 #include "common/primitive_iface.hpp"
 #include "common/stream.hpp"
 
-#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_SYCL
-const size_t DNNL_CPU_MEMALIGNMENT = 64;
-#endif
-
 #ifdef DNNL_WITH_SYCL
 #include "oneapi/dnnl/dnnl_sycl.hpp"
-const size_t DNNL_SYCL_MEMALIGNMENT = 64;
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include "oneapi/dnnl/dnnl_ocl.hpp"
-const size_t DNNL_OCL_MEMALIGNMENT = 0;
 #endif
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
@@ -59,80 +48,6 @@ namespace dnnl {
 namespace impl {
 namespace graph {
 namespace dnnl_impl {
-
-void *dnnl_allocator_t::malloc(size_t size, const dnnl::engine &p_engine,
-        const graph::allocator_t *alc, allocator_t::mem_type_t type) {
-    if (p_engine.get_kind() == dnnl::engine::kind::cpu) {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-        return alc->allocate(size, dnnl::sycl_interop::get_device(p_engine),
-                dnnl::sycl_interop::get_context(p_engine),
-                {type, DNNL_SYCL_MEMALIGNMENT});
-#else
-        return alc->allocate(size, {type, DNNL_CPU_MEMALIGNMENT});
-#endif
-    } else if (p_engine.get_kind() == dnnl::engine::kind::gpu) {
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-        return alc->allocate(size, dnnl::sycl_interop::get_device(p_engine),
-                dnnl::sycl_interop::get_context(p_engine),
-                {type, DNNL_SYCL_MEMALIGNMENT});
-#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        return alc->allocate(size, dnnl::ocl_interop::get_device(p_engine),
-                dnnl::ocl_interop::get_context(p_engine),
-                {type, DNNL_OCL_MEMALIGNMENT});
-#else
-        return nullptr;
-#endif
-    } else {
-        return nullptr;
-    }
-}
-
-void dnnl_allocator_t::free(
-        void *p, const dnnl::engine &p_engine, const allocator_t *alc) {
-    if (p_engine.get_kind() == dnnl::engine::kind::cpu) {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-        assert(!"use event based free");
-#else
-        return alc->deallocate(p);
-#endif
-    } else if (p_engine.get_kind() == dnnl::engine::kind::gpu) {
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL \
-        || DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        assert(!"use event based free");
-#endif
-    }
-}
-
-#ifdef DNNL_WITH_SYCL
-void dnnl_allocator_t::free(void *p, const dnnl::engine &p_engine,
-        const allocator_t *alc, const ::sycl::event &deps) {
-    if (p_engine.get_kind() == dnnl::engine::kind::cpu) {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-        alc->deallocate(p, dnnl::sycl_interop::get_device(p_engine),
-                dnnl::sycl_interop::get_context(p_engine), deps);
-#else
-        alc->deallocate(p);
-#endif
-    } else if (p_engine.get_kind() == dnnl::engine::kind::gpu) {
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-        alc->deallocate(p, dnnl::sycl_interop::get_device(p_engine),
-                dnnl::sycl_interop::get_context(p_engine), deps);
-#endif
-    }
-}
-#endif
-
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-void dnnl_allocator_t::free(void *p, const dnnl::engine &p_engine,
-        const allocator_t *alc, const cl_event &deps) {
-    if (p_engine.get_kind() != dnnl::engine::kind::gpu) {
-        assert(!"the engine kind should be gpu");
-        return;
-    }
-    alc->deallocate(p, dnnl::ocl_interop::get_device(p_engine),
-            dnnl::ocl_interop::get_context(p_engine), deps);
-}
-#endif
 
 format_tag get_ncx_format(size_t ndim) {
     switch (ndim) {

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -19,15 +19,11 @@
 
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 #include <unordered_map>
 
 #include "oneapi/dnnl/dnnl.hpp"
-#include "oneapi/dnnl/dnnl_graph_types.h"
 
-#include "graph/interface/allocator.hpp"
-#include "graph/interface/constant_tensor_cache.hpp"
 #include "graph/interface/logical_tensor.hpp"
 #include "graph/interface/value.hpp"
 
@@ -53,23 +49,6 @@ using algorithm = dnnl::algorithm;
 using exec_args = std::unordered_map<int, memory>;
 
 using pd_cache_t = std::unordered_map<op_t *, graph::utils::any_t>;
-struct dnnl_allocator_t {
-    static void *malloc(size_t size, const dnnl::engine &p_engine,
-            const allocator_t *alc, allocator_t::mem_type_t type);
-
-    static void free(
-            void *p, const dnnl::engine &p_engine, const allocator_t *alc);
-
-#ifdef DNNL_WITH_SYCL
-    static void free(void *p, const dnnl::engine &p_engine,
-            const allocator_t *alc, const ::sycl::event &deps);
-#endif
-
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    static void free(void *p, const dnnl::engine &p_engine,
-            const allocator_t *alc, const cl_event &deps);
-#endif
-};
 
 format_tag get_ncx_format(size_t ndim);
 

--- a/src/graph/backend/dnnl/dnnl_allocator.cpp
+++ b/src/graph/backend/dnnl/dnnl_allocator.cpp
@@ -1,0 +1,129 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "graph/backend/dnnl/dnnl_allocator.hpp"
+
+#include "common/engine.hpp"
+#include "common/utils.hpp"
+
+#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_SYCL
+const size_t DNNL_CPU_MEMALIGNMENT = 64;
+#endif
+
+#ifdef DNNL_WITH_SYCL
+#include "xpu/sycl/engine_impl.hpp"
+const size_t DNNL_SYCL_MEMALIGNMENT = 64;
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include "xpu/ocl/engine_impl.hpp"
+const size_t DNNL_OCL_MEMALIGNMENT = 0;
+#endif
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+static graph::allocator_t *get_allocator(const engine_t &eng) {
+    return reinterpret_cast<graph::allocator_t *>(eng.get_allocator());
+}
+
+void *dnnl_allocator_t::malloc(
+        size_t size, const engine_t &eng, allocator_t::mem_type_t type) {
+    const auto *alc = get_allocator(eng);
+    if (eng.kind() == engine_kind::cpu) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
+        const auto *sycl_eng
+                = utils::downcast<const xpu::sycl::engine_impl_t *>(eng.impl());
+        return alc->allocate(size, sycl_eng->device(), sycl_eng->context(),
+                {type, DNNL_SYCL_MEMALIGNMENT});
+#else
+        return alc->allocate(size, {type, DNNL_CPU_MEMALIGNMENT});
+#endif
+    } else if (eng.kind() == engine_kind::gpu) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+        const auto *sycl_eng
+                = utils::downcast<const xpu::sycl::engine_impl_t *>(eng.impl());
+        return alc->allocate(size, sycl_eng->device(), sycl_eng->context(),
+                {type, DNNL_SYCL_MEMALIGNMENT});
+#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+        const auto *ocl_eng
+                = utils::downcast<const xpu::ocl::engine_impl_t *>(eng.impl());
+        return alc->allocate(size, ocl_eng->device(), ocl_eng->context(),
+                {type, DNNL_OCL_MEMALIGNMENT});
+#else
+        return nullptr;
+#endif
+    } else {
+        return nullptr;
+    }
+}
+
+void dnnl_allocator_t::free(void *p, const engine_t &eng) {
+    if (eng.kind() == engine_kind::cpu) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
+        assert(!"use event based free");
+#else
+        const auto *alc = get_allocator(eng);
+        return alc->deallocate(p);
+#endif
+    } else if (eng.kind() == engine_kind::gpu) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL \
+        || DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+        assert(!"use event based free");
+#endif
+    }
+}
+
+#ifdef DNNL_WITH_SYCL
+void dnnl_allocator_t::free(
+        void *p, const engine_t &eng, const ::sycl::event &deps) {
+    const auto *alc = get_allocator(eng);
+    const auto *sycl_eng
+            = utils::downcast<const xpu::sycl::engine_impl_t *>(eng.impl());
+    if (eng.kind() == engine_kind::cpu) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
+        alc->deallocate(p, sycl_eng->device(), sycl_eng->context(), deps);
+#else
+        alc->deallocate(p);
+#endif
+    } else if (eng.kind() == engine_kind::gpu) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+        alc->deallocate(p, sycl_eng->device(), sycl_eng->context(), deps);
+#endif
+    }
+}
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+void dnnl_allocator_t::free(
+        void *p, const engine_t &eng, const cl_event &deps) {
+    if (eng.kind() != engine_kind::gpu) {
+        assert(!"the engine kind should be gpu");
+        return;
+    }
+    const auto *alc = get_allocator(eng);
+    const auto *ocl_eng
+            = utils::downcast<const xpu::ocl::engine_impl_t *>(eng.impl());
+    alc->deallocate(p, ocl_eng->device(), ocl_eng->context(), deps);
+}
+#endif
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl

--- a/src/graph/backend/dnnl/dnnl_allocator.hpp
+++ b/src/graph/backend/dnnl/dnnl_allocator.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GRAPH_BACKEND_DNNL_DNNL_ALLOCATOR_HPP
+#define GRAPH_BACKEND_DNNL_DNNL_ALLOCATOR_HPP
+
+#include "graph/interface/allocator.hpp"
+
+#ifdef DNNL_WITH_SYCL
+#include <sycl/sycl.hpp>
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include <CL/cl.h>
+#endif
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+// dnnl_allocator_t is a utility class that provides static methods for memory
+// allocation and deallocation using the graph's allocator.
+struct dnnl_allocator_t {
+    static void *malloc(
+            size_t size, const engine_t &eng, allocator_t::mem_type_t type);
+
+    static void free(void *p, const engine_t &eng);
+
+#ifdef DNNL_WITH_SYCL
+    static void free(void *p, const engine_t &eng, const ::sycl::event &deps);
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    static void free(void *p, const engine_t &eng, const cl_event &deps);
+#endif
+};
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
+++ b/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
@@ -18,9 +18,10 @@
 
 #include "graph/interface/constant_tensor_cache.hpp"
 
-#include "graph/backend/dnnl/common.hpp"
 #include "graph/backend/dnnl/dnnl_allocator.hpp"
 #include "graph/backend/dnnl/dnnl_backend.hpp"
+
+#include "graph/utils/utils.hpp"
 
 #include "oneapi/dnnl/dnnl.hpp"
 
@@ -30,19 +31,15 @@ namespace graph {
 namespace dnnl_impl {
 
 struct dnnl_constant_buffer_t : public graph::constant_buffer_t {
-    dnnl_constant_buffer_t(
-            size_t size, dnnl::engine &engine, graph::allocator_t *alc)
-        : graph::constant_buffer_t(
-                  size, engine.get(), alc, malloc_func, free_func) {}
+    dnnl_constant_buffer_t(size_t size, engine_t &engine)
+        : graph::constant_buffer_t(size, &engine, malloc_func, free_func) {}
 
-    static void *malloc_func(
-            size_t size, impl::engine_t *eng, graph::allocator_t *alc) {
+    static void *malloc_func(size_t size, engine_t *eng) {
         return dnnl_allocator_t::malloc(
                 size, *eng, allocator_t::mem_type_t::persistent);
     }
 
-    static void free_func(
-            void *data, impl::engine_t *eng, graph::allocator_t *alc) {
+    static void free_func(void *data, engine_t *eng) {
         if (eng->kind() == engine_kind::cpu) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
             dnnl_allocator_t::free(data, *eng, ::sycl::event());

--- a/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
+++ b/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
@@ -56,6 +56,12 @@ struct dnnl_constant_buffer_t : public graph::constant_buffer_t {
     }
 };
 
+inline bool is_constant_cache_enabled(const dnnl::engine &eng) {
+    auto cache = graph::get_constant_tensor_cache(
+            eng.get()->kind(), eng.get()->index());
+    return cache && cache->get_capacity() != 0;
+}
+
 inline graph::constant_tensor_cache_t::value_t dnnl_constant_cache_get_or_add(
         const dnnl::engine &eng, graph::constant_tensor_cache_t::key_t key,
         size_t size, const graph::constant_tensor_cache_t::value_t &value) {
@@ -67,6 +73,11 @@ inline graph::constant_tensor_cache_t::value_t dnnl_constant_cache_get_or_add(
             dnnl_backend_t::get_singleton().get_id(), key, size, value);
 }
 
+// The global constant_tensor_cache_t instances are managed by
+// global_cache_manager_t (in constant_tensor_cache.cpp) as a process-lifetime
+// singleton. Cached buffers are evicted only by the capacity-based policy. The
+// retain/release/remove_if_exist wrappers below are provided for potential
+// future use but are currently not called by any backend code.
 inline void dnnl_constant_cache_remove_if_exist(
         const dnnl::engine &eng, graph::constant_tensor_cache_t::key_t key) {
     auto cache = graph::get_constant_tensor_cache(
@@ -74,12 +85,6 @@ inline void dnnl_constant_cache_remove_if_exist(
     assertm(cache,
             "no available constant cache for specified engine kind and index");
     cache->remove_if_exist(dnnl_backend_t::get_singleton().get_id(), key);
-}
-
-inline bool is_constant_cache_enabled(const dnnl::engine &eng) {
-    auto cache = graph::get_constant_tensor_cache(
-            eng.get()->kind(), eng.get()->index());
-    return cache && cache->get_capacity() != 0;
 }
 
 inline void dnnl_constant_cache_retain(const dnnl::engine &eng) {

--- a/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
+++ b/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
@@ -19,6 +19,7 @@
 #include "graph/interface/constant_tensor_cache.hpp"
 
 #include "graph/backend/dnnl/common.hpp"
+#include "graph/backend/dnnl/dnnl_allocator.hpp"
 #include "graph/backend/dnnl/dnnl_backend.hpp"
 
 #include "oneapi/dnnl/dnnl.hpp"
@@ -36,27 +37,23 @@ struct dnnl_constant_buffer_t : public graph::constant_buffer_t {
 
     static void *malloc_func(
             size_t size, impl::engine_t *eng, graph::allocator_t *alc) {
-        dnnl::engine engine;
-        engine.reset(eng, true); // not own
         return dnnl_allocator_t::malloc(
-                size, engine, alc, allocator_t::mem_type_t::persistent);
+                size, *eng, allocator_t::mem_type_t::persistent);
     }
 
     static void free_func(
             void *data, impl::engine_t *eng, graph::allocator_t *alc) {
-        dnnl::engine engine;
-        engine.reset(eng, true); // not own
         if (eng->kind() == engine_kind::cpu) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-            dnnl_allocator_t::free(data, engine, alc, ::sycl::event());
+            dnnl_allocator_t::free(data, *eng, ::sycl::event());
 #else
-            dnnl_allocator_t::free(data, engine, alc);
+            dnnl_allocator_t::free(data, *eng);
 #endif
         } else if (eng->kind() == engine_kind::gpu) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-            dnnl_allocator_t::free(data, engine, alc, ::sycl::event());
+            dnnl_allocator_t::free(data, *eng, ::sycl::event());
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-            dnnl_allocator_t::free(data, engine, alc, cl_event());
+            dnnl_allocator_t::free(data, *eng, cl_event());
 #endif
         }
     }

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -126,8 +126,7 @@ status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -196,8 +195,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -271,8 +269,7 @@ status_t batch_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -408,8 +405,7 @@ status_t batch_norm_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -438,8 +434,7 @@ status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -472,8 +467,7 @@ status_t batch_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -56,8 +56,6 @@ status_t batch_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -149,8 +147,8 @@ status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -218,8 +216,8 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -292,8 +290,8 @@ status_t batch_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -332,8 +330,6 @@ status_t batch_norm_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/batch_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.hpp
@@ -40,8 +40,6 @@ namespace dnnl_impl {
 
 struct batch_norm_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
@@ -100,8 +98,6 @@ public:
 #if BUILD_TRAINING
 struct batch_norm_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -56,8 +56,6 @@ status_t binary_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -122,8 +122,7 @@ status_t binary_t::execute_impl(const stream_t *g_stream,
     }
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -152,8 +151,7 @@ status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -186,8 +184,7 @@ status_t binary_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/binary.hpp
+++ b/src/graph/backend/dnnl/kernels/binary.hpp
@@ -47,8 +47,6 @@ namespace dnnl_impl {
 //   one of them does not exist.
 struct binary_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -116,8 +116,7 @@ status_t concat_t<quantized>::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -146,8 +145,7 @@ status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -180,8 +178,7 @@ status_t concat_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -37,8 +37,6 @@ status_t concat_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/concat.hpp
+++ b/src/graph/backend/dnnl/kernels/concat.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct concat_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/conv.cpp
+++ b/src/graph/backend/dnnl/kernels/conv.cpp
@@ -37,8 +37,6 @@ status_t conv_fwd_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -151,8 +149,6 @@ status_t conv_bwd_data_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -212,8 +208,6 @@ status_t conv_bwd_weights_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -77,8 +77,8 @@ status_t conv_base_t::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -146,8 +146,8 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -220,8 +220,8 @@ status_t conv_base_t::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -54,8 +54,7 @@ status_t conv_base_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -124,8 +123,7 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -199,8 +197,7 @@ status_t conv_base_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;

--- a/src/graph/backend/dnnl/kernels/conv_base.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.hpp
@@ -40,8 +40,6 @@ namespace dnnl_impl {
 
 struct conv_base_t : public kernel_base_t {
 protected:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/conv_transpose.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_transpose.cpp
@@ -37,8 +37,6 @@ status_t conv_transpose_fwd_t<quantized>::compile_impl(
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -132,8 +130,6 @@ status_t conv_transpose_bwd_data_t::compile_impl(
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -194,8 +190,6 @@ status_t conv_transpose_bwd_weights_t::compile_impl(
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -37,8 +37,6 @@ status_t eltwise_fwd_t<quantized>::compile_impl(
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -165,8 +163,8 @@ status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -235,8 +233,8 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -310,8 +308,8 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -349,8 +347,6 @@ status_t eltwise_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -142,8 +142,7 @@ status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -213,8 +212,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -289,8 +287,7 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -421,8 +418,7 @@ status_t eltwise_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -450,8 +446,7 @@ status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -483,8 +478,7 @@ status_t eltwise_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/eltwise.hpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.hpp
@@ -42,8 +42,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct eltwise_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
@@ -113,8 +111,6 @@ using quantized_eltwise = eltwise_fwd_t</* quantized */ true>;
 #if BUILD_TRAINING
 struct eltwise_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
@@ -152,8 +152,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::execute_impl(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -183,8 +182,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -218,8 +216,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
@@ -49,7 +49,6 @@ status_t gated_mlp_primitive_kernel_t<quantized>::compile_impl(
 #endif
 
     p_engine_ = make_dnnl_engine(*eng);
-    g_alloc_ = reinterpret_cast<graph::allocator_t *>(eng->get_allocator());
 
     // First, dry run on a deep copy
     subgraph_

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct gated_mlp_primitive_kernel_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -39,8 +39,6 @@ status_t genindex_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/gen_index.hpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.hpp
@@ -38,8 +38,6 @@ namespace dnnl_impl {
 using ltw = logical_tensor_wrapper_t;
 struct genindex_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -36,8 +36,6 @@ status_t group_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -157,8 +155,8 @@ status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -226,8 +224,8 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -300,8 +298,8 @@ status_t group_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -134,8 +134,7 @@ status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -204,8 +203,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -279,8 +277,7 @@ status_t group_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;

--- a/src/graph/backend/dnnl/kernels/group_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 
 struct group_norm_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -206,8 +206,6 @@ status_t larger_partition_kernel_t::compile_impl(
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -284,8 +282,8 @@ status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -352,8 +350,8 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -424,8 +422,8 @@ status_t larger_partition_kernel_t::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -261,8 +261,7 @@ status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -330,8 +329,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -403,8 +401,7 @@ status_t larger_partition_kernel_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;

--- a/src/graph/backend/dnnl/kernels/large_partition.hpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 
 class larger_partition_kernel_t : public kernel_base_t {
 protected:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -131,8 +131,7 @@ status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -201,8 +200,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -276,8 +274,7 @@ status_t layer_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -407,8 +404,7 @@ status_t layer_norm_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -436,8 +432,7 @@ status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -469,8 +464,7 @@ status_t layer_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -36,8 +36,6 @@ status_t layer_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -154,8 +152,8 @@ status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -223,8 +221,8 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -297,8 +295,8 @@ status_t layer_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -336,8 +334,6 @@ status_t layer_norm_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/layer_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 
 struct layer_norm_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
@@ -101,8 +99,6 @@ public:
 #if BUILD_TRAINING
 struct layer_norm_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -34,8 +34,6 @@ status_t logsoftmax_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -187,8 +185,6 @@ status_t logsoftmax_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -104,8 +104,7 @@ status_t logsoftmax_fwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -134,8 +133,7 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -168,8 +166,7 @@ status_t logsoftmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -262,8 +259,7 @@ status_t logsoftmax_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -292,8 +288,7 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -326,8 +321,7 @@ status_t logsoftmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/log_softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.hpp
@@ -41,7 +41,6 @@ namespace dnnl_impl {
 
 struct logsoftmax_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -103,8 +102,6 @@ public:
 #if BUILD_TRAINING
 struct logsoftmax_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -37,8 +37,6 @@ status_t matmul_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(
             part->get_ops(), p_engine_, part->get_fpmath_mode(), true, true);
@@ -225,8 +223,8 @@ status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -295,8 +293,8 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -370,8 +368,8 @@ status_t matmul_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -202,8 +202,7 @@ status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -273,8 +272,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -349,8 +347,7 @@ status_t matmul_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;

--- a/src/graph/backend/dnnl/kernels/matmul.hpp
+++ b/src/graph/backend/dnnl/kernels/matmul.hpp
@@ -42,8 +42,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct matmul_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -188,7 +188,7 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
     // allocate the internal memory
     size_t block_size = mqa_registry_.size();
     auto scratchpad = std::make_shared<scratchpad_t>(
-            scratchpad_buf, block_size * mqa_cfg_.nthr, p_engine_, *g_alloc_);
+            scratchpad_buf, block_size * mqa_cfg_.nthr, p_engine_);
     grantor_t var_grantor = mqa_registry_.grantor(scratchpad->get_buffer());
 
     const auto get_mem_dt_size = [](const memory &m) -> size_t {

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -44,8 +44,6 @@ status_t mqa_decomp_kernel_t<quantized, dt>::compile_impl(
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
@@ -44,9 +44,7 @@ namespace dnnl_impl {
 // int8 mqa pattern. It doesn't take any effect if quantized param is false.
 template <bool quantized = false, memory::data_type dt = memory::data_type::f32>
 struct mqa_decomp_kernel_t : public kernel_base_t {
-private:
-    allocator_t *g_alloc_ = nullptr;
-    // used for mqa internal memory planning
+private: // used for mqa internal memory planning
     registry_t mqa_registry_;
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
@@ -115,8 +115,7 @@ public:
     // shared memory
     memory sub_max_src1_src2, sub_max_dst1_dst2;
 
-private:
-    // Used to record the ops contained in MQA
+private: // Used to record the ops contained in MQA
     std::vector<std::shared_ptr<op_t>> mqa_op;
 
 public:

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -161,8 +161,7 @@ status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -232,8 +231,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -308,8 +306,7 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -453,8 +450,7 @@ status_t pooling_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -484,8 +480,7 @@ status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -519,8 +514,7 @@ status_t pooling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -45,8 +45,6 @@ status_t pooling_fwd_t<quantized>::compile_impl(
         return status::unimplemented;
 
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -184,8 +182,8 @@ status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -254,8 +252,8 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -329,8 +327,8 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -368,8 +366,6 @@ status_t pooling_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/pool.hpp
+++ b/src/graph/backend/dnnl/kernels/pool.hpp
@@ -42,8 +42,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct pooling_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
@@ -106,8 +104,6 @@ using quantized_pooling = pooling_fwd_t</* quantized */ true>;
 #if BUILD_TRAINING
 struct pooling_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -41,8 +41,6 @@ status_t prelu_fwd_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
         return status::unimplemented;
 
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -205,8 +203,6 @@ status_t prelu_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -120,8 +120,7 @@ status_t prelu_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -151,8 +150,7 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -186,8 +184,7 @@ status_t prelu_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -282,8 +279,7 @@ status_t prelu_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -312,8 +308,7 @@ status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -346,8 +341,7 @@ status_t prelu_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/prelu.hpp
+++ b/src/graph/backend/dnnl/kernels/prelu.hpp
@@ -42,8 +42,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct prelu_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
@@ -103,8 +101,6 @@ using float_prelu_fwd = prelu_fwd_t</* quantized */ false>;
 #if BUILD_TRAINING
 struct prelu_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -125,8 +125,7 @@ status_t quantize_dequantize_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -200,8 +199,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -275,8 +273,7 @@ status_t quantize_dequantize_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -35,8 +35,6 @@ status_t quantize_dequantize_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -148,8 +146,8 @@ status_t quantize_dequantize_t::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -222,8 +220,8 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -296,8 +294,8 @@ status_t quantize_dequantize_t::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {

--- a/src/graph/backend/dnnl/kernels/quantize.hpp
+++ b/src/graph/backend/dnnl/kernels/quantize.hpp
@@ -41,7 +41,6 @@ namespace dnnl_impl {
 
 struct quantize_dequantize_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -119,8 +119,7 @@ status_t reduction_t<quantized>::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -149,8 +148,7 @@ status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -183,8 +181,7 @@ status_t reduction_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -37,8 +37,6 @@ status_t reduction_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/reduction.hpp
+++ b/src/graph/backend/dnnl/kernels/reduction.hpp
@@ -42,8 +42,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct reduction_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -144,8 +144,7 @@ status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -215,8 +214,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -291,8 +289,7 @@ status_t reorder_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -37,8 +37,6 @@ status_t reorder_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -167,8 +165,8 @@ status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -237,8 +235,8 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -312,8 +310,8 @@ status_t reorder_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {

--- a/src/graph/backend/dnnl/kernels/reorder.hpp
+++ b/src/graph/backend/dnnl/kernels/reorder.hpp
@@ -42,8 +42,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct reorder_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -36,8 +36,6 @@ status_t resampling_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -203,8 +201,6 @@ status_t resampling_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -122,8 +122,7 @@ status_t resampling_fwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -151,8 +150,7 @@ status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -184,8 +182,7 @@ status_t resampling_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -276,8 +273,7 @@ status_t resampling_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -305,8 +301,7 @@ status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -338,8 +333,7 @@ status_t resampling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/resampling.hpp
+++ b/src/graph/backend/dnnl/kernels/resampling.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 
 struct resampling_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
@@ -105,8 +103,6 @@ public:
 #if BUILD_TRAINING
 struct resampling_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -66,8 +66,6 @@ status_t sdp_bwd_primitive_kernel_t::compile_impl(
 #endif
 
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // First, dry run on a deep copy
     subgraph_

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -164,8 +164,7 @@ status_t sdp_bwd_primitive_kernel_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -194,8 +193,7 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -228,8 +226,7 @@ status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
@@ -40,8 +40,6 @@ namespace dnnl_impl {
 
 struct sdp_bwd_primitive_kernel_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -43,8 +43,6 @@ status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -189,7 +189,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
 
     size_t block_size = sdp_registry_.size();
     auto scratchpad = std::make_shared<scratchpad_t>(
-            scratchpad_buf, block_size * sdp_cfg_.nthr, p_engine_, *g_alloc_);
+            scratchpad_buf, block_size * sdp_cfg_.nthr, p_engine_);
     grantor_t var_grantor = sdp_registry_.grantor(scratchpad->get_buffer());
 
     const auto get_mem_dt_size = [](const memory &m) -> size_t {

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -44,9 +44,7 @@ namespace dnnl_impl {
 // int8 sdp pattern. It doesn't take any effect if quantized param is false.
 template <bool quantized = false, memory::data_type dt = memory::data_type::f32>
 struct sdp_decomp_kernel_t : public kernel_base_t {
-private:
-    allocator_t *g_alloc_ = nullptr;
-    // used for sdp internal memory planning
+private: // used for sdp internal memory planning
     registry_t sdp_registry_;
 
     std::shared_ptr<subgraph_t> subgraph_;

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -142,8 +142,7 @@ public:
     // select's 1st input connected to previous matmul.
     bool select_fusiable = false;
 
-private:
-    // Used to record the ops contained in SDP
+private: // Used to record the ops contained in SDP
     // sdp_op = [reorder1, mm1, softmax, reorder2, mm2, binary_select]
     // reorder1 is using mm1 weight u8->s8
     // reorder2 is using mm2 weight u8->s8

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -172,8 +172,7 @@ status_t sdp_primitive_kernel_t<quantized>::execute_impl(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -203,8 +202,7 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -238,8 +236,7 @@ status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -51,8 +51,6 @@ status_t sdp_primitive_kernel_t<quantized>::compile_impl(
 #endif
 
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     // First, dry run on a deep copy
     subgraph_

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
@@ -43,8 +43,6 @@ namespace dnnl_impl {
 template <bool quantized>
 struct sdp_primitive_kernel_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -36,8 +36,6 @@ status_t shuffle_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     const bool reset_layout = false;
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -118,8 +118,7 @@ status_t shuffle_fwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -148,8 +147,7 @@ status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -182,8 +180,7 @@ status_t shuffle_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/shuffle.hpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 
 struct shuffle_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -36,8 +36,6 @@ status_t softmax_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -152,8 +150,8 @@ status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -221,8 +219,8 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -295,8 +293,8 @@ status_t softmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             }
         } else {
             c_buffer = std::make_shared<dnnl_constant_buffer_t>(
-                    memory_planner_.total_internal_persistent_size(), p_engine_,
-                    g_alloc_);
+                    memory_planner_.total_internal_persistent_size(),
+                    *p_engine_.get());
             grantor_t c_grantor = memory_planner_.internal_persistent_grantor(
                     c_buffer->data<char>());
             for (auto &mem_offkey : res->get_mems_use_internal_persistent()) {
@@ -334,8 +332,6 @@ status_t softmax_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -129,8 +129,7 @@ status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -199,8 +198,7 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -274,8 +272,7 @@ status_t softmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     constant_tensor_cache_t::cached_t c_buffer;
@@ -409,8 +406,7 @@ status_t softmax_bwd_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -439,8 +435,7 @@ status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -473,8 +468,7 @@ status_t softmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/softmax.hpp
@@ -41,7 +41,6 @@ namespace dnnl_impl {
 
 struct softmax_fwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -105,8 +104,6 @@ public:
 #if BUILD_TRAINING
 struct softmax_bwd_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -119,8 +119,7 @@ status_t sum_t::execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -149,8 +148,7 @@ status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
@@ -183,8 +181,7 @@ status_t sum_t::ocl_execute_impl(const stream_t *g_stream,
             reinterpret_cast<size_t>(this), resource_ctor_);
 
     auto scratchpad = std::make_shared<scratchpad_t>(scratchpad_buf,
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
+            memory_planner_.total_internal_temporary_size(), p_engine_);
     prepare_args_set(res, inputs, outputs, *scratchpad);
 
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -36,8 +36,6 @@ status_t sum_t::compile_impl(const dnnl_partition_impl_t *part,
         const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
-    g_alloc_
-            = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);

--- a/src/graph/backend/dnnl/kernels/sum.hpp
+++ b/src/graph/backend/dnnl/kernels/sum.hpp
@@ -41,8 +41,6 @@ namespace dnnl_impl {
 
 struct sum_t : public kernel_base_t {
 private:
-    allocator_t *g_alloc_ = nullptr;
-
     std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 

--- a/src/graph/backend/dnnl/scratchpad.cpp
+++ b/src/graph/backend/dnnl/scratchpad.cpp
@@ -16,8 +16,10 @@
 
 #include "graph/interface/tensor.hpp"
 
+#include "graph/backend/dnnl/dnnl_allocator.hpp"
 #include "graph/backend/dnnl/scratchpad.hpp"
 
+#include "common/engine.hpp"
 #include "common/stream.hpp"
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
@@ -29,13 +31,12 @@ namespace impl {
 namespace graph {
 namespace dnnl_impl {
 
-scratchpad_t::scratchpad_t(const tensor_t *user_buf, size_t size,
-        const dnnl::engine &eng, const allocator_t &alloc)
+scratchpad_t::scratchpad_t(
+        const tensor_t *user_buf, size_t size, const dnnl::engine &eng)
     : buffer_(nullptr)
     , size_(size)
     , user_managed_(user_buf != nullptr)
-    , eng_(&eng)
-    , alloc_(&alloc)
+    , eng_(eng.get())
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     , ocl_e_(nullptr)
 #endif
@@ -44,26 +45,25 @@ scratchpad_t::scratchpad_t(const tensor_t *user_buf, size_t size,
         buffer_ = reinterpret_cast<char *>(user_buf->get_data_handle());
     } else if (size > 0) {
         buffer_ = reinterpret_cast<char *>(dnnl_allocator_t::malloc(
-                size, eng, &alloc, allocator_t::mem_type_t::temp));
+                size, *eng_, allocator_t::mem_type_t::temp));
         if (!buffer_) { size_ = 0; }
     }
 }
 
 scratchpad_t::~scratchpad_t() {
     if (user_managed_) return;
-    if (bool(*eng_) == false) return;
-    const auto ekind = eng_->get_kind();
-    if (ekind == dnnl::engine::kind::cpu) {
+    const auto ekind = eng_->kind();
+    if (ekind == engine_kind::cpu) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
-        dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
+        dnnl_allocator_t::free(buffer_, *eng_, e_);
 #else
-        dnnl_allocator_t::free(buffer_, *eng_, alloc_);
+        dnnl_allocator_t::free(buffer_, *eng_);
 #endif
-    } else if (ekind == dnnl::engine::kind::gpu) {
+    } else if (ekind == engine_kind::gpu) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        dnnl_allocator_t::free(buffer_, *eng_, alloc_, ocl_e_);
+        dnnl_allocator_t::free(buffer_, *eng_, ocl_e_);
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-        dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
+        dnnl_allocator_t::free(buffer_, *eng_, e_);
 #else
         assert(!"unsupported gpu runtime");
 #endif

--- a/src/graph/backend/dnnl/scratchpad.hpp
+++ b/src/graph/backend/dnnl/scratchpad.hpp
@@ -40,8 +40,8 @@ namespace dnnl_impl {
 // is managed by the user; otherwise the library allocates and frees the buffer.
 class scratchpad_t {
 public:
-    scratchpad_t(const tensor_t *user_buf, size_t size, const dnnl::engine &eng,
-            const allocator_t &alloc);
+    scratchpad_t(
+            const tensor_t *user_buf, size_t size, const dnnl::engine &eng);
 
     ~scratchpad_t();
 
@@ -69,8 +69,7 @@ private:
     char *buffer_;
     size_t size_;
     bool user_managed_;
-    const dnnl::engine *eng_;
-    const allocator_t *alloc_;
+    const engine_t *eng_;
 #ifdef DNNL_WITH_SYCL
     ::sycl::event e_;
 #endif

--- a/src/graph/interface/constant_tensor_cache.cpp
+++ b/src/graph/interface/constant_tensor_cache.cpp
@@ -18,9 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <unordered_map>
 
-#include "common/engine.hpp"
 #include "common/utils.hpp"
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE

--- a/src/graph/interface/constant_tensor_cache.hpp
+++ b/src/graph/interface/constant_tensor_cache.hpp
@@ -17,18 +17,15 @@
 #define GRAPH_INTERFACE_CONSTANT_TENSOR_CACHE_HPP
 
 #include <atomic>
-#include <functional>
 #include <future>
-#include <limits>
 #include <memory>
-#include <type_traits>
+#include <string>
 #include <unordered_map>
 
 #include "common/c_types_map.hpp"
 #include "common/engine.hpp"
 #include "common/rw_mutex.hpp"
 
-#include "graph/interface/allocator.hpp"
 #include "graph/interface/c_types_map.hpp"
 
 namespace dnnl {
@@ -37,23 +34,22 @@ namespace graph {
 
 class constant_buffer_t {
 public:
-    using malloc_func_t = void *(*)(size_t, impl::engine_t *, allocator_t *);
-    using free_func_t = void (*)(void *, impl::engine_t *, allocator_t *);
+    using malloc_func_t = void *(*)(size_t, engine_t *);
+    using free_func_t = void (*)(void *, engine_t *);
 
     // Backends should provide these malloc and free function handles
-    constant_buffer_t(size_t size, impl::engine_t *eng, allocator_t *alc,
-            malloc_func_t malloc_func, free_func_t free_func)
+    constant_buffer_t(size_t size, engine_t *eng, malloc_func_t malloc_func,
+            free_func_t free_func)
         : size_(size)
         , eng_(eng)
-        , alc_(alc)
         , malloc_func_(malloc_func)
         , free_func_(free_func) {
-        data_ = malloc_func_(size, eng, alc);
+        data_ = malloc_func_(size, eng);
         eng_->retain();
     }
 
     virtual ~constant_buffer_t() {
-        free_func_(data_, eng_, alc_);
+        free_func_(data_, eng_);
         eng_->release();
     }
 
@@ -77,8 +73,7 @@ public:
 protected:
     void *data_;
     size_t size_;
-    impl::engine_t *eng_;
-    allocator_t *alc_;
+    engine_t *eng_;
 
 private:
     malloc_func_t malloc_func_;
@@ -166,7 +161,7 @@ private:
 };
 
 constant_tensor_cache_t *get_constant_tensor_cache(
-        impl::engine_kind_t eng_kind, size_t index);
+        engine_kind_t eng_kind, size_t index);
 
 } // namespace graph
 } // namespace impl

--- a/tests/gtests/graph/unit/backend/dnnl/test_constant_cache.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_constant_cache.cpp
@@ -64,8 +64,6 @@ TEST(test_constant_cache, CombineKey) {
 
 TEST(test_constant_cache, NoEvictWhenCacheFull) {
     graph::engine_t &engine = *get_engine();
-    auto p_engine_ = dnnl_impl::make_dnnl_engine(engine);
-    auto g_alloc_ = static_cast<graph::allocator_t *>(engine.get_allocator());
 
     graph::constant_tensor_cache_t cache(0);
     ASSERT_EQ(cache.set_capacity(0), graph::status::success);
@@ -74,8 +72,7 @@ TEST(test_constant_cache, NoEvictWhenCacheFull) {
     std::promise<graph::constant_tensor_cache_t::cached_t> c_promise1;
     ASSERT_NO_THROW(cache.get_or_add(0, 1, 1, c_promise1.get_future()));
     graph::constant_tensor_cache_t::cached_t c_buffer1
-            = std::make_shared<dnnl_impl::dnnl_constant_buffer_t>(
-                    1, p_engine_, g_alloc_);
+            = std::make_shared<dnnl_impl::dnnl_constant_buffer_t>(1, engine);
     c_promise1.set_value(c_buffer1);
 
     // should cache hit
@@ -85,8 +82,7 @@ TEST(test_constant_cache, NoEvictWhenCacheFull) {
     std::promise<graph::constant_tensor_cache_t::cached_t> c_promise2;
     ASSERT_NO_THROW(cache.get_or_add(0, 2, 2, c_promise2.get_future()));
     graph::constant_tensor_cache_t::cached_t c_buffer2
-            = std::make_shared<dnnl_impl::dnnl_constant_buffer_t>(
-                    2, p_engine_, g_alloc_);
+            = std::make_shared<dnnl_impl::dnnl_constant_buffer_t>(2, engine);
     c_promise2.set_value(c_buffer2);
     ASSERT_EQ(cache.get_size(), 3U); // c_buffer1 + c_buffer2
 
@@ -95,8 +91,7 @@ TEST(test_constant_cache, NoEvictWhenCacheFull) {
     // ignore since we use no_evict policy
     ASSERT_NO_THROW(cache.get_or_add(0, 3, 3, c_promise3.get_future()));
     graph::constant_tensor_cache_t::cached_t c_buffer3
-            = std::make_shared<dnnl_impl::dnnl_constant_buffer_t>(
-                    3, p_engine_, g_alloc_);
+            = std::make_shared<dnnl_impl::dnnl_constant_buffer_t>(3, engine);
     c_promise3.set_value(c_buffer3);
     ASSERT_EQ(cache.get_size(), 3U); // c_buffer1 + c_buffer2
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_scratchpad.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_scratchpad.cpp
@@ -31,25 +31,23 @@
 namespace graph = dnnl::impl::graph;
 
 TEST(test_scratchpad, TemporaryScratchpad) {
-    using dnnl::impl::graph::allocator_t;
     using dnnl::impl::graph::dnnl_impl::scratchpad_t;
 
     graph::engine_t *g_eng = get_engine();
-    allocator_t *alloc = static_cast<allocator_t *>(g_eng->get_allocator());
     dnnl::engine p_eng = dnnl::impl::graph::dnnl_impl::make_dnnl_engine(*g_eng);
 
     // No seg fault here because the memory will be deleted when
     // scratchpad_t is destroyed
     std::vector<size_t> buf_sizes = {512, 1024, 2048, 4096};
     for (size_t i = 0; i < buf_sizes.size(); i++) {
-        scratchpad_t scratchpad(nullptr, buf_sizes[i], p_eng, *alloc);
+        scratchpad_t scratchpad(nullptr, buf_sizes[i], p_eng);
         // the scratchpad size will be changed
         ASSERT_EQ(buf_sizes[i], scratchpad.size());
     }
 
     buf_sizes = {4096, 2048, 1024, 512};
     for (size_t i = 0; i < buf_sizes.size(); i++) {
-        scratchpad_t scratchpad(nullptr, buf_sizes[i], p_eng, *alloc);
+        scratchpad_t scratchpad(nullptr, buf_sizes[i], p_eng);
         // the scratchpad size will be changed
         ASSERT_EQ(buf_sizes[i], scratchpad.size());
     }


### PR DESCRIPTION
- The main purpose is to fix a few legacy code initially caused by graph engine and primitive engine.
- Rework dnnl_allocator_t: separate files, use internal engine_t, etc.
- Rework dnnl_constant_buffer_t: allocator is part of engine now so no need to pass both. (The next step will be making them using internal `engine_t`, rather than public `dnnl::engine`).
