### PR TITLE
xe: fix missing clobbers in SDPA

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
@@ -22,7 +22,7 @@ namespace microkernel {
 
 using namespace ngen;
 
-Package::Status Package::finalize() {
+Package::Status Package::finalize(const ClobberSet &knownClobbers) {
     using namespace ngen;
 
     auto status = Status::Success;
@@ -35,19 +35,20 @@ Package::Status Package::finalize() {
     Decoder decoder(hw, binary);
     DependencyRegion dstRegion;
 
-    /* Track clobbered registers at full register granularity for simplicity. */
-    std::array<bool, GRF::maxRegs() + 1> clobbered = {false};
+    auto clobbered = knownClobbers;
 
     for (; !decoder.done(); decoder.advance()) {
         // Check for systolic usage.
         auto op = decoder.opcode();
         systolic |= (op == Opcode::dpas || op == Opcode::dpasw);
 
-        // Get destination region and add to clobbers.
+        // Get destination region and add to clobbers. This indeterminate for
+        // indirect or variable sized destinations. In this case, rely on
+        // knownClobbers.
         if (decoder.getOperandRegion(dstRegion, -1)) {
-            if (dstRegion.unspecified) {
-                // Indirect destination -- cannot reliably detect clobbers.
-                status = Status::UncertainClobbers;
+            if (dstRegion.unspecified
+                && !(dstRegion.isValid() && knownClobbers[dstRegion.base])) {
+                    status = Status::UncertainClobbers;
             } else
                 for (int j = 0; j < dstRegion.size; j++)
                     clobbered[dstRegion.base + j] = true;
@@ -71,6 +72,8 @@ Package::Status Package::finalize() {
             len = 0;
         }
     }
+    if (len > 0)
+        clobbers.emplace_back(RegisterRange(base * regBytes, len * regBytes));
 
     // Capture GRF usage from clobbers and arguments.
     uint32_t last = 0;

--- a/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
@@ -25,12 +25,16 @@ using namespace ngen;
 Package::Status Package::finalize(const ClobberSet &knownClobbers) {
     using namespace ngen;
 
-    auto status = Status::Success;
+    auto &status = this->status;
+    status = Status::Success;
 
     auto product = npack::decodeHWIPVersion(gmdidCompat);
     auto hw = getCore(product.family);
 
-    if (hw == HW::Unknown) return Status::UnsupportedHW;
+    if (hw == HW::Unknown) {
+        status = Status::UnsupportedHW;
+        return status;
+    }
 
     Decoder decoder(hw, binary);
     DependencyRegion dstRegion;

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -37,6 +37,7 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
 
     outputCRange = GRFMultirange();
     outputCLayout.clear();
+    knownClobbers.clear();
 
     strategy.forceWGUpdate = WGFixed;
     strategy.forceFixedWGK = true;
@@ -324,7 +325,7 @@ microkernel::Package Generator<hw>::gemmMicrokernelPackage(const GEMMProblem &pr
 
     package.barrierCount = interface.getBarrierCount();
 
-    package.finalize();
+    package.finalize(knownClobbers);
 
     return package;
 }

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
@@ -492,6 +492,18 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
         }
     }
 
+    // Track clobbers which cannot be determined from decoded assembly.
+    auto addClobbers = [&](const std::vector<GRFMultirange> &regs) {
+        for (const auto &reg : regs) {
+            for (auto &r : reg.ranges) {
+                knownClobbers.add(r.getBase(), r.getLen());
+            }
+        }
+    };
+
+    if (strategy.A.base.getModel() != ngen::ModelInvalid) { addClobbers(state.A_regs); }
+    if (strategy.B.base.getModel() != ngen::ModelInvalid) { addClobbers(state.B_regs); }
+
     if (repackC) {
         state.Cr_regs = C_regs;
         C_regCountPerBuffer = state.C_layout.regs();
@@ -521,10 +533,16 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
     // Allocate registers for SLM copies.
     state.Ai_regs.resize(strategy.slmCopies);
     state.Bi_regs.resize(strategy.slmCopies);
-    if (strategy.slmA) for (int q = 0; q < strategy.slmCopies; q++)
-        state.Ai_regs[q] = state.ra.alloc_range(state.Ai_regCount);
-    if (strategy.slmB) for (int q = 0; q < strategy.slmCopies; q++)
-        state.Bi_regs[q] = state.ra.alloc_range(state.Bi_regCount);
+    if (strategy.slmA) {
+        for (int q = 0; q < strategy.slmCopies; q++)
+            state.Ai_regs[q] = state.ra.alloc_range(state.Ai_regCount);
+        addClobbers(state.Ai_regs);
+    }
+    if (strategy.slmB) {
+        for (int q = 0; q < strategy.slmCopies; q++)
+            state.Bi_regs[q] = state.ra.alloc_range(state.Bi_regCount);
+        addClobbers(state.Bi_regs);
+    }
 
     // Allocate registers for A/B sums.
     state.Asr_regs = state.ra.alloc_range(state.Asr_layout.regs());

--- a/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
@@ -83,6 +83,7 @@ protected:
     std::exception_ptr lastException;
     GRFMultirange outputCRange;
     RegisterLayout outputCLayout;
+    microkernel::ClobberSet knownClobbers;
 
     using Injector = PostOpsProblem::Injector<hw>;
     std::unique_ptr<Injector> postOpInjector;

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
@@ -103,10 +103,13 @@ struct Package {
     }
 
     enum class Status {
+        Pending,
         Success,
         UncertainClobbers,
         UnsupportedHW,
     };
+
+    Status status = Status::Pending;
 
     // Analyzes the package and deduces information from the raw microkernel binary.
     Status finalize(const ClobberSet &knownClobbers = {});

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
@@ -17,6 +17,10 @@
 #ifndef GEMMSTONE_INCLUDE_GEMMSTONE_MICROKERNEL_PACKAGE_HPP
 #define GEMMSTONE_INCLUDE_GEMMSTONE_MICROKERNEL_PACKAGE_HPP
 
+#include <algorithm>
+#include <array>
+#include <string>
+
 #include "gemmstone/microkernel/protocol.hpp"
 
 GEMMSTONE_NAMESPACE_START
@@ -25,6 +29,38 @@ namespace microkernel {
 struct Argument;
 struct RegisterRange;
 struct Setting;
+
+struct ClobberSet {
+    static constexpr int maxRegs = 512;
+    std::array<bool, maxRegs> clobbered = {};
+
+    void clear() { clobbered.fill(false); }
+    bool empty() const { return std::none_of(clobbered.begin(), clobbered.end(), [](bool b) { return b; }); }
+    size_t size() const { return clobbered.size(); }
+    bool operator[](uint32_t reg) const { return clobbered[reg]; }
+    bool &operator[](uint32_t reg) { return clobbered[reg]; }
+
+    std::string str() const {
+        std::string out = "{";
+        int i = 0;
+        while (i < maxRegs) {
+            int start = i;
+            while (i < maxRegs && clobbered[i]) i++;
+            i++;
+            if(i == start + 1) continue;
+            if (out.size() > 1) out += ", ";
+            out += "r" + std::to_string(start);
+            if (i - 2 > start) out += "-r" + std::to_string(i - 2);
+        }
+        out += "}";
+        return out;
+    }
+
+    void add(uint32_t regStart, uint32_t regLen) {
+        for (uint32_t i = regStart; i < regStart + regLen && i < maxRegs; i++)
+            clobbered[i] = true;
+    }
+};
 
 // Microkernel package.
 // Fields marked [*] are automatically filled in by finalize().
@@ -73,7 +109,7 @@ struct Package {
     };
 
     // Analyzes the package and deduces information from the raw microkernel binary.
-    Status finalize();
+    Status finalize(const ClobberSet &knownClobbers = {});
 };
 
 // Contiguous span of register space.

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -46,6 +46,32 @@ namespace {
 
 using namespace gemmstone;
 
+status_t validate_microkernel(
+        micro::Package &package, const char *kernel_name) {
+    switch (package.status) {
+        case micro::Package::Status::Pending:
+            VCHECK_SDPA_COND(false,
+                    "%s microkernel package was not finalized before "
+                    "validation.",
+                    kernel_name);
+            break;
+        case micro::Package::Status::Success: return status::success;
+        case micro::Package::Status::UncertainClobbers:
+            VCHECK_SDPA_COND(false,
+                    "%s microkernel has uncertain register clobbers and is "
+                    "not supported by SDPA.",
+                    kernel_name);
+            break;
+        case micro::Package::Status::UnsupportedHW:
+            VCHECK_SDPA_COND(false,
+                    "%s microkernel package is incompatible with the current "
+                    "hardware.",
+                    kernel_name);
+            break;
+    }
+    return status::runtime_error;
+}
+
 /// Returns true if a common quantization value is used for each slice of the
 /// tensor operation. For 4D case it's when the mask's two first bits are on
 /// and two last bits are off.
@@ -1203,6 +1229,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
                 "gemm_kq microkernel generation failure with message: %s",
                 ex.what());
     }
+    CHECK(validate_microkernel(gemm_kq, "gemm_kq"));
 
     /* Ask microkernel provider for microkernel */
     auto vs_strat_override = [&](gemmstone::GEMMStrategy &strat) {
@@ -1241,6 +1268,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
                 "gemm_vs microkernel generation failure with message: %s",
                 ex.what());
     }
+    CHECK(validate_microkernel(gemm_vs, "gemm_vs"));
 
     VDEBUGINFO(4, primitive, sdpa, "kq_gemm: %s, vs_gemm: %s,",
             problem_kq.toString().c_str(), problem_vs.toString().c_str());
@@ -1385,6 +1413,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_kq microkernel generation failure with message: %s",
                 ex.what());
     }
+    CHECK(validate_microkernel(gemm_kq, "gemm_kq"));
 
     try {
         if (use_systolic_ukernel) {
@@ -1403,6 +1432,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_vs microkernel generation failure with message: %s",
                 ex.what());
     }
+    CHECK(validate_microkernel(gemm_vs, "gemm_vs"));
 
     VDEBUGINFO(4, primitive, sdpa,
             "kq_gemm: %s, vs_gemm: %s, vtdA_gemm: %s, ktq_gemm: %s, qdSt: %s\n",
@@ -1435,6 +1465,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_vtdA microkernel generation failure with message: %s",
                 ex.what());
     }
+    CHECK(validate_microkernel(gemm_vtdA, "gemm_vtdA"));
 
     shimOptions.microkernelID++;
     shimOptions.decorator = "vtdA";
@@ -1451,6 +1482,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_ktq microkernel generation failure with message: %s",
                 ex.what());
     }
