### PR TITLE
xe: copy plan: zip small immediates to a vector immediate

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -3013,7 +3013,7 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
 
             auto zippable = [&](const CopyOperand &o1, const CopyOperand &o2, bool zip2D = false, bool zipImm = false) {
                 if (o1.kind != o2.kind) return false;
-                if (o1.kind == CopyOperand::Immediate) return (o1.value == o2.value || (zipImm && !(hw >= ngen::HW::Xe3p)));
+                if (o1.kind == CopyOperand::Immediate) return (o1.value == o2.value || zipImm);
                 if (o1.kind != CopyOperand::GRF) return true;
                 if (o1.type != o2.type || o1.stride != o2.stride || o1.grf != o2.grf) return false;
                 if (o1.temp != o2.temp) return false;
@@ -3037,7 +3037,11 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
 
             CopyOperand zippedSrc1;
             if (zip && i1.src1.kind == CopyOperand::Immediate && i1.src1.value != i2.src1.value) {
-                zippedSrc1 = zipImmediates(i1.src1, i2.src1);
+                const auto bits = getBits(i1.dst.type);
+                const auto offset = std::min(i1.dst.offset, i2.dst.offset);
+                const auto stride = i1.dst.stride >> 1;
+                const auto ok = ((offset * bits) % 128 == 0) && ((stride * bits) % 16 == 0);
+                zippedSrc1 = zipImmediates(i1.src1, i2.src1, ok ? stride : 0);
                 zip = zip && zippedSrc1;
             }
 
@@ -3070,14 +3074,48 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
         legalizeSIMD();     /* 2D zipping comes late in the pipeline */
 }
 
