### PR TITLE
x64: brgemm: Skip f32 regression blacklist for deconv with post-ops

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1592,7 +1592,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                             && everyone_is(14, jcp.oh, jcp.ow)
                             && everyone_is(4, jcp.kh, jcp.kw)
                             && everyone_is(2, jcp.stride_h, jcp.stride_w)));
-    VDISPATCH_CONV_IC(!(is_f32 && is_regression_shape),
+    VDISPATCH_CONV_IC(!(is_f32 && !(jcp.is_deconv && attr.post_ops_.len() > 0)
+                              && is_regression_shape),
             "implementation skipped due to low performance");
 
     const bool is_signed_input = jcp.src_dt == s8;


### PR DESCRIPTION
## Description

The f32 regression shape blacklist in `brgconv_strided` was blocking `brg_deconv` from using this implementation for certain deconvolution shapes with post-ops. The `jit:avx512_core` fallback handles post-ops via a reference implementation (separate pass over output), making deconv+post-ops drastically slower than deconv alone.

With `brgconv_strided`, post-ops are fused directly into the kernel, eliminating the expensive separate pass.

Without post-ops, the jit fallback remains faster for these shapes, so the blacklist is kept active in that case.

## Performance (SPR 56c)

JIRA shapes, deconv FWD_I f32:

**Before (main):** deconv+relu is much slower than deconv alone (post-ops handled via ref impl)

| Shape | Deconv alone | Deconv+relu (jit ref post-ops) | Overhead |
|-------|-------------|-------------------------------|----------|
| `mb1ic512oc256_kh5sh2` | 0.80 ms | 2.52 ms | **215%** |
| `mb1ic256oc128_kh5sh2` | 0.93 ms | 2.16 ms | **132%** |
| `mb1ic128oc3_kh7sh2` | 0.50 ms | 1.57 ms | **214%** |

**After (fix):** deconv+relu uses brgemm with fused post-ops

| Shape | Deconv alone | Deconv+relu (brgemm fused) | Overhead |
|-------|-------------|---------------------------|----------|
| `mb1ic512oc256_kh5sh2` | 0.80 ms | 1.10 ms | **36%** |
| `mb1ic256oc128_kh5sh2` | 0.93 ms | 1.11 ms | **19%** |
| `mb1ic128oc3_kh7sh2` | 0.50 ms | 0.55 ms | **9%** |

Post-op overhead reduced from **132-215% to 9-36%**.

## Notes

- The blacklist remains active for `conv --dir=BWD_D` and `deconv` without post-ops (unchanged behavior).
- Only deconv with post-ops bypasses the blacklist, where fused execution eliminates the reference post-op penalty.

Fixes: MFDNN-8240