+    CHECK(validate_microkernel(gemm_ktq, "gemm_ktq"));
 
     shimOptions.microkernelID++;
     shimOptions.decorator = "ktq";
@@ -1467,6 +1499,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_qdSt microkernel generation failure with message: %s",
                 ex.what());
     }
+    CHECK(validate_microkernel(gemm_qdSt, "gemm_qdSt"));
 
     shimOptions.microkernelID++;
     shimOptions.decorator = "qdSt";

--- a/third_party/ngen/ngen_asm.hpp
+++ b/third_party/ngen/ngen_asm.hpp
@@ -425,8 +425,10 @@ bool AsmInstruction::getOperandRegion(autoswsb::DependencyRegion &region, int op
         }
         if (len == 0)
             return false;
-        else if (len == -1)
-            region = DependencyRegion();
+        else if (len == -1) {
+            region = DependencyRegion(hw);
+            region.base = rd.getBase();
+        }
         else
             region = DependencyRegion(hw, GRFRange(rd.getBase(), len));
     } else if (op == Opcode::sendg || op == Opcode::sendgc || op == Opcode::sendgx || op == Opcode::sendgxc) {
@@ -435,8 +437,10 @@ bool AsmInstruction::getOperandRegion(autoswsb::DependencyRegion &region, int op
             desc.all = static_cast<uint64_t>(src[4].imm);
             int execSize = mod.getExecSize();
             int len = desc.dstLen(hw, execSize, static_cast<SharedFunction>(ext & 0xF));
-            if (len == -1)
-                region = DependencyRegion();
+            if (len == -1) {
+                region = DependencyRegion(hw);
+                region.base = rd.getBase();
+            }
             else
                 region = DependencyRegion(hw, GRFRange(rd.getBase(), len));
         } else

--- a/third_party/ngen/ngen_auto_swsb.hpp
+++ b/third_party/ngen/ngen_auto_swsb.hpp
@@ -123,8 +123,9 @@ struct DependencyRegion {
     HW hw;
     std::array<uint32_t, 32> masks;
 
+    static const uint16_t invalidBase = 0xffff;
     DependencyRegion() : DependencyRegion(HW::Unknown) {}
-    explicit DependencyRegion(HW hw_) : base(0), size(0), unspecified{true}, checkWAW{false}, rf{RegFileGRF}, hw{hw_} {
+    explicit DependencyRegion(HW hw_) : base(invalidBase), size(0), unspecified{true}, checkWAW{false}, rf{RegFileGRF}, hw{hw_} {
         for (auto &m: masks) m = 0;
     }
     inline DependencyRegion(HW hw, RegisterRange r);
@@ -148,6 +149,7 @@ struct DependencyRegion {
             masks[size + i] = masks[i];
         size *= 2;
     }
+    bool isValid() const { return base != invalidBase; };
 
 #ifdef NGEN_DEBUG
     inline void dump() const;
@@ -1785,7 +1787,8 @@ PVCWARWA analyzePVCWARWA(HW hw, Program &program, BasicBlock &bb, int phase,
 
         // Check if we can move the dependency further down the pipe.
         if (srcN >= 0) {
-            int after = std::max(0, dep.region.base + dep.region.size - regions[0].base - 1);
+            int depEnd = dep.region.unspecified ? 0 : dep.region.base + dep.region.size;
+            int after = std::max(0, depEnd - regions[0].base - 1);
             bool higherPri = false;
             switch (consumeOp.pipe.type()) {
                 case GeneralizedPipe::vInOrder:

--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -1312,9 +1312,10 @@ bool Instruction12::getOperandRegion(autoswsb::DependencyRegion &region, int opN
 
             if (len == 0)
                 return false;
-            else if (len == -1)
+            else if (len == -1) {
                 region = DependencyRegion(hw);
-            else
+                region.base = base;
+            } else
                 region = DependencyRegion(hw, GRFRange(base, len));
             return true;
         }
@@ -1335,9 +1336,10 @@ bool Instruction12::getOperandRegion(autoswsb::DependencyRegion &region, int opN
                 case -1: {
                     if (sendg.dstRegFile == RegFileARF) return false;
                     int dstLen = getSendgDesc().dstLen(hw, 1 << common.execSize, static_cast<SharedFunction>(sendg.sfid));
-                    if (dstLen == -1)
+                    if (dstLen == -1) {
                         region = DependencyRegion(hw);
-                    else
+                        region.base = sendg.dstReg;
+                    } else
                         region = DependencyRegion(hw, GRFRange(sendg.dstReg, dstLen));
                     break;
                 }
@@ -1392,9 +1394,10 @@ bool Instruction12::getOperandRegion(autoswsb::DependencyRegion &region, int opN
             }
             if (regNum == 0x1FF)
                 return false;
-            else if (len == -1)
+            else if (len == -1) {
                 region = DependencyRegion(hw);
-            else
+                region.base = regNum;
+            } else
                 region = DependencyRegion(hw, GRFRange(regNum, len));
             return true;
         }


### PR DESCRIPTION
The current microkernel::Package API determines clobbered registers by decoding instructions. Some instructions can have a runtime determined output size (such as block_2d loads), and these are silently ignored. The end result is that IGC may allocate variables in regions that are clobbered by the microkernel and corrupt the kernel behavior.

This PR fixes this by erroring if we cannot reliably determine the clobbered registers and providing an override API so that microkernel generators can explicitly communicate these clobbered regions.