### PR TITLE
Deprecate Intel SSE4.1 and Intel AVX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ The library is optimized for the following GPUs:
   * Intel Graphics for future Intel Core Ultra processors (code name Nova Lake)
 
 > **NOTE**
-> Optimizations for Intel Iris Xe MAX Graphics and Intel Graphics included with 11th-14th Generation Intel Core Processors are deprecated and will be removed in the future releases.
 > Optimizations for processors with Intel SSE4.1 support and Intel AVX support are deprecated and will be removed in the future releases.
 
 [CPU dispatcher control]: https://uxlfoundation.github.io/oneDNN/dev_guide_cpu_dispatcher_control.html

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ oneDNN supports platforms based on the following architectures:
 
 The library is optimized for the following CPUs:
 * Intel 64/AMD64 architecture
-  * Intel Atom(R) processor (at least Intel SSE4.1 support is required)
-  * Intel Core(TM) processor (at least Intel SSE4.1 support is required)
-  * Intel Xeon(R) processor E3, E5, and E7 family (formerly Sandy Bridge,
-    Ivy Bridge, Haswell, and Broadwell)
+  * **[deprecated]** Intel Atom(R) processor (at least Intel SSE4.1 support is required)
+  * **[deprecated]** Intel Core(TM) processor (at least Intel SSE4.1 support is required)
+  * **[deprecated]** Intel Xeon(R) processor E3, E5, and E7 family v1 and v2 lineups
+    (formerly Sandy Bridge, Ivy Bridge and Westmere)
+  * Intel Xeon(R) processor E3, E5, and E7 family v3+ lineups (formerly Haswell and Broadwell)
   * Intel Xeon Scalable processor (formerly Skylake, Cascade Lake, Cooper
     Lake, Ice Lake, Sapphire Rapids, and Emerald Rapids)
   * Intel Xeon CPU Max Series (formerly Sapphire Rapids HBM)
@@ -126,6 +127,7 @@ The library is optimized for the following GPUs:
 
 > **NOTE**
 > Optimizations for Intel Iris Xe MAX Graphics and Intel Graphics included with 11th-14th Generation Intel Core Processors are deprecated and will be removed in the future releases.
+> Optimizations for processors with Intel SSE4.1 support and Intel AVX support are deprecated and will be removed in the future releases.
 
 [CPU dispatcher control]: https://uxlfoundation.github.io/oneDNN/dev_guide_cpu_dispatcher_control.html
 [Linking Guide]: https://uxlfoundation.github.io/oneDNN/dev_guide_link.html


### PR DESCRIPTION
Added deprecation notice about Intel SSE4.1 and Intel AVX that are planned to be removed in future releases
to be included to rls-v3.13 and corresponding release notes

