### PR TITLE
[GPU][CRI] Update denorm flag to cover all floats

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/common.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/common.cxx
@@ -31,13 +31,15 @@ using namespace ngen::utils;
 template <HW hw>
 void Generator<hw>::prologue(const CommonStrategy &strategy, int internalSIMD)
 {
-    uint16_t cr0Enable;
+    uint32_t cr0Enable;
 
     interface.generatePrologue(*this);
 
-    cr0Enable = 0x1000;                                // IEEE float->int rounding.
-    if (strategy.ieeeDenormals) cr0Enable |= 0x4C0;    // Enable hf|f|df denormals.
-    if (strategy.spf)           cr0Enable |= 0x4;      // Enable single program flow.
+    bool denorm = strategy.ieeeDenormals;
+    cr0Enable = 0x1000;                                     // IEEE float->int rounding.
+    if (denorm)                   cr0Enable |= 0x4C0;       // Enable hf|f|df denormals.
+    if (hw >= HW::Xe2 && denorm)  cr0Enable |= 0x40000000;  // Enable bf|tf|f8|f4 denormals.
+    if (strategy.spf)             cr0Enable |= 0x4;         // Enable single program flow.
 
     or_(1, cr0, cr0, cr0Enable);
 


### PR DESCRIPTION
# Description

expand denorm flag width and add bit to enable denorm for bf/tf/fp8/fp4 . Resolves precision based issue in mxfp4 on CRI. 

Fixes # [MFDNN-14490](https://jira.devtools.intel.com/browse/MFDNN-14490)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?