### PR TITLE
benchdnn: decouple certain modules from the library dependency

### DIFF
--- a/src/common/nibble.hpp
+++ b/src/common/nibble.hpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef COMMON_NIBBLE_HPP
+#define COMMON_NIBBLE_HPP
+
+#include <cassert>
+#include <cstdint>
+
+namespace dnnl {
+namespace impl {
+
+// Common abstraction to manipulate nibbles in memory as pairs
+struct nibble2_t {
+
+    // constructs a nibble pair from a pair of uint8_t values
+    nibble2_t(uint8_t low_, uint8_t high_) : low(low_), high(high_) {}
+
+    // constructs a nibble pairs from an uin8_t, taking its low and high part
+    nibble2_t(uint8_t pack_) : low(pack_ & 0xf), high((pack_ >> 4) & 0xf) {}
+
+    // sets low (idx=0) or high (idx=1)  nibble.
+    inline void set(uint8_t val, int idx) {
+        switch (idx) {
+            case 0: low = val; return;
+            case 1: high = val; return;
+            default: assert(!"Out of range index"); return;
+        }
+    }
+
+    // returns low (idx = 0) or high (idx = 1) nibble in a uint8_t
+    inline uint8_t get(int idx) const {
+        switch (idx) {
+            case 0: return low;
+            case 1: return high;
+            default: assert(!"out of range index"); return 0;
+        }
+    }
+
+    // returns pair of nibbles as uint8_t
+    inline uint8_t get() const { return static_cast<uint8_t>(high << 4 | low); }
+
+private:
+    uint8_t low : 4;
+    uint8_t high : 4;
+};
+static_assert(sizeof(nibble2_t) == 1, "nibble2_t must be 1 byte");
+
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -907,42 +907,6 @@ template <typename T>
 using maybe_unique_ptr = std::unique_ptr<T, nop_deleter_t>;
 #endif // DNNL_MAYBE_UNIQUE_PTR_IS_UNIQUE
 
-// Common abstraction to manipulate nibbles in memory as pairs
-struct nibble2_t {
-
-    // constructs a nibble pair from a pair of uint8_t values
-    nibble2_t(uint8_t low_, uint8_t high_) : low(low_), high(high_) {}
-
-    // constructs a nibble pairs from an uin8_t, taking its low and high part
-    nibble2_t(uint8_t pack_) : low(pack_ & 0xf), high((pack_ >> 4) & 0xf) {}
-
-    // sets low (idx=0) or high (idx=1)  nibble.
-    inline void set(uint8_t val, int idx) {
-        switch (idx) {
-            case 0: low = val; return;
-            case 1: high = val; return;
-            default: assert(!"Out of range index"); return;
-        }
-    }
-
-    // returns low (idx = 0) or high (idx = 1) nibble in a uint8_t
-    inline uint8_t get(int idx) const {
-        switch (idx) {
-            case 0: return low;
-            case 1: return high;
-            default: assert(!"out of range index"); return 0;
-        }
-    }
-
-    // returns pair of nibbles as uint8t
-    inline uint8_t get() const { return static_cast<uint8_t>(high << 4 | low); }
-
-private:
-    uint8_t low : 4;
-    uint8_t high : 4;
-};
-static_assert(sizeof(nibble2_t) == 1, "nibble2_t must be 1 byte");
-
 /// Iterates through a binary integer
 /// usage:
 ///

--- a/src/cpu/ref_io_helper.hpp
+++ b/src/cpu/ref_io_helper.hpp
@@ -21,6 +21,7 @@
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_traits.hpp"
+#include "common/nibble.hpp"
 #include "common/type_helpers.hpp"
 
 #include "cpu/simple_q10n.hpp"

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -24,6 +24,7 @@
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/math_utils.hpp"
+#include "common/nibble.hpp"
 #include "common/primitive.hpp"
 #include "common/primitive_attr.hpp"
 #include "common/tag_traits.hpp"

--- a/tests/benchdnn/binary/binary_aux.cpp
+++ b/tests/benchdnn/binary/binary_aux.cpp
@@ -14,9 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "binary/binary.hpp"
 
@@ -25,7 +24,7 @@ namespace binary {
 std::string prb_t::set_repro_line() {
     using ::operator<<;
 
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/bnorm/bench_bnorm.cpp
+++ b/tests/benchdnn/bnorm/bench_bnorm.cpp
@@ -20,6 +20,7 @@
 
 #include "dnnl_common.hpp"
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 #include "utils/task_executor.hpp"
 
 #include "bnorm/bnorm.hpp"
@@ -54,7 +55,7 @@ int verify_input(const settings_t &s, const settings_t &def) {
 
     for (const auto &i_strides : s.strides) {
         if (i_strides.size() != n_inputs) {
-            dnnl::impl::stringstream_t ss;
+            stringstream_t ss;
             ss << vdims2str(i_strides);
             BENCHDNN_PRINT(0,
                     "Error: `strides` option expects two inputs in format "
@@ -66,7 +67,7 @@ int verify_input(const settings_t &s, const settings_t &def) {
         for (int i = 0; i < n_inputs; i++) {
             if (i_strides[i].size() != static_cast<size_t>(s.desc.ndims)
                     && !i_strides[i].empty()) {
-                dnnl::impl::stringstream_t ss;
+                stringstream_t ss;
                 ss << vdims2str(i_strides);
                 BENCHDNN_PRINT(0,
                         "Error: number of dimensions in the `strides` option "

--- a/tests/benchdnn/bnorm/bnorm_aux.cpp
+++ b/tests/benchdnn/bnorm/bnorm_aux.cpp
@@ -14,12 +14,11 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <assert.h>
 #include <stdlib.h>
 
 #include "bnorm/bnorm.hpp"
+#include "utils/stringstream.hpp"
 
 namespace bnorm {
 
@@ -195,7 +194,7 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/brgemm/brgemm_aux.cpp
+++ b/tests/benchdnn/brgemm/brgemm_aux.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -25,6 +23,7 @@
 
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "brgemm/brgemm.hpp"
 
@@ -205,7 +204,7 @@ void prb_t::skip_invalid(res_t *res) const {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/concat/concat_aux.cpp
+++ b/tests/benchdnn/concat/concat_aux.cpp
@@ -14,17 +14,16 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "concat/concat.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 namespace concat {
 
 std::string prb_t::set_repro_line() {
     using ::operator<<;
 
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/conv/conv_aux.cpp
+++ b/tests/benchdnn/conv/conv_aux.cpp
@@ -14,10 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
+#include "utils/stringstream.hpp"
 
 #include "conv/conv.hpp"
 
@@ -402,7 +401,7 @@ void prb_t::count_ops() {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/deconv/deconv_aux.cpp
+++ b/tests/benchdnn/deconv/deconv_aux.cpp
@@ -14,10 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
+#include "utils/stringstream.hpp"
 
 #include "deconv/deconv.hpp"
 
@@ -400,7 +399,7 @@ void prb_t::count_ops() {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -47,8 +47,6 @@
 #include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
-#include "src/common/nibble.hpp"
-
 extern "C" dnnl_status_t dnnl_memory_desc_create_with_string_tag(
         dnnl_memory_desc_t *, int, const dnnl_dims_t, dnnl_data_type_t,
         const char *);
@@ -336,92 +334,12 @@ size_t dnn_mem_t::sizeof_dt() const {
 
 float dnn_mem_t::get_elem(int64_t idx, int buffer_index) const {
     void *data = get_mapped_pointer<void>(buffer_index);
-    float elem = 0.0;
-
-    switch (dt(buffer_index)) {
-        case dnnl_s8: elem = static_cast<int8_t *>(data)[idx]; break;
-        case dnnl_u8: elem = static_cast<uint8_t *>(data)[idx]; break;
-        case dnnl_s32: elem = static_cast<int32_t *>(data)[idx]; break;
-        case dnnl_s64: elem = static_cast<int64_t *>(data)[idx]; break;
-        case dnnl_f32: elem = static_cast<float *>(data)[idx]; break;
-        case dnnl_f64: elem = static_cast<double *>(data)[idx]; break;
-        case dnnl_f16:
-            elem = static_cast<dnnl::impl::float16_t *>(data)[idx];
-            break;
-        case dnnl_bf16:
-            elem = static_cast<dnnl::impl::bfloat16_t *>(data)[idx];
-            break;
-        case dnnl_e8m0:
-            elem = static_cast<dnnl::impl::float8_e8m0_t *>(data)[idx];
-            break;
-        case dnnl_f8_e5m2:
-            elem = static_cast<dnnl::impl::float8_e5m2_t *>(data)[idx];
-            break;
-        case dnnl_f8_e4m3:
-            elem = static_cast<dnnl::impl::float8_e4m3_t *>(data)[idx];
-            break;
-        case dnnl_s4: {
-            dnnl::impl::nibble2_t nibble_pair(
-                    reinterpret_cast<uint8_t *>(data)[idx / 2]);
-            elem = dnnl::impl::int4_t(nibble_pair.get(idx % 2));
-            break;
-        }
-        case dnnl_u4: {
-            dnnl::impl::nibble2_t nibble_pair(
-                    reinterpret_cast<uint8_t *>(data)[idx / 2]);
-            elem = dnnl::impl::uint4_t(nibble_pair.get(idx % 2));
-            break;
-        }
-        case dnnl_f4_e2m1: {
-            dnnl::impl::nibble2_t nibble_pair(
-                    reinterpret_cast<uint8_t *>(data)[idx / 2]);
-            elem = dnnl::impl::float4_e2m1_t(nibble_pair.get(idx % 2));
-            break;
-        }
-        default: assert(!"bad data type");
-    }
-    return elem;
+    return get_element(dt(buffer_index), idx, data);
 }
 
 void dnn_mem_t::set_elem(int64_t idx, float value, int buffer_index) const {
     void *data = get_mapped_pointer<void>(buffer_index);
-
-    switch (dt(buffer_index)) {
-        case dnnl_s8: ((int8_t *)data)[idx] = value; break;
-        case dnnl_u8: ((uint8_t *)data)[idx] = value; break;
-        case dnnl_s32: ((int32_t *)data)[idx] = value; break;
-        case dnnl_s64: ((int64_t *)data)[idx] = value; break;
-        case dnnl_f32: ((float *)data)[idx] = value; break;
-        case dnnl_f64: ((double *)data)[idx] = value; break;
-        case dnnl_f16: ((dnnl::impl::float16_t *)data)[idx] = value; break;
-        case dnnl_bf16: ((dnnl::impl::bfloat16_t *)data)[idx] = value; break;
-        case dnnl_e8m0: ((dnnl::impl::float8_e8m0_t *)data)[idx] = value; break;
-        case dnnl_f8_e5m2:
-            ((dnnl::impl::float8_e5m2_t *)data)[idx] = value;
-            break;
-        case dnnl_f8_e4m3:
-            ((dnnl::impl::float8_e4m3_t *)data)[idx] = value;
-            break;
-        case dnnl_s4: {
-            auto dst_val = ((dnnl::impl::nibble2_t *)data)[idx / 2];
-            dst_val.set(dnnl::impl::int4_t(value).raw_bits_, idx % 2);
-            ((dnnl::impl::nibble2_t *)data)[idx / 2] = dst_val;
-            break;
-        }
-        case dnnl_u4: {
-            auto dst_val = ((dnnl::impl::nibble2_t *)data)[idx / 2];
-            dst_val.set(dnnl::impl::uint4_t(value).raw_bits_, idx % 2);
-            ((dnnl::impl::nibble2_t *)data)[idx / 2] = dst_val;
-            break;
-        }
-        case dnnl_f4_e2m1: {
-            auto dst_val = ((dnnl::impl::nibble2_t *)data)[idx / 2];
-            dst_val.set(dnnl::impl::float4_e2m1_t(value).raw_bits_, idx % 2);
-            ((dnnl::impl::nibble2_t *)data)[idx / 2] = dst_val;
-            break;
-        }
-        default: assert(!"bad data type");
-    }
+    set_element(dt(buffer_index), idx, data, value);
 }
 
 // Returns an updated logical index based on input `logical_index` and
@@ -1328,8 +1246,7 @@ static dnnl_dim_t md_off_l(dnnl_dims_t _pos, const dnn_mem_t &mem,
     return md_off_v(mem, pos, is_pos_padded);
 }
 
-template <typename T>
-static int check_zero_padding_impl(
+int check_zero_padding(
         const dnn_mem_t &mem, int arg, res_t *res, int *error_count) {
     const int ndims = mem.ndims();
     const auto &dims = mem.dims();
@@ -1403,36 +1320,6 @@ static int check_zero_padding_impl(
     if (error_count != nullptr) *error_count = errors;
 
     return ok ? OK : FAIL;
-}
-
-int check_zero_padding(
-        const dnn_mem_t &mem, int arg, res_t *res, int *error_count) {
-#define CASE(dt, type) \
-    case dt: return check_zero_padding_impl<type>(mem, arg, res, error_count);
-
-    switch (mem.dt()) {
-        case dnnl_data_type_undef:
-            return OK;
-
-            CASE(dnnl_e8m0, dnnl::impl::float8_e8m0_t);
-            CASE(dnnl_f8_e5m2, dnnl::impl::float8_e5m2_t);
-            CASE(dnnl_f8_e4m3, dnnl::impl::float8_e4m3_t);
-            CASE(dnnl_bf16, dnnl::impl::bfloat16_t);
-            CASE(dnnl_f16, dnnl::impl::float16_t);
-            CASE(dnnl_f32, float);
-            CASE(dnnl_f64, double);
-            CASE(dnnl_s32, int32_t);
-            CASE(dnnl_s64, int64_t);
-            CASE(dnnl_s8, int8_t);
-            CASE(dnnl_u8, uint8_t);
-            CASE(dnnl_s4, dnnl::impl::int4_t);
-            CASE(dnnl_u4, dnnl::impl::uint4_t);
-            CASE(dnnl_f4_e2m1, dnnl::impl::float4_e2m1_t);
-        default: assert(!"bad data_type");
-    };
-#undef CASE
-
-    return FAIL;
 }
 
 int check_buffer_overwrite(const dnn_mem_t &mem, int arg, res_t *res) {

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -47,6 +47,8 @@
 #include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
+#include "src/common/nibble.hpp"
+
 extern "C" dnnl_status_t dnnl_memory_desc_create_with_string_tag(
         dnnl_memory_desc_t *, int, const dnnl_dims_t, dnnl_data_type_t,
         const char *);

--- a/tests/benchdnn/eltwise/bench_eltwise.cpp
+++ b/tests/benchdnn/eltwise/bench_eltwise.cpp
@@ -17,10 +17,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sstream>
-
 #include "dnnl_common.hpp"
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 #include "utils/task_executor.hpp"
 
 #include "eltwise/eltwise.hpp"
@@ -55,7 +54,7 @@ int verify_input(const settings_t &s) {
     for (const auto &i_alg : s.alg) {
         bool ok = i_alg > alg_t::ELTWISE_START && i_alg < alg_t::ELTWISE_END;
         if (!ok) {
-            dnnl::impl::stringstream_t ss;
+            stringstream_t ss;
             ss << i_alg;
             BENCHDNN_PRINT(0, "%s%s%s\n", "ERROR: unknown algorithm `",
                     ss.str().c_str(), "`.");

--- a/tests/benchdnn/eltwise/eltwise_aux.cpp
+++ b/tests/benchdnn/eltwise/eltwise_aux.cpp
@@ -14,17 +14,16 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "eltwise/eltwise.hpp"
 
 namespace eltwise {
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/gnorm/gnorm_aux.cpp
+++ b/tests/benchdnn/gnorm/gnorm_aux.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "gnorm/gnorm.hpp"
+#include "utils/stringstream.hpp"
 
 namespace gnorm {
 
@@ -161,7 +162,7 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -20,10 +20,10 @@
 #include <map>
 #include <numeric>
 #include <queue>
-#include <sstream>
 #include <stdexcept>
 
 #include "deserialize.hpp"
+#include "utils/stringstream.hpp"
 
 namespace graph {
 
@@ -553,7 +553,7 @@ std::ostream &operator<<(std::ostream &s, const deserialized_lt_t &dlt) {
 }
 
 std::string deserialized_lt_t::get_string() const {
-    dnnl::impl::stringstream_t ss;
+    stringstream_t ss;
     ss << *this;
     return ss.str();
 }
@@ -623,7 +623,7 @@ std::ostream &operator<<(std::ostream &s, const deserialized_op_t &dop) {
 }
 
 std::string deserialized_op_t::get_string() const {
-    dnnl::impl::stringstream_t ss;
+    stringstream_t ss;
     ss << *this;
     return ss.str();
 }
@@ -636,7 +636,7 @@ std::ostream &operator<<(std::ostream &s, const deserialized_graph_t &dg) {
 }
 
 std::string deserialized_graph_t::get_string() const {
-    dnnl::impl::stringstream_t ss;
+    stringstream_t ss;
     ss << *this;
     return ss.str();
 }

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -28,6 +28,7 @@
 #include "utils/execution_mode.hpp"
 #include "utils/parser.hpp"
 #include "utils/stream_kind.hpp"
+#include "utils/stringstream.hpp"
 
 namespace {
 
@@ -363,7 +364,7 @@ std::string case_to_str(const std::string &json_file,
         const dnnl_data_type_t dt,
         const std::map<size_t, dnnl_data_type_t> &dt_map,
         const std::map<size_t, std::string> &op_kind_map) {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
 
     if (mb != 0) { s << "--mb=" << mb << " "; }

--- a/tests/benchdnn/graph/parser.cpp
+++ b/tests/benchdnn/graph/parser.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 
 #include "parser.hpp"
 #include "utils.hpp"
@@ -183,7 +184,7 @@ bool parse_graph_expected_n_partitions(
     if (!parse_string(expected_n_partitions_str, str, "expected-n-partitions"))
         return false;
 
-    dnnl::impl::stringstream_t ss(expected_n_partitions_str);
+    stringstream_t ss(expected_n_partitions_str);
 
     std::string expected_n_partitions;
     while (std::getline(ss, expected_n_partitions, ',')) {
@@ -212,7 +213,7 @@ bool parse_graph_fpmath_mode(
     std::string graph_attrs_str;
     if (!parse_string(graph_attrs_str, str, "attr-fpmath")) return false;
 
-    dnnl::impl::stringstream_t ss(graph_attrs_str);
+    stringstream_t ss(graph_attrs_str);
 
     std::string mode;
     while (std::getline(ss, mode, ',')) {

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -23,6 +23,7 @@
 #include "allocator.hpp"
 #include "dnnl_common.hpp"
 #include "utils.hpp"
+#include "utils/stringstream.hpp"
 #include "utils/timer.hpp"
 
 namespace graph {
@@ -713,7 +714,7 @@ std::string verbose_partitions_n_ops(
 std::string lt_dims2str(const dnnl::graph::logical_tensor::dims &dims) {
     if (dims.empty()) return std::string();
 
-    dnnl::impl::stringstream_t ss;
+    stringstream_t ss;
     std::copy(
             dims.begin(), dims.end(), std::ostream_iterator<int64_t>(ss, "x"));
     auto res = ss.str();

--- a/tests/benchdnn/ip/ip_aux.cpp
+++ b/tests/benchdnn/ip/ip_aux.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -24,6 +22,7 @@
 
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "ip/ip.hpp"
 
@@ -146,7 +145,7 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/lnorm/lnorm_aux.cpp
+++ b/tests/benchdnn/lnorm/lnorm_aux.cpp
@@ -14,11 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <assert.h>
 #include <stdlib.h>
 #include "lnorm/lnorm.hpp"
+#include "utils/stringstream.hpp"
 
 namespace lnorm {
 
@@ -44,7 +43,7 @@ flags_t str2flags(const char *str) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/lrn/lrn_aux.cpp
+++ b/tests/benchdnn/lrn/lrn_aux.cpp
@@ -14,12 +14,11 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <assert.h>
 #include <stdlib.h>
 
 #include "lrn/lrn.hpp"
+#include "utils/stringstream.hpp"
 
 namespace lrn {
 
@@ -168,7 +167,7 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/matmul/bench_matmul.cpp
+++ b/tests/benchdnn/matmul/bench_matmul.cpp
@@ -20,6 +20,7 @@
 
 #include "dnnl_common.hpp"
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 #include "utils/task_executor.hpp"
 
 #include "matmul/matmul.hpp"
@@ -78,7 +79,7 @@ int verify_input(const settings_t &s, const settings_t &def) {
 
     for (const auto &i_strides : s.strides) {
         if (i_strides.size() != n_inputs) {
-            dnnl::impl::stringstream_t ss;
+            stringstream_t ss;
             ss << i_strides;
             fprintf(stderr,
                     "ERROR: matmul driver: `strides` option expects three "

--- a/tests/benchdnn/matmul/matmul_aux.cpp
+++ b/tests/benchdnn/matmul/matmul_aux.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -25,6 +23,7 @@
 
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "matmul/matmul.hpp"
 
@@ -66,7 +65,7 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/pool/pool_aux.cpp
+++ b/tests/benchdnn/pool/pool_aux.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
@@ -27,6 +25,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
 #include "pool/pool.hpp"
+#include "utils/stringstream.hpp"
 
 namespace pool {
 
@@ -321,7 +320,7 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/prelu/prelu_aux.cpp
+++ b/tests/benchdnn/prelu/prelu_aux.cpp
@@ -14,17 +14,16 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "prelu/prelu.hpp"
 
 namespace prelu {
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     using ::operator<<;
 
     dump_global_params(s);

--- a/tests/benchdnn/reduction/reduction_aux.cpp
+++ b/tests/benchdnn/reduction/reduction_aux.cpp
@@ -14,9 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "reduction.hpp"
+#include "utils/stringstream.hpp"
 
 namespace reduction {
 
@@ -76,7 +75,7 @@ dnnl_alg_kind_t alg2alg_kind(alg_t alg) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/reorder/bench_reorder.cpp
+++ b/tests/benchdnn/reorder/bench_reorder.cpp
@@ -18,6 +18,7 @@
 
 #include "dnnl_common.hpp"
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 #include "utils/task_executor.hpp"
 
 #include "reorder.hpp"
@@ -74,7 +75,7 @@ int verify_input(const settings_t &s, const settings_t &def) {
 
     for (const auto &i_strides : s.strides) {
         if (i_strides.size() != n_inputs) {
-            dnnl::impl::stringstream_t ss;
+            stringstream_t ss;
             ss << vdims2str(i_strides);
             BENCHDNN_PRINT(0,
                     "Error: `strides` option expects two inputs in format "
@@ -86,7 +87,7 @@ int verify_input(const settings_t &s, const settings_t &def) {
         for (int i = 0; i < n_inputs; i++) {
             if (i_strides[i].size() != static_cast<size_t>(s.prb_dims.ndims)
                     && !i_strides[i].empty()) {
-                dnnl::impl::stringstream_t ss;
+                stringstream_t ss;
                 ss << vdims2str(i_strides);
                 BENCHDNN_PRINT(0,
                         "Error: number of dimensions in the `strides` option "

--- a/tests/benchdnn/reorder/reorder_aux.cpp
+++ b/tests/benchdnn/reorder/reorder_aux.cpp
@@ -15,12 +15,12 @@
 *******************************************************************************/
 
 #include <algorithm>
-#include <sstream>
 #include <string>
 #include <utility>
 
 #include "reorder/reorder.hpp"
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 
 namespace reorder {
 
@@ -155,7 +155,7 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/resampling/resampling_aux.cpp
+++ b/tests/benchdnn/resampling/resampling_aux.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
@@ -27,6 +25,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
 #include "resampling/resampling.hpp"
+#include "utils/stringstream.hpp"
 
 namespace resampling {
 
@@ -213,7 +212,7 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/rnn/bench_rnn.cpp
+++ b/tests/benchdnn/rnn/bench_rnn.cpp
@@ -18,12 +18,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <sstream>
-
 #include "oneapi/dnnl/dnnl.h"
 
 #include "dnnl_common.hpp"
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 
 #include "rnn/rnn.hpp"
 
@@ -73,7 +72,7 @@ int verify_input(const settings_t &s) {
     for (const auto &i_scale_policy : s.scale_policy) {
         if (!(i_scale_policy == policy_t::COMMON
                     || i_scale_policy == policy_t::PER_OC)) {
-            dnnl::impl::stringstream_t ss;
+            stringstream_t ss;
             ss << i_scale_policy;
             const std::string cpp_pstr = ss.str();
             const char *policy_s = cpp_pstr.c_str();

--- a/tests/benchdnn/rnn/cfg.cpp
+++ b/tests/benchdnn/rnn/cfg.cpp
@@ -334,8 +334,8 @@ CFG(f32s8f32f32) {
 
 const dt_conf_t &dt_conf_t::create(const std::string &str, const attr_t &attr) {
     if (str == "f32") {
-        if (dnnl::impl::utils::one_of(attr.fpmath_mode.mode,
-                    dnnl_fpmath_mode_bf16, dnnl_fpmath_mode_tf32))
+        if (attr.fpmath_mode.mode == dnnl_fpmath_mode_bf16
+                || attr.fpmath_mode.mode == dnnl_fpmath_mode_tf32)
             return conf_bf32;
         if (attr.fpmath_mode.mode == dnnl_fpmath_mode_f16) return conf_f16_math;
     }

--- a/tests/benchdnn/rnn/rnn_aux.cpp
+++ b/tests/benchdnn/rnn/rnn_aux.cpp
@@ -14,11 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "oneapi/dnnl/dnnl.h"
 
 #include "rnn/rnn_aux.hpp"
+#include "utils/stringstream.hpp"
 
 namespace rnn {
 
@@ -273,7 +272,7 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 std::string prb_t::set_repro_line() {
     using ::operator<<;
 
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/sdpa/sdpa_aux.cpp
+++ b/tests/benchdnn/sdpa/sdpa_aux.cpp
@@ -14,11 +14,11 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
 #include <string.h>
 
 #include "dnnl_common.hpp"
 #include "dnnl_memory.hpp"
+#include "utils/stringstream.hpp"
 
 #include "sdpa/sdpa.hpp"
 
@@ -108,7 +108,7 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/self/self.hpp
+++ b/tests/benchdnn/self/self.hpp
@@ -21,10 +21,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <sstream>
-
 #include "common.hpp"
 #include "dnnl_common.hpp"
+#include "utils/stringstream.hpp"
 
 namespace self {
 
@@ -53,7 +52,7 @@ namespace self {
     SELF_CHECK(strcasecmp((a).c_str(), b), "'%s' == '%s'", (a).c_str(), b)
 #define SELF_CHECK_PRINT_EQ2(obj, expect_str1, expect_str2) \
     do { \
-        dnnl::impl::stringstream_t ss; \
+        stringstream_t ss; \
         ss << (obj); \
         std::string obj_str = ss.str(); \
         if (std::string(expect_str1) == std::string(expect_str2) \

--- a/tests/benchdnn/shuffle/shuffle_aux.cpp
+++ b/tests/benchdnn/shuffle/shuffle_aux.cpp
@@ -14,17 +14,16 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "shuffle/shuffle.hpp"
 
 namespace shuffle {
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/softmax/softmax_aux.cpp
+++ b/tests/benchdnn/softmax/softmax_aux.cpp
@@ -14,10 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/stringstream.hpp"
 
 #include "softmax/softmax.hpp"
 
@@ -46,7 +45,7 @@ const char *alg2str(alg_t alg) {
 }
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/sum/sum_aux.cpp
+++ b/tests/benchdnn/sum/sum_aux.cpp
@@ -14,10 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnnl_debug.hpp"
 #include "sum/sum.hpp"
+#include "utils/stringstream.hpp"
 
 namespace sum {
 
@@ -39,7 +38,7 @@ std::string prb_t::set_repro_line() {
     using ::operator<<;
     using sum::operator<<;
 
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -25,6 +25,7 @@
 #include "common.hpp"
 #include "utils/compare.hpp"
 #include "utils/norm.hpp"
+#include "utils/stringstream.hpp"
 
 #include "eltwise/eltwise.hpp"
 
@@ -33,7 +34,7 @@ namespace compare {
 namespace {
 void dump_point_values(
         const std::string &kind_str, const compare_t::dump_point_ctx_t &ctx) {
-    dnnl::impl::stringstream_t ss;
+    stringstream_t ss;
     dims_t l_dims = md2dims(ctx.md);
     dims_t dims_idx = off2dims_idx(l_dims, ctx.l_offset);
     ss << dims_idx;

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -16,7 +16,6 @@
 
 #include <cstring>
 #include <random>
-#include <sstream>
 #include <unordered_map>
 
 #include "dnnl_debug.hpp"
@@ -24,6 +23,7 @@
 #include "utils/fill.hpp"
 #include "utils/numeric.hpp"
 #include "utils/parallel.hpp"
+#include "utils/stringstream.hpp"
 
 fill_cfg_t::fill_cfg_t(dnnl_data_type_t dt, float range_min_val,
         float range_max_val, bool only_integer, attr_t::post_ops_t::kind_t alg,
@@ -70,7 +70,7 @@ fill_cfg_t::fill_cfg_t(const std::vector<float> &user_set, float density,
 }
 
 std::string fill_cfg_t::print_verbose() const {
-    std::stringstream ss;
+    stringstream_t ss;
 
     ss << "[FILL_CFG]";
     if (!name_.empty()) ss << " name:\'" << name_ << "\';";
@@ -464,7 +464,7 @@ std::string execarg2str(int exec_arg) {
         auto it = map.find(i);
         if (it != map.end()) return SPACE + it->second;
         if (!i) return std::string();
-        std::ostringstream oss;
+        ostringstream_t oss;
         oss << std::hex << i;
         return SPACE "0x" + oss.str();
     };

--- a/tests/benchdnn/utils/numeric.cpp
+++ b/tests/benchdnn/utils/numeric.cpp
@@ -18,6 +18,7 @@
 #include "src/common/float16.hpp"
 #include "src/common/float4.hpp"
 #include "src/common/float8.hpp"
+#include "src/common/nibble.hpp"
 #include "src/common/nstl.hpp"
 
 #include "common.hpp"
@@ -64,6 +65,10 @@ struct prec_traits<dnnl_f64> {
 template <>
 struct prec_traits<dnnl_s32> {
     using type = int32_t;
+};
+template <>
+struct prec_traits<dnnl_s64> {
+    using type = int64_t;
 };
 template <>
 struct prec_traits<dnnl_s8> {
@@ -249,4 +254,85 @@ size_t bits_dt(dnnl_data_type_t dt) {
 
 bool is_fp8_dt(dnnl_data_type_t type) {
     return type == dnnl_f8_e5m2 || type == dnnl_f8_e4m3;
+}
+
+float get_element(dnnl_data_type_t dt, int64_t idx, void *ptr) {
+    float elem = 0.f;
+#define CASE(dt) \
+    case dt: elem = static_cast<prec_traits<dt>::type *>(ptr)[idx]; break;
+
+    switch (dt) {
+        CASE(dnnl_s8);
+        CASE(dnnl_u8);
+        CASE(dnnl_s32);
+        CASE(dnnl_s64);
+        CASE(dnnl_f32);
+        CASE(dnnl_f16);
+        CASE(dnnl_bf16);
+        CASE(dnnl_e8m0);
+        CASE(dnnl_f8_e5m2);
+        CASE(dnnl_f8_e4m3);
+        case dnnl_f64: elem = static_cast<double *>(ptr)[idx]; break;
+        case dnnl_s4: {
+            dnnl::impl::nibble2_t nibble_pair(
+                    reinterpret_cast<uint8_t *>(ptr)[idx / 2]);
+            elem = dnnl::impl::int4_t(nibble_pair.get(idx % 2));
+            break;
+        }
+        case dnnl_u4: {
+            dnnl::impl::nibble2_t nibble_pair(
+                    reinterpret_cast<uint8_t *>(ptr)[idx / 2]);
+            elem = dnnl::impl::uint4_t(nibble_pair.get(idx % 2));
+            break;
+        }
+        case dnnl_f4_e2m1: {
+            dnnl::impl::nibble2_t nibble_pair(
+                    reinterpret_cast<uint8_t *>(ptr)[idx / 2]);
+            elem = dnnl::impl::float4_e2m1_t(nibble_pair.get(idx % 2));
+            break;
+        }
+        default: assert(!"bad data type");
+    }
+#undef CASE
+
+    return elem;
+}
+
+void set_element(dnnl_data_type_t dt, int64_t idx, void *ptr, float value) {
+#define CASE(dt) \
+    case dt: static_cast<prec_traits<dt>::type *>(ptr)[idx] = value; break;
+
+    switch (dt) {
+        CASE(dnnl_s8);
+        CASE(dnnl_u8);
+        CASE(dnnl_s32);
+        CASE(dnnl_s64);
+        CASE(dnnl_f32);
+        CASE(dnnl_f16);
+        CASE(dnnl_bf16);
+        CASE(dnnl_e8m0);
+        CASE(dnnl_f8_e5m2);
+        CASE(dnnl_f8_e4m3);
+        case dnnl_f64: ((double *)ptr)[idx] = value; break;
+        case dnnl_s4: {
+            auto dst_val = ((dnnl::impl::nibble2_t *)ptr)[idx / 2];
+            dst_val.set(dnnl::impl::int4_t(value).raw_bits_, idx % 2);
+            ((dnnl::impl::nibble2_t *)ptr)[idx / 2] = dst_val;
+            break;
+        }
+        case dnnl_u4: {
+            auto dst_val = ((dnnl::impl::nibble2_t *)ptr)[idx / 2];
+            dst_val.set(dnnl::impl::uint4_t(value).raw_bits_, idx % 2);
+            ((dnnl::impl::nibble2_t *)ptr)[idx / 2] = dst_val;
+            break;
+        }
+        case dnnl_f4_e2m1: {
+            auto dst_val = ((dnnl::impl::nibble2_t *)ptr)[idx / 2];
+            dst_val.set(dnnl::impl::float4_e2m1_t(value).raw_bits_, idx % 2);
+            ((dnnl::impl::nibble2_t *)ptr)[idx / 2] = dst_val;
+            break;
+        }
+        default: assert(!"bad data type");
+    }
+#undef CASE
 }

--- a/tests/benchdnn/utils/numeric.hpp
+++ b/tests/benchdnn/utils/numeric.hpp
@@ -38,6 +38,8 @@ float round_to_nearest_representable(dnnl_data_type_t dt, float value);
 bool is_subbyte_type(dnnl_data_type_t type);
 size_t bits_dt(dnnl_data_type_t dt);
 bool is_fp8_dt(dnnl_data_type_t dt);
+float get_element(dnnl_data_type_t dt, int64_t idx, void *ptr);
+void set_element(dnnl_data_type_t dt, int64_t idx, void *ptr, float value);
 
 template <class T>
 T gcd(std::initializer_list<T> ilist) {

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -23,6 +23,7 @@
 #include "utils/fill.hpp"
 #include "utils/parser.hpp"
 #include "utils/stream_kind.hpp"
+#include "utils/stringstream.hpp"
 #include "utils/summary.hpp"
 
 #include "dnnl_common.hpp"
@@ -30,7 +31,7 @@
 namespace parser {
 
 bool last_parsed_is_problem = false;
-dnnl::impl::stringstream_t help_ss;
+stringstream_t help_ss;
 
 static const std::string benchdnn_url
         = "https://github.com/uxlfoundation/oneDNN/blob/main/tests/benchdnn";

--- a/tests/benchdnn/utils/parser.hpp
+++ b/tests/benchdnn/utils/parser.hpp
@@ -20,7 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -33,11 +32,12 @@
 #include "utils/execution_mode.hpp"
 #include "utils/impl_filter.hpp"
 #include "utils/settings.hpp"
+#include "utils/stringstream.hpp"
 
 namespace parser {
 
 extern bool last_parsed_is_problem;
-extern dnnl::impl::stringstream_t help_ss;
+extern stringstream_t help_ss;
 
 namespace utils {
 

--- a/tests/benchdnn/utils/perf_report.cpp
+++ b/tests/benchdnn/utils/perf_report.cpp
@@ -17,13 +17,14 @@
 
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
+#include "utils/stringstream.hpp"
 
 #include "utils/perf_report.hpp"
 
 void base_perf_report_t::report(res_t *res, const char *prb_str) const {
     dump_perf_header();
 
-    dnnl::impl::stringstream_t ss;
+    stringstream_t ss;
 
     const char *pt = pt_;
     char c;
@@ -168,7 +169,7 @@ void base_perf_report_t::dump_perf_header() const {
     // dataframe (i.e. no symbols other than _ and not starting with a number)
     const char *pt = pt_;
     char c;
-    dnnl::impl::stringstream_t ss;
+    stringstream_t ss;
     while ((c = *pt++) != '\0') {
         // Print anything that isn't %
         if (c != '%') {

--- a/tests/benchdnn/utils/stringstream.hpp
+++ b/tests/benchdnn/utils/stringstream.hpp
@@ -1,0 +1,81 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef UTILS_STRINGSTREAM_HPP
+#define UTILS_STRINGSTREAM_HPP
+
+// This is a copy-paste from the library type.
+// It's copied to untie from the library dependencies. Can't include it directly
+// due to the responsible headers brings a lot of undesired code.
+//
+// TODO: consolidate when the library isolate this class not to have any extra
+// dependencies.
+
+#include <locale>
+#include <sstream>
+
+struct stringstream_t : public std::stringstream {
+    template <typename... Args>
+    stringstream_t(Args &&...args)
+        : std::stringstream(std::forward<Args>(args)...) {
+        this->imbue(std::locale::classic());
+    }
+
+    stringstream_t(const stringstream_t &) = delete;
+    stringstream_t &operator=(const stringstream_t &) = delete;
+
+    stringstream_t(stringstream_t &&) = delete;
+    stringstream_t &operator=(stringstream_t &&) = delete;
+
+private:
+    using std::stringstream::imbue;
+};
+
+struct istringstream_t : public std::istringstream {
+    template <typename... Args>
+    istringstream_t(Args &&...args)
+        : std::istringstream(std::forward<Args>(args)...) {
+        this->imbue(std::locale::classic());
+    }
+
+    istringstream_t(const istringstream_t &) = delete;
+    istringstream_t &operator=(const istringstream_t &) = delete;
+
+    istringstream_t(istringstream_t &&) = delete;
+    istringstream_t &operator=(istringstream_t &&) = delete;
+
+private:
+    using std::istringstream::imbue;
+};
+
+struct ostringstream_t : public std::ostringstream {
+    template <typename... Args>
+    ostringstream_t(Args &&...args)
+        : std::ostringstream(std::forward<Args>(args)...) {
+        this->imbue(std::locale::classic());
+    }
+
+    ostringstream_t(const ostringstream_t &) = delete;
+    ostringstream_t &operator=(const ostringstream_t &) = delete;
+
+    ostringstream_t(ostringstream_t &&) = delete;
+    ostringstream_t &operator=(ostringstream_t &&) = delete;
+
+private:
+    using std::ostringstream::imbue;
+};
+
+#endif

--- a/tests/benchdnn/zeropad/zeropad_aux.cpp
+++ b/tests/benchdnn/zeropad/zeropad_aux.cpp
@@ -14,16 +14,15 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <sstream>
-
 #include "dnnl_common.hpp"
+#include "utils/stringstream.hpp"
 
 #include "zeropad/zeropad.hpp"
 
 namespace zeropad {
 
 std::string prb_t::set_repro_line() {
-    dnnl::impl::stringstream_t s;
+    stringstream_t s;
     dump_global_params(s);
     settings_t def;
 

--- a/tests/gtests/internals/test_nibble.cpp
+++ b/tests/gtests/internals/test_nibble.cpp
@@ -19,6 +19,7 @@
 
 #include "src/common/float4.hpp"
 #include "src/common/int4.hpp"
+#include "src/common/nibble.hpp"
 #include "src/common/nstl.hpp"
 
 namespace dnnl {


### PR DESCRIPTION
* Move nibble2_t type to a dedicated header since it's used in 4 spots to avoid bringing utils.hpp with it.
* Copy-paste stringstream_t implementation to rely on a local copy. Will move to a dedicated header later and re-use it in benchdnn. So far - copy.
* Move explicit data_type-d functionality to numeric header which is the only place that includes custom type headers from the library.

This is needed after test_thread.hpp dependency will be decoupled from benchdnn.