### PR TITLE
x64: matmul: add VCONDCHECK on src+wei scales combination

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1847,6 +1847,13 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
     }
 
+    // AMX is not supported src scales with common non-f32 weights scales
+    // combination.
+    VCONDCHECK_BG(IMPLICATION(bgmmc.is_amx && bgmmc.with_src_scales
+                                  && bgmmc.is_wei_scale_common,
+                          bgmmc.wei_scales_dt == f32),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
     bgmmc.with_dst_scales = !dst_scales.has_default_values();
     // only common scales are supported


### PR DESCRIPTION
Mirroring assert in [brgemm AMX uker](https://github.com/uxlfoundation/oneDNN/blob/main/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp#L1276)
in order to skip this test case: [--attr-scales=src:common:2:f32+wei:common:2:f16 ](https://github.com/uxlfoundation/oneDNN/blob/b23a29087298ccbc3a72bf77497e18274561b4f3/tests/benchdnn/inputs/matmul/harness_matmul_generated_ci#L300)