### PR TITLE
oneDNN v3.12.2 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.12.1")
+set(PROJECT_VERSION "3.12.2")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.12.1:

* Fixed correctness issue in grouped convolution on x64 processors with Intel AVX 10.1 instruction set support (680d58a2d86f0e8b1529205c9820ad5fea3bf905, 9c3d576882439df9598e952ab6012509cde22f48)
* Fixed crash in matmul with 4D shapes and trivial batch dimensions on x64 processors (9236298b6de75079b50eb1c6d6030c9082f5f38d)
* Fixed correctness issue in convolution on x64 processors (b1115314a42f80f8d22d4a6dfbe5217ea0838b63)
* Fixed crash in convolution and deconvolution with certain combinations of post-op data types on x64 processors (69c39dbdaddae1fb6c91d7968608ad76b696eff0)
