### PR TITLE
cpu: rv64: pool: add fwdd and bwdd impl

### DIFF
--- a/src/cpu/cpu_pooling_list.cpp
+++ b/src/cpu/cpu_pooling_list.cpp
@@ -91,6 +91,8 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_pooling_bwd_t<avx, f32>)
             CPU_INSTANCE_X64(jit_uni_pooling_bwd_t<sse41, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_pooling_bwd_t<sve, f32>)
+            CPU_INSTANCE_RV64(jit_uni_pooling_bwd_t<v>)
+            CPU_INSTANCE_RV64(jit_uni_pooling_bwd_t<zvfh>)
             CPU_INSTANCE(nchw_pooling_bwd_t<bf16>)
             CPU_INSTANCE(nchw_pooling_bwd_t<f32>)
             CPU_INSTANCE(nchw_pooling_bwd_t<f16>)

--- a/src/cpu/rv64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_binary_injector.cpp
@@ -61,7 +61,10 @@ void jit_uni_binary_injector_t<isa>::compute_body(const Vmm &dst) {
             h_->flw(f_rhs_, gpr_, 0);
         else {
             h_->add(gpr_, gpr_, off_);
-            h_->vle32_v(v_rhs_, gpr_);
+            if (strided_)
+                h_->vlse32_v(v_rhs_, gpr_, rhs_stride_);
+            else
+                h_->vle32_v(v_rhs_, gpr_);
         }
     } else if (scalar)
         h_->flw(f_rhs_, rhs_addr_, 0);

