### PR TITLE
cpu: rv64: gate unsupported post-ops/attributes in f16 dwconv

### DIFF
--- a/src/cpu/rv64/jit_uni_dwconv.hpp
+++ b/src/cpu/rv64/jit_uni_dwconv.hpp
@@ -70,6 +70,8 @@ struct jit_uni_dwconv_fwd_t : public primitive_t {
             VDISPATCH_CONV(IMPLICATION(with_bias(),
                                    utils::one_of(bia_d.data_type(), f16, f32)),
                     VERBOSE_UNSUPPORTED_BIAS_CFG);
+            VDISPATCH_CONV(
+                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_CONV(i == 1, VERBOSE_BAD_DIM, "weights", gr_shift + 1);
             VDISPATCH_CONV(kh == 3 && kw == 3, VERBOSE_BAD_DIM, "weights",
                     gr_shift + 2);


### PR DESCRIPTION
## Description

The f16 depthwise convolution kernel `jit_dw:uni` added in #5345 only computes `conv + bias` — it has no post-op injector and does not read `dst` for `sum`. However its primitive descriptor `init()` performs **no attribute/post-op validation**, so it accepts descriptors carrying post-ops (or scales/zero-points) and silently returns the raw convolution result, producing incorrect output.

This makes `test_benchdnn_modeC_conv_ci_cpu` fail on the `conv_basic_2d:depthwise` shapes whenever a post-op is attached, e.g.:
- `--attr-post-ops=sum:0.5` → post-op not applied (got raw conv)
- `--attr-post-ops=linear:2:1` → post-op not applied (`got=3`, `exp=2*3+1=7`)
- `--attr-post-ops=add:f32` → `initialize_memory_create` returns `invalid_arguments`

jit_dw:uni: For now, do not actually implement post-ops (they can be handled later via the existing RV64 injector framework).First, fix this bug.

cc @xiazhuozhao @zhangjian29