### PR TITLE
fix: common: stream: remove additional verbose profiler warning

### DIFF
--- a/src/common/stream.hpp
+++ b/src/common/stream.hpp
@@ -81,10 +81,6 @@ struct dnnl_stream : public dnnl::impl::c_compatible {
             const std::string &pd_info, double start_ms) {
         // TODO: Change interface to std::string &&pd_info to allow direct
         // move into primitive profiling data, avoiding string copy overhead
-        if (!is_verbose_profiler_enabled())
-            VWARN(primitive, exec,
-                    "attempting to run verbose profiler when it is not "
-                    "enabled");
         return dnnl::impl::status::unimplemented;
     }
 


### PR DESCRIPTION
# Description

Windows builds for OpenVINO nightly fail after the addition of asynchronous verbose mode (PR #5102). 
The failure comes from including verbose warning messages in `src/common/stream.hpp` where the verbose.hpp header is added through transitive includes. 
The compilation fails when the include order differs such as in the case of OpenVINO. 

The fix involves removing the VWARN message entirely for the following reasons:
- the virtual method returns an unimplemented status for unsupported runtimes.
- overridden `run_verbose_profiler()` functions print the necessary warnings when running with a disabled verbose profiler
- keeps the stream header lightweight by not directly including `common/verbose.hpp`