### PR TITLE
third_party: xbyak_riscv: upgrade to v1.31

### DIFF
--- a/third_party/xbyak_riscv/README.md
+++ b/third_party/xbyak_riscv/README.md
@@ -1,3 +1,3 @@
 This code is from [Xbyak_riscv](https://github.com/herumi/xbyak_riscv)
 
-tag: 1.10
+tag: 1.31

--- a/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv.hpp
@@ -83,11 +83,30 @@
 	#define XBYAK_RISCV_CONSTEXPR
 #endif
 
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+
+#ifndef XBYAK_RISCV_VSETV_DEFAULT_OLD
+	#pragma message "XBYAK_RISCV_VSETV_DEFAULT_OLD is 0 in the future"
+	#define XBYAK_RISCV_VSETV_DEFAULT_OLD 1
+#endif
+#if defined(XBYAK_RISCV_VSETV_DEFAULT_OLD) && XBYAK_RISCV_VSETV_DEFAULT_OLD == 1
+	// for backward compatibility
+	#define XBYAK_RISCV_VSETV_DEFAULT_LMUL =LMUL::m1
+	#define XBYAK_RISCV_VSETV_DEFAULT_VTA =VTA::tu
+	#define XBYAK_RISCV_VSETV_DEFAULT_VMA =VMA::mu
+#else
+	// no default arguments, the same as the assembler
+	#define XBYAK_RISCV_VSETV_DEFAULT_LMUL
+	#define XBYAK_RISCV_VSETV_DEFAULT_VTA
+	#define XBYAK_RISCV_VSETV_DEFAULT_VMA
+#endif
+#endif
+
 namespace Xbyak_riscv {
 
 enum {
 	DEFAULT_MAX_CODE_SIZE = 4096,
-	VERSION = 0x1010 /* 0xABCD = A.BC.D */
+	VERSION = 0x1310 /* 0xABCD = A.BC.D */
 };
 
 inline uint32_t getVersion() { return VERSION; }
@@ -941,6 +960,7 @@ private:
 	int XLEN_;
 	bool isRV32_;
 	bool supportRVC_;
+	bool supportBext_;
 	void opJmp(const Label& label, const Jmp& jmp)
 	{
 		const uint8_t* addr = labelMgr_.getAddr(label);
@@ -1311,6 +1331,7 @@ public:
 		, XLEN_(64)
 		, isRV32_(false)
 		, supportRVC_(false)
+		, supportBext_(false)
 	{
 		labelMgr_.set(this);
 	}
@@ -1323,6 +1344,7 @@ public:
 		XLEN_ = 64;
 		isRV32_ = false;
 		supportRVC_ = false;
+		supportBext_ = false;
 	}
 	void setRV32(bool on = true)
 	{
@@ -1332,6 +1354,10 @@ public:
 	void supportRVC(bool on = true)
 	{
 		supportRVC_ = on;
+	}
+	void supportBext(bool on = true)
+	{
+		supportBext_ = on;
 	}
 	bool hasUndefinedLabel() const { return labelMgr_.hasUndefClabel(); }
 	static inline void clearCache(void *p, size_t n)

--- a/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -1,4 +1,4 @@
-const char *getVersionString() const { return "1.01"; }
+const char *getVersionString() const { return "1.31"; }
 void add(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && rd == rs1 && c_mv(rd, rs2, 1)) return; Rtype(0x33, 0, 0x0, rd, rs1, rs2); }
 void sub(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x23, 0)) return; Rtype(0x33, 0, 0x20, rd, rs1, rs2); }
 void sll(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x0, rd, rs1, rs2); }
@@ -107,6 +107,50 @@ void csrrc(const Reg& rd, CSR csr, const Reg& rs1) { opCSR(0x3073, csr, rs1, rd)
 void csrrwi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x5073, csr, imm, rd); }
 void csrrsi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x6073, csr, imm, rd); }
 void csrrci(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x7073, csr, imm, rd); }
