### PR TITLE
x64: matmul: reject select post-op with broadcast condition

### DIFF
--- a/src/cpu/binary_injector_utils.cpp
+++ b/src/cpu/binary_injector_utils.cpp
@@ -13,9 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#include "cpu/binary_injector_utils.hpp"
+#include <algorithm>
+
 #include "common/primitive.hpp"
 #include "common/primitive_attr.hpp"
+#include "cpu/binary_injector_utils.hpp"
 #include "oneapi/dnnl/dnnl_types.h"
 
 namespace dnnl {
@@ -88,6 +90,22 @@ memory_desc_t get_src2_desc(
     } else {
         return memory_desc_t();
     }
+}
+
+bool any_binary_postop_with_ternary_bcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d) {
+    return std::any_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) -> bool {
+        if (!entry.is_binary_with_ternary_op()) return false;
+        // Use user_src2_desc: the resolved src2_desc is not yet
+        // populated at primitive-descriptor init time, whereas the
+        // user-provided condition descriptor carries the real dims.
+        const memory_desc_wrapper src2_d(entry.binary.user_src2_desc);
+        if (src2_d.ndims() != dst_d.ndims()) return true;
+        for (int d = 0; d < dst_d.ndims(); ++d)
+            if (src2_d.dims()[d] != dst_d.dims()[d]) return true;
+        return false;
+    });
 }
 
 std::vector<broadcasting_strategy_t> extract_bcast_strategies(

--- a/src/cpu/binary_injector_utils.hpp
+++ b/src/cpu/binary_injector_utils.hpp
@@ -55,6 +55,14 @@ memory_desc_t get_src1_desc(
 memory_desc_t get_src2_desc(
         const post_ops_t::entry_t &post_op, const memory_desc_wrapper &dst_d);
 
+// Returns true if any select (binary-with-ternary) post-op has a condition
+// (ternary src2) that is broadcast against dst, i.e. its dims differ from dst.
+// Post-op application loads the condition at full dst shape; a broadcast
+// condition is not implemented and would read out of bounds, so callers must
+// reject such post-ops (falling back to a reference implementation).
+bool any_binary_postop_with_ternary_bcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d);
+
 /*
  * Returns a tuple of bools, which size is equal to number of bcast
  * strategies passed in. Values at consecutive positions indicate existence of

--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -133,8 +133,16 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
                                 post_ops.entry_, dst_md()),
                         broadcasting_strategy_t::per_oc);
         const bool has_prelu = post_ops.find(prelu) != -1;
+        // A select post-op with a broadcast condition (ternary src2) is not
+        // implemented: post-op application loads the condition at full dst
+        // shape and would read out of bounds. Reject it so a reference
+        // implementation, which handles condition broadcast, is used instead.
+        const bool has_ternary_bcast
+                = binary_injector_utils::any_binary_postop_with_ternary_bcast(
+                        post_ops, dst_md());
         return cpu::inner_product_utils::post_ops_ok(
                        post_ops, dst_md(), enabled_bcast_strategy)
+                && !has_ternary_bcast
                 && IMPLICATION(is_binary_po_per_oc,
                         gemm_based::check_gemm_binary_per_oc_compatible_formats(
                                 *this))

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -76,8 +76,16 @@ status_t gemm_f32_matmul_t::pd_t::init(engine_t *engine) {
                                 post_ops.entry_, dst_md()),
                         broadcasting_strategy_t::per_oc);
         const bool has_prelu = post_ops.find(prelu) != -1;
+        // A select post-op with a broadcast condition (ternary src2) is not
+        // implemented: post-op application loads the condition at full dst
+        // shape and would read out of bounds. Reject it so a reference
+        // implementation, which handles condition broadcast, is used instead.
+        const bool has_ternary_bcast
+                = binary_injector_utils::any_binary_postop_with_ternary_bcast(
+                        post_ops, dst_md());
         return cpu::inner_product_utils::post_ops_ok(
                        post_ops, dst_md(), enabled_bcast_strategy)
+                && !has_ternary_bcast
                 && IMPLICATION(is_binary_po_per_oc,
                         gemm_based::check_gemm_binary_per_oc_compatible_formats(
                                 *this))

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -2961,7 +2961,15 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary_with_ternary_op(
         // blending the tensors, the current approach reserves
         // fewer registers for operation.
         if (is_superset(isa, avx512_core)) {
-            const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;
+            // Use a dedicated auxiliary opmask (guaranteed distinct from
+            // tail_opmask) for the select comparison instead of borrowing
+            // tail_opmask. Reusing tail_opmask here collides with the tail
+            // mask that the scalar-broadcast src1 load below needs to keep
+            // (execute_broadcast_*_with_opmask reads tail_opmask), which is
+            // why scalar-broadcast ternary post-ops used to be rejected on
+            // avx512. Preserving it lets that dispatch restriction be lifted.
+            // Anchor: TERNARY_SCALAR_BCAST_AVX512_ONLY.
+            const auto cmp_mask = get_aux_kmask();
             push_opmask(host_, cmp_mask);
             push_vmm(host_, dst);
             host_->vxorps(dst, dst, dst);
@@ -2971,7 +2979,6 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary_with_ternary_op(
             host_->vblendmps(dst | cmp_mask, tmp_vmm, dst);
             host_->knotw(cmp_mask, cmp_mask);
             host_->vpmovm2b(tmp_vmm, cmp_mask);
-            pop_opmask(host_, cmp_mask);
             push_vmm(host_, dst);
 
             if (rhs_addr.isBroadcast())
@@ -2982,14 +2989,13 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary_with_ternary_op(
                         with_tail);
             if (types::is_integral_dt(rhs_arg_data_type)) cvt_to_f32(dst);
 
-            push_opmask(host_, cmp_mask);
             host_->vpmovb2m(cmp_mask, tmp_vmm);
 
             host_->vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
             host_->vblendmps(tmp_vmm | cmp_mask, tmp_vmm, dst);
-            pop_opmask(host_, cmp_mask);
             pop_vmm(host_, dst);
             host_->vpaddd(dst, dst, tmp_vmm);
+            pop_opmask(host_, cmp_mask);
         } else {
             push_vmm(host_, dst);
             host_->vxorps(dst, dst, dst);

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -327,9 +327,25 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     VDISPATCH_MATMUL(po.check_sum_consistency(dst_dt, is_int8),
             VERBOSE_UNSUPPORTED_POSTOP);
 
+    // Scalar-broadcast ternary (select) post-ops are supported by the binary
+    // injector on avx512_core and below: the avx512 select path uses a dedicated
+    // auxiliary opmask (get_aux_kmask) for its comparison instead of clobbering
+    // tail_opmask, so it no longer collides with the tail mask a scalar-broadcast
+    // src1 load needs. The AMX brgemm post-op path does not handle this case
+    // correctly yet, so it stays gated here; the iterator then falls back to a
+    // correct implementation (avx512_core brgemm or ref). Keying on the AMX ISA
+    // (not the declared dtype) also covers f32 + fpmath=bf16, which down-converts
+    // onto AMX. This is not a bugfix for a live defect (ref is correct today); it
+    // only avoids flipping AMX-bound scenarios from ref onto an impl that cannot
+    // handle them. Enabling AMX fusion for this case is future perf work.
+    // Anchor: TERNARY_SCALAR_BCAST_AVX512_ONLY.
+    // TODO(perf): support scalar-broadcast ternary select in the AMX brgemm
+    // post-op path (jit_brgemm_amx_uker.cpp) and lift the AMX gate below.
     VDISPATCH_MATMUL(
-            !binary_injector::any_binary_postop_rhs_with_ternary_scalar_bcast(
-                    po, dst_d),
+            !(is_superset(isa, avx512_core_amx)
+                    && binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    po, dst_d)),
             VERBOSE_UNSUPPORTED_POSTOP);
 
     VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -348,6 +348,16 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                                     po, dst_d)),
             VERBOSE_UNSUPPORTED_POSTOP);
 
+    // A select post-op with a broadcast condition (ternary src2 smaller than
+    // dst) is not implemented: post-op application loads the condition at full
+    // dst shape and would read out of bounds, segfaulting the kernel. Reject it
+    // so the iterator falls back to the reference path, which handles condition
+    // broadcast correctly.
+    VDISPATCH_MATMUL(
+            !binary_injector_utils::any_binary_postop_with_ternary_bcast(
+                    po, dst_d),
+            VERBOSE_UNSUPPORTED_POSTOP);
+
     VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
     VDISPATCH_MATMUL(
             check_attr_zero_points(is_bf16_with_int_wei || is_f16_with_int_wei

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -764,11 +764,27 @@ std::vector<std::pair<int, int>> attr_t::post_ops_t::get_po_masks(
         assert(mask >= 0);
         v_masks.emplace_back(DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | arg, mask);
 
-        // there is no broadcasting support for the ternary src2 input, hence
-        // no mask is required.
-        if (e.is_binary_kind_with_ternary_op())
+        // Condition (src2) mask for the ternary select input, derived from its
+        // policy so a broadcast condition is filled accordingly. With no
+        // explicit src2 spec the condition spans the full dst shape (mask -1),
+        // preserving prior behavior.
+        if (e.is_binary_kind_with_ternary_op()) {
+            int src2_mask = -1;
+            switch (e.binary.src2_mask_input) {
+                case attr_t::mask_input_t::none: src2_mask = -1; break;
+                case attr_t::mask_input_t::mask:
+                    src2_mask = e.binary.src2_mask;
+                    break;
+                case attr_t::mask_input_t::policy:
+                    src2_mask = attr_t::policy2mask(DNNL_ARG_SRC_2,
+                            e.binary.src2_policy, ndims, prim_kind);
+                    break;
+                default: assert(!"unknown mask_input value"); break;
+            }
             v_masks.emplace_back(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2, -1);
+                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2,
+                    src2_mask);
+        }
     }
     return v_masks;
 }
@@ -1396,8 +1412,32 @@ int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
                     std::move(rhs_tensor_desc));
 
             if (e.is_binary_kind_with_ternary_op()) {
+                // Deduce the condition (src2) dims from its mask/policy so a
+                // broadcast condition (e.g. per_tensor, or broadcast on outer
+                // dims) is expressed as size-1 dims, mirroring src1 above.
+                // With no explicit src2 spec the condition defaults to the full
+                // dst shape (all mask bits set) to preserve prior behavior.
+                const int full_mask = (1 << ndims) - 1;
+                int src2_mask = full_mask;
+                switch (e.binary.src2_mask_input) {
+                    case attr_t::mask_input_t::none:
+                        src2_mask = full_mask;
+                        break;
+                    case attr_t::mask_input_t::mask:
+                        src2_mask = e.binary.src2_mask;
+                        break;
+                    case attr_t::mask_input_t::policy:
+                        src2_mask = attr_t::policy2mask(DNNL_ARG_SRC_2,
+                                e.binary.src2_policy, ndims, prim_kind);
+                        break;
+                    default: assert(!"unknown mask_input value"); break;
+                }
+                dnnl_dims_t src2_tensor_dims = {};
+                for (auto d = 0; d < ndims; ++d)
+                    src2_tensor_dims[d]
+                            = (!(src2_mask & (1 << d))) ? 1 : dims[d];
                 auto rhs_src2_tensor_desc = dnn_mem_t::init_md(
-                        ndims, dims, e.binary.src2_dt, tag::any);
+                        ndims, src2_tensor_dims, e.binary.src2_dt, tag::any);
                 mds.emplace(
                         (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2),
                         std::move(rhs_src2_tensor_desc));

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -214,8 +214,16 @@
 --stag=ab --wtag=ab --dtag=ab
 --attr-post-ops=select:f32,\
                 select:f32.per_oc,\
+                select:f32.per_tensor,\
                 select:s8.per_tensor+add:f32
 --batch=shapes_2d
+
+# Post-ops with binary select op with broadcast condition
+--reset
+--dt=f32,bf16
+--stag=abcd --wtag=abcd --dtag=abcd
+--attr-post-ops=select:f32,select:f32.per_tensor
+1x16x32x256:1x16x256x33n"sdpa"
 
 # Rounding Mode
 --reset

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -218,12 +218,21 @@
                 select:s8.per_tensor+add:f32
 --batch=shapes_2d
 
-# Post-ops with binary select op with broadcast condition
+# Post-ops with binary select op, scalar-broadcast src1
 --reset
 --dt=f32,bf16
 --stag=abcd --wtag=abcd --dtag=abcd
 --attr-post-ops=select:f32,select:f32.per_tensor
 1x16x32x256:1x16x256x33n"sdpa"
+
+# Post-ops with binary select op, broadcast condition (ternary src2).
+# The condition broadcast is not fused; these must fall back cleanly (no crash).
+--reset
+--dt=f32,bf16
+--stag=abcd --wtag=abcd --dtag=abcd
+--attr-post-ops=select:f32:common
+1x16x32x256:1x16x256x33n"sdpa_cond_bcast"
+1x16x33x257:1x16x257x37n"sdpa_cond_bcast_tail"
 
 # Rounding Mode
 --reset

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -382,13 +382,13 @@ attr_t::post_ops_t str2attr_post_ops(const std::string &s) {
                         e.binary.src2_policy = src_policy;
                         e.binary.src2_mask_input = attr_t::mask_input_t::policy;
 
-                        if (e.binary.src2_policy != attr_t::policy_t::COMMON) {
+                        if (e.binary.src2_policy
+                                == attr_t::policy_t::POLICY_TOTAL) {
                             BENCHDNN_PRINT(0, "%s \'%s\' %s\n",
                                     "Error: binary post-op policy for the "
                                     "src2 tensor",
                                     mask_input_str.c_str(),
-                                    "is not supported - broadcasting is "
-                                    "not supported for the src2 tensor.");
+                                    "is not recognized.");
                             SAFE_V(FAIL);
                         }
                     }


### PR DESCRIPTION
A select (binary-with-ternary) post-op whose **condition** input is broadcast against dst crashed at execute: post-op application loads the condition at full dst shape and read out of bounds. This affected `brgemm_matmul` and the gemm-based bf16/f32 matmul independently.

Reject a broadcast condition (ternary src2 dims differ from dst) at matmul dispatch so the iterator falls back to the reference implementation, which handles condition broadcast correctly. Full-shape conditions are unaffected.

Also extends benchdnn to allow specifying a broadcast condition (src2) policy so the fallback is covered by a test, and adds matmul cases for it.

Reproducers (before this change, both SIGSEGV at execute):
```
# brgemm path (f32)
./benchdnn --matmul --stag=abcd --wtag=abcd --dtag=abcd --dt=f32   --attr-post-ops=select:f32:common 1x16x32x256:1x16x256x33
# gemm path (bf16)
./benchdnn --matmul --stag=abcd --wtag=abcd --dtag=abcd --dt=bf16   --attr-post-ops=select:f32:common 1x16x33x257:1x16x257x37
```
Confirmed on an Intel Xeon 6767P (Granite Rapids, AVX-512 + AMX): both now fall back to ref and pass; full-shape select still fuses to brg_matmul; `test_binary_ci` and `test_matmul_ci` pass (0 failed) on avx512_core and avx512_core_amx.

Fixes MFDNN-15313

> Note: stacked on #5520 — the first commit here is #5520's scalar-broadcast-src1 change. Review only the second commit (`reject select post-op with broadcast condition`); merge after #5520, or this can be rebased onto main once #5520 lands.

> Triage fix — please review carefully before merging.