### PR TITLE
x64: brgemm: Fix AMX sp_block heuristic for strided deconv

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1063,6 +1063,12 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         if (spb == prev_spb || spb > start_sp_block) continue;
         if (spb % stride_w != 0) continue;
         if (!has_uneven_iw && iw % spb != 0) continue;
+        // For AMX with stride, skip sp_blocks where the brgemm M dimension
+        // is smaller than amx_h (16). Such small M values severely
+        // underutilize AMX tiles and incur disproportionate setup overhead.
+        if (is_amx(isa) && stride_w > 1 && div_up(spb, stride_w) < amx_h
+                && spb < sp)
+            continue;
 
         prev_spb = spb;
         iw_block = spb;


### PR DESCRIPTION
For AMX with stride > 1, the `sp_block` selection could choose very small blocks (e.g. `sp_block=10`) where the effective brgemm M dimension (`sp_block/stride_w`) is smaller than `amx_h` (16). This causes severe AMX tile underutilization and disproportionate setup overhead, making AMX slower than VNNI for the same shape.

Solution: Skip `sp_block` candidates where `div_up(sp_block, stride_w) < amx_h`, forcing AMX to use larger blocks with better tile utilization.

Performance (4 threads, mb1_oc3ic64_oh1030ih512_kh7sh2, u8:s8:u8):
  Before: AMX 11.3ms, VNNI 9.9ms (AMX **15%** slower)
  After:  AMX 2.8ms,  VNNI 9.9ms (AMX **3.6x** faster)

No regressions on SPR model perf testing vs ww25-main.

Fixes: MFDNN-10709
