### PR TITLE
cpu: x64: fix inp_buffer_size underestimate for stride > kernel

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -156,9 +156,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     // utils
     static int get_inp_size(
             int max_src_size, int dst_size, int k, int stride, int dilate) {
-        auto adj_str = nstl::min(k, stride);
         const auto res = nstl::min(max_src_size,
-                calculate_end_padding(0, dst_size, 0, adj_str,
+                calculate_end_padding(0, dst_size, 0, stride,
                         calculate_extended_filter_size(k, dilate)));
         return res;
     }

--- a/tests/benchdnn/inputs/conv/shapes_regression_1x1
+++ b/tests/benchdnn/inputs/conv/shapes_regression_1x1
@@ -28,3 +28,7 @@ mb1_ic16oc16_ih14oh1kh1sh14dh0ph0_n"1x1_shape_with_huge_stride"
 
 # Shape with nb_os tail
 mb1_ic96oc96_ih6oh6kh1sh1dh0ph0_iw6ow6kw1sw1dw0pw0_n"1x1_with_nb_os_tail"
+
+# sh > 1 with sw=1: H-only stride, exec_trans path (not RTUS)
+mb1_ic32oc48_ih67oh23kh1sh3dh0ph0_iw4ow5kw1sw1dw0pw1_n"sh3_sw1_multi_oh_block"
+mb16_ic32oc139_ih111oh37kh1sh3dh0ph0_iw4ow5kw1sw1dw0pw1_n"sh3_sw1_tall_input"


### PR DESCRIPTION
# fix inp_buffer_size underestimate for stride > kernel in brgemm conv

Fix for [MFDNN-15263](https://jira.devtools.intel.com/browse/MFDNN-15263)

## TLDR summary
**Problem:** `brgemm_convolution_fwd_t` AMX kernel was producing incorrect
results when `stride_h > 1` or `stride_d > 1` and `!is_os_blocking`.

**Root cause:** `brg_blocking_t::get_inp_size()` clamped the effective stride
to `min(k, stride)`, underestimating `jcp.inp_buffer_size` when `stride > k`.
The AMX scratch buffer was then placed by the scratchpad allocator within the
actual copy-input buffer footprint, and the brgemm kernel overwrote source
data with accumulator values, producing silently wrong results.

**Fix:** Remove the `min(k, stride)` clamp from `get_inp_size()` so that
`stride` is used directly. The fix is a one-line change in
`src/cpu/x64/jit_brgemm_conv_utils.cpp`.

## Problem

The failure is reproducible at `OMP_NUM_THREADS=1` with an appropriate shape
using `brg_conv_fwd:avx10_1_512_amx` (`exec_trans` path).
The original report used high thread counts because those shapes happened to
produce `oh_block > 1` under the threading pressure, but threading is not the
root cause.

### Minimal reproducer

```
OMP_NUM_THREADS=1 ./tests/benchdnn/benchdnn --conv --dt=bf16:bf16:s8 \
  "mb1ic32id1ih67iw4oc48od1oh23ow5kd1kh1kw1sd1sh3sw1pd0ph0pw1dd0dh0dw1"
```

### Original reported reproducer

```
OMP_NUM_THREADS=192 ./tests/benchdnn/benchdnn --conv --dt=bf16:bf16:s8 \
  "mb16ic32id1ih111iw4oc139od1oh37ow5kd1kh1kw1sd1sh3sw1pd0ph0pw1dd0dh0dw1"
```

---

## Root Cause

`brg_blocking_t::get_inp_size()` in `jit_brgemm_conv_utils.cpp` computes the
number of source rows required for a block of `dst_size` output rows:

```cpp
// before fix
static int get_inp_size(
        int max_src_size, int dst_size, int k, int stride, int dilate) {
    auto adj_str = nstl::min(k, stride);          // BUG: clips stride to k
    const auto res = nstl::min(max_src_size,
            calculate_end_padding(0, dst_size, 0, adj_str,
                    calculate_extended_filter_size(k, dilate)));
    return res;
}
```

When `stride > k` the effective step is clipped to `k` instead of `stride`.
For `kh=1, sh=3, oh_block=23` this gives:

```
hs = (oh_block - 1) * min(kh, sh) + kh
   = (23 - 1) * 1 + 1
   = 23      <-- wrong, should be 67
```

The correct value is `(oh_block - 1) * stride_h + kh = (23-1)*3 + 1 = 67`.

`jcp.inp_buffer_size` is computed from `hs`, so it ends up undersized: 4096
elements (rounded up to the next 4096-byte page boundary) instead of the
correct 12288 elements.

The scratchpad allocator places allocations contiguously, so the AMX tile
workspace (`key_conv_amx_tile_buffer`) is placed at byte offset 20480 from
the start of `inp_buffer`.  The actual copy-input buffer (pbuf) extends to
byte offset 21439; 960 bytes past the end of the undersized allocation.

During the brgemm call the AMX kernel writes accumulator data into the tile
workspace.  Because the workspace overlaps the top rows of the pbuf, source
data for rows `ih=64..66` is overwritten with accumulator values.  Output
rows that depend on those source rows (`oh=20..22`) read garbage, producing
wrong results.

The failure is silent: because the scratchpad is one flat allocation, ASAN
does not detect the intra-buffer overwrite as a heap overflow.

---

## Fix

Remove the `min(k, stride)` clamp and use `stride` directly:

```cpp
// after fix
static int get_inp_size(
        int max_src_size, int dst_size, int k, int stride, int dilate) {
    const auto res = nstl::min(max_src_size,
            calculate_end_padding(0, dst_size, 0, stride,
                    calculate_extended_filter_size(k, dilate)));
    return res;
}
```

For the common case where `stride <= k`, `min(k, stride) = stride`, so the
result is unchanged.  The fix only affects shapes where `stride > k`, which
is exactly the class of shapes that were broken.

With the fix, `hs = 67`, `inp_buffer_size = 12288` elements, and the scratchpad
places the AMX tile workspace at byte offset 28672 from `inp_buffer` -- well
beyond the 21440-byte pbuf footprint.

---

## Affected Shapes

Any shape routed to `brg_conv_fwd:avx10_1_512_amx` via the `exec_trans` path
where:

- `stride_h > kh`, OR
- `stride_d > kd`

and `!is_os_blocking` and `oh_block > 1` (or `od_block > 1` for the depth case).

In practice this means convolutions with unit (or small) kernels and non-unit
strides: `kh=1 sh=2`, `kh=1 sh=3`, `kd=1 sd=2`, etc.

---

## Testing

Two regression shapes covering the `sh > 1, sw=1` (H-only stride, exec_trans
path) case have been added to
`tests/benchdnn/inputs/conv/shapes_regression_1x1` and are exercised by the
existing `test_conv_bfloat16` harness.
