### PR TITLE
Fixes for GPU reference implementation

### DIFF
--- a/src/common/engine.hpp
+++ b/src/common/engine.hpp
@@ -162,7 +162,6 @@ struct dnnl_engine : public dnnl::impl::c_compatible {
     }
 
     virtual bool mayiuse_system_memory_allocators() const { return false; }
-    virtual bool mayiuse_f16_accumulator_with_f16() const { return false; }
 
     const dnnl::impl::engine_impl_t *impl() const { return impl_.get(); }
 

--- a/src/gpu/intel/conv/ref.cl
+++ b/src/gpu/intel/conv/ref.cl
@@ -164,7 +164,7 @@ __kernel void ref_convolution_fwd(
 
     POST_OP_DATA_T sum_src;
 #if WITH_SUM
-    sum_src = load(tmp, dst + DST_OFF(n, g * OC + oc, od, oh, ow));
+    sum_src = SUM_TO_REF(dst[DST_OFF(n, g * OC + oc, od, oh, ow)]);
 #endif
 
 #if NDIMS == 3

--- a/src/gpu/intel/engine.hpp
+++ b/src/gpu/intel/engine.hpp
@@ -128,16 +128,6 @@ public:
         return result != nullptr ? status::success : status::unimplemented;
     }
 
-    bool mayiuse_f16_accumulator_with_f16() const override {
-        // XeHPC+ must use f32 accumulation with f16 operations as documented.
-        switch (device_info_->gpu_arch()) {
-            case compute::gpu_arch_t::xe_lp:
-            case compute::gpu_arch_t::xe_hp:
-            case compute::gpu_arch_t::xe_hpg: return true;
-            default: return false;
-        }
-    }
-
     bool mayiuse(compute::device_ext_t ext) const {
         return device_info_->has(ext);
     }

