### PR TITLE
cpu: rv64: change to agnostic vector policy of xbyak_riscv

### DIFF
--- a/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/rv64/brgemm/jit_brgemm_kernel.cpp
@@ -893,7 +893,7 @@ void jit_brgemm_bf16_kernel_t::generate() {
     // e32/m4 for C/bias; toggle to e16/m2 around the FMA loop because
     // vfwmaccbf16.vf is defined at SEW=e16. LMUL=m2 chosen so VLMAX
     // matches the outer e32/m4 setting and vl is preserved.
-    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     li(reg_lda, LDA_bytes);
     li(reg_ldb, LDB_bytes);
@@ -931,7 +931,7 @@ void jit_brgemm_bf16_kernel_t::generate() {
     vmv_v_i(v_c3, 0);
 
     // Switch to e16/m2 for the K loop (vfwmaccbf16.vf requires SEW=e16).
-    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
 
     mv(reg_k, x0);
     Label lbl_k_main_end, lbl_k_tail, lbl_k_tail_end;
@@ -1031,7 +1031,7 @@ void jit_brgemm_bf16_kernel_t::generate() {
     L(lbl_k_tail_end);
 
     // Switch back to e32/m4 for bias add + C store (f32 ops on m4 accums).
-    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     // Bias is f32 (same as f32 kernel) → vle32_v + vfadd_vv.
     {
@@ -1110,7 +1110,7 @@ void jit_brgemm_bf16_kernel_t::generate() {
     vmv_v_i(v_c0, 0);
 
     // Switch to e16/m2 for single-column FMA loop.
-    vsetvli(x0, reg_M, SEW::e16, LMUL::m2);
+    vsetvli(x0, reg_M, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
 
     mv(reg_k, x0);
     Label lbl_kt2, lbl_kt2_end;
@@ -1129,7 +1129,7 @@ void jit_brgemm_bf16_kernel_t::generate() {
     L(lbl_kt2_end);
 
     // Back to e32/m4 for bias + C store.
-    vsetvli(x0, reg_M, SEW::e32, LMUL::m4);
+    vsetvli(x0, reg_M, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
     {
         Label lbl_no_bias2;

--- a/src/cpu/rv64/cpu_isa_traits.hpp
+++ b/src/cpu/rv64/cpu_isa_traits.hpp
@@ -29,6 +29,18 @@
 #define XBYAK_RISCV_V 1
 #endif
 
+/*
+ * Opt out of Xbyak_riscv's backwards-compat default arguments for
+ * vsetvli/vsetivli (LMUL=m1, VTA=tu, VMA=mu). The upstream #pragma message
+ * literally says "XBYAK_RISCV_VSETV_DEFAULT_OLD is 0 in the future" — we
+ * early-adopt that future, which removes the implicit defaults and forces
+ * every call site to pass LMUL/VTA/VMA explicitly. Most call sites pass
+ * VTA::ta, VMA::ma (tail-agnostic, mask-agnostic) so the microarchitecture
+ * is free to zero inactive lanes instead of preserving them; the small set
+ * of accumulator-tail sites that genuinely need preservation pass VTA::tu.
+ */
+#define XBYAK_RISCV_VSETV_DEFAULT_OLD 0
+
 #include "xbyak_riscv/xbyak_riscv_util.hpp"
 
 namespace dnnl {

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <cstddef>
 
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #include "xbyak_riscv/xbyak_riscv_util.hpp"
 
 namespace dnnl {

--- a/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
@@ -102,7 +102,7 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
     Label loop, done;
     L(loop);
     beqz(reg_len, done);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     vle32_v(v_src, reg_src);
     if (per_elem_params_) {
         vle32_v(v_mean, reg_mean);

--- a/src/cpu/rv64/jit_rvv_gemm_convolution_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_gemm_convolution_kernel.cpp
@@ -89,7 +89,7 @@ void jit_rvv_gemm_convolution_copy_kernel_t::generate() {
     L(loop);
     beqz(reg_len, done);
 
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
     vle32_v(v_data, reg_src);
     vse32_v(v_data, reg_dst);
 
@@ -197,7 +197,7 @@ void jit_rvv_gemm_convolution_post_kernel_t::generate() {
     L(loop);
     beqz(reg_len, done);
 
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
     vle32_v(v_dst, reg_dst);
 
     if (vector_bias_) {

--- a/src/cpu/rv64/jit_rvv_inner_product_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_inner_product_kernel.cpp
@@ -105,7 +105,7 @@ void jit_rvv_inner_product_kernel_t::generate_x8_s8(bool src_is_u8) {
     L(loop);
     beqz(reg_len, done);
 
-    vsetvli(reg_vl, reg_len, SEW::e8, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
     vle8_v(v_src, reg_src);
     vle8_v(v_wei, reg_wei);
     if (src_is_u8)
@@ -113,7 +113,7 @@ void jit_rvv_inner_product_kernel_t::generate_x8_s8(bool src_is_u8) {
     else
         vwmul_vv(v_prod, v_src, v_wei);
 
-    vsetvli(reg_vl, reg_vl, SEW::e16, LMUL::m2);
+    vsetvli(reg_vl, reg_vl, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
     vmv_v_x(v_zero, x0);
     vwredsum_vs(v_sum, v_prod, v_zero);
     vmv_x_s(reg_part, v_sum);

--- a/src/cpu/rv64/jit_rvv_layernorm_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_layernorm_kernel.cpp
@@ -87,7 +87,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
     const VReg v_shift3(21);
     fmv_w_x(f_zero, x0);
 
-    vsetvli(reg_vlmax, x0, SEW::e32, LMUL::m1);
+    vsetvli(reg_vlmax, x0, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     slli(reg_bytes, reg_vlmax, 2);
     slli(reg_bytes4, reg_bytes, 2);
     slli(reg_block, reg_vlmax, 2);
@@ -104,7 +104,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
     vfmv_v_f(v_tmp2, f_zero);
     vfmv_v_f(v_tmp3, f_zero);
 
-    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1);
+    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     L(mean_main_loop);
     blt(reg_len, reg_block, mean_vec_tail);
     vle32_v(v_in0, reg_src);
@@ -124,7 +124,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
 
     L(mean_vec_tail);
     beqz(reg_len, mean_reduce_loop);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::tu, VMA::ma);
     slli(reg_tmp, reg_vl, 2);
     vle32_v(v_in0, reg_src);
     vfadd_vv(v_tmp0, v_tmp0, v_in0);
@@ -133,7 +133,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
     j_(mean_vec_tail);
 
     L(mean_reduce_loop);
-    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1);
+    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     vfadd_vv(v_tmp0, v_tmp0, v_tmp1);
     vfadd_vv(v_tmp2, v_tmp2, v_tmp3);
     vfadd_vv(v_tmp0, v_tmp0, v_tmp2);
@@ -154,7 +154,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
     vfmv_v_f(v_tmp1, f_zero);
     vfmv_v_f(v_tmp2, f_zero);
     vfmv_v_f(v_tmp3, f_zero);
-    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1);
+    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     vfmv_v_f(v_mean, f_mean);
 
     L(var_main_loop);
@@ -180,7 +180,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
 
     L(var_vec_tail);
     beqz(reg_len, var_reduce_loop);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::tu, VMA::ma);
     slli(reg_tmp, reg_vl, 2);
     vle32_v(v_in0, reg_src);
     vfsub_vv(v_in0, v_in0, v_mean);
@@ -190,7 +190,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
     j_(var_vec_tail);
 
     L(var_reduce_loop);
-    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1);
+    vsetvli(x0, reg_vlmax, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     vfadd_vv(v_tmp0, v_tmp0, v_tmp1);
     vfadd_vv(v_tmp2, v_tmp2, v_tmp3);
     vfadd_vv(v_tmp0, v_tmp0, v_tmp2);
@@ -227,7 +227,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
     ld(reg_shift, reg_param, GET_FUSED_OFF(shift));
     ld(reg_len, reg_param, GET_FUSED_OFF(len));
 
-    vsetvli(reg_vlmax, x0, SEW::e32, LMUL::m1);
+    vsetvli(reg_vlmax, x0, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     slli(reg_bytes, reg_vlmax, 2);
     slli(reg_bytes4, reg_bytes, 2);
     slli(reg_block, reg_vlmax, 2);
@@ -332,7 +332,7 @@ void jit_rvv_layernorm_fused_kernel_t::generate() {
 
     L(data_tail_loop);
     beqz(reg_len, done);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     slli(reg_tmp, reg_vl, 2);
     vle32_v(v_in0, reg_src);
     vfsub_vv(v_in0, v_in0, v_mean);
@@ -413,7 +413,7 @@ void jit_rvv_layernorm_data_kernel_t::generate() {
     flw(f_mean, reg_param, GET_DATA_OFF(mean));
     flw(f_inv, reg_param, GET_DATA_OFF(inv_std));
 
-    vsetvli(reg_vlmax, x0, SEW::e32, LMUL::m1);
+    vsetvli(reg_vlmax, x0, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     slli(reg_bytes, reg_vlmax, 2);
     slli(reg_bytes4, reg_bytes, 2);
     slli(reg_block, reg_vlmax, 2);
@@ -521,7 +521,7 @@ void jit_rvv_layernorm_data_kernel_t::generate() {
 
     L(tail_loop);
     beqz(reg_len, done);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     slli(reg_tmp, reg_vl, 2);
     vfmv_v_f(v_mean, f_mean);
     vfmv_v_f(v_inv, f_inv);
@@ -613,26 +613,26 @@ void jit_rvv_layernorm_f16_fused_kernel_t::generate() {
     // ---- pass 1: accumulate Sx in f32 ----
     ld(reg_src, reg_param, GET_F16_OFF(src));
     ld(reg_t1, reg_param, GET_F16_OFF(len));
-    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
     vmv_v_x(v_sum, x0);
     vmv_v_x(v_work, x0);
 
     L(sum_loop);
     beqz(reg_t1, sum_done);
-    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4);
+    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4, VTA::ta, VMA::ma);
     sub(reg_t1, reg_t1, reg_vl);
     vle16_v(v_ld, reg_src);
     slli(reg_tmp, reg_vl, 1);
     add(reg_src, reg_src, reg_tmp);
     vfwcvt_f_f_v(v_work, v_ld); // f16 -> f32, first reg_vl elems
-    vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8);
+    vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8, VTA::tu, VMA::ma);
     vfadd_vv(v_sum, v_sum, v_work);
     vmv_v_x(v_work, x0); // keep tail zero for next widen
     j_(sum_loop);
     L(sum_done);
 
     // ---- finish mean ----
-    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
     vmv_v_v(v_work, v_sum);
     vmv_v_x(v_sum, x0); // reuse as reduction init (elem0 = 0)
     vfredosum_vs(v_work, v_work, v_sum);
@@ -650,26 +650,26 @@ void jit_rvv_layernorm_f16_fused_kernel_t::generate() {
     // ---- pass 2: accumulate variance as sum((x - mean)^2) ----
     ld(reg_src, reg_param, GET_F16_OFF(src));
     ld(reg_t1, reg_param, GET_F16_OFF(len));
-    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
     vmv_v_x(v_sumsq, x0);
     vmv_v_x(v_work, x0);
 
     L(var_loop);
     beqz(reg_t1, var_done);
-    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4);
+    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4, VTA::ta, VMA::ma);
     sub(reg_t1, reg_t1, reg_vl);
     vle16_v(v_ld, reg_src);
     slli(reg_tmp, reg_vl, 1);
     add(reg_src, reg_src, reg_tmp);
     vfwcvt_f_f_v(v_work, v_ld); // f16 -> f32
-    vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8);
+    vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8, VTA::tu, VMA::ma);
     vfsub_vf(v_work, v_work, f_mean);
     vfmacc_vv(v_sumsq, v_work, v_work);
     vmv_v_x(v_work, x0); // keep tail zero for next widen
     j_(var_loop);
     L(var_done);
 
-    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
     vmv_v_x(v_sum, x0); // reuse as reduction init
     vfredosum_vs(v_sumsq, v_sumsq, v_sum);
     vfmv_f_s(f_var_sum, v_sumsq);
@@ -698,7 +698,7 @@ void jit_rvv_layernorm_f16_fused_kernel_t::generate() {
 
     L(out_loop);
     beqz(reg_t1, out_done);
-    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4);
+    vsetvli(reg_vl, reg_t1, SEW::e16, LMUL::m4, VTA::ta, VMA::ma);
     sub(reg_t1, reg_t1, reg_vl);
 
     vle16_v(v_ld, reg_src);
@@ -714,18 +714,18 @@ void jit_rvv_layernorm_f16_fused_kernel_t::generate() {
             vfwcvt_f_f_v(v_beta, v_bld); // beta -> f32 (v8 m8)
         }
     } else if (with_scale_ || with_shift_) {
-        vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8);
+        vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
         if (with_scale_) vle32_v(v_gamma, reg_scale);
         if (with_shift_) vle32_v(v_beta, reg_shift);
     }
 
-    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8);
+    vsetvli(reg_tmp, x0, SEW::e32, LMUL::m8, VTA::ta, VMA::ma);
     vfsub_vf(v_work, v_work, f_mean); // x - mean
     vfmul_vf(v_work, v_work, f_inv); // * inv
     if (with_scale_) vfmul_vv(v_work, v_work, v_gamma);
     if (with_shift_) vfadd_vv(v_work, v_work, v_beta);
 
-    vsetvli(reg_tmp, reg_vl, SEW::e16, LMUL::m4);
+    vsetvli(reg_tmp, reg_vl, SEW::e16, LMUL::m4, VTA::ta, VMA::ma);
     vfncvt_f_f_w(v_ld, v_work); // f32 -> f16
     vse16_v(v_ld, reg_dst);
 

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -94,7 +94,7 @@ void jit_rvv_softmax_affine_kernel_t::generate() {
     Label loop, done;
     L(loop);
     beqz(reg_len, done);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     vle32_v(v_src, reg_src);
     vfsub_vf(v_src, v_src, f_sub);
     vfmul_vf(v_src, v_src, f_mul);
@@ -187,18 +187,18 @@ void jit_rvv_softmax_f16_affine_kernel_t::generate() {
     beqz(reg_len, done);
 
     if (src_f32_) {
-        vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m2);
+        vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
         vle32_v(v_f32, reg_src);
     } else {
-        vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m1);
+        vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vle16_v(v_src, reg_src);
         vfwcvt_f_f_v(v_f32, v_src);
-        vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m2);
+        vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
     }
 
     vfsub_vf(v_f32, v_f32, f_sub);
     vfmul_vf(v_f32, v_f32, f_mul);
-    vsetvli(reg_vl, reg_vl, SEW::e16, LMUL::m1);
+    vsetvli(reg_vl, reg_vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
     vfncvt_f_f_w(v_dst, v_f32);
     vse16_v(v_dst, reg_dst);
 
@@ -241,7 +241,7 @@ void jit_rvv_softmax_f16_strided_kernel_t::generate() {
     L(loop);
     beqz(reg_len, done);
 
-    vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m1);
+    vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
     if (gather_) {
         vlse16_v(v_data, reg_src, reg_stride);
         vse16_v(v_data, reg_dst);
@@ -335,20 +335,20 @@ void jit_rvv_softmax_f16_exp_sub_sum_kernel_t::generate() {
     li(reg_minexp, static_cast<int64_t>(0xC1000000u));
     li(reg_maxexp, static_cast<int64_t>(0x3F800000u));
 
-    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4);
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
     vfmv_v_f(v_acc, f_zero);
 
     Label loop, finish;
     L(loop);
     beqz(reg_len, finish);
 
-    vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m2);
+    vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
     vle16_v(v_in16, reg_src);
     slli(reg_bytes, reg_vl, 1);
     add(reg_src, reg_src, reg_bytes);
     vfwcvt_f_f_v(v_x, v_in16);
 
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4, VTA::tu, VMA::ma);
     vfsub_vf(v_x, v_x, f_sub);
     vfmv_v_f(v_bias, f_round);
     vmflt_vf(v_mask, v_x, f_lower);
@@ -392,7 +392,7 @@ void jit_rvv_softmax_f16_exp_sub_sum_kernel_t::generate() {
     j_(loop);
 
     L(finish);
-    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4);
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
     vfmv_v_f(v_red, f_zero);
     vfredosum_vs(v_red, v_acc, v_red);
     vfmv_f_s(f_sum, v_red);

--- a/src/cpu/rv64/jit_uni_binary.cpp
+++ b/src/cpu/rv64/jit_uni_binary.cpp
@@ -39,22 +39,22 @@ namespace {
 void set_load_vtype(
         jit_generator_t *h, data_type_t dt, const Reg &vl, const Reg &len) {
     if (dt == data_type::f32 || dt == data_type::s32)
-        h->vsetvli(vl, len, SEW::e32, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     else if (dt == data_type::f16)
-        h->vsetvli(vl, len, SEW::e16, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
     else
-        h->vsetvli(vl, len, SEW::e8, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
 }
 
 // Switch to the f32 compute vtype for `dt` (m1 for f32/s32, m2 for f16, m4 for
 // s8/u8), keeping vl.
 void set_compute_vtype(jit_generator_t *h, data_type_t dt, const Reg &vl) {
     if (dt == data_type::f32 || dt == data_type::s32)
-        h->vsetvli(x0, vl, SEW::e32, LMUL::m1);
+        h->vsetvli(x0, vl, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     else if (dt == data_type::f16)
-        h->vsetvli(x0, vl, SEW::e32, LMUL::m2);
+        h->vsetvli(x0, vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
     else
-        h->vsetvli(x0, vl, SEW::e32, LMUL::m4);
+        h->vsetvli(x0, vl, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 }
 
 // Load one chunk from `ptr` (narrow vtype already set) into `vdst` and widen to
@@ -113,12 +113,12 @@ void emit_binary_loop(jit_generator_t *h, alg_kind_t alg, bool scalar_src1,
             h->fcvt_s_wu(f_s1, gpr);
         } else { // f16: widen via the vector unit, extract lane 0
             h->li(gpr, 1);
-            h->vsetvli(x0, gpr, SEW::e16, LMUL::m1);
+            h->vsetvli(x0, gpr, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
             h->vle16_v(vt, p1);
             h->vfwcvt_f_f_v(vs1, vt); // e16m1 -> e32m2
             // vfmv_f_s reads lane 0 at the CURRENT SEW: switch to e32 first, or
             // it would extract 16 bits of the widened f32 (wrong scalar).
-            h->vsetvli(x0, gpr, SEW::e32, LMUL::m2);
+            h->vsetvli(x0, gpr, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
             h->vfmv_f_s(f_s1, vs1);
         }
     }
@@ -249,13 +249,13 @@ void emit_binary_loop(jit_generator_t *h, alg_kind_t alg, bool scalar_src1,
         Label sloop, sdone;
         h->L(sloop);
         h->beqz(len, sdone);
-        h->vsetvli(vl, len, nsew, LMUL::m1);
+        h->vsetvli(vl, len, nsew, LMUL::m1, VTA::ta, VMA::ma);
         vld(vd, p0);
         vld(vs1, p1);
-        h->vsetvli(x0, vl, SEW::e8, LMUL::m1);
+        h->vsetvli(x0, vl, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
         h->vle8_v(vt, p2);
         h->vmsne_vx(VReg(0), vt, x0); // v0 = (src2 != 0)
-        h->vsetvli(x0, vl, nsew, LMUL::m1);
+        h->vsetvli(x0, vl, nsew, LMUL::m1, VTA::ta, VMA::ma);
         h->vmerge_vvm(vt2, vs1, vd); // v0 ? src0(vd) : src1(vs1)
         if (nsew == SEW::e32)
             h->vse32_v(vt2, pd);
@@ -328,7 +328,7 @@ void emit_binary_loop(jit_generator_t *h, alg_kind_t alg, bool scalar_src1,
         h->vfcvt_x_f_v(vd, vd);
         h->vse32_v(vd, pd);
     } else if (dt == data_type::f16) {
-        h->vsetvli(x0, vl, SEW::e16, LMUL::m1);
+        h->vsetvli(x0, vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         h->vfncvt_f_f_w(vt, vd);
         h->vse16_v(vt, pd);
     } else { // s8 / u8
@@ -340,9 +340,9 @@ void emit_binary_loop(jit_generator_t *h, alg_kind_t alg, bool scalar_src1,
             h->vfcvt_x_f_v(vd, vd);
         else
             h->vfcvt_xu_f_v(vd, vd);
-        h->vsetvli(x0, vl, SEW::e16, LMUL::m2);
+        h->vsetvli(x0, vl, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
         h->vnsrl_wi(vs1, vd, 0); // i32m4 -> i16m2 (vs1 reused as temp)
-        h->vsetvli(x0, vl, SEW::e8, LMUL::m1);
+        h->vsetvli(x0, vl, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
         h->vnsrl_wi(vt, vs1, 0); // i16m2 -> i8m1
         h->vse8_v(vt, pd);
     }

--- a/src/cpu/rv64/jit_uni_eltwise.cpp
+++ b/src/cpu/rv64/jit_uni_eltwise.cpp
@@ -69,11 +69,11 @@ void emit_eltwise_loop(jit_generator_t *h, alg_kind_t alg, float alpha,
 
     // ---- load src (+ diff_dst) and widen to f32 in vd (and vdd) ----
     if (dt == data_type::f32) {
-        h->vsetvli(vl, len, SEW::e32, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         h->vle32_v(vd, p_in);
         if (!is_fwd) h->vle32_v(vdd, p_dd);
     } else if (dt == data_type::s32) {
-        h->vsetvli(vl, len, SEW::e32, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         h->vle32_v(vd, p_in);
         h->vfcvt_f_x_v(vd, vd);
         if (!is_fwd) {
@@ -81,22 +81,22 @@ void emit_eltwise_loop(jit_generator_t *h, alg_kind_t alg, float alpha,
             h->vfcvt_f_x_v(vdd, vdd);
         }
     } else if (dt == data_type::f16) {
-        h->vsetvli(vl, len, SEW::e16, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         h->vle16_v(vt, p_in);
         h->vfwcvt_f_f_v(vd, vt); // e16m1 -> e32m2
         if (!is_fwd) {
             h->vle16_v(vt, p_dd);
             h->vfwcvt_f_f_v(vdd, vt);
         }
-        h->vsetvli(x0, vl, SEW::e32, LMUL::m2);
+        h->vsetvli(x0, vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
     } else { // s8 / u8
         const VReg vt2(3); // second 8-bit staging reg (backward diff_dst)
-        h->vsetvli(vl, len, SEW::e8, LMUL::m1);
+        h->vsetvli(vl, len, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
         h->vle8_v(vt, p_in);
         if (!is_fwd) h->vle8_v(vt2, p_dd);
         // vsext/vzext.vf4 operate at the DESTINATION vtype (e32m4) and read the
         // source group as 8-bit, so switch vtype before extending.
-        h->vsetvli(x0, vl, SEW::e32, LMUL::m4);
+        h->vsetvli(x0, vl, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
         if (is_s8) {
             h->vsext_vf4(vd, vt);
             if (!is_fwd) h->vsext_vf4(vdd, vt2);
@@ -125,7 +125,7 @@ void emit_eltwise_loop(jit_generator_t *h, alg_kind_t alg, float alpha,
         h->vfcvt_x_f_v(vd, vd);
         h->vse32_v(vd, p_out);
     } else if (dt == data_type::f16) {
-        h->vsetvli(x0, vl, SEW::e16, LMUL::m1);
+        h->vsetvli(x0, vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         h->vfncvt_f_f_w(vt, vd); // e32m2 -> e16m1
         h->vse16_v(vt, p_out);
     } else { // s8 / u8
@@ -139,9 +139,9 @@ void emit_eltwise_loop(jit_generator_t *h, alg_kind_t alg, float alpha,
             h->vfcvt_xu_f_v(vd, vd);
         // narrow i32(m4) -> i16(m2) -> i8(m1); values pre-clamped so truncation
         // via vnsrl by 0 is exact.
-        h->vsetvli(x0, vl, SEW::e16, LMUL::m2);
+        h->vsetvli(x0, vl, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
         h->vnsrl_wi(vi16, vd, 0);
-        h->vsetvli(x0, vl, SEW::e8, LMUL::m1);
+        h->vsetvli(x0, vl, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
         h->vnsrl_wi(vt, vi16, 0);
         h->vse8_v(vt, p_out);
     }

--- a/src/cpu/rv64/jit_uni_group_normalization.cpp
+++ b/src/cpu/rv64/jit_uni_group_normalization.cpp
@@ -51,7 +51,7 @@ namespace {
 // Reduces one group to (sum, sum_of_squares) written as doubles. f32 accumulates
 // in f64 (vfwadd.wv / vfwmacc.vv); f16 widens f16->f32->f64 first. Both layouts:
 //   ncsp - the group is one contiguous C_PER_G*SP run, consumed by a VLA loop
-//          (vsetvli defaults to tail-undisturbed, so the partial-vl tail safely
+//          (partial-vl vsetvli passes VTA::tu explicitly so the tail safely
 //          accumulates into the running f64 vector before the final reduction).
 //   nspc - channel chunks (vl fixed per chunk) accumulated across spatial; lanes
 //          are independent partial sums reduced together at the end.
@@ -106,7 +106,8 @@ void stat_kernel_t<isa, d_type>::generate() {
         const VReg v_zero(24), v_red(25);
         const Reg reg_n = a7, reg_p = t3, reg_t = t4;
 
-        vsetvli(reg_vl, x0, SEW::e64, LMUL::m2); // zero accumulators
+        vsetvli(reg_vl, x0, SEW::e64, LMUL::m2, VTA::ta,
+                VMA::ma); // zero accumulators
         vmv_v_x(vS0, x0);
         vmv_v_x(vS1, x0);
         vmv_v_x(vS2, x0);
@@ -117,7 +118,8 @@ void stat_kernel_t<isa, d_type>::generate() {
         vmv_v_x(vQ3, x0);
 
         mul(reg_n, reg_cpg, reg_sp); // group_len = C_PER_G * SP
-        vsetvli(reg_vl, x0, SEW::e32, LMUL::m1); // vtype e32/m1, reg_vl = VLMAX
+        vsetvli(reg_vl, x0, SEW::e32, LMUL::m1, VTA::ta,
+                VMA::ma); // vtype e32/m1, reg_vl = VLMAX
         slli(reg_tmp, reg_vl, 2); // 4*VLMAX (== VLMAX*4 bytes for f32)
         slli(reg_tmp2, reg_tmp, 2); // 16*VLMAX bytes = src advance per iter
 
@@ -146,7 +148,7 @@ void stat_kernel_t<isa, d_type>::generate() {
         L(main_done);
 
         // Combine the four accumulator pairs (under e64/m2).
-        vsetvli(reg_t, x0, SEW::e64, LMUL::m2);
+        vsetvli(reg_t, x0, SEW::e64, LMUL::m2, VTA::ta, VMA::ma);
         vfadd_vv(vS0, vS0, vS1);
         vfadd_vv(vS2, vS2, vS3);
         vfadd_vv(vS0, vS0, vS2);
@@ -158,7 +160,7 @@ void stat_kernel_t<isa, d_type>::generate() {
         Label tail, tail_done;
         L(tail);
         beqz(reg_n, tail_done);
-        vsetvli(reg_vl, reg_n, SEW::e32, LMUL::m1);
+        vsetvli(reg_vl, reg_n, SEW::e32, LMUL::m1, VTA::tu, VMA::ma);
         vle32_v(vx0, reg_src);
         vfwadd_wv(vS0, vS0, vx0);
         vfwmacc_vv(vQ0, vx0, vx0);
@@ -168,9 +170,9 @@ void stat_kernel_t<isa, d_type>::generate() {
         j_(tail);
         L(tail_done);
 
-        vsetvli(reg_t, x0, SEW::e64, LMUL::m1);
+        vsetvli(reg_t, x0, SEW::e64, LMUL::m1, VTA::ta, VMA::ma);
         vmv_v_x(v_zero, x0);
-        vsetvli(reg_t, x0, SEW::e64, LMUL::m2);
+        vsetvli(reg_t, x0, SEW::e64, LMUL::m2, VTA::ta, VMA::ma);
         vfredusum_vs(v_red, vS0, v_zero);
         vfmv_f_s(fa0, v_red);
         fsd(fa0, reg_sum, 0);
@@ -192,7 +194,7 @@ void stat_kernel_t<isa, d_type>::generate() {
     const VReg v_zero = is_f16 ? VReg(16) : VReg(12);
     const VReg v_red = is_f16 ? VReg(17) : VReg(13);
 
-    vsetvli(reg_vl, x0, SEW::e64, acc_lmul);
+    vsetvli(reg_vl, x0, SEW::e64, acc_lmul, VTA::ta, VMA::ma);
     vmv_v_x(v_sum, x0);
     vmv_v_x(v_sq, x0);
 
@@ -205,7 +207,7 @@ void stat_kernel_t<isa, d_type>::generate() {
         } else {
             vle16_v(v_h, reg_src);
             vfwcvt_f_f_v(v_f, v_h); // f16 -> f32 (m2), under e16/m1
-            vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m2);
+            vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m2, VTA::tu, VMA::ma);
             vfwadd_wv(v_sum, v_sum, v_f); // f32 (m2) -> f64 (m4)
             vfwmacc_vv(v_sq, v_f, v_f);
         }
@@ -220,7 +222,7 @@ void stat_kernel_t<isa, d_type>::generate() {
         Label loop, done;
         L(loop);
         beqz(reg_n, done);
-        vsetvli(reg_vl, reg_n, load_sew, LMUL::m1);
+        vsetvli(reg_vl, reg_n, load_sew, LMUL::m1, VTA::tu, VMA::ma);
         accumulate();
         slli(reg_tmp, reg_vl, dtshift);
         add(reg_src, reg_src, reg_tmp);
@@ -236,7 +238,7 @@ void stat_kernel_t<isa, d_type>::generate() {
         Label cblk, creduce;
         L(cblk);
         beqz(reg_crem, creduce);
-        vsetvli(reg_vl, reg_crem, load_sew, LMUL::m1);
+        vsetvli(reg_vl, reg_crem, load_sew, LMUL::m1, VTA::tu, VMA::ma);
         mv(reg_sprem, reg_sp);
         mv(reg_ptr, reg_cbase);
         Label sp_loop, sp_done;
@@ -245,7 +247,8 @@ void stat_kernel_t<isa, d_type>::generate() {
         mv(reg_src, reg_ptr); // accumulate() reads reg_src
         accumulate();
         if (is_f16)
-            vsetvli(reg_vl, reg_crem, load_sew, LMUL::m1); // restore vtype
+            vsetvli(reg_vl, reg_crem, load_sew, LMUL::m1, VTA::tu,
+                    VMA::ma); // restore vtype
         add(reg_ptr, reg_ptr, reg_tmp2);
         addi(reg_sprem, reg_sprem, -1);
         j_(sp_loop);
@@ -258,9 +261,9 @@ void stat_kernel_t<isa, d_type>::generate() {
     }
 
     // Horizontal reduction of the f64 accumulators -> scalar sum / sumsq.
-    vsetvli(reg_vl, x0, SEW::e64, LMUL::m1);
+    vsetvli(reg_vl, x0, SEW::e64, LMUL::m1, VTA::ta, VMA::ma);
     vmv_v_x(v_zero, x0);
-    vsetvli(reg_vl, x0, SEW::e64, acc_lmul);
+    vsetvli(reg_vl, x0, SEW::e64, acc_lmul, VTA::ta, VMA::ma);
     vfredusum_vs(v_red, v_sum, v_zero);
     vfmv_f_s(fa0, v_red);
     fsd(fa0, reg_sum, 0);
@@ -361,13 +364,13 @@ void norm_kernel_t<isa, d_type>::generate() {
     // vs broadcast (ncsp) scale/shift.
     auto emit_chunk = [&](bool gamma_vec) {
         if (!is_f16) {
-            vsetvli(reg_vl, reg_runrem, SEW::e32, LMUL::m1);
+            vsetvli(reg_vl, reg_runrem, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
             vle32_v(v_dst, reg_rsrc);
         } else {
-            vsetvli(reg_vl, reg_runrem, SEW::e16, LMUL::m1);
+            vsetvli(reg_vl, reg_runrem, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
             vle16_v(v_h, reg_rsrc);
             vfwcvt_f_f_v(v_dst, v_h); // f16 -> f32 (m2)
-            vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m2);
+            vsetvli(reg_tmp, reg_vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
         }
         vfsub_vf(v_dst, v_dst, ft0); // - mean
         vfmul_vf(v_dst, v_dst, ft1); // * inv_std
@@ -389,7 +392,7 @@ void norm_kernel_t<isa, d_type>::generate() {
         if (!is_f16) {
             vse32_v(v_dst, reg_rdst);
         } else {
-            vsetvli(reg_tmp, reg_vl, SEW::e16, LMUL::m1);
+            vsetvli(reg_tmp, reg_vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
             vfncvt_f_f_w(v_h, v_dst);
             vse16_v(v_h, reg_rdst);
         }

--- a/src/cpu/rv64/jit_uni_postops_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_postops_kernel.cpp
@@ -87,7 +87,7 @@ struct jit_uni_postops_kernel_t::impl_t : public jit_generator_t {
         L(loop);
         beqz(reg_len, done);
 
-        vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4);
+        vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
         vle32_v(v_data, reg_dst);
 
         // bias add (before the post-op chain), scalar or per-element.

--- a/src/cpu/rv64/reorder/jit_blk_reorder.cpp
+++ b/src/cpu/rv64/reorder/jit_blk_reorder.cpp
@@ -255,7 +255,7 @@ void jit_single_blk_kernel_t::emit_segment_kernel() {
         mv(t0, a2); // remaining columns
         L(col_loop);
         beqz(t0, col_done);
-        vsetvli(t6, t0, SEW::e32, LMUL::m1);
+        vsetvli(t6, t0, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         if (plain_to_blocked_)
             emit_plain_to_blocked(full_block);
         else
@@ -317,11 +317,12 @@ void jit_single_blk_kernel_t::emit_transpose_kernel() {
         }
     };
 
-    auto set_vl_cols = [&]() { vsetvli(x0, t6, SEW::e32, LMUL::m1); };
+    auto set_vl_cols
+            = [&]() { vsetvli(x0, t6, SEW::e32, LMUL::m1, VTA::ta, VMA::ma); };
 
     auto set_vl_tile = [&]() {
         li(t4, (uint32_t)tile_cols_);
-        vsetvli(x0, t4, SEW::e32, LMUL::m1);
+        vsetvli(x0, t4, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     };
 
     auto emit_plain_to_blocked_group = [&](int g, bool full_block) {
@@ -422,7 +423,7 @@ void jit_single_blk_kernel_t::emit_transpose_kernel() {
         L(cols_tail);
         mv(t6, t0);
         L(cols_step_ready);
-        vsetvli(t6, t6, SEW::e32, LMUL::m1);
+        vsetvli(t6, t6, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
 
         for (int g = 0; g < block_sz_; g += tile_cols_) {
             if (plain_to_blocked_)

--- a/src/cpu/rv64/reorder/jit_uni_reorder_kernel.cpp
+++ b/src/cpu/rv64/reorder/jit_uni_reorder_kernel.cpp
@@ -209,7 +209,7 @@ void jit_uni_reorder_kernel_f32_t::load_to_f32(const VReg &v, const Reg &addr,
     }
 
     if (dt == data_type::f16 || dt == data_type::bf16) {
-        vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2);
+        vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
         if (unit)
             vle16_v(vreg_stg_, addr);
         else {
@@ -218,10 +218,10 @@ void jit_uni_reorder_kernel_f32_t::load_to_f32(const VReg &v, const Reg &addr,
         }
         if (dt == data_type::f16) {
             vfwcvt_f_f_v(v, vreg_stg_); // e16/mf2 -> e32/m1
-            vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1);
+            vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         } else {
             // bf16 -> f32 is a left shift by 16 of the zero-extended bits.
-            vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1);
+            vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
             vzext_vf2(v, vreg_stg_);
             li(reg_tmp1_, 16);
             vsll_vx(v, v, reg_tmp1_);
@@ -230,14 +230,14 @@ void jit_uni_reorder_kernel_f32_t::load_to_f32(const VReg &v, const Reg &addr,
     }
 
     // s8 / u8: stage as 8-bit (e8/mf4), widen to e32/m1, convert to f32.
-    vsetvli(x0, reg_vl_, SEW::e8, LMUL::mf4);
+    vsetvli(x0, reg_vl_, SEW::e8, LMUL::mf4, VTA::ta, VMA::ma);
     if (unit)
         vle8_v(vreg_stg_, addr);
     else {
         li(reg_tmp1_, (uint32_t)(stride_elems * sz));
         vlse8_v(vreg_stg_, addr, reg_tmp1_);
     }
-    vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1);
+    vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
     if (dt == data_type::s8) {
         vsext_vf4(v, vreg_stg_);
         vfcvt_f_x_v(v, v);
@@ -284,7 +284,7 @@ void jit_uni_reorder_kernel_f32_t::store_from_f32(const VReg &v,
     }
 
     if (dt == data_type::f16) {
-        vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2);
+        vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
         vfncvt_f_f_w(vreg_stg_, v); // e32/m1 -> e16/mf2 (round-to-nearest-even)
         if (unit)
             vse16_v(vreg_stg_, addr);
@@ -292,7 +292,7 @@ void jit_uni_reorder_kernel_f32_t::store_from_f32(const VReg &v,
             li(reg_tmp1_, (uint32_t)(stride_elems * sz));
             vsse16_v(vreg_stg_, addr, reg_tmp1_);
         }
-        vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1);
+        vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         return;
     }
 
@@ -304,7 +304,7 @@ void jit_uni_reorder_kernel_f32_t::store_from_f32(const VReg &v,
         li(reg_tmp1_, 0x7FFF);
         vadd_vx(v, v, reg_tmp1_);
         vadd_vv(v, v, vreg_aux_);
-        vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2);
+        vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
         vnsrl_wi(vreg_stg_, v, 16);
         if (unit)
             vse16_v(vreg_stg_, addr);
@@ -312,7 +312,7 @@ void jit_uni_reorder_kernel_f32_t::store_from_f32(const VReg &v,
             li(reg_tmp1_, (uint32_t)(stride_elems * sz));
             vsse16_v(vreg_stg_, addr, reg_tmp1_);
         }
-        vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1);
+        vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         return;
     }
 
@@ -327,9 +327,9 @@ void jit_uni_reorder_kernel_f32_t::store_from_f32(const VReg &v,
     else
         vfcvt_xu_f_v(v, v);
     // narrow e32/m1 -> e16/mf2 -> e8/mf4 (values pre-clamped, truncation exact)
-    vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2);
+    vsetvli(x0, reg_vl_, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
     vnsrl_wi(vreg_aux_, v, 0);
-    vsetvli(x0, reg_vl_, SEW::e8, LMUL::mf4);
+    vsetvli(x0, reg_vl_, SEW::e8, LMUL::mf4, VTA::ta, VMA::ma);
     vnsrl_wi(vreg_stg_, vreg_aux_, 0);
     if (unit)
         vse8_v(vreg_stg_, addr);
@@ -337,7 +337,8 @@ void jit_uni_reorder_kernel_f32_t::store_from_f32(const VReg &v,
         li(reg_tmp1_, (uint32_t)(stride_elems * sz));
         vsse8_v(vreg_stg_, addr, reg_tmp1_);
     }
-    vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1); // restore vtype for the next iter
+    vsetvli(x0, reg_vl_, SEW::e32, LMUL::m1, VTA::ta,
+            VMA::ma); // restore vtype for the next iter
 }
 
 // Computes the per-call running base addresses from the outer loop counters.
@@ -410,7 +411,7 @@ void jit_uni_reorder_kernel_f32_t::emit_zero_region(const Reg &count) {
     Label zl, ze;
     L(zl);
     beqz(count, ze);
-    vsetvli(reg_vl_, count, sew, LMUL::m1);
+    vsetvli(reg_vl_, count, sew, LMUL::m1, VTA::ta, VMA::ma);
     vmv_v_i(vreg_data_, 0);
     if (otype_sz_ == 4)
         vse32_v(vreg_data_, reg_addr2_);
@@ -447,7 +448,7 @@ void jit_uni_reorder_kernel_f32_t::emit_core() {
     Label vloop, vend;
     L(vloop);
     beqz(reg_rem_, vend);
-    vsetvli(reg_vl_, reg_rem_, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl_, reg_rem_, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
 
     load_to_f32(vreg_data_, reg_addr_, itype, is0);
 
@@ -550,7 +551,7 @@ void jit_uni_reorder_kernel_f32_t::emit_pure_copy_core() {
     Label vloop, vend;
     L(vloop);
     beqz(reg_rem_, vend);
-    vsetvli(reg_vl_, reg_rem_, sew, LMUL::m1);
+    vsetvli(reg_vl_, reg_rem_, sew, LMUL::m1, VTA::ta, VMA::ma);
 
     if (sew == SEW::e32) {
         if (in_unit)

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -156,12 +156,13 @@ protected:
         beqz(reg_rows_remaining, copy_done);
 
         if (input_typesize_ == 4) {
-            vsetvli(reg_vl, reg_rows_remaining, SEW::e32, LMUL::m4);
+            vsetvli(reg_vl, reg_rows_remaining, SEW::e32, LMUL::m4, VTA::ta,
+                    VMA::ma);
             vle32_v(v_tmp, reg_src);
             vse32_v(v_tmp, reg_dst);
         } else {
-            // bf16/f16 (int8 takes the early-return path above).
-            vsetvli(reg_vl, reg_rows_remaining, SEW::e16, LMUL::m4);
+            vsetvli(reg_vl, reg_rows_remaining, SEW::e16, LMUL::m4, VTA::ta,
+                    VMA::ma);
             vle16_v(v_tmp, reg_src);
             vse16_v(v_tmp, reg_dst);
         }

--- a/src/cpu/rv64/rvv_winograd_convolution.cpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.cpp
@@ -178,7 +178,7 @@ void jit_wino_input_transform_t::generate() {
     bge(reg_ic_base, reg_ic_total, lbl_ic_end);
 
     sub(t0, reg_ic_total, reg_ic_base);
-    vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, t0, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
 
     // src_row_base = src + ic_base * ic_spb
     mul(a0, reg_ic_base, reg_ic_spb);
@@ -468,7 +468,7 @@ void jit_wino_output_transform_t::generate() {
     bge(reg_oc_base, reg_oc_total, lbl_oc_end);
 
     sub(t0, reg_oc_total, reg_oc_base);
-    vsetvli(reg_vl, t0, SEW::e32, LMUL::m1);
+    vsetvli(reg_vl, t0, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
 
     // Load bias once per OC chunk
     if (with_bias_) {


### PR DESCRIPTION
# Description

This PR switches the default `vsetvli` / `vsetivli` tail/mask policy in the RV64 JIT backend from `tu, mu` (tail-undisturbed, mask-undisturbed) to `ta, ma` (tail-agnostic, mask-agnostic). The agnostic policy removes a false data-dependency that the previous default imposed on every vector op: under `tu`/`mu` the hardware must preserve inactive lanes, which on current RVV implementations costs extra bookkeeping without benefit, since almost none of our JIT code actually relies on tail or masked-lane preservation. Sites that *do* rely on it now pass `VTA::tu` explicitly.

## xbyak_riscv is removing the implicit defaults

The `xbyak_riscv` (v1.31) ships this block near the top of `xbyak_riscv.hpp`:

```cpp
#ifndef XBYAK_RISCV_VSETV_DEFAULT_OLD
    #pragma message "XBYAK_RISCV_VSETV_DEFAULT_OLD is 0 in the future"
    #define XBYAK_RISCV_VSETV_DEFAULT_OLD 1
#endif
#if XBYAK_RISCV_VSETV_DEFAULT_OLD == 1
    // backward-compat: defaults are tu, mu
    #define XBYAK_RISCV_VSETV_DEFAULT_VTA  =VTA::tu
    #define XBYAK_RISCV_VSETV_DEFAULT_VMA  =VMA::mu
#else
    // no default arguments, the same as the assembler
    #define XBYAK_RISCV_VSETV_DEFAULT_VTA
    #define XBYAK_RISCV_VSETV_DEFAULT_VMA
#endif
```

The `#pragma message` is an explicit upstream signal: the `OLD=1` defaults (`tu`/`mu`/`m1`) are a *backwards-compat shim* that the library intends to drop. The future mode — `OLD=0` — provides no implicit defaults, matching the RISC-V assembler's behaviour where every `vsetvli` must name its policy fields explicitly.

This PR defines `XBYAK_RISCV_VSETV_DEFAULT_OLD=0` in `cpu_isa_traits.hpp` before any `xbyak_riscv` header is included. With the switch on, every `vsetvli` / `vsetivli` call site in the JIT backend must pass `LMUL`, `VTA`, `VMA` explicitly — there is no longer a default to inherit.

The change is delivered by:

1. Setting `XBYAK_RISCV_VSETV_DEFAULT_OLD=0` in `cpu_isa_traits.hpp`, ahead of any `xbyak_riscv_util.hpp` include.
2. Adding `VTA::ta, VMA::ma` to every `vsetvli` / `vsetivli` call site that does not need tail preservation (136 sites across 18 files).
3. Adding `VMA::ma` to the 10 sites that already passed `VTA::tu` (they were relying on the previous default for `VMA`).
4. Including `cpu_isa_traits.hpp` from `gemm/rvv_gemm_utils_f32.hpp` before `xbyak_riscv_util.hpp`, so the `OLD=0` switch is visible in every translation unit that ends up emitting `vsetvli`.

No code under `third_party/` is modified.

# Checklist

## General

- [x] Code formatted with `clang-format-18`.
- [x] All affected primitives pass correctness tests on SG2044 (`tests/benchdnn/inputs/{lnorm,gnorm,softmax,binary,eltwise,pool,bnorm,conv,ip,reorder,prelu}/test_*_smoke`, plus targeted non-aligned shapes such as `1000x1000`, `333x777`).

## Performance

All experiments are performed on an SG2044 (`rv64imafdcv`, VLEN=128), single core (`taskset -c 32`), `march=rv64gcv -O3`. We compare:

1. **baseline**: upstream `main` (`d5ae448809`), default `tu, mu` policy.
2. **this PR**: same source, default `ta, ma` policy with explicit `VTA::tu` at the accumulator-tail callsites.

### Per-primitive single-core latency

| Primitive        | Dataset                                    | Baseline (ms) | This PR (ms) | Δ      |
|------------------|--------------------------------------------|---------------|--------------|--------|
| matmul (f32)     | 128×256:256×128 + 1024² + 256×512:512×256  | 165.587       | 150.290      | **+9.24%** |
| batch norm       | shapes_resnet_50 (FWD_I, acdb)             | 297.196       | 285.168      | **+4.04%** |
| inner product    | shapes_resnet_50 (FWD_B)                   | 3.894         | 3.829        | +1.68% |
| eltwise          | test_eltwise_smoke                         | 5.531         | 5.484        | +0.85% |
| layernorm (f32)  | 1024²+2048×768+1000²+333×777+4096²         | 48.532        | 48.344       | +0.39% |
| layernorm (f16)  | 1024²+2048×768+1000²+333×777+4096²         | 28.476        | 28.469       | +0.02% |
| conv (resnet-50) | shapes_resnet_50                           | 13266.1       | 13298.4      | −0.24% |
| pooling          | shapes_resnet_50 (FWD_I, axb)              | 345.257       | 345.593      | −0.10% |
| binary           | 256x3x224x224 ×2                           | 107.239       | 107.648      | −0.38% |

### Notes

Most of our hot loops were already written in a style that is tail-policy-agnostic (load → compute → store, with each iteration's tail overwritten by the next load). For those, switching the default is a correctness no-op and a performance wash. The win shows up where it can: loops that *do* care about the inactive lanes got faster once we let the hardware ignore them. The bulk of the diff is the mechanical `, VTA::ta, VMA::ma` additions — that's the cost of `OLD=0`, paid once.