--- a/src/cpu/rv64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/rv64/injectors/jit_uni_binary_injector.hpp
@@ -89,6 +89,23 @@ struct static_params_t {
         , off(off)
         , gpr(gpr)
         , indirect(true) {}
+    // Indirect + strided: like the indirect ctor but per-element lanes are
+    // rhs_stride bytes apart (vlse from base + off). Used when the rhs lanes are
+    // not contiguous in memory (e.g. a full-dst binary over a channels-strided
+    // ncsp destination) while still carrying any number of binaries via the
+    // per-binary pointer array.
+    static_params_t(const Xbyak_riscv::VReg &v_rhs,
+            const Xbyak_riscv::FReg &f_rhs, const Xbyak_riscv::Reg &rhs_ptrs,
+            const Xbyak_riscv::Reg &off, const Xbyak_riscv::Reg &gpr,
+            const Xbyak_riscv::Reg &rhs_stride)
+        : v_rhs(v_rhs)
+        , f_rhs(f_rhs)
+        , rhs_addr(rhs_ptrs)
+        , rhs_stride(rhs_stride)
+        , strided(true)
+        , off(off)
+        , gpr(gpr)
+        , indirect(true) {}
 
     Xbyak_riscv::VReg v_rhs; // scratch to load a per-element rhs vector
     Xbyak_riscv::FReg f_rhs; // scratch to load a scalar rhs value

--- a/src/cpu/rv64/jit_primitive_conf.hpp
+++ b/src/cpu/rv64/jit_primitive_conf.hpp
@@ -28,49 +28,116 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
-// Memory layout family handled by the pooling kernel. Both are plain (no
-// blocked tags): nspc vectorizes along C, ncsp vectorizes along OW.
-enum class jit_pool_tag_kind_t { undef, nspc, ncsp };
+inline int calculate_end_padding(int start_padding, int dst_size, int src_size,
+        int spatial_stride, int dilated_filter_size) {
+    return (dst_size - 1) * spatial_stride + dilated_filter_size
+            - (src_size + start_padding);
+}
 
-// Centralized pooling configuration, populated by
-// jit_uni_pool_kernel_t::init_conf and consumed by the driver and the kernel.
-// Mirrors the role of aarch64/x64 jit_pool_conf_t (kept lean: no c_block /
-// blocked-format / transpose fields, which the RVV path does not use).
+// Memory layout family handled by the pooling primitive.
+//   blocked - nChw{c_block}c (c_block = VLEN/32), the x64/aarch64-style baked
+//             kernel path (channels are the vector dim, c_block per register).
+//   nspc    - channels-last plain; also the baked kernel (c_off = C).
+//   ncsp    - plain nchw; the RETAINED rv64-native path (vectorize along OW/C,
+//             no plain<->blocked transpose since rv64 has no JIT transpose).
+enum class jit_pool_tag_kind_t { undef, nspc, ncsp, blocked };
+
+// Fused-binary src1 broadcast category relative to dst, uniform across the whole
+// post-op chain (enforced by the pd gate). Classified ONCE during init_conf and
+// stored in jpp.binary_bcast; the kernels and driver read it back instead of
+// re-deriving the category, so the injector rhs load form (scalar flw / per-oc
+// contiguous vle / full-dst strided vlse) and the shared rhs offset stay in sync.
+//   none    - eltwise-only chain or no post-ops (no binary rhs)
+//   scalar  - per-tensor src1 (one value broadcast to every lane)
+//   per_oc  - [1,C,1,..] dense, matching dst's channel dim
+//   full_dst - dst-shaped src1 (per-element)
+enum class pool_binary_bcast_t {
+    none = 0,
+    scalar = 1,
+    per_oc = 2,
+    full_dst = 3
+};
+
+// Centralized pooling configuration. For the blocked/nspc baked kernel this is
+// the x64/aarch64 jit_pool_conf_t superset (c_block, ur, ur_bc, training,
+// backward, workspace dtype, ...). The native path (nspc/ncsp forward inference,
+// which is faster on RV64 than the baked port) additionally uses the fields
+// grouped at the bottom (ur_w / fuse_* / with_relu); use_native selects it.
 struct jit_pool_conf_t {
     int ndims;
-    int mb, c;
+    int mb, c, c_without_padding;
     int id, ih, iw, od, oh, ow;
     int stride_d, stride_h, stride_w;
     int kd, kh, kw;
     int f_pad, t_pad, l_pad;
     alg_kind_t alg;
+    bool is_training;
     bool is_backward;
+    bool simple_alg; // backward: kd<=stride_d (single accumulation pass)
+    bool is_c_padded; // blocked tag with padded channels (c_without_padding<c)
+    data_type_t ind_dt; // workspace index dtype (u8 or s32), max training/bwd
     data_type_t src_dt;
     data_type_t dst_dt;
     int dt_size;
+    bool is_f16; // f16 data (f32 accumulation; requires zvfh)
+
+    // Blocked/nspc vectorization: one m1 register == c_block f32 lanes.
+    int c_block, c_tail, nb_c;
+    int ur; // output-width unroll baked into the kernel
+    int ur_bc, ur_bc_tail; // channel-block unroll (nspc) / 1 (blocked)
+
     jit_pool_tag_kind_t tag_kind;
+    // True: the retained native kernel (nspc/ncsp forward inference). False: the
+    // x64/aarch64-style baked kernel (blocked, and nspc/blocked training +
+    // backward).
+    bool use_native;
     cpu_isa_t isa;
-    bool with_postops;
-    bool with_relu; // f32 single-ReLU flag; feeds empty_window_value() only.
-            // The post-op chain is fused via fuse_eltwise/fuse_binary.
-    bool fuse_eltwise; // eltwise post-op chain fused in-kernel via the injector
-            // (f32 and f16 eltwise-only)
-    bool fuse_binary; // f32 binary post-op fused in-kernel (channel-vec path)
-    float relu_alpha;
+
     post_ops_t post_ops;
+    bool with_postops;
+    bool with_eltwise;
+    bool with_binary;
+    // Broadcast category of the fused binary chain (classified once by the pd
+    // gate; none when there is no binary). See pool_binary_bcast_t.
+    pool_binary_bcast_t binary_bcast;
     int nthr;
-    // Output-width unroll for the shape-baked interior kernel (number of OW
-    // positions whose accumulators share loaded inputs, ARM max_step style).
-    int ur_w;
+
+    // --- native ncsp path only (retained rv64 design) ---
+    bool with_relu; // f32 single-ReLU flag; feeds empty_window_value()
+    bool fuse_eltwise; // eltwise chain fused (ncsp native)
+    bool fuse_binary; // binary fused (ncsp native, channel-vec)
+    float relu_alpha;
+    int ur_w; // ncsp native interior OW-unroll
 };
 
-// Per-call arguments for the agnostic (runtime-shape) kernel. Unlike aarch64/x64
-// — which bake the pooling window into the generated code — this kernel is
-// shape-agnostic and receives the window bounds and strides here, so one routine
-// per instantiation serves ncsp, OW==1, the nspc boundary columns, and (for f16)
-// the whole nspc row. (The f32 nspc interior uses the shape-baked kernel with
-// jit_uni_pool_interior_args_t.)
+// Per-call arguments for the x64/aarch64-style baked kernel (blocked/nspc).
+// Mirrors aarch64 jit_uni_pooling_args_t: the pooling window is baked into the
+// generated code and the driver passes per-(n,oh[,od]) padding counts and the
+// channel-block slice. The last two fields carry the rv64 in-kernel binary
+// post-op rhs (host-prepared pointer array + dst logical origin for full-dst).
 struct jit_uni_pooling_args_t {
+    const void *src;
+    const void *dst;
+    const void *indices; // max training (store) / backward (load) workspace
+    const void *zero_ptr; // backward: diff_src zeroing base
+    size_t zero_id; // backward: # input planes to zero
+    size_t zero_ih; // backward: # input rows to zero
+    size_t kd_padding; // valid kernel planes (kd - front/back overflow)
+    size_t kh_padding; // valid kernel rows   (kh - top/bottom overflow)
+    size_t kh_padding_shift; // index base offset from t/f overflow
+    size_t kd_padding_shift; // index d-step adjustment
+    float ker_area_h; // avg_exclude divisor base (valid kh*kd area)
+    size_t ur_bc; // # channel blocks to process in this call
+    size_t b_c; // # channel blocks already processed
+    const void *post_ops_binary_rhs_arg_vec; // per-binary rhs pointer array
+    const void *dst_orig; // dst logical origin (raw base + off_l(0)); the
+            // full-dst binary offset is (dst - dst_orig)
+};
+
+// Per-call arguments for the RETAINED native ncsp kernel (renamed from the old
+// jit_uni_pooling_args_t). Shape-agnostic: the window bounds and strides are
+// passed here, so one routine serves ncsp, OW==1, and boundary columns.
+struct jit_uni_pool_ncsp_args_t {
     const void *src;
     void *dst;
     dim_t channels;
@@ -85,25 +152,42 @@ struct jit_uni_pooling_args_t {
     bool with_relu;
     dim_t src_vec_byte_stride; // byte stride between vector elements in src
     dim_t dst_vec_byte_stride; // byte stride between vector elements in dst
-    // Binary post-op rhs (src1) base for this call. For full-dst per-element it
-    // points at the element matching this position's channel 0; for per-oc /
-    // per-tensor it points at the channel-0 / scalar value. Unused otherwise.
+    // Binary post-op: the injector runs in indirect mode so one chain can carry
+    // any number of binaries (all sharing one broadcast). post_op_rhs is the base
+    // of the per-binary rhs (src1) ORIGIN pointer array (one f32 pointer per
+    // binary). post_op_off0 is the shared byte offset of the first active lane:
+    // 0 for scalar/per-oc, and the full-dst position's channel-0 element offset
+    // (* sizeof(f32)) otherwise; the kernel advances it per channel chunk.
     const void *post_op_rhs = nullptr;
+    dim_t post_op_off0 = 0;
     // f16 generic path row unrolling: process n_pos output positions in one
     // call (adjacent positions share the window, so only the base pointers
-    // advance). The f32 agnostic kernel ignores these fields and always handles
-    // a single output position; f32 nspc interior reuse is handled by
-    // jit_uni_pool_interior_args_t instead.
+    // advance). The f32 kernel ignores these and handles a single position.
     dim_t n_pos = 1;
     dim_t pos_src_byte_stride = 0;
     dim_t pos_dst_byte_stride = 0;
+    // Max forward-training only (f32): the argmax workspace for this output
+    // position (indices) and the running kernel-window index. pos_base = the
+    // flattened index of the first (clamped) window element
+    // (kd_base*KH*KW + kh_base*KW + kw_base); as the kernel sweeps the clamped
+    // window it increments by 1 per iw, then adds pos_ih_step (= KW - kw_count)
+    // after each row and pos_id_step (= KH*KW - kh_count*KW) after each plane to
+    // skip the clamped-off positions. The per-channel argmax is stored here.
+    void *indices = nullptr;
+    dim_t pos_base = 0;
+    dim_t pos_ih_step = 0;
+    dim_t pos_id_step = 0;
+    // Byte stride between channel elements in the argmax workspace: ind_dt_size
+    // for the contiguous nspc workspace, dst_spatial * ind_dt_size for the
+    // strided ncsp workspace. The per-channel store is unit when this equals
+    // ind_dt_size, otherwise strided (vsse).
+    dim_t ws_vec_byte_stride = 0;
 };
 
-// Per-call arguments for the shape-baked interior kernel. The unroll structure
-// (kw, stride_w, ur_w), the algorithm, init value, avg_include scale, and the
-// fused eltwise post-op chain are baked into the generated code. Element strides
-// are passed (not baked) so the kernel stays correct for tensors whose strides
-// exceed 32 bits; the kernel derives the per-block strides from w_stride.
+// Per-call arguments for the shape-baked interior kernel (nspc f32 forward
+// inference). The unroll structure (kw, stride_w, ur_w), algorithm, init value,
+// avg_include scale, and the fused eltwise chain are baked into the generated
+// code; element strides are passed so 64-bit strides stay correct.
 struct jit_uni_pool_interior_args_t {
     const void *src; // channel 0 of (id_start, ih_start, iw_block_start)
     void *dst; // channel 0 of the first output column in the block
@@ -115,6 +199,33 @@ struct jit_uni_pool_interior_args_t {
     dim_t inW_stride; // byte stride between H rows (= iw * C * dt_size)
     dim_t inD_stride; // byte stride between D planes (= ih * iw * C * dt_size)
     float scale_val; // 1 / window for avg_exclude (ignored otherwise)
+};
+
+// One covering-output contribution to a single input position in the native
+// gather backward. Backward pooling is a gather: for each input position the
+// driver enumerates the (few) output positions whose pooling window covers it
+// and fills one contribution per output; the kernel accumulates their diff_dst
+// channel rows into the input's diff_src channel row and stores it once (no
+// scatter read-modify-write, so parallelising over inputs has no data race).
+// index/scale carry the max/avg payload: max adds diff_dst only where the stored
+// argmax equals index; avg adds diff_dst * scale (scale = 1 / num_summands, so
+// include- and exclude-padding are uniform per contribution).
+struct jit_uni_pool_bwd_contrib_t {
+    const void *diff_dst; // channel 0 of the covering output
+    const void *ws; // channel 0 of the covering output workspace (max)
+    int32_t index; // full-kernel index of this input in the window (max)
+    float scale; // 1 / num_summands for this output (avg)
+};
+
+// Per-call arguments for the native gather backward kernel (one input position).
+struct jit_uni_pool_bwd_args_t {
+    void *diff_src; // channel 0 of this input position (store target)
+    const jit_uni_pool_bwd_contrib_t *contribs;
+    dim_t count; // number of covering outputs (0 -> diff_src row is zeroed)
+    dim_t channels;
+    dim_t src_vec_byte_stride; // diff_src channel stride (nspc: dt, ncsp: ID*IH*IW*dt)
+    dim_t dst_vec_byte_stride; // diff_dst channel stride (nspc: dt, ncsp: OD*OH*OW*dt)
+    dim_t ws_vec_byte_stride; // ws channel stride (max; ncsp: OD*OH*OW*ind_sz)
 };
 
 struct jit_1x1_conv_conf_t {

--- a/src/cpu/rv64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_pool_kernel.cpp
@@ -17,12 +17,16 @@
 
 #include <cfloat>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
+#include "common/memory_desc_wrapper.hpp"
 #include "common/nstl.hpp"
+#include "common/pooling_pd.hpp"
 #include "common/type_helpers.hpp"
+#include "common/utils.hpp"
 
 #include "cpu/rv64/jit_uni_pool_kernel.hpp"
 
@@ -32,40 +36,56 @@ namespace cpu {
 namespace rv64 {
 
 using namespace Xbyak_riscv;
+using namespace alg_kind;
 
-template <cpu_isa_t isa, data_type_t d_type>
-jit_uni_pool_kernel_t<isa, d_type>::jit_uni_pool_kernel_t(
-        const jit_pool_conf_t &jpp)
-    : jit_generator_t(jpp.alg == alg_kind::pooling_max ? "jit_rvv_pool_fwd_max"
-                      : jpp.alg == alg_kind::pooling_avg_include_padding
-                      ? "jit_rvv_pool_fwd_avg_inc"
-                      : "jit_rvv_pool_fwd_avg_exc")
-    , jpp_(jpp)
-    , is_max_pool_(jpp.alg == alg_kind::pooling_max) {
-    create_kernel();
+#define GET_OFF(field) static_cast<int>(offsetof(jit_uni_pooling_args_t, field))
+// Parameter-struct offset helpers for the native kernels. Each references the
+// local `using p_t/a_t/c_t = ...;` alias in scope at the call site, mirroring the
+// x64/aarch64 GET_OFF convention instead of open-coding offsetof everywhere.
+#define GET_OFF_P(field) static_cast<int>(offsetof(p_t, field))
+#define GET_OFF_A(field) static_cast<int>(offsetof(a_t, field))
+#define GET_OFF_C(field) static_cast<int>(offsetof(c_t, field))
+
+// True when src1 is per-oc ([1,C,1,..] matching dst's channel dim, densely
+// stored) — the rv64 binary injector reads it as a contiguous [c_block] run.
+static bool binary_src1_is_per_oc(
+        const memory_desc_wrapper &s1, const memory_desc_wrapper &dst_d) {
+    if (dst_d.ndims() < 2 || s1.ndims() != dst_d.ndims()) return false;
+    if (s1.dims()[1] != dst_d.dims()[1] || !s1.is_dense(true)) return false;
+    for (int k = 0; k < dst_d.ndims(); k++)
+        if (k != 1 && s1.dims()[k] != 1) return false;
+    return true;
 }
 
-template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_pool_kernel_t<isa, d_type>::init_conf(
-        jit_pool_conf_t &jpp, primitive_attr_t &attr, const pooling_pd_t *ppd) {
-    using namespace alg_kind;
-    using namespace format_tag;
+// Single source of truth for the fused-binary broadcast category. Both pd gates
+// (baked post_ops_ok and native init_conf) classify with this; the result is
+// stored in jpp.binary_bcast so downstream code (apply_postops, the native
+// generate_* rhs load form, the driver's binary_off0) never re-derives it.
+// Returns none for a src1 layout the kernels cannot fuse (the gate then rejects
+// the chain to the reference).
+static pool_binary_bcast_t classify_binary_src1(
+        const memory_desc_wrapper &s1, const memory_desc_wrapper &dst_d) {
+    if (s1.nelems(true) == 1) return pool_binary_bcast_t::scalar;
+    if (binary_src1_is_per_oc(s1, dst_d)) return pool_binary_bcast_t::per_oc;
+    if (s1.similar_to(dst_d, true, false)) return pool_binary_bcast_t::full_dst;
+    return pool_binary_bcast_t::none;
+}
 
-    const memory_desc_wrapper src_d(ppd->src_md());
-    const memory_desc_wrapper dst_d(ppd->dst_md());
+// Fill the shape/stride/kernel/padding fields shared verbatim by all three
+// init_conf paths (baked, native forward, native backward). Channel bookkeeping
+// (c / c_block / c_without_padding) differs per path and stays with the caller.
+static void set_pool_spatial_dims(jit_pool_conf_t &jpp,
+        const memory_desc_wrapper &src_d, const memory_desc_wrapper &dst_d,
+        const pooling_desc_t &pd) {
     const int ndims = src_d.ndims();
-    const auto &pd = *ppd->desc();
-
     jpp.ndims = ndims;
     jpp.mb = src_d.dims()[0];
-    jpp.c = src_d.dims()[1];
     jpp.id = (ndims == 5) ? src_d.dims()[ndims - 3] : 1;
     jpp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
     jpp.iw = src_d.dims()[ndims - 1];
     jpp.od = (ndims == 5) ? dst_d.dims()[ndims - 3] : 1;
     jpp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
     jpp.ow = dst_d.dims()[ndims - 1];
-
     jpp.stride_d = (ndims == 5) ? pd.strides[0] : 1;
     jpp.stride_h = (ndims == 3) ? 1 : pd.strides[ndims - 4];
     jpp.stride_w = pd.strides[ndims - 3];
@@ -75,21 +95,856 @@ status_t jit_uni_pool_kernel_t<isa, d_type>::init_conf(
     jpp.f_pad = (ndims == 5) ? pd.padding[0][0] : 0;
     jpp.t_pad = (ndims == 3) ? 0 : pd.padding[0][ndims - 4];
     jpp.l_pad = pd.padding[0][ndims - 3];
+}
+
+// Callee-saved GPRs in save order (s0..s11); their register numbers are not
+// contiguous, so the sequence is spelled out for the preamble helpers below.
+static const Reg pool_saved_gprs[]
+        = {s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11};
+
+// Manual preamble/postamble: rv64 jit_generator_t emits no automatic frame, so
+// every pool kernel saves/restores the s* registers it clobbers into consecutive
+// 8-byte slots at the base of its frame. These fold the otherwise-repeated
+// straight-line sd/ld runs; the frame allocation and any extra scratch slots
+// (e.g. the baked kd-loop input/output spill) stay with each generate().
+static void save_saved_gprs(jit_generator_t *h, int count) {
+    for (int i = 0; i < count; i++)
+        h->sd(pool_saved_gprs[i], sp, i * 8);
+}
+static void restore_saved_gprs(jit_generator_t *h, int count) {
+    for (int i = 0; i < count; i++)
+        h->ld(pool_saved_gprs[i], sp, i * 8);
+}
+
+// Extra frame scratch slots that sit above the s0..s11 save area (slots 0..88).
+// The baked kernel spills reg_input/reg_output across the 3d kd-loop; the native
+// forward kernels spill the n_pos loop counter.
+static constexpr int kBakedSpillInput = 96;
+static constexpr int kBakedSpillOutput = 104;
+static constexpr int kNativePosSpill = 96;
+
+template <cpu_isa_t isa>
+jit_uni_pool_kernel_t<isa>::~jit_uni_pool_kernel_t() = default;
+
+template <cpu_isa_t isa>
+jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
+        const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md)
+    : jit_generator_t("jit_rvv_pool"), jpp(ajpp) {
+    // dst_md is kept only for signature parity with the x64/aarch64 kernels,
+    // which build the binary post-op injector in the ctor and need the dst
+    // descriptor there. The rv64 kernel builds its injector in generate() from
+    // jpp.post_ops instead, so it never reads dst_md.
+    UNUSED(dst_md);
+}
+
+static status_t set_binary_postops_formats(
+        post_ops_t &post_ops, const memory_desc_t *dst_md) {
+    for (int idx = 0; idx < post_ops.len(); ++idx) {
+        if (!post_ops.contain(primitive_kind::binary, idx)) continue;
+
+        auto &src1_md = post_ops.entry_[idx].binary.src1_desc;
+        const memory_desc_wrapper src1_mdw(src1_md);
+        if (!src1_mdw.format_any()) {
+            if (src1_mdw.is_blocking_desc())
+                continue;
+            else
+                return status::unimplemented;
+        }
+
+        const memory_desc_wrapper dst_mdw(dst_md);
+        assert(!dst_mdw.format_any());
+
+        CHECK(memory_desc_init_by_blocking_desc(
+                src1_md, dst_mdw.blocking_desc()));
+    }
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+bool jit_uni_pool_kernel_t<isa>::post_ops_ok(jit_pool_conf_t &jpp,
+        const primitive_attr_t &attr, const memory_desc_wrapper &dst_d) {
+    const auto &post_ops = attr.post_ops_;
+    jpp.with_postops = false;
+    jpp.with_eltwise = false;
+    jpp.with_binary = false;
+    jpp.binary_bcast = pool_binary_bcast_t::none;
+
+    if (jpp.is_backward) return post_ops.len() == 0;
+
+    // Accept an injector-supported chain: any number of forward eltwise ops plus
+    // any number of binaries. Binaries fuse at f32 (for f16 the accumulator is
+    // already widened to f32 at the inject point, and the rhs is loaded as f32).
+    // The rv64 injector positions every binary in a chain at ONE shared byte
+    // offset, so all binaries must share the same broadcast category (scalar /
+    // per-oc / full-dst); a mixed chain would need per-entry offsets and is left
+    // to the reference. src1 must be f32.
+    pool_binary_bcast_t bcast = pool_binary_bcast_t::none;
+    for (const auto &e : post_ops.entry_) {
+        if (e.is_eltwise()) {
+            if (!eltwise_injector::is_alg_supported(e.eltwise.alg))
+                return false;
+            jpp.with_eltwise = true;
+        } else if (e.is_binary()) {
+            if (!binary_injector::is_alg_supported(e.binary.alg)) return false;
+            if (e.binary.src1_desc.data_type != data_type::f32) return false;
+            const memory_desc_wrapper s1(e.binary.src1_desc);
+            const pool_binary_bcast_t k = classify_binary_src1(s1, dst_d);
+            if (k == pool_binary_bcast_t::none) return false;
+            if (bcast != pool_binary_bcast_t::none && bcast != k)
+                return false; // no mixing
+            bcast = k;
+            jpp.with_binary = true;
+        } else
+            return false;
+    }
+
+    jpp.binary_bcast = bcast;
+    jpp.with_postops = jpp.with_eltwise || jpp.with_binary;
+    return true;
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_pool_kernel_t<isa>::init_conf(jit_pool_conf_t &jpp,
+        memory_tracking::registrar_t &scratchpad, primitive_attr_t &attr,
+        const pooling_pd_t *ppd) {
+    using namespace format_tag;
+
+    const auto &pd = *ppd->desc();
+    const memory_desc_wrapper src_d(
+            ppd->is_fwd() ? ppd->src_md() : ppd->diff_src_md());
+    const memory_desc_wrapper dst_d(
+            ppd->is_fwd() ? ppd->dst_md() : ppd->diff_dst_md());
+    const int ndims = src_d.ndims();
+
+    // One m1 register == c_block f32 lanes; the blocked tag matches this width.
+    const uint32_t vlen = get_platform_vlen();
+    if (vlen == 0) return status::unimplemented;
+    int c_block = (int)(vlen / 32);
+    if (c_block > 16) c_block = 16;
+    if (c_block != 4 && c_block != 8 && c_block != 16)
+        return status::unimplemented;
+
+    dnnl_format_tag_t blocked_fmt_tag = dnnl_format_tag_undef;
+    switch (c_block) {
+        case 16:
+            blocked_fmt_tag = utils::pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
+            break;
+        case 8:
+            blocked_fmt_tag = utils::pick(ndims - 3, nCw8c, nChw8c, nCdhw8c);
+            break;
+        case 4:
+            blocked_fmt_tag = utils::pick(ndims - 3, nCw4c, nChw4c, nCdhw4c);
+            break;
+        default: return status::unimplemented;
+    }
+    const auto nspc_fmt_tag = utils::pick(ndims - 3, nwc, nhwc, ndhwc);
+    const auto fmt_tag
+            = src_d.matches_one_of_tag(blocked_fmt_tag, nspc_fmt_tag);
+    if (fmt_tag == format_tag::undef) return status::unimplemented;
+    if (!dst_d.matches_tag(fmt_tag)) return status::unimplemented;
+
+    jpp.tag_kind = (fmt_tag == nspc_fmt_tag) ? jit_pool_tag_kind_t::nspc
+                                             : jit_pool_tag_kind_t::blocked;
+    jpp.use_native = false; // x64/aarch64-style baked kernel
+
+    jpp.nthr = dnnl_get_max_threads();
+    jpp.is_training = pd.prop_kind == prop_kind::forward_training;
+    jpp.is_backward = pd.prop_kind == prop_kind::backward_data;
+    set_pool_spatial_dims(jpp, src_d, dst_d, pd);
+    jpp.c_without_padding = src_d.dims()[1];
+    jpp.c_block = c_block;
+
+    jpp.alg = pd.alg_kind;
+    jpp.src_dt = ppd->is_fwd() ? src_d.data_type() : dst_d.data_type();
+    jpp.dst_dt = ppd->is_fwd() ? dst_d.data_type() : src_d.data_type();
+    jpp.is_f16 = (src_d.data_type() == data_type::f16);
+    jpp.dt_size = types::data_type_size(src_d.data_type());
+    jpp.isa = isa;
+
+    // Blocked with padded channels (is_c_padded) is left to the reference: the
+    // RVV tail is a vl reduction, which cleanly covers nspc but not the padded
+    // blocked store/postop lanes.
+    jpp.is_c_padded = jpp.tag_kind == jit_pool_tag_kind_t::blocked
+            && (jpp.c_without_padding % c_block != 0);
+    if (jpp.is_c_padded) return status::unimplemented;
+
+    jpp.c = jpp.c_without_padding;
+    jpp.nb_c = utils::div_up(jpp.c, c_block);
+    jpp.c_tail = jpp.c % c_block; // nonzero only for nspc
+
+    const int back_pad = calculate_end_padding(
+            jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
+    const int bottom_pad = calculate_end_padding(
+            jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
+    const int right_pad = calculate_end_padding(
+            jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
+    if (jpp.f_pad >= jpp.kd || jpp.t_pad >= jpp.kh || jpp.l_pad >= jpp.kw
+            || back_pad >= jpp.kd || bottom_pad >= jpp.kh
+            || right_pad >= jpp.kw)
+        return status::unimplemented;
+
+    jpp.ind_dt = ppd->workspace_md() ? ppd->workspace_md()->data_type
+                                     : data_type::undef;
+
+    jpp.simple_alg = jpp.is_training
+            || IMPLICATION(jpp.is_backward, jpp.kd <= jpp.stride_d);
+
+    // Output-width unroll (ur_bc is always 1 on RVV). Capped so the per-shift
+    // register tiles fit in the 24-register tile space (v8..v31): max forward
+    // and both avg use acc+input (2 shifts) -> 12; max training/backward add an
+    // index tile (3 shifts) -> 8 / 6.
+    if (jpp.alg == pooling_max) {
+        jpp.ur = jpp.is_training ? 8 : (jpp.is_backward ? 6 : 12);
+    } else {
+        jpp.ur = 12; // acc + input, both fwd and bwd
+    }
+    if (jpp.ur > jpp.ow) jpp.ur = jpp.ow;
+    if (jpp.ur < 1) jpp.ur = 1;
+    jpp.ur_bc = 1;
+    jpp.ur_bc_tail = 0;
+
+    if (!post_ops_ok(jpp, attr, dst_d)) return status::unimplemented;
+    if (ppd->is_fwd() && jpp.with_binary)
+        CHECK(set_binary_postops_formats(attr.post_ops_, dst_d.md_));
+    jpp.post_ops = attr.post_ops_;
+
+    UNUSED(scratchpad); // no plain<->blocked transpose on RVV
+    return status::success;
+}
+
+// ---- small emit helpers --------------------------------------------------
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::load_f32_const(
+        const FReg &f, float v, const Reg &gpr) {
+    uint32_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    li(gpr, (int64_t)(int32_t)bits);
+    fmv_w_x(f, gpr);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::addr_off(
+        const Reg &dst, const Reg &base, int off) {
+    if (off >= -2048 && off <= 2047) {
+        addi(dst, base, off);
+    } else {
+        // Materialize the offset in a distinct scratch (t2): several callers use
+        // dst == base (pointer self-advance), where `li(dst, off)` would clobber
+        // base before the add. t2 is never a base argument here.
+        li(t2, off);
+        add(dst, base, t2);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::beqz_far(const Reg &r, Label &t) {
+    Label cont;
+    bnez(r, cont);
+    j_(t);
+    L(cont);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::bnez_far(const Reg &r, Label &t) {
+    Label cont;
+    beqz(r, cont);
+    j_(t);
+    L(cont);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::blt_far(const Reg &a, const Reg &b, Label &t) {
+    Label cont;
+    bge(a, b, cont);
+    j_(t);
+    L(cont);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::set_vl_e32() {
+    // Tail-agnostic (VTA::ta): the tail (lanes >= vl) is never stored or read
+    // back — every store here is vl-limited — so preserving it is only a false
+    // dependency. Mask-undisturbed (VMA::mu) is REQUIRED, not optional here:
+    // max_step_bwd() runs a masked vfadd_vv under this vtype and then stores the
+    // whole vector, so the masked-off (non-argmax) lanes must keep their loaded
+    // diff_src value. All other pool vsetvli sites use VMA::ma.
+    vsetvli(t0, reg_vl, SEW::e32, LMUL::m1, VTA::ta, VMA::mu);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::load(int idx, const Reg &reg_ptr, int offset) {
+    addr_off(t1, reg_ptr, offset);
+    if (jpp.is_f16) {
+        // vfwcvt.f.f.v takes the NARROW (source) vtype: run it under e16/mf2 so
+        // it widens f16->f32 (dest e32/m1), not f32->f64. Restore e32 after.
+        vsetvli(t0, reg_vl, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
+        vle16_v(v_tmp, t1);
+        vfwcvt_f_f_v(vreg(idx), v_tmp);
+        set_vl_e32();
+    } else {
+        vle32_v(vreg(idx), t1);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::store(
+        int idx, const Reg &reg_ptr, int offset) {
+    addr_off(t1, reg_ptr, offset);
+    if (jpp.is_f16) {
+        vsetvli(t0, reg_vl, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
+        vfncvt_f_f_w(v_tmp, vreg(idx));
+        vse16_v(v_tmp, t1);
+        set_vl_e32();
+    } else {
+        vse32_v(vreg(idx), t1);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::load_indices(
+        int idx, const Reg &reg_ptr, int offset) {
+    addr_off(t1, reg_ptr, offset);
+    if (jpp.ind_dt == data_type::u8) {
+        vsetvli(t0, reg_vl, SEW::e8, LMUL::mf4, VTA::ta, VMA::ma);
+        vle8_v(v_tmp, t1);
+        set_vl_e32();
+        vzext_vf4(vreg(idx), v_tmp);
+    } else {
+        vle32_v(vreg(idx), t1);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::store_indices(
+        int idx, const Reg &reg_ptr, int offset) {
+    addr_off(t1, reg_ptr, offset);
+    if (jpp.ind_dt == data_type::u8) {
+        // values < 256: narrow e32 -> e16 -> e8 (truncation is exact).
+        vsetvli(t0, reg_vl, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
+        vnsrl_wi(v_tmp, vreg(idx), 0);
+        vsetvli(t0, reg_vl, SEW::e8, LMUL::mf4, VTA::ta, VMA::ma);
+        vnsrl_wi(v_tmp, v_tmp, 0);
+        vse8_v(v_tmp, t1);
+        set_vl_e32();
+    } else {
+        vse32_v(vreg(idx), t1);
+    }
+}
+
+// ---- avg -----------------------------------------------------------------
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(
+        int jj, int ur_w, int pad_l, int pad_r) {
+    if (jpp.alg != pooling_avg_exclude_padding) return;
+    int non_zero_kw = jpp.kw;
+    non_zero_kw -= nstl::max(0, pad_l - jj * jpp.stride_w);
+    non_zero_kw -= nstl::max(0, pad_r - (ur_w - 1 - jj) * jpp.stride_w);
+    if (non_zero_kw == prev_kw) return;
+    prev_kw = non_zero_kw;
+    // f_tmp = non_zero_kw * ker_area_h  (the exclude-padding divisor)
+    li(t2, non_zero_kw);
+    fcvt_s_w(f_tmp, t2);
+    fmul_s(f_tmp, f_tmp, f_area);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int pad_l, int pad_r) {
+    const int iw = jpp.iw;
+    const int kw = jpp.kw;
+    const int stride_w = jpp.stride_w;
+    const int c_off
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c : jpp.c_block;
+    const int dt = jpp.dt_size;
+
+    // include-padding divisor is the constant window volume; exclude-padding
+    // divisor is recomputed per output column in maybe_recalculate_divisor().
+    if (jpp.alg == pooling_avg_include_padding)
+        load_f32_const(f_tmp, (float)(jpp.kw * jpp.kh * jpp.kd), t2);
+
+    // Initialise accumulators: backward loads output/divisor; forward zeroes.
+    for (int jj = 0; jj < ur_w; jj++) {
+        if (jpp.is_backward) maybe_recalculate_divisor(jj, ur_w, pad_l, pad_r);
+        const int accr = reg_ind(0, jj, ur_w);
+        if (jpp.is_backward) {
+            load(accr, reg_output, dt * jj * c_off);
+            vfdiv_vf(vreg(accr), vreg(accr), f_tmp); // acc = out / divisor
+        } else {
+            vmv_v_x(vreg(accr), x0); // 0.0f
+        }
+    }
+
+    Label kd_label;
+    const bool kd_loop = jpp.simple_alg && jpp.ndims == 5;
+    if (kd_loop) {
+        sd(reg_input, sp, kBakedSpillInput);
+        sd(reg_output, sp, kBakedSpillOutput);
+        mv(aux_reg_input_d, reg_input);
+        ld(reg_kd, reg_param, GET_OFF(kd_padding));
+        L(kd_label);
+        mv(aux_reg_input, aux_reg_input_d);
+    } else {
+        mv(aux_reg_input, reg_input);
+    }
+
+    mv(t5, reg_kh); // kj = kh_padding
+    Label kh_label;
+    L(kh_label);
+    for (int ki = 0; ki < kw; ki++) {
+        const int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
+        const int jj_end = ur_w
+                - utils::div_up(nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (int jj = jj_start; jj < jj_end; jj++) {
+            const int aux_input_offset = (ki + jj * stride_w - pad_l) * c_off;
+            if (aux_input_offset >= iw * c_off) continue;
+            const int accr = reg_ind(0, jj, ur_w);
+            const int inpr = reg_ind(1, jj, ur_w);
+            if (jpp.is_backward) {
+                load(inpr, aux_reg_input, dt * aux_input_offset);
+                vfadd_vv(vreg(inpr), vreg(inpr), vreg(accr));
+                store(inpr, aux_reg_input, dt * aux_input_offset);
+            } else {
+                load(inpr, aux_reg_input, dt * aux_input_offset);
+                vfadd_vv(vreg(accr), vreg(accr), vreg(inpr));
+            }
+        }
+    }
+    addr_off(aux_reg_input, aux_reg_input, dt * iw * c_off);
+    addi(t5, t5, -1);
+    bnez_far(t5, kh_label);
+
+    if (kd_loop) {
+        addr_off(aux_reg_input_d, aux_reg_input_d, dt * jpp.ih * iw * c_off);
+        addi(reg_kd, reg_kd, -1);
+        bnez_far(reg_kd, kd_label);
+        ld(reg_input, sp, kBakedSpillInput);
+        ld(reg_output, sp, kBakedSpillOutput);
+    }
+
+    if (!jpp.is_backward) {
+        for (int jj = 0; jj < ur_w; jj++) {
+            maybe_recalculate_divisor(jj, ur_w, pad_l, pad_r);
+            const int accr = reg_ind(0, jj, ur_w);
+            vfdiv_vf(vreg(accr), vreg(accr), f_tmp); // acc /= divisor
+        }
+        if (jpp.with_postops) apply_postops(ur_w, c_off);
+        for (int jj = 0; jj < ur_w; jj++)
+            store(reg_ind(0, jj, ur_w), reg_output, dt * jj * c_off);
+    }
+}
+
+// ---- max forward ---------------------------------------------------------
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int pad_l, int pad_r) {
+    const int iw = jpp.iw;
+    const int kw = jpp.kw;
+    const int stride_w = jpp.stride_w;
+    const int c_off
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c : jpp.c_block;
+    const int dt = jpp.dt_size;
+
+    // Init accumulators to the dtype lowest (f16 lowest for f16 so an all-pad
+    // window narrows exactly); zero the index accumulators for training.
+    const float init_val
+            = jpp.is_f16 ? -65504.0f : nstl::numeric_limits<float>::lowest();
+    load_f32_const(f_tmp, init_val, t2);
+    for (int jj = 0; jj < ur_w; jj++) {
+        vfmv_v_f(vreg(reg_ind(0, jj, ur_w)), f_tmp);
+        if (jpp.is_training) vmv_v_x(vreg(reg_ind(2, jj, ur_w)), x0);
+    }
+    if (jpp.is_training) vmv_v_x(v_k_offset, reg_k_shift);
+
+    Label kd_label;
+    if (jpp.ndims == 5) {
+        sd(reg_input, sp, kBakedSpillInput);
+        sd(reg_output, sp, kBakedSpillOutput);
+        mv(aux_reg_input_d, reg_input);
+        ld(reg_kd, reg_param, GET_OFF(kd_padding));
+        L(kd_label);
+        mv(aux_reg_input, aux_reg_input_d);
+    } else {
+        mv(aux_reg_input, reg_input);
+    }
+
+    mv(t5, reg_kh);
+    Label kh_label;
+    L(kh_label);
+    for (int ki = 0; ki < kw; ki++) {
+        const int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
+        const int jj_end = ur_w
+                - utils::div_up(nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (int jj = jj_start; jj < jj_end; jj++) {
+            const int aux_input_offset = (ki + jj * stride_w - pad_l) * c_off;
+            if (aux_input_offset >= iw * c_off) continue;
+            const int accr = reg_ind(0, jj, ur_w);
+            const int inpr = reg_ind(1, jj, ur_w);
+            load(inpr, aux_reg_input, dt * aux_input_offset);
+            vmflt_vv(v_mask, vreg(accr), vreg(inpr)); // acc < inp
+            vmerge_vvm(vreg(accr), vreg(accr), vreg(inpr)); // acc = max
+            if (jpp.is_training) {
+                const int indr = reg_ind(2, jj, ur_w);
+                vmerge_vvm(vreg(indr), vreg(indr), v_k_offset);
+            }
+        }
+        if (jpp.is_training) vadd_vv(v_k_offset, v_k_offset, v_one);
+    }
+    addr_off(aux_reg_input, aux_reg_input, dt * iw * c_off);
+    addi(t5, t5, -1);
+    bnez_far(t5, kh_label);
+
+    if (jpp.ndims == 5) {
+        addr_off(aux_reg_input_d, aux_reg_input_d, dt * jpp.ih * iw * c_off);
+        if (jpp.is_training) {
+            ld(t2, reg_param, GET_OFF(kd_padding_shift));
+            vadd_vx(v_k_offset, v_k_offset, t2);
+        }
+        addi(reg_kd, reg_kd, -1);
+        bnez_far(reg_kd, kd_label);
+        ld(reg_input, sp, kBakedSpillInput);
+        ld(reg_output, sp, kBakedSpillOutput);
+    }
+
+    if (jpp.with_postops) apply_postops(ur_w, c_off);
+    for (int jj = 0; jj < ur_w; jj++) {
+        store(reg_ind(0, jj, ur_w), reg_output, dt * jj * c_off);
+        if (jpp.is_training)
+            store_indices(reg_ind(2, jj, ur_w), reg_index,
+                    (jj * c_off) * (int)types::data_type_size(jpp.ind_dt));
+    }
+}
+
+// ---- max backward --------------------------------------------------------
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int pad_l, int pad_r) {
+    const int iw = jpp.iw;
+    const int kw = jpp.kw;
+    const int stride_w = jpp.stride_w;
+    const int c_off
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c : jpp.c_block;
+    const int dt = jpp.dt_size;
+
+    for (int jj = 0; jj < ur_w; jj++) {
+        load(reg_ind(0, jj, ur_w), reg_output, dt * jj * c_off); // diff_dst
+        load_indices(reg_ind(1, jj, ur_w), reg_index,
+                (jj * c_off) * (int)types::data_type_size(jpp.ind_dt));
+    }
+    vmv_v_x(v_k_offset, reg_k_shift);
+
+    Label kd_label;
+    const bool kd_loop = jpp.simple_alg && jpp.ndims == 5;
+    if (kd_loop) {
+        sd(reg_input, sp, kBakedSpillInput);
+        sd(reg_output, sp, kBakedSpillOutput);
+        mv(aux_reg_input_d, reg_input);
+        ld(reg_kd, reg_param, GET_OFF(kd_padding));
+        ld(reg_kd_pad_shift, reg_param, GET_OFF(kd_padding_shift));
+        L(kd_label);
+        mv(aux_reg_input, aux_reg_input_d);
+    } else {
+        mv(aux_reg_input, reg_input);
+    }
+
+    mv(t5, reg_kh);
+    Label kh_label;
+    L(kh_label);
+    for (int ki = 0; ki < kw; ki++) {
+        const int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
+        const int jj_end = ur_w
+                - utils::div_up(nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (int jj = jj_start; jj < jj_end; jj++) {
+            const int aux_input_offset = (ki + jj * stride_w - pad_l) * c_off;
+            if (aux_input_offset >= iw * c_off) continue;
+            const int outr = reg_ind(0, jj, ur_w);
+            const int indr = reg_ind(1, jj, ur_w);
+            const int inpr = reg_ind(2, jj, ur_w);
+            load(inpr, aux_reg_input, dt * aux_input_offset); // diff_src
+            vmseq_vv(v_mask, vreg(indr), v_k_offset); // index == k_offset
+            // diff_src += (mask ? diff_dst : 0); the VMA::mu set in set_vl_e32()
+            // keeps the masked-off (non-argmax) lanes at their loaded diff_src.
+            vfadd_vv(vreg(inpr), vreg(inpr), vreg(outr), VM::masked);
+            store(inpr, aux_reg_input, dt * aux_input_offset);
+        }
+        vadd_vv(v_k_offset, v_k_offset, v_one);
+    }
+    addr_off(aux_reg_input, aux_reg_input, dt * iw * c_off);
+    addi(t5, t5, -1);
+    bnez_far(t5, kh_label);
+
+    if (kd_loop) {
+        addr_off(aux_reg_input_d, aux_reg_input_d, dt * jpp.ih * iw * c_off);
+        vadd_vx(v_k_offset, v_k_offset, reg_kd_pad_shift);
+        addi(reg_kd, reg_kd, -1);
+        bnez_far(reg_kd, kd_label);
+        ld(reg_input, sp, kBakedSpillInput);
+        ld(reg_output, sp, kBakedSpillOutput);
+    }
+}
+
+// ---- backward diff_src zeroing (simple_alg) ------------------------------
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::zero_diff_src() {
+    const int c_off
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c : jpp.c_block;
+    const int dt = jpp.dt_size;
+    const int width = jpp.iw * c_off; // elements per input row for this block
+
+    Label l_skip, id_label, ih_label;
+    // reg registers reused locally: this runs before the window loop uses them.
+    const Reg reg_zero_ptr = aux_reg_input; // s7
+    const Reg reg_zero_id = reg_kd; // s9
+    const Reg reg_zero_ih = t5;
+    const Reg aux_ptr = t3;
+    const Reg aux_ih = t4;
+
+    vmv_v_x(v_tmp, x0); // zero vector (f32) / f16 store narrows zero anyway
+
+    ld(reg_zero_ptr, reg_param, GET_OFF(zero_ptr));
+    ld(reg_zero_id, reg_param, GET_OFF(zero_id));
+    beqz_far(reg_zero_id, l_skip);
+    ld(reg_zero_ih, reg_param, GET_OFF(zero_ih));
+    beqz_far(reg_zero_ih, l_skip);
+
+    L(id_label);
+    mv(aux_ptr, reg_zero_ptr);
+    mv(aux_ih, reg_zero_ih);
+    L(ih_label);
+    // Step by the column stride (c_off): for nspc, consecutive iw positions are
+    // C apart and each stores c_block (=vl) channels; for blocked c_off==c_block
+    // (contiguous). Either way this zeroes iw columns * c_block channels.
+    for (int i = 0; i < width; i += c_off) {
+        if (jpp.is_f16) {
+            vsetvli(t0, reg_vl, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
+            vmv_v_x(v_tmp, x0);
+            addr_off(t1, aux_ptr, dt * i);
+            vse16_v(v_tmp, t1);
+            set_vl_e32();
+        } else {
+            addr_off(t1, aux_ptr, dt * i);
+            vse32_v(v_tmp, t1);
+        }
+    }
+    addr_off(aux_ptr, aux_ptr, dt * width);
+    addi(aux_ih, aux_ih, -1);
+    bnez_far(aux_ih, ih_label);
+
+    addr_off(reg_zero_ptr, reg_zero_ptr, dt * width * jpp.ih);
+    addi(reg_zero_id, reg_zero_id, -1);
+    bnez_far(reg_zero_id, id_label);
+    L(l_skip);
+}
+
+// ---- post-ops ------------------------------------------------------------
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_w, int c_off) {
+    const int dt = jpp.dt_size;
+    const int rhs_es = (int)sizeof(float); // binary rhs (src1) is always f32
+
+    // Fused-binary broadcast (uniform across the chain), classified once in the
+    // pd gate and read back here: 0 = eltwise-only, 1 = scalar, 2 = per-oc,
+    // 3 = full-dst (see pool_binary_bcast_t).
+    const int bcast = static_cast<int>(jpp.binary_bcast);
+
+    // Position the shared rhs BYTE offset (reg t2) for the injector. src1 is f32,
+    // so the offset is (element index) * sizeof(f32) irrespective of the dst
+    // dtype — for f16 the accumulator is widened to f32 before this point, and
+    // the binary is applied at f32.
+    if (bcast == 1) {
+        li(t2, 0);
+    } else if (bcast == 2) { // per-oc: element (b_c * c_block) of the [C] rhs
+        li(t3, jpp.c_block * rhs_es);
+        mul(t2, reg_bc, t3);
+    } else if (bcast == 3) {
+        // full-dst: element index of this call's output base = dst_byte_off / dt
+        // (dst element size); the per-column term is added below.
+        ld(reg_kd_pad_shift, reg_param, GET_OFF(dst_orig));
+        sub(t5, reg_output, reg_kd_pad_shift); // dst byte offset
+        srli(t5, t5, (dt == 2) ? 1 : 2); // -> element index
+    }
+
+    for (int jj = 0; jj < ur_w; jj++) {
+        if (bcast == 3) {
+            addr_off(t2, t5, jj * c_off); // element index of output column jj
+            slli(t2, t2, 2); // * sizeof(f32)
+        }
+        postops_injector_->compute_vector(vreg(reg_ind(0, jj, ur_w)).getIdx());
+    }
+}
+
+// ---- generate ------------------------------------------------------------
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel_t<isa>::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const int c_off
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c : jpp.c_block;
+    const int dt = jpp.dt_size;
+    const int ind_sz = jpp.ind_dt != data_type::undef
+            ? (int)types::data_type_size(jpp.ind_dt)
+            : 0;
+    const bool has_index
+            = jpp.alg == pooling_max && (jpp.is_training || jpp.is_backward);
+
+    // Preamble: save s0..s11 (+ two spill slots for the 3d kd-loop at 96/104).
+    const int stack = 112;
+    addi(sp, sp, -stack);
+    save_saved_gprs(this, 12);
+
+    // backward: src=diff_src (accumulated into), dst=diff_dst (read).
+    ld(reg_input, reg_param, GET_OFF(src));
+    ld(reg_output, reg_param, GET_OFF(dst));
+    if (has_index) ld(reg_index, reg_param, GET_OFF(indices));
+    ld(reg_kh, reg_param, GET_OFF(kh_padding));
+    ld(reg_k_shift, reg_param, GET_OFF(kh_padding_shift));
+    flw(f_area, reg_param, GET_OFF(ker_area_h));
+    ld(reg_bc, reg_param, GET_OFF(b_c));
+    if (jpp.with_binary)
+        ld(reg_rhs, reg_param, GET_OFF(post_ops_binary_rhs_arg_vec));
+
+    // Channel AVL for this block: c_block, or c_tail for the nspc last block.
+    li(reg_vl, jpp.c_block);
+    if (jpp.c_tail != 0) {
+        Label skip_tail;
+        li(t2, jpp.nb_c - 1);
+        bne(reg_bc, t2, skip_tail);
+        li(reg_vl, jpp.c_tail);
+        L(skip_tail);
+    }
+    set_vl_e32();
+
+    if (has_index) {
+        li(t2, 1);
+        vmv_v_x(v_one, t2); // index increment
+    }
+
+    if (jpp.with_postops) {
+        eltwise_injector::static_params_t esp(v_eltw0, v_eltw1, v_eltw2,
+                f_eltw0, f_eltw1, t4, /*is_fwd=*/true);
+        binary_injector::static_params_t bsp(v_bin_rhs, f_bin, reg_rhs, t2, t3);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
+                        this, jpp.post_ops, esp,
+                        jpp.with_binary ? &bsp : nullptr);
+    }
+
+    prev_kw = 0;
+    if (jpp.is_backward && jpp.simple_alg) zero_diff_src();
+
+    const int ur_w = jpp.ur;
+    const int ow = jpp.ow;
+    const int iw = jpp.iw;
+    const int kw = jpp.kw;
+    const int stride_w = jpp.stride_w;
+    const int l_pad = jpp.l_pad;
+
+    auto process_oi = [&](int cur_ur_w, int lpad, int rpad) {
+        step(cur_ur_w, lpad, rpad);
+        addr_off(reg_input, reg_input,
+                dt * nstl::max(0, cur_ur_w * stride_w - lpad) * c_off);
+        addr_off(reg_output, reg_output, dt * cur_ur_w * c_off);
+        if (has_index)
+            addr_off(reg_index, reg_index, cur_ur_w * c_off * ind_sz);
+    };
+
+    const int n_oi = utils::div_up(ow, ur_w);
+    const int ur_stride_w = ur_w * stride_w;
+    const int l_pad_iters = nstl::min(n_oi, utils::div_up(l_pad, ur_stride_w));
+
+    for (int i = 0; i < l_pad_iters; ++i) {
+        const int ow_s = i * ur_w;
+        const int ow_e = nstl::min(ow, ow_s + ur_w);
+        const int cur_l_pad = l_pad - i * ur_stride_w;
+        const int cur_r_pad = nstl::max(
+                0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+        process_oi(ow_e - ow_s, cur_l_pad, cur_r_pad);
+    }
+
+    const int rem_n_oi = n_oi - l_pad_iters;
+    const int cur_iw = l_pad_iters * ur_stride_w - l_pad;
+    const int cur_iw_rightmost = cur_iw + kw - 1;
+    const int no_pad_full = utils::saturate<int>(
+            0, rem_n_oi, (iw - cur_iw_rightmost) / ur_stride_w);
+
+    if (no_pad_full > 0) {
+        Label ow_loop;
+        if (no_pad_full > 1) li(t6, 0);
+        L(ow_loop);
+        process_oi(ur_w, 0, 0);
+        if (no_pad_full > 1) {
+            addi(t6, t6, 1);
+            li(t5, no_pad_full);
+            blt_far(t6, t5, ow_loop);
+        }
+    }
+
+    for (int i = l_pad_iters + no_pad_full; i < n_oi; ++i) {
+        const int ow_s = i * ur_w;
+        const int ow_e = nstl::min(ow, ow_s + ur_w);
+        const int cur_r_pad = nstl::max(
+                0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+        process_oi(ow_e - ow_s, 0, cur_r_pad);
+    }
+
+    restore_saved_gprs(this, 12);
+    addi(sp, sp, stack);
+    ret();
+#else
+    ret();
+#endif
+}
+
+template struct jit_uni_pool_kernel_t<v>;
+template struct jit_uni_pool_kernel_t<zvfh>;
+
+// ================== native VLA forward kernel (nspc/ncsp) ==================
+
+template <cpu_isa_t isa, data_type_t d_type>
+jit_uni_pool_ncsp_kernel_t<isa, d_type>::jit_uni_pool_ncsp_kernel_t(
+        const jit_pool_conf_t &jpp)
+    : jit_generator_t(jpp.alg == alg_kind::pooling_max ? "jit_rvv_pool_fwd_max"
+                      : jpp.alg == alg_kind::pooling_avg_include_padding
+                      ? "jit_rvv_pool_fwd_avg_inc"
+                      : "jit_rvv_pool_fwd_avg_exc")
+    , jpp_(jpp)
+    , is_max_pool_(jpp.alg == alg_kind::pooling_max) {
+    // create_kernel() is called (and CHECK'd) by the primitive's init(); a
+    // codegen failure must propagate a status, not be swallowed here.
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+status_t jit_uni_pool_ncsp_kernel_t<isa, d_type>::init_conf(
+        jit_pool_conf_t &jpp, primitive_attr_t &attr, const pooling_pd_t *ppd) {
+    using namespace alg_kind;
+    using namespace format_tag;
+
+    const memory_desc_wrapper src_d(ppd->src_md());
+    const memory_desc_wrapper dst_d(ppd->dst_md());
+    const int ndims = src_d.ndims();
+    const auto &pd = *ppd->desc();
+
+    set_pool_spatial_dims(jpp, src_d, dst_d, pd);
+    jpp.c = src_d.dims()[1];
+    jpp.c_without_padding = jpp.c;
 
     jpp.alg = pd.alg_kind;
     jpp.is_backward = false;
+    jpp.is_training = pd.prop_kind == prop_kind::forward_training;
+    // Max forward-training tracks the argmax into this workspace (u8/s32).
+    jpp.ind_dt = ppd->workspace_md() ? ppd->workspace_md()->data_type
+                                     : data_type::undef;
     jpp.src_dt = src_d.data_type();
     jpp.dst_dt = dst_d.data_type();
     jpp.dt_size = types::data_type_size(jpp.src_dt);
+    jpp.is_f16 = d_type == data_type::f16;
     jpp.isa = isa;
     jpp.nthr = dnnl_get_max_threads();
-    // Output-width unroll for the shape-baked interior kernel. 4 keeps register
-    // pressure low (ur_w accumulators + tmp + mask) while giving real input
-    // reuse for the common small strides.
     jpp.ur_w = 4;
 
-    // Memory layout: nspc (vectorize along C) or ncsp (vectorize along OW).
-    // No blocked-format support — plain layouts are handled natively.
+    // Native path: nspc or ncsp (plain layouts). blocked -> baked kernel.
     const auto nspc_tag = utils::pick(ndims - 3, nwc, nhwc, ndhwc);
     const auto ncsp_tag = utils::pick(ndims - 3, ncw, nchw, ncdhw);
     if (src_d.matches_tag(nspc_tag) && dst_d.matches_tag(nspc_tag))
@@ -98,19 +953,47 @@ status_t jit_uni_pool_kernel_t<isa, d_type>::init_conf(
         jpp.tag_kind = jit_pool_tag_kind_t::ncsp;
     else
         return status::unimplemented;
+    jpp.use_native = true;
 
-    // Post-ops: the pd's post_ops_ok() already accepted only chains this kernel
-    // can fuse in-kernel via the post-op injector (f32: any eltwise + at most one
-    // binary; f16: eltwise-only); everything else went to ref_pooling. The
-    // fuse_eltwise / fuse_binary flags below drive that injector fusion.
-    // with_relu (f32 single-ReLU) is separate — it only feeds the empty-window
-    // fill value (empty_window_value()), not the fusion.
+    // f32 nspc builds the shape-baked interior kernel, which fully unrolls the
+    // width sweep over max_p = (ur_w-1)*sw + kw input positions. Its per-channel
+    // loop body must stay within a RISC-V B-type branch's ±4 KiB reach; a very
+    // large window (e.g. a global-style kw) would overrun it and fail codegen.
+    // Decline such shapes here so dispatch falls through to the baked kernel /
+    // reference instead of building an interior kernel that cannot be generated.
+    // Realistic pooling windows are far below this bound (f16/ncsp never build
+    // the interior kernel, so they are unaffected).
+    if (d_type == data_type::f32 && jpp.tag_kind == jit_pool_tag_kind_t::nspc) {
+        constexpr int max_interior_positions = 64;
+        const int max_p = (jpp.ur_w - 1) * jpp.stride_w + jpp.kw;
+        if (max_p > max_interior_positions) return status::unimplemented;
+    }
+
+    // Post-ops fused in-kernel via the post-op injector: any eltwise chain plus
+    // any number of binaries (indirect injector mode; they share one broadcast
+    // category), for both f32 and f16 (f16 widens the accumulator to f32 before
+    // the chain; the rhs is always f32). Anything else is rejected below to
+    // ref_pooling. with_relu
+    // (f32 single-ReLU) is separate — it only feeds the empty-window fill value
+    // (empty_window_value()), not the fusion.
     const auto &po = attr.post_ops_;
     jpp.post_ops = po;
     jpp.with_postops = !po.has_default_values();
+    // Max forward-training generates the argmax workspace. Native handles both
+    // plain layouts for f32 (generate_f32, e32 index) and f16 (generate_f16, e16
+    // index); the index store is contiguous for nspc and strided for ncsp via
+    // ws_vec_byte_stride. A max-training chain may also fuse post-ops (the injector
+    // runs after the argmax is computed). f16 tracks the argmax in e16, so guard
+    // the (never-hit-by-real-pooling) window volume that would overflow a signed
+    // 16-bit index.
+    if (jpp.alg == alg_kind::pooling_max && jpp.is_training
+            && d_type == data_type::f16
+            && (int64_t)jpp.kd * jpp.kh * jpp.kw > 32768)
+        return status::unimplemented;
     jpp.with_relu = false;
-    jpp.fuse_eltwise = jpp.fuse_binary = false;
+    jpp.binary_bcast = pool_binary_bcast_t::none;
     jpp.relu_alpha = 0.f;
+    // fuse_eltwise / fuse_binary are assigned unconditionally below.
     if (po.len() == 1) {
         const auto &e = po.entry_[0];
         // with_relu is an f32-only flag feeding empty_window_value(); it is
@@ -122,26 +1005,51 @@ status_t jit_uni_pool_kernel_t<isa, d_type>::init_conf(
             jpp.relu_alpha = e.eltwise.alpha;
         }
     }
-    // Post-op chains (any number of eltwise + at most one binary, in attribute
-    // order) are fused in-kernel via the post-op injector. An eltwise-only chain
-    // fuses for both f32 (generate_f32 / interior) and f16 (generate_f16, at
-    // f32). A chain that contains the binary fuses for f32 only, via the
-    // channel-vectorized single-position path (the driver forces it when
-    // fuse_binary) so the rhs broadcast is uniform; the injector loads the rhs
-    // per channel chunk. post_ops_ok already gated the chain shape/algs.
+    // Post-op chains (any number of eltwise + any number of binaries, in
+    // attribute order) are fused in-kernel via the post-op injector, for both f32
+    // (generate_f32) and f16 (generate_f16, computed at f32). A chain that
+    // contains the binary is routed by the driver through the channel-vectorized
+    // single-position path so the rhs broadcast is uniform; the injector loads
+    // the rhs (f32) per channel chunk. post_ops_ok already gated the chain.
     const bool inj_ok
             = injector::jit_uni_postops_injector_t<isa>::post_ops_ok(po);
     bool po_has_binary = false;
     for (int i = 0; i < po.len(); i++)
         if (po.entry_[i].is_binary()) po_has_binary = true;
     jpp.fuse_eltwise = jpp.with_postops && inj_ok && !po_has_binary;
-    jpp.fuse_binary = jpp.with_postops && inj_ok && po_has_binary
-            && d_type == data_type::f32;
+    // Binary fuses at f32 for both f32 and f16 dst (f16 widens the accumulator to
+    // f32 before applying the chain). The rhs is always f32.
+    jpp.fuse_binary = jpp.with_postops && inj_ok && po_has_binary;
+
+    // Reject post-op chains this kernel cannot fully fuse so dispatch falls to
+    // the reference instead of silently dropping the post-op. The injector runs
+    // in indirect mode, so ANY number of binaries is allowed, but (like the baked
+    // kernel) they must share ONE broadcast category — the kernel positions a
+    // single shared rhs offset. src1 must be f32; broadcast in {scalar, per-oc,
+    // full-dst}. A mixed-broadcast chain goes to the reference.
+    if (jpp.with_postops) {
+        if (!inj_ok) return status::unimplemented;
+        pool_binary_bcast_t bcast = pool_binary_bcast_t::none;
+        for (int i = 0; i < po.len(); i++) {
+            if (!po.entry_[i].is_binary()) continue;
+            const auto &b = po.entry_[i].binary;
+            if (b.src1_desc.data_type != data_type::f32)
+                return status::unimplemented;
+            const memory_desc_wrapper s1(b.src1_desc);
+            const pool_binary_bcast_t k = classify_binary_src1(s1, dst_d);
+            if (k == pool_binary_bcast_t::none)
+                return status::unimplemented; // unsupported src1 layout
+            if (bcast != pool_binary_bcast_t::none && bcast != k)
+                return status::unimplemented; // mixed broadcast -> reference
+            bcast = k;
+        }
+        jpp.binary_bcast = bcast;
+    }
     return status::success;
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
-void jit_uni_pool_kernel_t<isa, d_type>::generate() {
+void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate() {
     if (d_type == data_type::f16)
         generate_f16();
     else
@@ -149,65 +1057,64 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate() {
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
-void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
+void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_f32() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const Reg reg_param = a0;
     const VReg v_mask(0);
     const VReg v_acc(4), v_tmp(8);
+    // Max forward-training (f32): track the per-channel argmax in v_ind while the
+    // window is swept, and store it to the workspace. t3 holds the running
+    // window index (reset to pos_base per channel chunk), advanced +1 per iw and
+    // by pos_ih_step/pos_id_step (from args, reloaded via a0) at row/plane ends.
+    const bool max_train = is_max_pool_ && jpp_.is_training;
+    // Max-training may also fuse post-ops (the injector runs on v_acc after the
+    // argmax is computed). When a binary is fused the ws pointer keeps s10 and the
+    // rhs origin array moves to a4, s11 carries the shared binary offset, and
+    // pos_base is reloaded per chunk (v_ind stays v28, clear of the injector).
+    const bool mt_bin = max_train && jpp_.fuse_binary;
+    const VReg v_ind(28);
+    const bool ind_u8 = jpp_.ind_dt == data_type::u8;
+    const int ind_sz = ind_u8 ? 1 : 4; // workspace index element size (u8/s32)
 
-    // Classify a fused binary post-op (if any) to pick the rhs load form. The
-    // driver routes binary through the channel-vectorized single-position path,
-    // so the lanes are channels: per-tensor -> scalar (flw); per-oc [1,C,1,..]
-    // -> [C]-contiguous per-element (vle); full-dst -> per-element strided by the
-    // dst channel stride (vlse), since src1 follows the dst layout.
-    bool bin_scalar = false, bin_strided = false;
-    if (jpp_.fuse_binary)
-        for (int i = 0; i < jpp_.post_ops.len(); i++) {
-            const auto &e = jpp_.post_ops.entry_[i];
-            if (!e.is_binary()) continue;
-            const memory_desc_wrapper s1(e.binary.src1_desc);
-            bin_scalar = s1.nelems() == 1;
-            const bool per_oc = !bin_scalar && s1.nelems() == (dim_t)jpp_.c;
-            bin_strided = !bin_scalar && !per_oc;
-        }
+    // Fused-binary rhs load form, from the broadcast category classified once in
+    // init_conf (the driver routes binary through the channel-vectorized
+    // single-position path, so the lanes are channels): scalar -> flw; per-oc
+    // [1,C,1,..] -> [C]-contiguous vle; full-dst -> per-channel strided vlse
+    // (src1 follows the dst layout).
+    const bool bin_scalar = jpp_.binary_bcast == pool_binary_bcast_t::scalar;
+    const bool bin_strided = jpp_.binary_bcast == pool_binary_bcast_t::full_dst;
 
     // Save callee-saved regs (s0-s9) holding loop invariants across the nested
     // id/ih/iw/channel loops. f32 always processes a single output position
-    // (the nspc interior heavy path uses the shape-baked kernel), so no
-    // position loop / row-unrolling is emitted here — keeping per-call overhead
-    // minimal for the high-call-count ncsp and boundary paths.
+    // (nspc interior heavy work is the baked kernel's job), so no position loop /
+    // row-unrolling is emitted here — keeping per-call overhead minimal for the
+    // high-call-count ncsp and boundary paths.
     // s10 additionally holds the binary post-op rhs pointer (advanced per
     // channel chunk) when a binary post-op is fused.
-    const int stack_size = jpp_.fuse_binary ? 96 : 80;
+    const int stack_size = (jpp_.fuse_binary || max_train) ? 96 : 80;
     addi(sp, sp, -stack_size);
-    sd(s0, sp, 0);
-    sd(s1, sp, 8);
-    sd(s2, sp, 16);
-    sd(s3, sp, 24);
-    sd(s4, sp, 32);
-    sd(s5, sp, 40);
-    sd(s6, sp, 48);
-    sd(s7, sp, 56);
-    sd(s8, sp, 64);
-    sd(s9, sp, 72);
-    if (jpp_.fuse_binary) sd(s10, sp, 80);
+    save_saved_gprs(this, 10);
+    if (jpp_.fuse_binary || max_train) {
+        sd(s10, sp, 80);
+        sd(s11, sp, 88);
+    }
 
-    // Load params from jit_uni_pooling_args_t
-    using p_t = jit_uni_pooling_args_t;
-    ld(s0, reg_param, static_cast<int>(offsetof(p_t, src)));
-    ld(s1, reg_param, static_cast<int>(offsetof(p_t, dst)));
-    ld(s2, reg_param, static_cast<int>(offsetof(p_t, channels)));
-    ld(s6, reg_param, static_cast<int>(offsetof(p_t, id_start)));
-    ld(s7, reg_param, static_cast<int>(offsetof(p_t, ih_start)));
-    ld(a1, reg_param, static_cast<int>(offsetof(p_t, iw_start)));
-    ld(t5, reg_param, static_cast<int>(offsetof(p_t, id_end)));
-    ld(t6, reg_param, static_cast<int>(offsetof(p_t, ih_end)));
-    ld(a2, reg_param, static_cast<int>(offsetof(p_t, iw_end)));
-    ld(t2, reg_param, static_cast<int>(offsetof(p_t, inW_stride)));
-    ld(t3, reg_param, static_cast<int>(offsetof(p_t, inD_stride)));
-    ld(s3, reg_param, static_cast<int>(offsetof(p_t, w_spatial_byte_stride)));
-    flw(fa0, reg_param, static_cast<int>(offsetof(p_t, init_val)));
-    flw(ft1, reg_param, static_cast<int>(offsetof(p_t, scale_val)));
+    // Load params from jit_uni_pool_ncsp_args_t
+    using p_t = jit_uni_pool_ncsp_args_t;
+    ld(s0, reg_param, GET_OFF_P(src));
+    ld(s1, reg_param, GET_OFF_P(dst));
+    ld(s2, reg_param, GET_OFF_P(channels));
+    ld(s6, reg_param, GET_OFF_P(id_start));
+    ld(s7, reg_param, GET_OFF_P(ih_start));
+    ld(a1, reg_param, GET_OFF_P(iw_start));
+    ld(t5, reg_param, GET_OFF_P(id_end));
+    ld(t6, reg_param, GET_OFF_P(ih_end));
+    ld(a2, reg_param, GET_OFF_P(iw_end));
+    ld(t2, reg_param, GET_OFF_P(inW_stride));
+    ld(t3, reg_param, GET_OFF_P(inD_stride));
+    ld(s3, reg_param, GET_OFF_P(w_spatial_byte_stride));
+    flw(fa0, reg_param, GET_OFF_P(init_val));
+    flw(ft1, reg_param, GET_OFF_P(scale_val));
 
     fmv_w_x(fa1, x0); // f_zero = 0.0
 
@@ -215,12 +1122,25 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     slli(s4, t2, 2); // inW_stride_bytes = inW_stride * 4
     slli(s5, t3, 2); // inD_stride_bytes = inD_stride * 4
 
-    ld(s8, reg_param, static_cast<int>(offsetof(p_t, src_vec_byte_stride)));
-    ld(s9, reg_param, static_cast<int>(offsetof(p_t, dst_vec_byte_stride)));
-    if (jpp_.fuse_binary)
-        ld(s10, reg_param, static_cast<int>(offsetof(p_t, post_op_rhs)));
+    ld(s8, reg_param, GET_OFF_P(src_vec_byte_stride));
+    ld(s9, reg_param, GET_OFF_P(dst_vec_byte_stride));
+    if (jpp_.fuse_binary && !max_train) {
+        // s10 = rhs origin pointer array; s11 = shared byte offset (advanced per
+        // channel chunk). The injector runs in indirect mode.
+        ld(s10, reg_param, GET_OFF_P(post_op_rhs));
+        ld(s11, reg_param, GET_OFF_P(post_op_off0));
+    }
+    if (max_train) {
+        ld(s10, reg_param, GET_OFF_P(indices));
+        // With a fused binary, s11 carries the shared rhs offset and pos_base is
+        // reloaded per chunk; otherwise s11 holds pos_base directly.
+        if (mt_bin)
+            ld(s11, reg_param, GET_OFF_P(post_op_off0));
+        else
+            ld(s11, reg_param, GET_OFF_P(pos_base));
+    }
 
-    addi(t4, x0, 4); // constant for unit-stride comparison
+    li(t4, 4); // constant for unit-stride comparison
 
     // Channel loop: process channels in vector chunks (single output position).
     Label ch_loop, ch_done;
@@ -228,7 +1148,7 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     beqz(s2, ch_done);
 
     // Set vector length for remaining channels
-    vsetvli(t0, s2, SEW::e32, LMUL::m1);
+    vsetvli(t0, s2, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
 
     // Initialize accumulator
     if (is_max_pool_) {
@@ -236,6 +1156,16 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
         vfmv_v_f(v_acc, fa0);
     } else {
         vfmv_v_f(v_acc, fa1); // zero
+    }
+    if (max_train) {
+        vmv_v_x(v_ind, x0); // argmax index accumulator = 0
+        if (mt_bin) {
+            // s11 is the binary offset; reload pos_base (a5 is free before the
+            // window sweep, which then reuses it as the iw counter).
+            ld(a5, reg_param, GET_OFF_P(pos_base));
+            mv(t3, a5);
+        } else
+            mv(t3, s11); // running window index = pos_base (reset per chunk)
     }
 
     // Depth (id) loop
@@ -278,6 +1208,10 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     if (is_max_pool_) {
         vmflt_vv(v_mask, v_acc, v_tmp);
         vmerge_vvm(v_acc, v_acc, v_tmp);
+        if (max_train) {
+            vmerge_vxm(v_ind, v_ind, t3); // ind = (acc < tmp) ? pos : ind
+            addi(t3, t3, 1); // advance window position (every iw)
+        }
     } else {
         vfadd_vv(v_acc, v_acc, v_tmp);
     }
@@ -286,11 +1220,21 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     add(a7, a7, s3); // advance src_ptr by w_spatial_byte_stride
     j_(iw_loop);
     L(iw_done);
+    // Skip the clamped-off kw positions so the window index stays full-kernel
+    // relative (pos_ih_step = KW - kw_count; reloaded via a0).
+    if (max_train) {
+        ld(t2, reg_param, GET_OFF_P(pos_ih_step));
+        add(t3, t3, t2);
+    }
 
     addi(a4, a4, 1); // ih++
     add(a6, a6, s4); // advance row_ptr by inW_stride_bytes
     j_(ih_loop);
     L(ih_done);
+    if (max_train) { // skip clamped-off kh rows (pos_id_step = KH*KW - kh_cnt*KW)
+        ld(t2, reg_param, GET_OFF_P(pos_id_step));
+        add(t3, t3, t2);
+    }
 
     addi(a3, a3, 1); // id++
     add(t1, t1, s5); // advance depth_ptr by inD_stride_bytes
@@ -300,18 +1244,25 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     // Apply avg pooling divide
     if (!is_max_pool_) { vfmul_vf(v_acc, v_acc, ft1); }
 
-    // Apply the fused post-op chain (any number of eltwise + at most one binary,
-    // in attribute order) via the in-kernel injector. Eltwise covers ReLU and
-    // the other supported algs; binary reads its rhs from s10 (host-positioned,
-    // advanced per channel chunk below). This is the f32 path; the f16 kernel
-    // fuses its eltwise chain in generate_f16 (f16 + binary -> ref_pooling).
+    // Apply the fused post-op chain (any number of eltwise + any number of
+    // binaries, in attribute order) via the in-kernel injector. Eltwise covers
+    // ReLU and the other supported algs; binary reads its rhs from s10
+    // (host-positioned, advanced per channel chunk below).
     if (jpp_.fuse_eltwise || jpp_.fuse_binary) {
         eltwise_injector::static_params_t esp(
                 VReg(12), VReg(16), VReg(20), fa3, fa4, t2, /*is_fwd=*/true);
-        // Binary rhs scratch v24/fa5; full-dst uses a strided (vlse) load keyed
-        // on the dst channel stride (s9), per-oc/scalar the contiguous form.
-        binary_injector::static_params_t bsp_contig(VReg(24), fa5, s10);
-        binary_injector::static_params_t bsp_strided(VReg(24), fa5, s10, s9);
+        // Indirect injector mode (any number of binaries): rhs origin array in
+        // s10 (or a4 when max-training, since s10 is then the ws pointer), s11 =
+        // shared byte offset, a3 = per-binary scratch. Binary rhs scratch v24/fa5
+        // (clear of v_ind = v28). full-dst uses a strided (vlse) load keyed on the
+        // dst channel stride (s9 == the f32 rhs channel stride); per-oc/scalar the
+        // contiguous form.
+        const Reg reg_rhs = mt_bin ? a4 : s10;
+        if (mt_bin) ld(a4, reg_param, GET_OFF_P(post_op_rhs));
+        binary_injector::static_params_t bsp_contig(
+                VReg(24), fa5, reg_rhs, s11, a3);
+        binary_injector::static_params_t bsp_strided(
+                VReg(24), fa5, reg_rhs, s11, a3, s9);
         injector::jit_uni_postops_injector_t<isa> po_inj(this, jpp_.post_ops,
                 esp,
                 jpp_.fuse_binary ? (bin_strided ? &bsp_strided : &bsp_contig)
@@ -327,6 +1278,38 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
         L(strided_dst);
         vsse32_v(v_acc, s1, s9);
         L(dst_st_done);
+    }
+    if (max_train) {
+        // Store the per-channel argmax to the workspace at s10. nspc: contiguous
+        // over channels (ws_vec_byte_stride == ind_sz) -> unit store. ncsp:
+        // channels are dst_spatial apart -> strided store (vsse). u8: narrow
+        // e32->e16->e8 (indices < 256); s32: direct. Uses t3 as the vsetvli
+        // scratch (free after the window sweep) so t0 (the channel vl) survives
+        // for the pointer advance below.
+        ld(t2, reg_param, GET_OFF_P(ws_vec_byte_stride));
+        li(t1, static_cast<int>(ind_sz));
+        if (ind_u8) {
+            vsetvli(t3, s2, SEW::e16, LMUL::mf2, VTA::ta, VMA::ma);
+            vnsrl_wi(v_tmp, v_ind, 0);
+            vsetvli(t3, s2, SEW::e8, LMUL::mf4, VTA::ta, VMA::ma);
+            vnsrl_wi(v_tmp, v_tmp, 0);
+            Label u8_unit, u8_done;
+            beq(t2, t1, u8_unit);
+            vsse8_v(v_tmp, s10, t2);
+            j_(u8_done);
+            L(u8_unit);
+            vse8_v(v_tmp, s10);
+            L(u8_done);
+            vsetvli(t3, s2, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
+        } else {
+            Label s32_unit, s32_done;
+            beq(t2, t1, s32_unit);
+            vsse32_v(v_ind, s10, t2);
+            j_(s32_done);
+            L(s32_unit);
+            vse32_v(v_ind, s10);
+            L(s32_done);
+        }
     }
 
     // Advance src/dst pointers by vl * stride
@@ -351,12 +1334,18 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     }
     add(s1, s1, t1);
     if (jpp_.fuse_binary && !bin_scalar) {
-        // advance the rhs by vl * per-channel byte stride (full-dst: dst channel
-        // stride s9; per-oc: contiguous element size).
+        // advance the shared rhs offset by vl * per-channel byte stride (full-dst:
+        // dst channel stride s9; per-oc: contiguous f32 element size). The origin
+        // array (s10) is fixed; the injector reads array[arg_idx] + s11.
         if (bin_strided)
             mul(t1, t0, s9);
         else
             slli(t1, t0, 2);
+        add(s11, s11, t1);
+    }
+    if (max_train) { // advance the workspace ptr by vl * ws_vec_byte_stride
+        ld(t2, reg_param, GET_OFF_P(ws_vec_byte_stride));
+        mul(t1, t0, t2);
         add(s10, s10, t1);
     }
     sub(s2, s2, t0); // channels -= vl
@@ -365,17 +1354,11 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
     L(ch_done);
 
     // Restore callee-saved regs
-    ld(s0, sp, 0);
-    ld(s1, sp, 8);
-    ld(s2, sp, 16);
-    ld(s3, sp, 24);
-    ld(s4, sp, 32);
-    ld(s5, sp, 40);
-    ld(s6, sp, 48);
-    ld(s7, sp, 56);
-    ld(s8, sp, 64);
-    ld(s9, sp, 72);
-    if (jpp_.fuse_binary) ld(s10, sp, 80);
+    restore_saved_gprs(this, 10);
+    if (jpp_.fuse_binary || max_train) {
+        ld(s10, sp, 80);
+        ld(s11, sp, 88);
+    }
     addi(sp, sp, stack_size);
 
     ret();
@@ -385,7 +1368,7 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f32() {
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
-void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
+void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_f16() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const Reg reg_param = a0;
     const VReg v_mask(0);
@@ -393,67 +1376,117 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
     // avg: v_acc(f32m2)=v4-v5, v_tmp(f16m1)=v8 (load buffer + narrowed result).
     const VReg v_acc(4), v_tmp(8);
     const VReg v_res = is_max_pool_ ? v_acc : v_tmp;
+    // Max forward-training tracks the per-channel argmax. The index fits e16 for
+    // any realistic pooling window (< 32768), so v_ind stays e16/m1 — the same
+    // vtype as the f16 data, avoiding a per-window-element vtype switch. It is
+    // narrowed to e8 (u8 ws) or widened to e32/m2 in v28 (s32 ws) only at store.
+    const bool max_train = is_max_pool_ && jpp_.is_training;
+    // Max-training may also fuse post-ops (applied to the widened f32 max before
+    // the narrow/store). When a binary is fused the ws pointer keeps s10, the rhs
+    // origin array moves to a4, the f32 rhs stride to a6, and pos_base is reloaded
+    // per chunk; s11 carries the shared binary offset.
+    const bool mt_bin = max_train && jpp_.fuse_binary;
+    // v_ind stays clear of the max-postop widen buffer (v24) and the binary rhs
+    // scratch (v28) so the argmax survives a fused post-op chain.
+    const VReg v_ind(10);
+    const bool ind_u8 = jpp_.ind_dt == data_type::u8;
+    const int ind_sz = ind_u8 ? 1 : 4;
 
     const int stack_size = 112;
     addi(sp, sp, -stack_size);
-    sd(s0, sp, 0);
-    sd(s1, sp, 8);
-    sd(s2, sp, 16);
-    sd(s3, sp, 24);
-    sd(s4, sp, 32);
-    sd(s5, sp, 40);
-    sd(s6, sp, 48);
-    sd(s7, sp, 56);
-    sd(s8, sp, 64);
-    sd(s9, sp, 72);
-    sd(s10, sp, 80);
-    sd(s11, sp, 88);
+    save_saved_gprs(this, 12);
 
-    using p_t = jit_uni_pooling_args_t;
-    ld(s0, reg_param, static_cast<int>(offsetof(p_t, src)));
-    ld(s1, reg_param, static_cast<int>(offsetof(p_t, dst)));
-    ld(s2, reg_param, static_cast<int>(offsetof(p_t, channels)));
-    ld(s6, reg_param, static_cast<int>(offsetof(p_t, id_start)));
-    ld(s7, reg_param, static_cast<int>(offsetof(p_t, ih_start)));
-    ld(a1, reg_param, static_cast<int>(offsetof(p_t, iw_start)));
-    ld(t5, reg_param, static_cast<int>(offsetof(p_t, id_end)));
-    ld(t6, reg_param, static_cast<int>(offsetof(p_t, ih_end)));
-    ld(a2, reg_param, static_cast<int>(offsetof(p_t, iw_end)));
-    ld(t2, reg_param, static_cast<int>(offsetof(p_t, inW_stride)));
-    ld(t3, reg_param, static_cast<int>(offsetof(p_t, inD_stride)));
-    ld(s3, reg_param, static_cast<int>(offsetof(p_t, w_spatial_byte_stride)));
-    flw(ft1, reg_param, static_cast<int>(offsetof(p_t, scale_val)));
+    using p_t = jit_uni_pool_ncsp_args_t;
+    ld(s0, reg_param, GET_OFF_P(src));
+    ld(s1, reg_param, GET_OFF_P(dst));
+    ld(s2, reg_param, GET_OFF_P(channels));
+    ld(s6, reg_param, GET_OFF_P(id_start));
+    ld(s7, reg_param, GET_OFF_P(ih_start));
+    ld(a1, reg_param, GET_OFF_P(iw_start));
+    ld(t5, reg_param, GET_OFF_P(id_end));
+    ld(t6, reg_param, GET_OFF_P(ih_end));
+    ld(a2, reg_param, GET_OFF_P(iw_end));
+    ld(t2, reg_param, GET_OFF_P(inW_stride));
+    ld(t3, reg_param, GET_OFF_P(inD_stride));
+    ld(s3, reg_param, GET_OFF_P(w_spatial_byte_stride));
+    flw(ft1, reg_param, GET_OFF_P(scale_val));
 
     // f16 element strides: inW_stride / inD_stride are element counts -> * 2.
     slli(s4, t2, 1);
     slli(s5, t3, 1);
 
-    ld(s8, reg_param, static_cast<int>(offsetof(p_t, src_vec_byte_stride)));
-    ld(s9, reg_param, static_cast<int>(offsetof(p_t, dst_vec_byte_stride)));
+    ld(s8, reg_param, GET_OFF_P(src_vec_byte_stride));
+    ld(s9, reg_param, GET_OFF_P(dst_vec_byte_stride));
 
-    addi(t4, x0, 2); // unit-stride comparison constant (f16 = 2 bytes)
+    li(t4, 2); // unit-stride comparison constant (f16 = 2 bytes)
 
-    mv(s10, s0);
-    mv(s11, s1);
-    ld(t0, reg_param, static_cast<int>(offsetof(p_t, n_pos)));
-    sd(t0, sp, 96);
+    // Fused-binary rhs load form, from the category classified once in init_conf
+    // (f16 computes the chain at f32; the rhs is always f32): scalar -> flw;
+    // per-oc [1,C,1,..] -> [C]-contiguous vle; full-dst -> per-channel strided
+    // vlse. The full-dst rhs channel stride is in f32 units = dst f16 channel
+    // stride (s9) * 2.
+    const bool bin_scalar = jpp_.binary_bcast == pool_binary_bcast_t::scalar;
+    const bool bin_strided = jpp_.binary_bcast == pool_binary_bcast_t::full_dst;
 
-    // In-kernel eltwise post-op injector (f16 computes the chain at f32). t1 is
-    // a scratch GPR reused across window iterations, free at the inject point.
+    if (max_train) {
+        // s10 = argmax workspace ptr. n_pos == 1, so no position loop. With a
+        // fused binary, s11 carries the shared rhs offset and pos_base is reloaded
+        // per chunk (the rhs origin array a4 and f32 rhs stride a6 are set at the
+        // inject point); otherwise s11 holds pos_base directly.
+        ld(s10, reg_param, GET_OFF_P(indices));
+        if (mt_bin)
+            ld(s11, reg_param, GET_OFF_P(post_op_off0));
+        else
+            ld(s11, reg_param, GET_OFF_P(pos_base));
+    } else if (jpp_.fuse_binary) {
+        // fuse_binary => the driver routes each output column through the
+        // single-position path (n_pos == 1), so no position loop is needed.
+        // Indirect injector mode: s10 = rhs origin array, s11 = shared byte
+        // offset, t3 = f32 rhs channel stride for full-dst (= 2 * the f16 dst
+        // channel stride s9; the rhs is f32 while the dst is f16). t3 held
+        // inD_stride only until s5 was derived above, so it is free here.
+        ld(s10, reg_param, GET_OFF_P(post_op_rhs));
+        ld(s11, reg_param, GET_OFF_P(post_op_off0));
+        slli(t3, s9, 1);
+    } else {
+        mv(s10, s0);
+        mv(s11, s1);
+        ld(t0, reg_param, GET_OFF_P(n_pos));
+        sd(t0, sp, kNativePosSpill);
+    }
+
+    // In-kernel post-op injector (f16 computes the chain at f32). t1 is a scratch
+    // GPR reused across window iterations, free at the inject point. The binary
+    // rhs scratch is v28/fa5 (f32); v24 is reserved for the max widen buffer.
     post_ops_t no_po;
     eltwise_injector::static_params_t esp(
             VReg(12), VReg(16), VReg(20), fa3, fa4, t1, /*is_fwd=*/true);
-    injector::jit_uni_postops_injector_t<isa> po_inj(
-            this, jpp_.fuse_eltwise ? jpp_.post_ops : no_po, esp);
+    // Indirect mode (any number of binaries): rhs origin array in s10 (or a4 when
+    // max-training, since s10 is then the ws pointer), s11 = shared byte offset,
+    // a3 = per-binary scratch. full-dst uses a strided (vlse) f32 load keyed on
+    // the f32 rhs channel stride (t3, or a6 when max-training); per-oc/scalar vle.
+    const Reg reg_rhs = mt_bin ? a4 : s10;
+    const Reg reg_stride = mt_bin ? a6 : t3;
+    binary_injector::static_params_t bsp_contig(
+            VReg(28), fa5, reg_rhs, s11, a3);
+    binary_injector::static_params_t bsp_strided(
+            VReg(28), fa5, reg_rhs, s11, a3, reg_stride);
+    injector::jit_uni_postops_injector_t<isa> po_inj(this,
+            (jpp_.fuse_eltwise || jpp_.fuse_binary) ? jpp_.post_ops : no_po,
+            esp,
+            jpp_.fuse_binary ? (bin_strided ? &bsp_strided : &bsp_contig)
+                             : nullptr);
 
     Label pos_loop, pos_done;
-    L(pos_loop);
-    ld(t0, sp, 96);
-    beqz(t0, pos_done);
+    if (!jpp_.fuse_binary && !max_train) {
+        L(pos_loop);
+        ld(t0, sp, kNativePosSpill);
+        beqz(t0, pos_done);
 
-    mv(s0, s10);
-    mv(s1, s11);
-    ld(s2, reg_param, static_cast<int>(offsetof(p_t, channels)));
+        mv(s0, s10);
+        mv(s1, s11);
+    }
+    ld(s2, reg_param, GET_OFF_P(channels));
 
     Label ch_loop, ch_done;
     L(ch_loop);
@@ -462,14 +1495,24 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
     // Initialize accumulator. Use vmv.v.x with the raw bit pattern to avoid
     // f16 scalar NaN-boxing concerns.
     if (is_max_pool_) {
-        vsetvli(t0, s2, SEW::e16, LMUL::m1);
+        vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         li(t1, 0xFBFF); // f16 lowest (-65504.0)
         vmv_v_x(v_acc, t1);
+        if (max_train) {
+            vmv_v_x(v_ind, x0); // argmax index accumulator = 0 (e16m1)
+            if (mt_bin) {
+                // s11 is the binary offset; reload pos_base (a5 is free before the
+                // window sweep, which then reuses it as the iw counter).
+                ld(a5, reg_param, GET_OFF_P(pos_base));
+                mv(t3, a5);
+            } else
+                mv(t3, s11); // running window index = pos_base (reset per chunk)
+        }
     } else {
         // avg: f32m2 accumulator zeroed; window runs under e16/m1 (same vl).
-        vsetvli(t0, s2, SEW::e32, LMUL::m2);
+        vsetvli(t0, s2, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
         vmv_v_x(v_acc, x0);
-        vsetvli(t0, s2, SEW::e16, LMUL::m1);
+        vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
     }
 
     mv(a3, s6);
@@ -505,6 +1548,10 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
     if (is_max_pool_) {
         vmflt_vv(v_mask, v_acc, v_tmp);
         vmerge_vvm(v_acc, v_acc, v_tmp);
+        if (max_train) {
+            vmerge_vxm(v_ind, v_ind, t3); // ind = (acc < tmp) ? cur_idx : ind
+            addi(t3, t3, 1); // advance window position (every iw)
+        }
     } else {
         // f32m2 += widen(f16m1), evaluated under the e16 vtype.
         vfwadd_wv(v_acc, v_acc, v_tmp);
@@ -514,11 +1561,21 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
     add(a7, a7, s3);
     j_(iw_loop);
     L(iw_done);
+    // Skip clamped-off kw positions so the window index stays full-kernel
+    // relative (pos_ih_step = KW - kw_count).
+    if (max_train) {
+        ld(t2, reg_param, GET_OFF_P(pos_ih_step));
+        add(t3, t3, t2);
+    }
 
     addi(a4, a4, 1);
     add(a6, a6, s4);
     j_(ih_loop);
     L(ih_done);
+    if (max_train) { // skip clamped-off kh rows (pos_id_step = KH*KW - kh*KW)
+        ld(t2, reg_param, GET_OFF_P(pos_id_step));
+        add(t3, t3, t2);
+    }
 
     addi(a3, a3, 1);
     add(t1, t1, s5);
@@ -528,19 +1585,27 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
     // avg: scale (e32/m2), apply the fused eltwise post-op (at f32), then narrow
     // to f16 (e16/m1).
     if (!is_max_pool_) {
-        vsetvli(t0, s2, SEW::e32, LMUL::m2);
+        vsetvli(t0, s2, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
         vfmul_vf(v_acc, v_acc, ft1);
-        if (jpp_.fuse_eltwise) po_inj.compute_vector(v_acc.getIdx());
-        vsetvli(t0, s2, SEW::e16, LMUL::m1);
+        if (jpp_.fuse_eltwise || jpp_.fuse_binary)
+            po_inj.compute_vector(v_acc.getIdx());
+        vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vfncvt_f_f_w(v_tmp, v_acc);
-    } else if (jpp_.fuse_eltwise) {
-        // max: the accumulator is f16; widen to f32 (v24/m2), apply the eltwise
-        // injector, then narrow back in place so the store path is unchanged.
-        vsetvli(t0, s2, SEW::e16, LMUL::m1);
+    } else if (jpp_.fuse_eltwise || jpp_.fuse_binary) {
+        // max: the accumulator is f16; widen to f32 (v24/m2), apply the post-op
+        // chain (eltwise and/or binary, rhs in v28), then narrow back in place
+        // so the store path is unchanged. For max-training the rhs origin array
+        // (a4) and f32 rhs stride (a6) are positioned here (s10/t3 hold the ws
+        // pointer / argmax scratch), free after the window sweep.
+        if (mt_bin) {
+            ld(a4, reg_param, GET_OFF_P(post_op_rhs));
+            slli(a6, s9, 1); // f32 rhs channel stride (= 2 * f16 dst stride)
+        }
+        vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vfwcvt_f_f_v(VReg(24), v_acc);
-        vsetvli(t0, s2, SEW::e32, LMUL::m2);
+        vsetvli(t0, s2, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
         po_inj.compute_vector(24);
-        vsetvli(t0, s2, SEW::e16, LMUL::m1);
+        vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vfncvt_f_f_w(v_acc, VReg(24));
     }
 
@@ -552,6 +1617,37 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
         L(strided_dst);
         vsse16_v(v_res, s1, s9);
         L(dst_st_done);
+    }
+    if (max_train) {
+        // Store the per-channel argmax (e16m1) to the workspace at s10. u8:
+        // narrow e16->e8; s32: widen e16->e32 (v28/m2). unit (nspc,
+        // ws_vec_byte_stride == ind_sz) vs strided (ncsp). t3 is the vsetvli
+        // scratch (free after the window sweep) so t0 (the channel vl) survives.
+        ld(t2, reg_param, GET_OFF_P(ws_vec_byte_stride));
+        li(t1, static_cast<int>(ind_sz));
+        if (ind_u8) {
+            vsetvli(t3, s2, SEW::e8, LMUL::mf2, VTA::ta, VMA::ma);
+            vnsrl_wi(v_tmp, v_ind, 0);
+            Label u8_unit, u8_done;
+            beq(t2, t1, u8_unit);
+            vsse8_v(v_tmp, s10, t2);
+            j_(u8_done);
+            L(u8_unit);
+            vse8_v(v_tmp, s10);
+            L(u8_done);
+        } else {
+            vsetvli(t3, s2, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+            vzext_vf2(v28, v_ind);
+            Label s32_unit, s32_done;
+            beq(t2, t1, s32_unit);
+            vsse32_v(v28, s10, t2);
+            j_(s32_done);
+            L(s32_unit);
+            vse32_v(v28, s10);
+            L(s32_done);
+        }
+        vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta,
+                VMA::ma); // restore e16 vtype (t0 = channel vl)
     }
 
     // Advance src/dst by vl * stride (f16 unit stride = vl * 2).
@@ -575,33 +1671,40 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
         L(dst_adv_done);
     }
     add(s1, s1, t1);
+    if (jpp_.fuse_binary && !bin_scalar) {
+        // advance the shared offset; the origin array is fixed. full-dst: vl *
+        // f32 channel stride (2 * s9); per-oc: vl * sizeof(f32). Derived from s9
+        // (t3 may hold the argmax scratch during max-training).
+        if (bin_strided) {
+            mul(t1, t0, s9);
+            slli(t1, t1, 1);
+        } else
+            slli(t1, t0, 2);
+        add(s11, s11, t1);
+    }
+    if (max_train) { // advance the workspace ptr by vl * ws_vec_byte_stride
+        ld(t2, reg_param, GET_OFF_P(ws_vec_byte_stride));
+        mul(t1, t0, t2);
+        add(s10, s10, t1);
+    }
     sub(s2, s2, t0);
 
     j_(ch_loop);
     L(ch_done);
 
-    ld(t0, reg_param, static_cast<int>(offsetof(p_t, pos_src_byte_stride)));
-    add(s10, s10, t0);
-    ld(t0, reg_param, static_cast<int>(offsetof(p_t, pos_dst_byte_stride)));
-    add(s11, s11, t0);
-    ld(t0, sp, 96);
-    addi(t0, t0, -1);
-    sd(t0, sp, 96);
-    j_(pos_loop);
-    L(pos_done);
+    if (!jpp_.fuse_binary && !max_train) {
+        ld(t0, reg_param, GET_OFF_P(pos_src_byte_stride));
+        add(s10, s10, t0);
+        ld(t0, reg_param, GET_OFF_P(pos_dst_byte_stride));
+        add(s11, s11, t0);
+        ld(t0, sp, kNativePosSpill);
+        addi(t0, t0, -1);
+        sd(t0, sp, kNativePosSpill);
+        j_(pos_loop);
+        L(pos_done);
+    }
 
-    ld(s0, sp, 0);
-    ld(s1, sp, 8);
-    ld(s2, sp, 16);
-    ld(s3, sp, 24);
-    ld(s4, sp, 32);
-    ld(s5, sp, 40);
-    ld(s6, sp, 48);
-    ld(s7, sp, 56);
-    ld(s8, sp, 64);
-    ld(s9, sp, 72);
-    ld(s10, sp, 80);
-    ld(s11, sp, 88);
+    restore_saved_gprs(this, 12);
     addi(sp, sp, stack_size);
     ret();
 #else
@@ -609,8 +1712,8 @@ void jit_uni_pool_kernel_t<isa, d_type>::generate_f16() {
 #endif
 }
 
-template struct jit_uni_pool_kernel_t<v, data_type::f32>;
-template struct jit_uni_pool_kernel_t<zvfh, data_type::f16>;
+template struct jit_uni_pool_ncsp_kernel_t<v, data_type::f32>;
+template struct jit_uni_pool_ncsp_kernel_t<zvfh, data_type::f16>;
 
 // === Shape-baked interior kernel (nspc, ur_w input reuse) ===
 
@@ -618,7 +1721,8 @@ template <cpu_isa_t isa, data_type_t d_type>
 jit_uni_pool_interior_kernel_t<isa, d_type>::jit_uni_pool_interior_kernel_t(
         const jit_pool_conf_t &ajpp)
     : jit_generator_t("jit_rvv_pool_interior"), jpp_(ajpp) {
-    create_kernel();
+    // create_kernel() is called (and CHECK'd) by the primitive's init(); a
+    // codegen failure must propagate a status, not be swallowed here.
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
@@ -658,29 +1762,18 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
     // Prologue: save s0-s11.
     const int stack = 96;
     addi(sp, sp, -stack);
-    sd(s0, sp, 0);
-    sd(s1, sp, 8);
-    sd(s2, sp, 16);
-    sd(s3, sp, 24);
-    sd(s4, sp, 32);
-    sd(s5, sp, 40);
-    sd(s6, sp, 48);
-    sd(s7, sp, 56);
-    sd(s8, sp, 64);
-    sd(s9, sp, 72);
-    sd(s10, sp, 80);
-    sd(s11, sp, 88);
+    save_saved_gprs(this, 12);
 
     // Persistent state (survives the block/channel/window loops).
-    ld(s0, reg_param, (int)offsetof(p_t, src)); // block_base_src
-    ld(s1, reg_param, (int)offsetof(p_t, dst)); // block_base_dst
-    ld(s2, reg_param, (int)offsetof(p_t, channels)); // channels_orig
-    ld(s3, reg_param, (int)offsetof(p_t, kh_count));
-    ld(s4, reg_param, (int)offsetof(p_t, kd_count));
-    ld(s5, reg_param, (int)offsetof(p_t, w_stride));
-    ld(s6, reg_param, (int)offsetof(p_t, inW_stride));
-    ld(s7, reg_param, (int)offsetof(p_t, inD_stride));
-    ld(s10, reg_param, (int)offsetof(p_t, n_blocks));
+    ld(s0, reg_param, GET_OFF_P(src)); // block_base_src
+    ld(s1, reg_param, GET_OFF_P(dst)); // block_base_dst
+    ld(s2, reg_param, GET_OFF_P(channels)); // channels_orig
+    ld(s3, reg_param, GET_OFF_P(kh_count));
+    ld(s4, reg_param, GET_OFF_P(kd_count));
+    ld(s5, reg_param, GET_OFF_P(w_stride));
+    ld(s6, reg_param, GET_OFF_P(inW_stride));
+    ld(s7, reg_param, GET_OFF_P(inD_stride));
+    ld(s10, reg_param, GET_OFF_P(n_blocks));
     // Per-block base strides derived from w_stride: src advances ur_w*sw W
     // positions, dst advances ur_w output columns (dst column stride == w_stride
     // for nspc).
@@ -694,7 +1787,7 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
     fmv_w_x(fa0, t0);
     fmv_w_x(fa3, x0); // zero
     if (is_avg_exclude) {
-        flw(fa1, reg_param, (int)offsetof(p_t, scale_val));
+        flw(fa1, reg_param, GET_OFF_P(scale_val));
     } else if (!is_max) { // avg_include: scale is baked
         li(t0, fbits(avg_inc_scale));
         fmv_w_x(fa1, t0);
@@ -721,7 +1814,7 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
     Label ch_loop, ch_done;
     L(ch_loop);
     beqz(a6, ch_done);
-    vsetvli(t0, a6, SEW::e32, LMUL::m1); // vl in t0
+    vsetvli(t0, a6, SEW::e32, LMUL::m1, VTA::ta, VMA::ma); // vl in t0
 
     for (int j = 0; j < ur_w; j++)
         vfmv_v_f(acc(j), fa0);
@@ -793,24 +1886,346 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
     L(block_done);
 
     // Epilogue.
-    ld(s0, sp, 0);
-    ld(s1, sp, 8);
-    ld(s2, sp, 16);
-    ld(s3, sp, 24);
-    ld(s4, sp, 32);
-    ld(s5, sp, 40);
-    ld(s6, sp, 48);
-    ld(s7, sp, 56);
-    ld(s8, sp, 64);
-    ld(s9, sp, 72);
-    ld(s10, sp, 80);
-    ld(s11, sp, 88);
+    restore_saved_gprs(this, 12);
     addi(sp, sp, stack);
     ret();
 }
 #endif
 
 template struct jit_uni_pool_interior_kernel_t<v, data_type::f32>;
+
+// ===================== native gather backward kernel =======================
+// One kernel call handles one input position: accumulate the diff_dst channel
+// rows of the covering outputs (listed in jit_uni_pool_bwd_contrib_t) into the
+// input's diff_src channel row and store it once. Channels are the vector dim
+// (VLA); unit-stride for nspc, strided for ncsp. max adds diff_dst only where the
+// stored argmax matches the contribution index; avg adds diff_dst * scale.
+
+template <cpu_isa_t isa, data_type_t d_type>
+jit_uni_pool_bwd_kernel_t<isa, d_type>::jit_uni_pool_bwd_kernel_t(
+        const jit_pool_conf_t &jpp)
+    : jit_generator_t(jpp.alg == alg_kind::pooling_max ? "jit_rvv_pool_bwd_max"
+                                                       : "jit_rvv_pool_bwd_avg")
+    , jpp_(jpp)
+    , is_max_pool_(jpp.alg == alg_kind::pooling_max) {
+    // create_kernel() is called (and CHECK'd) by the primitive's init(); a
+    // codegen failure must propagate a status, not be swallowed here.
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+status_t jit_uni_pool_bwd_kernel_t<isa, d_type>::init_conf(
+        jit_pool_conf_t &jpp, const pooling_pd_t *ppd) {
+    using namespace alg_kind;
+    using namespace format_tag;
+
+    const memory_desc_wrapper src_d(ppd->diff_src_md());
+    const memory_desc_wrapper dst_d(ppd->diff_dst_md());
+    const int ndims = src_d.ndims();
+    const auto &pd = *ppd->desc();
+
+    set_pool_spatial_dims(jpp, src_d, dst_d, pd);
+    jpp.c = src_d.dims()[1];
+    jpp.c_without_padding = jpp.c;
+
+    jpp.alg = pd.alg_kind;
+    jpp.is_backward = true;
+    jpp.is_training = false;
+    jpp.ind_dt = ppd->workspace_md() ? ppd->workspace_md()->data_type
+                                     : data_type::undef;
+    jpp.src_dt = src_d.data_type();
+    jpp.dst_dt = dst_d.data_type();
+    jpp.dt_size = types::data_type_size(jpp.src_dt);
+    jpp.is_f16 = d_type == data_type::f16;
+    jpp.isa = isa;
+    jpp.nthr = dnnl_get_max_threads();
+
+    // Native path: nspc or ncsp (plain layouts). blocked -> baked kernel.
+    const auto nspc_tag = utils::pick(ndims - 3, nwc, nhwc, ndhwc);
+    const auto ncsp_tag = utils::pick(ndims - 3, ncw, nchw, ncdhw);
+    if (src_d.matches_tag(nspc_tag) && dst_d.matches_tag(nspc_tag))
+        jpp.tag_kind = jit_pool_tag_kind_t::nspc;
+    else if (src_d.matches_tag(ncsp_tag) && dst_d.matches_tag(ncsp_tag))
+        jpp.tag_kind = jit_pool_tag_kind_t::ncsp;
+    else
+        return status::unimplemented;
+    jpp.use_native = true;
+
+    // The per-input covering-output count is bounded by ceil(K/S)+1 per spatial
+    // dim (and by the output extent). Decline windows that could exceed the cap
+    // so the driver's fixed stack contribution array can never overflow.
+    auto cov = [](int k, int s, int o) {
+        return nstl::min(o, utils::div_up(k, s) + 1);
+    };
+    const int64_t bound = (int64_t)cov(jpp.kd, jpp.stride_d, jpp.od)
+            * cov(jpp.kh, jpp.stride_h, jpp.oh)
+            * cov(jpp.kw, jpp.stride_w, jpp.ow);
+    if (bound > max_contrib) return status::unimplemented;
+
+    jpp.post_ops = post_ops_t();
+    jpp.with_postops = false;
+    jpp.fuse_eltwise = jpp.fuse_binary = false;
+    jpp.with_relu = false;
+    jpp.binary_bcast = pool_binary_bcast_t::none; // backward has default attrs
+    return status::success;
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_pool_bwd_kernel_t<isa, d_type>::generate() {
+    if (d_type == data_type::f16)
+        generate_f16();
+    else
+        generate_f32();
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_pool_bwd_kernel_t<isa, d_type>::generate_f32() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    using a_t = jit_uni_pool_bwd_args_t;
+    using c_t = jit_uni_pool_bwd_contrib_t;
+    const Reg reg_param = a0;
+    const VReg v_mask(0), v_acc(4), v_tmp(8), v_ws(12), v_ws_raw(16),
+            v_zero(20);
+    const bool ind_u8 = jpp_.ind_dt == data_type::u8;
+    const int csize = static_cast<int>(sizeof(c_t));
+
+    const int stack_size = 80; // save s0-s8
+    addi(sp, sp, -stack_size);
+    save_saved_gprs(this, 9);
+
+    ld(s0, reg_param, GET_OFF_A(diff_src));
+    ld(s1, reg_param, GET_OFF_A(contribs));
+    ld(s2, reg_param, GET_OFF_A(count));
+    ld(s3, reg_param, GET_OFF_A(channels));
+    ld(s4, reg_param, GET_OFF_A(src_vec_byte_stride));
+    ld(s5, reg_param, GET_OFF_A(dst_vec_byte_stride));
+    if (is_max_pool_) ld(s6, reg_param, GET_OFF_A(ws_vec_byte_stride));
+    mv(s7, x0); // diff_dst running channel byte offset
+    if (is_max_pool_) mv(s8, x0); // ws running channel byte offset
+    li(t4, 4); // f32 unit-stride comparison constant
+
+    Label ch_loop, ch_done;
+    L(ch_loop);
+    beqz(s3, ch_done);
+    vsetvli(t0, s3, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
+    vmv_v_x(v_acc, x0); // acc = 0
+    if (is_max_pool_) vmv_v_x(v_zero, x0);
+
+    // Contribution loop: accumulate each covering output's diff_dst channel row.
+    mv(a1, s1); // contrib ptr
+    mv(a2, s2); // count remaining
+    Label c_loop, c_done;
+    L(c_loop);
+    beqz(a2, c_done);
+    ld(a3, a1, GET_OFF_C(diff_dst));
+    add(a3, a3, s7);
+    {
+        Label str, done;
+        bne(s5, t4, str);
+        vle32_v(v_tmp, a3);
+        j_(done);
+        L(str);
+        vlse32_v(v_tmp, a3, s5);
+        L(done);
+    }
+    if (is_max_pool_) {
+        ld(a4, a1, GET_OFF_C(ws));
+        add(a4, a4, s8);
+        lw(a5, a1, GET_OFF_C(index));
+        if (ind_u8) {
+            Label str, done;
+            li(t1, 1);
+            vsetvli(t2, s3, SEW::e8, LMUL::mf4, VTA::ta, VMA::ma);
+            bne(s6, t1, str);
+            vle8_v(v_ws_raw, a4);
+            j_(done);
+            L(str);
+            vlse8_v(v_ws_raw, a4, s6);
+            L(done);
+            vsetvli(t2, s3, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
+            vzext_vf4(v_ws, v_ws_raw); // u8 index -> e32
+        } else {
+            Label str, done;
+            li(t1, 4);
+            bne(s6, t1, str);
+            vle32_v(v_ws, a4);
+            j_(done);
+            L(str);
+            vlse32_v(v_ws, a4, s6);
+            L(done);
+        }
+        vmseq_vx(v_mask, v_ws, a5); // mask = (ws == index)
+        vmerge_vvm(v_tmp, v_zero, v_tmp); // v_tmp = mask ? diff_dst : 0
+        vfadd_vv(v_acc, v_acc, v_tmp);
+    } else {
+        flw(fa0, a1, GET_OFF_C(scale));
+        vfmacc_vf(v_acc, fa0, v_tmp); // acc += scale * diff_dst
+    }
+    addi(a1, a1, csize);
+    addi(a2, a2, -1);
+    j_(c_loop);
+    L(c_done);
+
+    // Store the accumulated diff_src channel row (0 if no covering output).
+    {
+        Label str, done;
+        bne(s4, t4, str);
+        vse32_v(v_acc, s0);
+        j_(done);
+        L(str);
+        vsse32_v(v_acc, s0, s4);
+        L(done);
+    }
+    // Advance to the next channel chunk (uniform vl * channel byte stride).
+    mul(t1, t0, s4);
+    add(s0, s0, t1);
+    mul(t1, t0, s5);
+    add(s7, s7, t1);
+    if (is_max_pool_) {
+        mul(t1, t0, s6);
+        add(s8, s8, t1);
+    }
+    sub(s3, s3, t0);
+    j_(ch_loop);
+    L(ch_done);
+
+    restore_saved_gprs(this, 9);
+    addi(sp, sp, stack_size);
+    ret();
+#else
+    ret();
+#endif
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_pool_bwd_kernel_t<isa, d_type>::generate_f16() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    using a_t = jit_uni_pool_bwd_args_t;
+    using c_t = jit_uni_pool_bwd_contrib_t;
+    const Reg reg_param = a0;
+    // acc/wide/ws/zero are f32/e32m2 (v4,v12,v16,v24); the f16 load and the
+    // narrowed store result share v8 (e16m1); v_ws_raw (v20) is the raw u8 load.
+    const VReg v_mask(0), v_acc(4), v_ddst(8), v_wide(12), v_ws(16),
+            v_ws_raw(20), v_zero(24);
+    const bool ind_u8 = jpp_.ind_dt == data_type::u8;
+    const int csize = static_cast<int>(sizeof(c_t));
+
+    const int stack_size = 80;
+    addi(sp, sp, -stack_size);
+    save_saved_gprs(this, 9);
+
+    ld(s0, reg_param, GET_OFF_A(diff_src));
+    ld(s1, reg_param, GET_OFF_A(contribs));
+    ld(s2, reg_param, GET_OFF_A(count));
+    ld(s3, reg_param, GET_OFF_A(channels));
+    ld(s4, reg_param, GET_OFF_A(src_vec_byte_stride));
+    ld(s5, reg_param, GET_OFF_A(dst_vec_byte_stride));
+    if (is_max_pool_) ld(s6, reg_param, GET_OFF_A(ws_vec_byte_stride));
+    mv(s7, x0);
+    if (is_max_pool_) mv(s8, x0);
+    li(t4, 2); // f16 unit-stride comparison constant
+
+    Label ch_loop, ch_done;
+    L(ch_loop);
+    beqz(s3, ch_done);
+    // f32m2 accumulator; e32m2 and e16m1 share the same vl (equal VLMAX), so t0
+    // (set here) is the channel vl reused by every vsetvli below.
+    vsetvli(t0, s3, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+    vmv_v_x(v_acc, x0);
+    if (is_max_pool_) vmv_v_x(v_zero, x0);
+
+    mv(a1, s1);
+    mv(a2, s2);
+    Label c_loop, c_done;
+    L(c_loop);
+    beqz(a2, c_done);
+    ld(a3, a1, GET_OFF_C(diff_dst));
+    add(a3, a3, s7);
+    vsetvli(t2, s3, SEW::e16, LMUL::m1, VTA::ta,
+            VMA::ma); // f16 load vtype (vl == t0)
+    {
+        Label str, done;
+        bne(s5, t4, str);
+        vle16_v(v_ddst, a3);
+        j_(done);
+        L(str);
+        vlse16_v(v_ddst, a3, s5);
+        L(done);
+    }
+    vfwcvt_f_f_v(v_wide, v_ddst); // f16 -> f32m2 (reads the e16 narrow vtype)
+    if (is_max_pool_) {
+        ld(a4, a1, GET_OFF_C(ws));
+        add(a4, a4, s8);
+        lw(a5, a1, GET_OFF_C(index));
+        if (ind_u8) {
+            Label str, done;
+            li(t1, 1);
+            vsetvli(t2, s3, SEW::e8, LMUL::mf2, VTA::ta, VMA::ma);
+            bne(s6, t1, str);
+            vle8_v(v_ws_raw, a4);
+            j_(done);
+            L(str);
+            vlse8_v(v_ws_raw, a4, s6);
+            L(done);
+            vsetvli(t2, s3, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+            vzext_vf4(v_ws, v_ws_raw);
+        } else {
+            Label str, done;
+            li(t1, 4);
+            vsetvli(t2, s3, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+            bne(s6, t1, str);
+            vle32_v(v_ws, a4);
+            j_(done);
+            L(str);
+            vlse32_v(v_ws, a4, s6);
+            L(done);
+        }
+        vmseq_vx(v_mask, v_ws, a5);
+        vmerge_vvm(v_wide, v_zero, v_wide); // mask ? wide : 0
+        vfadd_vv(v_acc, v_acc, v_wide);
+    } else {
+        vsetvli(t2, s3, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+        flw(fa0, a1, GET_OFF_C(scale));
+        vfmacc_vf(v_acc, fa0, v_wide);
+    }
+    addi(a1, a1, csize);
+    addi(a2, a2, -1);
+    j_(c_loop);
+    L(c_done);
+
+    // Narrow the f32 accumulator to f16 and store.
+    vsetvli(t2, s3, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+    vfncvt_f_f_w(v_ddst, v_acc);
+    {
+        Label str, done;
+        bne(s4, t4, str);
+        vse16_v(v_ddst, s0);
+        j_(done);
+        L(str);
+        vsse16_v(v_ddst, s0, s4);
+        L(done);
+    }
+    mul(t1, t0, s4);
+    add(s0, s0, t1);
+    mul(t1, t0, s5);
+    add(s7, s7, t1);
+    if (is_max_pool_) {
+        mul(t1, t0, s6);
+        add(s8, s8, t1);
+    }
+    sub(s3, s3, t0);
+    j_(ch_loop);
+    L(ch_done);
+
+    restore_saved_gprs(this, 9);
+    addi(sp, sp, stack_size);
+    ret();
+#else
+    ret();
+#endif
+}
+
+template struct jit_uni_pool_bwd_kernel_t<v, data_type::f32>;
+template struct jit_uni_pool_bwd_kernel_t<zvfh, data_type::f16>;
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/rv64/jit_uni_pool_kernel.hpp
@@ -18,7 +18,11 @@
 #ifndef CPU_RV64_JIT_UNI_POOL_KERNEL_HPP
 #define CPU_RV64_JIT_UNI_POOL_KERNEL_HPP
 
+#include <functional>
+#include <memory>
+
 #include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
 #include "common/primitive_attr.hpp"
 
 #include "cpu/cpu_pooling_pd.hpp"
@@ -31,25 +35,156 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
-// Forward pooling kernel for the agnostic (runtime-shape) path. Templated on
-// isa and data type: generate_f32() emits the f32 path and generate_f16() the
-// zvfh f16 path, so the generated code differs per d_type. The kernel is
-// vector-length-agnostic (vsetvli) and shape-agnostic (window/strides come in
-// via jit_uni_pooling_args_t), so one routine per instantiation serves ncsp,
-// OW==1, the nspc boundary columns, and (for f16) the whole nspc row.
-template <cpu_isa_t isa, impl::data_type_t d_type>
+// x64/aarch64-style pooling kernel for the blocked (nChw{c_block}c) and nspc
+// layouts. Faithful port of aarch64 jit_uni_pool_kernel_t: the pooling window is
+// baked into the generated code, ur output columns share loaded inputs, and
+// channels are the vector dimension (one m1 register == c_block f32 lanes,
+// c_block = min(VLEN/32, 16), one of {4,8,16}). Covers forward inference,
+// forward training (max index workspace), and backward (max via index, avg).
+// f16 accumulates in f32 (widen on load, narrow on store, requires zvfh).
+//
+// RVV adaptation notes:
+//   - ur_bc is always 1 (one channel block per call); the driver loops nb_c
+//     blocks. Channel tail (nspc, C not a multiple of c_block) is handled by
+//     vsetvli(vl=c_tail) for the last block — no predicate masks.
+//   - blocked with padded channels (is_c_padded) is declined to the reference.
+//   - Register map: v0=mask, v1..v3=eltwise injector scratch, v4=binary rhs
+//     scratch, v5..v7=compute transients, v8..v31=24-register acc/input/index
+//     tile (vreg(i)=v8+i). Post-ops apply after the window loop (inputs dead).
+template <cpu_isa_t isa>
 struct jit_uni_pool_kernel_t : public jit_generator_t {
 
-    jit_uni_pool_kernel_t(const jit_pool_conf_t &jpp);
+    jit_uni_pool_kernel_t(
+            const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md);
+    ~jit_uni_pool_kernel_t() override;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_pool_kernel_t)
 
-    // Populate jpp from the primitive descriptor (dims, strides, window, pad,
-    // algorithm, memory tag, post-ops). Mirrors aarch64/x64 init_conf.
-    static status_t init_conf(jit_pool_conf_t &jpp, primitive_attr_t &attr,
+    static status_t init_conf(jit_pool_conf_t &jpp,
+            memory_tracking::registrar_t &scratchpad, primitive_attr_t &attr,
             const pooling_pd_t *ppd);
 
     void operator()(const jit_uni_pooling_args_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+    jit_pool_conf_t jpp;
+
+private:
+    using Vmm = Xbyak_riscv::VReg;
+    using Reg = Xbyak_riscv::Reg;
+    using FReg = Xbyak_riscv::FReg;
+
+    // Tile registers: 24-register acc/input/index space at v8..v31.
+    static constexpr int tile_base = 8;
+    static constexpr int tile_size = 24;
+    Vmm vreg(int idx) const { return Vmm(tile_base + idx); }
+    static int reg_ind(int shift, int j, int ur_w) { return shift * ur_w + j; }
+
+    // Reserved scratch (see class comment).
+    const Vmm v_mask = Vmm(0);
+    const Vmm v_eltw0 = Vmm(1), v_eltw1 = Vmm(2), v_eltw2 = Vmm(3);
+    const Vmm v_bin_rhs = Vmm(4);
+    const Vmm v_tmp = Vmm(5); // init value / avg divisor / area / conversions
+    const Vmm v_one = Vmm(6); // integer 1 (index increment, training)
+    const Vmm v_k_offset = Vmm(7); // running kernel-index (training/backward)
+
+    // GPRs (callee-saved s* are preserved by the manual preamble).
+    const Reg reg_param = Xbyak_riscv::a0;
+    const Reg reg_input = Xbyak_riscv::s0;
+    const Reg reg_output = Xbyak_riscv::s1;
+    const Reg reg_index = Xbyak_riscv::s2;
+    const Reg reg_kh = Xbyak_riscv::s3; // kh_padding count
+    const Reg reg_k_shift = Xbyak_riscv::s4; // kh_padding_shift (index base)
+    const Reg reg_kd_pad_shift = Xbyak_riscv::s5; // 3d backward index shift
+    const Reg reg_bc = Xbyak_riscv::s6; // b_c (channel-block index)
+    const Reg aux_reg_input = Xbyak_riscv::s7;
+    const Reg aux_reg_input_d = Xbyak_riscv::s8;
+    const Reg reg_kd = Xbyak_riscv::s9; // 3d kd loop counter
+    const Reg reg_rhs = Xbyak_riscv::s10; // binary post-op rhs ptr array
+    const Reg reg_vl = Xbyak_riscv::s11; // channel AVL for this call
+
+    // FP scratch.
+    const FReg f_tmp = Xbyak_riscv::ft0;
+    const FReg f_area
+            = Xbyak_riscv::ft1; // ker_area_h (avg_exclude divisor base)
+    const FReg f_eltw0 = Xbyak_riscv::fa4; // eltwise injector scratch
+    const FReg f_eltw1 = Xbyak_riscv::fa5;
+    const FReg f_bin = Xbyak_riscv::fa6; // binary injector scalar scratch
+
+    int prev_kw = 0;
+
+    // Set the active vl for this call's channel block (c_block or, for the nspc
+    // tail block, c_tail) at SEW=e32/m1. Uses reg_vl (precomputed in generate()).
+    void set_vl_e32();
+
+    // Load/store one c_block-wide vector at reg_ptr+offset (bytes). f16 widens on
+    // load / narrows on store; the accumulator group is always f32/m1.
+    void load(int idx, const Reg &reg_ptr, int offset);
+    void store(int idx, const Reg &reg_ptr, int offset);
+    void load_indices(int idx, const Reg &reg_ptr, int offset);
+    void store_indices(int idx, const Reg &reg_ptr, int offset);
+
+    void maybe_recalculate_divisor(int jj, int ur_w, int pad_l, int pad_r);
+    void avg_step(int ur_w, int pad_l, int pad_r);
+    void max_step_fwd(int ur_w, int pad_l, int pad_r);
+    void max_step_bwd(int ur_w, int pad_l, int pad_r);
+    void zero_diff_src();
+
+    void step(int ur_w, int pad_l, int pad_r) {
+        if (jpp.alg == alg_kind::pooling_max) {
+            if (jpp.is_backward)
+                max_step_bwd(ur_w, pad_l, pad_r);
+            else
+                max_step_fwd(ur_w, pad_l, pad_r);
+        } else
+            avg_step(ur_w, pad_l, pad_r);
+    }
+
+    void apply_postops(int ur_w, int c_off);
+
+    void generate() override;
+
+    static bool post_ops_ok(jit_pool_conf_t &jpp, const primitive_attr_t &attr,
+            const memory_desc_wrapper &dst_d);
+
+    // Load a float constant into an FReg via a GPR (reg materialization).
+    void load_f32_const(const FReg &f, float v, const Reg &gpr);
+    // dst = base + off (bytes), using addi for small offsets, li+add otherwise.
+    void addr_off(const Reg &dst, const Reg &base, int off);
+
+    // Far conditional branches. RISC-V B-type branches reach only +/-4KiB; a
+    // large loop body (fused post-op chain, big window, wide zeroing) can exceed
+    // that and make generate() throw. These emit the branch as a short skip over
+    // a J-type jump (+/-1MiB reach).
+    void beqz_far(const Reg &r, Xbyak_riscv::Label &t);
+    void bnez_far(const Reg &r, Xbyak_riscv::Label &t);
+    void blt_far(const Reg &a, const Reg &b, Xbyak_riscv::Label &t);
+
+    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+            postops_injector_;
+};
+
+// Retained native rv64 forward kernel for the nspc and ncsp (plain) layouts,
+// used for both inference and training (blocked uses the baked kernel). This
+// direct vectorization is preferred over the x64/aarch64 baked port on the plain
+// layouts. ncsp vectorizes along OW (interior) or along C (boundary / OW==1);
+// nspc vectorizes along C (f16 via generate_f16's n_pos batching, f32 via the
+// interior kernel). Shape-agnostic (window bounds via jit_uni_pool_ncsp_args_t),
+// VLA (vsetvli).
+template <cpu_isa_t isa, impl::data_type_t d_type>
+struct jit_uni_pool_ncsp_kernel_t : public jit_generator_t {
+
+    jit_uni_pool_ncsp_kernel_t(const jit_pool_conf_t &jpp);
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_pool_ncsp_kernel_t)
+
+    // Populate jpp for the native path (nspc or ncsp). Returns unimplemented for
+    // any other layout (blocked -> baked kernel).
+    static status_t init_conf(jit_pool_conf_t &jpp, primitive_attr_t &attr,
+            const pooling_pd_t *ppd);
+
+    void operator()(const jit_uni_pool_ncsp_args_t *p) const {
         jit_generator_t::operator()(p);
     }
 
@@ -61,20 +196,56 @@ private:
     bool is_max_pool_;
     void generate_f32();
     // f16 path: max accumulates in f16; avg widens to f32 (vfwadd_wv), scales,
-    // and narrows back to f16 (vfncvt). Requires the zvfh extension. Eltwise
-    // post-ops are fused here (computed at f32 before narrowing); f16 binary
-    // post-ops fall back to ref_pooling.
+    // and narrows back to f16 (vfncvt). Requires the zvfh extension. Eltwise and
+    // (at f32) binary post-ops are fused here.
     void generate_f16();
 };
 
-// Shape-baked forward pooling kernel for the interior (full-kw) region of an
-// nspc row (f32 only; f16 uses the agnostic kernel above). kw, stride_w, ur_w,
-// the algorithm, the fused eltwise post-op chain, and the avg_include scale are
-// baked into the generated code; the W window is fully unrolled and ur_w output
-// columns share each loaded input vector (ARM max_step/avg_step style). Base
-// pointers, the VLA channel count, the runtime H/D extents, the element strides
-// (passed, not baked, so 64-bit strides stay correct), and the avg_exclude
-// scale are passed at call time.
+// Native gather backward kernel for the nspc and ncsp (plain) layouts (f32 via
+// the v ISA, f16 via zvfh). Backward pooling is a gather: the driver enumerates,
+// per input position, the output positions whose window covers it (see
+// jit_uni_pool_bwd_contrib_t) and this kernel accumulates their diff_dst channel
+// rows into the input's diff_src row, then stores it once. max adds diff_dst only
+// where the stored argmax matches; avg adds diff_dst * (1/num_summands). f16
+// accumulates in f32. Channels are the vector dim (VLA vsetvli); unit-stride for
+// nspc, strided (vlse/vsse) for ncsp. No post-ops (backward has default attrs).
+template <cpu_isa_t isa, impl::data_type_t d_type>
+struct jit_uni_pool_bwd_kernel_t : public jit_generator_t {
+
+    jit_uni_pool_bwd_kernel_t(const jit_pool_conf_t &jpp);
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_pool_bwd_kernel_t)
+
+    // Populate jpp for the native backward path (nspc or ncsp). Returns
+    // unimplemented for blocked (-> baked kernel) and for windows whose
+    // per-input covering-output count could exceed the contribution cap.
+    static status_t init_conf(jit_pool_conf_t &jpp, const pooling_pd_t *ppd);
+
+    void operator()(const jit_uni_pool_bwd_args_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+    // Upper bound on covering outputs per input = ceil(KD/SD)*ceil(KH/SH)*
+    // ceil(KW/SW). The driver builds a stack array of this many contributions;
+    // init_conf declines windows that would exceed the cap.
+    static constexpr int max_contrib = 512;
+
+protected:
+    void generate() override;
+
+private:
+    jit_pool_conf_t jpp_;
+    bool is_max_pool_;
+    void generate_f32();
+    void generate_f16();
+};
+
+// Shape-baked interior kernel for the full-window interior of an nspc row (f32
+// only; f16 uses generate_f16's n_pos batching). kw/stride_w/ur_w, the algorithm,
+// the eltwise chain, and the avg_include scale are baked; ur_w output columns
+// share each loaded input vector (ARM max_step/avg_step style). Base pointers,
+// the VLA channel count, runtime H/D extents, element strides, and the
+// avg_exclude scale come in via jit_uni_pool_interior_args_t.
 template <cpu_isa_t isa, impl::data_type_t d_type>
 struct jit_uni_pool_interior_kernel_t : public jit_generator_t {
 

--- a/src/cpu/rv64/jit_uni_pooling.cpp
+++ b/src/cpu/rv64/jit_uni_pooling.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cfloat>
+#include <vector>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
@@ -33,17 +34,20 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
+// ====================== native plain-layout drivers =======================
+// Retained rv64-native drivers for the nspc and ncsp (plain) layouts (vectorize
+// along OW or strided C; no plain<->blocked transpose). Cover forward inference
+// and training and the native backward gather.
 namespace {
 
 template <cpu_isa_t isa, data_type_t d_type>
-using kernel_t = jit_uni_pool_kernel_t<isa, d_type>;
+using ncsp_kernel_t = jit_uni_pool_ncsp_kernel_t<isa, d_type>;
 
 struct init_scale_t {
     float init_val;
     float scale_val;
 };
 
-// Initial accumulator value and post-window scale for a vectorized output.
 init_scale_t compute_init_scale(alg_kind_t alg, int id_start, int id_end,
         int ih_start, int ih_end, int iw_start, int iw_end, dim_t kerD,
         dim_t kerH, dim_t kerW) {
@@ -59,18 +63,11 @@ init_scale_t compute_init_scale(alg_kind_t alg, int id_start, int id_end,
     }
 }
 
-// Value the kernel would write for an output whose pooling window lies entirely
-// in padding: the accumulator init (max -> dtype lowest, avg -> 0), which avg
-// scaling leaves at 0, with the fused f32 single-ReLU baked in (with_relu). Used
-// to fast-fill such outputs, skipping the per-output JIT call. Post-ops are fused
-// in-kernel now (there is no separate post-op pass); a fused chain this value
-// cannot reproduce has its empty windows routed through the kernel instead (see
-// execute_forward), and unsupported chains fall back to ref_pooling.
 template <typename data_t>
 data_t empty_window_value(const jit_pool_conf_t &jpp) {
     if (jpp.alg == alg_kind::pooling_max) {
         float v = (float)nstl::numeric_limits<data_t>::lowest();
-        if (jpp.with_relu) { // fused only for f32
+        if (jpp.with_relu) {
             if (jpp.relu_alpha == 0.0f)
                 v = v < 0.0f ? 0.0f : v;
             else if (v <= 0.0f)
@@ -81,9 +78,8 @@ data_t empty_window_value(const jit_pool_conf_t &jpp) {
     return (data_t)0;
 }
 
-// Per-output-pixel kernel arguments for the nspc layout (vectorize along C).
 template <typename data_t>
-jit_uni_pooling_args_t make_pooling_params(alg_kind_t alg,
+jit_uni_pool_ncsp_args_t make_pooling_params(alg_kind_t alg,
         const data_t *src_mb_base, data_t *dst, dim_t mb, dim_t channels,
         dim_t od, dim_t oh, dim_t ow, dim_t outD, dim_t outH, dim_t outW,
         dim_t inD, dim_t inH, dim_t inW, dim_t kerD, dim_t kerH, dim_t kerW,
@@ -108,7 +104,7 @@ jit_uni_pooling_args_t make_pooling_params(alg_kind_t alg,
     auto iv = compute_init_scale(alg, id_start, id_end, ih_start, ih_end,
             iw_start, iw_end, kerD, kerH, kerW);
 
-    jit_uni_pooling_args_t p;
+    jit_uni_pool_ncsp_args_t p;
     p.src = src_mb_base;
     p.dst = &dst[dst_spatial_base];
     p.channels = channels;
@@ -130,148 +126,42 @@ jit_uni_pooling_args_t make_pooling_params(alg_kind_t alg,
     return p;
 }
 
-// Binary post-op rhs base for a channel-vectorized kernel call writing to
-// p_dst. A full-dst src1 follows the dst layout, so it offsets with the output
-// position (rhs + (p_dst - dst)); per-oc ([1,C,1,..]) and per-tensor src1 use
-// the base directly. Returns nullptr when no binary post-op is fused.
+// Shared byte offset of the first active lane for the in-kernel binary injector
+// (indirect mode). 0 for scalar/per-oc (the rhs origin is already the first
+// element); for full-dst it is this output position's channel-0 element offset,
+// scaled by sizeof(f32) since src1 is always f32 (the dst may be f16).
 template <typename data_t>
-const void *binary_rhs_for(const jit_pool_conf_t &jpp, const void *rhs,
-        const data_t *dst, const void *p_dst) {
-    if (!jpp.fuse_binary || rhs == nullptr) return nullptr;
-    bool full = false;
-    for (int i = 0; i < jpp.post_ops.len(); i++) {
-        const auto &e = jpp.post_ops.entry_[i];
-        if (!e.is_binary()) continue;
-        const memory_desc_wrapper s1(e.binary.src1_desc);
-        full = s1.nelems() != 1 && s1.nelems() != (dim_t)jpp.c;
-    }
-    if (!full) return rhs;
-    return static_cast<const void *>(static_cast<const data_t *>(rhs)
-            + (static_cast<const data_t *>(p_dst) - dst));
+dim_t binary_off0(
+        const jit_pool_conf_t &jpp, const data_t *dst, const void *p_dst) {
+    // Only a full-dst src1 needs a per-position base offset; scalar/per-oc read
+    // from a fixed origin. The broadcast category is classified once by the pd
+    // gate (jpp.binary_bcast; none when there is no fused binary).
+    if (jpp.binary_bcast != pool_binary_bcast_t::full_dst) return 0;
+    const dim_t elem_off = static_cast<const data_t *>(p_dst) - dst;
+    return elem_off * (dim_t)sizeof(float);
 }
 
-// nspc: vectorize along C. Interior columns are handled by the shape-baked
-// ur_w-reuse kernel (full ur_w blocks); the few boundary columns and the
-// sub-ur_w interior remainder fall back to one vectorize-C call per column.
-template <cpu_isa_t isa, data_type_t d_type>
-void pooling_nspc(const kernel_t<isa, d_type> &kernel,
-        const jit_uni_pool_interior_kernel_t<isa, d_type> &ikernel,
-        const jit_pool_conf_t &jpp, const float *src, float *dst,
-        const void *po_rhs) {
-    const dim_t batch = jpp.mb, channels = jpp.c;
-    const dim_t outD = jpp.od, outH = jpp.oh, outW = jpp.ow;
-    const dim_t inD = jpp.id, inH = jpp.ih, inW = jpp.iw;
-    const dim_t kerD = jpp.kd, kerH = jpp.kh, kerW = jpp.kw;
-    const dim_t strideD = jpp.stride_d, strideH = jpp.stride_h,
-                strideW = jpp.stride_w;
-    const dim_t padFront = jpp.f_pad, padTop = jpp.t_pad, padLeft = jpp.l_pad;
-    const alg_kind_t alg = jpp.alg;
-    const bool with_relu = jpp.with_relu;
-    const float relu_alpha = jpp.relu_alpha;
-    const dim_t ur_w = jpp.ur_w;
-
-    const dim_t inW_stride = inW * channels;
-    const dim_t inD_stride = inH * inW * channels;
-
-    const dim_t int_lo = std::max((padLeft + strideW - 1) / strideW, (dim_t)0);
-    // Guard against truncating division: when inW + padLeft < kerW (kernel
-    // wider than the padded input) the numerator is negative and integer
-    // division would round toward zero, over-counting int_hi and marking a
-    // partial window as full. In that case no full-window column exists.
-    const dim_t int_hi = (inW + padLeft >= kerW)
-            ? std::min(std::max((inW - kerW + padLeft) / strideW + 1, int_lo),
-                      outW)
-            : int_lo;
-
-    parallel_nd(batch, outD, outH, [&](dim_t mb, dim_t od, dim_t oh) {
-        const size_t mb_offset = (size_t)mb * (size_t)inD * inD_stride;
-        const float *src_mb_base = &src[mb_offset];
-
-        auto call_one = [&](dim_t ow) {
-            auto p = make_pooling_params(alg, src_mb_base, dst, mb, channels,
-                    od, oh, ow, outD, outH, outW, inD, inH, inW, kerD, kerH,
-                    kerW, strideD, strideH, strideW, padFront, padTop, padLeft,
-                    inW_stride, inD_stride, with_relu, relu_alpha);
-            if ((p.id_start >= p.id_end || p.ih_start >= p.ih_end
-                        || p.iw_start >= p.iw_end)
-                    && !jpp.fuse_eltwise && !jpp.fuse_binary) {
-                // Empty window, no fused post-op: fill channels, skip the kernel.
-                const float ev = empty_window_value<float>(jpp);
-                float *d = static_cast<float *>(p.dst);
-                for (dim_t c = 0; c < channels; c++)
-                    d[c] = ev;
-                return;
-            }
-            p.post_op_rhs = binary_rhs_for(jpp, po_rhs, dst, p.dst);
-            kernel(&p);
-        };
-
-        // D/H window for this (od, oh), clamped to the input. The shape-baked
-        // kernel uses count-based loops (beqz + decrement), so it must not run
-        // for a row whose window lies entirely in D/H padding (zero/negative
-        // counts) — those rows fall through to the per-column path, which
-        // clamps the window in the agnostic kernel (bge bounds).
-        const int od_off = (int)(od * strideD - padFront);
-        const int oh_off = (int)(oh * strideH - padTop);
-        const int id_start = std::max(od_off, 0);
-        const int ih_start = std::max(oh_off, 0);
-        const int id_end = std::min(od_off + (int)kerD, (int)inD);
-        const int ih_end = std::min(oh_off + (int)kerH, (int)inH);
-        const dim_t kd_count = std::max(0, id_end - id_start);
-        const dim_t kh_count = std::max(0, ih_end - ih_start);
-        const bool row_in_pad = (kd_count == 0 || kh_count == 0);
-
-        const dim_t n_int = (int_lo < int_hi) ? (int_hi - int_lo) : 0;
-        // Binary post-ops are applied only on the channel-vectorized
-        // single-position path, so skip the shape-baked interior kernel then.
-        const dim_t n_blocks
-                = (row_in_pad || jpp.fuse_binary) ? 0 : (n_int / ur_w);
-        const dim_t baked_hi = int_lo + n_blocks * ur_w;
-
-        // Left boundary columns.
-        const dim_t lo = std::min(int_lo, outW);
-        for (dim_t ow = 0; ow < lo; ++ow)
-            call_one(ow);
-
-        // Interior: full ur_w blocks via the shape-baked kernel. Reached only
-        // when kd_count > 0 && kh_count > 0 (n_blocks gated on !row_in_pad).
-        if (n_blocks > 0) {
-            const int iw_start = (int)(int_lo * strideW - padLeft);
-
-            jit_uni_pool_interior_args_t ip;
-            ip.src = src_mb_base + (size_t)id_start * inD_stride
-                    + (size_t)ih_start * inW_stride
-                    + (size_t)iw_start * channels;
-            ip.dst = dst
-                    + (((((size_t)mb * outD + od) * outH + oh) * outW + int_lo)
-                            * channels);
-            ip.channels = channels;
-            ip.kh_count = kh_count;
-            ip.kd_count = kd_count;
-            ip.n_blocks = n_blocks;
-            ip.w_stride = (dim_t)channels * sizeof(float);
-            ip.inW_stride = inW_stride * (dim_t)sizeof(float);
-            ip.inD_stride = inD_stride * (dim_t)sizeof(float);
-            const dim_t cnt = kd_count * kh_count * (dim_t)kerW;
-            ip.scale_val = (cnt > 0) ? 1.0f / (float)cnt : 0.0f;
-            ikernel(&ip);
+// Per-binary src1 origin pointer array (in attribute order) for the indirect
+// injector mode: each entry is the binary's src1 base advanced to its logical
+// origin (off_l(0)), in f32 units since src1 is always f32. Shared by the baked
+// blocked/nspc drivers and the native forward path.
+static std::vector<const void *> collect_binary_rhs(
+        const jit_pool_conf_t &jpp, const exec_ctx_t &ctx) {
+    std::vector<const void *> rhs;
+    for (int i = 0; i < jpp.post_ops.len(); i++)
+        if (jpp.post_ops.entry_[i].is_binary()) {
+            const memory_desc_wrapper s1_d(
+                    jpp.post_ops.entry_[i].binary.src1_desc);
+            const auto *base = static_cast<const char *>(ctx.host_ptr(
+                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
+            rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
         }
-
-        // Interior remainder (< ur_w, or the whole interior when row_in_pad),
-        // then right boundary columns.
-        for (dim_t ow = baked_hi; ow < int_hi; ++ow)
-            call_one(ow);
-        for (dim_t ow = int_hi; ow < outW; ++ow)
-            call_one(ow);
-    });
+    return rhs;
 }
 
-// Vectorize along C (strided) for a single ncsp output column (mb, od, oh, ow).
-// Used for OW==1 and for the boundary columns of the OW>1 path, where each
-// column has its own (possibly truncated) window and so cannot join the
-// interior row-unrolled call.
+// Vectorize along C (strided) for a single ncsp output column.
 template <cpu_isa_t isa, data_type_t d_type>
-void pool_column_vec_c(const kernel_t<isa, d_type> &kernel,
+void pool_column_vec_c(const ncsp_kernel_t<isa, d_type> &kernel,
         const jit_pool_conf_t &jpp,
         const typename prec_traits_t<d_type>::type *src,
         typename prec_traits_t<d_type>::type *dst, dim_t mb, dim_t od, dim_t oh,
@@ -302,12 +192,6 @@ void pool_column_vec_c(const kernel_t<isa, d_type> &kernel,
     data_t *dst_base = dst + (size_t)mb * channels * dst_spatial_size
             + od * outH * outW + oh * outW + ow;
 
-    // Output whose window lies entirely in padding (legal for max /
-    // avg_include; only avg_exclude is rejected upstream). With no fused post-op
-    // we fill all channels directly with the value the kernel would produce and
-    // skip the JIT call (avoids per-call overhead and an out-of-range src_base).
-    // With a fused post-op the kernel must run so the post-op is applied to the
-    // init value; the window loops are skipped (id_end==0, ...) so src is unread.
     const bool empty = (kd_cnt == 0 || kh_cnt == 0 || kw_cnt == 0);
     if (empty && !jpp.fuse_eltwise && !jpp.fuse_binary) {
         const data_t ev = empty_window_value<data_t>(jpp);
@@ -319,14 +203,12 @@ void pool_column_vec_c(const kernel_t<isa, d_type> &kernel,
     auto iv = compute_init_scale(jpp.alg, id_start, id_end, ih_start, ih_end,
             iw_start, iw_end, kerD, kerH, kerW);
 
-    // Empty window: the kernel reads no src, so use the channel base to avoid
-    // forming an out-of-range pointer (start indices can exceed the input).
     const data_t *src_base = empty ? src + (size_t)mb * channels * spatial_size
                                    : src + (size_t)mb * channels * spatial_size
                     + (size_t)id_start * inH * inW + (size_t)ih_start * inW
                     + iw_start;
 
-    jit_uni_pooling_args_t p;
+    jit_uni_pool_ncsp_args_t p;
     p.src = src_base;
     p.dst = dst_base;
     p.channels = channels;
@@ -345,15 +227,13 @@ void pool_column_vec_c(const kernel_t<isa, d_type> &kernel,
     p.with_relu = jpp.with_relu;
     p.src_vec_byte_stride = (dim_t)(spatial_size * sizeof(data_t));
     p.dst_vec_byte_stride = (dim_t)(dst_spatial_size * sizeof(data_t));
-    p.post_op_rhs = binary_rhs_for(jpp, po_rhs, dst, p.dst);
+    p.post_op_rhs = po_rhs;
+    p.post_op_off0 = binary_off0(jpp, dst, p.dst);
     kernel(&p);
 }
 
-// ncsp, OW > 1: interior columns vectorize along OW (one row-unrolled call per
-// channel); boundary columns vectorize along C (one call per column, all
-// channels) via pool_column_vec_c.
 template <cpu_isa_t isa, data_type_t d_type>
-void pooling_ncsp(const kernel_t<isa, d_type> &kernel,
+void pooling_ncsp(const ncsp_kernel_t<isa, d_type> &kernel,
         const jit_pool_conf_t &jpp,
         const typename prec_traits_t<d_type>::type *src,
         typename prec_traits_t<d_type>::type *dst, const void *po_rhs) {
@@ -372,14 +252,9 @@ void pooling_ncsp(const kernel_t<isa, d_type> &kernel,
     const size_t spatial_size = (size_t)inD * inH * inW;
     const size_t dst_spatial_size = (size_t)outD * outH * outW;
 
-    // Binary post-ops are applied only on the channel-vectorized path, so when
-    // a binary post-op is fused force every column through pool_column_vec_c by
-    // emptying the OW-vectorized interior range.
     const dim_t int_lo = jpp.fuse_binary
             ? 0
             : std::max((padL + strideW - 1) / strideW, (dim_t)0);
-    // See pooling_nspc: avoid truncating-division over-count when the kernel
-    // is wider than the padded input (no full-window column then).
     const dim_t int_hi = jpp.fuse_binary
             ? 0
             : ((inW + padL >= kerW)
@@ -389,7 +264,6 @@ void pooling_ncsp(const kernel_t<isa, d_type> &kernel,
                                         outW)
                               : int_lo);
 
-    // Interior columns: vectorize along OW.
     if (int_lo < int_hi) {
         parallel_nd(batch, channels, outD, outH,
                 [&](dim_t mb, dim_t c, dim_t od, dim_t oh) {
@@ -406,13 +280,6 @@ void pooling_ncsp(const kernel_t<isa, d_type> &kernel,
             const int ih_end
                     = std::min((int)(oh * strideH - padT + kerH), (int)inH);
 
-            // Whole (od, oh) row in front/top or back/bottom padding: every
-            // interior column is an empty window. With no fused post-op, fill
-            // them directly and skip the JIT call (big win on heavily-padded
-            // shapes). With a fused chain, fall through so the kernel applies the
-            // post-op to the init value (avg scale is 0 for an empty window, so
-            // the result is post_op(0); max is post_op(lowest)) — matching the
-            // call_one paths and x86/ARM, which always run the kernel.
             if ((id_start >= id_end || ih_start >= ih_end) && !jpp.fuse_eltwise
                     && !jpp.fuse_binary) {
                 const data_t ev = empty_window_value<data_t>(jpp);
@@ -424,11 +291,9 @@ void pooling_ncsp(const kernel_t<isa, d_type> &kernel,
             auto iv = compute_init_scale(alg, id_start, id_end, ih_start,
                     ih_end, 0, (int)kerW, kerD, kerH, kerW);
 
-            jit_uni_pooling_args_t p;
+            jit_uni_pool_ncsp_args_t p;
             p.src = src_ch + (int_lo * strideW - padL);
             p.dst = dst_oh + int_lo;
-            // 'channels' is repurposed as the interior OW count: the kernel's
-            // vector loop walks OW with src_vec_byte_stride between positions.
             p.channels = int_hi - int_lo;
             p.id_start = id_start;
             p.ih_start = ih_start;
@@ -449,7 +314,6 @@ void pooling_ncsp(const kernel_t<isa, d_type> &kernel,
         });
     }
 
-    // Boundary columns: [0, lo) on the left, [hi, outW) on the right.
     const dim_t lo = std::min(int_lo, outW);
     const dim_t hi = (int_lo < int_hi) ? int_hi : lo;
     const dim_t n_bnd = lo + (outW - hi);
@@ -463,9 +327,8 @@ void pooling_ncsp(const kernel_t<isa, d_type> &kernel,
     }
 }
 
-// ncsp, OW == 1: every column is handled by the vectorize-along-C path.
 template <cpu_isa_t isa, data_type_t d_type>
-void pooling_ncsp_ow1(const kernel_t<isa, d_type> &kernel,
+void pooling_ncsp_ow1(const ncsp_kernel_t<isa, d_type> &kernel,
         const jit_pool_conf_t &jpp,
         const typename prec_traits_t<d_type>::type *src,
         typename prec_traits_t<d_type>::type *dst, const void *po_rhs) {
@@ -475,11 +338,112 @@ void pooling_ncsp_ow1(const kernel_t<isa, d_type> &kernel,
     });
 }
 
-// nspc without a shape-baked interior kernel: one row-unrolled heavy call per
-// interior OW run + one call per boundary column (the pre-bake path). Used for
-// data types that have no baked interior kernel (f16).
+// nspc (f32): vectorize along C. Interior columns handled by the shape-baked
+// ur_w-reuse kernel (full ur_w blocks); boundary columns and the sub-ur_w
+// interior remainder fall back to one vectorize-C call per column.
 template <cpu_isa_t isa, data_type_t d_type>
-void pooling_nspc_generic(const kernel_t<isa, d_type> &kernel,
+void pooling_nspc(const ncsp_kernel_t<isa, d_type> &kernel,
+        const jit_uni_pool_interior_kernel_t<isa, d_type> &ikernel,
+        const jit_pool_conf_t &jpp, const float *src, float *dst,
+        const void *po_rhs) {
+    const dim_t batch = jpp.mb, channels = jpp.c;
+    const dim_t outD = jpp.od, outH = jpp.oh, outW = jpp.ow;
+    const dim_t inD = jpp.id, inH = jpp.ih, inW = jpp.iw;
+    const dim_t kerD = jpp.kd, kerH = jpp.kh, kerW = jpp.kw;
+    const dim_t strideD = jpp.stride_d, strideH = jpp.stride_h,
+                strideW = jpp.stride_w;
+    const dim_t padFront = jpp.f_pad, padTop = jpp.t_pad, padLeft = jpp.l_pad;
+    const alg_kind_t alg = jpp.alg;
+    const bool with_relu = jpp.with_relu;
+    const float relu_alpha = jpp.relu_alpha;
+    const dim_t ur_w = jpp.ur_w;
+
+    const dim_t inW_stride = inW * channels;
+    const dim_t inD_stride = inH * inW * channels;
+
+    const dim_t int_lo = std::max((padLeft + strideW - 1) / strideW, (dim_t)0);
+    const dim_t int_hi = (inW + padLeft >= kerW)
+            ? std::min(std::max((inW - kerW + padLeft) / strideW + 1, int_lo),
+                      outW)
+            : int_lo;
+
+    parallel_nd(batch, outD, outH, [&](dim_t mb, dim_t od, dim_t oh) {
+        const size_t mb_offset = (size_t)mb * (size_t)inD * inD_stride;
+        const float *src_mb_base = &src[mb_offset];
+
+        auto call_one = [&](dim_t ow) {
+            auto p = make_pooling_params(alg, src_mb_base, dst, mb, channels,
+                    od, oh, ow, outD, outH, outW, inD, inH, inW, kerD, kerH,
+                    kerW, strideD, strideH, strideW, padFront, padTop, padLeft,
+                    inW_stride, inD_stride, with_relu, relu_alpha);
+            if ((p.id_start >= p.id_end || p.ih_start >= p.ih_end
+                        || p.iw_start >= p.iw_end)
+                    && !jpp.fuse_eltwise && !jpp.fuse_binary) {
+                const float ev = empty_window_value<float>(jpp);
+                float *d = static_cast<float *>(p.dst);
+                for (dim_t c = 0; c < channels; c++)
+                    d[c] = ev;
+                return;
+            }
+            p.post_op_rhs = po_rhs;
+            p.post_op_off0 = binary_off0(jpp, dst, p.dst);
+            kernel(&p);
+        };
+
+        // Whole (od,oh) row in D/H padding must not run the count-based interior
+        // kernel; such rows fall through to the per-column (bge-clamped) path.
+        const int od_off = (int)(od * strideD - padFront);
+        const int oh_off = (int)(oh * strideH - padTop);
+        const int id_start = std::max(od_off, 0);
+        const int ih_start = std::max(oh_off, 0);
+        const int id_end = std::min(od_off + (int)kerD, (int)inD);
+        const int ih_end = std::min(oh_off + (int)kerH, (int)inH);
+        const dim_t kd_count = std::max(0, id_end - id_start);
+        const dim_t kh_count = std::max(0, ih_end - ih_start);
+        const bool row_in_pad = (kd_count == 0 || kh_count == 0);
+
+        const dim_t n_int = (int_lo < int_hi) ? (int_hi - int_lo) : 0;
+        // Binary post-ops run only on the channel-vec single-position path.
+        const dim_t n_blocks
+                = (row_in_pad || jpp.fuse_binary) ? 0 : (n_int / ur_w);
+        const dim_t baked_hi = int_lo + n_blocks * ur_w;
+
+        const dim_t lo = std::min(int_lo, outW);
+        for (dim_t ow = 0; ow < lo; ++ow)
+            call_one(ow);
+
+        if (n_blocks > 0) {
+            const int iw_start = (int)(int_lo * strideW - padLeft);
+            jit_uni_pool_interior_args_t ip;
+            ip.src = src_mb_base + (size_t)id_start * inD_stride
+                    + (size_t)ih_start * inW_stride
+                    + (size_t)iw_start * channels;
+            ip.dst = dst
+                    + (((((size_t)mb * outD + od) * outH + oh) * outW + int_lo)
+                            * channels);
+            ip.channels = channels;
+            ip.kh_count = kh_count;
+            ip.kd_count = kd_count;
+            ip.n_blocks = n_blocks;
+            ip.w_stride = (dim_t)channels * sizeof(float);
+            ip.inW_stride = inW_stride * (dim_t)sizeof(float);
+            ip.inD_stride = inD_stride * (dim_t)sizeof(float);
+            const dim_t cnt = kd_count * kh_count * (dim_t)kerW;
+            ip.scale_val = (cnt > 0) ? 1.0f / (float)cnt : 0.0f;
+            ikernel(&ip);
+        }
+
+        for (dim_t ow = baked_hi; ow < int_hi; ++ow)
+            call_one(ow);
+        for (dim_t ow = int_hi; ow < outW; ++ow)
+            call_one(ow);
+    });
+}
+
+// nspc without the shape-baked interior kernel (f16): one row-unrolled call per
+// interior OW run + one call per boundary column.
+template <cpu_isa_t isa, data_type_t d_type>
+void pooling_nspc_generic(const ncsp_kernel_t<isa, d_type> &kernel,
         const jit_pool_conf_t &jpp,
         const typename prec_traits_t<d_type>::type *src,
         typename prec_traits_t<d_type>::type *dst, const void *po_rhs) {
@@ -498,12 +462,14 @@ void pooling_nspc_generic(const kernel_t<isa, d_type> &kernel,
     const dim_t inW_stride = inW * channels;
     const dim_t inD_stride = inH * inW * channels;
 
-    const dim_t int_lo = std::max((padLeft + strideW - 1) / strideW, (dim_t)0);
-    // Guard against truncating division: when inW + padLeft < kerW (kernel
-    // wider than the padded input) the numerator is negative and integer
-    // division would round toward zero, over-counting int_hi and marking a
-    // partial window as full. In that case no full-window column exists.
-    const dim_t int_hi = (inW + padLeft >= kerW)
+    // A fused binary is applied on the single-position path only (generate_f16's
+    // binary path handles one output column), so collapse the n_pos-batched
+    // interior range and route every column through call_one.
+    const dim_t int_lo = jpp.fuse_binary
+            ? 0
+            : std::max((padLeft + strideW - 1) / strideW, (dim_t)0);
+    const dim_t int_hi = jpp.fuse_binary ? 0
+            : (inW + padLeft >= kerW)
             ? std::min(std::max((inW - kerW + padLeft) / strideW + 1, int_lo),
                       outW)
             : int_lo;
@@ -520,14 +486,14 @@ void pooling_nspc_generic(const kernel_t<isa, d_type> &kernel,
             if ((p.id_start >= p.id_end || p.ih_start >= p.ih_end
                         || p.iw_start >= p.iw_end)
                     && !jpp.fuse_eltwise && !jpp.fuse_binary) {
-                // Empty window, no fused post-op: fill channels, skip the kernel.
                 const data_t ev = empty_window_value<data_t>(jpp);
                 data_t *d = static_cast<data_t *>(p.dst);
                 for (dim_t c = 0; c < channels; c++)
                     d[c] = ev;
                 return;
             }
-            p.post_op_rhs = binary_rhs_for(jpp, po_rhs, dst, p.dst);
+            p.post_op_rhs = po_rhs;
+            p.post_op_off0 = binary_off0(jpp, dst, p.dst);
             kernel(&p);
         };
 
@@ -553,13 +519,146 @@ void pooling_nspc_generic(const kernel_t<isa, d_type> &kernel,
     });
 }
 
+// nspc max forward-training: one per-output channel-vec call that tracks the
+// argmax into the workspace (contiguous over channels). A fused post-op chain is
+// applied to the pooled value before the store (po_rhs = binary origin array).
+template <cpu_isa_t isa, data_type_t d_type>
+void pooling_train_max_nspc(const ncsp_kernel_t<isa, d_type> &kernel,
+        const jit_pool_conf_t &jpp,
+        const typename prec_traits_t<d_type>::type *src,
+        typename prec_traits_t<d_type>::type *dst, char *indices,
+        const void *po_rhs) {
+    using data_t = typename prec_traits_t<d_type>::type;
+    const dim_t batch = jpp.mb, channels = jpp.c;
+    const dim_t outD = jpp.od, outH = jpp.oh, outW = jpp.ow;
+    const dim_t inD = jpp.id, inH = jpp.ih, inW = jpp.iw;
+    const dim_t kerD = jpp.kd, kerH = jpp.kh, kerW = jpp.kw;
+    const dim_t strideD = jpp.stride_d, strideH = jpp.stride_h,
+                strideW = jpp.stride_w;
+    const dim_t padF = jpp.f_pad, padT = jpp.t_pad, padL = jpp.l_pad;
+    const dim_t inW_stride = inW * channels;
+    const dim_t inD_stride = inH * inW * channels;
+    const dim_t KHKW = kerH * kerW;
+    const size_t ind_sz = types::data_type_size(jpp.ind_dt);
+
+    parallel_nd(batch, outD, outH, outW,
+            [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
+        const data_t *src_mb_base = &src[(size_t)mb * inD * inD_stride];
+        auto p = make_pooling_params(alg_kind::pooling_max, src_mb_base, dst,
+                mb, channels, od, oh, ow, outD, outH, outW, inD, inH, inW, kerD,
+                kerH, kerW, strideD, strideH, strideW, padF, padT, padL,
+                inW_stride, inD_stride, /*with_relu=*/false,
+                /*relu_alpha=*/0.f);
+        // Full-kernel-relative index of the first (clamped) window element, plus
+        // the per-row/plane skips of the clamped-off positions.
+        const dim_t kd_base = std::max<dim_t>(0, padF - od * strideD);
+        const dim_t kh_base = std::max<dim_t>(0, padT - oh * strideH);
+        const dim_t kw_base = std::max<dim_t>(0, padL - ow * strideW);
+        p.pos_base = kd_base * KHKW + kh_base * kerW + kw_base;
+        p.pos_ih_step = kerW - (p.iw_end - p.iw_start);
+        p.pos_id_step = KHKW - (p.ih_end - p.ih_start) * kerW;
+        const size_t out_flat
+                = ((((size_t)mb * outD + od) * outH + oh) * outW + ow)
+                * channels;
+        p.indices = indices + out_flat * ind_sz;
+        p.ws_vec_byte_stride = (dim_t)ind_sz; // nspc: contiguous over channels
+        p.post_op_rhs = po_rhs;
+        p.post_op_off0 = binary_off0(jpp, dst, p.dst);
+        kernel(&p);
+    });
+}
+
+// ncsp max forward-training: one per-output channel-vec call (vectorize along C,
+// strided) that tracks the argmax into the strided ncsp workspace. Mirrors the
+// nspc variant but the src/dst/ws channel elements are dst_spatial apart.
+template <cpu_isa_t isa, data_type_t d_type>
+void pooling_train_max_ncsp(const ncsp_kernel_t<isa, d_type> &kernel,
+        const jit_pool_conf_t &jpp,
+        const typename prec_traits_t<d_type>::type *src,
+        typename prec_traits_t<d_type>::type *dst, char *indices,
+        const void *po_rhs) {
+    using data_t = typename prec_traits_t<d_type>::type;
+    const dim_t batch = jpp.mb, channels = jpp.c;
+    const dim_t outD = jpp.od, outH = jpp.oh, outW = jpp.ow;
+    const dim_t inD = jpp.id, inH = jpp.ih, inW = jpp.iw;
+    const dim_t kerD = jpp.kd, kerH = jpp.kh, kerW = jpp.kw;
+    const dim_t strideD = jpp.stride_d, strideH = jpp.stride_h,
+                strideW = jpp.stride_w;
+    const dim_t padF = jpp.f_pad, padT = jpp.t_pad, padL = jpp.l_pad;
+    const dim_t KHKW = kerH * kerW;
+    const size_t ind_sz = types::data_type_size(jpp.ind_dt);
+    const size_t spatial_size = (size_t)inD * inH * inW;
+    const size_t dst_spatial_size = (size_t)outD * outH * outW;
+
+    parallel_nd(batch, outD, outH, outW,
+            [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
+        const int id_start = std::max((int)(od * strideD - padF), 0);
+        const int id_end
+                = std::min((int)(od * strideD - padF + kerD), (int)inD);
+        const int ih_start = std::max((int)(oh * strideH - padT), 0);
+        const int ih_end
+                = std::min((int)(oh * strideH - padT + kerH), (int)inH);
+        const int iw_start = std::max((int)(ow * strideW - padL), 0);
+        const int iw_end
+                = std::min((int)(ow * strideW - padL + kerW), (int)inW);
+        const dim_t kd_cnt = std::max(0, id_end - id_start);
+        const dim_t kh_cnt = std::max(0, ih_end - ih_start);
+        const dim_t kw_cnt = std::max(0, iw_end - iw_start);
+        const bool empty = (kd_cnt == 0 || kh_cnt == 0 || kw_cnt == 0);
+
+        const data_t *src_base = empty
+                ? src + (size_t)mb * channels * spatial_size
+                : src + (size_t)mb * channels * spatial_size
+                        + (size_t)id_start * inH * inW + (size_t)ih_start * inW
+                        + iw_start;
+
+        jit_uni_pool_ncsp_args_t p;
+        p.src = src_base;
+        p.dst = dst + (size_t)mb * channels * dst_spatial_size
+                + od * outH * outW + oh * outW + ow;
+        p.channels = channels;
+        p.id_start = 0;
+        p.ih_start = 0;
+        p.iw_start = 0;
+        p.id_end = kd_cnt;
+        p.ih_end = kh_cnt;
+        p.iw_end = kw_cnt;
+        p.inW_stride = inW;
+        p.inD_stride = inH * inW;
+        p.w_spatial_byte_stride = (dim_t)sizeof(data_t);
+        p.init_val = -FLT_MAX;
+        p.scale_val = 0.0f;
+        p.relu_alpha = 0.f;
+        p.with_relu = false;
+        p.src_vec_byte_stride = (dim_t)(spatial_size * sizeof(data_t));
+        p.dst_vec_byte_stride = (dim_t)(dst_spatial_size * sizeof(data_t));
+        // Full-kernel-relative index of the first (clamped) window element and
+        // the per-row/plane skips of the clamped-off positions.
+        const dim_t kd_base = std::max<dim_t>(0, padF - od * strideD);
+        const dim_t kh_base = std::max<dim_t>(0, padT - oh * strideH);
+        const dim_t kw_base = std::max<dim_t>(0, padL - ow * strideW);
+        p.pos_base = kd_base * KHKW + kh_base * kerW + kw_base;
+        p.pos_ih_step = kerW - kw_cnt;
+        p.pos_id_step = KHKW - kh_cnt * kerW;
+        const size_t out_flat
+                = od * outH * outW + oh * outW + ow; // channel-0 spatial offset
+        p.indices = indices
+                + ((size_t)mb * channels * dst_spatial_size + out_flat)
+                        * ind_sz;
+        p.ws_vec_byte_stride
+                = (dim_t)(dst_spatial_size * ind_sz); // ncsp strided
+        p.post_op_rhs = po_rhs;
+        p.post_op_off0 = binary_off0(jpp, dst, p.dst);
+        kernel(&p);
+    });
+}
+
 // Compile-time selection between the f32 shape-baked interior path and the
-// generic nspc path (f16). C++11 has no `if constexpr`, so this uses a struct
-// partial specialization to keep the f32-only baked call from being
-// instantiated for f16 (where the pointer types would not match).
+// generic nspc path (f16); a struct partial specialization keeps the f32-only
+// baked call from being instantiated for f16.
 template <cpu_isa_t isa, data_type_t d_type>
 struct nspc_exec {
-    static void run(const kernel_t<isa, d_type> &k,
+    static void run(const ncsp_kernel_t<isa, d_type> &k,
             const jit_uni_pool_interior_kernel_t<isa, d_type> *ik,
             const jit_pool_conf_t &jpp,
             const typename prec_traits_t<d_type>::type *src,
@@ -571,7 +670,7 @@ struct nspc_exec {
 
 template <cpu_isa_t isa>
 struct nspc_exec<isa, data_type::f32> {
-    static void run(const kernel_t<isa, data_type::f32> &k,
+    static void run(const ncsp_kernel_t<isa, data_type::f32> &k,
             const jit_uni_pool_interior_kernel_t<isa, data_type::f32> *ik,
             const jit_pool_conf_t &jpp, const float *src, float *dst,
             const void *po_rhs) {
@@ -579,7 +678,114 @@ struct nspc_exec<isa, data_type::f32> {
     }
 };
 
+// Native gather backward (nspc/ncsp). Parallelises over input positions; for each
+// input enumerates the covering outputs (see jit_uni_pool_bwd_contrib_t) and
+// calls the kernel, which accumulates their diff_dst rows into diff_src and
+// stores it once. max reads the argmax workspace; avg computes 1/num_summands per
+// output (uniform include- vs exclude-padding). No data race: each input's
+// diff_src is written by exactly one task.
+template <cpu_isa_t isa, data_type_t d_type>
+void pooling_bwd(const jit_uni_pool_bwd_kernel_t<isa, d_type> &kernel,
+        const jit_pool_conf_t &jpp,
+        typename prec_traits_t<d_type>::type *diff_src,
+        const typename prec_traits_t<d_type>::type *diff_dst, const char *ws) {
+    using data_t = typename prec_traits_t<d_type>::type;
+    const dim_t MB = jpp.mb, C = jpp.c;
+    const dim_t OD = jpp.od, OH = jpp.oh, OW = jpp.ow;
+    const dim_t ID = jpp.id, IH = jpp.ih, IW = jpp.iw;
+    const dim_t KD = jpp.kd, KH = jpp.kh, KW = jpp.kw;
+    const dim_t SD = jpp.stride_d, SH = jpp.stride_h, SW = jpp.stride_w;
+    const dim_t padF = jpp.f_pad, padT = jpp.t_pad, padL = jpp.l_pad;
+    const alg_kind_t alg = jpp.alg;
+    const bool is_max = alg == alg_kind::pooling_max;
+    const bool nspc = jpp.tag_kind == jit_pool_tag_kind_t::nspc;
+    const size_t ind_sz = is_max ? types::data_type_size(jpp.ind_dt) : 0;
+
+    const size_t in_spatial = (size_t)ID * IH * IW;
+    const size_t out_spatial = (size_t)OD * OH * OW;
+    const dim_t KHKW = KH * KW;
+
+    const dim_t src_vec = nspc ? (dim_t)sizeof(data_t)
+                               : (dim_t)(in_spatial * sizeof(data_t));
+    const dim_t dst_vec = nspc ? (dim_t)sizeof(data_t)
+                               : (dim_t)(out_spatial * sizeof(data_t));
+    const dim_t ws_vec
+            = nspc ? (dim_t)ind_sz : (dim_t)(out_spatial * (dim_t)ind_sz);
+
+    parallel_nd(MB, ID, IH, IW, [&](dim_t mb, dim_t id, dim_t ih, dim_t iw) {
+        // Channel-0 element offset of this input position.
+        const size_t src_off = nspc
+                ? ((((size_t)mb * ID + id) * IH + ih) * IW + iw) * C
+                : (size_t)mb * C * in_spatial + ((size_t)id * IH + ih) * IW
+                        + iw;
+
+        // Loose covering-output ranges (as in the reference); the kd/kh/kw checks
+        // below drop the positions whose window does not actually cover (id,ih,iw).
+        const dim_t od_l = std::max((id + padF - KD + 1) / SD, (dim_t)0);
+        const dim_t oh_l = std::max((ih + padT - KH + 1) / SH, (dim_t)0);
+        const dim_t ow_l = std::max((iw + padL - KW + 1) / SW, (dim_t)0);
+        const dim_t od_r = std::min((id + padF) / SD + 1, OD);
+        const dim_t oh_r = std::min((ih + padT) / SH + 1, OH);
+        const dim_t ow_r = std::min((iw + padL) / SW + 1, OW);
+
+        jit_uni_pool_bwd_contrib_t
+                contribs[jit_uni_pool_bwd_kernel_t<isa, d_type>::max_contrib];
+        int cnt = 0;
+        for (dim_t od = od_l; od < od_r; ++od) {
+            const dim_t kd = id - od * SD + padF;
+            if (kd < 0 || kd >= KD) continue;
+            for (dim_t oh = oh_l; oh < oh_r; ++oh) {
+                const dim_t kh = ih - oh * SH + padT;
+                if (kh < 0 || kh >= KH) continue;
+                for (dim_t ow = ow_l; ow < ow_r; ++ow) {
+                    const dim_t kw = iw - ow * SW + padL;
+                    if (kw < 0 || kw >= KW) continue;
+                    const size_t out_off = nspc
+                            ? ((((size_t)mb * OD + od) * OH + oh) * OW + ow) * C
+                            : (size_t)mb * C * out_spatial
+                                    + ((size_t)od * OH + oh) * OW + ow;
+                    auto &e = contribs[cnt++];
+                    e.diff_dst = diff_dst + out_off;
+                    if (is_max) {
+                        e.ws = ws + out_off * ind_sz;
+                        e.index = (int32_t)(kd * KHKW + kh * KW + kw);
+                        e.scale = 0.f;
+                    } else {
+                        e.ws = nullptr;
+                        e.index = 0;
+                        dim_t num;
+                        if (alg == alg_kind::pooling_avg_include_padding)
+                            num = KD * KH * KW;
+                        else {
+                            const dim_t d0 = std::max(od * SD - padF, (dim_t)0);
+                            const dim_t d1 = std::min(od * SD - padF + KD, ID);
+                            const dim_t h0 = std::max(oh * SH - padT, (dim_t)0);
+                            const dim_t h1 = std::min(oh * SH - padT + KH, IH);
+                            const dim_t w0 = std::max(ow * SW - padL, (dim_t)0);
+                            const dim_t w1 = std::min(ow * SW - padL + KW, IW);
+                            num = (d1 - d0) * (h1 - h0) * (w1 - w0);
+                        }
+                        e.scale = num > 0 ? 1.0f / (float)num : 0.f;
+                    }
+                }
+            }
+        }
+
+        jit_uni_pool_bwd_args_t p;
+        p.diff_src = diff_src + src_off;
+        p.contribs = contribs;
+        p.count = cnt;
+        p.channels = C;
+        p.src_vec_byte_stride = src_vec;
+        p.dst_vec_byte_stride = dst_vec;
+        p.ws_vec_byte_stride = ws_vec;
+        kernel(&p);
+    });
+}
+
 } // namespace
+
+// ============================ forward =====================================
 
 template <cpu_isa_t isa>
 jit_uni_pooling_fwd_t<isa>::jit_uni_pooling_fwd_t(const pd_t *apd)
@@ -591,73 +797,440 @@ jit_uni_pooling_fwd_t<isa>::~jit_uni_pooling_fwd_t() = default;
 template <cpu_isa_t isa>
 status_t jit_uni_pooling_fwd_t<isa>::init(engine_t *engine) {
     UNUSED(engine);
-    CHECK(safe_ptr_assign(
-            kernel_, new jit_uni_pool_kernel_t<isa, d_type>(pd()->jpp_)));
-    // The shape-baked interior kernel is f32-only; f16 uses the generic path.
-    if (d_type == data_type::f32
-            && pd()->jpp_.tag_kind == jit_pool_tag_kind_t::nspc)
-        CHECK(safe_ptr_assign(interior_kernel_,
-                new jit_uni_pool_interior_kernel_t<isa, d_type>(pd()->jpp_)));
-    return status::success;
+    if (pd()->jpp_.use_native) {
+        // Native forward-inference kernel (nspc / ncsp). nspc f32 additionally
+        // uses the shape-baked interior kernel (f32-only; the d_type==f32 guard
+        // lets the f16 path drop it). create_kernel() is CHECK'd here so a
+        // codegen failure surfaces as a status instead of a null jit_ker_ that
+        // segfaults when called (the interior kernel's fully-unrolled width
+        // sweep can overrun a branch's reach for a very large window; the pd
+        // gate declines such shapes, this is the backstop).
+        CHECK(safe_ptr_assign(ncsp_kernel_,
+                new jit_uni_pool_ncsp_kernel_t<isa, d_type>(pd()->jpp_)));
+        CHECK(ncsp_kernel_->create_kernel());
+        if (d_type == data_type::f32
+                && pd()->jpp_.tag_kind == jit_pool_tag_kind_t::nspc) {
+            CHECK(safe_ptr_assign(interior_kernel_,
+                    new jit_uni_pool_interior_kernel_t<isa, d_type>(
+                            pd()->jpp_)));
+            CHECK(interior_kernel_->create_kernel());
+        }
+        return status::success;
+    }
+    CHECK(safe_ptr_assign(kernel_,
+            new jit_uni_pool_kernel_t<isa>(pd()->jpp_, pd()->dst_md())));
+    return kernel_->create_kernel();
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pooling_fwd_t<isa>::execute_forward_blk(const data_t *src,
+        data_t *dst, char *indices, const exec_ctx_t &ctx) const {
+    const memory_desc_wrapper src_d = pd()->src_md();
+    const memory_desc_wrapper dst_d = pd()->dst_md();
+    const memory_desc_wrapper indices_d = pd()->workspace_md();
+    const int ind_dt_size
+            = indices ? (int)types::data_type_size(indices_d.data_type()) : 0;
+    const auto &jpp = pd()->jpp_;
+
+    std::vector<const void *> po_rhs = collect_binary_rhs(jpp, ctx);
+    const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
+
+    const int c_mult
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c_block : 1;
+
+    auto ker = [&](dim_t n, dim_t b_c, dim_t oh) {
+        auto arg = jit_uni_pooling_args_t();
+        const int ij = oh * jpp.stride_h;
+        const int i_t_over = nstl::max(0, jpp.t_pad - ij);
+        const int i_b_over
+                = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
+        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const dim_t c_off = (dim_t)c_mult * b_c;
+        arg.src = &src[src_d.blk_off(n, c_off, ih)];
+        arg.dst = &dst[dst_d.blk_off(n, c_off, oh)];
+        // full-dst binary offset = (arg.dst - dst_orig); dst_orig must be the
+        // dst LOGICAL origin (raw base + off_l(0)) so the offset excludes the
+        // md's offset0. blk_off() already includes offset0, and the rhs base is
+        // advanced by its own off_l(0) in collect_binary_rhs(); a raw-base
+        // dst_orig would double-count offset0 for a non-zero-offset submemory.
+        arg.dst_orig = dst + dst_d.off_l(0);
+        if (indices)
+            arg.indices
+                    = &indices[indices_d.blk_off(n, c_off, oh) * ind_dt_size];
+        arg.kh_padding = jpp.kh - i_t_over - i_b_over;
+        arg.kh_padding_shift = i_t_over * jpp.kw;
+        arg.kd_padding = jpp.kd;
+        arg.kd_padding_shift = 0;
+        arg.ker_area_h = (float)(jpp.kh - i_t_over - i_b_over);
+        arg.b_c = b_c;
+        arg.post_ops_binary_rhs_arg_vec = po_rhs_arr;
+        (*kernel_)(&arg);
+    };
+
+    parallel_nd(jpp.mb, (dim_t)jpp.nb_c, (dim_t)jpp.oh,
+            [&](dim_t n, dim_t b_c, dim_t oh) { ker(n, b_c, oh); });
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pooling_fwd_t<isa>::execute_forward_blk_3d(const data_t *src,
+        data_t *dst, char *indices, const exec_ctx_t &ctx) const {
+    const memory_desc_wrapper src_d = pd()->src_md();
+    const memory_desc_wrapper dst_d = pd()->dst_md();
+    const memory_desc_wrapper indices_d = pd()->workspace_md();
+    const int ind_dt_size
+            = indices ? (int)types::data_type_size(indices_d.data_type()) : 0;
+    const auto &jpp = pd()->jpp_;
+
+    std::vector<const void *> po_rhs = collect_binary_rhs(jpp, ctx);
+    const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
+
+    const int c_mult
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c_block : 1;
+
+    auto ker = [&](dim_t n, dim_t b_c, dim_t od, dim_t oh, dim_t id,
+                       int d_t_over, int d_b_over) {
+        auto arg = jit_uni_pooling_args_t();
+        const int ij = oh * jpp.stride_h;
+        const int i_t_over = nstl::max(0, jpp.t_pad - ij);
+        const int i_b_over
+                = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
+        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const dim_t c_off = (dim_t)c_mult * b_c;
+        arg.src = &src[src_d.blk_off(n, c_off, id, ih)];
+        arg.dst = &dst[dst_d.blk_off(n, c_off, od, oh)];
+        // dst_orig = dst LOGICAL origin (see execute_forward_blk); excludes
+        // offset0 so the full-dst binary offset is not double-counted.
+        arg.dst_orig = dst + dst_d.off_l(0);
+        if (indices)
+            arg.indices = &indices[indices_d.blk_off(n, c_off, od, oh)
+                    * ind_dt_size];
+        arg.kd_padding = jpp.kd - d_t_over - d_b_over;
+        arg.kh_padding = jpp.kh - i_t_over - i_b_over;
+        arg.kh_padding_shift = i_t_over * jpp.kw + d_t_over * jpp.kw * jpp.kh;
+        arg.kd_padding_shift = (i_t_over + i_b_over) * jpp.kw;
+        arg.ker_area_h = (float)(jpp.kh - i_t_over - i_b_over)
+                * (float)(jpp.kd - d_t_over - d_b_over);
+        arg.b_c = b_c;
+        arg.post_ops_binary_rhs_arg_vec = po_rhs_arr;
+        (*kernel_)(&arg);
+    };
+
+    parallel_nd(jpp.mb, (dim_t)jpp.nb_c, (dim_t)jpp.od,
+            [&](dim_t n, dim_t b_c, dim_t od) {
+        const int ik = od * jpp.stride_d;
+        const int d_t_over = nstl::max(0, jpp.f_pad - ik);
+        const int d_b_over
+                = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
+        const dim_t id = nstl::max(ik - jpp.f_pad, 0);
+        for (dim_t oh = 0; oh < jpp.oh; ++oh)
+            ker(n, b_c, od, oh, id, d_t_over, d_b_over);
+    });
 }
 
 template <cpu_isa_t isa>
 status_t jit_uni_pooling_fwd_t<isa>::execute_forward(
         const exec_ctx_t &ctx) const {
-
-    auto src_raw = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
-    auto dst_raw = CTX_OUT_MEM(void *, DNNL_ARG_DST);
-
-    const memory_desc_wrapper src_d(pd()->src_md());
-    const memory_desc_wrapper dst_d(pd()->dst_md());
-    const size_t dt_size = types::data_type_size(src_d.data_type());
-
-    src_raw = (const uint8_t *)src_raw + src_d.off_l(0) * dt_size;
-    dst_raw = (uint8_t *)dst_raw + dst_d.off_l(0) * dt_size;
-
-    const data_t *src = static_cast<const data_t *>(src_raw);
-    data_t *dst = static_cast<data_t *>(dst_raw);
-
     const auto &jpp = pd()->jpp_;
 
-    // Binary post-op src1 base (the lone binary in the fused chain when
-    // fuse_binary); the kernels position/advance it per output position and
-    // channel chunk. The binary may sit anywhere in the chain, so use its index.
-    const void *po_rhs = nullptr;
-    if (jpp.fuse_binary) {
-        int bin_idx = 0;
-        for (int i = 0; i < jpp.post_ops.len(); i++)
-            if (jpp.post_ops.entry_[i].is_binary()) bin_idx = i;
-        po_rhs = ctx.host_ptr(
-                DNNL_ARG_ATTR_MULTIPLE_POST_OP(bin_idx) | DNNL_ARG_SRC_1);
-        // dst was shifted to its logical element 0 (off_l(0) above), and
-        // binary_rhs_for()/the kernel address the rhs relative to that logical
-        // layout (full-dst uses rhs + (p_dst - dst)). Shift the rhs base by
-        // src1's own offset0 so the two are consistent — nonzero only for
-        // submemory src1 descriptors, but otherwise it would read the wrong
-        // address.
-        const memory_desc_wrapper s1_d(
-                jpp.post_ops.entry_[bin_idx].binary.src1_desc);
-        po_rhs = (const uint8_t *)po_rhs + s1_d.off_l(0) * dt_size;
+    if (jpp.use_native) {
+        // Native forward inference: nspc (vectorize along C) or ncsp (along
+        // OW/C). Both take logical-origin pointers and the single-binary rhs.
+        auto src_raw = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+        auto dst_raw = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+        const memory_desc_wrapper src_d(pd()->src_md());
+        const memory_desc_wrapper dst_d(pd()->dst_md());
+        const size_t dt_size = types::data_type_size(src_d.data_type());
+        src_raw = (const uint8_t *)src_raw + src_d.off_l(0) * dt_size;
+        dst_raw = (uint8_t *)dst_raw + dst_d.off_l(0) * dt_size;
+        const data_t *src = static_cast<const data_t *>(src_raw);
+        data_t *dst = static_cast<data_t *>(dst_raw);
+
+        // Per-binary rhs (src1) origin pointer array for the indirect injector
+        // mode (one f32 pointer per binary, in attribute order). The kernel adds
+        // the shared per-call offset (post_op_off0 + channel offset).
+        std::vector<const void *> po_rhs_vec;
+        if (jpp.fuse_binary) po_rhs_vec = collect_binary_rhs(jpp, ctx);
+        const void *po_rhs = po_rhs_vec.empty()
+                ? nullptr
+                : (const void *)po_rhs_vec.data();
+
+        const bool max_train
+                = jpp.is_training && jpp.alg == alg_kind::pooling_max;
+        if (max_train) {
+            // Max training: per-output argmax into the workspace (contiguous over
+            // channels for nspc, strided for ncsp).
+            auto ws_raw = CTX_OUT_MEM(char *, DNNL_ARG_WORKSPACE);
+            const memory_desc_wrapper ws_d(pd()->workspace_md());
+            char *ws = ws_raw
+                    + ws_d.off_l(0) * types::data_type_size(ws_d.data_type());
+            if (jpp.tag_kind == jit_pool_tag_kind_t::nspc)
+                pooling_train_max_nspc<isa, d_type>(
+                        *ncsp_kernel_, jpp, src, dst, ws, po_rhs);
+            else
+                pooling_train_max_ncsp<isa, d_type>(
+                        *ncsp_kernel_, jpp, src, dst, ws, po_rhs);
+        } else if (jpp.tag_kind == jit_pool_tag_kind_t::nspc) {
+            nspc_exec<isa, d_type>::run(*ncsp_kernel_, interior_kernel_.get(),
+                    jpp, src, dst, po_rhs);
+        } else if (jpp.ow == 1) {
+            pooling_ncsp_ow1<isa, d_type>(*ncsp_kernel_, jpp, src, dst, po_rhs);
+        } else {
+            pooling_ncsp<isa, d_type>(*ncsp_kernel_, jpp, src, dst, po_rhs);
+        }
+        return status::success;
     }
 
-    if (jpp.tag_kind == jit_pool_tag_kind_t::nspc) {
-        // f32 uses the shape-baked interior kernel; f16 uses the generic path.
-        nspc_exec<isa, d_type>::run(
-                *kernel_, interior_kernel_.get(), jpp, src, dst, po_rhs);
-    } else { // ncsp
-        if (jpp.ow == 1)
-            pooling_ncsp_ow1<isa, d_type>(*kernel_, jpp, src, dst, po_rhs);
-        else
-            pooling_ncsp<isa, d_type>(*kernel_, jpp, src, dst, po_rhs);
+    // Baked kernel: blocked (all fwd) and nspc/blocked training.
+    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+    auto ws = CTX_OUT_MEM(char *, DNNL_ARG_WORKSPACE);
+    if (pd()->ndims() == 5)
+        execute_forward_blk_3d(src, dst, ws, ctx);
+    else
+        execute_forward_blk(src, dst, ws, ctx);
+    return status::success;
+}
+
+// ============================ backward ====================================
+
+template <cpu_isa_t isa>
+jit_uni_pooling_bwd_t<isa>::jit_uni_pooling_bwd_t(const pd_t *apd)
+    : primitive_t(apd) {}
+
+template <cpu_isa_t isa>
+jit_uni_pooling_bwd_t<isa>::~jit_uni_pooling_bwd_t() = default;
+
+template <cpu_isa_t isa>
+status_t jit_uni_pooling_bwd_t<isa>::init(engine_t *engine) {
+    UNUSED(engine);
+    if (pd()->jpp_.use_native) {
+        // Native gather backward kernel (nspc/ncsp). create_kernel() is CHECK'd
+        // here so a codegen failure surfaces as a status instead of a null
+        // jit_ker_ that segfaults when called.
+        CHECK(safe_ptr_assign(bwd_kernel_,
+                new jit_uni_pool_bwd_kernel_t<isa, d_type>(pd()->jpp_)));
+        CHECK(bwd_kernel_->create_kernel());
+        return status::success;
+    }
+    CHECK(safe_ptr_assign(kernel_,
+            new jit_uni_pool_kernel_t<isa>(pd()->jpp_, pd()->diff_dst_md())));
+    return kernel_->create_kernel();
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pooling_bwd_t<isa>::execute_backward_blk(const data_t *diff_dst,
+        const char *indices, data_t *diff_src, const exec_ctx_t &ctx) const {
+    UNUSED(ctx);
+    const memory_desc_wrapper diff_src_d = pd()->diff_src_md();
+    const memory_desc_wrapper diff_dst_d = pd()->diff_dst_md();
+    const memory_desc_wrapper indices_d = pd()->workspace_md();
+    const int ind_dt_size
+            = indices ? (int)types::data_type_size(indices_d.data_type()) : 0;
+    const auto &jpp = pd()->jpp_;
+    const int c_mult
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c_block : 1;
+
+    auto get_first_ih = [&](int oh) {
+        return nstl::min(nstl::max(oh * jpp.stride_h - jpp.t_pad, 0), jpp.ih);
+    };
+    auto get_last_ih = [&](int oh) {
+        return nstl::min(
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+    };
+
+    auto ker = [&](dim_t n, dim_t b_c, dim_t oh) {
+        auto arg = jit_uni_pooling_args_t();
+        const int ih = get_first_ih(oh);
+        const dim_t c_off = (dim_t)c_mult * b_c;
+        arg.src = &diff_src[diff_src_d.blk_off(n, c_off, ih)];
+        arg.dst = &diff_dst[diff_dst_d.blk_off(n, c_off, oh)];
+        if (indices)
+            arg.indices
+                    = &indices[indices_d.blk_off(n, c_off, oh) * ind_dt_size];
+
+        const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+        const int zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
+        arg.zero_id = 1;
+        arg.zero_ih = zero_ih_end - zero_ih_start;
+        arg.zero_ptr = &diff_src[diff_src_d.blk_off(n, c_off, zero_ih_start)];
+
+        const int i_t_over = nstl::max(0, jpp.t_pad - (int)oh * jpp.stride_h);
+        const int i_b_over
+                = nstl::max(jpp.ih, (int)oh * jpp.stride_h + jpp.kh - jpp.t_pad)
+                - jpp.ih;
+        arg.kh_padding = jpp.kh - i_t_over - i_b_over;
+        arg.kh_padding_shift = i_t_over * jpp.kw;
+        arg.kd_padding = jpp.kd;
+        arg.ker_area_h = (float)(jpp.kh - i_t_over - i_b_over);
+        arg.b_c = b_c;
+        (*kernel_)(&arg);
+    };
+
+    parallel_nd(jpp.mb, (dim_t)jpp.nb_c, [&](dim_t n, dim_t b_c) {
+        for (dim_t oh = 0; oh < jpp.oh; ++oh)
+            ker(n, b_c, oh);
+    });
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pooling_bwd_t<isa>::execute_backward_blk_3d(const data_t *diff_dst,
+        const char *indices, data_t *diff_src, const exec_ctx_t &ctx) const {
+    UNUSED(ctx);
+    const memory_desc_wrapper diff_src_d = pd()->diff_src_md();
+    const memory_desc_wrapper diff_dst_d = pd()->diff_dst_md();
+    const memory_desc_wrapper indices_d = pd()->workspace_md();
+    const int ind_dt_size
+            = indices ? (int)types::data_type_size(indices_d.data_type()) : 0;
+    const auto &jpp = pd()->jpp_;
+    const int c_mult
+            = (jpp.tag_kind == jit_pool_tag_kind_t::nspc) ? jpp.c_block : 1;
+
+    auto get_last_ih = [&](int oh) {
+        return nstl::min(
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+    };
+    auto get_last_id = [&](int od) {
+        return nstl::min(
+                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, 0), jpp.id);
+    };
+
+    auto ker = [&](dim_t n, dim_t b_c, dim_t od, dim_t oh, dim_t id,
+                       int d_t_over, int d_b_over, bool zero_inp, int kd) {
+        auto arg = jit_uni_pooling_args_t();
+        const int ij = oh * jpp.stride_h;
+        const int i_t_over = nstl::max(0, jpp.t_pad - ij);
+        const int i_b_over
+                = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
+        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const dim_t c_off = (dim_t)c_mult * b_c;
+        arg.src = &diff_src[diff_src_d.blk_off(n, c_off, id + kd, ih)];
+        arg.dst = &diff_dst[diff_dst_d.blk_off(n, c_off, od, oh)];
+        if (indices)
+            arg.indices = &indices[indices_d.blk_off(n, c_off, od, oh)
+                    * ind_dt_size];
+
+        if (zero_inp) {
+            const int zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
+            const int zero_id_end
+                    = (od == jpp.od - 1) ? jpp.id : get_last_id(od);
+            arg.zero_id = zero_id_end - zero_id_start;
+            const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+            const int zero_ih_end
+                    = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
+            arg.zero_ih = zero_ih_end - zero_ih_start;
+            arg.zero_ptr = &diff_src[diff_src_d.blk_off(
+                    n, c_off, zero_id_start, zero_ih_start)];
+        } else {
+            arg.zero_id = 0;
+            arg.zero_ih = 0;
+        }
+
+        arg.kd_padding = jpp.kd - d_t_over - d_b_over;
+        arg.kh_padding = jpp.kh - i_t_over - i_b_over;
+        arg.kh_padding_shift = i_t_over * jpp.kw + d_t_over * jpp.kw * jpp.kh
+                + kd * jpp.kw * jpp.kh;
+        arg.kd_padding_shift = (i_t_over + i_b_over) * jpp.kw;
+        arg.ker_area_h = (float)(jpp.kh - i_t_over - i_b_over)
+                * (float)(jpp.kd - d_t_over - d_b_over);
+        arg.b_c = b_c;
+        (*kernel_)(&arg);
+    };
+
+    if (jpp.simple_alg) {
+        parallel_nd(jpp.mb, (dim_t)jpp.nb_c, [&](dim_t n, dim_t b_c) {
+            for (dim_t od = 0; od < jpp.od; ++od) {
+                const int ik = od * jpp.stride_d;
+                const int d_t_over = nstl::max(0, jpp.f_pad - ik);
+                const int d_b_over
+                        = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
+                const dim_t id = nstl::max(ik - jpp.f_pad, 0);
+                for (dim_t oh = 0; oh < jpp.oh; ++oh)
+                    ker(n, b_c, od, oh, id, d_t_over, d_b_over, true, 0);
+            }
+        });
+    } else {
+        // Non-simple: zero diff_src, then accumulate over kd. For nspc the block
+        // channels are strided (C apart), so zero the whole tensor per (mb,id)
+        // plane; for blocked each block is contiguous.
+        if (jpp.tag_kind == jit_pool_tag_kind_t::nspc) {
+            const size_t chunk = (size_t)jpp.ih * jpp.iw * jpp.c;
+            parallel_nd(jpp.mb, (dim_t)jpp.id, [&](dim_t n, dim_t id) {
+                data_t *ds = &diff_src[diff_src_d.blk_off(n, 0, id, 0)];
+                for (size_t i = 0; i < chunk; ++i)
+                    ds[i] = (data_t)0;
+            });
+        } else {
+            const size_t chunk = (size_t)jpp.id * jpp.ih * jpp.iw * jpp.c_block;
+            parallel_nd(jpp.mb, (dim_t)jpp.nb_c, [&](dim_t n, dim_t b_c) {
+                data_t *ds = &diff_src[diff_src_d.blk_off(n, b_c)];
+                for (size_t i = 0; i < chunk; ++i)
+                    ds[i] = (data_t)0;
+            });
+        }
+        for (dim_t kd = 0; kd < jpp.kd; ++kd) {
+            parallel_nd(jpp.mb, (dim_t)jpp.nb_c, [&](dim_t n, dim_t b_c) {
+                for (dim_t od = 0; od < jpp.od; ++od) {
+                    const int ik = od * jpp.stride_d;
+                    const int d_t_over = nstl::max(0, jpp.f_pad - ik);
+                    const int d_b_over
+                            = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad)
+                            - jpp.id;
+                    if (kd >= jpp.kd - d_t_over - d_b_over) continue;
+                    const dim_t id = nstl::max(ik - jpp.f_pad, 0);
+                    for (dim_t oh = 0; oh < jpp.oh; ++oh)
+                        ker(n, b_c, od, oh, id, d_t_over, d_b_over, false,
+                                (int)kd);
+                }
+            });
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_pooling_bwd_t<isa>::execute_backward(
+        const exec_ctx_t &ctx) const {
+    const auto &jpp = pd()->jpp_;
+
+    if (jpp.use_native) {
+        // Native gather backward (nspc/ncsp). Logical-origin pointers; the driver
+        // indexes channel 0 of each input/output position.
+        auto dd_raw = CTX_IN_MEM(const void *, DNNL_ARG_DIFF_DST);
+        auto ds_raw = CTX_OUT_MEM(void *, DNNL_ARG_DIFF_SRC);
+        const memory_desc_wrapper ds_d(pd()->diff_src_md());
+        const memory_desc_wrapper dd_d(pd()->diff_dst_md());
+        const size_t dt_size = types::data_type_size(ds_d.data_type());
+        dd_raw = (const uint8_t *)dd_raw + dd_d.off_l(0) * dt_size;
+        ds_raw = (uint8_t *)ds_raw + ds_d.off_l(0) * dt_size;
+
+        const char *ws = nullptr;
+        if (jpp.alg == alg_kind::pooling_max) {
+            auto ws_raw = CTX_IN_MEM(const char *, DNNL_ARG_WORKSPACE);
+            const memory_desc_wrapper ws_d(pd()->workspace_md());
+            ws = ws_raw
+                    + ws_d.off_l(0) * types::data_type_size(ws_d.data_type());
+        }
+        pooling_bwd<isa, d_type>(*bwd_kernel_, jpp,
+                static_cast<data_t *>(ds_raw),
+                static_cast<const data_t *>(dd_raw), ws);
+        return status::success;
     }
 
-    // All accepted post-ops are fused in the kernel; nothing to apply here.
+    // Baked kernel: blocked (and any plain window native declined).
+    auto diff_dst = CTX_IN_MEM(const data_t *, DNNL_ARG_DIFF_DST);
+    auto ws = CTX_IN_MEM(const char *, DNNL_ARG_WORKSPACE);
+    auto diff_src = CTX_OUT_MEM(data_t *, DNNL_ARG_DIFF_SRC);
+
+    if (pd()->ndims() == 5)
+        execute_backward_blk_3d(diff_dst, ws, diff_src, ctx);
+    else
+        execute_backward_blk(diff_dst, ws, diff_src, ctx);
     return status::success;
 }
 
 template struct jit_uni_pooling_fwd_t<v>;
 template struct jit_uni_pooling_fwd_t<zvfh>;
+template struct jit_uni_pooling_bwd_t<v>;
+template struct jit_uni_pooling_bwd_t<zvfh>;
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_uni_pooling.hpp
+++ b/src/cpu/rv64/jit_uni_pooling.hpp
@@ -33,6 +33,11 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
+// Forward pooling. The retained native kernel (jit_uni_pool_ncsp_kernel_t)
+// handles the plain nspc and ncsp layouts for both inference and training (f32
+// via v, f16 via zvfh; max and avg). The x64/aarch64-style baked kernel
+// (jit_uni_pool_kernel_t) handles the blocked (nChw{c_block}c) layout. rv64 has
+// no JIT plain<->blocked transpose, so the two layout families never mix.
 template <cpu_isa_t isa>
 struct jit_uni_pooling_fwd_t : public primitive_t {
     static constexpr data_type_t d_type
@@ -47,9 +52,11 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
         status_t init(engine_t *engine) {
             using namespace utils;
             using namespace data_type;
+            using namespace prop_kind;
 
             VDISPATCH_POOLING(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
-            VDISPATCH_POOLING(desc_.prop_kind == prop_kind::forward_inference,
+            VDISPATCH_POOLING(one_of(desc_.prop_kind, forward_inference,
+                                      forward_training),
                     VERBOSE_BAD_PROPKIND);
             VDISPATCH_POOLING(one_of(desc()->alg_kind, alg_kind::pooling_max,
                                       alg_kind::pooling_avg_include_padding,
@@ -61,9 +68,6 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
             VDISPATCH_POOLING(
                     platform::has_data_type_support(src_md()->data_type),
                     VERBOSE_UNSUPPORTED_DT);
-            // f16 accumulates in f32 (checked just below). f16 eltwise post-ops
-            // fuse in the f16 kernel (generate_f16); an f16 + binary chain is
-            // rejected by post_ops_ok() to ref_pooling.
             constexpr bool is_f16 = d_type == data_type::f16;
             VDISPATCH_POOLING(
                     IMPLICATION(
@@ -80,76 +84,52 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
                                       primitive_attr_t::skip_mask_t::post_ops),
                     VERBOSE_UNSUPPORTED_ATTR);
             // Resolve post-op binary src1 formats (may be format_any) against dst
-            // before post_ops_ok() inspects their layout via similar_to(); dst is
-            // already concrete here (set_default_params above). Matches x86/ARM
-            // pooling, which set binary post-op formats before the post-op check.
+            // before the kernels inspect their layout; matches x86/ARM pooling.
             VDISPATCH_POOLING(
                     attr_.set_default_formats(dst_md(0)) == status::success,
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_POOLING(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_POOLING(KW() < max_kernel_width,
-                    VERBOSE_UNSUPPORTED_FEATURE,
-                    "kernel width exceeds maximum");
 
-            // init_conf fills jpp_ and selects the memory layout (nspc/ncsp);
-            // it returns unimplemented for any other tag. (Computed in a
-            // separate statement so the template-argument comma is not parsed
-            // as a macro-argument separator.)
-            const status_t conf_status
-                    = jit_uni_pool_kernel_t<isa, d_type>::init_conf(
-                            jpp_, attr_, this);
+            // Max training needs the argmax workspace; set it before init_conf,
+            // which reads workspace_md() for the index dtype.
+            const bool is_training
+                    = desc_.prop_kind == prop_kind::forward_training;
+            if (desc()->alg_kind == alg_kind::pooling_max && is_training)
+                init_default_ws();
+
+            // Plain layouts (nspc/ncsp) use the retained native kernel. It
+            // handles forward inference and training for both layouts, f32 and
+            // f16, max (max training writes the argmax workspace) and avg. It
+            // declines blocked, and f16 max training with a window too large for
+            // a 16-bit index, which fall to the baked kernel below.
+            {
+                status_t st
+                        = jit_uni_pool_ncsp_kernel_t<isa, d_type>::init_conf(
+                                jpp_, attr_, this);
+                if (st == status::success) return status::success;
+            }
+
+            // Baked kernel: blocked (all fwd props) and the plain training cases
+            // native declined (f16/post-op max training).
+            auto scratchpad = scratchpad_registry().registrar();
+            status_t st = jit_uni_pool_kernel_t<isa>::init_conf(
+                    jpp_, scratchpad, attr_, this);
+            VDISPATCH_POOLING(st == status::success, VERBOSE_UNSUPPORTED_TAG);
+
+            // f32 nspc reaching the baked kernel (a case the native kernel
+            // declined) issues many narrow per-channel-block calls with little
+            // per-element work, so it defers to the nhwc_pooling reduction. f16
+            // nspc keeps the baked kernel (its f16<->f32 conversion outweighs the
+            // call overhead), and blocked has no reduction fallback, so both
+            // stay.
             VDISPATCH_POOLING(
-                    conf_status == status::success, VERBOSE_UNSUPPORTED_TAG);
-
-            // Post-ops accepted by post_ops_ok() are all fused in the kernel
-            // (eltwise for f32/f16, binary for f32); nothing runs as a separate
-            // primitive, so there is no post-op orchestrator here.
+                    !(d_type == data_type::f32
+                            && jpp_.tag_kind == jit_pool_tag_kind_t::nspc),
+                    VERBOSE_IMPL_HEURISTIC_FAIL,
+                    "f32 nspc forward defers to the nhwc_pooling reduction");
             return status::success;
         }
 
         jit_pool_conf_t jpp_;
-
-    private:
-        bool post_ops_ok() const {
-            const auto &po = attr()->post_ops_;
-            if (po.has_default_values()) return true;
-            // Accept an injector-supported chain (any number of eltwise plus
-            // binary, in attribute order); every entry is fused in the kernel.
-            // The pool kernel positions a single host-computed rhs (channel-vec
-            // forcing), so at most ONE binary is supported here even though the
-            // injector itself allows more (that capability is used by
-            // matmul/conv). Binary is fused for f32 only. Anything else (sum,
-            // prelu, >1 binary, f16+binary, unsupported alg) falls back to
-            // ref_pooling.
-            if (!injector::jit_uni_postops_injector_t<isa>::post_ops_ok(po))
-                return false;
-            const memory_desc_wrapper dst_d(dst_md());
-            int n_binary = 0;
-            for (int i = 0; i < po.len(); i++) {
-                if (!po.entry_[i].is_binary()) continue;
-                if (++n_binary > 1) return false; // single host-positioned rhs
-                if (d_type != data_type::f32) return false; // f32 fusion only
-                const auto &b = po.entry_[i].binary;
-                // The injector loads the rhs as f32; binary_rhs_for() only knows
-                // three broadcasts: scalar, per-oc ([1,C,1,..]) and full-dst
-                // (read 1:1 with the output via p_dst-dst, so it must share dst's
-                // layout). Reject anything else (e.g. broadcast-over-C like
-                // [N,1,OH,OW]) so it falls back to ref_pooling.
-                if (b.src1_desc.data_type != data_type::f32) return false;
-                const memory_desc_wrapper s1(b.src1_desc);
-                const bool scalar = s1.nelems(true) == 1;
-                // per-oc is read as a contiguous [C] vector (vle32), so the C
-                // values must be dense; full-dst is read 1:1 via similar_to
-                // (which already enforces strides).
-                bool per_oc = dst_d.ndims() >= 2 && s1.ndims() == dst_d.ndims()
-                        && s1.dims()[1] == dst_d.dims()[1] && s1.is_dense(true);
-                for (int k = 0; per_oc && k < dst_d.ndims(); k++)
-                    if (k != 1 && s1.dims()[k] != 1) per_oc = false;
-                const bool full = s1.similar_to(dst_d, true, false);
-                if (!scalar && !per_oc && !full) return false;
-            }
-            return true;
-        }
     };
 
     jit_uni_pooling_fwd_t(const pd_t *apd);
@@ -163,17 +143,130 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
         return execute_forward(ctx);
     }
 
-    static constexpr int max_kernel_width = 32;
-
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
+    // Baked kernel drivers (blocked/nspc), ported from aarch64.
+    void execute_forward_blk(const data_t *src, data_t *dst, char *indices,
+            const exec_ctx_t &ctx) const;
+    void execute_forward_blk_3d(const data_t *src, data_t *dst, char *indices,
+            const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_uni_pool_kernel_t<isa, d_type>> kernel_;
-    // Shape-baked interior kernel (ur_w input reuse), used for the full-window
-    // interior of nspc rows; null for other layouts.
+    std::unique_ptr<jit_uni_pool_kernel_t<isa>> kernel_;
+    std::unique_ptr<jit_uni_pool_ncsp_kernel_t<isa, d_type>> ncsp_kernel_;
+    // nspc f32 forward-inference interior (shape-baked ur_w reuse); null else.
     std::unique_ptr<jit_uni_pool_interior_kernel_t<isa, d_type>>
             interior_kernel_;
+};
+
+// Backward pooling. Plain layouts (nspc/ncsp) use the native gather kernel
+// (jit_uni_pool_bwd_kernel_t); blocked uses the x64/aarch64-style baked kernel.
+// Both handle max (via the index workspace) and avg.
+template <cpu_isa_t isa>
+struct jit_uni_pooling_bwd_t : public primitive_t {
+    static constexpr data_type_t d_type
+            = (isa == zvfh) ? data_type::f16 : data_type::f32;
+
+    struct pd_t : public cpu_pooling_bwd_pd_t {
+        using cpu_pooling_bwd_pd_t::cpu_pooling_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
+                jit_uni_pooling_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace utils;
+            using namespace data_type;
+
+            VDISPATCH_POOLING(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_POOLING(!is_fwd(), VERBOSE_BAD_PROPKIND);
+            VDISPATCH_POOLING(one_of(desc()->alg_kind, alg_kind::pooling_max,
+                                      alg_kind::pooling_avg_include_padding,
+                                      alg_kind::pooling_avg_exclude_padding),
+                    VERBOSE_BAD_ALGORITHM);
+            VDISPATCH_POOLING(everyone_is(d_type, diff_src_md()->data_type,
+                                      diff_dst_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_POOLING(
+                    platform::has_data_type_support(diff_src_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            constexpr bool is_f16 = d_type == data_type::f16;
+            VDISPATCH_POOLING(
+                    IMPLICATION(
+                            is_f16, desc()->accum_data_type == data_type::f32),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_POOLING(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+            VDISPATCH_POOLING(!is_dilated(), VERBOSE_UNSUPPORTED_FEATURE,
+                    "does not support dilations");
+            VDISPATCH_POOLING(set_default_params() == status::success,
+                    VERBOSE_UNSUPPORTED_TAG);
+            VDISPATCH_POOLING(
+                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+
+            if (desc()->alg_kind == alg_kind::pooling_max) {
+                init_default_ws();
+                if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;
+            }
+
+            // The native gather backward kernel is used only for f16 nspc, where
+            // its vectorized f16<->f32 conversion outweighs the extra traffic.
+            // f32 (both layouts) and f16 ncsp keep the pre-existing dispatch
+            // (baked for blocked/nspc, the nhwc/nchw reference otherwise). For a
+            // non-nspc f16 layout init_conf still populates jpp_, but the baked
+            // path below repopulates it.
+            if (d_type == data_type::f16) {
+                status_t st = jit_uni_pool_bwd_kernel_t<isa, d_type>::init_conf(
+                        jpp_, this);
+                if (st == status::success
+                        && jpp_.tag_kind == jit_pool_tag_kind_t::nspc)
+                    return status::success;
+            }
+
+            // Baked kernel: blocked and nspc (pre-existing path).
+            auto scratchpad = scratchpad_registry().registrar();
+            VDISPATCH_POOLING(jit_uni_pool_kernel_t<isa>::init_conf(
+                                      jpp_, scratchpad, attr_, this)
+                            == status::success,
+                    VERBOSE_UNSUPPORTED_TAG);
+
+            // f32 nspc backward is a memory-bound read-modify-write (each input
+            // is updated once per covering output window, ~ceil(K/S)^ndims x the
+            // diff_src traffic), which loses to the nhwc_pooling gather (each
+            // input written once); with no dtype conversion to amortize it, defer
+            // to that reference. f16 nspc took the native kernel above, and
+            // blocked has no gather fallback, so it stays on the baked kernel.
+            VDISPATCH_POOLING(
+                    !(d_type == data_type::f32
+                            && jpp_.tag_kind == jit_pool_tag_kind_t::nspc),
+                    VERBOSE_IMPL_HEURISTIC_FAIL,
+                    "f32 nspc backward defers to the nhwc_pooling gather");
+            return status::success;
+        }
+
+        jit_pool_conf_t jpp_;
+    };
+
+    jit_uni_pooling_bwd_t(const pd_t *apd);
+    ~jit_uni_pooling_bwd_t() override;
+
+    using data_t = typename prec_traits_t<d_type>::type;
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_backward(ctx);
+    }
+
+private:
+    status_t execute_backward(const exec_ctx_t &ctx) const;
+    void execute_backward_blk(const data_t *diff_dst, const char *indices,
+            data_t *diff_src, const exec_ctx_t &ctx) const;
+    void execute_backward_blk_3d(const data_t *diff_dst, const char *indices,
+            data_t *diff_src, const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_uni_pool_kernel_t<isa>> kernel_;
+    // Native gather backward kernel (nspc/ncsp); null when the baked kernel runs.
+    std::unique_ptr<jit_uni_pool_bwd_kernel_t<isa, d_type>> bwd_kernel_;
 };
 
 } // namespace rv64


### PR DESCRIPTION
## Summary

Add new RVV JIT pooling forward training (FWD_D) and backward (BWD_D) kernels for the rv64 backend, supporting f32 (`v`) and f16 (`zvfh`) data types, layouts ncsp / nspc / blocked, and algorithms max / avg_include_padding / avg_exclude_padding. Post-ops are fused inside the kernel via the shared rv64 injector.

The implementation consists of three parts (all pure JIT, Xbyak_riscv):

| Kernel | Role | Origin |
|---|---|---|
| `jit_uni_pool_kernel_t<isa>` | **baked**: blocked (all directions) + plain fallback for training/backward | Structured port of x64/aarch64 baked kernel |
| `jit_uni_pool_ncsp_kernel_t<isa,dt>` + `jit_uni_pool_interior_kernel_t<isa,dt>` | **native**: plain (ncsp/nspc) forward; interior is a shape‑baked ur_w reuse kernel for f32 nspc FWD_I | Native RVV straight‑vectorization kernels |
| `jit_uni_pool_bwd_kernel_t<isa,dt>` | **native gather**: plain backward (contrib‑list, parallel‑over‑inputs, write‑once) | New for rv64 |

- `c_block = min(16, VLEN/32)` → VLEN 128/256/≥512 correspond to blocked tags `nChw{4,8,16}c`.

## Dispatch Status

### FWD_I (forward_inference)

| dtype \ layout | ncsp | nspc | blocked |
|---|---|---|---|
| **f32** | `jit:rvv` (native) | `jit:rvv` (native, +interior) | `jit:rvv` (baked) |
| **f16** | `jit:rvv_zvfh` (native) | `jit:rvv_zvfh` (native) | `jit:rvv_zvfh` (baked) |

### FWD_D (forward_training)

| dtype \ layout | ncsp | nspc | blocked |
|---|---|---|---|
| **f32** | `jit:rvv` (native) | `jit:rvv` (native) | `jit:rvv` (baked) |
| **f16** | `jit:rvv_zvfh` (native) | `jit:rvv_zvfh` (native) | `jit:rvv_zvfh` (baked) |

### BWD_D

| dtype \ layout | ncsp | nspc | blocked |
|---|---|---|---|
| **f32** | reference (`nchw_pooling`) | reference (`nhwc_pooling`, performance‑gated) | `jit:rvv` (baked) |
| **f16** | reference (`nchw_pooling`) | `jit:rvv_zvfh` (native gather) | `jit:rvv_zvfh` (baked) |

## Post‑op Support

- **Forward (FWD_I / FWD_D): supported** – both native and baked kernels fuse post‑ops via the shared rv64 post‑op injector inside the kernel.
- **Backward (BWD_D): not supported** for any post‑op (the pd requires the attribute to be default); with post‑ops → reference. This matches x64/aarch64/ref backward behavior.

## Functional Verification

```
100% tests passed, 0 tests failed out of 233

Total Test time (real) = 4614.98 sec
```

## Performance

All performance tests run on SG2044.

### FWD_D Performance Comparison

#### f32 - abx

| Test Case | main (ms) | now (ms) | Speedup |
| :--- | ---: | ---: | ---: |
| shapes_googlenetv3 | 264.43 | 206.74 | 1.28 |
| shapes_resnet_50 | 13.87 | 6.32 | 2.19 |
| shapes_i3d_resnet50_v1 | 5.50 | 5.24 | 1.05 |
| shapes_3d_unet | 4.77 | 7.79 | 0.61 |
| shapes_global_pooling | 0.09 | 0.12 | 0.81 |
| shapes_1d | 0.47 | 0.46 | 1.01 |
| shapes_2d | 24.60 | 11.65 | 2.11 |
| shapes_3d | 35.40 | 32.70 | 1.08 |

---

#### f32 - axb

| Test Case | main (ms) | now (ms) | Speedup |
| :--- | ---: | ---: | ---: |
| shapes_googlenetv3 | 128.78 | 73.76 | 1.75 |
| shapes_resnet_50 | 7.49 | 5.47 | 1.37 |
| shapes_i3d_resnet50_v1 | 2.83 | 2.53 | 1.12 |
| shapes_3d_unet | 1.66 | 1.54 | 1.08 |
| shapes_global_pooling | 0.48 | 0.23 | 2.12 |
| shapes_1d | 0.57 | 0.50 | 1.16 |
| shapes_2d | 15.75 | 7.61 | 2.07 |
| shapes_3d | 31.19 | 17.21 | 1.81 |

---

#### f16 - abx

| Test Case | main (ms) | now (ms) | Speedup |
| :--- | ---: | ---: | ---: |
| shapes_googlenetv3 | 381.05 | 143.06 | 2.66 |
| shapes_resnet_50 | 23.44 | 4.23 | 5.54 |
| shapes_i3d_resnet50_v1 | 8.17 | 4.59 | 1.78 |
| shapes_3d_unet | 6.76 | 5.42 | 1.25 |
| shapes_global_pooling | 0.16 | 0.10 | 1.71 |
| shapes_1d | 0.60 | 0.47 | 1.27 |
| shapes_2d | 31.33 | 9.22 | 3.40 |
| shapes_3d | 51.38 | 19.97 | 2.57 |

---

#### f16 - axb

| Test Case | main (ms) | now (ms) | Speedup |
| :--- | ---: | ---: | ---: |
| shapes_googlenetv3 | 317.38 | 34.39 | 9.23 |
| shapes_resnet_50 | 20.58 | 2.25 | 9.14 |
| shapes_i3d_resnet50_v1 | 7.87 | 0.82 | 9.55 |
| shapes_3d_unet | 4.89 | 0.64 | 7.60 |
| shapes_global_pooling | 0.76 | 0.10 | 7.62 |
| shapes_1d | 0.62 | 0.52 | 1.19 |
| shapes_2d | 50.38 | 5.88 | 8.56 |
| shapes_3d | 154.68 | 12.71 | 12.17 |

---

### BWD_D Performance Comparison

#### f16 - axb

| Test Case | main (ms) | now (ms) | Speedup |
| :--- | ---: | ---: | ---: |
| shapes_googlenetv3 | 451.29 | 54.31 | 8.31 |
| shapes_resnet_50 | 41.28 | 4.12 | 10.03 |
| shapes_i3d_resnet50_v1 | 14.07 | 1.27 | 11.07 |
| shapes_3d_unet | 12.54 | 1.07 | 11.75 |
| shapes_global_pooling | 0.29 | 0.09 | 3.14 |
| shapes_1d | 0.47 | 0.37 | 1.26 |
| shapes_2d | 50.92 | 6.51 | 7.82 |
| shapes_3d | 199.11 | 13.90 | 14.32 |

---

### Blocked Layout Performance Comparison

#### f32

| Direction | Layout | Test Case | main (ms) | now (ms) | Speedup |
| :--- | :--- | :--- | ---: | ---: | ---: |
| fwdi | aBc4b | shapes_1d | 0.64 | 0.52 | 1.22 |
| fwdi | aBcd4b | shapes_2d | 123.15 | 16.28 | 7.56 |
| fwdi | aBcd4b | shapes_resnet_50 | 74.86 | 2.19 | 34.24 |
| fwdi | aBcde4b | shapes_3d | 250.37 | 116.91 | 2.14 |
| fwdd | aBc4b | shapes_1d | 1.09 | 0.84 | 1.30 |
| fwdd | aBcd4b | shapes_2d | 160.78 | 21.85 | 7.36 |
| fwdd | aBcd4b | shapes_resnet_50 | 91.65 | 2.49 | 36.80 |
| fwdd | aBcde4b | shapes_3d | 264.82 | 135.14 | 1.96 |
| bwdd | aBc4b | shapes_1d | 0.59 | 0.52 | 1.13 |
| bwdd | aBcd4b | shapes_2d | 23.73 | 8.66 | 2.74 |
| bwdd | aBcd4b | shapes_resnet_50 | 17.63 | 3.99 | 4.41 |
| bwdd | aBcde4b | shapes_3d | 32.22 | 31.99 | 1.01 |

---

#### f16

| Direction | Layout | Test Case | main (ms) | now (ms) | Speedup |
| :--- | :--- | :--- | ---: | ---: | ---: |
| fwdi | aBc4b | shapes_1d | 0.67 | 0.55 | 1.21 |
| fwdi | aBcd4b | shapes_2d | 139.48 | 18.31 | 7.62 |
| fwdi | aBcd4b | shapes_resnet_50 | 86.69 | 1.50 | 57.80 |
| fwdi | aBcde4b | shapes_3d | 270.32 | 133.57 | 2.02 |
| fwdd | aBc4b | shapes_1d | 1.07 | 0.85 | 1.26 |
| fwdd | aBcd4b | shapes_2d | 169.56 | 23.09 | 7.34 |
| fwdd | aBcd4b | shapes_resnet_50 | 101.43 | 1.52 | 66.78 |
| fwdd | aBcde4b | shapes_3d | 293.14 | 151.04 | 1.94 |
| bwdd | aBc4b | shapes_1d | 0.70 | 0.63 | 1.12 |
| bwdd | aBcd4b | shapes_2d | 25.47 | 14.23 | 1.79 |
| bwdd | aBcd4b | shapes_resnet_50 | 15.64 | 3.45 | 4.53 |
| bwdd | aBcde4b | shapes_3d | 35.95 | 41.96 | 0.86 |