### PR TITLE
tests: shred test_thread.hpp

### DIFF
--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -384,9 +384,13 @@ int init_kernel(kernel_args_t &kernel_args) {
     // Create BRGeMM kernel, analogous to primitive creation.
     // ctx_init can here be used to select core type on hetero ISA with TBB.
     brgemm_kernel_t **brgemm_kernel_addr = &kernel_args.brgemm_kernel_;
-    DNN_SAFE(create_in_thr_ctx(prb->ctx_init, brgemm_kernel_create,
-                     brgemm_kernel_addr, brgemm_desc),
-            WARN);
+    // The lambda performs the return type conversion (dnnl_status_t -> int)
+    // required by create_in_thr_ctx.
+    std::function<int()> brgemm_kernel_create_fn = [&] {
+        DNN_SAFE(brgemm_kernel_create(brgemm_kernel_addr, brgemm_desc), WARN);
+        return OK;
+    };
+    SAFE(create_in_thr_ctx(prb->ctx_init, brgemm_kernel_create_fn), WARN);
 
 #if defined(brg_x64)
     // Palette configuration is required here to have `kernel_args`

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -677,11 +677,15 @@ int measure_perf(const thr_ctx_t &ctx, res_t *res, perf_function_t &perf_func,
     // For async threadpool CPU: use aggregate as well, similar to DPCPP CPU.
     int ret = OK;
     if (is_async(engine)) {
-        ret = execute_in_thr_ctx(
-                ctx, measure_perf_aggregate, t, v_stream, perf_func, dnnl_args);
+        std::function<int()> measure_perf_aggregate_fn = std::bind(
+                measure_perf_aggregate, std::ref(t), std::cref(v_stream),
+                std::ref(perf_func), std::ref(dnnl_args));
+        ret = execute_in_thr_ctx(ctx, measure_perf_aggregate_fn);
     } else {
-        ret = execute_in_thr_ctx(ctx, measure_perf_individual, t, v_stream[0],
-                perf_func, dnnl_args[0]);
+        std::function<int()> measure_perf_individual_fn = std::bind(
+                measure_perf_individual, std::ref(t), std::ref(v_stream[0]),
+                std::ref(perf_func), std::ref(dnnl_args[0]));
+        ret = execute_in_thr_ctx(ctx, measure_perf_individual_fn);
     }
 
     res->state = (ret == OK ? EXECUTED : FAILED);

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -45,8 +45,6 @@
 
 #include "cpu/platform.hpp"
 
-#include "tests/test_thread.hpp"
-
 #include "dnnl_common.hpp"
 #include "dnnl_memory.hpp"
 

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -40,7 +40,7 @@
 #include "utils/prb.hpp"
 #include "utils/stream_kind.hpp"
 
-#include "tests/test_thread.hpp"
+#include "tests/test_thread_decl.hpp"
 
 #define for_ for
 

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -201,10 +201,12 @@ inline int check_caches(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &primw,
     // of infinite cache though.
     if (!has_bench_mode_modifier(mode_modifier_t::par_create)) {
         const_dnnl_primitive_desc_t pd = query_pd(primw);
-        SAFE(create_in_thr_ctx(ctx_init, check_pd_cache, pd, res), WARN);
+        std::function<int()> pd_cache_fn = std::bind(check_pd_cache, pd, res);
+        SAFE(create_in_thr_ctx(ctx_init, pd_cache_fn), WARN);
         // Check primitive is picked up from the cache if applicable.
-        SAFE(create_in_thr_ctx(ctx_init, check_primitive_cache, primw, res),
-                WARN);
+        std::function<int()> prim_cache_fn
+                = std::bind(check_primitive_cache, std::ref(primw), res);
+        SAFE(create_in_thr_ctx(ctx_init, prim_cache_fn), WARN);
     }
 
     // Check primitive is picked up from the persistent cache if applicable.
@@ -483,8 +485,9 @@ inline int init_prim(const thr_ctx_t &thr_ctx,
             const init_pd_func_t &, const base_prb_t *, res_t *, dir_t,
             const_dnnl_primitive_desc_t, bool)
             = init_prim;
-    return create_in_thr_ctx(thr_ctx, f, user_prim, init_pd_func, base_prb, res,
-            dir, hint, is_service_prim);
+    std::function<int()> call_fn = std::bind(f, std::ref(user_prim),
+            init_pd_func, base_prb, res, dir, hint, is_service_prim);
+    return create_in_thr_ctx(thr_ctx, call_fn);
 }
 
 // `setup_cmp_func` function is defined in every driver.

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -37,8 +37,6 @@
 #include "src/xpu/ze/usm_utils.hpp"
 #endif
 
-#include "tests/test_thread.hpp"
-
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "dnnl_memory.hpp"

--- a/tests/benchdnn/graph/graph_memory.cpp
+++ b/tests/benchdnn/graph/graph_memory.cpp
@@ -19,6 +19,8 @@
 
 #include "oneapi/dnnl/dnnl_graph.hpp"
 
+#include <cstring>
+
 // 0.75f is taken randomly and is subject to change in future.
 static constexpr float capacity_factor = 0.75f;
 

--- a/tests/benchdnn/utils/engine.cpp
+++ b/tests/benchdnn/utils/engine.cpp
@@ -31,7 +31,7 @@
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
 #include "oneapi/dnnl/dnnl_threadpool.hpp"
-#include "tests/test_thread.hpp"
+#include "tests/test_thread_decl.hpp"
 #endif
 
 // Engine kind used to run oneDNN primitives for testing

--- a/tests/benchdnn/utils/parallel.cpp
+++ b/tests/benchdnn/utils/parallel.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "tests/test_thread.hpp"
+#include "tests/test_thread_decl.hpp"
 
 #include "utils/parallel.hpp"
 

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1517,7 +1517,7 @@ bool parse_ctx(std::vector<thr_ctx_t> &ctx,
                     "(TBB runtime only).\n");
 
     auto str2ctx = [&option_name](const char *str) {
-        thr_ctx_t result = default_thr_ctx;
+        thr_ctx_t result = get_default_thr_ctx();
         try {
             size_t start_pos = 0;
             /* concurrency piece */

--- a/tests/benchdnn/utils/parser.hpp
+++ b/tests/benchdnn/utils/parser.hpp
@@ -27,12 +27,13 @@
 
 #include "dnn_types.hpp"
 #include "dnnl_debug.hpp"
-#include "tests/test_thread.hpp"
 #include "utils/dims.hpp"
 #include "utils/execution_mode.hpp"
 #include "utils/impl_filter.hpp"
 #include "utils/settings.hpp"
 #include "utils/stringstream.hpp"
+
+#include "tests/thread_context.hpp"
 
 namespace parser {
 

--- a/tests/benchdnn/utils/perf_report.hpp
+++ b/tests/benchdnn/utils/perf_report.hpp
@@ -32,6 +32,8 @@
 #include "common.hpp"
 #include "utils/timer.hpp"
 
+#include "tests/thread_context.hpp"
+
 struct base_perf_report_t {
     base_perf_report_t(const char *perf_template) : pt_(perf_template) {}
     virtual ~base_perf_report_t() = default;

--- a/tests/benchdnn/utils/settings.hpp
+++ b/tests/benchdnn/utils/settings.hpp
@@ -100,8 +100,8 @@ struct base_settings_t {
     std::vector<attr_t::dropout_t> dropout {attr_t::dropout_t()};
     std::vector<attr_t::rounding_mode_t> rounding_mode {
             attr_t::rounding_mode_t()};
-    std::vector<thr_ctx_t> ctx_init {default_thr_ctx};
-    std::vector<thr_ctx_t> ctx_exe {default_thr_ctx};
+    std::vector<thr_ctx_t> ctx_init {get_default_thr_ctx()};
+    std::vector<thr_ctx_t> ctx_exe {get_default_thr_ctx()};
     impl_filter_t impl_filter;
     const char *pattern = nullptr;
     // Non-parsed members

--- a/tests/benchdnn/utils/settings.hpp
+++ b/tests/benchdnn/utils/settings.hpp
@@ -20,6 +20,8 @@
 
 #include "utils/impl_filter.hpp"
 
+#include "tests/thread_context.hpp"
+
 struct base_settings_t {
     struct settings_attributes_t {
         void clear() { attrs_.clear(); }

--- a/tests/benchdnn/utils/stream_kind.cpp
+++ b/tests/benchdnn/utils/stream_kind.cpp
@@ -23,7 +23,7 @@
 
 #include "utils/dnnl_query.hpp"
 
-#include "tests/test_thread.hpp"
+#include "tests/test_thread_decl.hpp"
 
 #include <thread>
 #endif

--- a/tests/benchdnn/zeropad/zeropad.cpp
+++ b/tests/benchdnn/zeropad/zeropad.cpp
@@ -160,7 +160,7 @@ int doit(const prb_t *prb, res_t *res) {
         res->obytes = dnnl_memory_desc_get_size(data_md)
                 - dnnl_memory_desc_get_size(plain_data_md);
     }
-    return measure_perf(default_thr_ctx, res, perf_func_, args);
+    return measure_perf(get_default_thr_ctx(), res, perf_func_, args);
 }
 
 } // namespace zeropad

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -64,7 +64,10 @@
 #include "src/common/nstl.hpp"
 #include "src/common/primitive_cache_test_api.hpp"
 #include "tests/gtests/test_malloc.hpp"
+
+// Explicit dependency on dnnl::impl::parallel calls.
 #include "tests/test_thread.hpp"
+#include "tests/test_thread_decl.hpp"
 
 #include "src/cpu/platform.hpp"
 

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -16,6 +16,7 @@
 #include <tuple>
 
 #include "tests/test_thread.hpp"
+#include "tests/test_thread_decl.hpp"
 
 std::ostream &operator<<(std::ostream &os, const thr_ctx_t &ctx) {
     if (ctx.max_concurrency == get_default_thr_ctx().max_concurrency)
@@ -463,6 +464,16 @@ thread_local threadpool_t::worker_data_t *threadpool_t::worker_self_ = nullptr;
 
 namespace dnnl {
 
+// Original threadpool utils are used by the scoped_tp_activation_t and thus
+// need to be re-declared because of the hack above.
+namespace impl {
+namespace threadpool_utils {
+void activate_threadpool(dnnl::threadpool_interop::threadpool_iface *tp);
+void deactivate_threadpool();
+dnnl::threadpool_interop::threadpool_iface *get_active_threadpool();
+} // namespace threadpool_utils
+} // namespace impl
+
 namespace testing {
 // Threadpool singleton
 dnnl::threadpool_interop::threadpool_iface *get_threadpool(
@@ -480,6 +491,24 @@ dnnl::threadpool_interop::threadpool_iface *get_threadpool(
         exit(1);
     }
     return &(res.first->second);
+}
+
+scoped_tp_activation_t::scoped_tp_activation_t(
+        dnnl::threadpool_interop::threadpool_iface *tp) {
+    impl::threadpool_utils::activate_threadpool(tp);
+}
+
+scoped_tp_activation_t::~scoped_tp_activation_t() {
+    impl::threadpool_utils::deactivate_threadpool();
+}
+
+scoped_tp_deactivation_t::scoped_tp_deactivation_t() {
+    impl::threadpool_utils::deactivate_threadpool();
+}
+
+scoped_tp_deactivation_t::~scoped_tp_deactivation_t() {
+    // we always use the same threadpool that is returned by `get_threadpool()`
+    impl::threadpool_utils::activate_threadpool(get_threadpool());
 }
 
 } // namespace testing

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -18,17 +18,17 @@
 #include "tests/test_thread.hpp"
 
 std::ostream &operator<<(std::ostream &os, const thr_ctx_t &ctx) {
-    if (ctx.max_concurrency == default_thr_ctx.max_concurrency)
+    if (ctx.max_concurrency == get_default_thr_ctx().max_concurrency)
         os << "auto:";
     else
         os << ctx.max_concurrency << ":";
 
-    if (ctx.core_type == default_thr_ctx.core_type)
+    if (ctx.core_type == get_default_thr_ctx().core_type)
         os << "auto:";
     else
         os << ctx.core_type << ":";
 
-    if (ctx.nthr_per_core == default_thr_ctx.nthr_per_core)
+    if (ctx.nthr_per_core == get_default_thr_ctx().nthr_per_core)
         os << "auto";
     else
         os << ctx.nthr_per_core;
@@ -506,3 +506,164 @@ int get_max_concurrency() {
 } // namespace dnnl
 
 #endif
+
+#ifdef TBB_INTERFACE_VERSION
+// tbb constraints on core type appear in 2021.2
+// tbb constraints on max_concurrency appear in 2020
+// we check only for 2021.2 to enable thread context knobs
+#define DNNL_TBB_CONSTRAINTS_ENABLED (TBB_INTERFACE_VERSION >= 12020)
+// API to do explicit finalization was introduced in 2021.6.
+#define DNNL_TBB_NEED_EXPLICIT_FINALIZE (TBB_INTERFACE_VERSION >= 12060)
+#else
+#define DNNL_TBB_CONSTRAINTS_ENABLED 0
+#define DNNL_TBB_NEED_EXPLICIT_FINALIZE 0
+#endif
+
+#define DNNL_TBB_THREADING_WITH_CONSTRAINTS \
+    (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB) \
+            && DNNL_TBB_CONSTRAINTS_ENABLED
+#define DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS \
+    (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB) \
+            && !DNNL_TBB_CONSTRAINTS_ENABLED
+
+#if DNNL_TBB_THREADING_WITH_CONSTRAINTS
+#include "oneapi/tbb/info.h"
+#endif
+
+void finalize_tbb() {
+#if DNNL_TBB_NEED_EXPLICIT_FINALIZE
+    oneapi::tbb::task_scheduler_handle handle
+            = oneapi::tbb::task_scheduler_handle {oneapi::tbb::attach {}};
+    oneapi::tbb::finalize(handle, std::nothrow);
+#endif
+}
+
+const thr_ctx_t &get_default_thr_ctx() {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ \
+        || DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL \
+        || DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
+    static const thr_ctx_t default_thr_ctx = {0, -1, 0};
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    static const thr_ctx_t default_thr_ctx = {omp_get_max_threads(), -1, 0};
+#elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
+    static const thr_ctx_t default_thr_ctx = {tbb::task_arena::automatic,
+            tbb::task_arena::automatic, tbb::task_arena::automatic};
+#endif
+    return default_thr_ctx;
+}
+
+#define THR_CTX_ASSERT(check, msg_fmt, ...) \
+    do { \
+        if (!(check)) { \
+            fprintf(stderr, msg_fmt, __VA_ARGS__); \
+            exit(1); \
+        } \
+    } while (0)
+
+// Single version of each function; the runtime-specific logic is handled inside
+// via preprocessor branching.
+int create_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f) {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ \
+        || DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
+    THR_CTX_ASSERT(ctx.core_type == get_default_thr_ctx().core_type
+                    && ctx.max_concurrency
+                            == get_default_thr_ctx().max_concurrency
+                    && ctx.nthr_per_core == get_default_thr_ctx().nthr_per_core,
+            "Threading knobs not supported for this runtime: %s\n",
+            DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ
+                    ? "sequential runtime has no threading"
+                    : "TBB version is too old (>=2021.2 required)");
+    return f();
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    THR_CTX_ASSERT(ctx.core_type == get_default_thr_ctx().core_type,
+            "core type %d is not supported for OMP runtime\n", ctx.core_type);
+
+    auto max_nthr = omp_get_max_threads();
+    omp_set_num_threads(ctx.max_concurrency);
+    auto st = f();
+    omp_set_num_threads(max_nthr);
+    return st;
+#elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
+    static auto core_types
+            = tbb::info::core_types(); // sorted by the relative strength
+
+    if ((ctx.core_type != get_default_thr_ctx().core_type)
+            && ((size_t)ctx.core_type >= core_types.size()))
+        printf("WARNING: TBB smallest core has index %d. Using this "
+               "instead of %d.\n",
+                (int)core_types.size() - 1, ctx.core_type);
+    size_t core_type_id = (size_t)ctx.core_type < core_types.size()
+            ? ctx.core_type
+            : core_types.size() - 1;
+    auto core_type = ctx.core_type == tbb::task_arena::automatic
+            ? tbb::task_arena::automatic
+            : core_types[core_type_id];
+    auto arena = tbb::task_arena {
+            tbb::task_arena::constraints {}
+                    .set_core_type(core_type)
+                    .set_max_threads_per_core(ctx.nthr_per_core)
+                    .set_max_concurrency(ctx.max_concurrency)};
+    return arena.execute([&] { return f(); });
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    THR_CTX_ASSERT(ctx.core_type == get_default_thr_ctx().core_type,
+            "core type %d is not supported for TP runtime\n", ctx.core_type);
+
+    auto tp = dnnl::testing::get_threadpool(ctx);
+    auto stp = dnnl::testing::scoped_tp_activation_t(tp);
+    return f();
+#else
+#error "unsupported threading runtime!"
+#endif
+}
+
+int execute_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f) {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ \
+        || DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
+    THR_CTX_ASSERT(ctx.core_type == get_default_thr_ctx().core_type
+                    && ctx.max_concurrency
+                            == get_default_thr_ctx().max_concurrency
+                    && ctx.nthr_per_core == get_default_thr_ctx().nthr_per_core,
+            "Threading knobs not supported for this runtime: %s\n",
+            DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ
+                    ? "sequential runtime has no threading"
+                    : "TBB version is too old (>=2021.2 required)");
+    return f();
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    THR_CTX_ASSERT(ctx.core_type == get_default_thr_ctx().core_type,
+            "core type %d is not supported for OMP runtime\n", ctx.core_type);
+
+    auto max_nthr = omp_get_max_threads();
+    omp_set_num_threads(ctx.max_concurrency);
+    auto st = f();
+    omp_set_num_threads(max_nthr);
+    return st;
+#elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
+    static auto core_types
+            = tbb::info::core_types(); // sorted by the relative strength
+
+    if ((ctx.core_type != get_default_thr_ctx().core_type)
+            && ((size_t)ctx.core_type >= core_types.size()))
+        printf("WARNING: TBB smallest core has index %d. Using this "
+               "instead of %d.\n",
+                (int)core_types.size() - 1, ctx.core_type);
+    size_t core_type_id = (size_t)ctx.core_type < core_types.size()
+            ? ctx.core_type
+            : core_types.size() - 1;
+    auto core_type = ctx.core_type == tbb::task_arena::automatic
+            ? tbb::task_arena::automatic
+            : core_types[core_type_id];
+    auto arena = tbb::task_arena {
+            tbb::task_arena::constraints {}
+                    .set_core_type(core_type)
+                    .set_max_threads_per_core(ctx.nthr_per_core)
+                    .set_max_concurrency(ctx.max_concurrency)};
+    return arena.execute([&] { return f(); });
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    // The function f shall take an interop obj as last argument.
+    THR_CTX_ASSERT(ctx.core_type == get_default_thr_ctx().core_type,
+            "core type %d is not supported for TP runtime\n", ctx.core_type);
+    return f();
+#else
+#error "unsupported threading runtime!"
+#endif
+}

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -464,8 +464,8 @@ thread_local threadpool_t::worker_data_t *threadpool_t::worker_self_ = nullptr;
 
 namespace dnnl {
 
-// Original threadpool utils are used by the scoped_tp_activation_t and thus
-// need to be re-declared because of the hack above.
+// Original threadpool utils are used by the scoped_tp_activation_t and, thus,
+// require re-declaration because of the hack above.
 namespace impl {
 namespace threadpool_utils {
 void activate_threadpool(dnnl::threadpool_interop::threadpool_iface *tp);
@@ -478,8 +478,7 @@ namespace testing {
 // Threadpool singleton
 dnnl::threadpool_interop::threadpool_iface *get_threadpool(
         const thr_ctx_t &ctx) {
-    // global default threadpool is returned when thr context is
-    // default
+    // The default threadpool is returned when `ctx` is default.
     static std::unordered_map<int, dnnl::testing::threadpool_t> tp_map;
     auto ret_val = tp_map.find(ctx.max_concurrency);
     if (ret_val != tp_map.end()) return &(ret_val->second);
@@ -507,14 +506,17 @@ scoped_tp_deactivation_t::scoped_tp_deactivation_t() {
 }
 
 scoped_tp_deactivation_t::~scoped_tp_deactivation_t() {
-    // we always use the same threadpool that is returned by `get_threadpool()`
+    // The same threadpool from `get_threadpool()` is re-used.
     impl::threadpool_utils::activate_threadpool(get_threadpool());
 }
 
 } // namespace testing
 
-// Implement a dummy threadpools_utils protocol here so that it is picked up
-// by parallel*() calls from the tests.
+// `parallel*(...)` calls in tests use `testing_threadpool_utils` namespace
+// when it comes to threadpool validation. It happens in `test_thread.hpp` when
+// the header substitutes the namespace and includes `dnnl_thread.hpp`. Since
+// header declares symbols, they must be defined and they are defined here since
+// this translation unit picks up `test_thread.hpp` as well.
 namespace impl {
 namespace testing_threadpool_utils {
 void activate_threadpool(dnnl::threadpool_interop::threadpool_iface *tp) {}
@@ -589,8 +591,6 @@ const thr_ctx_t &get_default_thr_ctx() {
         } \
     } while (0)
 
-// Single version of each function; the runtime-specific logic is handled inside
-// via preprocessor branching.
 int create_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f) {
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ \
         || DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
@@ -613,8 +613,8 @@ int create_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f) {
     omp_set_num_threads(max_nthr);
     return st;
 #elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
-    static auto core_types
-            = tbb::info::core_types(); // sorted by the relative strength
+    // sorted by the relative strength
+    static auto core_types = tbb::info::core_types();
 
     if ((ctx.core_type != get_default_thr_ctx().core_type)
             && ((size_t)ctx.core_type >= core_types.size()))
@@ -667,8 +667,8 @@ int execute_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f) {
     omp_set_num_threads(max_nthr);
     return st;
 #elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
-    static auto core_types
-            = tbb::info::core_types(); // sorted by the relative strength
+    // sorted by the relative strength
+    static auto core_types = tbb::info::core_types();
 
     if ((ctx.core_type != get_default_thr_ctx().core_type)
             && ((size_t)ctx.core_type >= core_types.size()))
@@ -688,7 +688,6 @@ int execute_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f) {
                     .set_max_concurrency(ctx.max_concurrency)};
     return arena.execute([&] { return f(); });
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    // The function f shall take an interop obj as last argument.
     THR_CTX_ASSERT(ctx.core_type == get_default_thr_ctx().core_type,
             "core type %d is not supported for TP runtime\n", ctx.core_type);
     return f();

--- a/tests/test_thread.hpp
+++ b/tests/test_thread.hpp
@@ -14,11 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef TEST_THREAD_HPP
-#define TEST_THREAD_HPP
-
-#include <functional>
-#include <iostream>
+#ifndef TESTS_TEST_THREAD_HPP
+#define TESTS_TEST_THREAD_HPP
 
 #include "oneapi/dnnl/dnnl_config.h"
 
@@ -47,22 +44,6 @@
 
 #endif
 
-// Here we define some types in global namespace to handle customized
-// threading context for creation and execution
-struct thr_ctx_t {
-    int max_concurrency;
-    int core_type;
-    int nthr_per_core;
-
-    bool operator==(const thr_ctx_t &rhs) const {
-        return max_concurrency == rhs.max_concurrency
-                && core_type == rhs.core_type
-                && nthr_per_core == rhs.nthr_per_core;
-    }
-    bool operator!=(const thr_ctx_t &rhs) const { return !(*this == rhs); }
-    void *get_interop_obj() const;
-};
-
 // This hack renames the namespaces used by threading functions for
 // threadpool-related functions so that the calls to dnnl::impl::parallel*()
 // from the test use a special testing threadpool.
@@ -84,80 +65,5 @@ struct thr_ctx_t {
 #ifndef COMMON_DNNL_THREAD_HPP
 #error "src/common/dnnl_thread.hpp" has an unexpected header guard
 #endif
-
-std::ostream &operator<<(std::ostream &os, const thr_ctx_t &ctx);
-
-const thr_ctx_t &get_default_thr_ctx();
-
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-#include "oneapi/dnnl/dnnl_threadpool_iface.hpp"
-namespace dnnl {
-
-// Original threadpool utils are used by the scoped_tp_activation_t and thus
-// need to be re-declared because of the hack above.
-namespace impl {
-namespace threadpool_utils {
-void activate_threadpool(dnnl::threadpool_interop::threadpool_iface *tp);
-void deactivate_threadpool();
-dnnl::threadpool_interop::threadpool_iface *get_active_threadpool();
-int get_max_concurrency();
-} // namespace threadpool_utils
-} // namespace impl
-
-namespace testing {
-
-dnnl::threadpool_interop::threadpool_iface *get_threadpool(
-        const thr_ctx_t &ctx = get_default_thr_ctx());
-
-// Sets the testing threadpool as active for the lifetime of the object.
-// Required for the tests that throw to work.
-struct scoped_tp_activation_t {
-    scoped_tp_activation_t(dnnl::threadpool_interop::threadpool_iface *tp_
-            = get_threadpool()) {
-        impl::threadpool_utils::activate_threadpool(tp_);
-    }
-    ~scoped_tp_activation_t() {
-        impl::threadpool_utils::deactivate_threadpool();
-    }
-};
-
-struct scoped_tp_deactivation_t {
-    scoped_tp_deactivation_t() {
-        impl::threadpool_utils::deactivate_threadpool();
-    }
-    ~scoped_tp_deactivation_t() {
-        // we always use the same threadpool that is returned by `get_threadpool()`
-        impl::threadpool_utils::activate_threadpool(get_threadpool());
-    }
-};
-
-} // namespace testing
-} // namespace dnnl
-#endif
-
-// These are free functions to allow running a function in a given threading
-// context.
-// A threading context is defined by:
-// - number of threads
-// - type of cores (TBB only)
-// - threads per core (TBB only)
-
-// Note: we have to differentiate creation and execution in thread
-// context because of threadpool as it uses different mecanisms in
-// both (in execution, tp is passed in stream)
-//
-// Definitions live in test_thread.cpp where the runtime-specific logic is
-// handled inside a single version of each function.
-
-int create_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
-// The function f shall take an interop obj as last argument
-int execute_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
-
-// TBB runtime may crash when it is used under CTest. This is a known TBB
-// limitation that can be worked around by doing explicit finalization.
-// The API to do that was introduced in 2021.6.0. When using an older TBB
-// runtime the crash may still happen.
-// Appropriate header lives in a `src/common/dnnl_thread_tbb_proxy.hpp`.
-void finalize_tbb();
 
 #endif

--- a/tests/test_thread.hpp
+++ b/tests/test_thread.hpp
@@ -17,6 +17,7 @@
 #ifndef TEST_THREAD_HPP
 #define TEST_THREAD_HPP
 
+#include <functional>
 #include <iostream>
 
 #include "oneapi/dnnl/dnnl_config.h"
@@ -187,9 +188,7 @@ struct scoped_tp_deactivation_t {
         || DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
 
 #define RUN_IN_THR_CTX(name) \
-    template <typename F, typename... Args_t> \
-    auto name(const thr_ctx_t &ctx, F &&f, \
-            Args_t &...args) -> decltype(f(args...)) { \
+    inline int name(const thr_ctx_t &ctx, const std::function<int()> &f) { \
 \
         THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type \
                         && ctx.max_concurrency \
@@ -200,7 +199,7 @@ struct scoped_tp_deactivation_t {
                         ? "sequential runtime has no threading" \
                         : "TBB version is too old (>=2021.2 required)"); \
 \
-        return f(args...); \
+        return f(); \
     }
 
 RUN_IN_THR_CTX(create_in_thr_ctx)
@@ -209,9 +208,7 @@ RUN_IN_THR_CTX(execute_in_thr_ctx)
 
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
 #define RUN_IN_THR_CTX(name) \
-    template <typename F, typename... Args_t> \
-    auto name(const thr_ctx_t &ctx, F &&f, \
-            Args_t &...args) -> decltype(f(args...)) { \
+    inline int name(const thr_ctx_t &ctx, const std::function<int()> &f) { \
 \
         THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type, \
                 "core type %d is not supported for OMP runtime\n", \
@@ -219,7 +216,7 @@ RUN_IN_THR_CTX(execute_in_thr_ctx)
 \
         auto max_nthr = omp_get_max_threads(); \
         omp_set_num_threads(ctx.max_concurrency); \
-        auto st = f(args...); \
+        auto st = f(); \
         omp_set_num_threads(max_nthr); \
         return st; \
     }
@@ -230,46 +227,9 @@ RUN_IN_THR_CTX(execute_in_thr_ctx)
 
 #elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
 
-// XXX: Some compilers cannot expand a parameter pack when it is
-// used inside a lambda function. E.g. `[&]{ return f(args...); }`
-// will cause the aforementioned issue. The workaround is to convert
-// the parameter pack into a tuple, then convert it to a parameter pack again
-// and then expand it in the regular way. This way the compiler can digest
-// the code.
-// The return type is not deduced due to the same issue. The solution for
-// that is to assume that the return type is always integer and convert the
-// return value to `dnnl_status_t` if necessary.
-template <typename T>
-constexpr size_t get_number_args() {
-    return std::tuple_size<typename std::remove_reference<T>::type> {};
-}
-
-template <size_t i, typename R>
-struct params_pack_helper_t {
-    template <typename F, typename T, typename... Args_t>
-    static R expand_and_call(F &&f, T &packed_args, Args_t &...unpacked_args) {
-        constexpr size_t cnt = (i == SIZE_MAX)
-                ? get_number_args<decltype(packed_args)>()
-                : i;
-        constexpr size_t idx = get_number_args<decltype(packed_args)>() - cnt;
-        return (R)params_pack_helper_t<cnt - 1, R>::expand_and_call(
-                f, packed_args, unpacked_args..., std::get<idx>(packed_args));
-    }
-};
-
-template <typename R>
-struct params_pack_helper_t<0, R> {
-    template <typename F, typename T, typename... Args_t>
-    static R expand_and_call(F &&f, T &packed_args, Args_t &...unpacked_args) {
-        return (R)f(unpacked_args...);
-    }
-};
-
 #include "oneapi/tbb/info.h"
 #define RUN_IN_THR_CTX(name) \
-    template <typename F, typename... Args_t> \
-    auto name(const thr_ctx_t &ctx, F &&f, \
-            Args_t &...args) -> decltype(f(args...)) { \
+    inline int name(const thr_ctx_t &ctx, const std::function<int()> &f) { \
         static auto core_types = tbb::info:: \
                 core_types(); /* sorted by the relative strength       */ \
 \
@@ -289,11 +249,7 @@ struct params_pack_helper_t<0, R> {
                         .set_core_type(core_type) \
                         .set_max_threads_per_core(ctx.nthr_per_core) \
                         .set_max_concurrency(ctx.max_concurrency)}; \
-        auto packed_args = std::make_tuple(std::ref(args)...); \
-        return (decltype(f(args...)))arena.execute([&] { \
-            return params_pack_helper_t<SIZE_MAX, int>::expand_and_call( \
-                    f, packed_args); \
-        }); \
+        return arena.execute([&] { return f(); }); \
     }
 
 RUN_IN_THR_CTX(create_in_thr_ctx)
@@ -301,24 +257,22 @@ RUN_IN_THR_CTX(execute_in_thr_ctx)
 #undef RUN_IN_THR_CTX
 
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-template <typename F, typename... Args_t>
-auto create_in_thr_ctx(
-        const thr_ctx_t &ctx, F &&f, Args_t &...args) -> decltype(f(args...)) {
+inline int create_in_thr_ctx(
+        const thr_ctx_t &ctx, const std::function<int()> &f) {
     THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type,
             "core type %d is not supported for TP runtime\n", ctx.core_type);
 
     auto tp = dnnl::testing::get_threadpool(ctx);
     auto stp = dnnl::testing::scoped_tp_activation_t(tp);
-    return f(args...);
+    return f();
 }
 
 // The function f shall take an interop obj as last argument
-template <typename F, typename... Args_t>
-auto execute_in_thr_ctx(
-        const thr_ctx_t &ctx, F &&f, Args_t &...args) -> decltype(f(args...)) {
+inline int execute_in_thr_ctx(
+        const thr_ctx_t &ctx, const std::function<int()> &f) {
     THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type,
             "core type %d is not supported for TP runtime\n", ctx.core_type);
-    return f(args...);
+    return f();
 }
 
 #else

--- a/tests/test_thread.hpp
+++ b/tests/test_thread.hpp
@@ -85,47 +85,9 @@ struct thr_ctx_t {
 #error "src/common/dnnl_thread.hpp" has an unexpected header guard
 #endif
 
-#ifdef TBB_INTERFACE_VERSION
-// tbb constraints on core type appear in 2021.2
-// tbb constraints on max_concurrency appear in 2020
-// we check only for 2021.2 to enable thread context knobs
-#define DNNL_TBB_CONSTRAINTS_ENABLED (TBB_INTERFACE_VERSION >= 12020)
-// API to do explicit finalization was introduced in 2021.6.
-#define DNNL_TBB_NEED_EXPLICIT_FINALIZE (TBB_INTERFACE_VERSION >= 12060)
-#else
-#define DNNL_TBB_CONSTRAINTS_ENABLED 0
-#define DNNL_TBB_NEED_EXPLICIT_FINALIZE 0
-#endif
-
-#define DNNL_TBB_THREADING_WITH_CONSTRAINTS \
-    (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB) \
-            && DNNL_TBB_CONSTRAINTS_ENABLED
-#define DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS \
-    (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB) \
-            && !DNNL_TBB_CONSTRAINTS_ENABLED
-
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ \
-        || DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL \
-        || DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
-const thr_ctx_t default_thr_ctx = {0, -1, 0};
-#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
-#include "omp.h"
-const thr_ctx_t default_thr_ctx = {omp_get_max_threads(), -1, 0};
-#elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
-#include "oneapi/tbb/task_arena.h"
-const thr_ctx_t default_thr_ctx = {tbb::task_arena::automatic,
-        tbb::task_arena::automatic, tbb::task_arena::automatic};
-#endif
-
 std::ostream &operator<<(std::ostream &os, const thr_ctx_t &ctx);
 
-#define THR_CTX_ASSERT(check, msg_fmt, ...) \
-    do { \
-        if (!(check)) { \
-            fprintf(stderr, msg_fmt, __VA_ARGS__); \
-            exit(1); \
-        } \
-    } while (0)
+const thr_ctx_t &get_default_thr_ctx();
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 #include "oneapi/dnnl/dnnl_threadpool_iface.hpp"
@@ -145,7 +107,7 @@ int get_max_concurrency();
 namespace testing {
 
 dnnl::threadpool_interop::threadpool_iface *get_threadpool(
-        const thr_ctx_t &ctx = default_thr_ctx);
+        const thr_ctx_t &ctx = get_default_thr_ctx());
 
 // Sets the testing threadpool as active for the lifetime of the object.
 // Required for the tests that throw to work.
@@ -183,121 +145,19 @@ struct scoped_tp_deactivation_t {
 // Note: we have to differentiate creation and execution in thread
 // context because of threadpool as it uses different mecanisms in
 // both (in execution, tp is passed in stream)
+//
+// Definitions live in test_thread.cpp where the runtime-specific logic is
+// handled inside a single version of each function.
 
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ \
-        || DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
-
-#define RUN_IN_THR_CTX(name) \
-    inline int name(const thr_ctx_t &ctx, const std::function<int()> &f) { \
-\
-        THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type \
-                        && ctx.max_concurrency \
-                                == default_thr_ctx.max_concurrency \
-                        && ctx.nthr_per_core == default_thr_ctx.nthr_per_core, \
-                "Threading knobs not supported for this runtime: %s\n", \
-                DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ \
-                        ? "sequential runtime has no threading" \
-                        : "TBB version is too old (>=2021.2 required)"); \
-\
-        return f(); \
-    }
-
-RUN_IN_THR_CTX(create_in_thr_ctx)
-RUN_IN_THR_CTX(execute_in_thr_ctx)
-#undef RUN_IN_THR_CTX
-
-#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
-#define RUN_IN_THR_CTX(name) \
-    inline int name(const thr_ctx_t &ctx, const std::function<int()> &f) { \
-\
-        THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type, \
-                "core type %d is not supported for OMP runtime\n", \
-                ctx.core_type); \
-\
-        auto max_nthr = omp_get_max_threads(); \
-        omp_set_num_threads(ctx.max_concurrency); \
-        auto st = f(); \
-        omp_set_num_threads(max_nthr); \
-        return st; \
-    }
-
-RUN_IN_THR_CTX(create_in_thr_ctx)
-RUN_IN_THR_CTX(execute_in_thr_ctx)
-#undef RUN_IN_THR_CTX
-
-#elif DNNL_TBB_THREADING_WITH_CONSTRAINTS
-
-#include "oneapi/tbb/info.h"
-#define RUN_IN_THR_CTX(name) \
-    inline int name(const thr_ctx_t &ctx, const std::function<int()> &f) { \
-        static auto core_types = tbb::info:: \
-                core_types(); /* sorted by the relative strength       */ \
-\
-        if ((ctx.core_type != default_thr_ctx.core_type) \
-                && ((size_t)ctx.core_type >= core_types.size())) \
-            printf("WARNING: TBB smallest core has index %d. Using this " \
-                   "instead of %d.\n", \
-                    (int)core_types.size() - 1, ctx.core_type); \
-        size_t core_type_id = (size_t)ctx.core_type < core_types.size() \
-                ? ctx.core_type \
-                : core_types.size() - 1; \
-        auto core_type = ctx.core_type == tbb::task_arena::automatic \
-                ? tbb::task_arena::automatic \
-                : core_types[core_type_id]; \
-        auto arena = tbb::task_arena { \
-                tbb::task_arena::constraints {} \
-                        .set_core_type(core_type) \
-                        .set_max_threads_per_core(ctx.nthr_per_core) \
-                        .set_max_concurrency(ctx.max_concurrency)}; \
-        return arena.execute([&] { return f(); }); \
-    }
-
-RUN_IN_THR_CTX(create_in_thr_ctx)
-RUN_IN_THR_CTX(execute_in_thr_ctx)
-#undef RUN_IN_THR_CTX
-
-#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-inline int create_in_thr_ctx(
-        const thr_ctx_t &ctx, const std::function<int()> &f) {
-    THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type,
-            "core type %d is not supported for TP runtime\n", ctx.core_type);
-
-    auto tp = dnnl::testing::get_threadpool(ctx);
-    auto stp = dnnl::testing::scoped_tp_activation_t(tp);
-    return f();
-}
-
+int create_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
 // The function f shall take an interop obj as last argument
-inline int execute_in_thr_ctx(
-        const thr_ctx_t &ctx, const std::function<int()> &f) {
-    THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type,
-            "core type %d is not supported for TP runtime\n", ctx.core_type);
-    return f();
-}
-
-#else
-#error __FILE__"(" __LINE__ ")" "unsupported threading runtime!"
-#endif
+int execute_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
 
 // TBB runtime may crash when it is used under CTest. This is a known TBB
 // limitation that can be worked around by doing explicit finalization.
 // The API to do that was introduced in 2021.6.0. When using an older TBB
 // runtime the crash may still happen.
 // Appropriate header lives in a `src/common/dnnl_thread_tbb_proxy.hpp`.
-#if DNNL_TBB_NEED_EXPLICIT_FINALIZE
-inline void finalize_tbb() {
-    oneapi::tbb::task_scheduler_handle handle
-            = oneapi::tbb::task_scheduler_handle {oneapi::tbb::attach {}};
-    oneapi::tbb::finalize(handle, std::nothrow);
-}
-#else
-inline void finalize_tbb() {};
-#endif
-
-#undef ALIAS_TO_RUN_IN_THR_CTX
-#undef THR_CTX_ASSERT
-#undef DNNL_TBB_THREADING_WITHOUT_CONSTRAINTS
-#undef DNNL_TBB_THREADING_WITH_CONSTRAINTS
-#undef DNNL_TBB_CONSTRAINTS_ENABLED
+void finalize_tbb();
 
 #endif

--- a/tests/test_thread_decl.hpp
+++ b/tests/test_thread_decl.hpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef TESTS_TEST_THREAD_DECL_HPP
+#define TESTS_TEST_THREAD_DECL_HPP
+
+// This header includes some essential declarations which are defined in
+// test_thread.cpp as they all rely on functions from src/common/dnnl_thread.hpp
+// and tangled macro dependency.
+//
+// It's cut off from test_thread.hpp for the purpose of de-tangling and getting
+// rid of the transitive library dependency when using classes and functions
+// declared below.
+//
+// If a test that included former 'test_thread.hpp' relies on the library
+// internals, it must include correspondent headers explicitly.
+
+#include "oneapi/dnnl/dnnl_config.h"
+
+#include "tests/thread_context.hpp"
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "oneapi/dnnl/dnnl_threadpool_iface.hpp"
+namespace dnnl {
+namespace testing {
+
+dnnl::threadpool_interop::threadpool_iface *get_threadpool(
+        const thr_ctx_t &ctx = get_default_thr_ctx());
+
+// Sets the testing threadpool as active for the lifetime of the object.
+// Required for the tests that throw to work.
+struct scoped_tp_activation_t {
+    scoped_tp_activation_t(
+            dnnl::threadpool_interop::threadpool_iface *tp = get_threadpool());
+    ~scoped_tp_activation_t();
+};
+
+struct scoped_tp_deactivation_t {
+    scoped_tp_deactivation_t();
+    ~scoped_tp_deactivation_t();
+};
+
+} // namespace testing
+} // namespace dnnl
+#endif
+
+// TBB runtime may crash when it is used under CTest. This is a known TBB
+// limitation that can be worked around by doing explicit finalization.
+// The API to do that was introduced in 2021.6.0. When using an older TBB
+// runtime the crash may still happen.
+// Appropriate header lives in a `src/common/dnnl_thread_tbb_proxy.hpp`.
+void finalize_tbb();
+
+#endif

--- a/tests/thread_context.hpp
+++ b/tests/thread_context.hpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef TESTS_THREAD_CONTEXT_HPP
+#define TESTS_THREAD_CONTEXT_HPP
+
+#include <functional>
+#include <iostream>
+
+struct thr_ctx_t {
+    int max_concurrency;
+    int core_type;
+    int nthr_per_core;
+
+    bool operator==(const thr_ctx_t &rhs) const {
+        return max_concurrency == rhs.max_concurrency
+                && core_type == rhs.core_type
+                && nthr_per_core == rhs.nthr_per_core;
+    }
+    bool operator!=(const thr_ctx_t &rhs) const { return !(*this == rhs); }
+    void *get_interop_obj() const;
+};
+
+std::ostream &operator<<(std::ostream &os, const thr_ctx_t &ctx);
+
+const thr_ctx_t &get_default_thr_ctx();
+
+// These are free functions to allow running a function in a given threading
+// context.
+// A threading context is defined by:
+// - number of threads
+// - type of cores (TBB only)
+// - threads per core (TBB only)
+
+// Note: we have to differentiate creation and execution in thread context
+// because of threadpool as it uses different mechanisms in both (in execution,
+// tp is passed in stream).
+//
+// Definitions live in test_thread.cpp where the runtime-specific logic is
+// handled inside a single version of each function.
+int create_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
+// The function f shall take an interop obj as last argument
+int execute_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
+
+#endif

--- a/tests/thread_context.hpp
+++ b/tests/thread_context.hpp
@@ -41,18 +41,17 @@ const thr_ctx_t &get_default_thr_ctx();
 // These are free functions to allow running a function in a given threading
 // context.
 // A threading context is defined by:
-// - number of threads
-// - type of cores (TBB only)
-// - threads per core (TBB only)
+// - the total number of threads.
+// - the type of cores (TBB only).
+// - the number of threads per core (TBB only).
 
 // Note: we have to differentiate creation and execution in thread context
 // because of threadpool as it uses different mechanisms in both (in execution,
-// tp is passed in stream).
+// threadpool argument is passed into a stream).
 //
 // Definitions live in test_thread.cpp where the runtime-specific logic is
 // handled inside a single version of each function.
 int create_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
-// The function f shall take an interop obj as last argument
 int execute_in_thr_ctx(const thr_ctx_t &ctx, const std::function<int()> &f);
 
 #endif


### PR DESCRIPTION
This is a culminating point of the refactor, though not the final.

The header brings dnnl_thread.hpp with it which in turn brings a bunch of stuff from the library. This dependency on the library makes code movement and abstraction separation harder many times, this is why benchdnn departs from it in the main header - dnnl_common.hpp.

I split the original header into three parts - one is a lightweight thr_ctx_t class and functions relying on it, then some declarations, mostly related to runtime specific things like TBB or Threadpool, and finally an include that brings dnnl_thread.hpp which is only used in parallel.cpp on benchdnn side now which is solely responsible for parallelism. All bodies are implemented in test_thread.cpp which is still a mess, but there's nothing can be done about it...

Additional refactor includes simplifying create/execute_in_thr_ctx functions since there's no more requirement to support templated functions as their arguments.