### PR TITLE
[rls-v3.13] arch: fix coverity issues

### DIFF
--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -252,7 +252,12 @@ struct quant_entries_t : public c_compatible {
     data_type_t get_data_type(int arg) const {
         return get(arg).get_data_type();
     }
-    dim_t get_group(int arg, int d) const { return get(arg).get_group(d); }
+
+    dim_t get_group(int arg, int d) const {
+        dim_t group = get(arg).get_group(d);
+        assert(group != 0 && "wrong dimension used");
+        return group;
+    }
 
     bool has_host_scalars() const {
         for (const auto &e : entries_) {

--- a/src/xpu/ocl/buffer_memory_storage.cpp
+++ b/src/xpu/ocl/buffer_memory_storage.cpp
@@ -163,16 +163,27 @@ std::unique_ptr<memory_storage_t> buffer_memory_storage_t::get_sub_storage(
 
     auto sub_storage
             = new buffer_memory_storage_t(this->engine(), root_storage());
-    if (sub_storage) {
-        sub_storage->init(memory_flags_t::use_runtime_ptr, size, sub_buffer);
-        sub_storage->base_offset_ = base_offset_ + offset;
+    if (!sub_storage) return nullptr;
+
+    status_t status = sub_storage->init(
+            memory_flags_t::use_runtime_ptr, size, sub_buffer);
+    if (status != status::success) {
+        delete sub_storage;
+        return nullptr;
     }
+    sub_storage->base_offset_ = base_offset_ + offset;
     return std::unique_ptr<memory_storage_t>(sub_storage);
 }
 
 std::unique_ptr<memory_storage_t> buffer_memory_storage_t::clone() const {
     auto storage = new buffer_memory_storage_t(engine());
-    if (storage) storage->init(memory_flags_t::use_runtime_ptr, 0, mem_object_);
+    if (!storage) return nullptr;
+    status_t status
+            = storage->init(memory_flags_t::use_runtime_ptr, 0, mem_object_);
+    if (status != status::success) {
+        delete storage;
+        return nullptr;
+    }
     return std::unique_ptr<memory_storage_t>(storage);
 }
 


### PR DESCRIPTION
# Description

Backport of PR #5457

Commit [567d1b3](https://github.com/uxlfoundation/oneDNN/pull/5457/changes/567d1b344aa4cbceacc1c038aee007aaeb456eab) is backported via PR #5408 as it is dependent on PR #5102.