### PR TITLE
xe: extend microkernel status validation

### DIFF
--- a/src/gpu/intel/compute/ukernels.cpp
+++ b/src/gpu/intel/compute/ukernels.cpp
@@ -16,6 +16,9 @@
 
 #include "gpu/intel/compute/ukernels.hpp"
 
+#include "common/verbose.hpp"
+#include "gemmstone/microkernel/package.hpp"
+
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include "gpu/intel/ocl/engine.hpp"
 #include "gpu/intel/ocl/utils.hpp"
@@ -88,6 +91,27 @@ bool mayiuse_microkernels(const engine_t *engine) {
     auto it = engine_microkernel_map.find(engine->engine_id());
     if (it != std::end(engine_microkernel_map)) return it->second;
     return engine_microkernel_map[engine->engine_id()] = mayiuse_mk(engine);
+}
+
+status_t validate_microkernel(const gemmstone::microkernel::Package &package,
+        const char *kernel_name) {
+    using Status = gemmstone::microkernel::Package::Status;
+    const char *reason = nullptr;
+    switch (package.status) {
+        case Status::Success: return status::success;
+        case Status::Pending:
+            reason = "was not finalized before validation";
+            break;
+        case Status::UncertainClobbers:
+            reason = "has uncertain register clobbers and is not supported";
+            break;
+        case Status::UnsupportedHW:
+            reason = "is incompatible with the current hardware";
+            break;
+    }
+    VCONDCHECK(primitive, create, check, gpu, reason == nullptr,
+            status::unimplemented, "%s microkernel %s", kernel_name, reason);
+    return status::runtime_error;
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/ukernels.hpp
+++ b/src/gpu/intel/compute/ukernels.hpp
@@ -20,6 +20,12 @@
 #include "common/engine.hpp"
 #include "gpu/intel/engine.hpp"
 
+namespace gemmstone {
+namespace microkernel {
+struct Package; // NOLINT(readability-identifier-naming)
+}
+} // namespace gemmstone
+
 namespace dnnl {
 namespace impl {
 namespace gpu {
@@ -28,6 +34,11 @@ namespace compute {
 
 extern const char *cl_microkernels_check_kernel_code;
 bool mayiuse_microkernels(const engine_t *engine);
+
+// Validates a finalized microkernel package, emitting a verbose message and
+// returning a non-success status if it cannot be used.
+status_t validate_microkernel(const gemmstone::microkernel::Package &package,
+        const char *kernel_name);
 
 } // namespace compute
 } // namespace intel

--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -270,6 +270,9 @@ status_t micro_horz_t::pd_t::init_microkernels(
                 "gemm_gateup microkernel generation failed with message: %s",
                 e.what());
     }
+
+    CHECK(compute::validate_microkernel(gemm_gate_up_pkg_, "gemm_gateup"));
+
     return status::success;
 }
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -32,10 +32,6 @@
 #include <stdexcept>
 #include <string>
 
-#define VCHECK_MATMUL(cond, msg, ...) \
-    VCONDCHECK(primitive, create, check, matmul, (cond), \
-            status::unimplemented, msg, ##__VA_ARGS__);
-
 namespace dnnl {
 namespace impl {
 namespace gpu {
@@ -272,6 +268,8 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
                     ex.what());
         }
     }
+
+    CHECK(compute::validate_microkernel(gemm_, "grouped_gemm"));
 
     /* Generate microkernel shims */
     ShimOptions shimOptions;

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -46,32 +46,6 @@ namespace {
 
 using namespace gemmstone;
 
-status_t validate_microkernel(
-        micro::Package &package, const char *kernel_name) {
-    switch (package.status) {
-        case micro::Package::Status::Pending:
-            VCHECK_SDPA_COND(false,
-                    "%s microkernel package was not finalized before "
-                    "validation.",
-                    kernel_name);
-            break;
-        case micro::Package::Status::Success: return status::success;
-        case micro::Package::Status::UncertainClobbers:
-            VCHECK_SDPA_COND(false,
-                    "%s microkernel has uncertain register clobbers and is "
-                    "not supported by SDPA.",
-                    kernel_name);
-            break;
-        case micro::Package::Status::UnsupportedHW:
-            VCHECK_SDPA_COND(false,
-                    "%s microkernel package is incompatible with the current "
-                    "hardware.",
-                    kernel_name);
-            break;
-    }
-    return status::runtime_error;
-}
-
 /// Returns true if a common quantization value is used for each slice of the
 /// tensor operation. For 4D case it's when the mask's two first bits are on
 /// and two last bits are off.
@@ -1229,7 +1203,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
                 "gemm_kq microkernel generation failure with message: %s",
                 ex.what());
     }
-    CHECK(validate_microkernel(gemm_kq, "gemm_kq"));
+    CHECK(compute::validate_microkernel(gemm_kq, "gemm_kq"));
 
     /* Ask microkernel provider for microkernel */
     auto vs_strat_override = [&](gemmstone::GEMMStrategy &strat) {
@@ -1268,7 +1242,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
                 "gemm_vs microkernel generation failure with message: %s",
                 ex.what());
     }
-    CHECK(validate_microkernel(gemm_vs, "gemm_vs"));
+    CHECK(compute::validate_microkernel(gemm_vs, "gemm_vs"));
 
     VDEBUGINFO(4, primitive, sdpa, "kq_gemm: %s, vs_gemm: %s,",
             problem_kq.toString().c_str(), problem_vs.toString().c_str());
@@ -1413,7 +1387,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_kq microkernel generation failure with message: %s",
                 ex.what());
     }
-    CHECK(validate_microkernel(gemm_kq, "gemm_kq"));
+    CHECK(compute::validate_microkernel(gemm_kq, "gemm_kq"));
 
     try {
         if (use_systolic_ukernel) {
@@ -1432,7 +1406,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_vs microkernel generation failure with message: %s",
                 ex.what());
     }
-    CHECK(validate_microkernel(gemm_vs, "gemm_vs"));
+    CHECK(compute::validate_microkernel(gemm_vs, "gemm_vs"));
 
     VDEBUGINFO(4, primitive, sdpa,
             "kq_gemm: %s, vs_gemm: %s, vtdA_gemm: %s, ktq_gemm: %s, qdSt: %s\n",
@@ -1465,7 +1439,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_vtdA microkernel generation failure with message: %s",
                 ex.what());
     }
-    CHECK(validate_microkernel(gemm_vtdA, "gemm_vtdA"));
+    CHECK(compute::validate_microkernel(gemm_vtdA, "gemm_vtdA"));
 
     shimOptions.microkernelID++;
     shimOptions.decorator = "vtdA";
@@ -1482,7 +1456,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_ktq microkernel generation failure with message: %s",
                 ex.what());
     }
-    CHECK(validate_microkernel(gemm_ktq, "gemm_ktq"));
+    CHECK(compute::validate_microkernel(gemm_ktq, "gemm_ktq"));
 
     shimOptions.microkernelID++;
     shimOptions.decorator = "ktq";
@@ -1499,7 +1473,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 "gemm_qdSt microkernel generation failure with message: %s",
                 ex.what());
     }
-    CHECK(validate_microkernel(gemm_qdSt, "gemm_qdSt"));
+    CHECK(compute::validate_microkernel(gemm_qdSt, "gemm_qdSt"));
 
     shimOptions.microkernelID++;
     shimOptions.decorator = "qdSt";


### PR DESCRIPTION
PR extracts SDPA `validate_microkernel()` into `compute::` to reuse it in the grouped matmul and gated MLP microkernel paths.

This is follow-up after https://github.com/uxlfoundation/oneDNN/pull/5434.