### PR TITLE
x64: matmul: int8: grouped quantization minor fixes

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -369,6 +369,7 @@ struct brgemm_desc_t {
     bool embd_bcst = false;
     bool with_bias = false;
     bool req_s8s8_compensation = false;
+    bool req_src_s8_shift = false;
     // `with_weights_scale_adjust` is controlled by the implementation and not
     // by kernel API.
     bool with_weights_scale_adjust = false;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -258,7 +258,7 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
 
     // --------------- microkernel ---------------
     // see vmm_inp_shift() in brgemm kernel
-    const int compensation_regs = brg->req_s8s8_compensation
+    const int compensation_regs = brg->req_src_s8_shift
                     || brg->zp_type_a != brgemm_broadcast_t::none
             ? 1
             : 0;
@@ -1101,11 +1101,13 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->has_int8_vnni = isa_has_int8_vnni(brg->isa_impl);
 
     set_brg_vmm(brg); // TODO: Investigate if it is really needed here.
+    brg->req_src_s8_shift = brg->is_int8 && brg->dt_a == data_type::s8
+            && !isa_has_s8s8(brg->isa_impl);
     // s8s8 compensation could be applied in per_mn_compensation kernel,
     // in that case brgemm kernel should supress this flag
     // to avoid double compensation.
-    brg->req_s8s8_compensation = brg->is_int8 && brg->dt_a == data_type::s8
-            && !isa_has_s8s8(brg->isa_impl) && !brg->with_per_mn_compensation;
+    brg->req_s8s8_compensation
+            = brg->req_src_s8_shift && !brg->with_per_mn_compensation;
 
     CHECK(safe_dim_to_int(brg->LDA, (brg->is_row_major()) ? LDA : LDB));
     brg->is_runtime_lda = (brg->is_row_major()) ? is_runtime_value(LDA)
@@ -1173,8 +1175,9 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
                 avx2_vnni);
     }
 
-    brg->req_s8s8_compensation = brg->is_int8 && brg->dt_a == data_type::s8
+    brg->req_src_s8_shift = brg->is_int8 && brg->dt_a == data_type::s8
             && !isa_has_s8s8(brg->isa_impl);
+    brg->req_s8s8_compensation = brg->req_src_s8_shift;
 
     brg->is_dgmm = true;
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -3166,7 +3166,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
     } else
         rd_loop = brg.rd_block;
 
-    if (brg.req_s8s8_compensation) {
+    if (brg.req_src_s8_shift) {
         reg_bdb_loop.save();
         mov(reg_s8_input_shift, 128);
         uni_vpbroadcastb(vmm_inp_shift(), reg_s8_input_shift.cvt8());
@@ -3217,7 +3217,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             }
         }
 
