### PR TITLE
xe: sdpa: force rounding for GQA cases

### DIFF
--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -115,7 +115,7 @@ inline void apply_dropout_s_tile(
     })
 
     /* Build float scale tile: inv_q if keep, 0.f if drop -- same type as s_tile */
-    s_tile_type scale_tile;
+    volatile s_tile_type scale_tile;
     tile_predicated_select_t(scale_tile, tile_offset_r, tile_offset_c,
             dropout_predicate, inv_q, 0.f, SUBGROUP_SIZE,
             ugemm_kq_c_type_block0, ugemm_kq_c_type_block1,

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -338,14 +338,13 @@ struct micro_fwd_t : public primitive_t {
                                                    == data_type::f32),
                                    with_causal_mask()),
                     "fused f32 SDPA only optimized for causal mask"); //TODO: update when performance improved
-            // Xe-HPG: enabling dropout on the systolic micro_sdpa fwd path
-            // triggers an IGC miscompile that yields NaN/zero outputs.
-            // Reject this combination so the caller falls back to the
-            // large partition graph
-            VDISPATCH_SDPA(IMPLICATION(arch() == compute::gpu_arch_t::xe_hpg,
-                                   attr()->dropout_.has_default_values()),
-                    "fused SDPA FWD with dropout leads to IGC miscompile "
-                    "on xe_hpg");
+            VDISPATCH_SDPA(
+                    IMPLICATION(arch() == compute::gpu_arch_t::xe_hpg
+                                    && !attr()->dropout_.has_default_values(),
+                            attr()->dropout_.use_host_scalars_),
+                    "fused SDPA FWD with device dropout not supported "
+                    "for xe_hpg");
+
             CHECK(init_conf_microkernels(engine));
             CHECK(init_conf(engine));
 

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -65,7 +65,7 @@ inline void apply_dropout_s_tile(s_tile_type *tile, int tile_offset_r,
         int k_stride, int use_dropout_offset, long seed, long offset,
         uint threshold, float inv_q) {
 
-    s_tile_type scale_tile;
+    volatile s_tile_type scale_tile;
     tile_predicated_select(scale_tile, tile_offset_r, tile_offset_c,
             dropout_predicate, inv_q, 0.f, SUBGROUP_SIZE,
             ugemm_kq_c_type_block0, ugemm_kq_c_type_block1,
@@ -83,7 +83,7 @@ inline void apply_dropout_dP_tile(p_tile_type *tile, int tile_offset_r,
         int k_stride, int use_dropout_offset, long seed, long offset,
         uint threshold, float inv_q) {
 
-    p_tile_type scale_p_tile;
+    volatile p_tile_type scale_p_tile;
     tile_predicated_select(scale_p_tile, tile_offset_r, tile_offset_c,
             dropout_predicate, inv_q, 0.f, SUBGROUP_SIZE,
             ugemm_vtdA_c_type_block0, ugemm_vtdA_c_type_block1,

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -436,12 +436,8 @@ inline void tile_store_k_slm(
 
 #if KV_GROUP_SIZE > 1
 #define IS_GQA 1
-#if defined(DST_DT_F16)
-#define REDUCE_DKDV_F16 1
-#else
 #define REDUCE_DKDV_F16 0
-#endif
-#if DST_DATA_T != float
+#if defined(DST_DT_F16) || defined(DST_DT_BF16)
 #define NEEDS_INTERMEDIATE_DKV 1
 #else
 #define NEEDS_INTERMEDIATE_DKV 0
@@ -487,8 +483,14 @@ inline float round_to_dst(float v) {
 #define SLM_DKDV_DATA_T float
 typedef dv_tile_type dv_acc_tile_type;
 typedef a_tile_type dk_acc_tile_type;
+// Round an f32 value to the destination precision (returned as f32) for the
+// GQA per-head dK/dV partials before they are summed across heads in f32
+// The natural form CONVERT_FLOAT_T(CONVERT_DATA_T(v)) is folded to the identity
+// by IGC, silently dropping the per-head rounding. Routing the rounded value
+// through a volatile forces the conversion to materialize
 inline float round_to_dst(float v) {
-    return CONVERT_FLOAT_T(CONVERT_DATA_T(v));
+    volatile DST_DATA_T tmp = CONVERT_DATA_T(v);
+    return CONVERT_FLOAT_T(tmp);
 }
 #endif
 

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -436,7 +436,6 @@ inline void tile_store_k_slm(
 
 #if KV_GROUP_SIZE > 1
 #define IS_GQA 1
-#define REDUCE_DKDV_F16 0
 #if defined(DST_DT_F16) || defined(DST_DT_BF16)
 #define NEEDS_INTERMEDIATE_DKV 1
 #else
@@ -454,60 +453,21 @@ inline void tile_store_k_slm(
 #define DST_DATA_T_DKDV DST_DATA_T
 #endif
 
-#if REDUCE_DKDV_F16
-// Enable SLM acummulation in f16 for f16 dV and dK reduce path
-// The global scratch is f32 (DST_DATA_T_DKDV=float); tile_atomic_add_f32
-// converts f16->f32 at the global write step, avoiding __builtin_IB_atomic_add_global_f16.
-DECLARE_2D_TILE(dv_reduce_tile_type, DST_DATA_T, SUBGROUP_SIZE,
-        ugemm_vs_c_type_block0, ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
-        ugemm_vs_c_type_nblock1)
-DECLARE_2D_TILE(a_reduce_tile_type, DST_DATA_T, SUBGROUP_SIZE,
-        ugemm_qdSt_c_type_block0, ugemm_qdSt_c_type_block1,
-        ugemm_qdSt_c_type_nblock0, ugemm_qdSt_c_type_nblock1)
-DECLARE_2D_TILE_SLM_ADD(dv_reduce_tile_type, DST_DATA_T, SUBGROUP_SIZE,
-        ugemm_vs_c_type_block0, ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
-        ugemm_vs_c_type_nblock1)
-DECLARE_2D_TILE_SLM_ADD(a_reduce_tile_type, DST_DATA_T, SUBGROUP_SIZE,
-        ugemm_qdSt_c_type_block0, ugemm_qdSt_c_type_block1,
-        ugemm_qdSt_c_type_nblock0, ugemm_qdSt_c_type_nblock1)
-DECLARE_2D_TILE_SLM_ADD_T(a_reduce_tile_type, DST_DATA_T, SUBGROUP_SIZE,
-        ugemm_qdSt_c_type_block0, ugemm_qdSt_c_type_block1,
-        ugemm_qdSt_c_type_nblock0, ugemm_qdSt_c_type_nblock1)
-#define SLM_DKDV_DATA_T DST_DATA_T
-typedef dv_reduce_tile_type dv_acc_tile_type;
-typedef a_reduce_tile_type dk_acc_tile_type;
-inline float round_to_dst(float v) {
-    return v;
-}
-#else
-#define SLM_DKDV_DATA_T float
-typedef dv_tile_type dv_acc_tile_type;
-typedef a_tile_type dk_acc_tile_type;
-// Round an f32 value to the destination precision (returned as f32) for the
-// GQA per-head dK/dV partials before they are summed across heads in f32
-// The natural form CONVERT_FLOAT_T(CONVERT_DATA_T(v)) is folded to the identity
-// by IGC, silently dropping the per-head rounding. Routing the rounded value
-// through a volatile forces the conversion to materialize
+// round f32 intermediate values to DST_DATA_T precision before GQA atomic
+// accumulation. Although less accurate, it matches the unfused path
+// where each query group matmul output passes through DST_DATA_T
+// storage before the reduction
 inline float round_to_dst(float v) {
     volatile DST_DATA_T tmp = CONVERT_DATA_T(v);
     return CONVERT_FLOAT_T(tmp);
 }
-#endif
 
-inline void tile_store_dV(dv_acc_tile_type *dV_tile_slm,
-        global DST_DATA_T_DKDV *dV, int m, int n, int ld, int offset_r,
-        int offset_c, int rem) {
+inline void tile_store_dV(dv_tile_type *dV_tile_slm, global DST_DATA_T_DKDV *dV,
+        int m, int n, int ld, int offset_r, int offset_c, int rem) {
 
 #if IS_GQA
-    // tile_copy: f16->f32 for REDUCE_DKDV_F16 (avoids __builtin_IB_atomic_add_global_f16
-    // which can produce NaN), identity for f32 SLM.
-    // round_to_dst: identity for f16 (precision already implicit from SLM);
-    // rounds to bf16 for bf16 dst to match the unfused path.
-    dv_acc_tile_type dV_tile_slm_copy = *dV_tile_slm;
-    dv_tile_type dV_tile_f32;
-    tile_copy(dV_tile_slm_copy, dV_tile_f32);
-    tile_elementwise_s(dV_tile_f32, round_to_dst);
-    tile_atomic_add(dV_tile_f32, dV, m, n, ld, offset_r, offset_c);
+    tile_elementwise_s(*dV_tile_slm, round_to_dst);
+    tile_atomic_add(*dV_tile_slm, dV, m, n, ld, offset_r, offset_c);
 
 #else // MHA update
 
@@ -525,16 +485,12 @@ inline void tile_store_dV(dv_acc_tile_type *dV_tile_slm,
 
 #if TRANSPOSE_K
 // uses transposed dv_tile_type (D*Bc) for dK update
-inline void tile_store_dK_t(dv_acc_tile_type *dK_tile,
-        global DST_DATA_T_DKDV *dK, int m, int n, int ld, int offset_r,
-        int offset_c, int rem) {
+inline void tile_store_dK_t(dv_tile_type *dK_tile, global DST_DATA_T_DKDV *dK,
+        int m, int n, int ld, int offset_r, int offset_c, int rem) {
 
 #if IS_GQA
-    dv_acc_tile_type dK_tile_slm_copy_t = *dK_tile;
-    dv_tile_type dK_tile_f32;
-    tile_copy(dK_tile_slm_copy_t, dK_tile_f32);
-    tile_elementwise_s(dK_tile_f32, round_to_dst);
-    tile_atomic_add(dK_tile_f32, dK, m, n, ld, offset_r, offset_c);
+    tile_elementwise_s(*dK_tile, round_to_dst);
+    tile_atomic_add(*dK_tile, dK, m, n, ld, offset_r, offset_c);
 #else // MHA update
     dv_tile_type_dst dK_tile_dst;
     tile_copy_reblock(*dK_tile, &dK_tile_dst);
@@ -551,15 +507,12 @@ inline void tile_store_dK_t(dv_acc_tile_type *dK_tile,
 #else
 
 // uses qdSt tile (Bc*D) for dK update
-inline void tile_store_dK(dk_acc_tile_type *dK_tile, global DST_DATA_T_DKDV *dK,
+inline void tile_store_dK(a_tile_type *dK_tile, global DST_DATA_T_DKDV *dK,
         int m, int n, int ld, int offset_r, int offset_c) {
 
 #if IS_GQA
-    dk_acc_tile_type dK_tile_slm_copy = *dK_tile;
-    a_tile_type dK_tile_f32;
-    tile_copy(dK_tile_slm_copy, dK_tile_f32);
-    tile_elementwise_s(dK_tile_f32, round_to_dst);
-    tile_atomic_add(dK_tile_f32, dK, m, n, ld, offset_r, offset_c);
+    tile_elementwise_s(*dK_tile, round_to_dst);
+    tile_atomic_add(*dK_tile, dK, m, n, ld, offset_r, offset_c);
 #else // MHA update
 
     a_tile_type_dst dK_tile_dst;
@@ -702,8 +655,8 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #define S2_f32_slm_size 0
 #endif
 
-#define dK_slm_size (ugemm_kq_wg_tile_m * D_MAX * sizeof(SLM_DKDV_DATA_T))
-#define dV_slm_size (ugemm_kq_wg_tile_m * D_MAX * sizeof(SLM_DKDV_DATA_T))
+#define dK_slm_size (ugemm_kq_wg_tile_m * D_MAX * sizeof(float))
+#define dV_slm_size (ugemm_kq_wg_tile_m * D_MAX * sizeof(float))
 
 #define ugemm_slm_size \
     MAX(MAX(MAX(MAX(ugemm_kq_slm_size, ugemm_vs_slm_size), \
@@ -729,10 +682,10 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             = (local uint *)&slm[K_slm_size + S_slm_size + S2_f32_slm_size];
 
     // used for accumulation of dV, dK across q-loop
-    local SLM_DKDV_DATA_T *dK_slm = (local SLM_DKDV_DATA_T *)&slm[K_slm_size
-            + S_slm_size + S2_f32_slm_size + ugemm_slm_size];
-    local SLM_DKDV_DATA_T *dV_slm = (local SLM_DKDV_DATA_T *)&slm[K_slm_size
-            + S_slm_size + S2_f32_slm_size + ugemm_slm_size + dK_slm_size];
+    local float *dK_slm = (local float *)&slm[K_slm_size + S_slm_size
+            + S2_f32_slm_size + ugemm_slm_size];
+    local float *dV_slm = (local float *)&slm[K_slm_size + S_slm_size
+            + S2_f32_slm_size + ugemm_slm_size + dK_slm_size];
 
     const size_t k_offset = KEY_BATCH(b1, b0_kv);
     const size_t v_offset = VAL_BATCH(b1, b0_kv);
@@ -819,8 +772,8 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #pragma unroll
     for (int i = get_local_id(0); i < ugemm_kq_wg_tile_m * D_MAX;
             i += get_local_size(0)) {
-        dK_slm[i] = (SLM_DKDV_DATA_T)0;
-        dV_slm[i] = (SLM_DKDV_DATA_T)0;
+        dK_slm[i] = 0.f;
+        dV_slm[i] = 0.f;
     }
 
     uint sg_i0_kq = sg_i_kq * ugemm_kq_sg_tile_m;
@@ -971,9 +924,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 
             // accumulate dv tile to slm
             if (sg_ij < sg_per_wg_BcD) {
-                dv_acc_tile_type dV_tile1_store;
-                tile_copy(dV_tile1, dV_tile1_store);
-                tile_slm_add(dV_tile1_store, dV_slm, D_MAX, sg_i0_vs, sg_j0_vs);
+                tile_slm_add(dV_tile1, dV_slm, D_MAX, sg_i0_vs, sg_j0_vs);
             }
         }
 
@@ -1072,14 +1023,11 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 
             // dk slm tile
             if (sg_ij < sg_per_wg_BcD) {
-                dk_acc_tile_type dK_tile1_store;
-                tile_copy(dK_tile1, dK_tile1_store);
 #if TRANSPOSE_K
-                tile_slm_add_t(
-                        dK_tile1_store, dK_slm, D_MAX, sg_i0_dk, sg_j0_dk);
+                tile_slm_add_t(dK_tile1, dK_slm, D_MAX, sg_i0_dk, sg_j0_dk);
 #else
-                tile_slm_add(dK_tile1_store, dK_slm, ugemm_kq_wg_tile_m,
-                        sg_i0_dk, sg_j0_dk);
+                tile_slm_add(dK_tile1, dK_slm, ugemm_kq_wg_tile_m, sg_i0_dk,
+                        sg_j0_dk);
 #endif
             }
         }
@@ -1128,7 +1076,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     // ensure all loops done writing to SLM
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    dv_acc_tile_type dV_tile_slm;
+    dv_tile_type dV_tile_slm;
 
     if (sg_ij < sg_per_wg_BcD) {
         tile_load(&dV_tile_slm, dV_slm, D_MAX, ugemm_kq_wg_tile_m, D_MAX,
@@ -1141,7 +1089,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     //////// update dK
 #if TRANSPOSE_K
     // transposed dK_slm (D*Bc) matches dV tile layout
-    dv_acc_tile_type dK_tile_t;
+    dv_tile_type dK_tile_t;
 
     if (sg_ij < sg_per_wg_BcD) {
         tile_load(&dK_tile_t, dK_slm, D_MAX, ugemm_kq_wg_tile_m, D_MAX,
@@ -1154,7 +1102,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     uint sg_i0_dk = sg_i_qdSt * ugemm_qdSt_sg_tile_m;
     uint sg_j0_dk = sg_j_qdSt * ugemm_qdSt_sg_tile_n;
 
-    dk_acc_tile_type dK_tile_slm;
+    a_tile_type dK_tile_slm;
     int wg_k_chunk = min(k - k0, ugemm_kq_wg_tile_m);
     if (sg_ij < sg_per_wg_BcD) {
         tile_load(&dK_tile_slm, dK_slm, ugemm_kq_wg_tile_m, D_MAX,


### PR DESCRIPTION
# Description

This PR ensures that f32 -> f16 GQA rounding will happen in cases where IGC optimizes away the round trip conversion. This fixes GQA f16 and bf16 tests on BMG. The explicit reduction in fp16 can also be reverted since the rounding will happen after the intra-head accumulation, and should closer match the reference path.

# Checklist

## General
- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