+void sh1add(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 2, 0x10, rd, rs1, rs2); }
+void sh2add(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 4, 0x10, rd, rs1, rs2); }
+void sh3add(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 6, 0x10, rd, rs1, rs2); }
+void add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 0, 0x4, rd, rs1, rs2); }
+void sh1add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 2, 0x10, rd, rs1, rs2); }
+void sh2add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 4, 0x10, rd, rs1, rs2); }
+void sh3add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 6, 0x10, rd, rs1, rs2); }
+void andn(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 7, 0x20, rd, rs1, rs2); }
+void orn(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 6, 0x20, rd, rs1, rs2); }
+void xnor(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 4, 0x20, rd, rs1, rs2); }
+void min(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 4, 0x5, rd, rs1, rs2); }
+void minu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x5, rd, rs1, rs2); }
+void max(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 6, 0x5, rd, rs1, rs2); }
+void maxu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 7, 0x5, rd, rs1, rs2); }
+void rol(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x30, rd, rs1, rs2); }
+void ror(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x30, rd, rs1, rs2); }
+void rolw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 1, 0x30, rd, rs1, rs2); }
+void rorw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 5, 0x30, rd, rs1, rs2); }
+void clmul(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x5, rd, rs1, rs2); }
+void clmulr(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 2, 0x5, rd, rs1, rs2); }
+void clmulh(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 3, 0x5, rd, rs1, rs2); }
+void bclr(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x24, rd, rs1, rs2); }
+void bext(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x24, rd, rs1, rs2); }
+void binv(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x34, rd, rs1, rs2); }
+void bset(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x14, rd, rs1, rs2); }
+void clz(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x600); }
+void ctz(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x601); }
+void cpop(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x602); }
+void clzw(const Reg& rd, const Reg& rs1) { Itype(0x1b, 1, rd, rs1, 0x600); }
+void ctzw(const Reg& rd, const Reg& rs1) { Itype(0x1b, 1, rd, rs1, 0x601); }
+void cpopw(const Reg& rd, const Reg& rs1) { Itype(0x1b, 1, rd, rs1, 0x602); }
+void orc_b(const Reg& rd, const Reg& rs1) { Itype(0x13, 5, rd, rs1, 0x287); }
+void rev8(const Reg& rd, const Reg& rs1) { Itype(0x13, 5, rd, rs1, isRV32_ ? 0x698 : 0x6b8); }
+void sext_b(const Reg& rd, const Reg& rs) { if (supportBext_) { Itype(0x13, 1, rd, rs, 0x604); return; } slli(rd, rs, XLEN_ - 8); srai(rd, rd, XLEN_ - 8); }
+void sext_h(const Reg& rd, const Reg& rs) { if (supportBext_) { Itype(0x13, 1, rd, rs, 0x605); return; } slli(rd, rs, XLEN_ - 16); srai(rd, rd, XLEN_ - 16); }
+void zext_h(const Reg& rd, const Reg& rs) { if (supportBext_) { Rtype(isRV32_ ? 0x33 : 0x3b, 4, 0x04, rd, rs, x0); return; } slli(rd, rs, XLEN_ - 16); srli(rd, rd, XLEN_ - 16); }
+void zext_w(const Reg& rd, const Reg& rs) { if (supportBext_) { add_uw(rd, rs, x0); return; } slli(rd, rs, XLEN_ - 32); srli(rd, rd, XLEN_ - 32); }
+void rori(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x30, 5, 0x13, rd, rs1, shamt); }
+void roriw(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x30, 5, 0x1b, rd, rs1, shamt, 5); }
+void slli_uw(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x4, 1, 0x1b, rd, rs1, shamt, 6); }
+void bclri(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x24, 1, 0x13, rd, rs1, shamt); }
+void bexti(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x24, 5, 0x13, rd, rs1, shamt); }
+void binvi(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x34, 1, 0x13, rd, rs1, shamt); }
+void bseti(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x14, 1, 0x13, rd, rs1, shamt); }
 void fadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x53, rs2, rs1, rm, rd); }
 void fclass_s(const Reg& rd, const FReg& rs1) { opFP(0xe0001053, 0, rs1, 0, rd); }
 void fcvt_s_w(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0000053, 0, rs1, rm, rd); }
@@ -233,12 +277,8 @@ void mv(const Reg& rd, const Reg& rs) { addi(rd, rs, 0); }
 void not_(const Reg& rd, const Reg& rs) { xori(rd, rs, -1); }
 void neg(const Reg& rd, const Reg& rs) { sub(rd, x0, rs); }
 void negw(const Reg& rd, const Reg& rs) { subw(rd, x0, rs); }
-void sext_b(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 8); srai(rd, rd, XLEN_ - 8); }
-void sext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srai(rd, rd, XLEN_ - 16); }
 void sext_w(const Reg& rd, const Reg& rs) { addiw(rd, rs, 0); }
 void zext_b(const Reg& rd, const Reg& rs) { andi(rd, rs, 255); }
