### PR TITLE
xe: sdpa: (re)Enable efficient64bit  for microkernel

### DIFF
--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -172,6 +172,7 @@ status_t micro_horz_t::pd_t::init_microkernels(
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = intel_engine->mayiuse(
             compute::device_ext_t::intel_subgroup_matrix_multiply_accumulate);
+    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     if (hw_info.gmdid == 0) return status::unimplemented;
 

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -215,6 +215,9 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
     matchParams.nExtraReqs = int(reqs.size());
     matchParams.extraReqs = reqs.data();
 
+    if (hw == ngen::HW::Xe3p && !hwInfo.isEfficient64Bit)
+        matchParams.selector.hw = kcatalog::HWTagXeHPC;
+
     auto tags = const_cast<char *>(matchParams.tags);
     while (*tags)
         tags++;
@@ -311,6 +314,10 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
                     problem.A.setAlignment(std::max<int>(problem.A.alignment, 16));
                 if (block2DB && strategy.legalBAlignment(problem, 16))
                     problem.B.setAlignment(std::max<int>(problem.B.alignment, 16));
+            }
+            if (hw == ngen::HW::Xe3p && !hwInfo.isEfficient64Bit) {
+                // Use XeHPC banking if reusing XeHPC strategies (legacy mode)
+                strategy.raHW = ngen::HW::XeHPC;
             }
         } else if (!reqs.empty() &&
                    !getStrategyByHeuristics(hw, strategy, localA, localB, problem, hwInfo, sizes, reqs))
@@ -554,6 +561,10 @@ static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool l
 
     if (hw == HW::Xe2 || hw == HW::Xe3)
         s.raHW = HW::XeHPC;
