### PR TITLE
[rls-v3.13] xe3p: copy plan: force src/dst alignment in hf<->int conversion

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -2761,6 +2761,9 @@ void CopyPlan::legalizeRegions()
                 } else
                     canSwizzle = false;
             }
+
+            if (hfIntConvert)
+                canSwizzle = false;
         }
 
         if (!canSwizzle) {


### PR DESCRIPTION
Backport of #5386.
