### PR TITLE
cpu: x64: matmul: blocking heuristics: disable K-thread split when zp compensation is required

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -134,6 +134,11 @@ bool matmul_amx_blocking_params_macro_t::divs_are_acceptable() const {
     }
 
     bool unacceptable_b_div = nthr_b_ > (size_t)batch;
+    if (nthr_k_ > 1 && calculate_compensations_in_copy_routines()) {
+        // If we have to calculate compensations in copy routines,
+        // we cannot split K dimension
+        unacceptable_k_div = true;
+    }
 
     return !unacceptable_m_div && !unacceptable_k_div && !unacceptable_n_div
             && !unacceptable_b_div;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -1827,10 +1827,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 copy_A_src_stride_
                         = helper.get_a_stride(bgmmc.ndims - 1) * bgmmc.a_dt_sz;
 
-            is_A_batch_layout_trivial_
-                    = is_batch_layout_trivial(src_d_);
-            is_C_batch_layout_trivial_
-                    = is_batch_layout_trivial(dst_d_);
+            is_A_batch_layout_trivial_ = is_batch_layout_trivial(src_d_);
+            is_C_batch_layout_trivial_ = is_batch_layout_trivial(dst_d_);
         } else {
             M_ = bgmmc.M;
             M_chunks_ = bgmmc.M_chunks;
@@ -1890,10 +1888,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 B_strides_[dim_idx] = bgmmc.b_dt_sz
                         * helper.get_b_stride(bgmmc.ndims - 1 - dim_idx);
 
-            is_B_batch_layout_trivial_
-                    = is_batch_layout_trivial(wei_d_);
-            is_C_batch_layout_trivial_
-                    = is_batch_layout_trivial(dst_d_);
+            is_B_batch_layout_trivial_ = is_batch_layout_trivial(wei_d_);
+            is_C_batch_layout_trivial_ = is_batch_layout_trivial(dst_d_);
         } else {
             N_ = bgmmc.N;
             N_chunks_ = bgmmc.N_chunks;
@@ -1958,22 +1954,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         num_threads_used_ = nthr_k_ * nthr_bmn_;
 
-        const bool need_to_calculate_compensation_for_a
-                = bgmmc.has_zero_point_b && !bgmmc.with_wei_decompression;
-        const bool need_to_calculate_compensation_for_b = !IMPLICATION(
-                (bgmmc.has_zero_point_a || bgmmc.s8s8_compensation_required),
-                bgmmc.blocked_B);
-        const bool calculate_compensations_in_copy_routines
-                = need_to_calculate_compensation_for_a
-                || need_to_calculate_compensation_for_b;
         // currently parallel reduction is supported only for case of
         // non-batched problems without computation of any compensations in
         // copy routines
         assert(IMPLICATION(parallel_reduction_is_used(),
-                bgmmc.batch == 1 && !calculate_compensations_in_copy_routines));
-        MAYBE_UNUSED(need_to_calculate_compensation_for_a);
-        MAYBE_UNUSED(need_to_calculate_compensation_for_b);
-        MAYBE_UNUSED(calculate_compensations_in_copy_routines);
+                bgmmc.batch == 1
+                        && !bgmmc.calculate_compensations_in_copy_routines()));
     }
 
     // NOTE: gb --> generalized batch, bb --> broadcast batch

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1922,6 +1922,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.wei_zp_type = get_zp_type(attr, DNNL_ARG_WEIGHTS);
     bgmmc.dst_zp_type = get_zp_type(attr, DNNL_ARG_DST);
 
+    bgmmc.has_zero_point_a = bgmmc.src_zp_type != brgemm_broadcast_t::none;
+    bgmmc.has_zero_point_b = bgmmc.wei_zp_type != brgemm_broadcast_t::none;
+    bgmmc.has_zero_point_c = bgmmc.dst_zp_type != brgemm_broadcast_t::none;
     // Non-default src zero points (per-tensor, common, host_scalar) with
     // int8 grouped quantization: the per-(M,N) compensation tile (set via
     // bgmmc.with_per_mn_compensation later in init) covers the remaining
@@ -2378,12 +2381,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                 : bgmmc.LDD;
     }
 
-    bgmmc.is_src_batch_layout_trivial
-            = is_batch_layout_trivial(src_d);
-    bgmmc.is_wei_batch_layout_trivial
-            = is_batch_layout_trivial(weights_d);
-    bgmmc.is_dst_batch_layout_trivial
-            = is_batch_layout_trivial(dst_d);
+    bgmmc.is_src_batch_layout_trivial = is_batch_layout_trivial(src_d);
+    bgmmc.is_wei_batch_layout_trivial = is_batch_layout_trivial(weights_d);
+    bgmmc.is_dst_batch_layout_trivial = is_batch_layout_trivial(dst_d);
 
     // Sets things related to chunks and others
     init_aux_values(bgmmc, src_d, weights_d, dst_d);
@@ -2775,9 +2775,6 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
             ? dst_d.blocking_desc().strides[0] * bgmmc.c_dt_sz
             : 0;
 
-    bgmmc.has_zero_point_a = bgmmc.src_zp_type != brgemm_broadcast_t::none;
-    bgmmc.has_zero_point_b = bgmmc.wei_zp_type != brgemm_broadcast_t::none;
-    bgmmc.has_zero_point_c = bgmmc.dst_zp_type != brgemm_broadcast_t::none;
     bgmmc.with_per_mn_compensation = bgmmc.with_int8_grouped_quantization
             && (bgmmc.has_zero_point_a || bgmmc.has_zero_point_b
                     || bgmmc.s8s8_compensation_required);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -323,6 +323,15 @@ struct brgemm_matmul_conf_t {
         const dim_t big_K_threshold = big_stride_threshold_in_bytes / a_dt_sz;
         return !transposed_A && math::is_pow2(K) && K >= big_K_threshold;
     }
+
+    inline bool calculate_compensations_in_copy_routines() const {
+        const bool need_to_calculate_compensation_for_a
+                = has_zero_point_b && !with_wei_decompression;
+        const bool need_to_calculate_compensation_for_b = !IMPLICATION(
+                (has_zero_point_a || s8s8_compensation_required), blocked_B);
+        return need_to_calculate_compensation_for_a
+                || need_to_calculate_compensation_for_b;
+    }
 };
 
 struct brgemm_matmul_conf_utils_t {

--- a/tests/benchdnn/inputs/matmul/test_matmul_int8
+++ b/tests/benchdnn/inputs/matmul/test_matmul_int8
@@ -86,3 +86,12 @@
 
 # regression
 --batch=harness_matmul_regression_int8
+
+# AMX macro heuristic selecting nthr_k > 1 when zp compensation
+# is required in copy routines, causing incorrect results.
+# Shape has small N (92) which with many threads triggers K-split selection.
+--reset
+--dt=s8:u8:f16 --stag=abx --wtag=abx --dtag=abx
+--attr-scales=src:per_tensor:f16:1x32+wei:per_oc:f16
+--attr-zero-points=wei:common:4:u8
+832x2944:2944x92


### PR DESCRIPTION
Do not split the work into K threads when compensation is calculated in copy kernels, as parallel reduction does not support this yet.
this fixes:
https://jira.devtools.intel.com/browse/MFDNN-15310