### PR TITLE
arch: fix coverity issues

### DIFF
--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -252,7 +252,12 @@ struct quant_entries_t : public c_compatible {
     data_type_t get_data_type(int arg) const {
         return get(arg).get_data_type();
     }
-    dim_t get_group(int arg, int d) const { return get(arg).get_group(d); }
+
+    dim_t get_group(int arg, int d) const {
+        dim_t group = get(arg).get_group(d);
+        assert(group != 0 && "wrong dimension used");
+        return group;
+    }
 
     bool has_host_scalars() const {
         for (const auto &e : entries_) {

--- a/src/xpu/ocl/buffer_memory_storage.cpp
+++ b/src/xpu/ocl/buffer_memory_storage.cpp
@@ -163,16 +163,27 @@ std::unique_ptr<memory_storage_t> buffer_memory_storage_t::get_sub_storage(
 
     auto sub_storage
             = new buffer_memory_storage_t(this->engine(), root_storage());
-    if (sub_storage) {
-        sub_storage->init(memory_flags_t::use_runtime_ptr, size, sub_buffer);
-        sub_storage->base_offset_ = base_offset_ + offset;
+    if (!sub_storage) return nullptr;
+
+    status_t status = sub_storage->init(
+            memory_flags_t::use_runtime_ptr, size, sub_buffer);
+    if (status != status::success) {
+        delete sub_storage;
+        return nullptr;
     }
+    sub_storage->base_offset_ = base_offset_ + offset;
     return std::unique_ptr<memory_storage_t>(sub_storage);
 }
 
 std::unique_ptr<memory_storage_t> buffer_memory_storage_t::clone() const {
     auto storage = new buffer_memory_storage_t(engine());
-    if (storage) storage->init(memory_flags_t::use_runtime_ptr, 0, mem_object_);
+    if (!storage) return nullptr;
+    status_t status
+            = storage->init(memory_flags_t::use_runtime_ptr, 0, mem_object_);
+    if (status != status::success) {
+        delete storage;
+        return nullptr;
+    }
     return std::unique_ptr<memory_storage_t>(storage);
 }
 

--- a/src/xpu/ocl/stream_profiler.cpp
+++ b/src/xpu/ocl/stream_profiler.cpp
@@ -16,6 +16,7 @@
 
 #include <CL/cl.h>
 
+#include <limits>
 #include <map>
 #include <unordered_set>
 
@@ -91,7 +92,7 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
         return status::success;
     }
 
-    cl_ulong agg_start = UINT64_MAX;
+    cl_ulong agg_start = std::numeric_limits<cl_ulong>::max();
     cl_ulong agg_end = 0;
 
     // For verbose logging, aggregate execution time for a primitive is
@@ -110,6 +111,8 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
         agg_start = std::min(agg_start, evbeg);
         agg_end = std::max(agg_end, evend);
     }
+
+    if (agg_end < agg_start) { return status::runtime_error; }
 
     // TODO: Consolidate timing calculation calls between different
     // profilers to avoid code duplication and ensure consistent time

--- a/src/xpu/sycl/stream_profiler.cpp
+++ b/src/xpu/sycl/stream_profiler.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <limits>
 #include <map>
 #include <unordered_set>
 
@@ -89,7 +90,7 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
         return status::success;
     }
 
-    uint64_t agg_start = UINT64_MAX;
+    uint64_t agg_start = std::numeric_limits<uint64_t>::max();
     uint64_t agg_end = 0;
 
     // For verbose logging, aggregate execution time for a primitive is
@@ -111,6 +112,8 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
         agg_start = std::min(agg_start, evbeg);
         agg_end = std::max(agg_end, evend);
     }
+
+    if (agg_end < agg_start) { return status::runtime_error; }
 
     // TODO: Consolidate timing calculation calls between different
     // profilers to avoid code duplication and ensure consistent time


### PR DESCRIPTION
# Description

Addresses [MFDNN-15234](https://jira.devtools.intel.com/browse/MFDNN-15234)

Fixes:

- commit [bc9d71c](https://github.com/uxlfoundation/oneDNN/pull/5457/changes/bc9d71c76d32c2e348bbd512f899745c37bb65c9): fixes divide-by-zero issue for `matmul` scales returning zero group values.
- commit [4d7274](https://github.com/uxlfoundation/oneDNN/pull/5457/changes/4d7274f488f1e6d3d112dd8cca6615d48738e57d): fixes unchecked `init()` return values for OpenCL buffer memory storage
- commit [55d8f0](https://github.com/uxlfoundation/oneDNN/pull/5457/changes/55d8f0cf9220374cbbbf99e62dfd600873a95f08): add integer overflow checks during exec time calculation for verbose profiler. 