-void zext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srli(rd, rd, XLEN_ - 16); }
-void zext_w(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 32); srli(rd, rd, XLEN_ - 32); }
 void seqz(const Reg& rd, const Reg& rs) { sltiu(rd, rs, 1); }
 void snez(const Reg& rd, const Reg& rs) { sltu(rd, x0, rs); }
 void sltz(const Reg& rd, const Reg& rs) { slt(rd, rs, x0); }

--- a/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv_util.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv_util.hpp
@@ -67,6 +67,22 @@ namespace Xbyak_riscv {
 #define RISCV_HWPROBE_IMA_V (1ULL << 2)
 #endif
 
+#ifndef RISCV_HWPROBE_EXT_ZBA
+#define RISCV_HWPROBE_EXT_ZBA (1ULL << 3)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZBB
+#define RISCV_HWPROBE_EXT_ZBB (1ULL << 4)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZBS
+#define RISCV_HWPROBE_EXT_ZBS (1ULL << 5)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZBC
+#define RISCV_HWPROBE_EXT_ZBC (1ULL << 7)
+#endif
+
 #ifndef RISCV_HWPROBE_EXT_ZVBB
 #define RISCV_HWPROBE_EXT_ZVBB (1ULL << 17)
 #endif
@@ -109,7 +125,11 @@ enum class RISCVExtension : uint64_t {
     Zvbb = 1ULL << 27,
     Zvbc = 1ULL << 28,
     Zvkg = 1ULL << 29,
-    Zvfbfwma = 1ULL << 30
+    Zvfbfwma = 1ULL << 30,
+    Zba = 1ULL << 31,
+    Zbb = 1ULL << 32,
+    Zbc = 1ULL << 33,
+    Zbs = 1ULL << 34
 };
 
 template <CSR csr>
@@ -171,7 +191,11 @@ public:
                 { RISCVExtension::Zvbb, RISCV_HWPROBE_EXT_ZVBB },
                 { RISCVExtension::Zvbc, RISCV_HWPROBE_EXT_ZVBC },
                 { RISCVExtension::Zvkg, RISCV_HWPROBE_EXT_ZVKG },
-                { RISCVExtension::Zvfbfwma, RISCV_HWPROBE_EXT_ZVFBFWMA }
+                { RISCVExtension::Zvfbfwma, RISCV_HWPROBE_EXT_ZVFBFWMA },
+                { RISCVExtension::Zba, RISCV_HWPROBE_EXT_ZBA },
+                { RISCVExtension::Zbb, RISCV_HWPROBE_EXT_ZBB },
+                { RISCVExtension::Zbc, RISCV_HWPROBE_EXT_ZBC },
+                { RISCVExtension::Zbs, RISCV_HWPROBE_EXT_ZBS }
             };
             for (const auto& entry : table) {
                 if (v & entry.hwprobe_bit) {

--- a/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv_v.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv/xbyak_riscv_v.hpp
@@ -58,6 +58,7 @@ void vfmv_f_s(const FReg& rd, const VReg& vs2) { opFVV(0x42001057, 0, vs2, 0, rd
 void vfmv_s_f(const VReg& vd, const FReg& rs1) { opFVF(0x42005057, 0, 0, rs1, vd); }
 void vfmv_v_f(const VReg& vd, const FReg& rs1) { opFVF(0x5e005057, 0, 0, rs1, vd); }
 void vfncvt_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480a1057, vm, vs2, 0, vd); }
+void vfncvtbf16_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480e9057, vm, vs2, 0, vd); }
 void vfncvt_f_x_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48099057, vm, vs2, 0, vd); }
 void vfncvt_f_xu_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48091057, vm, vs2, 0, vd); }
 void vfncvt_rod_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480a9057, vm, vs2, 0, vd); }
@@ -97,6 +98,7 @@ void vfwadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmas
 void vfwadd_wf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0xd0005057, vm, vs2, rs1, vd); }
 void vfwadd_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xd0001057, vm, vs2, vs1, vd); }
 void vfwcvt_f_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48061057, vm, vs2, 0, vd); }
+void vfwcvtbf16_f_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48069057, vm, vs2, 0, vd); }
 void vfwcvt_f_x_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48059057, vm, vs2, 0, vd); }
 void vfwcvt_f_xu_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48051057, vm, vs2, 0, vd); }
 void vfwcvt_rtz_x_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48079057, vm, vs2, 0, vd); }
