### PR TITLE
Revert "xe: ukernel: check efficent64bit on xe3p to set register allocation

### DIFF
--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -172,7 +172,6 @@ status_t micro_horz_t::pd_t::init_microkernels(
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = intel_engine->mayiuse(
             compute::device_ext_t::intel_subgroup_matrix_multiply_accumulate);
-    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     if (hw_info.gmdid == 0) return status::unimplemented;
 

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -215,9 +215,6 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
     matchParams.nExtraReqs = int(reqs.size());
     matchParams.extraReqs = reqs.data();
 
-    if (hw == ngen::HW::Xe3p && !hwInfo.isEfficient64Bit)
-        matchParams.selector.hw = kcatalog::HWTagXeHPC;
-
     auto tags = const_cast<char *>(matchParams.tags);
     while (*tags)
         tags++;
@@ -241,7 +238,6 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
 
     /* Generate interface */
     InterfaceHandler interface = effOptions.generateInterface(hw);
-    interface.setEfficient64Bit(hwInfo.isEfficient64Bit);
 
     kcatalog::Catalog catalog = [&]() {
         if (localA)
@@ -315,10 +311,6 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
                     problem.A.setAlignment(std::max<int>(problem.A.alignment, 16));
                 if (block2DB && strategy.legalBAlignment(problem, 16))
                     problem.B.setAlignment(std::max<int>(problem.B.alignment, 16));
-            }
-            if (hw == ngen::HW::Xe3p && !hwInfo.isEfficient64Bit) {
-                // Use XeHPC banking if reusing XeHPC strategies (legacy mode)
-                strategy.raHW = ngen::HW::XeHPC;
             }
         } else if (!reqs.empty() &&
                    !getStrategyByHeuristics(hw, strategy, localA, localB, problem, hwInfo, sizes, reqs))
@@ -564,10 +556,6 @@ static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool l
 
     if (hw == HW::Xe2 || hw == HW::Xe3)
         s.raHW = HW::XeHPC;
-    // Use XeHPC banking if reusing XeHPC strategies (legacy mode)
-    if (hw == ngen::HW::Xe3p && !hwInfo.isEfficient64Bit) {
-        s.raHW = ngen::HW::XeHPC;
-    }
 
     adjustStrategy(hw, problem, strategy);
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -31,7 +31,6 @@ struct HWInformation {
     uint32_t gmdid;
     int euCount;
     bool systolicAvailable;
-    bool isEfficient64Bit;
 };
 
 struct GEMMOptions {

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -58,7 +58,6 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     hw_info.euCount = dev_info->eu_count();
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = use_systolic_ukernel;
-    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     if (hw_info.gmdid == 0) return status::unimplemented;
 

--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -835,7 +835,6 @@ void deserialize_config_to_gemmstone(micro::HWInformation &hwInfo,
     hwInfo.gmdid = ukernel_config.hwinfo.gmdid;
     hwInfo.euCount = ukernel_config.hwinfo.euCount;
     hwInfo.systolicAvailable = ukernel_config.hwinfo.systolicAvailable;
-    hwInfo.isEfficient64Bit = ukernel_config.hwinfo.isEfficient64Bit;
 
     // options kq, vs
     auto deserialize_options
@@ -935,7 +934,6 @@ void deserialize_config_to_gemmstone(micro::HWInformation &hwInfo,
     hwInfo.gmdid = ukernel_config.hwinfo.gmdid;
     hwInfo.euCount = ukernel_config.hwinfo.euCount;
     hwInfo.systolicAvailable = ukernel_config.hwinfo.systolicAvailable;
-    hwInfo.isEfficient64Bit = ukernel_config.hwinfo.isEfficient64Bit;
 
     // options kq, vs
     auto deserialize_options

--- a/src/gpu/intel/sdpa/configs.hpp
+++ b/src/gpu/intel/sdpa/configs.hpp
@@ -158,14 +158,12 @@ struct ukernel_serialized_hwinfo_t
     ukernel_serialized_hwinfo_t(micro::HWInformation &hwInfo)
         : gmdid(static_cast<uint32_t>(hwInfo.gmdid))
         , euCount(static_cast<uint32_t>(hwInfo.euCount))
-        , systolicAvailable(hwInfo.systolicAvailable)
-        , isEfficient64Bit(hwInfo.isEfficient64Bit) {}
+        , systolicAvailable(hwInfo.systolicAvailable) {}
 
     uint32_t gmdid;
     uint32_t euCount;
     bool systolicAvailable;
-    bool isEfficient64Bit;
-    uint8_t padding[6] = {0};
+    uint8_t padding[7] = {0};
 };
 DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(ukernel_serialized_hwinfo_t);
 static_assert(sizeof(ukernel_serialized_hwinfo_t) == 16,

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -261,7 +261,6 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     hw_info.euCount = dev_info->eu_count();
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = use_systolic_ukernel_;
-    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     VDISPATCH_SDPA(
             hw_info.gmdid != 0, "gmdid is 0, microkernels not supported.");
@@ -574,7 +573,6 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     hw_info.euCount = dev_info->eu_count();
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = use_systolic_ukernel_;
-    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     VDISPATCH_SDPA(
             hw_info.gmdid != 0, "gmdid is 0, microkernels not supported.");


### PR DESCRIPTION
This PR reverts an offending commit that is causing failures with gmlp and a couple of SDPA cases. This is a temporary workaround. The root cause is unknown.
