### PR TITLE
src: gpu: intel: sdpa: fix condition for skipping dropout with xe_hpg

### DIFF
--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -339,14 +339,13 @@ struct micro_fwd_t : public primitive_t {
                                    with_causal_mask()),
                     "fused f32 SDPA only optimized for causal mask"); //TODO: update when performance improved
             // Xe-HPG: enabling dropout on the systolic micro_sdpa fwd path
-            // triggers an IGC miscompile that yields partial-zero outputs.
-            // Neither dropout alone nor mask alone is affected.
-            // Reject this specific combination so the graph API
-            // falls back to the unfused decompositio
-            VDISPATCH_SDPA((arch() == compute::gpu_arch_t::xe_hpg
-                                   && !attr()->dropout_.has_default_values()),
-                    "fused SDPA FWD with device dropout leads to IGC miscompile"
-                    "for xe_hpg");
+            // triggers an IGC miscompile that yields NaN/zero outputs.
+            // Reject this combination so the caller falls back to the
+            // large partition graph
+            VDISPATCH_SDPA(IMPLICATION(arch() == compute::gpu_arch_t::xe_hpg,
+                                   attr()->dropout_.has_default_values()),
+                    "fused SDPA FWD with dropout leads to IGC miscompile "
+                    "on xe_hpg");
             CHECK(init_conf_microkernels(engine));
             CHECK(init_conf(engine));
 


### PR DESCRIPTION
Fix xe_hpg condition to skip other architectures enabled