### PR TITLE
Upconvert fp8 weights to xf16 in Matmul in case of xf16 activations

### DIFF
--- a/src/common/float8.cpp
+++ b/src/common/float8.cpp
@@ -16,6 +16,7 @@
 
 #include <array>
 
+#include "common/bfloat16.hpp"
 #include "common/bit_cast.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/float16.hpp"
@@ -70,6 +71,89 @@ float8_e5m2_t &float8_e5m2_t::operator=(float16_t f) {
     return *this;
 }
 
+float8_e5m2_t &float8_e5m2_t::operator=(bfloat16_t f) {
+    constexpr auto bf16_mantissa_len = 7;
+    constexpr auto bf16_mantissa_mask = 0x007f;
+    constexpr auto bf16_exp_mask = 0x7f80;
+    constexpr auto f8_e5m2_mantissa_len = 2;
+
+    const bool is_special = (f.raw_bits_ & bf16_exp_mask)
+            == bf16_exp_mask; // exp has all bits set
+    const bool is_nan = is_special
+            && (f.raw_bits_ & bf16_mantissa_mask); // and non-zero mantissa
+
+    if (is_special) {
+        // sign bit and 5 exp bits = 6 bits, they are S'11111
+        raw_bits_ = ((f.raw_bits_ >> 8) & 0xfc);
+
+        // we always set quiet bit for NaN
+        if (is_nan) {
+            // also add 2 mantissa bits
+            raw_bits_ = raw_bits_ | ((f.raw_bits_ >> 5) & 0x3) | 0x2;
+            return *this;
+        }
+
+        // if infinity then mantissa is zero
+        return *this;
+    }
+
+    // first we extract the sign and make the input positive
+    const unsigned int s8 = (f.raw_bits_ & 0x8000) >> 8;
+    const int fraw = f.raw_bits_ & 0x7fff;
+
+    // we filter out overflow
+    // Note: values in [57344;61184] round to 57344, which is representable
+    // So we overflow above 61184
+    constexpr auto bf16_61184_raw = 0x476f;
+    if (fraw > bf16_61184_raw) {
+        raw_bits_ = s8 | 0x7c; // S'11111'00
+        return *this;
+    }
+    // we filter out underflow when f <= 2^-17
+    constexpr auto bf16_2_to_minus17_raw = 0x3700;
+    if (fraw <= bf16_2_to_minus17_raw) {
+        raw_bits_ = s8;
+        return *this;
+    }
+
+    // Here the idea is to add a large constant to the bfloat16_t to force the
+    // proper rounding to f8_e5m2 accuracy.
+    // Compute the rounding shifter by taking its exponent + 5.
+    // It does not overflow as fraw <= 61184.
+    // This allows to discard 5 bits of mantissa during addition,
+    // leaving the remaining 2 bits perfectly rounded.
+    constexpr bool is_bitcast = true;
+    constexpr auto shifter_exp_adjustment = 5 << bf16_mantissa_len;
+    bfloat16_t shifter(
+            (fraw & bf16_exp_mask) + shifter_exp_adjustment, is_bitcast);
+    // e8 = e16 - e16_bias + e8_bias = e16 - 127 + 15
+    // e8 will be denorm if e8 <= 0 or e16 + 5 < 118
+    constexpr int exp_threshold = 0x3b00; // raw bits of exponent = 118
+    const bool is_denorm = shifter.raw_bits_ < exp_threshold;
+    if (is_denorm) shifter.raw_bits_ = exp_threshold;
+
+    bfloat16_t rounded = (bfloat16_t(fraw, is_bitcast) + shifter);
+    // separate line to force line above to round to bf16
+    rounded = rounded - shifter;
+
+    constexpr auto exp_bias_diff = 112; // bf16_bias - f8_e5m2_bias = 127 - 15
+    int e8 = ((rounded.raw_bits_ & bf16_exp_mask) >> bf16_mantissa_len)
+            - exp_bias_diff;
+
+    constexpr auto mantissa_len_diff = bf16_mantissa_len - f8_e5m2_mantissa_len;
+    uint8_t m8 = (rounded.raw_bits_ & bf16_mantissa_mask) >> mantissa_len_diff;
+
+    // we need to make the implicit mantissa bit explicit for
+    // denorm f8_e5m2
+    if (is_denorm) {
+        m8 = (m8 | (1 << f8_e5m2_mantissa_len)) >> (-e8 + 1);
+        e8 = 0;
+    }
+
+    raw_bits_ = s8 | (e8 << f8_e5m2_mantissa_len) | m8;
+    return *this;
+}
+
 float8_e5m2_t &float8_e5m2_t::operator=(float f) {
     float16_t f16 = f;
     float8_e5m2_t f8 = f16;
@@ -90,6 +174,43 @@ float8_e5m2_t::operator float16_t() const {
     std::array<uint8_t, 2> iraw = {{0, raw}};
     auto f16 = utils::bit_cast<float16_t>(iraw);
     return f16;
+}
+
+float8_e5m2_t::operator bfloat16_t() const {
+    const uint16_t s8 = (raw_bits_ & 0x80) >> 7;
+    const uint16_t e8 = (raw_bits_ & 0x7c) >> 2;
+    const uint16_t m8 = (raw_bits_ & 0x3);
+
+    const uint16_t s_bf16 = s8;
+    uint16_t e_bf16 = 0;
+    uint16_t m_bf16 = 0;
+
+    if (e8 == 0 && m8 == 0) {
+        // Zero
+        e_bf16 = 0;
+        m_bf16 = 0;
+    } else if (e8 == 0x1f && m8 != 0) {
+        // NaN: convert to quiet NaN, preserve payload
+        e_bf16 = 0xff;
+        m_bf16 = 0x40 | (m8 << 5);
+    } else if (e8 == 0x1f && m8 == 0) {
+        // Infinity
+        e_bf16 = 0xff;
+        m_bf16 = 0;
+    } else if (e8 == 0) {
+        // Need to convert f8_e5m2 denormal into bf16 normal
+        const int shift = (m8 & 0x2) ? 1 : 2;
+        // e5m2 bias=15, bf16 bias=127
+        e_bf16 = 1 - shift + 112; // 112 = 127 - 15
+        m_bf16 = ((m8 << shift) & 0x3) << 5;
+    } else {
+        // Normal values
+        e_bf16 = e8 + 112; // = (e8 - 15) + 127
+        m_bf16 = m8 << 5;
+    }
+
+    const uint16_t bf16_bits = (s_bf16 << 15) | (e_bf16 << 7) | m_bf16;
+    return utils::bit_cast<bfloat16_t>(bf16_bits);
 }
 
 float8_e4m3_t &float8_e4m3_t::operator=(float16_t f) {
@@ -152,6 +273,71 @@ float8_e4m3_t &float8_e4m3_t::operator=(float f) {
     return *this;
 }
 
+float8_e4m3_t &float8_e4m3_t::operator=(bfloat16_t f) {
+    constexpr auto bf16_mantissa_len = 7;
+    constexpr auto bf16_mantissa_mask = 0x007f;
+    constexpr auto bf16_exp_mask = 0x7f80;
+    constexpr auto f8_e4m3_mantissa_len = 3;
+
+    int fraw = f.raw_bits_;
+
+    // first we extract the sign and make the input positive
+    const unsigned int s8 = (fraw & 0x8000) >> 8;
+    fraw = fraw & 0x7fff;
+
+    // we filter out overflow, nan
+    // Note: values in [448;464] round to 448, which is representable
+    // So we overflow above 464
+    constexpr auto bf16_464_raw = 0x43e8;
+    if (fraw > bf16_464_raw) {
+        raw_bits_ = s8 | 0x7f; // S'1111'111
+        return *this;
+    }
+    // we filter out underflow when f <= 2^-10
+    constexpr auto bf16_2_to_minus10_raw = 0x3a80;
+    if (fraw <= bf16_2_to_minus10_raw) {
+        raw_bits_ = s8;
+        return *this;
+    }
+
+    // Here the idea is to add a large constant to the bfloat16_t to force the
+    // proper rounding to f8_e4m3 accuracy.
+    // Compute the rounding shifter by taking its exponent + 4.
+    // It does not overflow as fraw <= 464.
+    // This allows to discard 4 bits of mantissa during addition,
+    // leaving the remaining 3 bits perfectly rounded.
+    constexpr bool is_bitcast = true;
+    constexpr auto shifter_exp_adjustment = 4 << bf16_mantissa_len;
+    bfloat16_t shifter(
+            (fraw & bf16_exp_mask) + shifter_exp_adjustment, is_bitcast);
+    // e8 = e16 - e16_bias + e8_bias = e16 - 127 + 7
+    // e8 will be denorm if e8 <= 0 or e16 + 4 < 125
+    constexpr int exp_threshold = 0x3e80; // raw bits of exponent = 125
+    const bool is_denorm = shifter.raw_bits_ < exp_threshold;
+    if (is_denorm) shifter.raw_bits_ = exp_threshold;
+
+    bfloat16_t rounded = (bfloat16_t(fraw, is_bitcast) + shifter);
+    // separate line to force line above to round to bf16
+    rounded = rounded - shifter;
+
+    constexpr auto exp_bias_diff = 120; // bf16_bias - f8_e4m3_bias = 127 - 7
+    int e8 = ((rounded.raw_bits_ & bf16_exp_mask) >> bf16_mantissa_len)
+            - exp_bias_diff;
+
+    constexpr auto mantissa_len_diff = bf16_mantissa_len - f8_e4m3_mantissa_len;
+    uint8_t m8 = (rounded.raw_bits_ & bf16_mantissa_mask) >> mantissa_len_diff;
+
+    // we need to make the implicit mantissa bit explicit for
+    // denorm f8_e4m3
+    if (is_denorm) {
+        m8 = (m8 | (1 << f8_e4m3_mantissa_len)) >> (-e8 + 1);
+        e8 = 0;
+    }
+
+    raw_bits_ = s8 | (e8 << f8_e4m3_mantissa_len) | m8;
+    return *this;
+}
+
 float8_e4m3_t::operator float() const {
     float16_t f16 = *this;
     return static_cast<float>(f16);
@@ -186,6 +372,40 @@ float8_e4m3_t::operator float16_t() const {
 
     const uint16_t u16 = s16 | e16 | m16;
     return utils::bit_cast<float16_t>(u16);
+}
+
+float8_e4m3_t::operator bfloat16_t() const {
+    const uint16_t s8 = (raw_bits_ & 0x80) >> 7;
+    const uint16_t e8 = (raw_bits_ & 0x78) >> 3;
+    const uint16_t m8 = (raw_bits_ & 0x7);
+
+    const uint16_t s_bf16 = s8;
+    uint16_t e_bf16 = 0;
+    uint16_t m_bf16 = 0;
+
+    if (e8 == 0 && m8 == 0) {
+        // Zero
+        e_bf16 = 0;
+        m_bf16 = 0;
+    } else if (e8 == 0xf && m8 == 0x7) {
+        // NaN (e4m3 has no infinity, only exp=15 mantissa=7 is NaN)
+        // Convert to quiet NaN, preserve payload
+        e_bf16 = 0xff;
+        m_bf16 = 0x40 | (m8 << 4);
+    } else if (e8 == 0) {
+        // Need to convert f8_e4m3 denormal into bf16 normal
+        const int shift = (m8 & 0x4) ? 1 : (m8 & 0x2) ? 2 : 3;
+        // e4m3 bias=7, bf16 bias=127
+        e_bf16 = 1 - shift + 120; // 120 = 127 - 7
+        m_bf16 = ((m8 << shift) & 0x7) << 4;
+    } else {
+        // Normal values
+        e_bf16 = e8 + 120; // = e8 - 7 + 127
+        m_bf16 = m8 << 4;
+    }
+
+    const uint16_t bf16_bits = (s_bf16 << 15) | (e_bf16 << 7) | m_bf16;
+    return utils::bit_cast<bfloat16_t>(bf16_bits);
 }
 
 void cvt_f8_e5m2_to_float(float *out, const float8_e5m2_t *inp, size_t nelems) {

--- a/src/common/float8.hpp
+++ b/src/common/float8.hpp
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 
+#include "common/bfloat16.hpp"
 #include "common/float16.hpp"
 
 namespace dnnl {
@@ -40,12 +41,15 @@ struct float8_e5m2_t {
     constexpr float8_e5m2_t(uint8_t r, bool) : raw_bits_(r) {}
     float8_e5m2_t(float f) { (*this) = f; }
     float8_e5m2_t(float16_t f) { (*this) = f; }
+    float8_e5m2_t(bfloat16_t f) { (*this) = f; }
 
     float8_e5m2_t DNNL_API &operator=(float f);
     float8_e5m2_t DNNL_API &operator=(float16_t f);
+    float8_e5m2_t DNNL_API &operator=(bfloat16_t f);
 
     DNNL_API operator float() const;
     DNNL_API operator float16_t() const;
+    DNNL_API operator bfloat16_t() const;
 
     float8_e5m2_t &operator+=(const float a) {
         (*this) = float {*this} + a;
@@ -60,12 +64,15 @@ struct float8_e4m3_t {
     constexpr float8_e4m3_t(uint8_t r, bool) : raw_bits_(r) {}
     float8_e4m3_t(float f) { (*this) = f; }
     float8_e4m3_t(float16_t f) { (*this) = f; }
+    float8_e4m3_t(bfloat16_t f) { (*this) = f; }
 
     float8_e4m3_t DNNL_API &operator=(float f);
     float8_e4m3_t DNNL_API &operator=(float16_t f);
+    float8_e4m3_t DNNL_API &operator=(bfloat16_t f);
 
     DNNL_API operator float() const;
     DNNL_API operator float16_t() const;
+    DNNL_API operator bfloat16_t() const;
 
     float8_e4m3_t &operator+=(const float a) {
         (*this) = float {*this} + a;

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -36,6 +36,7 @@ void fp8_conversion_base_t::bcst_f8_to_f32(
 void fp8_conversion_e5m2_t::prepare_table() {
     host_->align(64);
     host_->L(label_vnni_permute_index_table_);
+    // Data for f16
     for (size_t i = 0; i < 64; ++i) {
         // 2, 0, 3, 1, ...
         size_t index = i;
@@ -45,6 +46,15 @@ void fp8_conversion_e5m2_t::prepare_table() {
             case 2: index = i + 1; break;
             case 3: index = i - 2; break;
         }
+        host_->db(index);
+    }
+    // Data for bf16
+    for (size_t i = 0; i < 32; ++i) {
+        size_t index = 4 * (i / 2) + (i % 2);
+        host_->db(index);
+    }
+    for (size_t i = 32; i < 64; ++i) {
+        size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
         host_->db(index);
     }
 
@@ -84,31 +94,49 @@ void fp8_conversion_e4m3_t::prepare_table() {
         host_->db(index);
     }
 
-    // Other tables are not needed if fp8 is native
-    if (is_fp8_native()) return;
-
     host_->L(label_table_from_f8_);
-    // 0: map from f8_e4m3 byte to high byte of f16 (ignoring sign)
+
+    // 0: map from f8_e4m3 byte to high byte of bf16 (ignoring sign)
     for (uint8_t u8 = 0; u8 < 128; ++u8) {
         const float8_e4m3_t x8(u8, /* bit_cast = */ true);
-        const float16_t x16 = static_cast<float16_t>(static_cast<float>(x8));
-        const uint16_t u16 = x16.raw >> 8;
+        const bfloat16_t x16 = x8;
+        const uint16_t u16 = x16.raw_bits_ >> 8;
         host_->db(u16);
     }
-    // 128: map from f8_e4m3 byte to low byte of f16 (ignoring sign)
+    // 128: map from f8_e4m3 byte to low byte of bf16 (ignoring sign)
     for (uint8_t u8 = 0; u8 < 128; ++u8) {
         const float8_e4m3_t x8(u8, /* bit_cast = */ true);
-        const float16_t x16 = static_cast<float16_t>(static_cast<float>(x8));
-        const uint16_t u16 = (x16.raw & 0xff);
+        const bfloat16_t x16 = x8;
+        const uint16_t u16 = (x16.raw_bits_ & 0xff);
         host_->db(u16);
     }
-    // 256: indices to interleave high and low bytes
+    if (!is_fp8_native()) {
+        // 256: map from f8_e4m3 byte to high byte of f16 (ignoring sign)
+        for (uint8_t u8 = 0; u8 < 128; ++u8) {
+            const float8_e4m3_t x8(u8, /* bit_cast = */ true);
+            const float16_t x16 = x8;
+            const uint16_t u16 = x16.raw >> 8;
+            host_->db(u16);
+        }
+        // 384: map from f8_e4m3 byte to low byte of f16 (ignoring sign)
+        for (uint8_t u8 = 0; u8 < 128; ++u8) {
+            const float8_e4m3_t x8(u8, /* bit_cast = */ true);
+            const float16_t x16 = x8;
+            const uint16_t u16 = (x16.raw & 0xff);
+            host_->db(u16);
+        }
+    }
+    // 256 or 512: indices to interleave high and low bytes
     for (uint8_t u8 = 0; u8 < 64; ++u8) {
         int idx = (u8 / 2) + 64 * (u8 % 2); // 0, 64, 1, 65, ...
         host_->db(idx);
     }
-    // 320: sign mask for fp8 values
+    // 320 or 576: sign mask for fp8 values
     host_->dq(0x8080808080808080);
+
+    // Other tables are not needed if fp8 is native
+    if (is_fp8_native()) return;
+
     host_->align(64);
     host_->L(label_table_to_f8_);
     // 0: map from f16 sign+exponent word to f8_e4m3 sign+exponent byte
@@ -187,6 +215,38 @@ void fp8_conversion_e5m2_t::vcvt_f8_to_f16(
     }
 }
 
+void fp8_conversion_e5m2_t::vcvt_f8_to_bf16(
+        const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) {
+    assert(utils::one_of(
+            true, op_in.isXMM(), op_in.isYMM(), op_in.isZMM(), op_in.isMEM()));
+    assert(xmm_out.isZMM());
+    assert(xmm_out.getIdx() != xmm_aux3_.getIdx());
+
+    // f16 <- f8_e5m2
+    // Floating point conversions typically set quiet bit for NaN inputs.
+    // Here we skip this step as it will be handled during f32<-f16 stage.
+    host_->vpmovzxbw(xmm_out, op_in);
+    host_->vpsllw(xmm_out, xmm_out, 8);
+
+    // copy high bytes to auxiliary register
+    const Xbyak::Zmm zmm_out(xmm_out.getIdx());
+    const Xbyak::Ymm ymm_aux_out_hi(xmm_aux3_.getIdx());
+    host_->vextractf64x4(ymm_aux_out_hi, zmm_out, 1);
+
+    // f32 <- f16
+    const Xbyak::Zmm zmm_aux_out_hi(xmm_aux3_.getIdx());
+    host_->vcvtph2psx(zmm_aux_out_hi, ymm_aux_out_hi);
+    const Xbyak::Ymm ymm_out(xmm_out.getIdx());
+    host_->vcvtph2psx(zmm_out, ymm_out);
+
+    // bf16 <- f32
+    host_->vcvtneps2bf16(ymm_aux_out_hi, zmm_aux_out_hi);
+    host_->vcvtneps2bf16(ymm_out, zmm_out);
+
+    // merge bytes
+    host_->vinsertf64x4(zmm_out, zmm_out, ymm_aux_out_hi, 1);
+}
+
 void fp8_conversion_e5m2_t::prepare_f8_to_f16_vnni_masks(int zmm_permute_idx) {
     const uint64_t mask_even = 0xAAAAAAAAAAAAAAAA;
     host_->mov(reg64_aux_, mask_even);
@@ -214,6 +274,25 @@ void fp8_conversion_e5m2_t::vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
             zmm_out1, zmm_out2, op_in, zmm_permute_idx);
 }
 
+void fp8_conversion_e5m2_t::vcvt_f8_to_bf16_vnni(const Xbyak::Zmm &zmm_out1,
+        const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) {
+    const Xbyak::Ymm ymm_out1(zmm_out1.getIdx());
+    const Xbyak::Ymm ymm_out2(zmm_out2.getIdx());
+
+    const Xbyak::Zmm zmm_permute(xmm_aux3_.getIdx());
+
+    host_->vmovups(zmm_permute,
+            host_->ptr[host_->rip + label_vnni_permute_index_table_ + 64]);
+    // first take the two low bytes from each quad and then the two upper bytes
+    host_->vpermb(zmm_out1, zmm_permute, op_in);
+    // ymm_aux1 contains fp8 values from low bytes
+    // move fp8 values from upper bytes to ymm_aux2
+    host_->vextractf64x4(ymm_out2, zmm_out1, 1);
+
+    vcvt_f8_to_bf16(zmm_out1, ymm_out1);
+    vcvt_f8_to_bf16(zmm_out2, ymm_out2);
+}
+
 void fp8_conversion_e5m2_t::vcvt_f8_to_f16_vnni_block(int num_rows,
         const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
         const Xbyak::Reg64 &reg_data_out) {
@@ -237,6 +316,38 @@ void fp8_conversion_e5m2_t::vcvt_f8_to_f16_vnni_block(int num_rows,
     }
 }
 
+void fp8_conversion_e5m2_t::vcvt_f8_to_bf16_vnni_block(int num_rows,
+        const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
+        const Xbyak::Reg64 &reg_data_out) {
+    constexpr auto zmm_width_in_bytes = cpu_isa_traits_t<avx512_core>::vlen;
+    const Xbyak::Zmm zmm_out1(xmm_aux1_.getIdx());
+    const Xbyak::Zmm zmm_out2(xmm_aux2_.getIdx());
+    const Xbyak::Ymm ymm_out1(zmm_out1.getIdx());
+    const Xbyak::Ymm ymm_out2(zmm_out2.getIdx());
+
+    const Xbyak::Zmm zmm_permute(xmm_aux3_.getIdx());
+    for (int r = 0; r < num_rows; r += 2) {
+        host_->vmovups(zmm_permute,
+                host_->ptr[host_->rip + label_vnni_permute_index_table_ + 64]);
+
+        host_->vpermb(
+                zmm_out1, zmm_permute, host_->ptr[reg_data_in]); // 3210 -> 1302
+        // ymm_out1 contains fp8 values from low bytes
+        // move fp8 values from upper bytes to ymm_out2
+        host_->vextractf64x4(ymm_out2, zmm_out1, 1);
+
+        vcvt_f8_to_bf16(zmm_out1, ymm_out1);
+        vcvt_f8_to_bf16(zmm_out2, ymm_out2);
+
+        host_->vmovups(
+                host_->ptr[reg_data_out + r * zmm_width_in_bytes], zmm_out1);
+        host_->vmovups(host_->ptr[reg_data_out + (r + 1) * zmm_width_in_bytes],
+                zmm_out2);
+
+        host_->lea(reg_data_in, host_->ptr[reg_data_in + reg_stride_in]);
+    }
+}
+
 void fp8_conversion_e5m2_t::vcvt_f8_to_f32(
         const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) {
     assert(utils::one_of(
@@ -254,12 +365,16 @@ void fp8_conversion_e5m2_t::vcvt_f8_to_f32(
     host_->vcvtph2psx(zmm_out, ymm_out);
 }
 
-void fp8_conversion_e4m3_t::vcvt_f8_to_f16(
-        const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) {
+void fp8_conversion_e4m3_t::vcvt_f8_to_xf16(const Xbyak::Xmm &xmm_out,
+        const Xbyak::Operand &op_in, data_type_t dt) {
+    assert(utils::one_of(dt, data_type::bf16, data_type::f16));
     assert(utils::one_of(
             true, op_in.isXMM(), op_in.isYMM(), op_in.isZMM(), op_in.isMEM()));
 
-    if (is_fp8_native()) {
+    const bool is_f16 = dt == data_type::f16;
+    const bool is_native_conv = is_fp8_native();
+
+    if (is_f16 && is_native_conv) {
         if (!op_in.isMEM()) {
             // src register must be at least half the size of dst register (xbyak checkCvt1)
             if (xmm_out.isZMM())
@@ -271,6 +386,11 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f16(
         }
         return;
     }
+
+    const int xf16_hi_bytes_offset = is_f16 ? 256 : 0;
+    const int xf16_lo_bytes_offset = is_f16 ? 384 : 128;
+    const int interleave_indices_offset = is_native_conv ? 256 : 512;
+    const int sign_mask_offset = interleave_indices_offset + 64;
 
     host_->lea(reg64_aux_,
             host_->ptr[host_->rip + label_table_from_f8_]); // base of table
@@ -287,24 +407,36 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f16(
                                         : ymm_mask(zmm_in, xmm_out);
 
     if (op_in.isMEM()) host_->vmovdqu8(vmm_in, op_in);
-    // f16 <- f8_e4m3
+    // xf16 <- f8_e4m3
     tabulate(data_type::f8_e4m3, zmm_aux1, zmm_in,
-            host_->zword[reg64_aux_]); // high byte
+            host_->zword[reg64_aux_ + xf16_hi_bytes_offset]); // high byte
     tabulate(data_type::f8_e4m3, zmm_aux2, zmm_in,
-            host_->zword[reg64_aux_ + 128]); // low byte
+            host_->zword[reg64_aux_ + xf16_lo_bytes_offset]); // low byte
     // sign correction
     // 0xf8 means A = A | (B & C)
-    // 320 is offset of sign mask in table
-    host_->vpternlogq(zmm_aux1, zmm_in, host_->ptr_b[reg64_aux_ + 320], 0xf8);
+    host_->vpternlogq(zmm_aux1, zmm_in,
+            host_->ptr_b[reg64_aux_ + sign_mask_offset], 0xf8);
     // merge high and low
-    host_->vmovdqu64(zmm_tmp, host_->zword[reg64_aux_ + 256]);
+    host_->vmovdqu64(
+            zmm_tmp, host_->zword[reg64_aux_ + interleave_indices_offset]);
     host_->vpermt2b(zmm_aux2, zmm_tmp, zmm_aux1);
 
     host_->vmovdqu16(xmm_out, zmm_aux2);
 }
 
-void fp8_conversion_e4m3_t::vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
-        const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) {
+void fp8_conversion_e4m3_t::vcvt_f8_to_f16(
+        const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) {
+    vcvt_f8_to_xf16(xmm_out, op_in, data_type::f16);
+}
+
+void fp8_conversion_e4m3_t::vcvt_f8_to_bf16(
+        const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) {
+    vcvt_f8_to_xf16(xmm_out, op_in, data_type::bf16);
+}
+
+void fp8_conversion_e4m3_t::vcvt_f8_to_xf16_vnni(const Xbyak::Zmm &zmm_out1,
+        const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in,
+        data_type_t dt) {
     const Xbyak::Ymm ymm_out1(zmm_out1.getIdx());
     const Xbyak::Ymm ymm_out2(zmm_out2.getIdx());
 
@@ -318,14 +450,24 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
     // move fp8 values from upper bytes to ymm_aux2
     host_->vextractf64x4(ymm_out2, zmm_out1, 1);
 
-    vcvt_f8_to_f16(zmm_out1, ymm_out1);
-    vcvt_f8_to_f16(zmm_out2, ymm_out2);
+    vcvt_f8_to_xf16(zmm_out1, ymm_out1, dt);
+    vcvt_f8_to_xf16(zmm_out2, ymm_out2, dt);
 }
 
-void fp8_conversion_e4m3_t::vcvt_f8_to_f16_vnni_block(int num_rows,
+void fp8_conversion_e4m3_t::vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
+        const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) {
+    vcvt_f8_to_xf16_vnni(zmm_out1, zmm_out2, op_in, data_type::f16);
+}
+
+void fp8_conversion_e4m3_t::vcvt_f8_to_bf16_vnni(const Xbyak::Zmm &zmm_out1,
+        const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) {
+    vcvt_f8_to_xf16_vnni(zmm_out1, zmm_out2, op_in, data_type::bf16);
+}
+
+void fp8_conversion_e4m3_t::vcvt_f8_to_xf16_vnni_block(int num_rows,
         const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
-        const Xbyak::Reg64 &reg_data_out) {
-    const auto zmm_width_in_bytes = cpu_isa_traits_t<avx512_core>::vlen;
+        const Xbyak::Reg64 &reg_data_out, data_type_t dt) {
+    constexpr auto zmm_width_in_bytes = cpu_isa_traits_t<avx512_core>::vlen;
     const Xbyak::Zmm zmm_out1(xmm_aux4_.getIdx());
     const Xbyak::Zmm zmm_out2(xmm_aux5_.getIdx());
     const Xbyak::Ymm ymm_out1(zmm_out1.getIdx());
@@ -342,8 +484,8 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f16_vnni_block(int num_rows,
         // move fp8 values from upper bytes to ymm_out2
         host_->vextractf64x4(ymm_out2, zmm_out1, 1);
 
-        vcvt_f8_to_f16(zmm_out1, ymm_out1);
-        vcvt_f8_to_f16(zmm_out2, ymm_out2);
+        vcvt_f8_to_xf16(zmm_out1, ymm_out1, dt);
+        vcvt_f8_to_xf16(zmm_out2, ymm_out2, dt);
 
         host_->vmovups(
                 host_->ptr[reg_data_out + r * zmm_width_in_bytes], zmm_out1);
@@ -352,6 +494,13 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f16_vnni_block(int num_rows,
 
         host_->lea(reg_data_in, host_->ptr[reg_data_in + reg_stride_in]);
     }
+}
+
+void fp8_conversion_e4m3_t::vcvt_f8_to_f16_vnni_block(int num_rows,
+        const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
+        const Xbyak::Reg64 &reg_data_out) {
+    vcvt_f8_to_xf16_vnni_block(
+            num_rows, reg_data_in, reg_stride_in, reg_data_out, data_type::f16);
 }
 
 void fp8_conversion_e4m3_t::vcvt_f8_to_f32(
@@ -366,6 +515,13 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f32(
     vcvt_f8_to_f16(ymm_mask(xmm_out), op_in);
     // f32 <- f16
     host_->vcvtph2psx(zmm_out, ymm_out);
+}
+
+void fp8_conversion_e4m3_t::vcvt_f8_to_bf16_vnni_block(int num_rows,
+        const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
+        const Xbyak::Reg64 &reg_data_out) {
+    vcvt_f8_to_xf16_vnni_block(num_rows, reg_data_in, reg_stride_in,
+            reg_data_out, data_type::bf16);
 }
 
 void fp8_conversion_e5m2_t::vcvt_f32_to_f8(

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
@@ -45,6 +45,9 @@ struct fp8_conversion_base_t {
     virtual void vcvt_f8_to_f16(
             const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in)
             = 0;
+    virtual void vcvt_f8_to_bf16(
+            const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in)
+            = 0;
     virtual void vcvt_f8_to_f32(
             const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in)
             = 0;
@@ -58,8 +61,16 @@ struct fp8_conversion_base_t {
     virtual void vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
             const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in)
             = 0;
+    virtual void vcvt_f8_to_bf16_vnni(const Xbyak::Zmm &zmm_out1,
+            const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in)
+            = 0;
 
     virtual void vcvt_f8_to_f16_vnni_block(int num_rows,
+            const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
+            const Xbyak::Reg64 &reg_data_out)
+            = 0;
+
+    virtual void vcvt_f8_to_bf16_vnni_block(int num_rows,
             const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
             const Xbyak::Reg64 &reg_data_out)
             = 0;
@@ -116,6 +127,8 @@ struct fp8_conversion_e5m2_t : public fp8_conversion_base_t {
 
     void vcvt_f8_to_f16(
             const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) override;
+    void vcvt_f8_to_bf16(
+            const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) override;
     void vcvt_f8_to_f32(
             const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) override;
     void vcvt_f16_to_f8(
@@ -125,8 +138,13 @@ struct fp8_conversion_e5m2_t : public fp8_conversion_base_t {
 
     void vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
             const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) override;
+    void vcvt_f8_to_bf16_vnni(const Xbyak::Zmm &zmm_out1,
+            const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) override;
 
     void vcvt_f8_to_f16_vnni_block(int num_rows,
+            const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
+            const Xbyak::Reg64 &reg_data_out) override;
+    void vcvt_f8_to_bf16_vnni_block(int num_rows,
             const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
             const Xbyak::Reg64 &reg_data_out) override;
 
@@ -152,6 +170,8 @@ struct fp8_conversion_e4m3_t : public fp8_conversion_base_t {
 
     void vcvt_f8_to_f16(
             const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) override;
+    void vcvt_f8_to_bf16(
+            const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) override;
     void vcvt_f8_to_f32(
             const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) override;
     void vcvt_f16_to_f8(
@@ -161,8 +181,13 @@ struct fp8_conversion_e4m3_t : public fp8_conversion_base_t {
 
     void vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
             const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) override;
+    void vcvt_f8_to_bf16_vnni(const Xbyak::Zmm &zmm_out1,
+            const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) override;
 
     void vcvt_f8_to_f16_vnni_block(int num_rows,
+            const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
+            const Xbyak::Reg64 &reg_data_out) override;
+    void vcvt_f8_to_bf16_vnni_block(int num_rows,
             const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
             const Xbyak::Reg64 &reg_data_out) override;
 
@@ -172,6 +197,15 @@ private:
     // Must use full Zmm registers to properly load all table values.
     void tabulate(const data_type_t dt, const Xbyak::Zmm &zmm_out,
             const Xbyak::Zmm &zmm_in, const Xbyak::Address &addr);
+
+    void vcvt_f8_to_xf16(const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in,
+            data_type_t dt);
+    void vcvt_f8_to_xf16_vnni(const Xbyak::Zmm &zmm_out1,
+            const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in,
+            data_type_t dt);
+    void vcvt_f8_to_xf16_vnni_block(int num_rows,
+            const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
+            const Xbyak::Reg64 &reg_data_out, data_type_t dt);
 
     Xbyak::Label label_table_from_f8_;
     const Xbyak::Xmm xmm_aux4_;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1142,7 +1142,9 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
                     || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
                     || bm_conf_utils.is_bf32()
                     || bm_conf_utils.is_bf16_with_int_wei()
-                    || bm_conf_utils.is_f16_with_int_wei());
+                    || bm_conf_utils.is_f16_with_int_wei()
+                    || bm_conf_utils.is_bf16_fp8()
+                    || bm_conf_utils.is_f16_fp8());
     const bool is_amx_int8 = bgmmc.is_amx && bm_conf_utils.is_int8();
 
     const bool runtime_dims

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -100,7 +100,8 @@ bool matmul_amx_blocking_params_macro_t::is_supported(
     bool a_dt_ok
             = one_of(bgmmc.orig_src_dt, dnnl_s8, dnnl_u8, dnnl_bf16, dnnl_f16);
     bool b_dt_ok
-            = one_of(bgmmc.orig_wei_dt, dnnl_s8, dnnl_u8, dnnl_bf16, dnnl_f16);
+            = one_of(bgmmc.orig_wei_dt, dnnl_s8, dnnl_u8, dnnl_bf16, dnnl_f16)
+            || bgmmc.is_xf16_fp8;
 
     bool a_tag_ok = bgmmc.src_tag == dnnl_format_tag_any
             || bm_conf_utils.check_is_plain(bgmmc.src_tag);
@@ -114,9 +115,9 @@ bool matmul_amx_blocking_params_macro_t::is_supported(
             || bgmmc.dst_zp_type != brgemm_broadcast_t::none;
 
     return bgmmc.orig_src_dt == bgmmc.src_dt
-            && bgmmc.orig_wei_dt == bgmmc.wei_dt && bgmmc.is_amx
-            && !bgmmc.is_runtime_N && !bgmmc.is_runtime_M && a_dt_ok && a_tag_ok
-            && b_dt_ok && b_tag_ok
+            && (bgmmc.orig_wei_dt == bgmmc.wei_dt || bgmmc.is_xf16_fp8)
+            && bgmmc.is_amx && !bgmmc.is_runtime_N && !bgmmc.is_runtime_M
+            && a_dt_ok && a_tag_ok && b_dt_ok && b_tag_ok
             && (bgmmc.reduce_kind == matmul_reduce_kind::undef) && !has_zp
             && !bgmmc.packed_sparse_weights;
 }

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -144,6 +144,9 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     const bool is_f8 = one_of(src_dt, f8_e5m2, f8_e4m3)
             && one_of(wei_dt, f8_e5m2, f8_e4m3)
             && one_of(dst_dt, f32, f16, bf16, f8_e5m2, f8_e4m3);
+    const bool is_xf16_fp8 = one_of(src_dt, bf16, f16)
+            && one_of(wei_dt, f8_e5m2, f8_e4m3)
+            && one_of(dst_dt, f32, f16, bf16, f8_e5m2, f8_e4m3);
     const bool is_bf16
             = everyone_is(bf16, src_dt, wei_dt) && one_of(dst_dt, bf16, f32);
     const bool is_f16
@@ -168,10 +171,10 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         const bool is_bia_dt_correct
                 = IMPLICATION(is_int8 == true,
                           one_of(bia_dt, f32, s32, s8, u8, f16, bf16))
-                && IMPLICATION(
-                        is_f8 == true, one_of(bia_dt, f32, f16, bf16, src_dt))
-                && IMPLICATION(
-                        !(is_int8 || is_f8), one_of(bia_dt, f32, src_dt));
+                && IMPLICATION((is_f8 || is_xf16_fp8),
+                        one_of(bia_dt, f32, f16, bf16, src_dt))
+                && IMPLICATION(!(is_int8 || is_f8 || is_xf16_fp8),
+                        one_of(bia_dt, f32, src_dt));
         return IMPLICATION(with_bias(), is_bia_dt_correct && is_bias_1xN());
     };
 
@@ -261,7 +264,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     };
     const bool problem_dt_correct = one_of(true, is_f4, is_int8, is_f8, is_bf16,
             is_f32, is_f16, is_f32_f16, is_f32_bf16, is_bf16_with_int_wei,
-            is_f16_with_int_wei, is_f32_with_int_wei);
+            is_f16_with_int_wei, is_f32_with_int_wei, is_xf16_fp8);
 
     auto src_d = memory_desc_wrapper(src_md_);
     auto weights_d = memory_desc_wrapper(weights_md_);
@@ -1813,8 +1816,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_data_B_kn_off(dim_t k, dim_t n) const {
-        const int wei_k_blk
-                = bgmmc_.is_bf32 ? get_wei_k_blk(f32) : bgmmc_.wei_k_blk;
+        const int wei_k_blk = bgmmc_.is_bf32 || bgmmc_.is_xf16_fp8
+                ? get_wei_k_blk(bgmmc_.orig_wei_dt)
+                : bgmmc_.wei_k_blk;
         const int k_idx = bgmmc_.blocked_B ? k / wei_k_blk : k;
         const int n_idx = bgmmc_.blocked_B ? n / bgmmc_.wei_n_blk : n;
         const int int4_fac = bgmmc_.is_int4_weights ? 2 : 1;
@@ -2046,10 +2050,17 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         if (!bgmmc_.blocked_B) return 0;
 
-        dim_t x0 = k % bgmmc_.wei_k_blk;
+        const int orig_wei_k_blk = bgmmc_.is_xf16_fp8
+                ? get_wei_k_blk(bgmmc_.orig_wei_dt)
+                : bgmmc_.wei_k_blk;
+        dim_t x0 = k % orig_wei_k_blk;
         dim_t x1 = n % bgmmc_.wei_n_blk;
-        dim_t offset = (x0 / vnni_factor) * vnni_factor * bgmmc_.wei_n_blk
-                + x1 * vnni_factor + x0 % vnni_factor;
+        const int orig_vnni_factor = bgmmc_.is_xf16_fp8
+                ? data_type_vnni_granularity(bgmmc_.orig_wei_dt)
+                : vnni_factor;
+        dim_t offset
+                = (x0 / orig_vnni_factor) * orig_vnni_factor * bgmmc_.wei_n_blk
+                + x1 * orig_vnni_factor + x0 % orig_vnni_factor;
         return bgmmc_.b_dt_sz * offset;
     }
 

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -18,6 +18,7 @@
 #include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
+#include "cpu/x64/jit_avx512_core_fp8cvt.hpp"
 #include "cpu/x64/jit_generator.hpp"
 
 #include "cpu/x64/matmul/brgemm_matmul_copy_utils.hpp"
@@ -5962,16 +5963,300 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
 }
 
 template struct jit_brgemm_matmul_copy_b_cvt_bf16_t<Zmm>;
+
+struct fp8_to_xf16_cvt_helper_t {
+    // Reserved by fp8 conversion routines
+    static constexpr int cvt_xmm0_idx = 0;
+    static constexpr int cvt_xmm1_idx = 1;
+    static constexpr int cvt_xmm2_idx = 2;
+    static constexpr int cvt_xmm3_idx = 3;
+    static constexpr int cvt_xmm4_idx = 4;
+    static constexpr int cvt_opmask_idx = 1;
+    static Xbyak::Reg64 cvt_scratch_gpr() { return Xbyak::util::r8; }
+
+    fp8_to_xf16_cvt_helper_t(
+            jit_generator_t *host, const brgemm_matmul_conf_t *conf)
+        : conf_(conf) {
+        if (conf_->orig_wei_dt == data_type::f8_e5m2) {
+            f8_e5m2_cvt_ = utils::make_unique<fp8_conversion_e5m2_t>(host,
+                    Xmm(cvt_xmm0_idx), Xmm(cvt_xmm1_idx), Xmm(cvt_xmm2_idx),
+                    Xbyak::Opmask(cvt_opmask_idx), cvt_scratch_gpr());
+        } else {
+            f8_e4m3_cvt_ = utils::make_unique<fp8_conversion_e4m3_t>(host,
+                    Xmm(cvt_xmm0_idx), Xmm(cvt_xmm1_idx), Xmm(cvt_xmm2_idx),
+                    Xmm(cvt_xmm3_idx), Xmm(cvt_xmm4_idx), cvt_scratch_gpr());
+        }
+    }
+
+    void prepare_tables() {
+        if (f8_e5m2_cvt_) f8_e5m2_cvt_->prepare_table();
+        if (f8_e4m3_cvt_) f8_e4m3_cvt_->prepare_table();
+    }
+
+    void convert_vnni(const Xbyak::Zmm &dst0, const Xbyak::Zmm &dst1,
+            const Xbyak::Operand &src_op) {
+        if (conf_->wei_dt == data_type::bf16) {
+            if (conf_->orig_wei_dt == data_type::f8_e5m2) {
+                f8_e5m2_cvt_->vcvt_f8_to_bf16_vnni(dst0, dst1, src_op);
+            } else {
+                f8_e4m3_cvt_->vcvt_f8_to_bf16_vnni(dst0, dst1, src_op);
+            }
+        } else {
+            if (conf_->orig_wei_dt == data_type::f8_e5m2) {
+                f8_e5m2_cvt_->vcvt_f8_to_f16_vnni(dst0, dst1, src_op);
+            } else {
+                f8_e4m3_cvt_->vcvt_f8_to_f16_vnni(dst0, dst1, src_op);
+            }
+        }
+    }
+
+private:
+    const brgemm_matmul_conf_t *conf_;
+    std::unique_ptr<fp8_conversion_e5m2_t> f8_e5m2_cvt_;
+    std::unique_ptr<fp8_conversion_e4m3_t> f8_e4m3_cvt_;
+};
+
+struct jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t
+    : public jit_brgemm_matmul_copy_b_t,
+      public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t)
+
+    jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t(const brgemm_matmul_conf_t *conf)
+        : jit_brgemm_matmul_copy_b_t(conf)
+        , jit_generator_t(jit_name())
+        , typesize_(conf->b_dt_sz)
+        , tr_typesize_(conf->tr_b_dt_sz)
+        , src_stride_(conf->LDB * k_blk_step * typesize_)
+        , tr_src_stride_(conf->LDB * tr_k_blk_step * tr_typesize_)
+        , cvt_helper_(this, conf) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
+
+private:
+    using reg64_t = const Xbyak::Reg64;
+
+    enum {
+        n_blk_step = 16,
+        // K-pack size in source (fp8) blocked layout
+        k_blk_step = 4,
+        // K-pack size in destination (xf16) blocked layout
+        tr_k_blk_step = 2,
+    };
+
+    const int typesize_, tr_typesize_;
+    // Bytes between consecutive fp8 packs and xf16 packs, respectively
+    const dim_t src_stride_, tr_src_stride_;
+
+    fp8_to_xf16_cvt_helper_t cvt_helper_;
+
+    reg64_t reg_src = rax;
+    reg64_t reg_tr_src = rbx;
+    reg64_t reg_K_iters = r9;
+    reg64_t reg_N_blk = r10;
+    reg64_t reg_tmp = r11;
+    reg64_t reg_src_back = r12;
+    reg64_t reg_tr_src_back = r13;
+    reg64_t reg_blk_src = r14;
+    reg64_t reg_blk_dst = r15;
+
+    Zmm zmm_dst0 = Zmm(5);
+    Zmm zmm_dst1 = Zmm(6);
+    Zmm zmm_src_pack = Zmm(7);
+
+    void copy_block(const int nrows, const int ncolumns, bool zeropad) {
+
+        const int simd_nrows_rounded = utils::rnd_up(nrows, k_blk_step);
+        const int simd_ncols_rounded = utils::rnd_up(ncolumns, n_blk_step);
+
+        for_(int k = 0; k < simd_nrows_rounded; k += k_blk_step)
+        for (int n = 0; n < simd_ncols_rounded; n += n_blk_step) {
+            // One loop step consumes one source K-pack (k_blk_step rows) and
+            // converts it into two destination K-packs (tr_k_blk_step rows
+            // each). The second destination pack is stored only when the
+            // source pack actually contributes more than tr_k_blk_step rows,
+            // so the write granularity equals the destination VNNI
+            // granularity tr_k_blk_step rather than the source pack size.
+            const int fp8_pack = k / k_blk_step;
+            const int xf16_pack_0 = fp8_pack * (k_blk_step / tr_k_blk_step);
+            const bool store_pack_1 = (nrows - k) > tr_k_blk_step;
+            const dim_t src_off
+                    = fp8_pack * src_stride_ + n * k_blk_step * typesize_;
+            const dim_t tr_src_off_0 = xf16_pack_0 * tr_src_stride_
+                    + n * tr_k_blk_step * tr_typesize_;
+            const dim_t tr_src_off_1 = tr_src_off_0 + tr_src_stride_;
+
+            if (zeropad) {
+                uni_vpxor(zmm_dst0, zmm_dst0, zmm_dst0);
+                if (store_pack_1) uni_vpxor(zmm_dst1, zmm_dst1, zmm_dst1);
+            } else {
+                const auto src_addr = EVEX_compress_addr(reg_src, src_off);
+                vmovdqu8(zmm_src_pack, src_addr);
+
+                cvt_helper_.convert_vnni(zmm_dst0, zmm_dst1, zmm_src_pack);
+            }
+
+            const auto store_addr_0
+                    = EVEX_compress_addr(reg_tr_src, tr_src_off_0);
+            uni_vmovups(store_addr_0, zmm_dst0);
+            if (store_pack_1) {
+                const auto store_addr_1
+                        = EVEX_compress_addr(reg_tr_src, tr_src_off_1);
+                uni_vmovups(store_addr_1, zmm_dst1);
+            }
+        }
+    }
+
+    void generate() override {
+        preamble();
+
+        mov(reg_src, ptr[param1 + GET_OFF(src)]);
+        mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
+        mov(reg_N_blk, ptr[param1 + GET_OFF(current_N_blk)]);
+
+        auto compute_K_loop_body
+                = [&](const reg64_t &reg_K, int ncolumns, bool zeropad) {
+            constexpr int k_step = k_blk_step;
+            constexpr int k_unroll = 8;
+            constexpr int k_unroll_rows = k_unroll * k_step;
+
+            Label K_loop_single, K_loop_tail_or_done;
+            // In the zeropad pass reg_K == current_K_pad, which is always
+            // < wei_k_blk (it pads a partial K-block up to wei_k_blk). Since
+            // wei_k_blk <= k_unroll_rows here (wei_dt is bf16/f16 -> wei_k_blk == 32,
+            // and k_unroll_rows == 32), it follows that reg_K < k_unroll_rows.
+            // The unrolled loop below only runs when reg_K >= k_unroll_rows, so
+            // it never runs in the zeropad pass. Assert the invariant
+            // and skip emitting the unrolled loop there to save a dead
+            // cmp/branch.
+            assert(conf_->wei_k_blk <= k_unroll_rows);
+            if (!zeropad) {
+                Label K_loop_unrolled;
+                cmp(reg_K, k_unroll_rows);
+                jl(K_loop_single, T_NEAR);
+
+                L(K_loop_unrolled);
+                copy_block(k_unroll_rows, ncolumns, zeropad);
+                add(reg_src, (k_unroll_rows / k_blk_step) * src_stride_);
+                add(reg_tr_src,
+                        (k_unroll_rows / tr_k_blk_step) * tr_src_stride_);
+
+                sub(reg_K, k_unroll_rows);
+                cmp(reg_K, k_unroll_rows);
+                jge(K_loop_unrolled, T_NEAR);
+            }
+
+            L(K_loop_single);
+            cmp(reg_K, k_step);
+            jl(K_loop_tail_or_done, T_NEAR);
+
+            copy_block(k_step, ncolumns, zeropad);
+            add(reg_src, (k_step / k_blk_step) * src_stride_);
+            add(reg_tr_src, (k_step / tr_k_blk_step) * tr_src_stride_);
+
+            sub(reg_K, k_step);
+            jmp(K_loop_single, T_NEAR);
+
+            L(K_loop_tail_or_done);
+            Label K_loop_done;
+            cmp(reg_K, 0);
+            jle(K_loop_done, T_NEAR);
+            // Tail of 1..k_blk_step-1 K-rows. The source is read as whole
+            // zero-padded fp8 packs, so the tail count only affects the
+            // destination: a tail wider than tr_k_blk_step writes two xf16
+            // packs, otherwise one (tails of 1 and 2 rows are identical).
+            // reg_src is not advanced: this is the last source read of the
+            // pass and reg_src is restored from reg_src_back afterwards.
+            Label tail_one_pack;
+            cmp(reg_K, tr_k_blk_step);
+            jle(tail_one_pack, T_NEAR);
+            copy_block(k_blk_step, ncolumns, zeropad);
+            add(reg_tr_src, (k_blk_step / tr_k_blk_step) * tr_src_stride_);
+            jmp(K_loop_done, T_NEAR);
+
+            L(tail_one_pack);
+            copy_block(tr_k_blk_step, ncolumns, zeropad);
+            add(reg_tr_src, tr_src_stride_);
+
+            L(K_loop_done);
+        };
+
+        auto compute_K_loop = [&](const int ncolumns) {
+            mov(reg_src_back, reg_src);
+            mov(reg_tr_src_back, reg_tr_src);
+
+            mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
+            compute_K_loop_body(reg_K_iters, ncolumns, false);
+
+            // The zero-padding pass fills the K-tail block up to wei_k_blk so brgemm
+            // can safely read the full block (extendable_k). It is only needed in case
+            // of a non-zero current_K_pad; otherwise it can be skipped.
+            // Even when emitted, a single runtime check skips it for the most common
+            // case (current_K_pad == 0), saving the block-copy work.
+            if (conf_->extendable_k || conf_->use_fused_copy_a) {
+                Label skip_zeropad;
+                mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+                cmp(reg_K_iters, 0);
+                jle(skip_zeropad, T_NEAR);
+                compute_K_loop_body(reg_K_iters, ncolumns, true);
+                L(skip_zeropad);
+            }
+
+            mov(reg_src, reg_src_back);
+            mov(reg_tr_src, reg_tr_src_back);
+        };
+
+        Label done;
+        cmp(reg_N_blk, 0);
+        jle(done, T_NEAR);
+
+        // LDB2 is always non-zero for is_xf16_fp8: these kernels are only created
+        // from the matmul path (init_brgemm_matmul_conf), which always sets LDB2.
+        assert(conf_->LDB2 != 0);
+
+        Label main_N_loop, main_N_loop_tail;
+        int tail = conf_->N % conf_->LDB;
+
+        if (tail != 0) {
+            cmp(reg_N_blk, conf_->LDB);
+            jl(main_N_loop_tail, T_NEAR);
+        }
+
+        L(main_N_loop);
+        compute_K_loop(conf_->LDB);
+        add(reg_src, conf_->B_strides[0]);
+        add(reg_tr_src, conf_->LDB2 * tr_typesize_);
+
+        sub(reg_N_blk, conf_->LDB);
+        cmp(reg_N_blk, conf_->LDB);
+        jge(main_N_loop, T_NEAR);
+
+        if (tail != 0) {
+            L(main_N_loop_tail);
+            cmp(reg_N_blk, 0);
+            jle(done, T_NEAR);
+            compute_K_loop(tail);
+        }
+
+        L(done);
+        postamble();
+        cvt_helper_.prepare_tables();
+    }
+};
+
 status_t create_brgemm_matmul_copy_b(
         std::unique_ptr<jit_brgemm_matmul_copy_b_t> &copy_ker,
         const brgemm_matmul_conf_t *conf) {
-    const bool is_bf16
-            = everyone_is(data_type::bf16, conf->src_dt, conf->wei_dt);
+    const bool is_bf16 = !conf->is_xf16_fp8
+            && everyone_is(data_type::bf16, conf->src_dt, conf->wei_dt);
     const bool is_f32 = everyone_is(data_type::f32, conf->src_dt, conf->wei_dt);
     // Note: f16 support through avx512_core_fp16 sets src_dt and wei_dt as f32
     // to imply upconverting. So, the assumption is `is_f16` below evaluates to
     // `false` on avx512_core_fp16.
-    const bool is_f16 = everyone_is(data_type::f16, conf->src_dt, conf->wei_dt);
+    const bool is_f16 = !conf->is_xf16_fp8
+            && everyone_is(data_type::f16, conf->src_dt, conf->wei_dt);
     if (conf->transposed_B) {
         if (is_superset(conf->isa, avx512_core))
             CHECK(safe_ptr_assign(copy_ker,
@@ -6012,6 +6297,16 @@ status_t create_brgemm_matmul_copy_b(
             else
                 CHECK(safe_ptr_assign(copy_ker,
                         new jit_brgemm_matmul_copy_b_f32_t<Ymm>(conf)));
+        } else if (conf->is_xf16_fp8) {
+            assert((is_superset(conf->isa, avx10_2)
+                           || (conf->wei_dt == data_type::f16
+                                           ? is_superset(conf->isa,
+                                                     avx10_1_512_amx_fp16)
+                                           : is_superset(conf->isa,
+                                                     avx512_core_amx)))
+                    && "Unsupported isa for xf16_fp8");
+            CHECK(safe_ptr_assign(copy_ker,
+                    new jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t(conf)));
         } else {
             if (mayiuse(avx512_core_amx))
                 CHECK(safe_ptr_assign(copy_ker,

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -269,6 +269,10 @@ status_t check_isa_with_datatype(
                     one_of(isa, avx512_core_amx_fp16, avx512_core_fp16))
             && IMPLICATION(bm_conf_utils.is_f32_with_int_wei(),
                     one_of(isa, avx512_core, avx2))
+            && IMPLICATION(bm_conf_utils.is_bf16_fp8(),
+                    one_of(isa, avx512_core_amx, avx512_core_amx_fp16, avx10_2))
+            && IMPLICATION(bm_conf_utils.is_f16_fp8(),
+                    one_of(isa, avx512_core_amx_fp16, avx10_2))
             && IMPLICATION(bm_conf_utils.is_f8(),
                     is_superset(isa, avx512_core_amx_fp16)
                             || is_superset(isa, avx10_2))
@@ -309,6 +313,7 @@ status_t check_datatype_cfg(const brgemm_matmul_conf_utils_t &bm_conf_utils) {
                       bm_conf_utils.is_f4_via_convert(),
                       bm_conf_utils.is_tf32(),
                       bm_conf_utils.is_bf16_with_int_wei(),
+                      bm_conf_utils.is_bf16_fp8(), bm_conf_utils.is_f16_fp8(),
                       bm_conf_utils.is_f16_with_int_wei(),
                       bm_conf_utils.is_f32_with_int_wei())
             && IMPLICATION(bm_conf_utils.is_bf16_with_int_wei()
@@ -367,6 +372,10 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
               && one_of(bgmmc.dst_dt, f16, f32))
     , f32_with_int_wei_dt(weights_decompression_support
               && everyone_is(f32, bgmmc.src_dt, bgmmc.dst_dt))
+    , bf16_fp8_dt(bgmmc.src_dt == bf16 && one_of(bgmmc.wei_dt, f8_e5m2, f8_e4m3)
+              && one_of(bgmmc.dst_dt, f16, f32, bf16, f8_e5m2, f8_e4m3))
+    , f16_fp8_dt(bgmmc.src_dt == f16 && one_of(bgmmc.wei_dt, f8_e5m2, f8_e4m3)
+              && one_of(bgmmc.dst_dt, f16, f32, bf16, f8_e5m2, f8_e4m3))
     , A_any_layout(A_any_layout)
     , B_any_layout(B_any_layout)
     , C_any_layout(C_any_layout)
@@ -594,6 +603,9 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
             assert(bgmmc.wei_tag != format_tag::undef
                 && "if bgmmc.is_gemv is true the format tag must be defined");
         } else {
+            VCONDCHECK_BG(
+                    IMPLICATION(bgmmc.is_xf16_fp8, blocked_B_layouts_allowed),
+                    VERBOSE_UNSUPPORTED_TAG)
             const int default_n_block = init_n_tag
                     ? get_default_n_block(format_tag::undef)
                     : bgmmc.N_blk;
@@ -630,6 +642,10 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
             bgmmc.wei_tag = get_gemv_B_tag(B_md);
             assert(bgmmc.wei_tag != format_tag::undef
                 && "if bgmmc.is_gemv is true the format tag must be defined");
+        } else if (bgmmc.is_xf16_fp8) {
+            bgmmc.wei_tag = memory_desc_matches_one_of_tag(B_md,
+                    blocked_64n_B_layout_tag, blocked_48n_B_layout_tag,
+                    blocked_32n_B_layout_tag, blocked_16n_B_layout_tag);
         } else {
             bgmmc.wei_tag = blocked_B_layouts_allowed && !bgmmc.is_runtime_N
                             && !bgmmc.is_int4_weights
@@ -706,7 +722,8 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_tags(memory_desc_t &A_md,
                     || this->is_f16() || this->is_f32_f16()
                     || this->is_f32_bf16() || this->is_bf16_with_int_wei()
                     || this->is_f16_with_int_wei() || this->is_tf32()
-                    || this->is_f32_with_int_wei();
+                    || this->is_f32_with_int_wei() || this->is_bf16_fp8()
+                    || this->is_f16_fp8();
             bgmmc.src_tag = is_adbc_allowed
                     ? memory_desc_matches_one_of_tag(A_md,
                               plain_tensor_layout_tag,
@@ -810,7 +827,7 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
 
     if (bgmmc.ndims > 3) return format_tag::undef;
 
-    if (is_int8() || is_f8()) {
+    if (is_int8() || is_f8() || is_bf16_fp8() || is_f16_fp8()) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c4b : BA16a64b4a;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c4b : BA16a48b4a;
@@ -1462,7 +1479,9 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
                       bm_conf_utils.is_bf16_with_int_wei(),
                       (bgmmc.is_amx
                               && (bm_conf_utils.is_f16()
-                                      || bm_conf_utils.is_f16_with_int_wei())))
+                                      || bm_conf_utils.is_f16_with_int_wei()
+                                      || bm_conf_utils.is_bf16_fp8()
+                                      || bm_conf_utils.is_f16_fp8())))
             && (bgmmc.isa != avx2_vnni_2) // no perf study yet.
             && bgmmc.lda_big_pow2() && bgmmc.M >= 1024 && !bgmmc.is_gemv;
 
@@ -1688,6 +1707,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.is_f32_with_int_wei = bm_conf_utils.is_f32_with_int_wei();
     bgmmc.is_f32_f16 = bm_conf_utils.is_f32_f16();
     bgmmc.is_f32_bf16 = bm_conf_utils.is_f32_bf16();
+    bgmmc.is_xf16_fp8
+            = bm_conf_utils.is_bf16_fp8() || bm_conf_utils.is_f16_fp8();
     bgmmc.with_wei_decompression = bm_conf_utils.with_weights_decompression();
     bgmmc.is_int4_weights = one_of(bgmmc.wei_dt, data_type::s4, data_type::u4);
     bgmmc.is_f4_via_convert = bm_conf_utils.is_f4_via_convert();
@@ -1731,6 +1752,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.wei_dt = f16;
         bgmmc.tr_a_dt_sz = types::data_type_size(f16);
         bgmmc.tr_b_dt_sz = types::data_type_size(f16);
+    } else if (bgmmc.is_xf16_fp8) {
+        bgmmc.wei_dt = bgmmc.src_dt;
+        bgmmc.tr_b_dt_sz = types::data_type_size(bgmmc.wei_dt);
     }
 
     bgmmc.acc_dt = bm_conf_utils.is_int8() ? s32 : f32;
@@ -2227,7 +2251,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             const dim_t buffer_a_chunk_sz_limit = 126;
             is_small_shapes = is_small_shapes
                     && bgmmc.buffer_a_gb_stride <= buffer_a_chunk_sz_limit;
-        } else if (bm_conf_utils.is_f8() || bm_conf_utils.is_bf8()) {
+        } else if (bm_conf_utils.is_f8() || bm_conf_utils.is_bf16_fp8()
+                || bm_conf_utils.is_f16_fp8() || bm_conf_utils.is_bf8()) {
             is_small_shapes = false;
         } else {
             is_small_shapes = is_small_shapes && bgmmc.ndims < 3

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -240,6 +240,7 @@ struct brgemm_matmul_conf_t {
     bool is_f32_with_int_wei = false;
     bool is_f32_f16 = false;
     bool is_f32_bf16 = false;
+    bool is_xf16_fp8 = false;
     bool is_int4_weights = false;
     bool is_f4_via_convert = false;
     bool is_tf32 = false;
@@ -325,6 +326,7 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool use_buffer_b(bool use_heuristic = true) const {
         if (bgmmc.is_runtime_N) return true;
+        if (bgmmc.is_xf16_fp8) return true;
         if (bgmmc.is_bf16_with_int_wei) return true;
         if (bgmmc.is_f16_with_int_wei) return true;
         if (bgmmc.is_f32_with_int_wei) return true;
@@ -401,6 +403,10 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool is_f8() const { return f8_dt; }
 
+    inline bool is_bf16_fp8() const { return bf16_fp8_dt; }
+
+    inline bool is_f16_fp8() const { return f16_fp8_dt; }
+
     inline bool is_bf8() const { return bf8_dt; }
 
     inline bool is_int8() const { return int8_dt; }
@@ -463,7 +469,8 @@ private:
     const bool f32_dt, bf16_dt, f16_dt, f4_via_convert_dt, f8_dt, bf8_dt,
             int8_dt, bf32_dt, tf32_dt;
     const bool weights_decompression_support, bf16_with_int_wei_dt, f32_f16_dt,
-            f32_bf16_dt, f16_with_int_wei_dt, f32_with_int_wei_dt;
+            f32_bf16_dt, f16_with_int_wei_dt, f32_with_int_wei_dt, bf16_fp8_dt,
+            f16_fp8_dt;
     const bool A_any_layout;
     const bool B_any_layout;
     const bool C_any_layout;

--- a/tests/benchdnn/inputs/matmul/harness_matmul_decompression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_decompression
@@ -357,3 +357,46 @@
 --attr-zero-points=,wei:common:2,wei:per_oc:s4,wei:per_ocic:s4:192x1
 --attr-fpmath=strict:true
 12x4x576:12x576x192
+
+
+# xf16:fp8:*
+--reset
+--skip-impl=ref
+--dt=bf16:f8_e4m3:bf16,bf16:f8_e5m2:bf16,f16:f8_e4m3:f16,f16:f8_e5m2:f16
+--stag=ab,ba,any --wtag=any --dtag=ab,any
+--batch=shapes_2d
+64x1184:1184x64
+
+--reset
+--skip-impl=ref
+--dt=bf16:f8_e4m3:bf16,bf16:f8_e5m2:bf16,f16:f8_e4m3:f16,f16:f8_e5m2:f16
+--stag=any --wtag=any --dtag=abx,any
+--batch=shapes_3d
+
+# xf16:fp8:* src/weight/dst scales.
+--reset
+--skip-impl=ref
+--stag=any --wtag=any --dtag=any
+--dt=bf16:f8_e4m3:f32,bf16:f8_e5m2:bf16,bf16:f8_e4m3:f16
+--attr-scales=wei:common:2,wei:per_oc,src:common:0.25+wei:common:0.5+dst:common:4,src:common:0.25+wei:per_oc+dst:common:4
+64x1184:1184x64
+64x97:97x64
+64x33:33x64
+
+--reset
+--skip-impl=ref
+--stag=any --wtag=any --dtag=any
+--dt=f16:f8_e4m3:f32,f16:f8_e5m2:f16
+--attr-scales=wei:common:2,wei:per_oc,src:common:0.25+wei:common:0.5+dst:common:4,src:common:0.25+wei:per_oc+dst:common:4
+64x1184:1184x64
+64x97:97x64
+64x33:33x64
+
+# 3D (batched) with scales.
+--reset
+--skip-impl=ref
+--stag=any --wtag=any --dtag=abc,any
+--dt=bf16:f8_e4m3:f32,f16:f8_e5m2:f16
+--attr-scales=wei:common:2,wei:per_oc,src:common:0.25+wei:per_oc+dst:common:4
+3x30x256:3x256x64
+2x10x97:2x97x64


### PR DESCRIPTION
Backport of [PR #4426](https://github.com/uxlfoundation/oneDNN/pull/4426)