### PR TITLE
oneDNN v3.11.4 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.11.3")
+set(PROJECT_VERSION "3.11.4")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.11.3:
* Fixed correctness issue in depthwise convolution on Intel GPUs (ac1c1d091db3ace75b575e4f32f9852e9b441fd9, 41782d4fa2193bf502e5c1001ccf3b12460b0134)
* Fixed synchronization issue on Intel GPUs with `ONEDNN_CPU_RUNTIME=THREADPOOL` (97f76775521c40bd1b1bf69c42987899044525e9)
* Fixed performance regressions in matmul with 4D shapes and trivial dimensions on x64 processors (0327a71fdb321e473839a0f746e8946c6ee64101)
* Fixed correctness issue in matmul with 4D shapes and trivial batch dimensions on x64 processors (9c654cd09d61eb527b863b1bdfe81b6fe0214a74)