+    // Use XeHPC banking if reusing XeHPC strategies (legacy mode)
+    if (hw == ngen::HW::Xe3p && !hwInfo.isEfficient64Bit) {
+        s.raHW = ngen::HW::XeHPC;
+    }
 
     adjustStrategy(hw, problem, strategy);
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -31,6 +31,7 @@ struct HWInformation {
     uint32_t gmdid;
     int euCount;
     bool systolicAvailable;
+    bool isEfficient64Bit;
 };
 
 struct GEMMOptions {

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -54,6 +54,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     hw_info.euCount = dev_info->eu_count();
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = use_systolic_ukernel;
+    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     if (hw_info.gmdid == 0) return status::unimplemented;
 

--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -835,6 +835,7 @@ void deserialize_config_to_gemmstone(micro::HWInformation &hwInfo,
     hwInfo.gmdid = ukernel_config.hwinfo.gmdid;
     hwInfo.euCount = ukernel_config.hwinfo.euCount;
     hwInfo.systolicAvailable = ukernel_config.hwinfo.systolicAvailable;
+    hwInfo.isEfficient64Bit = ukernel_config.hwinfo.isEfficient64Bit;
 
     // options kq, vs
     auto deserialize_options
@@ -934,6 +935,7 @@ void deserialize_config_to_gemmstone(micro::HWInformation &hwInfo,
     hwInfo.gmdid = ukernel_config.hwinfo.gmdid;
     hwInfo.euCount = ukernel_config.hwinfo.euCount;
     hwInfo.systolicAvailable = ukernel_config.hwinfo.systolicAvailable;
+    hwInfo.isEfficient64Bit = ukernel_config.hwinfo.isEfficient64Bit;
 
     // options kq, vs
     auto deserialize_options

--- a/src/gpu/intel/sdpa/configs.hpp
+++ b/src/gpu/intel/sdpa/configs.hpp
@@ -158,12 +158,14 @@ struct ukernel_serialized_hwinfo_t
     ukernel_serialized_hwinfo_t(micro::HWInformation &hwInfo)
         : gmdid(static_cast<uint32_t>(hwInfo.gmdid))
         , euCount(static_cast<uint32_t>(hwInfo.euCount))
-        , systolicAvailable(hwInfo.systolicAvailable) {}
+        , systolicAvailable(hwInfo.systolicAvailable)
+        , isEfficient64Bit(hwInfo.isEfficient64Bit) {}
 
     uint32_t gmdid;
     uint32_t euCount;
     bool systolicAvailable;
-    uint8_t padding[7] = {0};
+    bool isEfficient64Bit;
+    uint8_t padding[6] = {0};
 };
 DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(ukernel_serialized_hwinfo_t);
 static_assert(sizeof(ukernel_serialized_hwinfo_t) == 16,

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -150,7 +150,7 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     assert(engine->kind() == engine_kind::gpu);
     auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
     auto *dev_info = intel_engine->device_info();
-    arch_ = dev_info->gpu_arch();
+
     auto *d = desc();
 
     VCHECK_SDPA_COND(compute::mayiuse_microkernels(intel_engine),
@@ -167,15 +167,11 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             || with_value_zp();
     bool is_integrated = intel_engine->device_info()->is_integrated();
     bool is_f32 = (desc()->qry_md()->data_type == data_type::f32);
-    use_systolic_ukernel_
-            = intel_engine->mayiuse(compute::device_ext_t::
-                              intel_subgroup_matrix_multiply_accumulate)
-            && !is_f32; // f32 -> non-systolic kernel only
 
-    bool use_fma_config = !use_systolic_ukernel_;
+    bool use_fma_config = !use_systolic_ukernel();
     bool is_f16_accumulate_gemm = (kq_acc_dt() == data_type::f16)
             || (vs_acc_dt() == data_type::f16);
-    VDISPATCH_SDPA(IMPLICATION(is_f16_accumulate_gemm, !use_systolic_ukernel_),
+    VDISPATCH_SDPA(IMPLICATION(is_f16_accumulate_gemm, !use_systolic_ukernel()),
             "f16 accumulate only available with FMA matmul."); //TODO: update once matmul primitive supports systolic f16 accumulate for testing
     config = choose_config(arch_, d->head_size(), d->keys(), thin_q, quantized,
             is_integrated, use_fma_config, is_f32, is_f16_accumulate_gemm);
@@ -234,15 +230,13 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     micro::HWInformation hw_info;
     hw_info.euCount = dev_info->eu_count();
     hw_info.gmdid = dev_info->ip_version();
-    hw_info.systolicAvailable = use_systolic_ukernel_;
+    hw_info.systolicAvailable = use_systolic_ukernel();
     hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     VDISPATCH_SDPA(
             hw_info.gmdid != 0, "gmdid is 0, microkernels not supported.");
 
     ukernel_params.hwinfo = {hw_info};
-
-    sg_size_ = dev_info->min_subgroup_size();
 
     auto convert_dnnl_to_kernel_layout = [](const memory_desc_t *md) {
         return (gemm_desc_t::get_trans(*md) == dnnl_trans) ? MatrixLayout::T
@@ -320,7 +314,7 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     if (use_systolic_ukernel()) {
         problem_kq.B.crosspack = 2;
         problem_kq.B.tileR = into<uint16_t>(d_max());
-        problem_kq.B.tileC = into<uint16_t>(sg_size_);
+        problem_kq.B.tileC = into<uint16_t>(sg_size());
     }
 
     ukernel_params.problem_kq = {problem_kq};

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -235,6 +235,7 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     hw_info.euCount = dev_info->eu_count();
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = use_systolic_ukernel_;
+    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     VDISPATCH_SDPA(
             hw_info.gmdid != 0, "gmdid is 0, microkernels not supported.");
@@ -547,6 +548,7 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     hw_info.euCount = dev_info->eu_count();
     hw_info.gmdid = dev_info->ip_version();
     hw_info.systolicAvailable = use_systolic_ukernel_;
+    hw_info.isEfficient64Bit = dev_info->is_efficient_64bit();
 
     VDISPATCH_SDPA(
             hw_info.gmdid != 0, "gmdid is 0, microkernels not supported.");

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -166,11 +166,23 @@ struct micro_fwd_t : public primitive_t {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 
+            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            auto *dev_info = intel_engine->device_info();
+            arch_ = dev_info->gpu_arch();
+            sg_size_ = dev_info->min_subgroup_size();
+
             VDISPATCH_SDPA(is_fwd(), VERBOSE_BAD_PROPKIND);
             memory_desc_wrapper qry_mdw(desc()->qry_md());
             memory_desc_wrapper key_mdw(desc()->key_md());
             memory_desc_wrapper val_mdw(desc()->val_md());
             memory_desc_wrapper dst_mdw(dst_md());
+
+            bool is_f32 = (qry_mdw.data_type() == data_type::f32);
+            use_systolic_ukernel_
+                    = intel_engine->mayiuse(compute::device_ext_t::
+                                      intel_subgroup_matrix_multiply_accumulate)
+                    && !is_f32; // f32 -> non-systolic kernel only
+
             VDISPATCH_SDPA(
                     utils::everyone_is(4, qry_mdw.ndims(), key_mdw.ndims(),
                             val_mdw.ndims(), dst_mdw.ndims()),


### PR DESCRIPTION
# Description

This PR reenables the checking of efficient64bit addressing for microkernels. This check was reverted because of failing when integrated into OpenVINO's SDPA implementation. This was caused because we were not setting the HWInformation parameter in OpenVINO so the member was not initialized when passed into the selectGEMM function. The selectGEMM function was using that parameter to set the interface to use efficient64bit addressing and causing errors. It turns out that the interface internally selects the correct value for that parameter based on the target hardware so setting it is not necessary. I have removed the call in this PR and verified that it is functioning as expected in the failing cases defined in MFDNN-15241.

Fixes: [MFDNN-15297](https://jira.devtools.intel.com/browse/MFDNN-15297)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

