### PR TITLE
fix: xpu: profiler: fix segfaults from polling checks in blocking wait calls

### DIFF
--- a/src/gpu/intel/ocl/stream.hpp
+++ b/src/gpu/intel/ocl/stream.hpp
@@ -55,8 +55,13 @@ struct stream_t : public intel::stream_t {
 
     status_t wait() override {
         auto status = impl()->wait();
-        // processes and logs any pending primitives after the blocking wait
-        if (auto *vp = verbose_profiler()) vp->check_for_completed_primitives();
+        // A verbose profiler polling call cannot be added here since sporadic
+        // wait() calls outside the normal primitive execution flow may
+        // interrupt in-flight primitives before all their events are complete.
+        // This causes the profiler to incorrectly log incomplete execution
+        // times and invalidate event storage for pending operations. Unlogged
+        // primitives are instead captured at the next after_exec_hook()
+        // polling cycle or during profiler destruction.
         return status;
     }
 

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -61,8 +61,13 @@ struct stream_t : public gpu::intel::stream_t {
 
     status_t wait() override {
         auto status = impl()->wait();
-        // processes and logs any pending primitives after the blocking wait
-        if (auto *vp = verbose_profiler()) vp->check_for_completed_primitives();
+        // A verbose profiler polling call cannot be added here since sporadic
+        // wait() calls outside the normal primitive execution flow may
+        // interrupt in-flight primitives before all their events are complete.
+        // This causes the profiler to incorrectly log incomplete execution
+        // times and invalidate event storage for pending operations. Unlogged
+        // primitives are instead captured at the next after_exec_hook()
+        // polling cycle or during profiler destruction.
         return status;
     }
 

--- a/src/xpu/stream_profiler.cpp
+++ b/src/xpu/stream_profiler.cpp
@@ -67,12 +67,6 @@ void verbose_profiler_t::check_for_completed_primitives() {
             continue;
         }
 
-        // TODO: Fix pd_info generation to ensure it's never empty when
-        // profiling occurs. Remove this safeguard once pd_info is guaranteed
-        // to be populated. This was observed in graph test cases
-        // (genindex.json with DNNL_VERBOSE=profile_exec).
-        if (prof_data.pd_info_.empty()) { continue; }
-
         // Check if the current primitive has finished executing and break
         // the loop if it is pending completion
         if (!is_event_complete(evts.back())) {
@@ -118,8 +112,6 @@ void verbose_profiler_t::wait_for_pending_primitives() {
     if (!profiling_data_.empty())
         VERROR(primitive, runtime,
                 "profiling error: failed to log all pending primitives");
-
-    reset();
 }
 
 } // namespace xpu


### PR DESCRIPTION
# Description

This PR is a fix for segfaults/invalid pointer errors encountered during sporadic `stream->wait()` calls when running the asynchronous verbose mode implemented in (PR #5102). The profiler implementation includes a polling check within `stream->wait()` that prints and clears any unlogged primitives in the profiler after the `impl()->wait()` call.  But this assumes that `stream->wait() is only called post execution when event profiler collection is complete.

The assumption breaks for two cases:
```
$ ONEDNN_VERBOSE=1 ./tests/benchdnn/benchdnn --mode-modifier=P --graph --engine=gpu --dt=10:f16+12:f16+13:f16+15:f16+30:f16+31:f16+33:f16+35:f16+100:f16+101:f16+102:f16+103:f16+104:f16+105:f16 --case=complex_fusion/mha/gqa-plain-training-bwd-w-dropout-bf16-f32.json
$ ONEDNN_VERBOSE=1 ctest -R test_batch_normalization_gpu --verbose
```

resulting in segfaults when the profiler queries unregistered primitives.

The issue is fixed with two updates:
- skipping empty profiling_data_ values during polling in :
https://github.com/uxlfoundation/oneDNN/blob/b45cc69dd0e5ddb7fb22c53787f05166b03eab87/src/xpu/stream_profiler.cpp#L70
   This check and TODO was added to account for empty verbose prints for graph test cases. The TODO is already resolved in commit [17ec0a](https://github.com/uxlfoundation/oneDNN/pull/5102/changes/17ec0aa6286666408555827cf643ba6d87f88e44) and no longer observed for genindex. 
- removing the additional polling `check_for_pending_primitives()` from `stream->wait()` calls. This removes sporadic profiler behavior during `stream->wait()` calls at odd places  and does not affect profiling operation as the unlogged primitives are printed in the next polling cycle.
 
Thanks @vpirogov for catching this.