### PR TITLE
x64: matmul: int8: Fix tile reloading issue

### DIFF
--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -3187,7 +3187,7 @@ void jit_brgemm_amx_uker_base_t::generate() {
             && IMPLICATION(brg.is_input_convert(), brg.is_fp8_via_convert())
             && IMPLICATION(
                     brg.is_f32 || brg.is_bf16, brg.dt_c == data_type::f32)
-            && IMPLICATION(brg.is_int8, brg.dt_c == data_type::s32)
+            && IMPLICATION(brg.is_int8, brg.is_integer_acc())
             && brg.brgattr.bd_mask_level == 0;
     need_to_apply_alpha_beta_
             = (brg.beta != 0.f && !may_load_accumulators_) || brg.alpha != 1.f;


### PR DESCRIPTION
## Description

Fixes [MFDNN-15250](https://jira.devtools.intel.com/browse/MFDNN-15250).
The tile AMX uker has a weak flag for loading.
Test cases will be enabled separately in #5317 .

Current test CI didn't catch this case, so "make test" here is useless. 