@@ -127,18 +129,18 @@ void vl1re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, r
 void vl1re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
 void vl1re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
 void vl1re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
-void vl2re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, rs1, vd); }
-void vl2re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
-void vl2re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
-void vl2re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
-void vl4re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, rs1, vd); }
-void vl4re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
-void vl4re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
-void vl4re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
-void vl8re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, rs1, vd); }
-void vl8re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
-void vl8re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
-void vl8re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
+void vl2re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x22805007, 0, 0, rs1, vd); }
+void vl2re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x22806007, 0, 0, rs1, vd); }
+void vl2re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x22807007, 0, 0, rs1, vd); }
+void vl2re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x22800007, 0, 0, rs1, vd); }
+void vl4re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x62805007, 0, 0, rs1, vd); }
+void vl4re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x62806007, 0, 0, rs1, vd); }
+void vl4re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x62807007, 0, 0, rs1, vd); }
+void vl4re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x62800007, 0, 0, rs1, vd); }
+void vl8re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0xe2805007, 0, 0, rs1, vd); }
+void vl8re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0xe2806007, 0, 0, rs1, vd); }
+void vl8re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0xe2807007, 0, 0, rs1, vd); }
+void vl8re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0xe2800007, 0, 0, rs1, vd); }
 void vlseg1e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10007007, vm, 0, rs1, vd); }
 void vlseg2e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x30007007, vm, 0, rs1, vd); }
 void vlseg3e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x50007007, vm, 0, rs1, vd); }
@@ -493,9 +495,9 @@ void vrgatherei16_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM:
 void vrsub_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xc003057, vm, vs2, simm5, vd); }
 void vrsub_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xc004057, vm, vs2, rs1, vd); }
 void vs1r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
-void vs2r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
-void vs4r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
-void vs8r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
+void vs2r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x22800027, 0, 0, rs1, vs3); }
+void vs4r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x62800027, 0, 0, rs1, vs3); }
+void vs8r_v(VReg vs3, const Reg& rs1) { opVectorStore(0xe2800027, 0, 0, rs1, vs3); }
 void vsadd_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x84003057, vm, vs2, simm5, vd); }
 void vsadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x84000057, vm, vs2, vs1, vd); }
 void vsadd_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x84004057, vm, vs2, rs1, vd); }
@@ -735,7 +737,7 @@ void vzext_vf2(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x48
 void vzext_vf4(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x48022057, vm, vs2, 0, vd); }
 void vzext_vf8(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x48012057, vm, vs2, 0, vd); }
 
-void vsetivli(const Reg& rd, uint32_t uimm, SEW sew, LMUL lmul=LMUL::m1, VTA vta=VTA::tu, VMA vma=VMA::mu) {
+void vsetivli(const Reg& rd, uint32_t uimm, SEW sew, LMUL lmul XBYAK_RISCV_VSETV_DEFAULT_LMUL, VTA vta XBYAK_RISCV_VSETV_DEFAULT_VTA, VMA vma XBYAK_RISCV_VSETV_DEFAULT_VMA) {
     uint32_t zimm = (static_cast<uint32_t>(vma)<<7) |
                     (static_cast<uint32_t>(vta)<<6) |
                     (static_cast<uint32_t>(sew)<<3) |
@@ -744,7 +746,7 @@ void vsetivli(const Reg& rd, uint32_t uimm, SEW sew, LMUL lmul=LMUL::m1, VTA vta
     append4B(v);
 }
 
-void vsetvli(const Reg& rd, const Reg& rs1, SEW sew, LMUL lmul=LMUL::m1, VTA vta=VTA::tu, VMA vma=VMA::mu) {
+void vsetvli(const Reg& rd, const Reg& rs1, SEW sew, LMUL lmul XBYAK_RISCV_VSETV_DEFAULT_LMUL, VTA vta XBYAK_RISCV_VSETV_DEFAULT_VTA, VMA vma XBYAK_RISCV_VSETV_DEFAULT_VMA) {
     uint32_t zimm = (static_cast<uint32_t>(vma)<<7) |
                     (static_cast<uint32_t>(vta)<<6) |
                     (static_cast<uint32_t>(sew)<<3) |


### PR DESCRIPTION
# Description

This PR updates xbyak_riscv to the latest version, 1.31.
This PR is a prerequisite for #5453.


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

