### PR TITLE
x64: matmul: int8: per-mn-copmensation hreduce fix

### DIFF
--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -287,8 +287,10 @@ private:
         if (is_zmm) {
             vextracti64x4(tmp_y, Xbyak::Zmm(src.getIdx()), 1);
             vpaddd(src_y, src_y, tmp_y);
+            vextracti32x4(tmp_x, src_y, 1);
+        } else {
+            vextracti128(tmp_x, src_y, 1);
         }
-        vextracti128(tmp_x, src_y, 1);
         vpaddd(src_x, src_x, tmp_x);
         vpshufd(tmp_x, src_x, 0x4E);
         vpaddd(src_x, src_x, tmp_x);


### PR DESCRIPTION
Fixes [MFDNN-15308](https://jira.devtools.intel.com/browse/MFDNN-15308). 

Incorrect instruction usage for EVEX-case. 

Test cases are in [5317](https://github.com/uxlfoundation/oneDNN/pull/5317).