-        if (brg.req_s8s8_compensation)
+        if (brg.req_src_s8_shift)
             uni_vpaddb(vmm_bcast, vmm_bcast, vmm_inp_shift());
     };
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -3629,11 +3629,13 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
 
         if (brg.is_per_k_src_scales) {
             const auto adj_bd_block = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
-            const auto src_scales_stack_ptr
-                    = reg_src_scales.getStoragePtr().getRegExp();
             const auto src_scales_offset
                     = adj_bd_block * bd_block2 * brg.src_scale_m_stride;
-            add(dword[src_scales_stack_ptr], src_scales_offset);
+            if (reg_src_scales.savable())
+                add(qword[reg_src_scales.getStoragePtr().getRegExp()],
+                        src_scales_offset);
+            else
+                add(reg_src_scales, src_scales_offset);
         }
 
         if (brg.is_gemv && brg.treat_y_as_row) {

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -1011,7 +1011,9 @@ void brgemm_matmul_t<isa>::fill_per_mn_compensation(
     const dim_t k_start = static_cast<dim_t>(k_blk_idx) * bgmmc.K_blk
                     * bgmmc.brgemm_batch_size
             + (is_tail ? batch_size * bgmmc.K_blk : dim_t {0});
-    const dim_t k_len = is_tail ? bgmmc.K_tail : batch_size * bgmmc.K_blk;
+    const dim_t k_len
+            = nstl::min(is_tail ? bgmmc.K_tail : batch_size * bgmmc.K_blk,
+                    bgmmc.K - k_start);
 
     const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
     const dim_t n = brgmm_ctx.get_N_idx(n_blk_idx, true);

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -418,6 +418,14 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         brgemm_desc_t &brg = brg_descs_[idx];
         const auto kernel_isa = i_M == max_m_ker_idx - 1 ? backup_isa : isa;
 
+        brg.with_per_mn_compensation = bgmmc_.with_per_mn_compensation;
+        if (bgmmc_.with_per_mn_compensation) {
+            brg.skip_zp_a_compensation = true;
+            brg.skip_zp_b_compensation = true;
+        }
+        if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
+            brg.skip_zp_b_compensation = true;
+
         if (bgmmc_.is_gemv) {
             const bool swap_a_b = bgmmc_.gemv_swap_a_b;
             const dim_t gemv_m = swap_a_b ? vN : vM;
@@ -442,16 +450,6 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         }
 
         auto LDD = bgmmc_.LDD;
-        if (bgmmc_.with_wei_decompression && bgmmc_.has_zero_point_b)
-            brg.skip_zp_b_compensation = true;
-        // The per-(M, N) compensation tile carries the full src+wei zero
-        // point correction in f32 (post per-K scales). Skip the kernel's
-        // built-in vpaddd-based zp_a path so it isn't applied twice.
-        if (bgmmc_.with_per_mn_compensation) {
-            brg.with_per_mn_compensation = true;
-            brg.skip_zp_a_compensation = true;
-            brg.skip_zp_b_compensation = true;
-        }
         brg.skip_wei_scales = bgmmc_.apply_scales_in_buffer_b;
         // Fill up the scales info in case it's computing in brgemm
         if (!brg.skip_wei_scales && bgmmc_.with_wei_scales) {

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -5576,8 +5576,10 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::copy_row_x_col(
             // Load packed int4 data into Ymm (half of Zmm), then
             // unpack to full int8 in Zmm and apply ZP shift.
             auto ymm_src = Ymm(src_reg.getIdx());
+            if (is_tail) init_tail_mask(columns_tail, /*use_int4_mask=*/true);
             auto ymm_src_load = maybe_mask(ymm_src, is_tail);
             vmovdqu8(ymm_src_load, addr);
+            if (is_tail) init_tail_mask(columns_tail, /*use_int4_mask=*/false);
             cvt_int4_to_int8_for_transposed(src_reg);
             maybe_apply_int8_grouped_zp(src_reg, i);
         } else {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2193,6 +2193,12 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
             VERBOSE_BLOCKING_FAIL, "");
 
+    auto get_actual_ldd = [&]() {
+        return dst_d.ndims() == 2 && bgmmc.M == 1
+                ? bgmmc.N
+                : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
+    };
+
     // Per-K (grouped) scales/ZP applied at kernel time (i.e. not folded into
     // buffer B) require each brgemm call to cover at most a single K-group
     // of every active per-K axis.
@@ -2224,7 +2230,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             }
 
             const dim_t new_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
-            if (new_chunk_K < prev_chunk_K && new_chunk_K < bgmmc.K) {
+            if ((new_chunk_K < prev_chunk_K && new_chunk_K < bgmmc.K)
+                    || get_actual_ldd() != bgmmc.N) {
                 bgmmc.use_buffer_c = true;
             }
         }
@@ -2273,9 +2280,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     if (bgmmc.is_gemv && bgmmc.gemv_swap_a_b) {
         bgmmc.LDC = bgmmc.LDD = 1;
     } else {
-        bgmmc.LDD = dst_d.ndims() == 2 && bgmmc.M == 1
-                ? bgmmc.N
-                : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
+        bgmmc.LDD = get_actual_ldd();
         bgmmc.LDC = bgmmc.use_buffer_c && bgmmc.nthr_k <= 1
                 ? (bgmmc.is_amx ? nstl::min((dim_t)32, bgmmc.N_blk)
                                 : bgmmc.N_blk)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1989,6 +1989,13 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     VCONDCHECK_BG(!(bgmmc.is_runtime_M && !runtime_M_supported),
             VERBOSE_RUNTIMEDIM_UNSUPPORTED)
 
+    // Runtime M combined with grouped per-K quantization scales applied at
+    // accumulation time is not yet supported
+    const bool per_k_scales_at_accumulation = bgmmc.is_src_scale_per_k
+            || (bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b);
+    VCONDCHECK_BG(!(bgmmc.is_runtime_M && per_k_scales_at_accumulation),
+            VERBOSE_RUNTIMEDIM_UNSUPPORTED)
+
     // Runtime N value is supported for 2d AMX int8/bfloat16 problems only.
     const bool runtime_N_supported = bgmmc.is_amx && bgmmc.ndims == 2
             && one_of(true, bm_conf_utils.is_int8(), bm_conf_utils.is_bf16());

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -83,8 +83,11 @@ struct jit_per_mn_comp_kernel_t : public per_mn_comp_kernel_t,
         , wei_k_stride_bytes_(wei_is_subbyte_ ? bgmmc->B_strides[1] / 2
                                               : bgmmc->B_strides[1])
         , LDC_(bgmmc->LDC)
-        , stripe_w_(
-                  static_cast<int>(nstl::min<dim_t>(bgmmc->LDC, bgmmc->N_blk)))
+        , n_blk_w_(static_cast<int>(nstl::min<dim_t>(bgmmc->LDC, bgmmc->N_blk)))
+        , n_tail_w_(bgmmc->N_tail > 0 ? static_cast<int>(nstl::min<dim_t>(
+                                                bgmmc->LDC, bgmmc->N_tail))
+                                      : 0)
+        , stripe_w_(n_blk_w_)
         , chunks_(static_cast<int>(utils::div_up(stripe_w_, simd_w))) {}
 
     status_t create_kernel() override {
@@ -111,8 +114,10 @@ private:
     const dim_t src_k_stride_bytes_;
     const dim_t wei_k_stride_bytes_;
     const dim_t LDC_;
-    const int stripe_w_;
-    const int chunks_;
+    const int n_blk_w_; // full block width  = min(LDC, N_blk)
+    const int n_tail_w_; // N-tail block width = min(LDC, N_tail), 0 if none
+    int stripe_w_;
+    int chunks_;
 
     static constexpr int f32_sz = sizeof(float);
     static constexpr int i32_sz = sizeof(int32_t);
@@ -539,10 +544,13 @@ private:
         jmp(k_bulk, T_NEAR);
         L(k_bulk_done);
 
+        const bool scalar_tail = !(has_vnni_ && isa_has_masks(isa_));
+        if (scalar_tail) xor_(reg_iter, reg_iter);
+
         Label k_tail_done;
         test(reg_k_iter, reg_k_iter);
         jz(k_tail_done, T_NEAR);
-        if (has_vnni_ && isa_has_masks(isa_)) {
+        if (!scalar_tail) {
             push(reg_tmp);
             build_low_bits_mask(reg_k_iter);
             pop(reg_tmp);
@@ -550,7 +558,6 @@ private:
                     ptr[reg_tmp]);
             vpdpbusd_ones(vmm_acc_tr(), vmm_data_tr(), src_is_signed_);
         } else {
-            const Xbyak::Xmm acc_x(vmm_acc_tr().getIdx());
             xor_(reg_n, reg_n);
             Label scalar_loop;
             L(scalar_loop);
@@ -558,8 +565,7 @@ private:
                 movsx(reg_b.cvt32(), byte[reg_tmp + reg_n]);
             else
                 movzx(reg_b.cvt32(), byte[reg_tmp + reg_n]);
-            vmovd(Xbyak::Xmm(vmm_data_tr().getIdx()), reg_b.cvt32());
-            vpaddd(acc_x, acc_x, Xbyak::Xmm(vmm_data_tr().getIdx()));
+            add(reg_iter.cvt32(), reg_b.cvt32());
             inc(reg_n);
             cmp(reg_n, reg_k_iter);
             jl(scalar_loop, T_NEAR);
@@ -568,6 +574,7 @@ private:
 
         hreduce_dword(vmm_acc_tr());
         vmovd(reg_T.cvt32(), Xmm(vmm_acc_tr().getIdx()));
+        if (scalar_tail) add(reg_T.cvt32(), reg_iter.cvt32());
 
         // Broadcast int32 -> vmm_T_bc; convert to f32.
         if (isa_has_masks(isa_)) {
@@ -677,15 +684,7 @@ private:
         L(m_done);
     }
 
-    void generate() override {
-        preamble();
-
-        load_param(reg_M_blk, GET_OFF(M_blk));
-        load_param(reg_stripe_w, GET_OFF(stripe_w));
-        load_param(reg_k_len, GET_OFF(k_len));
-
-        if (!isa_has_masks(isa_)) { vmovups(vmm_idx_, ptr[rip + idx_table_]); }
-
+    void emit_compute() {
         // (B) S-reduce (lives across the m-loop). Uses slots chunks_+0..+5
         //     as scratch; persistents loaded AFTER S-reduce.
         //     S[n]=Sum_K wei is needed for the src-zp term and, on non-AMX s8
@@ -714,6 +713,35 @@ private:
 
         // (C) m-loop with per-m T-reduce and combine.
         emit_m_combine_loop();
+    }
+
+    // Select and emit the compute body for a given N-block width.
+    void emit_body_for_width(int width) {
+        stripe_w_ = width;
+        chunks_ = static_cast<int>(utils::div_up(width, simd_w));
+        emit_compute();
+    }
+
+    void generate() override {
+        preamble();
+
+        load_param(reg_M_blk, GET_OFF(M_blk));
+        load_param(reg_stripe_w, GET_OFF(stripe_w));
+        load_param(reg_k_len, GET_OFF(k_len));
+
+        if (!isa_has_masks(isa_)) { vmovups(vmm_idx_, ptr[rip + idx_table_]); }
+        if (!isa_has_masks(isa_) && n_tail_w_ > 0) {
+            Label main_blk, done;
+            cmp(reg_stripe_w, n_blk_w_);
+            je(main_blk, T_NEAR);
+            emit_body_for_width(n_tail_w_); // N-tail block
+            jmp(done, T_NEAR);
+            L(main_blk);
+            emit_body_for_width(n_blk_w_); // full N_blk block
+            L(done);
+        } else {
+            emit_body_for_width(n_blk_w_);
+        }
 
         postamble();
 

--- a/src/cpu/x64/ukernel/brgemm.cpp
+++ b/src/cpu/x64/ukernel/brgemm.cpp
@@ -121,6 +121,7 @@ status_t brgemm_t::finalize() {
     // Note: API can't take a compensation buffer externally. Users must add
     // compensation on their own as a binary post-op.
     brgemm_desc_.req_s8s8_compensation = false;
+    brgemm_desc_.req_src_s8_shift = false;
 
     // Precompute the pallette
     // If status isn't successful, it means tiles configuration is not required.


### PR DESCRIPTION
Fixes [MFDNN-15256](https://jira.devtools.intel.com/browse/MFDNN-15256) and [MFDNN-15250](https://jira.devtools.intel.com/browse/MFDNN-15250). 

1. [x64: matmul: int8: Fix src shift in compensation strategies](https://github.com/uxlfoundation/oneDNN/pull/5446/commits/aa49470f77c5dac0582566690f71ab958efd00a9)
- On the top of https://github.com/uxlfoundation/oneDNN/pull/5407 and https://github.com/uxlfoundation/oneDNN/pull/5431
compensations require split "input shift +128" logic and "post-gemm-compensation" into separate flags, considering both post-ops(s8s8_compensation) compensation and per-mn-compensation could reuse it. 

- Init comp-attributes before `brgemm_desc_init()` invoked.
2. [x64: matmul: int8: padded K-tail for AMX fix](https://github.com/uxlfoundation/oneDNN/pull/5446/commits/c4b16ae49ffa14bd58c362d4b0e45bfc7b56efb5)
K-tail for AMX is padded, so init `k_len` should be more consistent.
3. [x64: matmul: int8: tail mask init for int4](https://github.com/uxlfoundation/oneDNN/pull/5446/commits/16f844083ca3a2745da8839abce399b0781f8e37)
Init subbyte mask for tail in copy routines.
4. [x64: matmul: int8: buffer C usage fix](https://github.com/uxlfoundation/oneDNN/pull/5446/commits/0c749c866c7b4dc0b5c5d5f1209002b998eb5e68)
Broaden buffer C usage for catching padded/strided/transposed cases in grouped quantization.
5. [x64: matmul: int8: src scales DMR segfault fix](https://github.com/uxlfoundation/oneDNN/pull/5446/commits/d4555b3b5e32b8c5ef46dc8e822e63e0f7d59bdd)
`reg64_savable_t::getStoragePtr()` only valid when `reg_savable_t::savable() == true`, which is false on AVX10_2-like systems. Wrapped advancing savable reg so getting save pointer to the stacked reg.
6. [x64: matmul: per-mn-compensation accumulation & tailing fix](https://github.com/uxlfoundation/oneDNN/pull/5446/commits/9e2135ac21426a0c09efb7ddff00406b034f2dbb)
Accumulation on SKX/CLX/ICX/SPR was truncating the tail. Reworked using GPR for accumulation.
Also fixes N-tailing cases.
7. [x64: matmul: int8: disable M-runtime for grouped quant](https://github.com/uxlfoundation/oneDNN/pull/5446/commits/66d754b4962a9f9b582de3664746dc4e06e6ded4)
Skipped grouped quant path when runtime M is set. (Not supported yet).

Changes related to all ISAs, which requires s8s8-compensation and grouped quantization (via using per-mn-compensation). 
[Job link](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f1762655-f32a-f11e-b4c9-d4f5ef20c6a0)
