### PR TITLE
graph: interface: partition: accept non-const engine and stream

### DIFF
--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -79,9 +79,9 @@ dims group_dims(const dims &adims, dim groups) {
     return new_dims;
 }
 
-dnnl::engine make_dnnl_engine(const engine_t &g_engine) {
+dnnl::engine make_dnnl_engine(engine_t &g_engine) {
     dnnl::engine engine;
-    engine.reset(const_cast<engine_t *>(&g_engine), true); // not own
+    engine.reset(&g_engine, true); // not own
     return engine;
 }
 
@@ -91,10 +91,10 @@ dnnl::engine make_host_engine() {
 }
 
 dnnl::stream make_dnnl_stream(
-        const dnnl::engine &p_engine, const stream_t &g_stream) {
+        const dnnl::engine &p_engine, stream_t &g_stream) {
     UNUSED(p_engine);
     dnnl::stream strm;
-    strm.reset(const_cast<stream_t *>(&g_stream), true); // not own
+    strm.reset(&g_stream, true); // not own
     return strm;
 }
 

--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -85,11 +85,6 @@ dnnl::engine make_dnnl_engine(engine_t &g_engine) {
     return engine;
 }
 
-// The function will throw expection if cpu runtime is none.
-dnnl::engine make_host_engine() {
-    return dnnl::engine(dnnl::engine::kind::cpu, 0);
-}
-
 dnnl::stream make_dnnl_stream(
         const dnnl::engine &p_engine, stream_t &g_stream) {
     UNUSED(p_engine);
@@ -369,13 +364,6 @@ bool is_format(const memory::desc &adesc, const std::string &tag) {
     if ("ncx" == tag) { return strides == get_ncx_strides(shape); }
 
     return strides == get_nxc_strides(shape);
-}
-
-bool is_4c_blocked(const memory::desc &adesc) {
-    if (adesc.get_format_kind() != format_kind::blocked) return false;
-
-    return adesc.get_inner_nblks() == 1 && adesc.get_inner_idxs()[0] == 1
-            && adesc.get_inner_blks()[0] == 4;
 }
 
 bool is_plain(const memory::desc &adesc) {

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -58,11 +58,11 @@ dims get_compatible_dilates(const dims &dilates, size_t input_size = 4);
 
 dims group_dims(const dims &adims, dim groups);
 
-engine make_dnnl_engine(const engine_t &g_engine);
+engine make_dnnl_engine(engine_t &g_engine);
 
 engine make_host_engine();
 
-stream make_dnnl_stream(const engine &p_engine, const stream_t &g_stream);
+stream make_dnnl_stream(const engine &p_engine, stream_t &g_stream);
 
 memory::desc make_dnnl_memory_desc(const logical_tensor_t &lt);
 

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -60,8 +60,6 @@ dims group_dims(const dims &adims, dim groups);
 
 engine make_dnnl_engine(engine_t &g_engine);
 
-engine make_host_engine();
-
 stream make_dnnl_stream(const engine &p_engine, stream_t &g_stream);
 
 memory::desc make_dnnl_memory_desc(const logical_tensor_t &lt);
@@ -95,8 +93,6 @@ memory::desc to_nxc_format(const memory::desc &adesc);
 bool is_format(const memory::desc &adesc, memory::format_tag tag);
 
 bool is_format(const memory::desc &adesc, const std::string &tag);
-
-bool is_4c_blocked(const memory::desc &adesc);
 
 bool is_plain(const memory::desc &adesc);
 

--- a/src/graph/backend/dnnl/dnnl_partition_impl.cpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.cpp
@@ -119,7 +119,7 @@ status_t dnnl_partition_impl_t::compile(
         compiled_partition_t *compiled_partition,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs,
-        const engine_t *g_engine) const {
+        engine_t *g_engine) const {
     // compile will transform the subgraph in partition, so we make
     // a copy
     auto part = std::dynamic_pointer_cast<dnnl_partition_impl_t>(this->clone());
@@ -170,7 +170,7 @@ status_t dnnl_partition_impl_t::compile(
 
     // wrapper kernel to dnnl_compiled_partition_impl_t
     auto pimpl = std::make_shared<dnnl_compiled_partition_impl_t>(
-            *g_engine, ordered_inputs, ordered_outputs, kernel);
+            g_engine, ordered_inputs, ordered_outputs, kernel);
     compiled_partition->init(pimpl);
 
     return status::success;

--- a/src/graph/backend/dnnl/dnnl_partition_impl.hpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.hpp
@@ -40,22 +40,21 @@ class dnnl_compiled_partition_impl_t : public compiled_partition_impl_t {
     friend class dnnl_partition_impl_t;
 
 public:
-    dnnl_compiled_partition_impl_t(const engine_t &engine,
+    dnnl_compiled_partition_impl_t(engine_t *engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs, kernel_ptr &kernel)
         : compiled_partition_impl_t(
                   engine, inputs, outputs, kernel->get_inplace_pairs())
         , kernel_(kernel) {}
 
-    status_t execute(const stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute(stream_t *g_stream, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
         return kernel_->execute(g_stream, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t execute_sycl(const stream_t *g_stream,
+    status_t execute_sycl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -69,7 +68,7 @@ public:
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     // It looks very similar to execute_sycl. Consider to merge them in the
     // future.
-    status_t execute_ocl(const stream_t *g_stream,
+    status_t execute_ocl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -121,7 +120,7 @@ public:
     status_t compile(compiled_partition_t *compiled_partition,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs,
-            const engine_t *g_engine) const override;
+            engine_t *g_engine) const override;
 
     status_t infer_shape(std::vector<const logical_tensor_t *> &inputs,
             std::vector<logical_tensor_t *> &outputs) const override;

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -53,7 +53,7 @@ void batch_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
 }
 
 status_t batch_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -113,7 +113,7 @@ status_t batch_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
     return status::success;
 }
 
-status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
+status_t batch_norm_fwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -177,7 +177,7 @@ status_t batch_norm_fwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t batch_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -252,7 +252,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t batch_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t batch_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -327,7 +327,7 @@ status_t batch_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
 //// backward part
 #if BUILD_TRAINING
 status_t batch_norm_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -390,7 +390,7 @@ void batch_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t batch_norm_bwd_t::execute_impl(const stream_t *g_stream,
+status_t batch_norm_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -414,7 +414,7 @@ status_t batch_norm_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t batch_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -448,7 +448,7 @@ status_t batch_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t batch_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t batch_norm_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/batch_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.hpp
@@ -63,18 +63,17 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -83,7 +82,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -115,8 +114,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -125,13 +123,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -140,7 +138,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -53,7 +53,7 @@ void binary_t::prepare_args_set(const execution_args_set_t *res,
 }
 
 status_t binary_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -100,7 +100,7 @@ status_t binary_t::compile_impl(const dnnl_partition_impl_t *part,
     return status::success;
 }
 
-status_t binary_t::execute_impl(const stream_t *g_stream,
+status_t binary_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -133,7 +133,7 @@ status_t binary_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
+status_t binary_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -167,7 +167,7 @@ status_t binary_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t binary_t::ocl_execute_impl(const stream_t *g_stream,
+status_t binary_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {

--- a/src/graph/backend/dnnl/kernels/binary.hpp
+++ b/src/graph/backend/dnnl/kernels/binary.hpp
@@ -74,18 +74,17 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -94,7 +93,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -34,7 +34,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t concat_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -104,7 +104,7 @@ void concat_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t concat_t<quantized>::execute_impl(const stream_t *g_stream,
+status_t concat_t<quantized>::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -128,7 +128,7 @@ status_t concat_t<quantized>::execute_impl(const stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
+status_t concat_t<quantized>::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -162,7 +162,7 @@ status_t concat_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t concat_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
+status_t concat_t<quantized>::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/concat.hpp
+++ b/src/graph/backend/dnnl/kernels/concat.hpp
@@ -58,8 +58,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -68,13 +67,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -83,7 +82,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/conv.cpp
+++ b/src/graph/backend/dnnl/kernels/conv.cpp
@@ -34,7 +34,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t conv_fwd_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -146,7 +146,7 @@ status_t conv_fwd_t<quantized>::prepare_inplace_pairs_impl() {
 
 #if BUILD_TRAINING
 status_t conv_bwd_data_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -205,7 +205,7 @@ status_t conv_bwd_data_t::compile_impl(const dnnl_partition_impl_t *part,
 }
 
 status_t conv_bwd_weights_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 

--- a/src/graph/backend/dnnl/kernels/conv.hpp
+++ b/src/graph/backend/dnnl/kernels/conv.hpp
@@ -27,8 +27,7 @@ namespace dnnl_impl {
 template <bool quantized>
 struct conv_fwd_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -44,8 +43,7 @@ using quantized_conv = conv_fwd_t</* quantized */ true>;
 #if BUILD_TRAINING
 struct conv_bwd_data_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -55,8 +53,7 @@ public:
 
 struct conv_bwd_weights_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -43,7 +43,7 @@ void conv_base_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t conv_base_t::execute_impl(const stream_t *g_stream,
+status_t conv_base_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -107,7 +107,7 @@ status_t conv_base_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
+status_t conv_base_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -182,7 +182,7 @@ status_t conv_base_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t conv_base_t::ocl_execute_impl(const stream_t *g_stream,
+status_t conv_base_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {

--- a/src/graph/backend/dnnl/kernels/conv_base.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.hpp
@@ -64,13 +64,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -79,7 +79,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/conv_transpose.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_transpose.cpp
@@ -33,7 +33,7 @@ namespace graph {
 namespace dnnl_impl {
 template <bool quantized>
 status_t conv_transpose_fwd_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
@@ -126,7 +126,7 @@ status_t conv_transpose_fwd_t<quantized>::prepare_inplace_pairs_impl() {
 
 #if BUILD_TRAINING
 status_t conv_transpose_bwd_data_t::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
@@ -186,7 +186,7 @@ status_t conv_transpose_bwd_data_t::compile_impl(
 }
 
 status_t conv_transpose_bwd_weights_t::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);

--- a/src/graph/backend/dnnl/kernels/conv_transpose.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_transpose.hpp
@@ -41,8 +41,7 @@ namespace dnnl_impl {
 template <bool quantized>
 struct conv_transpose_fwd_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -58,8 +57,7 @@ using quantized_convtranspose = conv_transpose_fwd_t</* quantized */ true>;
 #if BUILD_TRAINING
 struct conv_transpose_bwd_data_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -69,8 +67,7 @@ public:
 
 struct conv_transpose_bwd_weights_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 

--- a/src/graph/backend/dnnl/kernels/dummy.cpp
+++ b/src/graph/backend/dnnl/kernels/dummy.cpp
@@ -26,7 +26,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t dummy_kernel_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -55,14 +55,14 @@ status_t dummy_kernel_t::compile_impl(const dnnl_partition_impl_t *part,
     return status::success;
 }
 
-status_t dummy_kernel_t::execute_impl(const stream_t *g_stream,
+status_t dummy_kernel_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t dummy_kernel_t::sycl_execute_impl(const stream_t *g_stream,
+status_t dummy_kernel_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -91,7 +91,7 @@ status_t dummy_kernel_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t dummy_kernel_t::ocl_execute_impl(const stream_t *g_stream,
+status_t dummy_kernel_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/dummy.hpp
+++ b/src/graph/backend/dnnl/kernels/dummy.hpp
@@ -42,18 +42,17 @@ public:
 
     ~dummy_kernel_t() override = default;
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -62,7 +61,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -33,7 +33,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t eltwise_fwd_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
@@ -129,7 +129,7 @@ void eltwise_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
+status_t eltwise_fwd_t<quantized>::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -194,7 +194,7 @@ status_t eltwise_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
+status_t eltwise_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -270,7 +270,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t eltwise_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
+status_t eltwise_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -344,7 +344,7 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t eltwise_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -404,7 +404,7 @@ void eltwise_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t eltwise_bwd_t::execute_impl(const stream_t *g_stream,
+status_t eltwise_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -427,7 +427,7 @@ status_t eltwise_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t eltwise_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -460,7 +460,7 @@ status_t eltwise_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t eltwise_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t eltwise_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/eltwise.hpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.hpp
@@ -68,8 +68,7 @@ public:
         return status::success;
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -78,13 +77,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -93,7 +92,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -128,8 +127,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -138,13 +136,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -153,7 +151,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp.hpp
@@ -43,8 +43,8 @@ private:
     std::shared_ptr<kernel_base_t> kernel;
 
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *engine, const std::vector<logical_tensor_t> &inputs,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *engine,
+            const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
         const engine_kind_t ekind = engine->kind();
         bool enable_ukernel = false;
@@ -78,15 +78,14 @@ public:
         return force > 0;
     }
 
-    status_t execute_impl(const stream_t *stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *stream, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
         return kernel->execute_impl(stream, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *stream,
+    status_t sycl_execute_impl(stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -98,7 +97,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *stream,
+    status_t ocl_execute_impl(stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
@@ -40,7 +40,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *eng,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
 // gated_mlp_primitive_kernel_t only supports Intel GPU.
@@ -141,8 +141,8 @@ void gated_mlp_primitive_kernel_t<quantized>::prepare_args_set(
 }
 
 template <bool quantized>
-status_t gated_mlp_primitive_kernel_t<quantized>::execute_impl(
-        const stream_t *stream, const std::vector<tensor_t> &inputs,
+status_t gated_mlp_primitive_kernel_t<quantized>::execute_impl(stream_t *stream,
+        const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *stream);
 
@@ -164,7 +164,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::execute_impl(
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
-        const stream_t *stream, const std::vector<tensor_t> &inputs,
+        stream_t *stream, const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps, ::sycl::event *ret_event) {
 // gated_mlp_primitive_kernel_t only supports Intel GPU.
@@ -202,7 +202,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
-        const stream_t *stream, const std::vector<tensor_t> &inputs,
+        stream_t *stream, const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ret_event) {
     auto deps = ocl_deps;

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
@@ -57,8 +57,8 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *engine, const std::vector<logical_tensor_t> &inputs,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *engine,
+            const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
     void prepare_args_set(const execution_args_set_t *res,
@@ -66,13 +66,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *stream, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *stream,
+    status_t sycl_execute_impl(stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -81,7 +80,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *stream,
+    status_t ocl_execute_impl(stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -36,7 +36,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t genindex_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -111,7 +111,7 @@ void genindex_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t genindex_t::execute_impl(const stream_t *g_stream,
+status_t genindex_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -132,7 +132,7 @@ status_t genindex_t::execute_impl(const stream_t *g_stream,
     return status::success;
 }
 #ifdef DNNL_WITH_SYCL
-status_t genindex_t::sycl_execute_impl(const stream_t *g_stream,
+status_t genindex_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -162,7 +162,7 @@ status_t genindex_t::sycl_execute_impl(const stream_t *g_stream,
 }
 #endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t genindex_t::ocl_execute_impl(const stream_t *g_stream,
+status_t genindex_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {

--- a/src/graph/backend/dnnl/kernels/gen_index.hpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.hpp
@@ -56,16 +56,15 @@ public:
     void prepare_args_set(const execution_args_set_t *res,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs);
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -73,7 +72,7 @@ public:
             ::sycl::event *sycl_event) override;
 #endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -33,7 +33,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t group_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -121,7 +121,7 @@ void group_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
+status_t group_norm_fwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -185,7 +185,7 @@ status_t group_norm_fwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t group_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -260,7 +260,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t group_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t group_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/group_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.hpp
@@ -60,8 +60,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -70,13 +69,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -85,7 +84,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/kernel_base.cpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.cpp
@@ -23,14 +23,14 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t kernel_base_t::compile(const dnnl_partition_impl_t *part,
-        const engine_t *aengine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *aengine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     auto ret = compile_impl(part, aengine, inputs, outputs);
     if (ret != status::success) return ret;
     return prepare_inplace_pairs_impl();
 }
 
-status_t kernel_base_t::execute(const stream_t *astream,
+status_t kernel_base_t::execute(stream_t *astream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     return execute_impl(astream, inputs, outputs, scratchpad_buf);

--- a/src/graph/backend/dnnl/kernels/kernel_base.hpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.hpp
@@ -41,31 +41,29 @@ class dnnl_partition_impl_t;
 struct kernel_base_t {
     virtual ~kernel_base_t() = default;
 
-    status_t compile(const dnnl_partition_impl_t *part, const engine_t *aengine,
+    status_t compile(const dnnl_partition_impl_t *part, engine_t *aengine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs);
 
     // each subclass should implement compile_impl()
     virtual status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *aengine,
-            const std::vector<logical_tensor_t> &inputs,
+            engine_t *aengine, const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs)
             = 0;
 
-    status_t execute(const stream_t *astream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute(stream_t *astream, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf = nullptr);
 
     // each subclass should implement execute_impl()
-    virtual status_t execute_impl(const stream_t *astream,
+    virtual status_t execute_impl(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf)
             = 0;
 
 #ifdef DNNL_WITH_SYCL
-    status_t execute_sycl(const stream_t *astream,
+    status_t execute_sycl(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -75,7 +73,7 @@ struct kernel_base_t {
                 sycl_deps, sycl_event);
     }
 
-    virtual status_t sycl_execute_impl(const stream_t *astream,
+    virtual status_t sycl_execute_impl(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -85,8 +83,7 @@ struct kernel_base_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t execute_ocl(const stream_t *astream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_ocl(stream_t *astream, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
@@ -94,7 +91,7 @@ struct kernel_base_t {
                 astream, inputs, outputs, scratchpad_buf, ocl_deps, ocl_event);
     }
 
-    virtual status_t ocl_execute_impl(const stream_t *astream,
+    virtual status_t ocl_execute_impl(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -202,7 +202,7 @@ void larger_partition_kernel_t::prepare_args_set(
 }
 
 status_t larger_partition_kernel_t::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
@@ -248,7 +248,7 @@ status_t larger_partition_kernel_t::compile_impl(
     return status::success;
 }
 
-status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
+status_t larger_partition_kernel_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -312,7 +312,7 @@ status_t larger_partition_kernel_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
+status_t larger_partition_kernel_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -386,7 +386,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t larger_partition_kernel_t::ocl_execute_impl(const stream_t *g_stream,
+status_t larger_partition_kernel_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *event) {

--- a/src/graph/backend/dnnl/kernels/large_partition.hpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.hpp
@@ -70,8 +70,7 @@ public:
     static void setup_pipeline(pass_pipeline_t &pipeline,
             memory_planner_t &mem_planner, bool enable_constant_cache);
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -85,13 +84,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -100,7 +99,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -33,7 +33,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t layer_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -118,7 +118,7 @@ void layer_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
+status_t layer_norm_fwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -182,7 +182,7 @@ status_t layer_norm_fwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t layer_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -257,7 +257,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t layer_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t layer_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -331,7 +331,7 @@ status_t layer_norm_fwd_t::ocl_execute_impl(const stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t layer_norm_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -390,7 +390,7 @@ void layer_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t layer_norm_bwd_t::execute_impl(const stream_t *g_stream,
+status_t layer_norm_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -413,7 +413,7 @@ status_t layer_norm_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t layer_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -446,7 +446,7 @@ status_t layer_norm_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t layer_norm_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t layer_norm_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/layer_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.hpp
@@ -60,8 +60,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
     void prepare_args_set(const execution_args_set_t *res,
@@ -69,13 +68,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -84,7 +83,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -116,8 +115,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -126,13 +124,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -141,7 +139,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -31,7 +31,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t logsoftmax_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -91,7 +91,7 @@ void logsoftmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t logsoftmax_fwd_t::execute_impl(const stream_t *g_stream,
+status_t logsoftmax_fwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -115,7 +115,7 @@ status_t logsoftmax_fwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t logsoftmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -149,7 +149,7 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t logsoftmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t logsoftmax_fwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -182,7 +182,7 @@ status_t logsoftmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t logsoftmax_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -244,7 +244,7 @@ void logsoftmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t logsoftmax_bwd_t::execute_impl(const stream_t *g_stream,
+status_t logsoftmax_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -268,7 +268,7 @@ status_t logsoftmax_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t logsoftmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -302,7 +302,7 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t logsoftmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t logsoftmax_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/log_softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.hpp
@@ -62,8 +62,7 @@ public:
         return status::success;
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -72,13 +71,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -87,7 +86,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -119,8 +118,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -129,13 +127,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -144,7 +142,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -34,7 +34,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t matmul_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -189,7 +189,7 @@ void matmul_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
+status_t matmul_t<quantized>::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -254,7 +254,7 @@ status_t matmul_t<quantized>::execute_impl(const stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
+status_t matmul_t<quantized>::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -330,7 +330,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t matmul_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
+status_t matmul_t<quantized>::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/matmul.hpp
+++ b/src/graph/backend/dnnl/kernels/matmul.hpp
@@ -61,8 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -71,13 +70,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -86,7 +85,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/mqa.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa.hpp
@@ -41,8 +41,7 @@ private:
     std::shared_ptr<kernel_base_t> kernel;
 
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
         const engine_kind_t ekind = g_engine->kind();
@@ -77,7 +76,7 @@ public:
 #endif
     }
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
@@ -85,7 +84,7 @@ public:
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -97,7 +96,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -40,7 +40,7 @@ namespace dnnl_impl {
 
 template <bool quantized, memory::data_type dt>
 status_t mqa_decomp_kernel_t<quantized, dt>::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
@@ -152,15 +152,15 @@ void mqa_decomp_kernel_t<quantized, dt>::prepare_sub_args(
 }
 
 template <bool quantized, memory::data_type dt>
-status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(
-        const stream_t *g_stream, const std::vector<tensor_t> &inputs,
+status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
+        const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream strm = make_dnnl_stream(p_engine_, *g_stream);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
-                    const_cast<stream_t *>(g_stream));
+                    g_stream);
 #endif
 
     // each thread's own local resource

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
@@ -65,8 +65,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -74,7 +73,7 @@ public:
             const size_t block_size,
             std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
@@ -134,7 +133,7 @@ public:
     std::function<std::shared_ptr<mqa_args_set_t>()> resource_ctor_;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -150,7 +149,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -33,7 +33,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t pooling_fwd_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     // TODO(wuxun): since oneDNN pooling primitive only support u8u8 or
@@ -148,7 +148,7 @@ void pooling_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
+status_t pooling_fwd_t<quantized>::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -213,7 +213,7 @@ status_t pooling_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
+status_t pooling_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -289,7 +289,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t pooling_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
+status_t pooling_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -363,7 +363,7 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t pooling_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -435,7 +435,7 @@ void pooling_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t pooling_bwd_t::execute_impl(const stream_t *g_stream,
+status_t pooling_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -460,7 +460,7 @@ status_t pooling_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t pooling_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -495,7 +495,7 @@ status_t pooling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t pooling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t pooling_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/pool.hpp
+++ b/src/graph/backend/dnnl/kernels/pool.hpp
@@ -61,8 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -71,13 +70,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -86,7 +85,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -121,8 +120,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -131,13 +129,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -146,7 +144,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -34,7 +34,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t prelu_fwd_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     // output tensor should have same data type as input tensor
     if (inputs[0].data_type != outputs[0].data_type)
@@ -107,7 +107,7 @@ void prelu_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t prelu_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
+status_t prelu_fwd_t<quantized>::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -132,7 +132,7 @@ status_t prelu_fwd_t<quantized>::execute_impl(const stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
+status_t prelu_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -167,7 +167,7 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t prelu_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
+status_t prelu_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -200,7 +200,7 @@ status_t prelu_fwd_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t prelu_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -264,7 +264,7 @@ void prelu_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t prelu_bwd_t::execute_impl(const stream_t *g_stream,
+status_t prelu_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -288,7 +288,7 @@ status_t prelu_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t prelu_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -322,7 +322,7 @@ status_t prelu_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t prelu_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t prelu_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/prelu.hpp
+++ b/src/graph/backend/dnnl/kernels/prelu.hpp
@@ -59,8 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -69,13 +68,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -84,7 +83,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -118,8 +117,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -128,13 +126,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -143,7 +141,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -32,7 +32,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t quantize_dequantize_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -112,7 +112,7 @@ void quantize_dequantize_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t quantize_dequantize_t::execute_impl(const stream_t *g_stream,
+status_t quantize_dequantize_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -181,7 +181,7 @@ status_t quantize_dequantize_t::prepare_inplace_pairs_impl() {
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
+status_t quantize_dequantize_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -256,7 +256,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t quantize_dequantize_t::ocl_execute_impl(const stream_t *g_stream,
+status_t quantize_dequantize_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/quantize.hpp
+++ b/src/graph/backend/dnnl/kernels/quantize.hpp
@@ -59,8 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -69,7 +68,7 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
@@ -77,7 +76,7 @@ public:
     status_t prepare_inplace_pairs_impl() override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -86,7 +85,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -34,7 +34,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t reduction_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -107,7 +107,7 @@ void reduction_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t reduction_t<quantized>::execute_impl(const stream_t *g_stream,
+status_t reduction_t<quantized>::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -131,7 +131,7 @@ status_t reduction_t<quantized>::execute_impl(const stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
+status_t reduction_t<quantized>::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -165,7 +165,7 @@ status_t reduction_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t reduction_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
+status_t reduction_t<quantized>::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/reduction.hpp
+++ b/src/graph/backend/dnnl/kernels/reduction.hpp
@@ -59,8 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -69,13 +68,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -84,7 +83,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -34,7 +34,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t reorder_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -131,7 +131,7 @@ void reorder_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
+status_t reorder_t<quantized>::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -196,7 +196,7 @@ status_t reorder_t<quantized>::execute_impl(const stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
+status_t reorder_t<quantized>::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -272,7 +272,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(const stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t reorder_t<quantized>::ocl_execute_impl(const stream_t *g_stream,
+status_t reorder_t<quantized>::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/reorder.hpp
+++ b/src/graph/backend/dnnl/kernels/reorder.hpp
@@ -61,8 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -71,13 +70,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -86,7 +85,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -33,7 +33,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t resampling_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -110,7 +110,7 @@ void resampling_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t resampling_fwd_t::execute_impl(const stream_t *g_stream,
+status_t resampling_fwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -133,7 +133,7 @@ status_t resampling_fwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t resampling_fwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -166,7 +166,7 @@ status_t resampling_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t resampling_fwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t resampling_fwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -198,7 +198,7 @@ status_t resampling_fwd_t::ocl_execute_impl(const stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t resampling_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -259,7 +259,7 @@ void resampling_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t resampling_bwd_t::execute_impl(const stream_t *g_stream,
+status_t resampling_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -282,7 +282,7 @@ status_t resampling_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t resampling_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -315,7 +315,7 @@ status_t resampling_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t resampling_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t resampling_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/resampling.hpp
+++ b/src/graph/backend/dnnl/kernels/resampling.hpp
@@ -63,8 +63,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -73,13 +72,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -88,7 +87,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -120,8 +119,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -130,13 +128,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -145,7 +143,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -46,8 +46,7 @@ private:
     std::shared_ptr<kernel_base_t> kernel;
 
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
         const engine_kind_t ekind = g_engine->kind();
@@ -111,7 +110,7 @@ public:
         return force > 0;
     }
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
@@ -119,7 +118,7 @@ public:
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -131,7 +130,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,

--- a/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
@@ -42,8 +42,7 @@ private:
     std::shared_ptr<kernel_base_t> kernel;
 
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
         const engine_kind_t ekind = g_engine->kind();
@@ -84,7 +83,7 @@ public:
         return force > 0;
     }
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
@@ -92,7 +91,7 @@ public:
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -104,7 +103,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -57,7 +57,7 @@ status_t sdp_bwd_primitive_kernel_t::initial_check(
 }
 
 status_t sdp_bwd_primitive_kernel_t::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
 // sdp_bwd_primitive_kernel_t only supports Intel GPU.
@@ -152,7 +152,7 @@ void sdp_bwd_primitive_kernel_t::prepare_args_set(
     }
 }
 
-status_t sdp_bwd_primitive_kernel_t::execute_impl(const stream_t *g_stream,
+status_t sdp_bwd_primitive_kernel_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -173,7 +173,7 @@ status_t sdp_bwd_primitive_kernel_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
+status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -210,7 +210,7 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(const stream_t *g_stream,
+status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
@@ -56,8 +56,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -66,13 +65,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -81,7 +80,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -39,7 +39,7 @@ namespace graph {
 namespace dnnl_impl {
 template <bool quantized, memory::data_type dt>
 status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
@@ -157,15 +157,15 @@ void sdp_decomp_kernel_t<quantized, dt>::prepare_sub_args(
 }
 
 template <bool quantized, memory::data_type dt>
-status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
-        const stream_t *g_stream, const std::vector<tensor_t> &inputs,
+status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
+        const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream strm = make_dnnl_stream(p_engine_, *g_stream);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
-                    const_cast<stream_t *>(g_stream));
+                    g_stream);
 #endif
 
     thread_local_cache_t<sdp_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -69,8 +69,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -78,7 +77,7 @@ public:
             const size_t block_size,
             std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
@@ -141,7 +140,7 @@ public:
     std::function<std::shared_ptr<sdp_args_set_t>()> resource_ctor_;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -157,7 +156,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -42,7 +42,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, const engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
 // sdp_primitive_kernel_t only supports Intel GPU.
@@ -160,8 +160,8 @@ void sdp_primitive_kernel_t<quantized>::prepare_args_set(
 }
 
 template <bool quantized>
-status_t sdp_primitive_kernel_t<quantized>::execute_impl(
-        const stream_t *g_stream, const std::vector<tensor_t> &inputs,
+status_t sdp_primitive_kernel_t<quantized>::execute_impl(stream_t *g_stream,
+        const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
@@ -183,7 +183,7 @@ status_t sdp_primitive_kernel_t<quantized>::execute_impl(
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
-        const stream_t *g_stream, const std::vector<tensor_t> &inputs,
+        stream_t *g_stream, const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
@@ -220,8 +220,8 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(
-        const stream_t *g_stream, const std::vector<tensor_t> &inputs,
+status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+        const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
     auto deps = cl_deps;

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
@@ -61,8 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -71,13 +70,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -86,7 +85,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -33,7 +33,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t shuffle_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -106,7 +106,7 @@ void shuffle_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t shuffle_fwd_t::execute_impl(const stream_t *g_stream,
+status_t shuffle_fwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -130,7 +130,7 @@ status_t shuffle_fwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t shuffle_fwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -164,7 +164,7 @@ status_t shuffle_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t shuffle_fwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t shuffle_fwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/shuffle.hpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.hpp
@@ -58,8 +58,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -68,13 +67,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -83,7 +82,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -33,7 +33,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t softmax_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -116,7 +116,7 @@ void softmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
+status_t softmax_fwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -180,7 +180,7 @@ status_t softmax_fwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t softmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -255,7 +255,7 @@ status_t softmax_fwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t softmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t softmax_fwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
@@ -329,7 +329,7 @@ status_t softmax_fwd_t::ocl_execute_impl(const stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t softmax_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -391,7 +391,7 @@ void softmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t softmax_bwd_t::execute_impl(const stream_t *g_stream,
+status_t softmax_bwd_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -415,7 +415,7 @@ status_t softmax_bwd_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
+status_t softmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -449,7 +449,7 @@ status_t softmax_bwd_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t softmax_bwd_t::ocl_execute_impl(const stream_t *g_stream,
+status_t softmax_bwd_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/softmax.hpp
@@ -64,8 +64,7 @@ public:
         return status::success;
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -74,13 +73,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -89,7 +88,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -121,8 +120,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -131,13 +129,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -146,7 +144,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -33,7 +33,7 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t sum_t::compile_impl(const dnnl_partition_impl_t *part,
-        const engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     p_engine_ = make_dnnl_engine(*g_engine);
 
@@ -106,7 +106,7 @@ void sum_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t sum_t::execute_impl(const stream_t *g_stream,
+status_t sum_t::execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
@@ -130,7 +130,7 @@ status_t sum_t::execute_impl(const stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
+status_t sum_t::sycl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -164,7 +164,7 @@ status_t sum_t::sycl_execute_impl(const stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t sum_t::ocl_execute_impl(const stream_t *g_stream,
+status_t sum_t::ocl_execute_impl(stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {

--- a/src/graph/backend/dnnl/kernels/sum.hpp
+++ b/src/graph/backend/dnnl/kernels/sum.hpp
@@ -59,8 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part,
-            const engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -69,13 +68,13 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(const stream_t *g_stream,
+    status_t execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(const stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -84,7 +83,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(const stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *g_stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/scratchpad.cpp
+++ b/src/graph/backend/dnnl/scratchpad.cpp
@@ -72,13 +72,13 @@ scratchpad_t::~scratchpad_t() {
     }
 }
 
-void prolong_scratchpad_lifetime(const stream_t *g_stream,
-        const std::shared_ptr<scratchpad_t> &scratchpad) {
+void prolong_scratchpad_lifetime(
+        stream_t *g_stream, const std::shared_ptr<scratchpad_t> &scratchpad) {
     if (scratchpad->is_user_managed()) return;
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
-                    const_cast<stream_t *>(g_stream));
+                    g_stream);
     tp_stream->before_exec_hook();
 
     parallel(1, [=](int, int) { UNUSED(scratchpad); });

--- a/src/graph/backend/dnnl/scratchpad.hpp
+++ b/src/graph/backend/dnnl/scratchpad.hpp
@@ -84,8 +84,8 @@ private:
 // is to manage its handles through a system of caches the same way it's done
 // for memory objects before they are passed into a primitive execute call.
 // No-op if the scratchpad is user-managed.
-void prolong_scratchpad_lifetime(const stream_t *g_stream,
-        const std::shared_ptr<scratchpad_t> &scratchpad);
+void prolong_scratchpad_lifetime(
+        stream_t *g_stream, const std::shared_ptr<scratchpad_t> &scratchpad);
 
 class registrar_t;
 class grantor_t;

--- a/src/graph/backend/fake/fake_partition_impl.hpp
+++ b/src/graph/backend/fake/fake_partition_impl.hpp
@@ -125,7 +125,7 @@ public:
     status_t compile(compiled_partition_t *compiled_partition,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs,
-            const engine_t *g_engine) const override {
+            engine_t *g_engine) const override {
         UNUSED(compiled_partition);
         UNUSED(inputs);
         UNUSED(outputs);

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -623,7 +623,7 @@ bool dnnl_graph_partition::is_supported() const {
 status_t dnnl_graph_partition::compile(compiled_partition_t *cp,
         std::vector<const logical_tensor_t *> &inputs,
         std::vector<const logical_tensor_t *> &outputs,
-        const engine_t *aengine) const {
+        engine_t *aengine) const {
     status_t ret;
 
     if (!aengine || aengine->kind() != pimpl_->get_engine_kind())
@@ -707,7 +707,7 @@ status_t dnnl_graph_partition::compile(
         std::pair<compiled_partition_t *, cache_state_t> &compiled_partition,
         std::vector<const logical_tensor_t *> &inputs,
         std::vector<const logical_tensor_t *> &outputs,
-        const engine_t *aengine) const {
+        engine_t *aengine) const {
     namespace partition_hashing = partition_hashing;
     auto &global_compiled_partition_cache = compiled_partition_cache();
     partition_hashing::key_t key(this, aengine, inputs, outputs);
@@ -716,7 +716,7 @@ status_t dnnl_graph_partition::compile(
         const partition_t *partition;
         std::vector<const logical_tensor_t *> &inputs;
         std::vector<const logical_tensor_t *> &outputs;
-        const engine_t *engine;
+        engine_t *engine;
         cache_state_t cache_status;
     };
     create_context_t context {this, inputs, outputs, aengine,
@@ -743,7 +743,7 @@ status_t dnnl_graph_partition::compile(
     return result.status;
 }
 
-status_t dnnl_graph_compiled_partition::execute(const stream_t *astream,
+status_t dnnl_graph_compiled_partition::execute(stream_t *astream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs,
         const tensor_t *scratchpad) const {
@@ -782,7 +782,7 @@ status_t dnnl_graph_compiled_partition::execute(const stream_t *astream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t dnnl_graph_compiled_partition::execute_sycl(const stream_t *astream,
+status_t dnnl_graph_compiled_partition::execute_sycl(stream_t *astream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
         const std::vector<::sycl::event> &sycl_deps,
@@ -809,11 +809,9 @@ status_t dnnl_graph_compiled_partition::execute_sycl(const stream_t *astream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 // It looks very similar to execute_sycl(). Consider to merge them in the
 // future.
-graph::status_t dnnl_graph_compiled_partition::execute_ocl(
-        const graph::stream_t *astream,
-        const std::vector<graph::tensor_t> &inputs,
-        const std::vector<graph::tensor_t> &outputs,
-        const graph::tensor_t *scratchpad,
+status_t dnnl_graph_compiled_partition::execute_ocl(stream_t *astream,
+        const std::vector<tensor_t> &inputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) const {
     if (!astream || (astream->engine()->kind() != pimpl_->get_engine()->kind()))
         return status::invalid_arguments;

--- a/src/graph/interface/partition.hpp
+++ b/src/graph/interface/partition.hpp
@@ -124,14 +124,14 @@ public:
     graph::status_t compile(graph::compiled_partition_t *compiled_partition,
             std::vector<const graph::logical_tensor_t *> &inputs,
             std::vector<const graph::logical_tensor_t *> &outputs,
-            const graph::engine_t *e = nullptr) const;
+            graph::engine_t *e = nullptr) const;
 
     graph::status_t compile(
             std::pair<graph::compiled_partition_t *, dnnl::impl::cache_state_t>
                     &compiled_partition,
             std::vector<const graph::logical_tensor_t *> &inputs,
             std::vector<const graph::logical_tensor_t *> &outputs,
-            const graph::engine_t *aengine) const;
+            graph::engine_t *aengine) const;
 
     graph::status_t infer_shape(
             std::vector<const graph::logical_tensor_t *> &inputs,
@@ -176,13 +176,13 @@ public:
         return pimpl_->get_inplace_pairs();
     }
 
-    graph::status_t execute(const graph::stream_t *astream,
+    graph::status_t execute(graph::stream_t *astream,
             const std::vector<graph::tensor_t> &inputs,
             const std::vector<graph::tensor_t> &outputs,
             const graph::tensor_t *scratchpad = nullptr) const;
 
 #ifdef DNNL_WITH_SYCL
-    graph::status_t execute_sycl(const graph::stream_t *astream,
+    graph::status_t execute_sycl(graph::stream_t *astream,
             const std::vector<graph::tensor_t> &inputs,
             const std::vector<graph::tensor_t> &outputs,
             const graph::tensor_t *scratchpad,
@@ -191,7 +191,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    graph::status_t execute_ocl(const graph::stream_t *astream,
+    graph::status_t execute_ocl(graph::stream_t *astream,
             const std::vector<graph::tensor_t> &inputs,
             const std::vector<graph::tensor_t> &outputs,
             const graph::tensor_t *scratchpad,

--- a/src/graph/interface/partition_impl.hpp
+++ b/src/graph/interface/partition_impl.hpp
@@ -174,7 +174,7 @@ public:
     virtual status_t compile(compiled_partition_t *compiled_partition,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs,
-            const engine_t *aengine) const
+            engine_t *aengine) const
             = 0;
 
     /// get partition_impl id
@@ -275,11 +275,11 @@ public:
     /// @param inplace_pairs The inplace pairs that used to indicate
     ///     which input and output tensor given on execute can share
     ///     same memory buffer
-    compiled_partition_impl_t(const engine_t &engine,
+    compiled_partition_impl_t(engine_t *engine,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs,
             const std::vector<inplace_pair_t> &inplace_pairs)
-        : engine_(&engine)
+        : engine_(engine)
         , inputs_(inputs)
         , outputs_(outputs)
         , inplace_pairs_(inplace_pairs) {}
@@ -349,13 +349,13 @@ public:
     ///     would like to manage device resource by its own, it may ignore
     ///     stream object. By doing this, it won’t support custom op
     ///     implemented outside oneDNN Graph.
-    virtual status_t execute(const stream_t *astream,
+    virtual status_t execute(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs, const tensor_t *scratchpad)
             = 0;
 
 #ifdef DNNL_WITH_SYCL
-    virtual status_t execute_sycl(const stream_t *astream,
+    virtual status_t execute_sycl(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
             const std::vector<::sycl::event> &sycl_deps,
@@ -364,7 +364,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    virtual status_t execute_ocl(const stream_t *astream,
+    virtual status_t execute_ocl(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
             const std::vector<cl_event> &ocl_deps, cl_event *ocl_event)

--- a/src/graph/interface/tensor.cpp
+++ b/src/graph/interface/tensor.cpp
@@ -40,15 +40,15 @@ static const size_t DNNL_OCL_MEMALIGNMENT = 0;
 using namespace dnnl::impl::graph;
 
 static void *tensor_malloc(
-        size_t size, const engine_t *eng, allocator_t::mem_type_t type) {
+        size_t size, engine_t *eng, allocator_t::mem_type_t type) {
     const auto *alc = static_cast<dnnl::impl::graph::allocator_t *>(
             eng->get_allocator());
 #ifdef DNNL_WITH_SYCL
     void *dev_ptr {nullptr};
-    dnnl_sycl_interop_engine_get_device(const_cast<engine_t *>(eng), &dev_ptr);
+    dnnl_sycl_interop_engine_get_device(eng, &dev_ptr);
     auto *dev = static_cast<sycl::device *>(dev_ptr);
     void *ctx_ptr {nullptr};
-    dnnl_sycl_interop_engine_get_context(const_cast<engine_t *>(eng), &ctx_ptr);
+    dnnl_sycl_interop_engine_get_context(eng, &ctx_ptr);
     auto *ctx = static_cast<sycl::context *>(ctx_ptr);
 #endif
     if (eng->kind() == engine_kind::cpu) {
@@ -77,15 +77,15 @@ static void *tensor_malloc(
     }
 }
 
-static void tensor_free(void *p, const engine_t *eng) {
+static void tensor_free(void *p, engine_t *eng) {
     const auto *alc = static_cast<dnnl::impl::graph::allocator_t *>(
             eng->get_allocator());
 #ifdef DNNL_WITH_SYCL
     void *dev_ptr {nullptr};
-    dnnl_sycl_interop_engine_get_device(const_cast<engine_t *>(eng), &dev_ptr);
+    dnnl_sycl_interop_engine_get_device(eng, &dev_ptr);
     auto *dev = static_cast<sycl::device *>(dev_ptr);
     void *ctx_ptr {nullptr};
-    dnnl_sycl_interop_engine_get_context(const_cast<engine_t *>(eng), &ctx_ptr);
+    dnnl_sycl_interop_engine_get_context(eng, &ctx_ptr);
     auto *ctx = static_cast<sycl::context *>(ctx_ptr);
 #endif
     if (eng->kind() == engine_kind::cpu) {
@@ -112,7 +112,7 @@ static void tensor_free(void *p, const engine_t *eng) {
 }
 
 dnnl_graph_tensor::dnnl_graph_tensor(
-        const logical_tensor_t &lt, const engine_t *eng, void *handle)
+        const logical_tensor_t &lt, engine_t *eng, void *handle)
     : lt_(lt), eng_(eng) {
     if (handle == DNNL_MEMORY_ALLOCATE) {
         size_t num_bytes = logical_tensor_wrapper_t(lt).size();
@@ -214,7 +214,7 @@ status_t DNNL_API dnnl_graph_tensor_get_engine(
     if (ltw.is_host_scalar()) {
         *engine = nullptr;
     } else {
-        *engine = const_cast<engine_t *>(tensor->get_engine());
+        *engine = tensor->get_engine();
     }
 
     return status::success;

--- a/src/graph/interface/tensor.hpp
+++ b/src/graph/interface/tensor.hpp
@@ -25,7 +25,7 @@ public:
     dnnl_graph_tensor() = default;
 
     dnnl_graph_tensor(const dnnl::impl::graph::logical_tensor_t &lt,
-            const dnnl::impl::graph::engine_t *eng, void *handle);
+            dnnl::impl::graph::engine_t *eng, void *handle);
 
     void *get_data_handle() const { return handle_.get(); }
 
@@ -46,7 +46,7 @@ public:
 
     operator bool() const { return handle_ != nullptr; }
 
-    const dnnl::impl::graph::engine_t *get_engine() const { return eng_; }
+    dnnl::impl::graph::engine_t *get_engine() const { return eng_; }
 
 private:
     static dnnl::impl::graph::status_t dummy_destructor(void *) {
@@ -55,7 +55,7 @@ private:
 
     dnnl::impl::graph::logical_tensor_t lt_
             = dnnl::impl::graph::zero_logical_tensor();
-    const dnnl::impl::graph::engine_t *eng_ {nullptr};
+    dnnl::impl::graph::engine_t *eng_ {nullptr};
 
     std::shared_ptr<void> handle_ {nullptr};
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_common.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_common.cpp
@@ -64,20 +64,6 @@ TEST(test_common, MakeDnnlMemory) {
     }
 }
 
-TEST(test_common, Is4cBlocked) {
-    {
-        graph::logical_tensor_t lt = utils::logical_tensor_init(
-                0, {1, 2}, graph::data_type::f32, graph::layout_type::any);
-        auto desc = dnnl_impl::make_dnnl_memory_desc(lt);
-        ASSERT_FALSE(dnnl_impl::is_4c_blocked(desc));
-    }
-    {
-        dnnl::memory::desc md3 {{1, 4, 3, 4}, dnnl::memory::data_type::f32,
-                dnnl::memory::format_tag::nChw4c, true};
-        ASSERT_TRUE(dnnl_impl::is_4c_blocked(md3));
-    }
-}
-
 TEST(test_common, FillLayoutInfoDeathTest) {
     {
         graph::logical_tensor_t lt = utils::logical_tensor_init(

--- a/tests/gtests/graph/unit/backend/dnnl/test_compiled_partition.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_compiled_partition.cpp
@@ -307,7 +307,7 @@ TEST(test_compiled_partition, GetAndInfoMethod) {
             = std::make_shared<graph::dnnl_impl::float_pooling_fwd>();
     auto cp_impl = std::make_shared<
             graph::dnnl_impl::dnnl_compiled_partition_impl_t>(
-            engine, inputs, outputs, kernel);
+            &engine, inputs, outputs, kernel);
     graph::partition_t par;
     const graph::fpmath_t fpm {graph::fpmath_mode::strict, false};
     auto par_impl = std::make_shared<graph::dnnl_impl::dnnl_partition_impl_t>(
@@ -348,7 +348,7 @@ TEST(test_compiled_partition, GetInputsAndOutputs) {
             = std::make_shared<graph::dnnl_impl::float_pooling_fwd>();
     auto cp = std::make_shared<
             graph::dnnl_impl::dnnl_compiled_partition_impl_t>(
-            engine, inputs, outputs, kernel);
+            &engine, inputs, outputs, kernel);
 
     ASSERT_EQ(cp->get_inputs().size(), inputs.size());
     for (size_t i = 0; i < cp->get_inputs().size(); ++i) {

--- a/tests/gtests/graph/unit/unit_test_common.hpp
+++ b/tests/gtests/graph/unit/unit_test_common.hpp
@@ -96,7 +96,7 @@ private:
     using ltw = dnnl::impl::graph::logical_tensor_wrapper_t;
 
     struct deletor_wrapper_t {
-        deletor_wrapper_t(const dnnl::impl::graph::engine_t *eng) : eng_(eng) {}
+        deletor_wrapper_t(dnnl::impl::graph::engine_t *eng) : eng_(eng) {}
         void operator()(void *p) const {
             if (p) {
                 const auto k = eng_->kind();
@@ -126,13 +126,13 @@ private:
                 }
             }
         }
-        const dnnl::impl::graph::engine_t *eng_;
+        dnnl::impl::graph::engine_t *eng_;
     };
 
     /// @brief Alloc memory by engine
     /// @return Alloced memory
     static std::shared_ptr<char> allocate(
-            const dnnl::impl::graph::engine_t *e, size_t size) {
+            dnnl::impl::graph::engine_t *e, size_t size) {
         std::shared_ptr<char> data;
         auto alc = static_cast<dnnl::impl::graph::allocator_t *>(
                 e->get_allocator());
@@ -169,7 +169,7 @@ public:
     test_tensor_t() = default;
 
     test_tensor_t(const dnnl::impl::graph::logical_tensor_t &lt,
-            const dnnl::impl::graph::engine_t *e)
+            dnnl::impl::graph::engine_t *e)
         : num_bytes_(ltw(lt).size()) {
         data_ = allocate(e, num_bytes_);
         ts_ = dnnl::impl::graph::tensor_t(lt, e, data_.get());
@@ -177,7 +177,7 @@ public:
 
     template <typename T>
     test_tensor_t(const dnnl::impl::graph::logical_tensor_t &lt,
-            const dnnl::impl::graph::engine_t *e, const std::vector<T> &data)
+            dnnl::impl::graph::engine_t *e, const std::vector<T> &data)
         : test_tensor_t(lt, e) {
         this->fill(data);
     }


### PR DESCRIPTION
This is one follow-up of the refactor work in #5392 .

Accept non-const engine and stream objects through the internal interfaces of partition compilation and execution. The rationale of this change:

- We accept non-const engine and stream object on the public C API.
- We need to pass non-const engine and stream to the primitive APIs in the backend.
- This patch helps to get rid of many `const_cast` around engine and stream in the backend.

This also includes a minor removal of two unused utility functions in the backend: `make_host_engine()` and `is_4c_blocked()`.