### PR TITLE
xe: gemm: update outer product indexing

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/k_loop.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/k_loop.cxx
@@ -1050,22 +1050,20 @@ void Generator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMMStrategy &
             return;
 
         int ka = ka_repack(h), kb = kb_load(h);
-        int ha = h % ka;
-        int hb = h % kb;
-        if (problem.backward()) {
-            ha = ka - 1 - ha;
-            hb = kb - 1 - hb;
-        }
 
         auto &layoutA = Ar_layout(h);
         auto &layoutB = Br_layout(h);
         auto &regsA = Ar_regs(h);
         auto &regsB = Br_regs(h);
 
-            outerProduct(h, ha, hb, oc, opRemActive(h), layoutA, layoutB, regsA, regsB, problem, strategy, state);
+            outerProduct(h, ka, kb, oc, opRemActive(h), layoutA, layoutB, regsA, regsB, problem, strategy, state);
 
         if (calcASums && !slmASums && !state.systolicSumA) {
             int ka_sum = (curPhase == LoopSequencer::PhaseMainLoop) ? ka_sumMain : oc;
+            int ha = h % ka;
+            if (problem.backward()) {
+                ha = ka - 1 - ha;
+            }
             int ha0 = ha - oc + minOPCount;
             if (ha0 % ka_sum == 0)
                 accumulateSum(false, regsA, layoutA, state.As_regs, state.As_layout, strategy, state, ha0, ha0 + ka_sum);
@@ -1073,6 +1071,10 @@ void Generator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMMStrategy &
 
         if (calcBSums && !slmBSums && !state.systolicSumB) {
             int kb_sum = (curPhase == LoopSequencer::PhaseMainLoop) ? kb_sumMain : oc;
+            int hb = h % kb;
+            if (problem.backward()) {
+                hb = kb - 1 - hb;
+            }
             int hb0 = hb - oc + minOPCount;
             if (hb0 % kb_sum == 0)
                 accumulateSum(true, regsB, layoutB, state.Bs_regs, state.Bs_layout, strategy, state, hb0, hb0 + kb_sum);

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -28,6 +28,16 @@ using namespace ngen;
 using namespace ngen::utils;
 using std::vector;
 
+inline namespace {
+int local_k_index(int h, int opCount, int period, const GEMMProblem &problem) {
+    int out = align_down(h, opCount) % period;
+    if (problem.backward()) {
+        if (period % opCount) stub();
+        return period - opCount - out;
+    }
+    return out;
+}
+} // anonymous namespace
 
 // Do one or more outer products (k = 1 slices) of A*B, updating C.
 //  ha and hb are the k indices within the A and B chunks, respectively.
@@ -75,7 +85,7 @@ void Generator<hw>::outerProductFMA(int h, int ha_period, int hb_period, int opC
     int Cr_unrollM = state.Cr_layout.rows(), Cr_unrollN = state.Cr_layout.cols();
     int Cr_unrollX = globalCM ? Cr_unrollM : Cr_unrollN;
     if (repackC) {
-        auto rphase = align_down(h, opCount) % state.cRepackPeriod;
+        auto rphase = local_k_index(h, opCount, state.cRepackPeriod, problem);
         startRepackC = rem || (rphase == 0);
         endRepackC = rem || (rphase + opCount >= state.cRepackPeriod);
     }
@@ -125,14 +135,8 @@ void Generator<hw>::outerProductFMA(int h, int ha_period, int hb_period, int opC
             setDefaultAutoSWSB(true);
     };
 
-    int ha = align_down(h, opCount) % ha_period;
-    int hb = align_down(h, opCount) % hb_period;
-    if (problem.backward()) {
-        if (ha_period % opCount) stub();
-        if (hb_period % opCount) stub();
-        ha = ha_period - opCount - ha;
-        hb = hb_period - opCount - hb;
-    }
+    int ha = local_k_index(h, opCount, ha_period, problem);
+    int hb = local_k_index(h, opCount, hb_period, problem);
 
     if (atomicFMA && hw >= HW::XeHPC) {
         // PVC onward can't use {Atomic} on float pipes.
@@ -323,7 +327,7 @@ void Generator<hw>::innerProductFMA(int h, int ha_period, int hb_period, int opC
     if (repackC) {
         if (state.Cr_layout.rows() != state.C_layout.rows()) stub();
         if (state.Cr_layout.cols() != state.C_layout.cols()) stub();
-        auto rphase = align_down(h, opCount) % state.cRepackPeriod;
+        auto rphase = local_k_index(h, opCount, state.cRepackPeriod, problem);
         startRepackC = rem || (rphase == 0);
         endRepackC = rem || (rphase + opCount >= state.cRepackPeriod);
     }
@@ -333,14 +337,8 @@ void Generator<hw>::innerProductFMA(int h, int ha_period, int hb_period, int opC
     const auto &C_regs   = repackC ? state.Cr_regs   : state.C_regs[0];
 
     bool globalCM = C_layout.colMajor();
-    int ha = align_down(h, opCount) % ha_period;
-    int hb = align_down(h, opCount) % hb_period;
-    if (problem.backward()) {
-        if (ha_period % opCount) stub();
-        if (hb_period % opCount) stub();
-        ha = ha_period - opCount - ha;
-        hb = hb_period - opCount - hb;
-    }
+    int ha = local_k_index(h, opCount, ha_period, problem);
+    int hb = local_k_index(h, opCount, hb_period, problem);
 
     int nx = globalCM ? strategy.unroll[LoopM] : strategy.unroll[LoopN];
     int ny = globalCM ? strategy.unroll[LoopN] : strategy.unroll[LoopM];
@@ -406,7 +404,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha_period, int hb_period, in
     int Cr_unrollM = state.Cr_layout.rows(), Cr_unrollN = state.Cr_layout.cols();
     int Cr_unrollX = globalCM ? Cr_unrollM : Cr_unrollN;
     if (repackC) {
-        auto rphase = align_down(h, opCount) % state.cRepackPeriod;
+        auto rphase = local_k_index(h, opCount, state.cRepackPeriod, problem);
         startRepackC = rem || (rphase == 0);
         endRepackC = rem || (rphase + opCount >= state.cRepackPeriod);
     }
@@ -415,14 +413,8 @@ void Generator<hw>::outerProductSystolic(int h, int ha_period, int hb_period, in
     sumBlock.colMajor = globalCM;
     sumBlock.crosspack = 1;
 
-    int ha = align_down(h, opCount) % ha_period;
-    int hb = align_down(h, opCount) % hb_period;
-    if (problem.backward()) {
-        if (ha_period % opCount) stub();
-        if (hb_period % opCount) stub();
-        ha = ha_period - opCount - ha;
-        hb = hb_period - opCount - hb;
-    }
+    int ha = local_k_index(h, opCount, ha_period, problem);
+    int hb = local_k_index(h, opCount, hb_period, problem);
 
     // Decide whether to loop in column or row major order, to facilitate macro sequences.
     //  x is the non-accumulating dimension of dpas src1 (V matrix)
@@ -505,11 +497,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha_period, int hb_period, in
                         int xqGroupK = isA ? problem.aqGroupK : problem.bqGroupK;
                         int kxq = isA ? state.kaq : state.kbq;
                         int kxq_load = xqGroupK * kxq;
-                        int hq = align_down(h, opCount) % kxq_load;
-                        if (problem.backward()) {
-                            if (kxq_load % opCount) stub();
-                            hq = kxq_load - opCount - hq;
-                        }
+                        int hq = local_k_index(h, opCount, kxq_load, problem);
                         hq = (hq + hh) % kxq_load;
                         int k = hq / xqGroupK;
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -33,22 +33,22 @@ using std::vector;
 //  ha and hb are the k indices within the A and B chunks, respectively.
 //  A_copy, B_copy are the indices of the A, B copies to use.
 template <HW hw>
-void Generator<hw>::outerProduct(int h, int ha, int hb, int opCount, bool rem,
+void Generator<hw>::outerProduct(int h, int ha_period, int hb_period, int opCount, bool rem,
                                  const RegisterLayout &A_layout, const RegisterLayout &B_layout,
                                  const GRFMultirange &A_regs, const GRFMultirange &B_regs,
                                  const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
     if (strategy.dotVL)
-        innerProductFMA(h, ha, hb, opCount, rem, A_layout, B_layout, A_regs, B_regs, problem, strategy, state);
+        innerProductFMA(h, ha_period, hb_period, opCount, rem, A_layout, B_layout, A_regs, B_regs, problem, strategy, state);
     else if (strategy.systolic)
-        outerProductSystolic(h, ha, hb, opCount, rem, A_layout, B_layout, A_regs, B_regs, problem, strategy, state);
+        outerProductSystolic(h, ha_period, hb_period, opCount, rem, A_layout, B_layout, A_regs, B_regs, problem, strategy, state);
     else
-        outerProductFMA(h, ha, hb, opCount, rem, A_layout, B_layout, A_regs, B_regs, problem, strategy, state);
+        outerProductFMA(h, ha_period, hb_period, opCount, rem, A_layout, B_layout, A_regs, B_regs, problem, strategy, state);
 }
 
 // FMA or dp4a-based outer product implementation.
 template <HW hw>
-void Generator<hw>::outerProductFMA(int h, int ha, int hb, int opCount, bool rem, const RegisterLayout &A_layout, const RegisterLayout &B_layout,
+void Generator<hw>::outerProductFMA(int h, int ha_period, int hb_period, int opCount, bool rem, const RegisterLayout &A_layout, const RegisterLayout &B_layout,
                                     const GRFMultirange &A_regs, const GRFMultirange &B_regs,
                                     const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
@@ -125,8 +125,14 @@ void Generator<hw>::outerProductFMA(int h, int ha, int hb, int opCount, bool rem
             setDefaultAutoSWSB(true);
     };
 
-    ha = align_down(ha, opCount);
-    hb = align_down(hb, opCount);
+    int ha = align_down(h, opCount) % ha_period;
+    int hb = align_down(h, opCount) % hb_period;
+    if (problem.backward()) {
+        if (ha_period % opCount) stub();
+        if (hb_period % opCount) stub();
+        ha = ha_period - opCount - ha;
+        hb = hb_period - opCount - hb;
+    }
 
     if (atomicFMA && hw >= HW::XeHPC) {
         // PVC onward can't use {Atomic} on float pipes.
@@ -305,7 +311,7 @@ void Generator<hw>::outerProductFMA(int h, int ha, int hb, int opCount, bool rem
 
 // FMA-based inner product (dot) implementation.
 template <HW hw>
-void Generator<hw>::innerProductFMA(int h, int ha, int hb, int opCount, bool rem, const RegisterLayout &A_layout, const RegisterLayout &B_layout,
+void Generator<hw>::innerProductFMA(int h, int ha_period, int hb_period, int opCount, bool rem, const RegisterLayout &A_layout, const RegisterLayout &B_layout,
                                     const GRFMultirange &A_regs, const GRFMultirange &B_regs,
                                     const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
@@ -327,8 +333,14 @@ void Generator<hw>::innerProductFMA(int h, int ha, int hb, int opCount, bool rem
     const auto &C_regs   = repackC ? state.Cr_regs   : state.C_regs[0];
 
     bool globalCM = C_layout.colMajor();
-    ha = align_down(ha, opCount);
-    hb = align_down(hb, opCount);
+    int ha = align_down(h, opCount) % ha_period;
+    int hb = align_down(h, opCount) % hb_period;
+    if (problem.backward()) {
+        if (ha_period % opCount) stub();
+        if (hb_period % opCount) stub();
+        ha = ha_period - opCount - ha;
+        hb = hb_period - opCount - hb;
+    }
 
     int nx = globalCM ? strategy.unroll[LoopM] : strategy.unroll[LoopN];
     int ny = globalCM ? strategy.unroll[LoopN] : strategy.unroll[LoopM];
@@ -371,7 +383,7 @@ void Generator<hw>::innerProductFMA(int h, int ha, int hb, int opCount, bool rem
 
 // Accumulate multiple outer products using the systolic array.
 template <HW hw>
-void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, bool rem,
+void Generator<hw>::outerProductSystolic(int h, int ha_period, int hb_period, int opCount, bool rem,
                                          const RegisterLayout &A_layout, const RegisterLayout &B_layout,
                                          const GRFMultirange &A_regs, const GRFMultirange &B_regs,
                                          const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
@@ -403,8 +415,14 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
     sumBlock.colMajor = globalCM;
     sumBlock.crosspack = 1;
 
-    ha = align_down(ha, opCount);
-    hb = align_down(hb, opCount);
+    int ha = align_down(h, opCount) % ha_period;
+    int hb = align_down(h, opCount) % hb_period;
+    if (problem.backward()) {
+        if (ha_period % opCount) stub();
+        if (hb_period % opCount) stub();
+        ha = ha_period - opCount - ha;
+        hb = hb_period - opCount - hb;
+    }
 
     // Decide whether to loop in column or row major order, to facilitate macro sequences.
     //  x is the non-accumulating dimension of dpas src1 (V matrix)
@@ -479,13 +497,21 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
 
                 const int cxCompA = -1, cxCompB = -1, cxCompC = -1, cBuffer = 0;
                 auto bdpasScaleArg = [&](const RegisterLayout Xr_scaleLayout, Type Tx_scaleOp,
-                                         GRFMultirange Xr_scaleRegs, bool isA, int x, int h) {
+                                         GRFMultirange Xr_scaleRegs, bool isA, int x) {
                     RegData XS;
                     if (state.useBDPAS && !Xr_scaleLayout.empty()) {
                         if (problem.aqGroupM > 1 || problem.bqGroupN > 1) stub();
 
                         int xqGroupK = isA ? problem.aqGroupK : problem.bqGroupK;
-                        int k = h / xqGroupK;
+                        int kxq = isA ? state.kaq : state.kbq;
+                        int kxq_load = xqGroupK * kxq;
+                        int hq = align_down(h, opCount) % kxq_load;
+                        if (problem.backward()) {
+                            if (kxq_load % opCount) stub();
+                            hq = kxq_load - opCount - hq;
+                        }
+                        hq = (hq + hh) % kxq_load;
+                        int k = hq / xqGroupK;
 
                         int io0 = isA ? x : k;
                         int jo0 = isA ? k : x;
@@ -510,8 +536,8 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                         C = state.Cr_layout.find(i % Cr_unrollM, j % Cr_unrollN, state.Cr_regs, &nc, &C_block, cxCompC);
                     else
                         C = state.C_layout.find(i, j, state.C_regs[cBuffer], &nc, &C_block, cxCompC);
-                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true,  i, hha);
-                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, j, hhb);
+                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true, i);
+                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, j);
                 } else if (state.systolicSumA) {
                     A = A_layout.find(x, hha, A_regs, &na, &A_block);
                     B = state.sysSumAll1s[0];
@@ -521,7 +547,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                         C = state.Asr_layout.find(x % Cr_unrollM, 0, state.Asr_regs, &nc, &C_block);
                     else
                         C = state.As_layout.find(x, 0, state.As_regs, &nc, &C_block);
-                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true, x, hha);
+                    AS = bdpasScaleArg(state.Ar_scaleLayout, state.Ta_scaleInt, state.Ar_scaleRegs, true, x);
                     BS = NullRegister().setType(Type::ngen_e8m0());
                 } else {
                     A = state.sysSumAll1s[0];
@@ -533,7 +559,7 @@ void Generator<hw>::outerProductSystolic(int h, int ha, int hb, int opCount, boo
                     else
                         C = state.Bs_layout.find(0, x, state.Bs_regs, &nc, &C_block);
                     AS = NullRegister().setType(Type::ngen_e8m0());
-                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, hhb, x);
+                    BS = bdpasScaleArg(state.Br_scaleLayout, state.Tb_scaleInt, state.Br_scaleRegs, false, x);
                 }
 
                 int nv = globalCM ? na : nb;


### PR DESCRIPTION
Addresses [MFDNN-15253](https://jira.devtools.intel.com/browse/MFDNN-15253). Recent changes to indexing inside of the outer product functions has gotten sloppy with periodicity of loads of various buffers, this changes to one coherent philosophy to indexing across all functions. Fixes an issue with bdpas where scale args are loaded with a different periodicity than A/B args. This resulted previously in using incorrect subregisters for scale args, resulting in accuracy issues (example below).

The philosophy for indexing in the k-loop and outer product functions is now:
- the k-loop triggers outer product code with `period=ksys*kchain`
- When triggered, it's at the last "chunk" of the period, i.e. `h = -minOpCount % period` (up to here already existing logic)
- This iteration count is then aligned down to `period` and each call to `outerProduct` processes `period` elements

Before, we would compute `ha` then align down to `opCount` - which could result in different k-iterations from one `h` value, if `ha` wraps across an `opCount` boundary. The main change here is to require align_down first, then overlay with the periodicity of the register layout for each buffer for local indices. Here's an image that shows the relevant indices, assuming `ka_repack=4*opCount` with matching scales periodicity, but `kb_load=3*opCount` and `kbq_load=6*opCount`. The red line indices the current `h` value, and the blue text indicates local offsets into the layouts:
<img width="2168" height="377" alt="image" src="https://github.com/user-attachments/assets/f830cd04-bed7-4baa-97ba-423f1ec6b26a" />

These changes themselves shouldn't change any functionality - the bdpas fixes come from using `h` directly in `bdpasScaleArgs`, then using the same align-then-wrap logic that now every buffer uses uniformly. This fixes issues when (in the cooldown loop, at least) periodicities can differ between data loads (from prefetches) and scale loads.

Fixed case:
```
0:FAILED (errors:14862 total:16384) (4478 ms) __REPRO: --matmul --engine=gpu --dt=f8_e4m3:f8_e4m3:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:e8m0:1x32+wei:per_ocic:e8m0:32x1 128x128:128x128
```