### PR TITLE
cpu: rv64: add-s8-brgemm-kernel

### DIFF
--- a/src/cpu/rv64/brgemm/brgemm.cpp
+++ b/src/cpu/rv64/brgemm/brgemm.cpp
@@ -42,12 +42,15 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
     //   f32  × f32  → f32  (always)
     //   bf16 × bf16 → f32  (Zvfbfwma widening FMA)
     //   f16  × f16  → f32  (Zvfh widening FMA)
+    //   s8   × s8   → s32  (always)
     const bool is_f32 = everyone_is(data_type::f32, dt_a, dt_b);
     const bool is_bf16
             = everyone_is(data_type::bf16, dt_a, dt_b) && mayiuse(zvfbfwma);
     const bool is_f16
             = everyone_is(data_type::f16, dt_a, dt_b) && mayiuse(zvfh);
-    if (!is_f32 && !is_bf16 && !is_f16) return status::unimplemented;
+    const bool is_int8 = everyone_is(data_type::s8, dt_a, dt_b);
+    if (!is_f32 && !is_bf16 && !is_f16 && !is_int8)
+        return status::unimplemented;
 
     *brg = utils::zero<brgemm_desc_t>();
 
@@ -65,11 +68,12 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
 
     brg->dt_a = dt_a;
     brg->dt_b = dt_b;
-    brg->dt_c = data_type::f32;
+    brg->dt_c = is_int8 ? data_type::s32 : data_type::f32;
     brg->typesize_A = static_cast<int>(types::data_type_size(dt_a));
     brg->typesize_B = static_cast<int>(types::data_type_size(dt_b));
     brg->typesize_C = static_cast<int>(types::data_type_size(brg->dt_c));
     brg->is_f32 = is_f32;
