### PR TITLE
graph: interface: add upper bounds ndims check for logical_tensor

### DIFF
--- a/src/graph/interface/logical_tensor.cpp
+++ b/src/graph/interface/logical_tensor.cpp
@@ -214,9 +214,10 @@ std::string logical_tensor_wrapper_t::str() const {
 status_t DNNL_API dnnl_graph_logical_tensor_init(
         logical_tensor_t *logical_tensor, size_t tid, data_type_t dtype,
         int32_t ndims, layout_type_t ltype, property_type_t ptype) {
-    if (logical_tensor == nullptr || ndims > DNNL_MAX_NDIMS) {
-        return status::invalid_arguments;
-    }
+    VCHECK_LOGICAL_TENSOR(logical_tensor != nullptr, status::invalid_arguments,
+            "%s (logical_tensor)", VERBOSE_NULL_ARG);
+    VCHECK_LOGICAL_TENSOR(ndims <= DNNL_MAX_NDIMS, status::invalid_arguments,
+            VERBOSE_BAD_NDIMS, "logical_tensor", ndims);
 
     // currently only supports s32 and f32 host scalar.
     if (ptype == property_type::host_scalar) {
@@ -254,7 +255,11 @@ status_t DNNL_API dnnl_graph_logical_tensor_init_with_dims(
         logical_tensor_t *logical_tensor, size_t tid, data_type_t dtype,
         int32_t ndims, const dims_t dims, layout_type_t ltype,
         property_type_t ptype) {
-    if (!logical_tensor || ndims < 0) return status::invalid_arguments;
+    VCHECK_LOGICAL_TENSOR(logical_tensor != nullptr, status::invalid_arguments,
+            "%s (logical_tensor)", VERBOSE_NULL_ARG);
+    VCHECK_LOGICAL_TENSOR(ndims >= 0 && ndims <= DNNL_MAX_NDIMS,
+            status::invalid_arguments, VERBOSE_BAD_NDIMS, "logical_tensor",
+            ndims);
 
     // currently only supports s32 and f32 host scalar.
     if (ptype == property_type::host_scalar) {
@@ -306,7 +311,11 @@ status_t DNNL_API dnnl_graph_logical_tensor_init_with_strides(
         logical_tensor_t *logical_tensor, size_t tid, data_type_t dtype,
         int32_t ndims, const dims_t dims, const dims_t strides,
         property_type_t ptype) {
-    if (!logical_tensor || ndims < 0) return status::invalid_arguments;
+    VCHECK_LOGICAL_TENSOR(logical_tensor != nullptr, status::invalid_arguments,
+            "%s (logical_tensor)", VERBOSE_NULL_ARG);
+    VCHECK_LOGICAL_TENSOR(ndims >= 0 && ndims <= DNNL_MAX_NDIMS,
+            status::invalid_arguments, VERBOSE_BAD_NDIMS, "logical_tensor",
+            ndims);
 
     // currently only supports s32 and f32 host scalar.
     if (ptype == property_type::host_scalar) {


### PR DESCRIPTION
# Description
The PR adds an upper bound ndims check during `logical_tensor` initialization to avoid potential memory corruption issues.

Addresses [MFDNN-15251](https://jira.devtools.intel.com/browse/MFDNN-15251).