### PR TITLE
cpu: matmul: fix LDC for M=1 cases in gemm based matmuls

### DIFF
--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -270,7 +270,10 @@ status_t gemm_bf16_matmul_t<dst_type>::execute_ref(
 
     const float alpha = params.get_gemm_alpha(scales);
     const float beta = params.gemm_beta_;
-    const dim_t acc_ldc = dst_is_acc ? ldc : N;
+    // `ldc` is the destination row stride. When `M == 1`, a degenerate stride
+    // (e.g. `acb` gives `ldc == 1`) can violate the `ldc >= N` requirement.
+    // Clamp `ldc` to `N`. This is safe for `M == 1` and has no effect for `M > 1`.
+    const dim_t acc_ldc = dst_is_acc ? nstl::max(ldc, N) : N;
     const int scale_idx_mult
             = this->pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS)
             == (1 << (ndims - 1));

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -253,7 +253,10 @@ status_t gemm_f32_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
         need_free_acc = true;
     }
 
-    const dim_t acc_ldc = dst_is_acc ? ldc : N;
+    // `ldc` is the destination row stride. When `M == 1`, a degenerate stride
+    // (e.g. `acb` gives `ldc == 1`) can violate the `ldc >= N` requirement.
+    // Clamp `ldc` to `N`. This is safe for `M == 1` and has no effect for `M > 1`.
+    const dim_t acc_ldc = dst_is_acc ? nstl::max(ldc, N) : N;
     const int scale_idx_mult
             = this->pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS)
             == (1 << (ndims - 1));

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -294,7 +294,10 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
 
     const float alpha = params.get_gemm_alpha(scales);
     const float beta = params.gemm_beta_;
-    const dim_t acc_ldc = dst_is_acc ? ldc : N;
+    // `ldc` is the destination row stride. When `M == 1`, a degenerate stride
+    // (e.g. `acb` gives `ldc == 1`) can violate the `ldc >= N` requirement.
+    // Clamp `ldc` to `N`. This is safe for `M == 1` and has no effect for `M > 1`.
+    const dim_t acc_ldc = dst_is_acc ? nstl::max(ldc, N) : N;
     const int scale_idx_mult
             = this->pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS)
             == (1 << (ndims - 1));


### PR DESCRIPTION
Fixes MFDNN-15248.

The GEMM-based matmul did not handle M=1 cases properly when inferring `acc_ldc`, resulting in a runtime issue because `ldc` turned out to be smaller than N, which violates the GEMM requirement.

This PR fixes the issue.