### PR TITLE
[rls-v3.13] xe: sdpa: resolve issue related to long microkernel generation time

### DIFF
--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -623,8 +623,8 @@ static std::vector<fwd_config_record_t> sorted_configs = []() {
         {{compute::gpu_arch_t::xe3p, 512},                                        {32, 16, 32, 16, 16, 2, 16, 2}},
         {{compute::gpu_arch_t::xe3p, 512, second_token },                         {32, 16, 32, 16, 16, 1, 16, 1}},
         {{compute::gpu_arch_t::xe3p, 512, second_token | quantized },             {32, 16, 32, 16, 16, 1, 16, 1}},
-        {{compute::gpu_arch_t::xe3p, 512, fma | quantized },                      {32, 16, 32, 16, 16, 1, 16, 1}},
-        {{compute::gpu_arch_t::xe3p, 512, fma | f32 | second_token | quantized }, {32, 16, 32, 16, 16, 1, 16, 1}},
+        {{compute::gpu_arch_t::xe3p, 512, fma | quantized },                      {16, 16, 32, 16, 16, 1, 16, 1}},
+        {{compute::gpu_arch_t::xe3p, 512, fma | f32 | second_token | quantized }, {16, 16, 32, 16, 16, 1, 16, 1}},
     };
     // clang-format on
 

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -321,13 +321,14 @@ struct micro_fwd_t : public primitive_t {
                         vgs, static_cast<long int>(desc()->val_md()->dims[3]));
             }
 
-            CHECK(init_conf_microkernels(engine));
-            CHECK(init_conf(engine));
             VDISPATCH_SDPA(IMPLICATION((arch() == compute::gpu_arch_t::xe_hpc)
                                            && (desc()->qry_md()->data_type
                                                    == data_type::f32),
                                    with_causal_mask()),
                     "fused f32 SDPA only optimized for causal mask"); //TODO: update when performance improved
+
+            CHECK(init_conf_microkernels(engine));
+            CHECK(init_conf(engine));
 
             return status::success;
         }

--- a/tests/gtests/internals/test_sdpa.cpp
+++ b/tests/gtests/internals/test_sdpa.cpp
@@ -3065,8 +3065,8 @@ INSTANTIATE_TEST_SUITE_P(DataTypes_f32, sdpa_test_datatypes,
                 ::testing::Values(seq_len_size_t {384, 384}, seq_len_size_t {1, 385}, seq_len_size_t {1024, 1024}, seq_len_size_t {1, 1025}), // seq_len
                 ::testing::Values(head_group_size_t {32, 32, 32}, head_group_size_t {64, 64, 64}, head_group_size_t {128, 128, 128}, head_group_size_t {256, 256, 256}, head_group_size_t {512, 512, 512}), // hd_size
                 ::testing::Values(tensor_type_t("Q", mdt::f32)), // dt
-                ::testing::Values(tensor_type_t("K", mdt::f32), tensor_type_t("K", mdt::s8, mdt::f32)), // kdt
-                ::testing::Values(tensor_type_t("V", mdt::f32), tensor_type_t("V", mdt::s8, mdt::f32)), // vdt
+                ::testing::Values(tensor_type_t("K", mdt::f32)), // kdt
+                ::testing::Values(tensor_type_t("V", mdt::f32)), // vdt
                 ::testing::Values(quantize_type::per_token), // qtype
                 ::testing::Values(dnnl::memory::format_tag::abcd, dnnl::memory::format_tag::abdc), // key_format_tag
                 ::testing::Values(mask_config_t {mask_type::twoD, mdt::f32}), // mask_type


### PR DESCRIPTION
Cherry-pick of #5437 (open at time of this cherry-pick) to rls-v3.13.

## Original description

This PR address long microkernel generation times on xe3p because of the addition of new SDPA configurations. The generated kernel from these configs has several thousands of dependencies in the kernel which causes large number instructions due to the swsb mechanism in ngen. We resolve the issue by changing the tile size of these kernels.

Fixes MFDNN-14904