### PR TITLE
benchdnn: move ctx_init and ctx_exe members to base_prb_t

### DIFF
--- a/tests/benchdnn/binary/binary.hpp
+++ b/tests/benchdnn/binary/binary.hpp
@@ -75,15 +75,13 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , base_prb_t(FLAG_FWD, inplace, attr, impl_filter)
+        , base_prb_t(FLAG_FWD, inplace, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
         , strides(strides)
-        , alg(alg)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , alg(alg) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
     std::vector<dnnl_data_type_t> sdt;
@@ -92,7 +90,6 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
     std::string dtag;
     vdims_t strides;
     alg_t alg;
-    thr_ctx_t ctx_init, ctx_exe;
 
     bool is_ternary_op() const { return alg == alg_t::SELECT; }
 

--- a/tests/benchdnn/bnorm/bnorm.hpp
+++ b/tests/benchdnn/bnorm/bnorm.hpp
@@ -108,16 +108,14 @@ struct prb_t : public desc_t, public base_prb_t {
             bool inplace, const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, inplace, attr, impl_filter)
+        , base_prb_t(dir, inplace, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , tag(tag)
         , strides(strides)
         , flags(flags)
         , check_alg(check_alg)
         , debug_check_ws(debug_check_ws)
-        , user_mb(mb)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , user_mb(mb) {
         if (mb) this->mb = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
@@ -128,7 +126,6 @@ struct prb_t : public desc_t, public base_prb_t {
     check_alg_t check_alg;
     bool debug_check_ws;
     int64_t user_mb;
-    thr_ctx_t ctx_init, ctx_exe;
     bool need_ws() const {
         return (flags & (FUSE_NORM_RELU | FUSE_NORM_ADD_RELU))
                 && !(dir & FLAG_INF);

--- a/tests/benchdnn/brgemm/brgemm.hpp
+++ b/tests/benchdnn/brgemm/brgemm.hpp
@@ -82,7 +82,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
             const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , base_prb_t(FWD_I, false, attr, impl_filter)
+        , base_prb_t(FWD_I, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , stag(stag)
         , wtag(wtag)
@@ -94,9 +94,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         , beta(beta)
         , batch_size(batch_size)
         , brgemm_attr(brgemm_attr)
-        , batch_kind(batch_kind)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , batch_kind(batch_kind) {
 
         // Broadcast data types if needed
         if (dt.size() == 1) {
@@ -133,7 +131,6 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
     int64_t batch_size;
     std::string brgemm_attr;
     std::string batch_kind;
-    thr_ctx_t ctx_init, ctx_exe;
     double ops;
 
     const dims_t &src_dims() const { return vdims[0]; }

--- a/tests/benchdnn/concat/concat.hpp
+++ b/tests/benchdnn/concat/concat.hpp
@@ -70,14 +70,12 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
+        , base_prb_t(FLAG_FWD, false, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
-        , axis(axis)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , axis(axis) {
         // If dst is omitted by `dtag = tag::undef`, omit `ddt` as well.
         if (dtag == tag::undef) this->ddt = dnnl_data_type_undef;
 
@@ -90,7 +88,6 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
     std::vector<std::string> stag;
     std::string dtag;
     int axis;
-    thr_ctx_t ctx_init, ctx_exe;
     int64_t axis_size() const {
         int64_t as = 0;
         for (int i = 0; i < n_inputs(); ++i)

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -135,7 +135,7 @@ struct prb_t : public desc_t, public base_prb_t {
             int64_t mb, const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , bia_dt_(bia_dt)
         , stag(stag)
@@ -144,9 +144,7 @@ struct prb_t : public desc_t, public base_prb_t {
         , strides(strides)
         , alg(alg)
         , user_mb(mb)
-        , ops(0)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , ops(0) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -165,7 +163,6 @@ struct prb_t : public desc_t, public base_prb_t {
     mutable alg_t alg; // `mutable` because of `AUTO`.
     int64_t user_mb;
     double ops;
-    thr_ctx_t ctx_init, ctx_exe;
     void count_ops();
     int64_t count_n_acc() const {
         return (dir & FLAG_FWD)    ? kd * kh * kw * ic / g

--- a/tests/benchdnn/deconv/deconv.hpp
+++ b/tests/benchdnn/deconv/deconv.hpp
@@ -135,7 +135,7 @@ struct prb_t : public desc_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , bia_dt_(bia_dt)
         , stag(stag)
@@ -143,9 +143,7 @@ struct prb_t : public desc_t, public base_prb_t {
         , dtag(dtag)
         , alg(alg)
         , user_mb(mb)
-        , ops(0)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , ops(0) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -163,7 +161,6 @@ struct prb_t : public desc_t, public base_prb_t {
     alg_t alg;
     int64_t user_mb;
     double ops;
-    thr_ctx_t ctx_init, ctx_exe;
     void count_ops();
     int64_t count_n_acc() const {
         return (dir & FLAG_FWD)    ? kd * kh * kw * ic / g

--- a/tests/benchdnn/eltwise/eltwise.hpp
+++ b/tests/benchdnn/eltwise/eltwise.hpp
@@ -73,15 +73,13 @@ struct prb_t : public prb_dims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , base_prb_t(dir, inplace, attr, impl_filter)
+        , base_prb_t(dir, inplace, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , tag(tag)
         , alg(alg)
         , alpha(alpha)
         , beta(beta)
-        , user_mb(mb)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , user_mb(mb) {
         if (mb) dims[0] = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
@@ -90,7 +88,6 @@ struct prb_t : public prb_dims_t, public base_prb_t {
     alg_t alg;
     float alpha, beta;
     int64_t user_mb;
-    thr_ctx_t ctx_init, ctx_exe;
     bool use_dst() const {
         return alg == alg_t::RELU_DST || alg == alg_t::TANH_DST
                 || alg == alg_t::ELU_DST || alg == alg_t::SQRT_DST

--- a/tests/benchdnn/gnorm/gnorm.hpp
+++ b/tests/benchdnn/gnorm/gnorm.hpp
@@ -93,14 +93,12 @@ struct prb_t : public desc_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, inplace, attr, impl_filter)
+        , base_prb_t(dir, inplace, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , tag(tag)
         , flags(flags)
         , check_alg(check_alg)
-        , user_mb(mb)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , user_mb(mb) {
 
         if (mb) this->mb = mb;
 
@@ -116,7 +114,6 @@ struct prb_t : public desc_t, public base_prb_t {
     flags_t flags;
     check_alg_t check_alg;
     int64_t user_mb;
-    thr_ctx_t ctx_init, ctx_exe;
     bool use_stats() const { return flags & GLOB_STATS; }
     bool use_sc() const { return flags & USE_SCALE; }
     bool use_sh() const { return flags & USE_SHIFT; }

--- a/tests/benchdnn/ip/ip.hpp
+++ b/tests/benchdnn/ip/ip.hpp
@@ -85,16 +85,14 @@ struct prb_t : public desc_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , bia_dt_(bia_dt)
         , stag(stag)
         , wtag(wtag)
         , dtag(dtag)
         , user_mb(mb)
-        , ops(0)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , ops(0) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -111,7 +109,6 @@ struct prb_t : public desc_t, public base_prb_t {
     std::string stag, wtag, dtag;
     int64_t user_mb;
     double ops;
-    thr_ctx_t ctx_init, ctx_exe;
     void count_ops() {
         if (ops > 0) return;
         ops = 2. * mb * ic * oc * id * ih * iw;

--- a/tests/benchdnn/lnorm/lnorm.hpp
+++ b/tests/benchdnn/lnorm/lnorm.hpp
@@ -94,15 +94,13 @@ struct prb_t : public prb_dims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , base_prb_t(dir, inplace, attr, impl_filter)
+        , base_prb_t(dir, inplace, attr, ctx_init, ctx_exe, impl_filter)
         , check_alg(check_alg)
         , tag(tag)
         , stat_tag(stat_tag)
         , ss_dt(ss_dt)
         , dt(dt)
         , flags(flags)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
         , n(1)
         , c(dims[ndims - 1])
         , eps(eps) {
@@ -124,7 +122,6 @@ struct prb_t : public prb_dims_t, public base_prb_t {
     dnnl_data_type_t ss_dt;
     std::vector<dnnl_data_type_t> dt;
     flags_t flags;
-    thr_ctx_t ctx_init, ctx_exe;
     int64_t n, c;
     float eps;
 

--- a/tests/benchdnn/lrn/lrn.hpp
+++ b/tests/benchdnn/lrn/lrn.hpp
@@ -86,13 +86,11 @@ struct prb_t : public desc_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , tag(tag)
         , alg(alg)
-        , user_mb(mb)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , user_mb(mb) {
         if (mb) this->mb = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
@@ -100,7 +98,6 @@ struct prb_t : public desc_t, public base_prb_t {
     std::string tag;
     alg_t alg;
     int64_t user_mb;
-    thr_ctx_t ctx_init, ctx_exe;
 
     static const prb_t *from(const base_prb_t *base_prb) {
         return downcast<const prb_t *>(base_prb);

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -85,7 +85,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
+        , base_prb_t(FLAG_FWD, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , stag(stag)
         , wtag(wtag)
@@ -94,9 +94,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         , bia_dt(bia_dt)
         , bia_mask(bia_mask)
         , rt_dims_masks(rt_dims_masks)
-        , sparse_options(sparse_options)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , sparse_options(sparse_options) {
 
         // Broadcast data types if needed
         if (dt.size() == 1) {
@@ -131,7 +129,6 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
     int bia_mask;
     std::vector<dims_mask_t> rt_dims_masks;
     sparse_options_t sparse_options;
-    thr_ctx_t ctx_init, ctx_exe;
     double ops;
 
     const dims_t &src_dims() const { return vdims[0]; }

--- a/tests/benchdnn/pool/pool.hpp
+++ b/tests/benchdnn/pool/pool.hpp
@@ -124,13 +124,11 @@ struct prb_t : public desc_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , tag(tag)
         , alg(alg)
-        , user_mb(mb)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , user_mb(mb) {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
@@ -145,7 +143,6 @@ struct prb_t : public desc_t, public base_prb_t {
     std::string tag;
     alg_t alg;
     int64_t user_mb;
-    thr_ctx_t ctx_init, ctx_exe;
     int64_t kernel_size() const { return kd * kh * kw; }
     bool has_ker_in_pad() const {
         bool ker_in_pad_d = pd >= kd || pd_r >= kd;

--- a/tests/benchdnn/prelu/prelu.hpp
+++ b/tests/benchdnn/prelu/prelu.hpp
@@ -66,11 +66,9 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
-        , stag(stag)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , stag(stag) {
         // Broadcast data types if needed
         if (sdt.size() == 1) {
             const auto val = sdt[0]; // Need a copy here.
@@ -81,7 +79,6 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
     }
     std::vector<dnnl_data_type_t> sdt;
     std::vector<std::string> stag;
-    thr_ctx_t ctx_init, ctx_exe;
 
     static const prb_t *from(const base_prb_t *base_prb) {
         return downcast<const prb_t *>(base_prb);

--- a/tests/benchdnn/reduction/reduction.hpp
+++ b/tests/benchdnn/reduction/reduction.hpp
@@ -95,23 +95,20 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
             const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
+        , base_prb_t(FLAG_FWD, false, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
         , alg(alg)
         , p(p)
-        , eps(eps)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , eps(eps) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
     dnnl_data_type_t sdt, ddt;
     std::string stag, dtag;
     alg_t alg;
     float p, eps;
-    thr_ctx_t ctx_init, ctx_exe;
 
     static const prb_t *from(const base_prb_t *base_prb) {
         return downcast<const prb_t *>(base_prb);

--- a/tests/benchdnn/reorder/reorder.hpp
+++ b/tests/benchdnn/reorder/reorder.hpp
@@ -99,7 +99,7 @@ struct prb_t : public prb_dims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
+        , base_prb_t(FLAG_FWD, false, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
@@ -107,9 +107,7 @@ struct prb_t : public prb_dims_t, public base_prb_t {
         , strides(strides)
         , oflag(oflag)
         , cross_engine(cross_engine)
-        , runtime_dim_mask(runtime_dim_mask)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , runtime_dim_mask(runtime_dim_mask) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
     dnnl_data_type_t sdt, ddt;
@@ -118,7 +116,6 @@ struct prb_t : public prb_dims_t, public base_prb_t {
     std::vector<flag_t> oflag;
     cross_engine_t cross_engine;
     unsigned runtime_dim_mask;
-    thr_ctx_t ctx_init, ctx_exe;
     bool is_reorder_with_compensation(flag_bit_t flag) const;
     dims_t get_compensation_dims(flag_bit_t flag) const;
     int get_compensation_mask(flag_bit_t flag) const;

--- a/tests/benchdnn/resampling/resampling.hpp
+++ b/tests/benchdnn/resampling/resampling.hpp
@@ -97,14 +97,12 @@ struct prb_t : public desc_t, public base_prb_t {
             const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , tag(tag)
         , alg(alg)
-        , user_mb(mb)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , user_mb(mb) {
         if (mb) this->mb = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
@@ -112,7 +110,6 @@ struct prb_t : public desc_t, public base_prb_t {
     std::string tag;
     alg_t alg;
     int64_t user_mb;
-    thr_ctx_t ctx_init, ctx_exe;
 
     static const prb_t *from(const base_prb_t *base_prb) {
         return downcast<const prb_t *>(base_prb);

--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -302,7 +302,7 @@ struct prb_t : public desc_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : desc_t(desc)
-        , base_prb_t(prop, false, attr, impl_filter)
+        , base_prb_t(prop, false, attr, ctx_init, ctx_exe, impl_filter)
         , cfg(cfg)
         , tag(tag)
         , prop(prop2prop_kind(prop))
@@ -321,8 +321,6 @@ struct prb_t : public desc_t, public base_prb_t {
         , user_mb(mb)
         , ops(0.0)
         , linear_cscale(0.0f)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe)
         , wei_nscales(0)
         , wei_scales_mask(0x0)
         , wei_proj_nscales(0)
@@ -522,7 +520,6 @@ struct prb_t : public desc_t, public base_prb_t {
     int64_t user_mb;
     double ops;
     float linear_cscale;
-    thr_ctx_t ctx_init, ctx_exe;
 
     float data_scale, data_shift;
 

--- a/tests/benchdnn/sdpa/sdpa.hpp
+++ b/tests/benchdnn/sdpa/sdpa.hpp
@@ -113,7 +113,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , qtag(qtag)
         , ktag(ktag)
@@ -121,9 +121,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         , dtag(dtag)
         , mdt(mdt)
         , mask_type(mask_type)
-        , scale_type(scale_type)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , scale_type(scale_type) {
 
         // Broadcast data types if needed: Q,K,V,DST
         if (this->dt.size() == 1) {
@@ -187,8 +185,6 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
     dnnl_data_type_t mdt;
     mask_type_t mask_type;
     scale_type_t scale_type;
-
-    thr_ctx_t ctx_init, ctx_exe;
 
     double ops;
     dims_t dst_dims;

--- a/tests/benchdnn/shuffle/shuffle.hpp
+++ b/tests/benchdnn/shuffle/shuffle.hpp
@@ -73,20 +73,17 @@ struct prb_t : public prb_dims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , base_prb_t(dir, false, attr, impl_filter)
+        , base_prb_t(dir, false, attr, ctx_init, ctx_exe, impl_filter)
         , dt(dt)
         , tag(tag)
         , axis(axis)
-        , group(group)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , group(group) {
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
     dnnl_data_type_t dt;
     std::string tag;
     int axis;
     int64_t group;
-    thr_ctx_t ctx_init, ctx_exe;
 
     static const prb_t *from(const base_prb_t *base_prb) {
         return downcast<const prb_t *>(base_prb);

--- a/tests/benchdnn/softmax/softmax.hpp
+++ b/tests/benchdnn/softmax/softmax.hpp
@@ -89,7 +89,7 @@ struct prb_t : public prb_dims_t, public base_prb_t {
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , base_prb_t(dir, inplace, attr, impl_filter)
+        , base_prb_t(dir, inplace, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
@@ -97,9 +97,7 @@ struct prb_t : public prb_dims_t, public base_prb_t {
         , alg(alg)
         , axis(axis)
         , has_stats(has_stats)
-        , user_mb(mb)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , user_mb(mb) {
         if (mb) dims[0] = mb;
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
@@ -109,7 +107,6 @@ struct prb_t : public prb_dims_t, public base_prb_t {
     int axis;
     bool has_stats;
     int64_t user_mb;
-    thr_ctx_t ctx_init, ctx_exe;
 
     static const prb_t *from(const base_prb_t *base_prb) {
         return downcast<const prb_t *>(base_prb);

--- a/tests/benchdnn/sum/sum.hpp
+++ b/tests/benchdnn/sum/sum.hpp
@@ -71,14 +71,12 @@ struct prb_t : public prb_dims_t, public base_prb_t {
             bool inplace, const attr_t &attr, const thr_ctx_t &ctx_init,
             const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
-        , base_prb_t(FLAG_FWD, inplace, attr, impl_filter)
+        , base_prb_t(FLAG_FWD, inplace, attr, ctx_init, ctx_exe, impl_filter)
         , sdt(sdt)
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
-        , input_scales(input_scales)
-        , ctx_init(ctx_init)
-        , ctx_exe(ctx_exe) {
+        , input_scales(input_scales) {
 
         broadcast_vector(this->stag, n_inputs());
 
@@ -96,7 +94,6 @@ struct prb_t : public prb_dims_t, public base_prb_t {
     std::vector<std::string> stag;
     std::string dtag;
     std::vector<float> input_scales;
-    thr_ctx_t ctx_init, ctx_exe;
 
     int n_inputs() const { return (int)sdt.size(); }
 

--- a/tests/benchdnn/utils/prb.hpp
+++ b/tests/benchdnn/utils/prb.hpp
@@ -22,6 +22,8 @@
 #include "utils/res.hpp"
 #include "utils/wrapper.hpp"
 
+#include "tests/thread_context.hpp"
+
 #include <cassert>
 #include <string>
 #include <vector>
@@ -32,14 +34,21 @@
 struct base_prb_t {
     base_prb_t() = default;
     base_prb_t(dir_t dir, bool inplace, const attr_t &attr,
+            const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
-        : dir(dir), inplace(inplace), attr(attr), impl_filter(impl_filter) {}
+        : dir(dir)
+        , inplace(inplace)
+        , attr(attr)
+        , ctx_init(ctx_init)
+        , ctx_exe(ctx_exe)
+        , impl_filter(impl_filter) {}
 
     virtual ~base_prb_t() = default;
 
     dir_t dir = FLAG_FWD;
     bool inplace = false;
     attr_t attr;
+    thr_ctx_t ctx_init, ctx_exe;
     impl_filter_t impl_filter;
 
     // Use to construct memory descriptor when dimensions are runtime since such


### PR DESCRIPTION
This is a pure mechanical PR that moves two members from each prb to base_prb_t (same as it was done in https://github.com/uxlfoundation/oneDNN/pull/5387)

This one was waiting for a lightweight header declaring `thr_ctx_t`.