### PR TITLE
gpu: ocl, sycl: add queue props check for enabling verbose profiler

### DIFF
--- a/src/gpu/intel/ocl/stream.cpp
+++ b/src/gpu/intel/ocl/stream.cpp
@@ -48,11 +48,6 @@ status_t stream_t::init() {
     // set_dnnl_verbose()
     CHECK(impl()->init_verbose_profiler(engine()->kind()));
 
-    if (is_verbose_profiler_enabled()) {
-        verbose_profiler_.set(
-                utils::make_unique<xpu::ocl::verbose_profiler_t>(this));
-    }
-
     // Restore queue on successful exit, otherwise queue may be released
     // without retain
     cl_command_queue queue = impl()->queue();
@@ -87,6 +82,20 @@ status_t stream_t::init() {
         OCL_CHECK(xpu::ocl::clRetainCommandQueue(queue));
     }
     CHECK(impl()->set_queue(queue));
+    if (is_verbose_profiler_enabled()) {
+        verbose_profiler_.set(
+                utils::make_unique<xpu::ocl::verbose_profiler_t>(this));
+        // Check if the queue has profiling enabled and pause the verbose
+        // profiler if it does not. Verbose lines are still emitted during
+        // logging, but without execution timing information.
+        if (!impl()->queue_has_profiling()) {
+            VWARN(common, ocl,
+                    "OpenCL queue does not have profiling enabled. "
+                    "Verbose profiling is paused and execution times "
+                    "will not be reported.");
+            verbose_profiler()->pause_profiling();
+        }
+    }
 
     if (is_profiling_enabled() || is_verbose_profiler_enabled()) {
         cl_command_queue_properties props;
@@ -131,6 +140,7 @@ void stream_t::before_exec_hook() {
     if (is_verbose_profiler_enabled()) {
         auto &verbose_profiler = verbose_profiler_.get_or_set(
                 utils::make_unique<xpu::ocl::verbose_profiler_t>(this));
+        if (!impl()->queue_has_profiling()) verbose_profiler->pause_profiling();
         verbose_profiler->update_event_list();
     }
 }

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -73,7 +73,8 @@ status_t stream_t::init() {
         }
         impl()->set_queue(::sycl::queue(sycl_ctx, sycl_dev, props));
 
-        // Re-initializes verbose profiler to check for supported backend
+        // Re-initializes verbose profiler after setting the queue to check for
+        // supported backends
         CHECK(impl()->init_verbose_profiler(engine()->kind()));
 
     } else {
@@ -92,6 +93,18 @@ status_t stream_t::init() {
     if (is_verbose_profiler_enabled()) {
         verbose_profiler_.set(
                 utils::make_unique<xpu::sycl::verbose_profiler_t>(this));
+        // Check if the queue has profiling enabled and pause the verbose
+        // profiler if it does not. Verbose lines are still emitted during
+        // logging, but without execution timing information.
+        const bool queue_has_profiling = queue().has_property<
+                ::sycl::property::queue::enable_profiling>();
+        if (!queue_has_profiling) {
+            VWARN(primitive, exec,
+                    "SYCL queue does not have profiling enabled. "
+                    "Verbose profiling is paused and execution times "
+                    "will not be reported.");
+            verbose_profiler()->pause_profiling();
+        }
     }
     if (is_profiling_enabled() && sycl_dev.is_gpu() && !queue().is_in_order()) {
         VERROR(common, dpcpp,
@@ -111,6 +124,10 @@ void stream_t::before_exec_hook() {
                         .get_or_set(utils::make_unique<
                                 xpu::sycl::verbose_profiler_t>(this))
                         .get());
+        const bool queue_has_profiling = queue().has_property<
+                ::sycl::property::queue::enable_profiling>();
+        if (!queue_has_profiling) { profiler->pause_profiling(); }
+
         // Device event profiling and SYCL graph recording are incompatible
         // because the graph execution creates a different execution context
         // with new events that do not inherit the original queue's profiling
@@ -123,10 +140,10 @@ void stream_t::before_exec_hook() {
         // graph is recording and resume thereafter to avoid runtime exceptions.
         // In this scenario, the profiler will report zero execution time for
         // the logged primitives.
-        if (!recording()) {
+        if (!recording() && queue_has_profiling) {
             profiler->start_profiling();
         } else {
-            if (profiler->is_active()) {
+            if (profiler->is_active() && queue_has_profiling) {
                 VWARN(primitive, exec,
                         "SYCL graph recording active - verbose profiling will "
                         "show zero "

--- a/src/xpu/ocl/stream_impl.cpp
+++ b/src/xpu/ocl/stream_impl.cpp
@@ -279,6 +279,13 @@ status_t stream_impl_t::init_verbose_profiler(engine_kind_t kind) {
     return status::success;
 }
 
+bool stream_impl_t::queue_has_profiling() const {
+    cl_command_queue_properties ocl_queue_props = 0;
+    cl_int err = clGetCommandQueueInfo(queue_, CL_QUEUE_PROPERTIES,
+            sizeof(ocl_queue_props), &ocl_queue_props, nullptr);
+    return (err == CL_SUCCESS && (ocl_queue_props & CL_QUEUE_PROFILING_ENABLE));
+}
+
 const xpu::ocl::context_t &stream_impl_t::ocl_ctx() const {
     return ctx_.get();
 }

--- a/src/xpu/ocl/stream_impl.hpp
+++ b/src/xpu/ocl/stream_impl.hpp
@@ -73,6 +73,8 @@ public:
 
     status_t init_verbose_profiler(engine_kind_t kind) override;
 
+    bool queue_has_profiling() const;
+
     const xpu::ocl::context_t &ocl_ctx() const;
     xpu::ocl::context_t &ocl_ctx();
     xpu::context_t &ctx();

--- a/src/xpu/ocl/stream_profiler.cpp
+++ b/src/xpu/ocl/stream_profiler.cpp
@@ -77,6 +77,8 @@ status_t stream_profiler_t::get_info(profiling_data_kind_t data_kind,
 
 status_t verbose_profiler_t::get_aggregate_exec_time(
         size_t index, double &duration_ms) const {
+    if (!active_) return status::success;
+
     if (index >= profiling_data_.size()) {
         VERROR(primitive, exec,
                 "profiling error: invalid index %zu, profiling_data size is "
@@ -123,6 +125,7 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
 
 bool verbose_profiler_t::is_event_complete(
         const std::shared_ptr<xpu::event_t> &event) const {
+    if (!active_) return true;
     if (!event) return true;
     const auto &ocl_event = xpu::ocl::event_t::from(*event);
     size_t last_idx = ocl_event.size() - 1;
@@ -142,6 +145,7 @@ bool verbose_profiler_t::is_event_complete(
 
 void verbose_profiler_t::wait_for_event_completion(
         const std::shared_ptr<xpu::event_t> &event) const {
+    if (!active_) return;
     if (!event) return;
     const auto &ocl_event = xpu::ocl::event_t::from(*event);
     size_t last_idx = ocl_event.size() - 1;

--- a/src/xpu/stream_profiler.cpp
+++ b/src/xpu/stream_profiler.cpp
@@ -60,10 +60,11 @@ void verbose_profiler_t::check_for_completed_primitives() {
         double duration_ms = 0.0;
 
         // Handles primitives with no kernels
-        if (evts.empty() && !prof_data.pd_info_.empty()) {
+        if (evts.empty()) {
             // Will be erased in second pass
-            VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
-                    prof_data.pd_info_.c_str(), duration_ms);
+            if (!prof_data.pd_info_.empty())
+                VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
+                        prof_data.pd_info_.c_str(), duration_ms);
             continue;
         }
 

--- a/src/xpu/stream_profiler.hpp
+++ b/src/xpu/stream_profiler.hpp
@@ -139,7 +139,8 @@ protected:
 // operating independently from other stream profilers during primitive
 // execution.
 struct verbose_profiler_t {
-    verbose_profiler_t(const stream_t *stream) : stream_(stream) {}
+    verbose_profiler_t(const stream_t *stream)
+        : stream_(stream), active_(true) {}
 
     virtual ~verbose_profiler_t() = default;
 
@@ -148,13 +149,15 @@ struct verbose_profiler_t {
         std::string pd_info_;
         std::vector<std::shared_ptr<xpu::event_t>> prim_events_;
     };
-
-    // For supported runtimes, querying events for profiling info
-    // can be force-paused for scenarios where profiling capabilities
-    // are temporarily unavailable (example: SYCL graph execution)
-    // This method checks profiler status where such force-pausing
-    // is supported.
-    virtual bool is_active() const { return true; }
+    // Pausing capabilities are added to allow skipping event profiling
+    // queries when they are temporarily unavailable (example:
+    // SYCL graph execution or when queue does not have profiling enabled).
+    // These methods check and update profiler status where such force-pausing
+    // is required. Pausing action is localized to each thread for multi-
+    // threaded execution
+    bool is_active() const { return true; }
+    void start_profiling() { active_ = true; }
+    void pause_profiling() { active_ = false; }
 
     // The profiler operates through a multi-step event tracking workflow:
     // 1. stream->before_exec_hook() calls update_event_list()
@@ -195,6 +198,7 @@ struct verbose_profiler_t {
 protected:
     const stream_t *stream_;
     std::vector<prim_profile_data_t> profiling_data_;
+    bool active_;
 
     // destructor logic to check for unlogged primitives before
     // stream destruction

--- a/src/xpu/sycl/stream_impl.cpp
+++ b/src/xpu/sycl/stream_impl.cpp
@@ -222,17 +222,18 @@ status_t stream_impl_t::init_verbose_profiler(engine_kind_t kind) {
     if (kind != engine_kind::gpu) return status::success;
     // verbose profiling support is only for in-order queues
     if (flags() & stream_flags::out_of_order) return status::success;
+
+    // The queue may not be set yet at this point; in that case the profiler
+    // is re-initialized once the queue is created. When the queue is
+    // available, verify that the backend supports verbose profiling.
+    if (queue_) {
+        const auto backend = queue_->get_backend();
+        if (!utils::one_of(backend, ::sycl::backend::ext_oneapi_level_zero,
+                    ::sycl::backend::opencl)) {
+            return status::success;
+        }
+    }
     use_verbose_profiler_ = true;
-
-    // if the queue is set, verbose profiling is disabled for
-    // unsupported backends
-    if (!queue_) return status::success;
-
-    const auto backend = queue_->get_backend();
-    if (!utils::one_of(backend, ::sycl::backend::ext_oneapi_level_zero,
-                ::sycl::backend::opencl))
-        use_verbose_profiler_ = false;
-
     return status::success;
 }
 

--- a/src/xpu/sycl/stream_profiler.cpp
+++ b/src/xpu/sycl/stream_profiler.cpp
@@ -72,7 +72,7 @@ status_t stream_profiler_t::get_info(profiling_data_kind_t data_kind,
 
 status_t verbose_profiler_t::get_aggregate_exec_time(
         size_t index, double &duration_ms) const {
-    if (!is_active()) return status::success;
+    if (!active_) return status::success;
 
     using namespace ::sycl::info;
     if (index >= profiling_data_.size()) {
@@ -124,7 +124,7 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
 
 bool verbose_profiler_t::is_event_complete(
         const std::shared_ptr<xpu::event_t> &event) const {
-    if (!is_active()) return true;
+    if (!active_) return true;
     if (!event) return true;
 
     const auto &sycl_event = xpu::sycl::event_t::from(*event);
@@ -140,7 +140,7 @@ bool verbose_profiler_t::is_event_complete(
 
 void verbose_profiler_t::wait_for_event_completion(
         const std::shared_ptr<xpu::event_t> &event) const {
-    if (!is_active()) return;
+    if (!active_) return;
     if (!event) return;
 
     const auto &sycl_event = xpu::sycl::event_t::from(*event);

--- a/src/xpu/sycl/stream_profiler.hpp
+++ b/src/xpu/sycl/stream_profiler.hpp
@@ -36,7 +36,7 @@ struct stream_profiler_t : public xpu::stream_profiler_t {
 
 struct verbose_profiler_t : public xpu::verbose_profiler_t {
     verbose_profiler_t(const impl::stream_t *stream)
-        : xpu::verbose_profiler_t(stream), active_(true) {}
+        : xpu::verbose_profiler_t(stream) {}
 
     ~verbose_profiler_t() override { cleanup(); }
 
@@ -48,17 +48,6 @@ struct verbose_profiler_t : public xpu::verbose_profiler_t {
 
     void wait_for_event_completion(
             const std::shared_ptr<xpu::event_t> &event) const override;
-
-    // pausing capabilities are added to allow skipping event profiling
-    // queires when they are temporarily unvaiable
-    // (sycl graph execution) -pausing action is localized to each
-    // thread for multi-threaded execution
-    bool is_active() const override { return active_; }
-    void start_profiling() { active_ = true; }
-    void pause_profiling() { active_ = false; }
-
-protected:
-    bool active_;
 };
 
 } // namespace sycl


### PR DESCRIPTION
# Description

The PR adds an additional check for queue profiling properties during verbose profiler initialization to disable async logging whenever profiling is not enabled on the interop queue. Follow-up from PR #5102 

Update:
By disabling async logging whenever profiling is not enabled on the queue, the logging operation falls back to blocked synchronous logging which does not sit well with SYCL Graph. 
The fix is modified so that when queue does not have profiling enabled:
- verbose profiler initialization throws a warning about queue profiling properties.
- profiling is paused and the logging continues with zero reported execution times.

Fixes [MFDNN-15292](https://jira.devtools.intel.com/browse/MFDNN-15292), [MFDNN-15319](https://jira.devtools.intel.com/browse/MFDNN-15319).