### PR TITLE
common: thread_local_storage: update class members

### DIFF
--- a/src/common/thread_local_storage.hpp
+++ b/src/common/thread_local_storage.hpp
@@ -46,18 +46,18 @@ struct thread_local_storage_t {
         return it.first->second;
     }
 
-    bool is_set() {
+    bool is_set() const {
         utils::lock_read_t lock_r(mutex_);
         return storage_.find(std::this_thread::get_id()) != storage_.end();
     }
 
-    T &get() {
+    const T &get() const {
         utils::lock_read_t lock_r(mutex_);
         return storage_.at(std::this_thread::get_id());
     }
 
     template <typename U>
-    T &get(U &&def_value) {
+    T &get_or_set(U &&def_value) {
         {
             utils::lock_read_t lock_r(mutex_);
             auto it = storage_.find(std::this_thread::get_id());
@@ -68,7 +68,7 @@ struct thread_local_storage_t {
 
 private:
     std::unordered_map<std::thread::id, T> storage_;
-    utils::rw_mutex_t mutex_;
+    mutable utils::rw_mutex_t mutex_;
 };
 
 } // namespace utils

--- a/src/cpu/sycl/stream.hpp
+++ b/src/cpu/sycl/stream.hpp
@@ -65,22 +65,17 @@ struct stream_t : public cpu::cpu_stream_t {
             exec_ctx_t &exec_ctx) override {
         assert(engine()->kind() == engine_kind::cpu);
         auto event = queue().submit([&](::sycl::handler &cgh) {
-            register_deps(cgh);
+            cgh.depends_on(sycl_ctx().get_sycl_deps().events);
             submit_cpu_primitive(this, prim_iface, exec_ctx, cgh);
         });
         sycl_ctx().set_deps({event});
         return status::success;
     }
 
-    const xpu::sycl::context_t &sycl_ctx() const { return impl()->sycl_ctx(); }
     xpu::sycl::context_t &sycl_ctx() { return impl()->sycl_ctx(); }
 
     ::sycl::event get_output_event() const {
         return impl()->get_output_event();
-    }
-
-    void register_deps(::sycl::handler &cgh) const {
-        return impl()->register_deps(cgh);
     }
 
     void after_exec_hook() override;

--- a/src/gpu/generic/sycl/stream.hpp
+++ b/src/gpu/generic/sycl/stream.hpp
@@ -87,18 +87,11 @@ public:
         return impl()->fill(dst, pattern, size, deps, out_dep, profiler_.get());
     }
 
-    const xpu::sycl::context_t &sycl_ctx() const { return impl()->sycl_ctx(); }
     xpu::sycl::context_t &sycl_ctx() { return impl()->sycl_ctx(); }
-
     xpu::context_t &ctx() override { return impl()->sycl_ctx(); }
-    const xpu::context_t &ctx() const override { return impl()->sycl_ctx(); }
 
     ::sycl::event get_output_event() const {
         return impl()->get_output_event();
-    }
-
-    void register_deps(::sycl::handler &cgh) const {
-        return impl()->register_deps(cgh);
     }
 
 private:

--- a/src/gpu/gpu_stream.hpp
+++ b/src/gpu/gpu_stream.hpp
@@ -41,7 +41,6 @@ public:
             = 0;
 
     virtual xpu::context_t &ctx() = 0;
-    virtual const xpu::context_t &ctx() const = 0;
 
     // These two calls are valid only when `profiler_` is not empty.
     // When the call relies on an underlying pointer, always use

--- a/src/gpu/gpu_stream.hpp
+++ b/src/gpu/gpu_stream.hpp
@@ -66,16 +66,7 @@ public:
 
 protected:
     std::unique_ptr<xpu::stream_profiler_t> profiler_;
-    // A mutable declaration is required due to thread_local_storage_t API
-    // design constraints - the thread_local_storage_t access methods are
-    // declared non-const but must be accessible from a const
-    // verbose_profiler() accessor) to maintain interface const-correctness.
-    // TODO: Update thread_local_storage_t::is_set(), get(), and get(factory)
-    // methods to be const-qualified to eliminate need for mutable specifier.
-    // Lazy initialization should be considered implementation detail, not
-    // logical state modification.
-    mutable utils::thread_local_storage_t<
-            std::unique_ptr<xpu::verbose_profiler_t>>
+    utils::thread_local_storage_t<std::unique_ptr<xpu::verbose_profiler_t>>
             verbose_profiler_;
 };
 

--- a/src/gpu/intel/ocl/stream.cpp
+++ b/src/gpu/intel/ocl/stream.cpp
@@ -129,7 +129,7 @@ cl_command_queue stream_t::create_queue(
 void stream_t::before_exec_hook() {
     if (is_profiling_enabled()) profiler_->start_profiling();
     if (is_verbose_profiler_enabled()) {
-        auto &verbose_profiler = verbose_profiler_.get(
+        auto &verbose_profiler = verbose_profiler_.get_or_set(
                 utils::make_unique<xpu::ocl::verbose_profiler_t>(this));
         verbose_profiler->update_event_list();
     }

--- a/src/gpu/intel/ocl/stream.hpp
+++ b/src/gpu/intel/ocl/stream.hpp
@@ -104,10 +104,8 @@ struct stream_t : public intel::stream_t {
 
     ~stream_t() override = default;
 
-    const xpu::ocl::context_t &ocl_ctx() const { return impl()->ocl_ctx(); }
     xpu::ocl::context_t &ocl_ctx() { return impl()->ocl_ctx(); }
     xpu::context_t &ctx() override { return impl()->ocl_ctx(); }
-    const xpu::context_t &ctx() const override { return impl()->ocl_ctx(); }
 
     const xpu::ocl::wrapper_t<cl_event> &get_output_event() const {
         return impl()->get_output_event();

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -108,8 +108,8 @@ void stream_t::before_exec_hook() {
     if (is_verbose_profiler_enabled()) {
         auto *profiler = static_cast<xpu::sycl::verbose_profiler_t *>(
                 verbose_profiler_
-                        .get(utils::make_unique<xpu::sycl::verbose_profiler_t>(
-                                this))
+                        .get_or_set(utils::make_unique<
+                                xpu::sycl::verbose_profiler_t>(this))
                         .get());
         // Device event profiling and SYCL graph recording are incompatible
         // because the graph execution creates a different execution context

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -110,18 +110,11 @@ struct stream_t : public gpu::intel::stream_t {
 
     status_t barrier() override { return impl()->barrier(); }
 
-    const xpu::sycl::context_t &sycl_ctx() const { return impl()->sycl_ctx(); }
     xpu::sycl::context_t &sycl_ctx() { return impl()->sycl_ctx(); }
-
     xpu::context_t &ctx() override { return impl()->sycl_ctx(); }
-    const xpu::context_t &ctx() const override { return impl()->sycl_ctx(); }
 
     ::sycl::event get_output_event() const {
         return impl()->get_output_event();
-    }
-
-    void register_deps(::sycl::handler &cgh) const {
-        return impl()->register_deps(cgh);
     }
 
     bool recording() const;

--- a/src/gpu/intel/ze/stream.hpp
+++ b/src/gpu/intel/ze/stream.hpp
@@ -35,9 +35,7 @@ public:
             impl::engine_t *engine, impl::stream_impl_t *stream_impl);
 
     xpu::ze::context_t &ze_ctx() { return impl()->ze_ctx(); }
-    const xpu::ze::context_t &ze_ctx() const { return impl()->ze_ctx(); }
     xpu::context_t &ctx() override { return impl()->ze_ctx(); }
-    const xpu::context_t &ctx() const override { return impl()->ze_ctx(); }
 
     ze_event_handle_t get_output_event() const {
         return impl()->get_output_event();

--- a/src/xpu/ocl/stream_impl.cpp
+++ b/src/xpu/ocl/stream_impl.cpp
@@ -280,14 +280,12 @@ status_t stream_impl_t::init_verbose_profiler(engine_kind_t kind) {
 }
 
 const xpu::ocl::context_t &stream_impl_t::ocl_ctx() const {
-    static xpu::ocl::context_t empty_ctx {};
-    return ctx_.get(empty_ctx);
+    return ctx_.get();
 }
 
 xpu::ocl::context_t &stream_impl_t::ocl_ctx() {
-    const xpu::ocl::context_t &ctx
-            = const_cast<const stream_impl_t *>(this)->ocl_ctx();
-    return *const_cast<xpu::ocl::context_t *>(&ctx);
+    static xpu::ocl::context_t empty_ctx {};
+    return ctx_.get_or_set(empty_ctx);
 }
 
 xpu::context_t &stream_impl_t::ctx() {

--- a/src/xpu/ocl/stream_impl.hpp
+++ b/src/xpu/ocl/stream_impl.hpp
@@ -99,7 +99,7 @@ public:
 private:
     cl_command_queue queue_;
 
-    mutable utils::thread_local_storage_t<xpu::ocl::context_t> ctx_;
+    utils::thread_local_storage_t<xpu::ocl::context_t> ctx_;
 };
 
 } // namespace ocl

--- a/src/xpu/sycl/stream_impl.cpp
+++ b/src/xpu/sycl/stream_impl.cpp
@@ -238,7 +238,7 @@ status_t stream_impl_t::init_verbose_profiler(engine_kind_t kind) {
 
 xpu::sycl::context_t &stream_impl_t::sycl_ctx() {
     static xpu::sycl::context_t empty_ctx {};
-    return ctx_.get(empty_ctx);
+    return ctx_.get_or_set(empty_ctx);
 }
 
 xpu::context_t &stream_impl_t::ctx() {

--- a/src/xpu/sycl/stream_impl.cpp
+++ b/src/xpu/sycl/stream_impl.cpp
@@ -236,21 +236,12 @@ status_t stream_impl_t::init_verbose_profiler(engine_kind_t kind) {
     return status::success;
 }
 
-const xpu::sycl::context_t &stream_impl_t::sycl_ctx() const {
+xpu::sycl::context_t &stream_impl_t::sycl_ctx() {
     static xpu::sycl::context_t empty_ctx {};
     return ctx_.get(empty_ctx);
 }
 
-xpu::sycl::context_t &stream_impl_t::sycl_ctx() {
-    const xpu::sycl::context_t &ctx
-            = const_cast<const stream_impl_t *>(this)->sycl_ctx();
-    return *const_cast<xpu::sycl::context_t *>(&ctx);
-}
-
 xpu::context_t &stream_impl_t::ctx() {
-    return sycl_ctx();
-}
-const xpu::context_t &stream_impl_t::ctx() const {
     return sycl_ctx();
 }
 
@@ -263,14 +254,10 @@ const xpu::context_t &stream_impl_t::ctx() const {
     // dummy task is needed to not get an error related to empty
     // kernel.
     auto e = queue()->submit([&](::sycl::handler &cgh) {
-        register_deps(cgh);
+        cgh.depends_on(sycl_ctx().get_sycl_deps().events);
         cgh.single_task<class dnnl_dummy_kernel>([]() {});
     });
     return e;
-}
-
-void stream_impl_t::register_deps(::sycl::handler &cgh) const {
-    cgh.depends_on(sycl_ctx().get_sycl_deps().events);
 }
 
 } // namespace sycl

--- a/src/xpu/sycl/stream_impl.hpp
+++ b/src/xpu/sycl/stream_impl.hpp
@@ -67,15 +67,10 @@ public:
 
     status_t barrier();
 
-    const xpu::sycl::context_t &sycl_ctx() const;
     xpu::sycl::context_t &sycl_ctx();
-
     xpu::context_t &ctx();
-    const xpu::context_t &ctx() const;
 
     ::sycl::event get_output_event();
-
-    void register_deps(::sycl::handler &cgh) const;
 
     status_t init_verbose_profiler(engine_kind_t kind) override;
 

--- a/src/xpu/sycl/stream_impl.hpp
+++ b/src/xpu/sycl/stream_impl.hpp
@@ -94,7 +94,7 @@ public:
 private:
     std::unique_ptr<::sycl::queue> queue_;
 
-    mutable utils::thread_local_storage_t<xpu::sycl::context_t> ctx_;
+    utils::thread_local_storage_t<xpu::sycl::context_t> ctx_;
 
     // XXX: this is a temporary solution to make sycl_memory_arg_t
     // default constructible.

--- a/src/xpu/ze/stream_impl.cpp
+++ b/src/xpu/ze/stream_impl.cpp
@@ -65,14 +65,12 @@ status_t stream_impl_t::init(
 }
 
 const xpu::ze::context_t &stream_impl_t::ze_ctx() const {
-    static xpu::ze::context_t empty_ctx {};
-    return ctx_.get(empty_ctx);
+    return ctx_.get();
 }
 
 xpu::ze::context_t &stream_impl_t::ze_ctx() {
-    const xpu::ze::context_t &ctx
-            = const_cast<const stream_impl_t *>(this)->ze_ctx();
-    return *const_cast<xpu::ze::context_t *>(&ctx);
+    static xpu::ze::context_t empty_ctx {};
+    return ctx_.get_or_set(empty_ctx);
 }
 
 xpu::context_t &stream_impl_t::ctx() {

--- a/src/xpu/ze/stream_impl.hpp
+++ b/src/xpu/ze/stream_impl.hpp
@@ -86,7 +86,7 @@ private:
     // (if this mode will ever be supported).
     std::list<xpu::ze::wrapper_t<ze_event_handle_t>> events_;
 
-    mutable utils::thread_local_storage_t<context_t> ctx_;
+    utils::thread_local_storage_t<context_t> ctx_;
 
     DNNL_DISALLOW_COPY_AND_ASSIGN(stream_impl_t);
 };


### PR DESCRIPTION
Basically, move mutable requirement from callers to the abstraction since its mutex requirement to be mutable even for const objects.

Follow-up of https://github.com/uxlfoundation/oneDNN/pull/5102