### PR TITLE
cpu: aarch64: matmul: jit_int8: check eltwise_injector support for alg

### DIFF
--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -16,6 +16,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <algorithm>
 #include <cassert>
 
 #include "common/c_types_map.hpp"
@@ -993,22 +994,12 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
     VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-    bool no_post_ops = attr()->post_ops_.has_default_values();
-
-    auto with_eltwise = [this]() -> bool {
-        // we only support eltwise post-op
-        for (auto &e : this->attr()->post_ops_.entry_) {
-            if (e.kind != primitive_kind::eltwise) return false;
-        }
-        return true;
-    };
-
     const bool problem_dt_correct = (is_s8 || is_u8 || is_u8_s8)
             && utils::one_of(dst_type, f32, s32, f16, bf16, s8, u8)
             && platform::has_data_type_support(dst_type);
 
     VDISPATCH_MATMUL(problem_dt_correct, VERBOSE_UNSUPPORTED_DT);
-    VDISPATCH_MATMUL(no_post_ops || with_eltwise(), VERBOSE_UNSUPPORTED_ATTR);
+    VDISPATCH_MATMUL(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
     VDISPATCH_MATMUL(formats_ok(), VERBOSE_UNSUPPORTED_TAG);
     VDISPATCH_MATMUL(mayiuse(sve) && utils::one_of(simd_bytes(isa), 16UL, 32UL),
             VERBOSE_UNSUPPORTED_ISA);
@@ -1243,6 +1234,70 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
     book_precomputed_scales(scratchpad, attr()->scales_, N());
 
     return status::success;
+}
+
+template <cpu_isa_t isa>
+bool jit_int8_matmul_t<isa>::pd_t::formats_ok() const {
+    const memory_desc_wrapper src_d(src_md_);
+    const memory_desc_wrapper weights_d(weights_md_);
+    const memory_desc_wrapper dst_d(dst_md_);
+    const bool is_dst = dst_d.matches_one_of_tag(format_tag::ab,
+                                format_tag::abc, format_tag::abcd)
+                    != format_tag::undef
+            || dst_d.format_kind() == format_kind::any;
+    const bool is_wei
+            = weights_d.matches_one_of_tag(format_tag::ab, format_tag::abc,
+                      format_tag::abcd, format_tag::BA24b8a,
+                      format_tag::aCB24c8b, format_tag::abDC24d8c,
+                      format_tag::BA16b8a, format_tag::aCB16c8b,
+                      format_tag::abDC16d8c, format_tag::BA12b8a,
+                      format_tag::aCB12c8b, format_tag::abDC12d8c,
+                      format_tag::BA4b8a, format_tag::aCB4c8b,
+                      format_tag::abDC4d8c, format_tag::BA8b8a,
+                      format_tag::aCB8c8b, format_tag::abDC8d8c)
+                    != format_tag::undef
+            || weights_d.format_kind() == format_kind::any;
+    const bool is_src = src_d.matches_one_of_tag(format_tag::ab,
+                                format_tag::abc, format_tag::abcd)
+                    != format_tag::undef
+            || src_d.format_kind() == format_kind::any;
+    return is_dst && is_wei && is_src;
+}
+
+template <cpu_isa_t isa>
+bool jit_int8_matmul_t<isa>::pd_t::post_ops_ok() const {
+    if (attr()->post_ops_.has_default_values()) { return true; }
+
+    const auto &eltwise_ok = [&](dnnl_post_ops::entry_t op) -> bool {
+        return op.is_eltwise()
+                && eltwise_injector::is_supported(isa, op.eltwise.alg);
+    };
+
+    const auto &post_ops = attr()->post_ops_.entry_;
+
+    return std::all_of(post_ops.begin(), post_ops.end(), eltwise_ok);
+}
+
+template <cpu_isa_t isa>
+int jit_int8_matmul_t<isa>::pd_t::get_idx(bool is_zp_cal, bool is_m_tail,
+        bool is_k_tail, bool is_n_tail, const brg_int8_t &brg) const {
+    if (brg.zp_type_a == jit_int8_broadcast_t::none
+            && brg.zp_type_b == jit_int8_broadcast_t::none && is_zp_cal) {
+        return -1;
+    }
+
+    int m_tail = brg.M % brg.m_blk;
+    int n_tail = brg.N % (brg.n_blk * brg.ld_block);
+    int k_tail = brg.K % (brg.k_blk * 4);
+
+    if ((is_m_tail && m_tail == 0) || (is_k_tail && k_tail == 0)
+            || (is_n_tail && n_tail == 0) || (!is_k_tail && k_tail == 1)) {
+        return -1;
+    }
+
+    return static_cast<int>(is_k_tail) + static_cast<int>(is_n_tail) * 2
+            + static_cast<int>(is_m_tail) * 2 * 2
+            + static_cast<int>(is_zp_cal) * 2 * 2 * 2;
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.hpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.hpp
@@ -38,62 +38,15 @@ struct jit_int8_matmul_utils_kernel_t;
 template <cpu_isa_t isa>
 struct jit_int8_matmul_t : public primitive_t {
     struct pd_t : public cpu::matmul::cpu_matmul_pd_t {
+    public:
         using cpu::matmul::cpu_matmul_pd_t::cpu_matmul_pd_t;
 
         DECLARE_COMMON_PD_T("jit:int8", jit_int8_matmul_t);
 
         status_t init(engine_t *engine);
 
-        bool formats_ok() const {
-            const memory_desc_wrapper src_d(src_md_);
-            const memory_desc_wrapper weights_d(weights_md_);
-            const memory_desc_wrapper dst_d(dst_md_);
-            const bool is_dst = dst_d.matches_one_of_tag(format_tag::ab,
-                                        format_tag::abc, format_tag::abcd)
-                            != format_tag::undef
-                    || dst_d.format_kind() == format_kind::any;
-            const bool is_wei
-                    = weights_d.matches_one_of_tag(format_tag::ab,
-                              format_tag::abc, format_tag::abcd,
-                              format_tag::BA24b8a, format_tag::aCB24c8b,
-                              format_tag::abDC24d8c, format_tag::BA16b8a,
-                              format_tag::aCB16c8b, format_tag::abDC16d8c,
-                              format_tag::BA12b8a, format_tag::aCB12c8b,
-                              format_tag::abDC12d8c, format_tag::BA4b8a,
-                              format_tag::aCB4c8b, format_tag::abDC4d8c,
-                              format_tag::BA8b8a, format_tag::aCB8c8b,
-                              format_tag::abDC8d8c)
-                            != format_tag::undef
-                    || weights_d.format_kind() == format_kind::any;
-            const bool is_src = src_d.matches_one_of_tag(format_tag::ab,
-                                        format_tag::abc, format_tag::abcd)
-                            != format_tag::undef
-                    || src_d.format_kind() == format_kind::any;
-            return is_dst && is_wei && is_src;
-        }
-
         int get_idx(bool is_zp_cal, bool is_m_tail, bool is_k_tail,
-                bool is_n_tail, const brg_int8_t &brg) const {
-            if (brg.zp_type_a == jit_int8_broadcast_t::none
-                    && brg.zp_type_b == jit_int8_broadcast_t::none
-                    && is_zp_cal) {
-                return -1;
-            }
-
-            int m_tail = brg.M % brg.m_blk;
-            int n_tail = brg.N % (brg.n_blk * brg.ld_block);
-            int k_tail = brg.K % (brg.k_blk * 4);
-
-            if ((is_m_tail && m_tail == 0) || (is_k_tail && k_tail == 0)
-                    || (is_n_tail && n_tail == 0)
-                    || (!is_k_tail && k_tail == 1)) {
-                return -1;
-            }
-
-            return static_cast<int>(is_k_tail) + static_cast<int>(is_n_tail) * 2
-                    + static_cast<int>(is_m_tail) * 2 * 2
-                    + static_cast<int>(is_zp_cal) * 2 * 2 * 2;
-        }
+                bool is_n_tail, const brg_int8_t &brg) const;
 
         static constexpr int m_block_sz = 32;
         int n_block_sz;
@@ -101,13 +54,18 @@ struct jit_int8_matmul_t : public primitive_t {
 
         brg_int8_t brg_int8_conf;
         dyn_vals_t dyn_vals;
+
+    private:
+        bool formats_ok() const;
+        bool post_ops_ok() const;
     };
 
     jit_int8_matmul_t(const pd_t *apd);
-    ~jit_int8_matmul_t() override;
-    int get_idx(int z, int m, int k, int n, int M, int K, int N);
+
     status_t init(engine_t *engine) override;
     status_t execute(const exec_ctx_t &ctx) const override;
+
+    ~jit_int8_matmul_t() override;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }


### PR DESCRIPTION
# Description

We were not correctly checking that the injector supproted the requested `eltwise` algorithm. This fixes the issue reported here: https://github.com/uxlfoundation/oneDNN/pull/5317#issuecomment-4898654152

```
# Before:
$ ./build/tests/benchdnn/benchdnn --matmul --dt=u8:u8:s32 --stag=abx --dtag=abx --attr-post-ops=pow 8x8:8x8
benchdnn: src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp:124: dnnl::impl::cpu::aarch64::jit_uni_eltwise_injector_t<isa>::jit_uni_eltwise_injector_t(dnnl::impl::cpu::aarch64::jit_generator_t*, dnnl::impl::alg_kind_t, float, float, float, bool, Xbyak_aarch64::XReg, Xbyak_aarch64::PReg, Xbyak_aarch64::PReg, bool, bool, bool, bool, dnnl::impl::data_type_t) [with dnnl::impl::cpu::aarch64::cpu_isa_t isa = dnnl::impl::cpu::aarch64::sve; dnnl::impl::alg_kind_t = dnnl_alg_kind_t; dnnl::impl::data_type_t = dnnl_data_type_t]: Assertion `eltwise_injector::is_supported(isa, alg_)' failed.
zsh: abort (core dumped)

# After
$ ./build/tests/benchdnn/benchdnn --matmul --dt=u8:u8:s32 --stag=abx --dtag=abx --attr-post-ops=pow 8x8:8x8
0:MISTRUSTED (7 ms) __REPRO: --matmul --dt=u8:u8:s32 --stag=abx --dtag=abx --attr-post-ops=pow 8x8:8x8
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| ref_int8:any : 1 (100%)                                  |
============================================================
tests:1 passed:0 skipped:0 mistrusted:1 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.01s; create_pd: 0.00s (2%); create_prim: 0.00s (1%); fill: 0.00s (7%); execute: 0.00s (22%); compute_ref: 0.00s (36%); compare: 0.00s (24%);
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
