### PR TITLE
gpu: intel: sdpa: disable fused fwd dropout+attn_mask on xe_hpg

### DIFF
--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -326,13 +326,15 @@ struct micro_fwd_t : public primitive_t {
                                                    == data_type::f32),
                                    with_causal_mask()),
                     "fused f32 SDPA only optimized for causal mask"); //TODO: update when performance improved
-            VDISPATCH_SDPA(
-                    IMPLICATION(arch() == compute::gpu_arch_t::xe_hpg
-                                    && !attr()->dropout_.has_default_values(),
-                            attr()->dropout_.use_host_scalars_),
-                    "fused SDPA FWD with device dropout not supported "
+            // Xe-HPG: enabling dropout on the systolic micro_sdpa fwd path
+            // triggers an IGC miscompile that yields partial-zero outputs.
+            // Neither dropout alone nor mask alone is affected.
+            // Reject this specific combination so the graph API
+            // falls back to the unfused decompositio
+            VDISPATCH_SDPA((arch() == compute::gpu_arch_t::xe_hpg
+                                   && !attr()->dropout_.has_default_values()),
+                    "fused SDPA FWD with device dropout leads to IGC miscompile"
                     "for xe_hpg");
-
             CHECK(init_conf_microkernels(engine));
             CHECK(init_conf(engine));
 


### PR DESCRIPTION
On Xe-HPG (DG2), enabling dropout on the systolic micro_sdpa forward path triggers an IGC miscompile that produces partial-zero outputs. A mere print_tile after softmax+dropout shows the tile being printed correctly and test-case passing; which alludes to a compiler issue. The ISA changes significantly without dropout. Another pointer to IGC issue is using-cl-disable-opt reduces the errors significantly but not completely.

This PR broadens the condition added by @TaoLv for this test-case - https://jira.devtools.intel.com/browse/MFDNN-15268

IGC filed.

# Description

Fixes # (MFDNN-15075)

# Checklist

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