-// Zip small immediates, converting to <0;2,1>-regioned resource access.
-CopyOperand CopyPlan::zipImmediates(const CopyOperand &o1, const CopyOperand &o2)
+// Zip small immediates, converting small values to a vector immediate, and
+// other cases to <0;2,1>-regioned resource access.
+CopyOperand CopyPlan::zipImmediates(const CopyOperand &o1, const CopyOperand &o2, uint8_t stride)
 {
-    if (!isInt(o1.type) || o1.type != o2.type || !isW(o1.type))
+    if (o1.type != o2.type)
         return CopyOperand{};
 
-    auto rkind = CopyResource::makeConstant32(((o2.value & 0xFFFF) << 16)
-                                             | (o1.value & 0xFFFF));
+    if (o1.type == DataType::uv || o1.type == DataType::v) {
+        if (stride <= 0 || stride >= 8)
+            return CopyOperand{};
+        // alternate vector entries for stride = 1, alternate consecutive
+        // pairs of vector entries for stride = 2, etc.
+        uint32_t mask = (1 << (4 * stride)) - 1;
+        for (auto bits = 8 * stride; bits < 32; bits <<= 1)
+            mask |= mask << bits;
+        auto value = ((uint32_t)o1.value & mask) | ((uint32_t)o2.value & ~mask);
+        return o1.type == DataType::uv ? Immediate::uv(value) : Immediate::v(value);
+    }
+
+    if (!isW(o1.type))
+        return CopyOperand{};
+
+    auto v1 = (uint16_t)o1.value;
+    auto v2 = (uint16_t)o2.value;
+
+    if (stride > 0 && stride < 8) {
+        auto pattern = (v1 & 0xF) | ((v2 & 0xF) << (4 * stride));
+        for (uint8_t i = 1; i < stride; i <<= 1)
+            pattern |= pattern << (4 * i);
+        auto bits = 8 * stride;
+        for (; bits < 32; bits <<= 1)
+            pattern |= pattern << bits;
+        if (v1 <= 0xF && v2 <= 0xF)
+            return ngen::Immediate::uv(pattern);
+        else if (o1.type == DataType::w && v1 + 8 <= 0xF && v2 + 8 <= 0xF)
+            return ngen::Immediate::v(pattern);
+    }
+
+    if (hw >= HW::Xe3p)
+        return CopyOperand{};
+
+    auto rkind = CopyResource::makeConstant32((v2 << 16) | v1);
     auto op = getResource(rkind);
     op.vs = 0;
     op.width = 2;

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -672,9 +672,12 @@ void CopyPlan::repositionSrc(CopyInstruction &i, int n, int stride, int offset)
     auto CopyInstruction::* src = (n == 0) ? &CopyInstruction::src0 :
                                   (n == 1) ? &CopyInstruction::src1 :
                                              &CopyInstruction::src2;
-    auto type = (i.*src).type;
+    auto &op = i.*src;
+    auto type = op.type;
+    if (type == DataType::v) type = DataType::w;
+    if (type == DataType::uv) type = DataType::uw;
     auto bytes = getBytes(type);
-    auto abs = (i.*src).abs;
+    auto abs = op.abs;
 
     bool inplaceDst = i.dst
                    && stride * bytes == i.dst.byteStride()
@@ -2943,7 +2946,9 @@ void CopyPlan::legalizeNegation()
 void CopyPlan::legalizeImmediateTypes()
 {
     for (auto &i: insns) {
+        int srcN = -1;
         for (auto *op: {&i.src0, &i.src1, &i.src2}) {
+            srcN++;
             if (op->kind != CopyOperand::Immediate)
                 continue;
             if (one_of(op->type, {DataType::ub, DataType::u4}))
@@ -2952,11 +2957,15 @@ void CopyPlan::legalizeImmediateTypes()
                 op->type = DataType::w;
             else if (hw == ngen::HW::Xe3p && i.op != Opcode::mov && op->type == DataType::f && i.dst.type == DataType::bf)
                 legalizeBfImmediate(i);
+            else if (one_of(op->type, {DataType::v, DataType::uv})) {
+                // Destination must be 128 bit-aligned for vector immediates.
+                if ((i.dst.offset * getBits(i.dst.type)) % 128 != 0)
+                    repositionSrc(i, srcN, i.dst.stride, 0);
+            }
         }
     }
     mergeChanges();
     legalizeRegions();
-
 }
 
 // Pass to sort instructions by phase and dst.
@@ -3001,6 +3010,7 @@ void CopyPlan::sort(SortType type)
 void CopyPlan::optimizeZip(bool zip2DSrc0)
 {
     bool didZip2D = false;
+    bool didStridedVecZip = false;
 
     auto ninsn = insns.size();
     for (size_t n1 = 0; n1 < ninsn; n1++) {
@@ -3018,11 +3028,12 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
                 if (o1.type != o2.type || o1.stride != o2.stride || o1.grf != o2.grf) return false;
                 if (o1.temp != o2.temp) return false;
                 if (o1.temp && o1.value != o2.value) return false;
-                if (o1.vs || o1.width) return false;
+                if (o1.vs != o2.vs || o1.width != o2.width) return false;
+                if (o1.width && (!zip2D || o1.stride != 2 * (o2.offset - o1.offset))) return false;
                 if (o1.neg != o2.neg) return false;
                 if (o1.abs != o2.abs) return false;
                 if (!is_zero_or_pow2(o2.offset - o1.offset)) return false;
-                bool can1D = ((o1.stride & 1) == 0)
+                bool can1D = (o1.width == 0) && ((o1.stride & 1) == 0)
                           && (o1.offset + (o1.stride >> 1) == o2.offset);
                 if (!can1D) {
                     unsigned od = (o2.offset - o1.offset);
@@ -3037,10 +3048,8 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
 
             CopyOperand zippedSrc1;
             if (zip && i1.src1.kind == CopyOperand::Immediate && i1.src1.value != i2.src1.value) {
-                const auto bits = getBits(i1.dst.type);
-                const auto offset = std::min(i1.dst.offset, i2.dst.offset);
                 const auto stride = i1.dst.stride >> 1;
-                const auto ok = ((offset * bits) % 128 == 0) && ((stride * bits) % 16 == 0);
+                const auto ok = ((stride * getBits(i1.dst.type)) % 16 == 0);
                 zippedSrc1 = zipImmediates(i1.src1, i2.src1, ok ? stride : 0);
                 zip = zip && zippedSrc1;
             }
@@ -3055,13 +3064,21 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
                         i.src0.stride /= 2;
                         std::swap(i1, i2);      /* move joined entry to end for further processing */
                     } else {
-                        i.src0.vs = i.src0.stride;
-                        i.src0.stride = i2.src0.offset - i1.src0.offset;
-                        i.src0.width = 2;
+                        if (!i.src0.width) {
+                            // transform 1D to equivalent 2D regioning
+                            // <N> -> <N;1,0>
+                            i.src0.width = 1;
+                            i.src0.vs = i.src0.stride;
+                            i.src0.stride = 0;
+                        }
+                        i.src0.width *= 2;
+                        i.src0.stride += i2.src0.offset - i1.src0.offset;
                         didZip2D = true;
                     }
-                    if (zippedSrc1)
+                    if (zippedSrc1) {
                         i.src1 = zippedSrc1;
+                        didStridedVecZip = (i.dst.stride > 1) && one_of(i.src1.type, {DataType::v, DataType::uv});
+                    }
                     break;
                 }
             }
@@ -3070,6 +3087,8 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
 
     mergeChanges();
 
+    if (didStridedVecZip)
+        optimizeZip(zip2DSrc0);  /* may be able to zip more vector immediates */
     if (didZip2D)
         legalizeSIMD();     /* 2D zipping comes late in the pipeline */
 }

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
@@ -308,7 +308,7 @@ protected:
     void optimizeMoveToIntPipe();
 
     CopyOperand bfImmediate(uint16_t bits, bool ternary);
-    CopyOperand zipImmediates(const CopyOperand &o1, const CopyOperand &o2);
+    CopyOperand zipImmediates(const CopyOperand &o1, const CopyOperand &o2, uint8_t stride);
 
     bool bfArithmeticOK(const CopyInstruction &i) const;
 };


### PR DESCRIPTION
A small optimization for 4-bit type handling on Xe3p.
