### PR TITLE
graph: fix coverity warnings

### DIFF
--- a/src/graph/backend/dnnl/scratchpad.cpp
+++ b/src/graph/backend/dnnl/scratchpad.cpp
@@ -51,20 +51,24 @@ scratchpad_t::scratchpad_t(const tensor_t *user_buf, size_t size,
 
 scratchpad_t::~scratchpad_t() {
     if (user_managed_) return;
-    if (eng_->get_kind() == dnnl::engine::kind::cpu) {
+    if (bool(*eng_) == false) return;
+    const auto ekind = eng_->get_kind();
+    if (ekind == dnnl::engine::kind::cpu) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
         dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
 #else
         dnnl_allocator_t::free(buffer_, *eng_, alloc_);
 #endif
-    } else if (eng_->get_kind() == dnnl::engine::kind::gpu) {
+    } else if (ekind == dnnl::engine::kind::gpu) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
         dnnl_allocator_t::free(buffer_, *eng_, alloc_, ocl_e_);
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
         dnnl_allocator_t::free(buffer_, *eng_, alloc_, e_);
 #else
-        assert(!"unsupport gpu runtime");
+        assert(!"unsupported gpu runtime");
 #endif
+    } else {
+        assert(!"unsupported engine kind");
     }
 }
 

--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -692,8 +692,8 @@ int partition_data_displacer_t::displace_input_data(size_t lt_id,
                     mem.ndims(), mem.dims(), mem_replace.dt(), mem.strides()));
             dnnl_memory_desc_destroy(mem_replace.md_);
             dnnl_memory_desc_clone(&mem_replace.md_, new_replace_md);
-            SAFE(mem.reorder(mem_replace), WARN);
             dnnl_memory_desc_destroy(new_replace_md);
+            SAFE(mem.reorder(mem_replace), WARN);
             break;
         }
 


### PR DESCRIPTION
1. Fix coverity warning about potential leak of memory descriptor if reorder fails.
2. Fix coverity warning about potential exception throw in destructor.