+    brg->is_int8 = is_int8;
 
     if (strides) {
         brg->stride_a = strides->stride_a;
@@ -97,8 +101,7 @@ status_t brgemm_kernel_create(
     if (!brg_kernel) return status::invalid_arguments;
     *brg_kernel = nullptr;
 
-    // Pick the per-dtype kernel class. f32 / bf16 / f16 each live in
-    // their own class so the f32 JIT codegen stays untouched.
+    // Pick the per-dtype kernel class.
     brgemm_kernel_t *kernel = nullptr;
     if (brg.is_f32) {
         kernel = new brgemm_kernel_common_t(brg);
@@ -106,6 +109,8 @@ status_t brgemm_kernel_create(
         kernel = new brgemm_kernel_bf16_t(brg);
     } else if (brg.dt_a == data_type::f16) {
         kernel = new brgemm_kernel_f16_t(brg);
+    } else if (brg.is_int8) {
+        kernel = new brgemm_kernel_s8_t(brg);
     } else {
         return status::unimplemented;
     }
@@ -127,7 +132,10 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, const void *ptr_A,
         const void *ptr_bias) {
 
     const auto &brg = brg_kernel->get_brg();
-    const int ts_a = brg.typesize_A;
+
+    // int8 A is pre-widened to s32 during packing (4 bytes/elem); dt_c is also
+    // s32, so typesize_C gives the correct packed-A stride.
+    const int ts_a = brg.is_int8 ? brg.typesize_C : brg.typesize_A;
     const int ts_b = brg.typesize_B;
     const int ts_c = brg.typesize_C;
     const int ts_bias = static_cast<int>(sizeof(float)); // bias is f32

--- a/src/cpu/rv64/brgemm/brgemm_types.hpp
+++ b/src/cpu/rv64/brgemm/brgemm_types.hpp
@@ -73,6 +73,7 @@ struct brgemm_desc_t {
 
     cpu_isa_t isa_impl;
     data_type_t dt_a, dt_b, dt_c;
+
     int typesize_A, typesize_B, typesize_C;
 
     brgemm_batch_kind_t type;
@@ -90,6 +91,7 @@ struct brgemm_desc_t {
     int rdb_tail; // K % rd_block
 
     bool is_f32;
+    bool is_int8;
 };
 
 // Runtime parameters passed to the JIT micro-kernel for one M-tile.

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -1187,6 +1187,360 @@ void brgemm_kernel_bf16_t::operator()(brgemm_kernel_params_t *p) const {
     (*jit_kernel_)(p);
 }
 
+// =====================================================================
+// int8 JIT kernel: s8 × s8 → s32.
+// A is pre-widened to s32 during packing and loaded here as e32/m4; B is
+// loaded one byte at a time with `lb` and accumulated with vmacc.vx.
+// u8 / mixed-sign combos are rejected at brgemm_desc_init.
+// =====================================================================
+
+struct jit_brgemm_s8_kernel_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_s8_kernel_t)
+
+    jit_brgemm_s8_kernel_t(const brgemm_desc_t &brg)
+        : jit_generator_t("rv64_brgemm_kernel_s8_jit"), brg_(brg) {}
+
+    void operator()(brgemm_kernel_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+    const brgemm_desc_t &get_brg() const { return brg_; }
+
+protected:
+    void generate() override;
+
+private:
+    brgemm_desc_t brg_;
+};
+
+void jit_brgemm_s8_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    using namespace Xbyak_riscv;
+
+    const dim_t s32_size
+            = static_cast<dim_t>(types::data_type_size(data_type::s32));
+    const dim_t LDA_bytes = brg_.LDA * s32_size;
+    const dim_t LDB_bytes = brg_.LDB * brg_.typesize_B;
+    const dim_t LDC_bytes = brg_.LDC * brg_.typesize_C;
+    const dim_t N_stride_B = 4 * LDB_bytes;
+    const dim_t N_stride_C = 4 * LDC_bytes;
+
+    const bool use_single_b = (3 * LDB_bytes <= 2047);
+
+    const Reg reg_param = a0;
+    const Reg reg_tmp0 = a0;
+
+    const Reg reg_A = a1;
+    const Reg reg_n = a2;
+    const Reg reg_C = a3;
+    const Reg reg_k = a4;
+    const Reg reg_K_main = a5;
+    const Reg reg_B0 = a6;
+    const Reg reg_B1 = a7;
+
+    const Reg reg_lda = t0;
+    const Reg reg_ldb = t1;
+    const Reg reg_ldc = t2;
+    const Reg reg_K_val = t3;
+    const Reg reg_N = t4;
+    const Reg reg_beta = t5;
+    const Reg reg_tmp1 = t6;
+
+    const Reg reg_A_base = s0;
+    const Reg reg_B_base = s1;
+
+    const Reg reg_B2 = s2;
+    const Reg reg_B3 = s3;
+    const Reg reg_n_stride_b = s2;
+    const Reg reg_n_stride_c = s3;
+
+    // Register layout (LMUL=m4 throughout, 28/32 phys regs, v0 free for mask):
+    //   v4-v7   v_c0   accumulator col 0
+    //   v8-v11  v_c1   accumulator col 1
+    //   v12-v15 v_c2   accumulator col 2
+    //   v16-v19 v_c3   accumulator col 3
+    //   v20-v23 v_a0   A double-buffer 0
+    //   v24-v27 v_a1   A double-buffer 1
+    //   v28-v31 v_tmp  scratch for C load/store
+    const VReg v_c0(4);
+    const VReg v_c1(8);
+    const VReg v_c2(12);
+    const VReg v_c3(16);
+    const VReg v_a0(20);
+    const VReg v_a1(24);
+    const VReg v_tmp(28);
+
+    addi(sp, sp, -32);
+    sd(reg_A_base, sp, 0);
+    sd(reg_B_base, sp, 8);
+    sd(reg_B2, sp, 16);
+    sd(reg_B3, sp, 24);
+
+    ld(reg_A_base, reg_param, 0);
+    ld(reg_B_base, reg_param, 8);
+    ld(reg_C, reg_param, 16);
+    ld(reg_N, reg_param, 24);
+    ld(reg_tmp1, reg_param, 32); // M (one-shot, for vsetvli)
+    ld(reg_K_val, reg_param, 40);
+    lw(reg_beta, reg_param, 48);
+
+    vsetvli(x0, reg_tmp1, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+
+    li(reg_lda, LDA_bytes);
+    li(reg_ldb, LDB_bytes);
+    li(reg_ldc, LDC_bytes);
+
+    if (use_single_b) {
+        li(reg_n_stride_b, N_stride_B);
+        li(reg_n_stride_c, N_stride_C);
+    }
+
+    // K_main = (K / 4) * 4 — the 4× unrolled portion of the K loop.
+    srli(reg_K_main, reg_K_val, 2);
+    slli(reg_K_main, reg_K_main, 2);
+
+    // ---- N outer loop: 4 columns per iteration ----
+    mv(reg_n, x0);
+
+    Label lbl_n_loop, lbl_n_tail, lbl_n_tail_loop, lbl_n_end;
+
+    // B-scalar FMA: load one signed byte from reg_b+imm_off into a GPR, then
+    // vmacc.vx into the named accumulator against the supplied A row.
+    auto emit_b_fma = [&](const Reg &reg_b, int imm_off, const VReg &v_c,
+                              const VReg &v_a_cur) {
+        lb(reg_tmp0, reg_b, imm_off);
+        vmacc_vx(v_c, reg_tmp0, v_a_cur);
+    };
+
+    auto emit_b_advance = [&]() {
+        addi(reg_B0, reg_B0, 1);
+        if (!use_single_b) {
+            addi(reg_B1, reg_B1, 1);
+            addi(reg_B2, reg_B2, 1);
+            addi(reg_B3, reg_B3, 1);
+        }
+    };
+
+    L(lbl_n_loop);
+    addi(reg_tmp0, reg_n, 4);
+    blt(reg_N, reg_tmp0, lbl_n_tail);
+
+    mv(reg_A, reg_A_base);
+    mv(reg_B0, reg_B_base);
+    if (!use_single_b) {
+        add(reg_B1, reg_B_base, reg_ldb);
+        add(reg_B2, reg_B1, reg_ldb);
+        add(reg_B3, reg_B2, reg_ldb);
+    }
+
+    vmv_v_i(v_c0, 0);
+    vmv_v_i(v_c1, 0);
+    vmv_v_i(v_c2, 0);
+    vmv_v_i(v_c3, 0);
+
+    // ---- K main loop (4× unrolled, double-buffered A loads) ----
+    mv(reg_k, x0);
+    Label lbl_k_tail, lbl_k_tail_end;
+
+    auto emit_fma4 = [&](const VReg &v_a_cur) {
+        if (use_single_b) {
+            emit_b_fma(reg_B0, 0, v_c0, v_a_cur);
+            emit_b_fma(reg_B0, (int)LDB_bytes, v_c1, v_a_cur);
+            emit_b_fma(reg_B0, (int)(2 * LDB_bytes), v_c2, v_a_cur);
+            emit_b_fma(reg_B0, (int)(3 * LDB_bytes), v_c3, v_a_cur);
+        } else {
+            emit_b_fma(reg_B0, 0, v_c0, v_a_cur);
+            emit_b_fma(reg_B1, 0, v_c1, v_a_cur);
+            emit_b_fma(reg_B2, 0, v_c2, v_a_cur);
+            emit_b_fma(reg_B3, 0, v_c3, v_a_cur);
+        }
+    };
+
+    // Pipelined step: prefetch next A into v_next while accumulating with
+    // the already-loaded v_cur.
+    auto emit_pipelined_step = [&](const VReg &v_next, const VReg &v_cur) {
+        vle32_v(v_next, reg_A);
+        add(reg_A, reg_A, reg_lda);
+        emit_fma4(v_cur);
+        emit_b_advance();
+    };
+
+    // Drain step: FMA only, no prefetch (avoids OOB A read).
+    auto emit_drain_step = [&](const VReg &v_cur) {
+        emit_fma4(v_cur);
+        emit_b_advance();
+    };
+
+    beq(reg_K_main, x0, lbl_k_tail);
+
+    // K_pipe = K_main - 4: loop bound for the fully-pipelined phase.
+    addi(reg_tmp1, reg_K_main, -4);
+
+    vle32_v(v_a0, reg_A); // preload A[0]
+    add(reg_A, reg_A, reg_lda);
+
+    align(16);
+    {
+        Label lbl_pipe, lbl_pipe_end;
+        L(lbl_pipe);
+        bge(reg_k, reg_tmp1, lbl_pipe_end);
+
+        emit_pipelined_step(v_a1, v_a0);
+        emit_pipelined_step(v_a0, v_a1);
+        emit_pipelined_step(v_a1, v_a0);
+        emit_pipelined_step(v_a0, v_a1);
+
+        addi(reg_k, reg_k, 4);
+        j_(lbl_pipe);
+        L(lbl_pipe_end);
+    }
+
+    // Remainder: 4 drain-equivalent steps covering A[K_pipe..K_main-1].
+    emit_pipelined_step(v_a1, v_a0);
+    emit_pipelined_step(v_a0, v_a1);
+    emit_pipelined_step(v_a1, v_a0);
+    emit_drain_step(v_a1);
+    addi(reg_k, reg_k, 4);
+
+    // ---- K tail (1 step at a time) ----
+    L(lbl_k_tail);
+    bge(reg_k, reg_K_val, lbl_k_tail_end);
+
+    vle32_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+    emit_fma4(v_a0);
+    emit_b_advance();
+    addi(reg_k, reg_k, 1);
+    j_(lbl_k_tail);
+
+    L(lbl_k_tail_end);
+
+    // ---- Store accumulators to C, honoring beta ----
+    {
+        mv(reg_tmp0, reg_C);
+        Label lbl_bz, lbl_store_done;
+        beq(reg_beta, x0, lbl_bz);
+
+        // beta != 0: C[col] = C[col] + accum
+        vle32_v(v_tmp, reg_tmp0);
+        vadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vadd_vv(v_tmp, v_tmp, v_c1);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vadd_vv(v_tmp, v_tmp, v_c2);
+        vse32_v(v_tmp, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+
+        vle32_v(v_tmp, reg_tmp0);
+        vadd_vv(v_tmp, v_tmp, v_c3);
+        vse32_v(v_tmp, reg_tmp0);
+
+        j_(lbl_store_done);
+
+        // beta == 0: C[col] = accum (overwrite)
+        L(lbl_bz);
+        vse32_v(v_c0, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c1, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c2, reg_tmp0);
+        add(reg_tmp0, reg_tmp0, reg_ldc);
+        vse32_v(v_c3, reg_tmp0);
+
+        L(lbl_store_done);
+    }
+
+    if (use_single_b) {
+        add(reg_B_base, reg_B_base, reg_n_stride_b);
+        add(reg_C, reg_C, reg_n_stride_c);
+    } else {
+        li(reg_tmp1, N_stride_B);
+        add(reg_B_base, reg_B_base, reg_tmp1);
+        li(reg_tmp1, N_stride_C);
+        add(reg_C, reg_C, reg_tmp1);
+    }
+
+    addi(reg_n, reg_n, 4);
+    j_(lbl_n_loop);
+
+    // ---- N tail: 1 column at a time ----
+    L(lbl_n_tail);
+
+    L(lbl_n_tail_loop);
+    bge(reg_n, reg_N, lbl_n_end);
+
+    mv(reg_A, reg_A_base);
+    mv(reg_B0, reg_B_base);
+
+    vmv_v_i(v_c0, 0);
+
+    mv(reg_k, x0);
+    Label lbl_kt2, lbl_kt2_end;
+
+    L(lbl_kt2);
+    bge(reg_k, reg_K_val, lbl_kt2_end);
+
+    vle32_v(v_a0, reg_A);
+    add(reg_A, reg_A, reg_lda);
+    emit_b_fma(reg_B0, 0, v_c0, v_a0);
+    addi(reg_B0, reg_B0, 1);
+    addi(reg_k, reg_k, 1);
+    j_(lbl_kt2);
+
+    L(lbl_kt2_end);
+
+    {
+        Label lbl_bz2, lbl_done2;
+        beq(reg_beta, x0, lbl_bz2);
+        vle32_v(v_tmp, reg_C);
+        vadd_vv(v_tmp, v_tmp, v_c0);
+        vse32_v(v_tmp, reg_C);
+        j_(lbl_done2);
+        L(lbl_bz2);
+        vse32_v(v_c0, reg_C);
+        L(lbl_done2);
+    }
+
+    add(reg_B_base, reg_B_base, reg_ldb);
+    add(reg_C, reg_C, reg_ldc);
+
+    addi(reg_n, reg_n, 1);
+    j_(lbl_n_tail_loop);
+
+    L(lbl_n_end);
+
+    ld(reg_A_base, sp, 0);
+    ld(reg_B_base, sp, 8);
+    ld(reg_B2, sp, 16);
+    ld(reg_B3, sp, 24);
+    addi(sp, sp, 32);
+    ret();
+#else
+    ret();
+#endif
+}
+
+brgemm_kernel_s8_t::brgemm_kernel_s8_t(const brgemm_desc_t &brg)
+    : brg_(brg), jit_kernel_(new jit_brgemm_s8_kernel_t(brg)) {}
+
+brgemm_kernel_s8_t::~brgemm_kernel_s8_t() {
+    delete jit_kernel_;
+}
+
+status_t brgemm_kernel_s8_t::create_kernel() {
+    return jit_kernel_->create_kernel();
+}
+
+void brgemm_kernel_s8_t::operator()(brgemm_kernel_params_t *p) const {
+    (*jit_kernel_)(p);
+}
+
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.hpp
@@ -28,6 +28,7 @@ namespace rv64 {
 struct jit_brgemm_kernel_t;
 struct jit_brgemm_bf16_kernel_t;
 struct jit_brgemm_f16_kernel_t;
+struct jit_brgemm_s8_kernel_t;
 
 struct brgemm_kernel_common_t : public brgemm_kernel_t {
     brgemm_kernel_common_t(const brgemm_desc_t &brg);
@@ -66,6 +67,19 @@ struct brgemm_kernel_f16_t : public brgemm_kernel_t {
 private:
     brgemm_desc_t brg_;
     jit_brgemm_f16_kernel_t *jit_kernel_ = nullptr;
+};
+
+struct brgemm_kernel_s8_t : public brgemm_kernel_t {
+    brgemm_kernel_s8_t(const brgemm_desc_t &brg);
+    ~brgemm_kernel_s8_t() override;
+
+    status_t create_kernel() override;
+    void operator()(brgemm_kernel_params_t *) const override;
+    const brgemm_desc_t &get_brg() const override { return brg_; }
+
+private:
+    brgemm_desc_t brg_;
+    jit_brgemm_s8_kernel_t *jit_kernel_ = nullptr;
 };
 
 } // namespace rv64

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -56,10 +56,12 @@ struct jit_pack_a_tile_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_pack_a_tile_t)
 
-    // input_typesize: 4 for f32, 2 for bf16/f16.
+    // input_typesize: 4 for f32, 2 for bf16/f16, 1 for int8 (widened to s32
+    // during packing so the brgemm kernel can use plain e32 ops).
     explicit jit_pack_a_tile_t(int input_typesize)
         : jit_generator_t("jit_pack_a_tile"), input_typesize_(input_typesize) {
-        assert(input_typesize == 2 || input_typesize == 4);
+        assert(input_typesize == 1 || input_typesize == 2
+                || input_typesize == 4);
         create_kernel();
     }
 
@@ -88,22 +90,53 @@ protected:
 
         const VReg v_tmp(0);
 
-        const int elem_shift = (input_typesize_ == 4) ? 2 : 1;
+        const int elem_shift = (input_typesize_ == 4) ? 2
+                : (input_typesize_ == 2)              ? 1
+                                                      : 0;
 
-        // Load parameters
+        // Load parameters.
         ld(reg_ws, reg_param, 0);
         ld(reg_A, reg_param, 8);
         ld(reg_LDA, reg_param, 16);
         ld(reg_bd, reg_param, 24);
-        ld(reg_rows_remaining, reg_param, 32); // reuse as valid_rows temp
         ld(reg_K, reg_param, 40);
 
         slli(reg_LDA, reg_LDA, elem_shift);
         slli(reg_bd, reg_bd, elem_shift);
 
-        // Save valid_rows for reuse in each k iteration
         const Reg reg_valid_rows = a6;
         ld(reg_valid_rows, reg_param, 32);
+
+        if (input_typesize_ == 1) {
+            const Reg reg_bidx = a7;
+            xor_(reg_k, reg_k, reg_k);
+            Label k_loop_i8, k_done_i8;
+            L(k_loop_i8);
+            beq(reg_k, reg_K, k_done_i8);
+
+            mul(reg_tmp, reg_k, reg_LDA);
+            add(reg_src, reg_A, reg_tmp);
+            mul(reg_tmp, reg_k, reg_bd);
+            slli(reg_tmp, reg_tmp, 2); // ×4 for s32 stride
+            add(reg_dst, reg_ws, reg_tmp);
+
+            xor_(reg_bidx, reg_bidx, reg_bidx);
+            Label row_loop, row_done;
+            L(row_loop);
+            beq(reg_bidx, reg_valid_rows, row_done);
+            lb(reg_tmp, reg_src, 0);
+            sw(reg_tmp, reg_dst, 0);
+            addi(reg_src, reg_src, 1);
+            addi(reg_dst, reg_dst, 4);
+            addi(reg_bidx, reg_bidx, 1);
+            j_(row_loop);
+            L(row_done);
+
+            addi(reg_k, reg_k, 1);
+            j_(k_loop_i8);
+            L(k_done_i8);
+            ret();
+        }
 
         xor_(reg_k, reg_k, reg_k); // k = 0
 
@@ -127,6 +160,7 @@ protected:
             vle32_v(v_tmp, reg_src);
             vse32_v(v_tmp, reg_dst);
         } else {
+            // bf16/f16 (int8 takes the early-return path above).
             vsetvli(reg_vl, reg_rows_remaining, SEW::e16, LMUL::m4);
             vle16_v(v_tmp, reg_src);
             vse16_v(v_tmp, reg_dst);
@@ -175,22 +209,41 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
                     && !bias_mdw.has_runtime_dims_or_strides(),
             VERBOSE_UNSUPPORTED_TAG);
 
-    // Accepted: f32/f32/f32, bf16/bf16/f32 (Zvfbfwma), f16/f16/f32 (Zvfh).
+    // Accepted: f32/f32/f32, bf16/bf16/f32 (Zvfbfwma), f16/f16/f32 (Zvfh),
+    //           s8/s8/s32. u8 / mixed-sign are rejected at brgemm_desc_init.
     const auto src_dt = src_mdw.data_type();
     const auto wei_dt = wei_mdw.data_type();
     const bool same_in_dt = src_dt == wei_dt;
     const bool in_dt_ok = same_in_dt
             && (src_dt == f32 || (src_dt == bf16 && mayiuse(zvfbfwma))
                     || (src_dt == f16 && mayiuse(zvfh)));
-    const bool types_ok = in_dt_ok && dst_mdw.data_type() == f32
-            && IMPLICATION(!bias_mdw.is_zero(), bias_mdw.data_type() == f32)
-            && desc()->accum_data_type == f32;
+    const bool in_dt_ok_int8 = (src_dt == s8 && wei_dt == s8);
+    const bool types_ok = (in_dt_ok || in_dt_ok_int8)
+            && IMPLICATION(in_dt_ok,
+                    dst_mdw.data_type() == f32
+                            && desc()->accum_data_type == f32)
+            && IMPLICATION(in_dt_ok_int8,
+                    dst_mdw.data_type() == s32
+                            && desc()->accum_data_type == s32)
+            // int8 path rejects any bias explicitly below.
+            && IMPLICATION(in_dt_ok && !bias_mdw.is_zero(),
+                    bias_mdw.data_type() == f32);
     VDISPATCH_MATMUL(types_ok, VERBOSE_UNSUPPORTED_DT);
 
     input_typesize_ = static_cast<int>(types::data_type_size(src_dt));
 
-    VDISPATCH_MATMUL(attr()->has_default_values(smask_t::post_ops, f32),
-            VERBOSE_UNSUPPORTED_ATTR);
+    // int8 path supports no bias / post-ops / scales / zero-points yet.
+    if (in_dt_ok_int8) {
+        VDISPATCH_MATMUL(bias_mdw.is_zero(), VERBOSE_UNSUPPORTED_BIAS_CFG);
+        VDISPATCH_MATMUL(
+                attr()->has_default_values(smask_t::post_ops | smask_t::scales
+                                | smask_t::zero_points,
+                        s32),
+                VERBOSE_UNSUPPORTED_ATTR);
+    } else {
+        VDISPATCH_MATMUL(attr()->has_default_values(smask_t::post_ops, f32),
+                VERBOSE_UNSUPPORTED_ATTR);
+    }
 
     // Resolve primary + post-op binary src1 formats before the post-op check:
     // a post-op binary src1 may be format_any and must be matched to dst before
@@ -279,13 +332,14 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     VDISPATCH_MATMUL(
             N_ >= 16, VERBOSE_IMPL_HEURISTIC_FAIL, "N too small for brgemm");
 
-    // f32 keeps the K/A_bytes thresholds; bf16/f16 only require batch*M.
+    // f32 keeps the K/A_bytes thresholds; bf16/f16/int8 only require batch*M.
     const bool is_low_prec
             = (src_dt == data_type::bf16 || src_dt == data_type::f16);
-    if (is_low_prec) {
+    const bool is_int8 = (src_dt == s8);
+    if (is_low_prec || is_int8) {
         VDISPATCH_MATMUL(K_ >= BRGEMM_BK && batch_ * M_ >= 128,
                 VERBOSE_IMPL_HEURISTIC_FAIL,
-                "shape too small for bf16/f16 brgemm matmul");
+                "shape too small for bf16/f16/int8 brgemm matmul");
     } else {
         const dim_t A_bytes = N_ * K_ * (dim_t)input_typesize_;
         const auto L2_bytes = platform::get_per_core_cache_size(3);
@@ -307,18 +361,17 @@ status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
     cpu_isa_t brg_isa = src_dt == bf16 ? zvfbfwma : (src_dt == f16 ? zvfh : v);
 
     brgemm_desc_t brg_desc;
-    CHECK(brgemm_desc_init(&brg_desc, brg_isa, brgemm_strd, src_dt, src_dt,
+    CHECK(brgemm_desc_init(&brg_desc, brg_isa, brgemm_strd, src_dt, wei_dt,
             brgemm_col_major, 1.0f, 0.0f, LDA, LDB, LDC, M_brg, N_brg, K_brg));
 
     brgemm_kernel_t *kernel = nullptr;
     CHECK(brgemm_kernel_create(&kernel, brg_desc));
     brg_kernel_.reset(kernel);
 
-    // Create JIT kernels for pack_a_tile and the per-row bias + post-op chain
-    // (the latter replaces the bespoke jit_bias_postops_row_t).
-    // pack_a_tile is dtype-aware; bias+postops touch only the f32 dst.
+    // pack_a_tile is dtype-aware; the bias+postops chain touches the dst and
+    // is only built for the non-int8 path (int8 has no bias/postops yet).
     pack_kernel_.reset(new jit_pack_a_tile_t(input_typesize_));
-    {
+    if (!in_dt_ok_int8) {
         const memory_desc_wrapper bias_d(desc()->bias_desc);
         jit_uni_postops_kernel_t::conf_t conf;
         conf.dst_dt = f32;
@@ -341,21 +394,24 @@ void rvv_brgemm_matmul_t::pd_t::init_scratchpad() {
     using namespace memory_tracking::names;
     const auto &brg = brg_kernel_->get_brg();
     auto scratchpad = scratchpad_registry().registrar();
-    const size_t ws_bytes = (size_t)brg.bd_block * K_ * input_typesize_;
+    // int8 A is pre-widened to s32 during packing (4 bytes/elem).
+    const int ws_typesize = (input_typesize_ == 1) ? 4 : input_typesize_;
+    const size_t ws_bytes = (size_t)brg.bd_block * K_ * ws_typesize;
     scratchpad.template book<char>(key_brgemm_primitive_buffer_a, ws_bytes);
 }
 
 status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
-    // Byte arithmetic so one code path handles f32/bf16/f16.
+    // Byte arithmetic so one code path handles f32/bf16/f16/int8.
     auto src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);
     auto weights = CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS);
-    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
+    auto dst_char = CTX_OUT_MEM(char *, DNNL_ARG_DST);
 
     const dim_t M = pd()->M_;
     const dim_t N = pd()->N_;
     const dim_t K = pd()->K_;
     const dim_t batch = pd()->batch_;
     const int in_ts = pd()->input_typesize_;
+    const bool is_int8 = pd()->brg_kernel_->get_brg().is_int8;
 
     const auto &brg = pd()->brg_kernel_->get_brg();
     const int bd = brg.bd_block;
@@ -376,9 +432,13 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
             memory_tracking::names::key_brgemm_primitive_buffer_a);
 
     const int num_tiles = bdb + (bdb_tail > 0 ? 1 : 0);
+    // int8 A is pre-widened to s32 inside the packing kernel (4 bytes/elem).
+    const int ws_typesize = (in_ts == 1) ? 4 : in_ts;
+    const int dst_typesize = brg.typesize_C; // 4 for both f32 and s32 dst
     for (int t = 0; t < num_tiles; t++) {
         const bool is_tail = (t == bdb);
         const int rows = is_tail ? bdb_tail : bd;
+        // Tile start in the unpacked weights tensor (in_ts bytes/elem).
         const char *A_tile = weights + (dim_t)t * bd * in_ts;
 
         jit_pack_a_tile_t::call_params_t pack_p;
@@ -395,9 +455,9 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
             const float beta_kb = (kb == 0) ? 0.0f : 1.0f;
 
             brgemm_kernel_params_t p;
-            p.ptr_A = ws + kb * bd * in_ts;
+            p.ptr_A = ws + kb * bd * ws_typesize;
             p.ptr_B = src + kb * in_ts;
-            p.ptr_C = dst + t * bd; // dst stays f32
+            p.ptr_C = dst_char + (dim_t)t * bd * dst_typesize;
             p.N = total_N;
             p.M = rows;
             p.K = K_inner;
@@ -406,6 +466,12 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
             (*brg_kernel)(&p);
         }
     }
+
+    // int8 path: no bias/post-ops yet.
+    if (is_int8) return status::success;
+
+    // Beyond here dst is f32.
+    auto dst = reinterpret_cast<float *>(dst_char);
 
     // Apply bias + post-ops using JIT kernel
     const memory_desc_wrapper dst_d(pd()->dst_md());

--- a/src/cpu/rv64/rvv_brgemm_matmul.hpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.hpp
@@ -55,7 +55,7 @@ struct rvv_brgemm_matmul_t : public primitive_t {
         dim_t K_ = 0;
         dim_t batch_ = 0;
         bool weights_are_broadcast_ = false;
-        // Input element size in bytes (4=f32, 2=bf16/f16). dst is always f32.
+        // Input element size in bytes (4=f32, 2=bf16/f16, 1=int8). dst is f32 or s32.
         int input_typesize_ = 4;
 
     private:


### PR DESCRIPTION
# Description

This PR introduces an int8 BRGEMM kernel for RISC-V (RV64) using the `xbyak_riscv_v` JIT code generator, and wires it into the `rvv_brgemm_matmul` primitive so int8 batch-broadcast matmul shapes can dispatch to the optimized BRGEMM path.

The initial version provides:

1. A JIT int8 BRGEMM kernel (`jit_brgemm_s8_kernel_t`) that accumulates into `s32`
2. Dispatch for `s8 × s8` → `s32` only 
3. int8 entry points in `brgemm_desc_init` / `brgemm_kernel_create` and in `rvv_brgemm_matmul_t::pd_t::init`, so the new path is reachable end-to-end

## Key Features

- **JIT BRGEMM Kernel**: dynamically generated code for the s8 × s8 → s32 path
- **Data Types**: `s8` inputs with `s32` accumulation; `f32`/`bf16`/`f16` paths are unchanged
- **Memory Layouts**: row-major src/weights/dst with broadcast weights across batch (3D+ shapes)
- **Beta Handling**: honored at store time so K-blocking (`BRGEMM_BK = 256`) produces identical results to a single-pass kernel

## Implementation Details

### int8 → s32 widening strategy

1. **Packing stage** (`jit_pack_a_tile_t`, int8 path): a scalar `lb`+`sw` loop widens A from `int8` to `int32` (4 bytes/elem) into the per-tile scratchpad. The packed buffer equals the f32 packed size (both 4 bytes/elem) and is 2× the bf16/f16 packed size; it stays within a few KB for `bd_block=16` and `BRGEMM_BK=256`.
2. **BRGEMM kernel** (`jit_brgemm_s8_kernel_t`): loads A as `e32/m4` with `vle32_v`, loads each B scalar with `lb` (sign-extended to XLEN in the GPR — only `s8 × s8` is dispatched), and accumulates with the non-widening `vmacc.vx`. Standard `vadd.vv` merges the partial accumulator with the previous C tile when `beta != 0`. SEW/LMUL never change, so a single `vsetvli` is issued before the loops (unlike bf16/f16, which toggle between `e16` for the FMA loop and `e32` for bias/store). The A row size uses `types::data_type_size(data_type::s32)` rather than a magic constant.

### K-blocking and beta

The matmul driver splits K into `BRGEMM_BK` chunks and invokes the kernel once per chunk with `beta=0` for the first tile and `beta=1` thereafter. The kernel reads `beta` (offset 48 in `brgemm_kernel_params_t`) and branches at store time:

- `beta == 0`: overwrite C with the accumulator
- `beta != 0`: load C, add the accumulator, store

This makes multi-tile K reductions produce identical results to a single-tile kernel.

# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on SG2044 with VLEN=128. We draw comparisons among:

1. **baseline (upstream/main)**: int8 matmul dispatched to `gemm:jit` (scalar) for all shapes
2. **this PR**: int8 matmul dispatched to `brgemm:rvv` (vectorized JIT) for shapes meeting the broadcast/single-thread guard, falling back to `gemm:jit` otherwise


### Single-Core Performance (taskset -c 32, OMP_NUM_THREADS=1)

To exercise the BRGEMM path we use shapes that satisfy the broadcast and minimum-size guard. Baseline dispatches to `gemm:jit`; this PR dispatches to `brgemm:rvv`. Numbers below are `min_time` reported by `benchdnn --mode=f`, on SG2044 (VLEN=128).

| Shape | Baseline `gemm:jit` (ms) | This PR `brgemm:rvv` (ms) | Speedup |
|-------|--------------------------|---------------------------|---------|
| 8x16x256:1x256x32  |  4.0320 | 0.0974 | **41.4×** |
| 8x16x512:1x512x64  | 14.8506 | 0.3938 | **37.7×** |
| 32x8x256:1x256x16  |  4.4551 | 0.0908 | **49.1×** |
| 16x16x256:1x256x32 |  7.9309 | 0.1843 | **43.0×** |
| 16x8x512:1x512x32  |  8.4380 | 0.1980 | **42.6×** |
| **Total**          | **39.71** | **0.964** | **41.2×** |

**Summary:** across these broadcast-weights shapes the BRGEMM kernel delivers a **~38–49× single-core speedup** over the scalar `gemm:jit` int8 path. The improvement comes from replacing the byte-at-a-time scalar inner loop with RVV vector loads, a 4× unrolled double-buffered K main loop (`vle32_v` prefetch + `vmacc.vx` FMA), the single-B-pointer immediate-offset addressing, and `vse32_v` stores.

#### Tail-path coverage (correctness + perf)

To exercise the kernel's tail code paths (N tail in the kernel, M tail in the BRGEMM view, K tail of the inner K-block), the following shapes were added on top of the friendly `N % 4 == 0` / `K % 4 == 0` shapes above. All four dispatch to `brgemm:rvv` and pass correctness on both builds.

| Shape | Tail type | Baseline `gemm:jit` (ms) | This PR `brgemm:rvv` (ms) | Speedup |
|-------|-----------|--------------------------|---------------------------|---------|
| 8x16x256:1x256x17 | N-tail (N=17, 1-col remainder)      | 2.0276 | 0.0903 | **22.5×** |
| 5x27x256:1x256x32 | M-tail (M=27, bdb_tail=11)          | 3.3174 | 0.1060 | **31.3×** |
| 8x16x259:1x259x32 | K-tail (last K-block K_inner=3)      | 3.9141 | 0.1003 | **39.0×** |
| 8x16x257:1x257x32 | K-tail (last K-block K_inner=1)      | 3.9285 | 0.1008 | **39.0×** |


### Correctness

All correctness tests pass:

```
shapes_transformer (--dt=s8:s8:s32):              tests:4 passed:4
shapes_converted_ip_inf_lb_gmnt (--dt=s8:s8:s32): tests:2 passed:2
shapes_converted_ip_inf_lb_resnet (--dt=s8:s8:s32): tests:2 passed:2
broadcast-weights shapes (5 friendly + 4 tail):   tests:9 passed:9
bf16 broadcast-weights (regression):              tests:1 passed:1
f32 shapes_transformer (regression):              tests:4 passed:4
```


## Future Optimizations

- Multi-threaded execution (relax the `dnnl_get_max_threads() <= 1` guard)
- Bias + output quantization (scales, zero-points) so int8 output (`s8`/`u8` dst) is supported end-to-end
- 2D / non-broadcast shapes by relaxing the `weights_are_broadcast_` guard
- Larger `bd_block` via register-tile blocking to raise compute-to-load ratio