--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/codegen.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/codegen.cpp
@@ -1814,6 +1814,7 @@ std::vector<uint8_t> make_binary(const kernel_t &ir_kernel) {
     auto &options = ir_kernel.options;
     auto &body = ir_kernel.body;
     auto &debug_cfg = ir_kernel.debug_cfg;
+    maybe_unused(debug_cfg);
 
     ngen::NEOInterfaceHandler interface = generate_ngen_interface(
             iface, options, body);
@@ -1870,6 +1871,7 @@ GEMMSTONE_XE3P_ISA(
     auto &options = ir_kernel.options;
     auto &body = ir_kernel.body;
     auto &debug_cfg = ir_kernel.debug_cfg;
+    maybe_unused(debug_cfg);
 
     ngen::NEOInterfaceHandler interface = generate_ngen_interface(
             iface, options, body);
@@ -1925,6 +1927,7 @@ cl_kernel make_kernel(
     auto &options = ir_kernel.options;
     auto &body = ir_kernel.body;
     auto &debug_cfg = ir_kernel.debug_cfg;
+    maybe_unused(debug_cfg);
 
     ngen::NEOInterfaceHandler interface = generate_ngen_interface(
             iface, options, body);
@@ -1972,6 +1975,7 @@ LevelZeroKernelAndModule make_kernel(const kernel_t &ir_kernel,
     auto &options = ir_kernel.options;
     auto &body = ir_kernel.body;
     auto &debug_cfg = ir_kernel.debug_cfg;
+    maybe_unused(debug_cfg);
 
     ngen::NEOInterfaceHandler interface = generate_ngen_interface(
             iface, options, body);

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -289,6 +289,9 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
         kb_load_masked = align_up(kb_load_masked, minOPCount);
     }
 
+    if (ka_load == 0 || kb_load == 0)
+        stub("Zero k-load granularity is invalid");
+
     // Systolic handling.
     if (systolic) {
         auto params = systolicParams(problem);

--- a/src/gpu/intel/gemm/ref.cl
+++ b/src/gpu/intel/gemm/ref.cl
@@ -33,9 +33,9 @@ void get_strides(int mask, long dim0, long dim1, long dim2, long *str0,
 __kernel void ref_gemm(__global A_DATA_T *a, __global B_DATA_T *b,
         __global C_DATA_T *c, __global BIA_DATA_T *bias, long offset_a0,
         long offset_b0, long offset_c0, long offset_bias0, int transa,
-        int transb, long MB, long M, long N, long K, long stride_a_mb,
-        long stride_b_mb, long stride_c, long lda, long ldb, long ldc,
-        float eltwise_alpha, float eltwise_beta, float eltwise_scale,
+        int transb, int transc, long MB, long M, long N, long K,
+        long stride_a_mb, long stride_b_mb, long stride_c, long lda, long ldb,
+        long ldc, float eltwise_alpha, float eltwise_beta, float eltwise_scale,
         int bias_mask,
 #if WITH_HOST_WEI_ZP
         int ao_value,
@@ -103,6 +103,8 @@ __kernel void ref_gemm(__global A_DATA_T *a, __global B_DATA_T *b,
     long stride_a_k = transa ? 1 : lda;
     long stride_b_k = transb ? ldb : 1;
     long stride_b_n = transb ? 1 : ldb;
+    long stride_c_m = transc ? ldc : 1;
+    long stride_c_n = transc ? 1 : ldc;
 
     ACC_DATA_T acc = 0;
     for (long k = 0; k < K; ++k) {
@@ -112,7 +114,7 @@ __kernel void ref_gemm(__global A_DATA_T *a, __global B_DATA_T *b,
                 * TO_ACC(B_TO_REF(b[off_b]) - ATTR_B0);
     }
 
-    long off_c = mb * stride_c + n * ldc + m;
+    long off_c = mb * stride_c + n * stride_c_n + m * stride_c_m;
 #if WITH_BIAS || NON_DEFAULT_ATTRS
     POST_OP_DATA_T temp = (POST_OP_DATA_T)acc;
 #if WITH_BIAS

--- a/src/gpu/intel/gemm/ref.cpp
+++ b/src/gpu/intel/gemm/ref.cpp
@@ -71,6 +71,7 @@ status_t ref_t::execute(const exec_ctx_t &ctx) const {
 
     const int tra = exec_d->transa() == transpose::trans;
     const int trb = exec_d->transb() == transpose::trans;
+    const int trc = exec_d->transc() == transpose::trans;
 
     compute::kernel_arg_list_t arg_list;
     arg_list.set(0, a);
@@ -83,25 +84,26 @@ status_t ref_t::execute(const exec_ctx_t &ctx) const {
     arg_list.set(7, off_bias0);
     arg_list.set(8, tra);
     arg_list.set(9, trb);
-    arg_list.set(10, MB);
-    arg_list.set(11, M);
-    arg_list.set(12, N);
-    arg_list.set(13, K);
-    arg_list.set(14, stride_a);
-    arg_list.set(15, stride_b);
-    arg_list.set(16, stride_c);
-    arg_list.set(17, lda);
-    arg_list.set(18, ldb);
-    arg_list.set(19, ldc);
-    arg_list.set(20, eltwise_alpha);
-    arg_list.set(21, eltwise_beta);
-    arg_list.set(22, eltwise_scale);
-    arg_list.set(23, bias_mask);
-    arg_list.set(24, a0);
-    arg_list.set(25, b0);
-    arg_list.set(26, c0);
-    arg_list.set(27, c0_mask);
-    arg_list.set(28, beta);
+    arg_list.set(10, trc);
+    arg_list.set(11, MB);
+    arg_list.set(12, M);
+    arg_list.set(13, N);
+    arg_list.set(14, K);
+    arg_list.set(15, stride_a);
+    arg_list.set(16, stride_b);
+    arg_list.set(17, stride_c);
+    arg_list.set(18, lda);
+    arg_list.set(19, ldb);
+    arg_list.set(20, ldc);
+    arg_list.set(21, eltwise_alpha);
+    arg_list.set(22, eltwise_beta);
+    arg_list.set(23, eltwise_scale);
+    arg_list.set(24, bias_mask);
+    arg_list.set(25, a0);
+    arg_list.set(26, b0);
+    arg_list.set(27, c0);
+    arg_list.set(28, c0_mask);
+    arg_list.set(29, beta);
 
     const compute::range_t gws = {(size_t)N, (size_t)M, (size_t)MB};
     const auto nd_range = compute::nd_range_t(gws);

--- a/src/gpu/intel/gemm/ref.hpp
+++ b/src/gpu/intel/gemm/ref.hpp
@@ -155,7 +155,7 @@ struct ref_t : public primitive_t {
                     ((utils::everyone_is(f32, a_dt, b_dt, c_dt)
                              && IMPLICATION(with_bias(), bia_dt == f32))
                             || (utils::everyone_is(f16, a_dt, b_dt)
-                                    && utils::one_of(c_dt, u8, s8, f16)
+                                    && utils::one_of(c_dt, u8, s8, f16, f32)
                                     && IMPLICATION(with_bias(),
                                             utils::one_of(bia_dt, f16, f32)))
                             || (utils::everyone_is(bf16, a_dt, b_dt)

--- a/src/gpu/intel/gemm/ref.hpp
+++ b/src/gpu/intel/gemm/ref.hpp
@@ -126,7 +126,8 @@ struct ref_t : public primitive_t {
             VDISPATCH_GEMM(
                     (b_strides[ndims - 1] == 1 || b_strides[ndims - 2] == 1),
                     VERBOSE_UNSUPPORTED_MEM_STRIDE);
-            VDISPATCH_GEMM((c_strides[ndims - 1] == 1),
+            VDISPATCH_GEMM(
+                    (c_strides[ndims - 1] == 1 || c_strides[ndims - 2] == 1),
                     VERBOSE_UNSUPPORTED_MEM_STRIDE);
             VDISPATCH_GEMM(
                     IMPLICATION(desc()->is_batched(),

--- a/src/gpu/intel/gemm/utils.hpp
+++ b/src/gpu/intel/gemm/utils.hpp
@@ -102,8 +102,7 @@ static inline status_t create_2d_desc(memory_desc_t *md_2d, int d0, int d1,
 static inline status_t create_gemm_desc(gemm_desc_t *_gemm_desc,
         const memory_desc_t *a_md, const memory_desc_t *b_md,
         const memory_desc_t *c_md, const memory_desc_t *bias_md,
-        data_type_t acc_dt, engine_t *engine,
-        sum_ab_t sum_ab = sum_ab::sum_none,
+        data_type_t acc_dt, sum_ab_t sum_ab = sum_ab::sum_none,
         data_type_t sum_ab_dt = data_type::undef) {
     auto gemm_desc = gemm_desc_t();
     gemm_desc.primitive_kind = primitive_kind::gemm;
@@ -114,12 +113,6 @@ static inline status_t create_gemm_desc(gemm_desc_t *_gemm_desc,
     gemm_desc.acc_type = acc_dt;
     gemm_desc.sum_ab = sum_ab;
     gemm_desc.sum_ab_type = sum_ab_dt;
-    // Downgrade accumulation type for f16 if allowed.
-    if (engine->mayiuse_f16_accumulator_with_f16()
-            && utils::everyone_is(
-                    data_type::f16, a_md->data_type, b_md->data_type)) {
-        gemm_desc.acc_type = data_type::f16;
-    }
     *_gemm_desc = gemm_desc;
     return status::success;
 }
@@ -132,8 +125,8 @@ static inline status_t create_gemm_pd(
         sum_ab_t sum_ab = sum_ab::sum_none,
         data_type_t sum_ab_dt = data_type::undef) {
     gemm_desc_t gemm_desc;
-    CHECK(create_gemm_desc(&gemm_desc, a_md, b_md, c_md, bias_md, acc_dt,
-            engine, sum_ab, sum_ab_dt));
+    CHECK(create_gemm_desc(
+            &gemm_desc, a_md, b_md, c_md, bias_md, acc_dt, sum_ab, sum_ab_dt));
 
     primitive_attr_t gemm_attr = *attr;
 

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -120,11 +120,9 @@ status_t with_post_ops_t::pd_t::init(impl::engine_t *engine) {
             VERBOSE_SKIP_PRIMITIVE_IMPL);
     auto desc = *this->desc();
     dst_type_ = desc.c_desc.data_type;
-    desc.c_desc.data_type = engine->mayiuse_f16_accumulator_with_f16()
-                    && utils::one_of(data_type::f16, desc.a_desc.data_type,
-                            desc.b_desc.data_type)
-            ? data_type::f32
-            : desc.acc_type;
+    // Force f32 destination even if f16 accumulation mode is used.
+    desc.c_desc.data_type
+            = desc.acc_type == data_type::f16 ? data_type::f32 : desc.acc_type;
     acc_type_ = desc.c_desc.data_type;
     use_reorder = dst_md(0)->data_type != desc.c_desc.data_type;
     desc.bias_desc = glob_zero_md;

--- a/src/gpu/intel/jit/codegen/kernel_ext.hpp
+++ b/src/gpu/intel/jit/codegen/kernel_ext.hpp
@@ -74,6 +74,7 @@ public:
         , options_(desc.options(engine))
         , local_range_(desc.local_range())
         , debug_config_(debug_config) {
+        MAYBE_UNUSED(debug_config_);
         desc.init_kernel_iface(kernel_iface_);
     }
 
@@ -84,7 +85,9 @@ public:
         : kernel_iface_(kernel_iface)
         , options_(options)
         , local_range_(local_range)
-        , debug_config_(debug_config) {}
+        , debug_config_(debug_config) {
+        MAYBE_UNUSED(debug_config_);
+    }
 
     const dsl::kernel::options_t &options() const { return options_; }
     const dsl::kernel::iface_t &kernel_iface() const { return kernel_iface_; }

--- a/src/gpu/intel/lnorm/vectorized_fused.cl
+++ b/src/gpu/intel/lnorm/vectorized_fused.cl
@@ -122,7 +122,7 @@ __kernel void vectorized_lnorm_bwd_fused(__global DATA_T *src,
             VECT_FLOAT_T diff_gamma_vect = 0;
             VECT_FLOAT_T diff_beta_vect = 0;
             for (int n_idx = n_start; n_idx < n_end; n_idx++) {
-                const float mean_vect = mean[n_idx];
+                const float mean_vect = SKIP_MEAN ? 0 : mean[n_idx];
                 const float variance_vect = variance[n_idx];
                 const float inv_sqrt_variance = rsqrt(variance_vect + eps);
 
@@ -220,7 +220,7 @@ __kernel void vectorized_lnorm_bwd_fused(__global DATA_T *src,
     VECT_FLOAT_T v_src[SRC_BUF_SIZE];
     VECT_FLOAT_T v_diff_dst[SRC_BUF_SIZE];
 
-    const float mean_val = mean[s_off];
+    const float mean_val = SKIP_MEAN ? 0 : mean[s_off];
     const float inv_sqrt_variance = rsqrt(variance[s_off] + eps);
 
     for (off_t c = 0; c < SRC_BUF_SIZE; c++) {

--- a/src/gpu/intel/matmul/gemm.cpp
+++ b/src/gpu/intel/matmul/gemm.cpp
@@ -75,8 +75,8 @@ status_t gemm_t::execute(const exec_ctx_t &ctx) const {
     args.exec_args = ctx.args();
     gemm::desc_t desc;
     CHECK(create_gemm_desc(&desc, src_d.md_, weights_d.md_, dst_d.md_,
-            bia_d.md_, pd()->desc()->accum_data_type, ctx.stream()->engine(),
-            pd()->sum_ab_, pd()->sum_ab_type_));
+            bia_d.md_, pd()->desc()->accum_data_type, pd()->sum_ab_,
+            pd()->sum_ab_type_));
 
     gemm::exec_ctx_t gemm_ctx(ctx, args, &desc);
 

--- a/src/gpu/intel/ocl/kernel.cpp
+++ b/src/gpu/intel/ocl/kernel.cpp
@@ -68,7 +68,13 @@ public:
 
     ~kernel_cache_t() {
         for (auto &kv : kernels_) {
-            OCL_CHECK_V(xpu::ocl::clReleaseKernel(kv.second));
+            // See the comment in 'src/xpu/ocl/utils.hpp' next to
+            // `xpu::ocl::clReleaseKernel(t)` call. It explains the logic behind
+            // such handling.
+            auto cl_st = xpu::ocl::clReleaseKernel(kv.second);
+            if (cl_st != CL_SUCCESS && cl_st != CL_INVALID_OPERATION) {
+                OCL_CHECK_V(cl_st);
+            }
         }
     }
 

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -195,6 +195,7 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
             });
             return OK;
         }
+        BENCHDNN_PRINT(0, "%s\n", "Error: failed to create a reorder.");
         return FAIL;
     }
 

--- a/tests/gtests/graph/api/test_c_api_compile.cpp
+++ b/tests/gtests/graph/api/test_c_api_compile.cpp
@@ -981,15 +981,6 @@ TEST(CAPI, CompileSumConv2DStridedBN) {
                            *(compiled_partition + 1), sum_output.id,
                            &opaque_sum_output),
             dnnl_success, COMPILE_SUM_CONV2D_STRIDED_BN_DESTROY_PLUS);
-// Blocked layout is supported on intel gpu only
-#if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
-        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
-    ASSERT_EQ(opaque_sum_output.layout_type,
-            engine == dnnl_gpu ? dnnl_graph_layout_type_opaque
-                               : dnnl_graph_layout_type_strided);
-#else
-    ASSERT_EQ(opaque_sum_output.layout_type, dnnl_graph_layout_type_strided);
-#endif
 
     // Check in-place pairs
     size_t num_inplace_pairs = 10; // Initialized with an impossible value.

--- a/tests/gtests/graph/api/test_cpp_api_partition.cpp
+++ b/tests/gtests/graph/api/test_cpp_api_partition.cpp
@@ -99,31 +99,11 @@ TEST(APIPartition, PartitionTest) {
 
     auto cp = partitions[0].compile(in0, out0, eng);
     // query logical tensor from compiled partition
-    auto lt4_opaque = cp.query_logical_tensor(3);
-#if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
-        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
-    ASSERT_EQ(lt4_opaque.get_layout_type(),
-            real_engine_kind == dnnl::engine::kind::gpu
-                    ? logical_tensor::layout_type::opaque
-                    : logical_tensor::layout_type::strided);
-#else
-    ASSERT_EQ(
-            lt4_opaque.get_layout_type(), logical_tensor::layout_type::strided);
-#endif
+    cp.query_logical_tensor(3);
 
     auto cp1 = partitions[0].compile(in0, out0, eng);
     // query logical tensor from compiled partition
-    auto lt5_opaque = cp1.query_logical_tensor(3);
-#if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
-        && DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
-    ASSERT_EQ(lt5_opaque.get_layout_type(),
-            real_engine_kind == dnnl::engine::kind::gpu
-                    ? logical_tensor::layout_type::opaque
-                    : logical_tensor::layout_type::strided);
-#else
-    ASSERT_EQ(
-            lt5_opaque.get_layout_type(), logical_tensor::layout_type::strided);
-#endif
+    cp1.query_logical_tensor(3);
 }
 
 TEST(APIPartition, GetInputOutputIDs) {

--- a/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
@@ -86,17 +86,6 @@ TEST(test_convolution_compile, ConvolutionFp32) {
 
     graph::logical_tensor_t lt;
     cp.query_logical_tensor(dst.id, &lt);
-
-// Blocked layout is supported on intel gpu only
-#if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
-        && DNNL_GPU_VENDOR != DNNL_VENDOR_INTEL
-    ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
-#else
-    ASSERT_EQ(lt.layout_type,
-            engine->kind() == graph::engine_kind::gpu
-                    ? graph::layout_type::opaque
-                    : graph::layout_type::strided);
-#endif
 }
 
 TEST(test_convolution_compile, ConvolutionBackwardDataFp32) {

--- a/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
@@ -532,16 +532,6 @@ TEST(test_convtranspose_compile, ConvtransposeFp32) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
     graph::logical_tensor_t lt;
     cp.query_logical_tensor(dst.id, &lt);
-    // Blocked layout is supported on intel gpu only
-#if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
-        && DNNL_GPU_VENDOR != DNNL_VENDOR_INTEL
-    ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
-#else
-    ASSERT_EQ(lt.layout_type,
-            eng->kind() == graph::engine_kind::gpu
-                    ? graph::layout_type::opaque
-                    : graph::layout_type::strided);
-#endif
 }
 
 TEST_P(convtranspose_4d_5d_t, TestConvtranspose) {


### PR DESCRIPTION
This PR addresses issues discovered during reference implementation testing using CI test set. Specific fixes:
* 9a164d630ad5f942e65d7edfd4fb4977835eef26 suppresses a warning issued when the library is built with `-DONEDNN_PRIMITIVE_GPU_ISA=""` to force reference implementation
* 3ac0881a9463a8cd74889d77db122163d4ac483b and be2713f34c06318d0c2df15e561359f5c8f7763c extend matmul reference implementation to avoid unimplemented cases in RNN and matmul tests
* 42aca1a222d5b26b466d066a92e71816c9b08021 removes convolution layout checks from Graph API gtests, as this behavior is implementation defined
* 3782512b6c1798cbd1391ca149a0b44017f9bd47 fixes sum datatype in reference convolution
* 38a2ecfc502f2acf2e0d811adcb99d2b550807e6 removes implicit `f16` accumulation in matmul, which now only applies to reference implementation
* b601c919b4485c8ce474dda71d0feaf28644eddc fixes crash in RMS normalization

With that only two clasess of issues remain:
* Lack of grouped quantization support in grouped matmul
* ~~1-2 ULP difference in f16 SDPA test on GPUs without systolic~~

Orphan test job: https://intel-ci.intel.com/f170d7b1-9e0a-f11f-afc2-d4f5ef20c6a0