### PR TITLE
x64: matmul: int8: Fix grouped scales with s8s8 compensation case

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -172,7 +172,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             || !attr_zps.get(DNNL_ARG_SRC).has_default_groups()
             || !attr_zps.get(DNNL_ARG_WEIGHTS).has_default_groups();
     const bool with_int8_grouped_quantization = one_of(src_dt, u8, s8)
-            && one_of(wei_dt, s4, u4, s8) && one_of(dst_dt, f16, bf16, f32)
+            && one_of(wei_dt, s4, u4, s8, u8) && one_of(dst_dt, f16, bf16, f32)
             && has_grouped_quant_attrs;
 
     auto check_bias = [&]() -> bool {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -372,13 +372,10 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
     , f32_with_int_wei_dt(weights_decompression_support
               && everyone_is(f32, bgmmc.src_dt, bgmmc.dst_dt))
     // int8 grouped quantization: any grouped scales/ZP attribute on
-    // int8 src x {s4,u4,s8} wei, dst in {f16,bf16,f32,s8,u8,s32}.
+    // int8 src x {s4,u4,s8,u8} wei, dst in {f16,bf16,f32,s8,u8,s32}.
     , int8_grouped_quantization_dt(one_of(bgmmc.src_dt, u8, s8)
-              && one_of(bgmmc.wei_dt, s4, u4, s8)
+              && one_of(bgmmc.wei_dt, s4, u4, s8, u8)
               && one_of(bgmmc.dst_dt, f16, bf16, f32, s8, u8, s32)
-              && (!attr.zero_points_.get(DNNL_ARG_SRC).has_default_values()
-                      || !attr.zero_points_.get(DNNL_ARG_WEIGHTS)
-                                  .has_default_values())
               && (utils::one_of(bgmmc.wei_dt, s4, u4)
                       || !attr.scales_.get(DNNL_ARG_SRC).has_default_groups()
                       || !attr.scales_.get(DNNL_ARG_WEIGHTS)
@@ -2661,7 +2658,8 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.has_zero_point_b = bgmmc.wei_zp_type != brgemm_broadcast_t::none;
     bgmmc.has_zero_point_c = bgmmc.dst_zp_type != brgemm_broadcast_t::none;
     bgmmc.with_per_mn_compensation = bgmmc.with_int8_grouped_quantization
-            && (bgmmc.has_zero_point_a || bgmmc.has_zero_point_b);
+            && (bgmmc.has_zero_point_a || bgmmc.has_zero_point_b
+                    || bgmmc.s8s8_compensation_required);
     bgmmc.post_ops_applicable = one_of(true, bgmmc.with_sum, bgmmc.with_bias,
             bgmmc.with_src_scales,
             bgmmc.with_wei_scales && !bgmmc.apply_scales_in_buffer_b,

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -776,7 +776,10 @@ status_t per_mn_comp_kernel_t::is_applicable(
     const int chunks_cap = zmm_path ? 24 : 6;
     if (chunks > chunks_cap) return status::unimplemented;
 
-    if (!bgmmc->has_zero_point_a && !bgmmc->has_zero_point_b)
+    // per-mn compensation is only needed when ZP is present or s8s8 compensation
+    // is required for each K-block(grouped scales are present).
+    if (!bgmmc->has_zero_point_a && !bgmmc->has_zero_point_b
+            && !bgmmc->s8s8_compensation_required)
         return status::unimplemented;
 
     // Per-axis activation:


### PR DESCRIPTION
## Description
Fixes AVX2_VNNI_2 part of [MFDNN-15250](https://jira.devtools.intel.com/browse/MFDNN-15250). 

When grouped scales are set, s8s8-compensation needs to be applied also after **each** K-block as it's done for ZP in 
https://github.com/uxlfoundation/oneDNN/pull/5407. 

Failed testcase `--matmul --dt=s8:s8:s32 --attr-scales=src:per_tensor:f32:1x32 1x64:64x1`  on ADL or any AVX2_VNNI_2-like system is already included in https://github.com/uxlfoundation/oneDNN/pull/5317. 

UPD: it's also contains small fix related to `int8_grouped_quantization_dt` initialization, which doesn't affect on test coverage, but represents more clear and readable version of supported cases. 