### PR TITLE
x64: matmul: s32 routing issue fix

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -372,10 +372,10 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
     , f32_with_int_wei_dt(weights_decompression_support
               && everyone_is(f32, bgmmc.src_dt, bgmmc.dst_dt))
     // int8 grouped quantization: any grouped scales/ZP attribute on
-    // int8 src x {s4,u4,s8} wei, dst in {f16,bf16,f32,s8,u8}.
+    // int8 src x {s4,u4,s8} wei, dst in {f16,bf16,f32,s8,u8,s32}.
     , int8_grouped_quantization_dt(one_of(bgmmc.src_dt, u8, s8)
               && one_of(bgmmc.wei_dt, s4, u4, s8)
-              && one_of(bgmmc.dst_dt, f16, bf16, f32, s8, u8)
+              && one_of(bgmmc.dst_dt, f16, bf16, f32, s8, u8, s32)
               && (!attr.zero_points_.get(DNNL_ARG_SRC).has_default_values()
                       || !attr.zero_points_.get(DNNL_ARG_WEIGHTS)
                                   .has_default_values())


### PR DESCRIPTION
## Description
Fixes [MFDNN-15247](https://jira.devtools.intel.com/browse/MFDNN-15247). 
Route s32 destination data type to int8_grouped_quantization, since testcases in https://github.com/uxlfoundation/oneDNN/pull/5317 includes it. 

 
