### PR TITLE
xe: ggemm: upconvert int4 to int8 for mixed dpas

### DIFF
--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -153,6 +153,19 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
                 = static_cast<int>(utils::rnd_up_pow2(src_group_sizes_[1]));
     }
 
+    // Mixed s8/s4 DPAS support:
+    // - Xe3p: Not supported, require s4->s8 upconversion
+    // - pre-Xe3p: supported, but only when s4 matrix doesn't have zero points
+    bool has_s8s4_dpas = dev_info->gpu_arch() != compute::gpu_arch_t::xe3p;
+    if (problem.Ta_ext.isInt4() && problem.Tb_ext.isInt8()) {
+        bool s8s4_dpas_ok = has_s8s4_dpas && !opts.offsetA;
+        if (!s8s4_dpas_ok) problem.Ta = Type::s8;
+    }
+    if (problem.Tb_ext.isInt4() && problem.Ta_ext.isInt8()) {
+        bool s8s4_dpas_ok = has_s8s4_dpas && !opts.offsetB;
+        if (!s8s4_dpas_ok) problem.Tb = Type::s8;
+    }
+
     // When both A and B are integers and group sums are needed, we
     // can avoid using group sums by converting one of the inputs to
     // f16/bf16.


### PR DESCRIPTION
Xe3p does not support mixed s8/s4 dpas. Promote the int4 operand to int8 when the mixed dpas is unavailable, mirroring the regular JIT GEMM path.

Jira: [MFDNN-15063](https://jira.devtools.intel.com/browse/MFDNN-15063).
See related https://github.com/uxlfoundation/oneDNN/pull/5211. 