### PR TITLE
cpu: rv64: add RVV JIT PReLU forward primitive

### DIFF
--- a/src/cpu/cpu_prelu_list.cpp
+++ b/src/cpu/cpu_prelu_list.cpp
@@ -45,9 +45,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
         {{forward}, {
             CPU_INSTANCE_X64(jit_prelu_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_prelu_fwd_t)
-            CPU_INSTANCE_RV64(jit_uni_prelu_fwd_t<v>)
-            CPU_INSTANCE_RV64(jit_uni_prelu_fwd_t<zvfh>)
-            CPU_INSTANCE_RV64(jit_uni_prelu_fwd_t<zvfbfwma>)
+            CPU_INSTANCE_RV64(jit_uni_prelu_fwd_t)
             CPU_INSTANCE(ref_prelu_fwd_t)
             nullptr,
         }},

--- a/src/cpu/cpu_prelu_list.cpp
+++ b/src/cpu/cpu_prelu_list.cpp
@@ -26,6 +26,9 @@ using namespace dnnl::impl::cpu::x64;
 #elif DNNL_AARCH64 && defined(DNNL_AARCH64_USE_ACL)
 #include "cpu/aarch64/acl_prelu.hpp"
 using namespace dnnl::impl::cpu::aarch64;
+#elif DNNL_RV64
+#include "cpu/rv64/jit_uni_prelu.hpp"
+using namespace dnnl::impl::cpu::rv64;
 #endif
 
 namespace dnnl {
@@ -42,6 +45,9 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
         {{forward}, {
             CPU_INSTANCE_X64(jit_prelu_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_prelu_fwd_t)
+            CPU_INSTANCE_RV64(jit_uni_prelu_fwd_t<v>)
+            CPU_INSTANCE_RV64(jit_uni_prelu_fwd_t<zvfh>)
+            CPU_INSTANCE_RV64(jit_uni_prelu_fwd_t<zvfbfwma>)
             CPU_INSTANCE(ref_prelu_fwd_t)
             nullptr,
         }},

--- a/src/cpu/rv64/jit_uni_prelu.cpp
+++ b/src/cpu/rv64/jit_uni_prelu.cpp
@@ -88,15 +88,18 @@ void emit_prelu_loop(jit_generator_t *h, data_type_t dt, data_type_t wei_dt,
     h->L(loop);
     h->beqz(len, done);
 
+    // All vsetvli use the tail/mask-agnostic policy (ta, ma): every iteration
+    // processes exactly vl elements (no masking, no tail reads), so agnostic is
+    // result-equivalent and avoids preserving inactive elements on OoO cores.
     // ---- load + widen src to f32 in vsrc; leaves vtype = e32, clmul ----
     if (!src16) {
-        h->vsetvli(vl, len, SEW::e32, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         h->vle32_v(vsrc, p_in);
     } else {
-        h->vsetvli(vl, len, SEW::e16, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         h->vle16_v(vt, p_in);
         emit_widen16(h, vsrc, vt, dt); // e16m1 -> e32m2
-        h->vsetvli(x0, vl, SEW::e32, LMUL::m2);
+        h->vsetvli(x0, vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
     }
 
     // ---- load + widen weights to f32 in vw (lockstep only) ----
@@ -107,10 +110,11 @@ void emit_prelu_loop(jit_generator_t *h, data_type_t dt, data_type_t wei_dt,
         } else {
             // 16-bit weights load at half the compute LMUL, then widen.
             const LMUL wlmul = (clmul == LMUL::m1) ? LMUL::mf2 : LMUL::m1;
-            h->vsetvli(x0, vl, SEW::e16, wlmul);
+            h->vsetvli(x0, vl, SEW::e16, wlmul, VTA::ta, VMA::ma);
             h->vle16_v(vt, p_w);
             emit_widen16(h, vw, vt, wei_dt); // e16(wlmul) -> e32(clmul)
-            h->vsetvli(x0, vl, SEW::e32, clmul); // restore compute vtype
+            h->vsetvli(x0, vl, SEW::e32, clmul, VTA::ta,
+                    VMA::ma); // restore compute vtype
         }
     }
 
@@ -127,7 +131,7 @@ void emit_prelu_loop(jit_generator_t *h, data_type_t dt, data_type_t wei_dt,
     if (!src16) {
         h->vse32_v(vmin, p_out);
     } else { // f16 / bf16: narrow f32 -> 16-bit (e32m2 -> e16m1) and store
-        h->vsetvli(x0, vl, SEW::e16, LMUL::m1);
+        h->vsetvli(x0, vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         if (dt == data_type::bf16)
             h->vfncvtbf16_f_f_w(vt, vmin); // Zvfbfmin, round-to-nearest-even
         else

--- a/src/cpu/rv64/jit_uni_prelu.cpp
+++ b/src/cpu/rv64/jit_uni_prelu.cpp
@@ -190,14 +190,10 @@ struct jit_uni_prelu_fwd_kernel_t : public jit_generator_t {
     bool scalar_mode_;
 };
 
-template <cpu_isa_t isa>
-jit_uni_prelu_fwd_t<isa>::jit_uni_prelu_fwd_t(const pd_t *apd)
-    : primitive_t(apd) {}
-template <cpu_isa_t isa>
-jit_uni_prelu_fwd_t<isa>::~jit_uni_prelu_fwd_t() = default;
+jit_uni_prelu_fwd_t::jit_uni_prelu_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+jit_uni_prelu_fwd_t::~jit_uni_prelu_fwd_t() = default;
 
-template <cpu_isa_t isa>
-status_t jit_uni_prelu_fwd_t<isa>::init(engine_t *engine) {
+status_t jit_uni_prelu_fwd_t::init(engine_t *engine) {
     UNUSED(engine);
     const data_type_t dt = pd()->src_md(0)->data_type;
     const data_type_t wei_dt = pd()->weights_md(0)->data_type;
@@ -214,8 +210,7 @@ status_t jit_uni_prelu_fwd_t<isa>::init(engine_t *engine) {
     return status::success;
 }
 
-template <cpu_isa_t isa>
-status_t jit_uni_prelu_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
+status_t jit_uni_prelu_fwd_t::execute(const exec_ctx_t &ctx) const {
     using kparams_t = jit_uni_prelu_fwd_kernel_t::call_params_t;
 
     const auto *src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);
@@ -340,10 +335,6 @@ status_t jit_uni_prelu_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
     }
     return status::success;
 }
-
-template struct jit_uni_prelu_fwd_t<v>;
-template struct jit_uni_prelu_fwd_t<zvfh>;
-template struct jit_uni_prelu_fwd_t<zvfbfwma>;
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_uni_prelu.cpp
+++ b/src/cpu/rv64/jit_uni_prelu.cpp
@@ -49,24 +49,37 @@ float load_weight_f32(const void *base, dim_t idx, data_type_t dt) {
     }
 }
 
+// Emit a widening f32 convert of a 16-bit group: bf16 via Zvfbfmin, f16 via Zvfh.
+void emit_widen16(
+        jit_generator_t *h, const VReg &vd, const VReg &vs, data_type_t dt) {
+    if (dt == data_type::bf16)
+        h->vfwcvtbf16_f_f_v(vd, vs); // Zvfbfmin
+    else
+        h->vfwcvt_f_f_v(vd, vs); // Zvfh
+}
+
 // Emit one vector-length-agnostic PReLU pass over `len` elements:
 //   dst = max(0, src) + weights * min(0, src)
 // computed in f32. Weights are either a per-element vector that walks in
 // lockstep with src (scalar_mode == false) or a single f32 splat (scalar_mode).
-// 16-bit types widen/narrow with the native FP-convert instructions: Zvfh's
-// vfwcvt/vfncvt for f16, and Zvfbfmin's vfwcvtbf16/vfncvtbf16 (RNE narrow) for
-// bf16 — Zvfbfwma, which this primitive gates bf16 on, implies Zvfbfmin.
+// src/dst share dtype `dt`; the lockstep weights carry their own `wei_dt`, so
+// every src x weights dtype combo is supported. 16-bit types widen/narrow with
+// the native FP converts (Zvfh vfwcvt/vfncvt, Zvfbfmin vfwcvtbf16/vfncvtbf16).
 //
-// Register layout: a1=src, a2=weights, a3=dst, a4=len; t0=vl, t1=bytes;
-// v8=f32 src/compute group, v12=max, v16=min (== dst), v20=weights vector,
-// v4=16-bit load staging; fa0=zero const, fa1=scalar weight.
-void emit_prelu_loop(jit_generator_t *h, data_type_t dt, bool scalar_mode,
-        size_t weight_off) {
-    const Reg p_in = a1, p_w = a2, p_out = a3, len = a4, vl = t0, bytes = t1;
+// Register layout: a1=src, a2=weights, a3=dst, a4=len; t0=vl, t1=bytes,
+// t2=wei bytes; v8=f32 src/compute group, v12=max, v16=min (== dst),
+// v20=weights vector, v4=16-bit load staging; fa0=zero const, fa1=scalar weight.
+void emit_prelu_loop(jit_generator_t *h, data_type_t dt, data_type_t wei_dt,
+        bool scalar_mode, size_t weight_off) {
+    const Reg p_in = a1, p_w = a2, p_out = a3, len = a4, vl = t0, bytes = t1,
+              wbytes = t2;
     const VReg vsrc(8), vmax(12), vmin(16), vw(20), vt(4);
     const FReg fzero = fa0, fw = fa1;
 
-    const bool is16 = utils::one_of(dt, data_type::f16, data_type::bf16);
+    const bool src16 = utils::one_of(dt, data_type::f16, data_type::bf16);
+    const bool wei16 = utils::one_of(wei_dt, data_type::f16, data_type::bf16);
+    // Compute LMUL: 16-bit src widens e16m1 -> e32m2, f32 src stays e32m1.
+    const LMUL clmul = src16 ? LMUL::m2 : LMUL::m1;
 
     h->fmv_w_x(fzero, x0); // 0.0f
     if (scalar_mode) h->flw(fw, a0, static_cast<int>(weight_off));
@@ -75,27 +88,30 @@ void emit_prelu_loop(jit_generator_t *h, data_type_t dt, bool scalar_mode,
     h->L(loop);
     h->beqz(len, done);
 
-    // ---- load src (+ weights) and widen to f32 ----
-    if (dt == data_type::f32) {
+    // ---- load + widen src to f32 in vsrc; leaves vtype = e32, clmul ----
+    if (!src16) {
         h->vsetvli(vl, len, SEW::e32, LMUL::m1);
         h->vle32_v(vsrc, p_in);
-        if (!scalar_mode) h->vle32_v(vw, p_w);
-    } else { // f16 / bf16: load 16-bit and widen to f32 (e16m1 -> e32m2)
-        const bool is_bf16 = dt == data_type::bf16;
+    } else {
         h->vsetvli(vl, len, SEW::e16, LMUL::m1);
         h->vle16_v(vt, p_in);
-        if (is_bf16)
-            h->vfwcvtbf16_f_f_v(vsrc, vt); // Zvfbfmin
-        else
-            h->vfwcvt_f_f_v(vsrc, vt); // Zvfh
-        if (!scalar_mode) {
-            h->vle16_v(vt, p_w);
-            if (is_bf16)
-                h->vfwcvtbf16_f_f_v(vw, vt);
-            else
-                h->vfwcvt_f_f_v(vw, vt);
-        }
+        emit_widen16(h, vsrc, vt, dt); // e16m1 -> e32m2
         h->vsetvli(x0, vl, SEW::e32, LMUL::m2);
+    }
+
+    // ---- load + widen weights to f32 in vw (lockstep only) ----
+    if (!scalar_mode) {
+        if (!wei16) {
+            // f32 weights: load directly at the compute vtype (e32, clmul).
+            h->vle32_v(vw, p_w);
+        } else {
+            // 16-bit weights load at half the compute LMUL, then widen.
+            const LMUL wlmul = (clmul == LMUL::m1) ? LMUL::mf2 : LMUL::m1;
+            h->vsetvli(x0, vl, SEW::e16, wlmul);
+            h->vle16_v(vt, p_w);
+            emit_widen16(h, vw, vt, wei_dt); // e16(wlmul) -> e32(clmul)
+            h->vsetvli(x0, vl, SEW::e32, clmul); // restore compute vtype
+        }
     }
 
     // ---- compute: dst = max(0, src) + weights * min(0, src) ----
@@ -107,8 +123,8 @@ void emit_prelu_loop(jit_generator_t *h, data_type_t dt, bool scalar_mode,
         h->vfmadd_vv(vmin, vw, vmax); // vmin = vmin * vw + vmax
     // result now in vmin
 
-    // ---- narrow + store ----
-    if (dt == data_type::f32) {
+    // ---- narrow + store (dst dtype == src dtype) ----
+    if (!src16) {
         h->vse32_v(vmin, p_out);
     } else { // f16 / bf16: narrow f32 -> 16-bit (e32m2 -> e16m1) and store
         h->vsetvli(x0, vl, SEW::e16, LMUL::m1);
@@ -119,12 +135,18 @@ void emit_prelu_loop(jit_generator_t *h, data_type_t dt, bool scalar_mode,
         h->vse16_v(vt, p_out);
     }
 
-    // ---- advance pointers by vl * sizeof(dtype) and loop ----
-    const int sh = is16 ? 1 : 2;
-    h->slli(bytes, vl, sh);
+    // ---- advance pointers (src/dst by dt size, weights by wei_dt size) ----
+    h->slli(bytes, vl, src16 ? 1 : 2);
     h->add(p_in, p_in, bytes);
     h->add(p_out, p_out, bytes);
-    if (!scalar_mode) h->add(p_w, p_w, bytes);
+    if (!scalar_mode) {
+        if (wei16 == src16) {
+            h->add(p_w, p_w, bytes);
+        } else {
+            h->slli(wbytes, vl, wei16 ? 1 : 2);
+            h->add(p_w, p_w, wbytes);
+        }
+    }
     h->sub(len, len, vl);
     h->j_(loop);
 
@@ -143,9 +165,11 @@ struct jit_uni_prelu_fwd_kernel_t : public jit_generator_t {
     };
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_prelu_fwd_kernel_t)
 
-    jit_uni_prelu_fwd_kernel_t(data_type_t dt, bool scalar_mode)
+    jit_uni_prelu_fwd_kernel_t(
+            data_type_t dt, data_type_t wei_dt, bool scalar_mode)
         : jit_generator_t("jit_uni_prelu_fwd")
         , dt_(dt)
+        , wei_dt_(wei_dt)
         , scalar_mode_(scalar_mode) {
         create_kernel();
     }
@@ -157,11 +181,12 @@ struct jit_uni_prelu_fwd_kernel_t : public jit_generator_t {
         if (!scalar_mode_) ld(a2, a0, offsetof(call_params_t, weights));
         ld(a3, a0, offsetof(call_params_t, dst));
         ld(a4, a0, offsetof(call_params_t, len));
-        emit_prelu_loop(
-                this, dt_, scalar_mode_, offsetof(call_params_t, weight));
+        emit_prelu_loop(this, dt_, wei_dt_, scalar_mode_,
+                offsetof(call_params_t, weight));
         ret();
     }
     data_type_t dt_;
+    data_type_t wei_dt_;
     bool scalar_mode_;
 };
 
@@ -175,14 +200,17 @@ template <cpu_isa_t isa>
 status_t jit_uni_prelu_fwd_t<isa>::init(engine_t *engine) {
     UNUSED(engine);
     const data_type_t dt = pd()->src_md(0)->data_type;
+    const data_type_t wei_dt = pd()->weights_md(0)->data_type;
+    // scalar / per_oc_nchw read the weight on the host (any dtype); the lockstep
+    // paths (full / per_oc_nhwc / per_oc_blocked) load weights in-kernel.
     const bool needs_scalar = utils::one_of(
             pd()->bcast_, prelu_bcast_t::scalar, prelu_bcast_t::per_oc_nchw);
     if (needs_scalar)
-        scalar_kernel_.reset(
-                new jit_uni_prelu_fwd_kernel_t(dt, /*scalar_mode=*/true));
+        scalar_kernel_.reset(new jit_uni_prelu_fwd_kernel_t(
+                dt, wei_dt, /*scalar_mode=*/true));
     else
-        kernel_.reset(
-                new jit_uni_prelu_fwd_kernel_t(dt, /*scalar_mode=*/false));
+        kernel_.reset(new jit_uni_prelu_fwd_kernel_t(
+                dt, wei_dt, /*scalar_mode=*/false));
     return status::success;
 }
 
@@ -195,14 +223,16 @@ status_t jit_uni_prelu_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
     auto *dst = CTX_OUT_MEM(char *, DNNL_ARG_DST);
 
     const data_type_t dt = pd()->src_md(0)->data_type;
+    const data_type_t wei_dt = pd()->weights_md(0)->data_type;
     const size_t es = types::data_type_size(dt);
+    const size_t wes = types::data_type_size(wei_dt);
 
     const memory_desc_wrapper src_d(pd()->src_md(0));
     const memory_desc_wrapper weights_d(pd()->weights_md(0));
     const dim_t nelems = src_d.nelems(true);
     const char *src_base = src + (size_t)src_d.offset0() * es;
     char *dst_base = dst + (size_t)src_d.offset0() * es;
-    const char *wei_base = weights + (size_t)weights_d.offset0() * es;
+    const char *wei_base = weights + (size_t)weights_d.offset0() * wes;
 
     const int max_thr = dnnl_get_max_threads();
 
@@ -215,7 +245,7 @@ status_t jit_uni_prelu_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                 if (start >= end) return;
                 kparams_t p;
                 p.src = src_base + start * es;
-                p.weights = wei_base + start * es;
+                p.weights = wei_base + start * wes;
                 p.dst = dst_base + start * es;
                 p.len = end - start;
                 (*kernel_)(&p);
@@ -223,7 +253,7 @@ status_t jit_uni_prelu_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
             break;
         }
         case prelu_bcast_t::scalar: {
-            const float w = load_weight_f32(wei_base, 0, dt);
+            const float w = load_weight_f32(wei_base, 0, wei_dt);
             parallel(max_thr, [&](int ithr, int nthr) {
                 dim_t start = 0, end = 0;
                 balance211(nelems, nthr, ithr, start, end);
@@ -272,8 +302,36 @@ status_t jit_uni_prelu_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                     p.src = src_base + (size_t)pl * SP * es;
                     p.dst = dst_base + (size_t)pl * SP * es;
                     p.len = SP;
-                    p.weight = load_weight_f32(wei_base, c, dt);
+                    p.weight = load_weight_f32(wei_base, c, wei_dt);
                     (*scalar_kernel_)(&p);
+                }
+            });
+            break;
+        }
+        case prelu_bcast_t::per_oc_blocked: {
+            // Channel-blocked (nChw{8,16}c): the layout is [N][C/blk][sp][blk],
+            // so each contiguous run of `blk` elements is one channel block at
+            // some (n, c_outer, sp) and pairs in lockstep with weights[c_outer
+            // * blk .. +blk). Walk over those runs, parallelizing across them.
+            const auto &bd = src_d.blocking_desc();
+            const dim_t blk = bd.inner_blks[0];
+            const dim_t N = src_d.padded_dims()[0];
+            const dim_t Cpad = src_d.padded_dims()[1];
+            const dim_t Cb = Cpad / blk;
+            const dim_t HW
+                    = nelems / (N * Cpad); // spatial positions per (n,co)
+            const dim_t runs = nelems / blk;
+            parallel(max_thr, [&](int ithr, int nthr) {
+                dim_t start = 0, end = 0;
+                balance211(runs, nthr, ithr, start, end);
+                for (dim_t r = start; r < end; ++r) {
+                    const dim_t c_outer = (r / HW) % Cb;
+                    kparams_t p;
+                    p.src = src_base + (size_t)r * blk * es;
+                    p.weights = wei_base + (size_t)c_outer * blk * wes;
+                    p.dst = dst_base + (size_t)r * blk * es;
+                    p.len = blk;
+                    (*kernel_)(&p);
                 }
             });
             break;

--- a/src/cpu/rv64/jit_uni_prelu.cpp
+++ b/src/cpu/rv64/jit_uni_prelu.cpp
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright 2026 openKylin community
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include <cstddef>
+
+#include "common/bfloat16.hpp"
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/float16.hpp"
+#include "common/memory_desc_wrapper.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/rv64/jit_generator.hpp"
+#include "cpu/rv64/jit_uni_prelu.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+namespace {
+
+// Read one weights element of an arbitrary supported dtype as f32 (host side,
+// used by the scalar-broadcast paths so the kernel only ever sees an f32).
+float load_weight_f32(const void *base, dim_t idx, data_type_t dt) {
+    switch (dt) {
+        case data_type::f32: return reinterpret_cast<const float *>(base)[idx];
+        case data_type::f16:
+            return static_cast<float>(
+                    reinterpret_cast<const float16_t *>(base)[idx]);
+        case data_type::bf16:
+            return static_cast<float>(
+                    reinterpret_cast<const bfloat16_t *>(base)[idx]);
+        default: assert(!"unsupported dtype"); return 0.f;
+    }
+}
+
+// Emit one vector-length-agnostic PReLU pass over `len` elements:
+//   dst = max(0, src) + weights * min(0, src)
+// computed in f32. Weights are either a per-element vector that walks in
+// lockstep with src (scalar_mode == false) or a single f32 splat (scalar_mode).
+// 16-bit types widen/narrow with the native FP-convert instructions: Zvfh's
+// vfwcvt/vfncvt for f16, and Zvfbfmin's vfwcvtbf16/vfncvtbf16 (RNE narrow) for
+// bf16 — Zvfbfwma, which this primitive gates bf16 on, implies Zvfbfmin.
+//
+// Register layout: a1=src, a2=weights, a3=dst, a4=len; t0=vl, t1=bytes;
+// v8=f32 src/compute group, v12=max, v16=min (== dst), v20=weights vector,
+// v4=16-bit load staging; fa0=zero const, fa1=scalar weight.
+void emit_prelu_loop(jit_generator_t *h, data_type_t dt, bool scalar_mode,
+        size_t weight_off) {
+    const Reg p_in = a1, p_w = a2, p_out = a3, len = a4, vl = t0, bytes = t1;
+    const VReg vsrc(8), vmax(12), vmin(16), vw(20), vt(4);
+    const FReg fzero = fa0, fw = fa1;
+
+    const bool is16 = utils::one_of(dt, data_type::f16, data_type::bf16);
+
+    h->fmv_w_x(fzero, x0); // 0.0f
+    if (scalar_mode) h->flw(fw, a0, static_cast<int>(weight_off));
+
+    Label loop, done;
+    h->L(loop);
+    h->beqz(len, done);
+
+    // ---- load src (+ weights) and widen to f32 ----
+    if (dt == data_type::f32) {
+        h->vsetvli(vl, len, SEW::e32, LMUL::m1);
+        h->vle32_v(vsrc, p_in);
+        if (!scalar_mode) h->vle32_v(vw, p_w);
+    } else { // f16 / bf16: load 16-bit and widen to f32 (e16m1 -> e32m2)
+        const bool is_bf16 = dt == data_type::bf16;
+        h->vsetvli(vl, len, SEW::e16, LMUL::m1);
+        h->vle16_v(vt, p_in);
+        if (is_bf16)
+            h->vfwcvtbf16_f_f_v(vsrc, vt); // Zvfbfmin
+        else
+            h->vfwcvt_f_f_v(vsrc, vt); // Zvfh
+        if (!scalar_mode) {
+            h->vle16_v(vt, p_w);
+            if (is_bf16)
+                h->vfwcvtbf16_f_f_v(vw, vt);
+            else
+                h->vfwcvt_f_f_v(vw, vt);
+        }
+        h->vsetvli(x0, vl, SEW::e32, LMUL::m2);
+    }
+
+    // ---- compute: dst = max(0, src) + weights * min(0, src) ----
+    h->vfmax_vf(vmax, vsrc, fzero);
+    h->vfmin_vf(vmin, vsrc, fzero);
+    if (scalar_mode)
+        h->vfmadd_vf(vmin, fw, vmax); // vmin = vmin * fw + vmax
+    else
+        h->vfmadd_vv(vmin, vw, vmax); // vmin = vmin * vw + vmax
+    // result now in vmin
+
+    // ---- narrow + store ----
+    if (dt == data_type::f32) {
+        h->vse32_v(vmin, p_out);
+    } else { // f16 / bf16: narrow f32 -> 16-bit (e32m2 -> e16m1) and store
+        h->vsetvli(x0, vl, SEW::e16, LMUL::m1);
+        if (dt == data_type::bf16)
+            h->vfncvtbf16_f_f_w(vt, vmin); // Zvfbfmin, round-to-nearest-even
+        else
+            h->vfncvt_f_f_w(vt, vmin); // Zvfh
+        h->vse16_v(vt, p_out);
+    }
+
+    // ---- advance pointers by vl * sizeof(dtype) and loop ----
+    const int sh = is16 ? 1 : 2;
+    h->slli(bytes, vl, sh);
+    h->add(p_in, p_in, bytes);
+    h->add(p_out, p_out, bytes);
+    if (!scalar_mode) h->add(p_w, p_w, bytes);
+    h->sub(len, len, vl);
+    h->j_(loop);
+
+    h->L(done);
+}
+
+} // namespace
+
+struct jit_uni_prelu_fwd_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const void *src;
+        const void *weights; // lockstep mode only
+        void *dst;
+        dim_t len;
+        float weight; // scalar mode only
+    };
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_prelu_fwd_kernel_t)
+
+    jit_uni_prelu_fwd_kernel_t(data_type_t dt, bool scalar_mode)
+        : jit_generator_t("jit_uni_prelu_fwd")
+        , dt_(dt)
+        , scalar_mode_(scalar_mode) {
+        create_kernel();
+    }
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+    void generate() override {
+        ld(a1, a0, offsetof(call_params_t, src));
+        if (!scalar_mode_) ld(a2, a0, offsetof(call_params_t, weights));
+        ld(a3, a0, offsetof(call_params_t, dst));
+        ld(a4, a0, offsetof(call_params_t, len));
+        emit_prelu_loop(
+                this, dt_, scalar_mode_, offsetof(call_params_t, weight));
+        ret();
+    }
+    data_type_t dt_;
+    bool scalar_mode_;
+};
+
+template <cpu_isa_t isa>
+jit_uni_prelu_fwd_t<isa>::jit_uni_prelu_fwd_t(const pd_t *apd)
+    : primitive_t(apd) {}
+template <cpu_isa_t isa>
+jit_uni_prelu_fwd_t<isa>::~jit_uni_prelu_fwd_t() = default;
+
+template <cpu_isa_t isa>
+status_t jit_uni_prelu_fwd_t<isa>::init(engine_t *engine) {
+    UNUSED(engine);
+    const data_type_t dt = pd()->src_md(0)->data_type;
+    const bool needs_scalar = utils::one_of(
+            pd()->bcast_, prelu_bcast_t::scalar, prelu_bcast_t::per_oc_nchw);
+    if (needs_scalar)
+        scalar_kernel_.reset(
+                new jit_uni_prelu_fwd_kernel_t(dt, /*scalar_mode=*/true));
+    else
+        kernel_.reset(
+                new jit_uni_prelu_fwd_kernel_t(dt, /*scalar_mode=*/false));
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_prelu_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
+    using kparams_t = jit_uni_prelu_fwd_kernel_t::call_params_t;
+
+    const auto *src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);
+    const auto *weights = CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS);
+    auto *dst = CTX_OUT_MEM(char *, DNNL_ARG_DST);
+
+    const data_type_t dt = pd()->src_md(0)->data_type;
+    const size_t es = types::data_type_size(dt);
+
+    const memory_desc_wrapper src_d(pd()->src_md(0));
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+    const dim_t nelems = src_d.nelems(true);
+    const char *src_base = src + (size_t)src_d.offset0() * es;
+    char *dst_base = dst + (size_t)src_d.offset0() * es;
+    const char *wei_base = weights + (size_t)weights_d.offset0() * es;
+
+    const int max_thr = dnnl_get_max_threads();
+
+    switch (pd()->bcast_) {
+        case prelu_bcast_t::full: {
+            // Flat lockstep over the whole tensor; src and weights share layout.
+            parallel(max_thr, [&](int ithr, int nthr) {
+                dim_t start = 0, end = 0;
+                balance211(nelems, nthr, ithr, start, end);
+                if (start >= end) return;
+                kparams_t p;
+                p.src = src_base + start * es;
+                p.weights = wei_base + start * es;
+                p.dst = dst_base + start * es;
+                p.len = end - start;
+                (*kernel_)(&p);
+            });
+            break;
+        }
+        case prelu_bcast_t::scalar: {
+            const float w = load_weight_f32(wei_base, 0, dt);
+            parallel(max_thr, [&](int ithr, int nthr) {
+                dim_t start = 0, end = 0;
+                balance211(nelems, nthr, ithr, start, end);
+                if (start >= end) return;
+                kparams_t p;
+                p.src = src_base + start * es;
+                p.dst = dst_base + start * es;
+                p.len = end - start;
+                p.weight = w;
+                (*scalar_kernel_)(&p);
+            });
+            break;
+        }
+        case prelu_bcast_t::per_oc_nhwc: {
+            // Channel is innermost: each contiguous run of C elements pairs with
+            // weights[0..C). Parallelize over the N*spatial outer runs.
+            const dim_t C = src_d.dims()[1];
+            const dim_t outer = nelems / C;
+            parallel(max_thr, [&](int ithr, int nthr) {
+                dim_t start = 0, end = 0;
+                balance211(outer, nthr, ithr, start, end);
+                for (dim_t i = start; i < end; ++i) {
+                    kparams_t p;
+                    p.src = src_base + (size_t)i * C * es;
+                    p.weights = wei_base;
+                    p.dst = dst_base + (size_t)i * C * es;
+                    p.len = C;
+                    (*kernel_)(&p);
+                }
+            });
+            break;
+        }
+        case prelu_bcast_t::per_oc_nchw: {
+            // Channel-major plain: each (n, c) spatial plane of SP contiguous
+            // elements shares one weight w[c]. Parallelize over the N*C planes.
+            const dim_t N = src_d.dims()[0];
+            const dim_t C = src_d.dims()[1];
+            const dim_t planes = N * C;
+            const dim_t SP = nelems / planes;
+            parallel(max_thr, [&](int ithr, int nthr) {
+                dim_t start = 0, end = 0;
+                balance211(planes, nthr, ithr, start, end);
+                for (dim_t pl = start; pl < end; ++pl) {
+                    const dim_t c = pl % C;
+                    kparams_t p;
+                    p.src = src_base + (size_t)pl * SP * es;
+                    p.dst = dst_base + (size_t)pl * SP * es;
+                    p.len = SP;
+                    p.weight = load_weight_f32(wei_base, c, dt);
+                    (*scalar_kernel_)(&p);
+                }
+            });
+            break;
+        }
+        default: assert(!"unsupported broadcast"); return status::runtime_error;
+    }
+    return status::success;
+}
+
+template struct jit_uni_prelu_fwd_t<v>;
+template struct jit_uni_prelu_fwd_t<zvfh>;
+template struct jit_uni_prelu_fwd_t<zvfbfwma>;
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_uni_prelu.hpp
+++ b/src/cpu/rv64/jit_uni_prelu.hpp
@@ -57,40 +57,35 @@ enum class prelu_bcast_t {
 // Zvfbfwma implies). Backward (the diff_weights reduction) is left to ref.
 struct jit_uni_prelu_fwd_kernel_t;
 
-template <cpu_isa_t isa>
 struct jit_uni_prelu_fwd_t : public primitive_t {
     struct pd_t : public cpu_prelu_fwd_pd_t {
         using cpu_prelu_fwd_pd_t::cpu_prelu_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T(
-                JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_prelu_fwd_t);
+        DECLARE_COMMON_PD_T("jit:rvv", jit_uni_prelu_fwd_t);
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
             using namespace dnnl::impl::data_type;
 
             const data_type_t dt = src_md(0)->data_type;
+            const data_type_t wdt = weights_md(0)->data_type;
 
             VDISPATCH_PRELU(is_fwd(), VERBOSE_BAD_PROPKIND);
-            VDISPATCH_PRELU(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
-            // isa drives which dtype this instance claims: zvfh owns f16,
-            // zvfbfwma owns bf16, the base vector isa owns f32.
-            const bool dt_ok = (isa == zvfh) ? (dt == f16)
-                    : (isa == zvfbfwma)      ? (dt == bf16)
-                                             : (dt == f32);
-            VDISPATCH_PRELU(dt_ok, VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_PRELU(platform::has_data_type_support(dt),
-                    VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_PRELU(dst_md(0)->data_type == dt, VERBOSE_UNSUPPORTED_DT);
-            // Weights may differ from src: the kernel converts per-element to
-            // f32 (lockstep) or on the host (scalar paths). Allow any f32/f16/
-            // bf16 weights; has_data_type_support gates the convert isa (f16 ->
-            // zvfh, bf16 -> zvfbfwma) so we never emit an unavailable convert.
-            const data_type_t wdt = weights_md(0)->data_type;
+            // Single JIT impl; the convert ISA is chosen internally from the
+            // data type. The base vector extension is always required; f16/bf16
+            // additionally need their convert ISA (zvfh / zvfbfwma), gated by
+            // has_data_type_support below so we never emit an unavailable
+            // convert. src/dst share a dtype; weights may differ.
+            VDISPATCH_PRELU(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_PRELU(
+                    utils::one_of(dt, f32, f16, bf16), VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_PRELU(
                     utils::one_of(wdt, f32, f16, bf16), VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_PRELU(platform::has_data_type_support(dt),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_PRELU(platform::has_data_type_support(wdt),
                     VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_PRELU(dst_md(0)->data_type == dt, VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_PRELU(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
             VDISPATCH_PRELU(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);

--- a/src/cpu/rv64/jit_uni_prelu.hpp
+++ b/src/cpu/rv64/jit_uni_prelu.hpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+* Copyright 2026 openKylin community
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_UNI_PRELU_HPP
+#define CPU_RV64_JIT_UNI_PRELU_HPP
+
+#include <memory>
+
+#include "common/broadcast_strategy.hpp"
+#include "common/c_types_map.hpp"
+#include "common/memory_desc_wrapper.hpp"
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/cpu_prelu_pd.hpp"
+#include "cpu/platform.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+// How the weights tensor maps onto src; selected once at init and consumed by
+// execute() to pick a kernel + iteration scheme. The two JIT kernels are a flat
+// lockstep loop (weights walk 1:1 with src) and a scalar-broadcast loop (one
+// f32 weight); the per_oc layouts are decomposed in C++ into runs that one of
+// those two kernels handles. `per_oc_blocked` and the more exotic broadcast
+// strategies are left to ref_prelu.
+enum class prelu_bcast_t {
+    unsupported,
+    full, // weights shape == src shape: flat lockstep over the whole tensor
+    scalar, // single weight broadcast over the whole tensor
+    per_oc_nhwc, // channel innermost (stride[1]==1): lockstep run of length C
+    per_oc_nchw, // channel-major plain: scalar weight per (n, c) spatial plane
+};
+
+// Standalone PReLU forward: dst = max(0, src) + weights * min(0, src). A thin
+// VLA JIT wrapper mirroring rv64/jit_uni_eltwise.cpp. The kernel computes in
+// f32; f16 (zvfh) and bf16 (zvfbfwma) are converted at the load/store boundary
+// with the native widening/narrowing FP-convert instructions (vfwcvt/vfncvt
+// for f16, vfwcvtbf16/vfncvtbf16 for bf16, the latter from Zvfbfmin which
+// Zvfbfwma implies). Backward (the diff_weights reduction) is left to ref.
+struct jit_uni_prelu_fwd_kernel_t;
+
+template <cpu_isa_t isa>
+struct jit_uni_prelu_fwd_t : public primitive_t {
+    struct pd_t : public cpu_prelu_fwd_pd_t {
+        using cpu_prelu_fwd_pd_t::cpu_prelu_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_prelu_fwd_t);
+
+        status_t init(engine_t *engine) {
+            UNUSED(engine);
+            using namespace dnnl::impl::data_type;
+
+            const data_type_t dt = src_md(0)->data_type;
+
+            VDISPATCH_PRELU(is_fwd(), VERBOSE_BAD_PROPKIND);
+            VDISPATCH_PRELU(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
+            // isa drives which dtype this instance claims: zvfh owns f16,
+            // zvfbfwma owns bf16, the base vector isa owns f32.
+            const bool dt_ok = (isa == zvfh) ? (dt == f16)
+                    : (isa == zvfbfwma)      ? (dt == bf16)
+                                             : (dt == f32);
+            VDISPATCH_PRELU(dt_ok, VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_PRELU(platform::has_data_type_support(dt),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_PRELU(dst_md(0)->data_type == dt, VERBOSE_UNSUPPORTED_DT);
+            // Lockstep / per_oc_nhwc load weights in-kernel as the src dtype, so
+            // require a matching weights dtype (scalar paths read on the host
+            // and could take any dtype, but keep one rule for simplicity).
+            VDISPATCH_PRELU(
+                    weights_md(0)->data_type == dt, VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_PRELU(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+            VDISPATCH_PRELU(
+                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+            VDISPATCH_PRELU(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
+
+            const memory_desc_wrapper src_d(src_md(0));
+            const memory_desc_wrapper dst_d(dst_md(0));
+            VDISPATCH_PRELU(
+                    src_d == dst_d, VERBOSE_INCONSISTENT_MDS, "src", "dst");
+
+            bcast_ = classify_bcast(src_d, weights_md(0));
+            VDISPATCH_PRELU(bcast_ != prelu_bcast_t::unsupported,
+                    VERBOSE_UNSUPPORTED_TAG);
+
+            return status::success;
+        }
+
+        prelu_bcast_t bcast_ = prelu_bcast_t::unsupported;
+
+    private:
+        // Mirrors x64 prelu::get_bcast_type for the layout split, but keyed off
+        // the common broadcasting-strategy helper that ref also uses.
+        static prelu_bcast_t classify_bcast(const memory_desc_wrapper &src_d,
+                const memory_desc_t *weights_md) {
+            const memory_desc_wrapper weights_d(weights_md);
+            const auto strategy
+                    = get_rhs_arg_broadcasting_strategy(*weights_md, src_d);
+
+            // Flat walks need a dense src (no internal gaps); per_oc walks need
+            // a known plain layout to compute channel offsets.
+            if (strategy == broadcasting_strategy_t::no_broadcast) {
+                // Identical dense layout guarantees the flat lockstep pairing.
+                if (src_d == weights_d && src_d.is_dense(true))
+                    return prelu_bcast_t::full;
+                return prelu_bcast_t::unsupported;
+            }
+            if (strategy == broadcasting_strategy_t::scalar) {
+                if (src_d.is_dense(true)) return prelu_bcast_t::scalar;
+                return prelu_bcast_t::unsupported;
+            }
+            // The helper splits channel-wise weights into per_oc (channel
+            // innermost, e.g. NHWC) and per_oc_spatial (channel-major plain,
+            // e.g. NCHW); the stride check below maps either onto the right run
+            // scheme, so accept both.
+            if (utils::one_of(strategy, broadcasting_strategy_t::per_oc,
+                        broadcasting_strategy_t::per_oc_spatial)) {
+                // The per_oc offset math (i*C runs / pl*SP planes) assumes a
+                // gapless, unpadded plain layout.
+                const bool no_padding = utils::array_cmp(
+                        src_d.dims(), src_d.padded_dims(), src_d.ndims());
+                if (!src_d.is_plain() || !src_d.is_dense() || !no_padding
+                        || src_d.ndims() < 2)
+                    return prelu_bcast_t::unsupported;
+                const auto &strides = src_d.blocking_desc().strides;
+                if (strides[1] == 1) return prelu_bcast_t::per_oc_nhwc;
+                bool channel_major = strides[0] >= strides[1];
+                for (int d = 2; d < src_d.ndims(); ++d)
+                    channel_major = channel_major && strides[1] >= strides[d];
+                if (channel_major) return prelu_bcast_t::per_oc_nchw;
+                return prelu_bcast_t::unsupported;
+            }
+            return prelu_bcast_t::unsupported;
+        }
+    };
+
+    jit_uni_prelu_fwd_t(const pd_t *apd);
+    ~jit_uni_prelu_fwd_t() override;
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::unique_ptr<jit_uni_prelu_fwd_kernel_t> kernel_;
+    std::unique_ptr<jit_uni_prelu_fwd_kernel_t> scalar_kernel_;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_JIT_UNI_PRELU_HPP

--- a/src/cpu/rv64/jit_uni_prelu.hpp
+++ b/src/cpu/rv64/jit_uni_prelu.hpp
@@ -38,14 +38,15 @@ namespace rv64 {
 // execute() to pick a kernel + iteration scheme. The two JIT kernels are a flat
 // lockstep loop (weights walk 1:1 with src) and a scalar-broadcast loop (one
 // f32 weight); the per_oc layouts are decomposed in C++ into runs that one of
-// those two kernels handles. `per_oc_blocked` and the more exotic broadcast
-// strategies are left to ref_prelu.
+// those two kernels handles. The more exotic broadcast strategies (shared_axes,
+// per_mb, ...) are left to ref_prelu.
 enum class prelu_bcast_t {
     unsupported,
     full, // weights shape == src shape: flat lockstep over the whole tensor
     scalar, // single weight broadcast over the whole tensor
     per_oc_nhwc, // channel innermost (stride[1]==1): lockstep run of length C
     per_oc_nchw, // channel-major plain: scalar weight per (n, c) spatial plane
+    per_oc_blocked, // nChw{8,16}c: lockstep run of length blk per channel block
 };
 
 // Standalone PReLU forward: dst = max(0, src) + weights * min(0, src). A thin
@@ -81,11 +82,15 @@ struct jit_uni_prelu_fwd_t : public primitive_t {
             VDISPATCH_PRELU(platform::has_data_type_support(dt),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_PRELU(dst_md(0)->data_type == dt, VERBOSE_UNSUPPORTED_DT);
-            // Lockstep / per_oc_nhwc load weights in-kernel as the src dtype, so
-            // require a matching weights dtype (scalar paths read on the host
-            // and could take any dtype, but keep one rule for simplicity).
+            // Weights may differ from src: the kernel converts per-element to
+            // f32 (lockstep) or on the host (scalar paths). Allow any f32/f16/
+            // bf16 weights; has_data_type_support gates the convert isa (f16 ->
+            // zvfh, bf16 -> zvfbfwma) so we never emit an unavailable convert.
+            const data_type_t wdt = weights_md(0)->data_type;
             VDISPATCH_PRELU(
-                    weights_md(0)->data_type == dt, VERBOSE_UNSUPPORTED_DT);
+                    utils::one_of(wdt, f32, f16, bf16), VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_PRELU(platform::has_data_type_support(wdt),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_PRELU(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
             VDISPATCH_PRELU(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
@@ -117,8 +122,28 @@ struct jit_uni_prelu_fwd_t : public primitive_t {
             // Flat walks need a dense src (no internal gaps); per_oc walks need
             // a known plain layout to compute channel offsets.
             if (strategy == broadcasting_strategy_t::no_broadcast) {
-                // Identical dense layout guarantees the flat lockstep pairing.
-                if (src_d == weights_d && src_d.is_dense(true))
+                // Same dims + same physical ordering (ignoring dtype) guarantees
+                // the flat lockstep pairing; weights may differ in dtype.
+                auto same_layout = [](const memory_desc_wrapper &a,
+                                           const memory_desc_wrapper &b) {
+                    if (a.ndims() != b.ndims()
+                            || a.format_kind() != b.format_kind())
+                        return false;
+                    if (!utils::array_cmp(a.dims(), b.dims(), a.ndims()))
+                        return false;
+                    if (!a.is_blocking_desc()) return true;
+                    const auto &ab = a.blocking_desc();
+                    const auto &bb = b.blocking_desc();
+                    return ab.inner_nblks == bb.inner_nblks
+                            && utils::array_cmp(
+                                    ab.strides, bb.strides, a.ndims())
+                            && utils::array_cmp(ab.inner_blks, bb.inner_blks,
+                                    ab.inner_nblks)
+                            && utils::array_cmp(ab.inner_idxs, bb.inner_idxs,
+                                    ab.inner_nblks);
+                };
+                if (same_layout(src_d, weights_d) && src_d.is_dense(true)
+                        && weights_d.is_dense(true))
                     return prelu_bcast_t::full;
                 return prelu_bcast_t::unsupported;
             }
@@ -132,12 +157,25 @@ struct jit_uni_prelu_fwd_t : public primitive_t {
             // scheme, so accept both.
             if (utils::one_of(strategy, broadcasting_strategy_t::per_oc,
                         broadcasting_strategy_t::per_oc_spatial)) {
-                // The per_oc offset math (i*C runs / pl*SP planes) assumes a
-                // gapless, unpadded plain layout.
+                if (src_d.ndims() < 2) return prelu_bcast_t::unsupported;
+                // Channel-blocked formats (nChw{8,16}c): exactly one inner block
+                // on the channel dim (idx 1). Require src and weights blocked
+                // alike; padding is expected and handled via padded_dims.
+                auto chan_block = [](const memory_desc_wrapper &md) -> dim_t {
+                    if (!md.is_blocking_desc()) return 0;
+                    const auto &b = md.blocking_desc();
+                    if (b.inner_nblks != 1 || b.inner_idxs[0] != 1) return 0;
+                    return b.inner_blks[0];
+                };
+                const dim_t sblk = chan_block(src_d),
+                            wblk = chan_block(weights_d);
+                if (sblk > 0 && sblk == wblk && src_d.is_dense(true))
+                    return prelu_bcast_t::per_oc_blocked;
+                // Plain layouts: the per_oc offset math (i*C runs / pl*SP planes)
+                // assumes a gapless, unpadded plain layout.
                 const bool no_padding = utils::array_cmp(
                         src_d.dims(), src_d.padded_dims(), src_d.ndims());
-                if (!src_d.is_plain() || !src_d.is_dense() || !no_padding
-                        || src_d.ndims() < 2)
+                if (!src_d.is_plain() || !src_d.is_dense() || !no_padding)
                     return prelu_bcast_t::unsupported;
                 const auto &strides = src_d.blocking_desc().strides;
                 if (strides[1] == 1) return prelu_bcast_t::per_oc_nhwc;


### PR DESCRIPTION
# Description

Adds a JIT (xbyak_riscv) PReLU forward primitive for RV64, replacing the reference fallback for the common cases. The kernel computes dst = max(0, src) + weights * min(0, src) in f32 with a vector-length-agnostic, strip-mined loop, structurally mirroring cpu/rv64/jit_uni_eltwise.

## Coverage
- Data types: f32 (RVV v), f16 (zvfh), bf16 (zvfbfwma). 16-bit types widen/narrow at the load/store boundary with the native FP converts (vfwcvt/vfncvt for f16, vfwcvtbf16/vfncvtbf16 for bf16); compute is always f32.
- Mixed weights dtype: the weights dtype is independent of src — any f32/f16/bf16 weights with any f32/f16/bf16 data. Scalar / channel-spatial paths convert the weight on the host; lockstep paths convert per-element in-kernel.
- Weight broadcast: full (no-broadcast), scalar, and per-channel (per_oc) for channel-last (NHWC) plain, channel-first (NCHW) plain, and channel-blocked (nChw{8,16}c) layouts. The per-channel/blocked decomposition is host-side, so the kernel stays two flat loops — lockstep-weights and scalar-weight.

Falls back to ref_prelu for: backward, non-dense/strided plain per_oc, and the more exotic broadcasts (shared_axes, per_mb, …) — which x86 also routes to ref.

## Dependency
Requires xbyak_riscv v1.31 for the bf16 converts (vfwcvtbf16.f.f.v / vfncvtbf16.f.f.w). Depends on #5452 — merge first; this PR won't build against the current vendored copy.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

All on a Spacemit X100 (RV64GCV + Zvfh/Zvfbfwma), built against xbyak v1.31:

- Regression sweep (shapes_prelu_sweep, 17 shapes × f32/f16/bf16 × FWD_D/FWD_I × NCHW/NHWC = 204 checks): all pass, jit:rvv* dispatch, 0 ref fallbacks.
- New paths: mixed-dtype {bf16:f32, f16:f32, f32:bf16, f32:f16} × {full, NHWC, NCHW} and blocked {f32, bf16, padded channels, blocked+mixed} — all pass, all jit:rvv*.
- Performance (vs scalar ref_prelu, FWD_I, 8 threads, 16×64×56×56):

| dtype | NHWC  | NCHW | full | scalar |
|-------|-------|------|------|--------|
| f32   | 23×   | 17×  | 10×  | 16×    |
| f16   | 71×   | 78×  | 25×  | 77×    |
| bf16  | ~128× | 142× | 48×  | 144×   |

- (f32 is the clean vectorization figure; f16/bf16 are inflated by ref's per-element scalar conversion. Memory-bandwidth-bound, as expected for an elementwise op.)