### PR TITLE
third_party: ngen: force unsigned operand types for shr

### DIFF
--- a/src/gpu/intel/gemm/zero_fill.cl
+++ b/src/gpu/intel/gemm/zero_fill.cl
@@ -15,6 +15,5 @@
 *******************************************************************************/
 
 __kernel void gemm_zero_fill(__global uint *buf, uint n) {
-    uint id = get_global_id(0);
-    buf[id] = 0;
+    buf[get_global_id(0)] = 0;
 }

--- a/third_party/ngen/ngen.hpp
+++ b/third_party/ngen/ngen.hpp
@@ -1274,11 +1274,18 @@ public:
     }
     template <typename DT = void>
     void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1, loc);
+        // shr is always zero-extend; force unsigned operand types.
+        auto udst = dst, usrc0 = src0;
+        udst.setType(unsignedType(dst.getType()));
+        usrc0.setType(unsignedType(src0.getType()));
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1, loc);
     }
     template <typename DT = void>
     void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1, loc);
+        auto udst = dst, usrc0 = src0;
+        udst.setType(unsignedType(dst.getType()));
+        usrc0.setType(unsignedType(src0.getType()));
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1, loc);
     }
     template <typename DT = void>
     void smov(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {

--- a/third_party/ngen/ngen_asm.hpp
+++ b/third_party/ngen/ngen_asm.hpp
@@ -1577,11 +1577,18 @@ public:
     }
     template <typename DT = void>
     void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1);
+        // shr is always zero-extend; force unsigned operand types.
+        auto udst = dst, usrc0 = src0;
+        udst.setType(unsignedType(dst.getType()));
+        usrc0.setType(unsignedType(src0.getType()));
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1);
     }
     template <typename DT = void>
     void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1);
+        auto udst = dst, usrc0 = src0;
+        udst.setType(unsignedType(dst.getType()));
+        usrc0.setType(unsignedType(src0.getType()));
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1);
     }
     template <typename DT = void>
     void smov(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {

--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -442,6 +442,13 @@ static inline constexpr bool isSigned(DataType type)
           || type == DataType::uw || type == DataType::ud || type == DataType::uq);
 }
 
+static inline constexpr DataType unsignedType(DataType type)
+{
+    return (type == DataType::b || type == DataType::w || type == DataType::d
+         || type == DataType::q || type == DataType::s2 || type == DataType::s4)
+        ? static_cast<DataType>(static_cast<uint8_t>(type) & ~1) : type;
+}
+
 template <typename T> static inline DataType getDataType() { return DataType::invalid; }
 
 template <> inline DataType getDataType<uint64_t>() { return DataType::uq; }


### PR DESCRIPTION
This is another fix for the `shr` issue from https://github.com/uxlfoundation/oneDNN/pull/5391. Opening a separate PR to test and review carefully and not block the original PR.

This fixes an issue with `shr` in Xe3p simulation: it treats `ud` x `d` usage as an error while it works on real silicon. Since the behavior of `shr` is well defined (zero-extension, as opposed to arithmetic shift right that uses sign-extension), forcing the unsigned types is a safe and universal fix.