### PR TITLE
 Introduce IR infrastructure for x64 JIT kernels with the first kernel GEMV

### DIFF
--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -49,11 +49,11 @@ void DNNL_WEAK *malloc(size_t size, int alignment);
 #define MALLOC(size, alignment) ::malloc(size)
 #define FREE(ptr) ::free(ptr)
 #else
-void *malloc(size_t size, int alignment);
+void DNNL_API *malloc(size_t size, int alignment);
 #define MALLOC(size, alignment) malloc(size, alignment)
 #define FREE(ptr) free(ptr)
 #endif
-void free(void *p);
+void DNNL_API free(void *p);
 
 struct c_compatible { // NOLINT(readability-identifier-naming)
     enum { default_alignment = 64 };

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -186,7 +186,8 @@ int getpagesize() {
 #endif
 }
 
-void *malloc(size_t size, int alignment) {
+// Add DNNL_API to make test_internals_cpu_ir work.
+void DNNL_API *malloc(size_t size, int alignment) {
     void *ptr;
     if (memory_debug::is_mem_debug())
         return memory_debug::malloc(size, alignment);
@@ -201,7 +202,8 @@ void *malloc(size_t size, int alignment) {
     return (rc == 0) ? ptr : nullptr;
 }
 
-void free(void *p) {
+// Add DNNL_API to make test_internals_cpu_ir work.
+void DNNL_API free(void *p) {
 
     if (memory_debug::is_mem_debug()) return memory_debug::free(p);
 

--- a/src/cpu/jit_utils/jit_utils.cpp
+++ b/src/cpu/jit_utils/jit_utils.cpp
@@ -22,6 +22,8 @@
 
 #include "cpu/platform.hpp"
 
+#include "cpu/jit_utils/jit_utils.hpp"
+
 #ifndef DNNL_ENABLE_JIT_PROFILING
 #define DNNL_ENABLE_JIT_PROFILING 1
 #endif

--- a/src/cpu/jit_utils/jit_utils.hpp
+++ b/src/cpu/jit_utils/jit_utils.hpp
@@ -24,7 +24,8 @@ namespace impl {
 namespace cpu {
 namespace jit_utils {
 
-void register_jit_code(const void *code, size_t code_size,
+// Add DNNL_API to make test_internals_cpu_ir work.
+void DNNL_API register_jit_code(const void *code, size_t code_size,
         const char *code_name, const char *source_file_name);
 
 } // namespace jit_utils

--- a/src/cpu/jit_utils/jit_utils.hpp
+++ b/src/cpu/jit_utils/jit_utils.hpp
@@ -27,7 +27,7 @@ namespace jit_utils {
 void register_jit_code(const void *code, size_t code_size,
         const char *code_name, const char *source_file_name);
 
-}
+} // namespace jit_utils
 } // namespace cpu
 } // namespace impl
 } // namespace dnnl

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -23,6 +23,7 @@
 #include "common/utils.hpp"
 
 #include "cpu/platform.hpp"
+#include "cpu/x64/brgemm/brgemv_ir.hpp"
 #include "cpu/x64/cpu_barrier.hpp"
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 
@@ -670,6 +671,17 @@ status_t brgemm_kernel_create(
     if (utils::one_of(data_type::f64, brg.dt_a, brg.dt_b, brg.dt_c, brg.dt_d,
                 brg.dt_bias, brg.sum_dt))
         return status::unimplemented;
+
+    // Try the IR-based GEMV kernel first. If the IR kernel is unsupported i.e.
+    // `create_brgemv_ir_kernel(brg)` returns `nullptr` then fall back to the
+    // brgemm implementation below.
+    if (brg.is_gemv) {
+        std::unique_ptr<brgemm_kernel_t> ir_ker(create_brgemv_ir_kernel(brg));
+        if (ir_ker && ir_ker->create_kernel() == status::success) {
+            *brg_kernel = ir_ker.release();
+            return status::success;
+        }
+    }
 
     if (brg.is_dgmm) {
         if (brg.type == brgemm_static_offs) return status::unimplemented;

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -30,6 +30,7 @@
 #include "common/c_types_map.hpp"
 #include "common/nstl.hpp"
 #include "common/utils.hpp"
+#include "common/verbose.hpp"
 
 #include "cpu/x64/brgemm/brgemv_ir.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp"
@@ -40,6 +41,10 @@
 
 #define GET_OFF(field) offsetof(brgemm_kernel_params_t, field)
 #define GET_OFF_BATCH_ELEMENT(field) offsetof(brgemm_batch_element_t, field)
+
+#define VCONDCHECK_BRGEMV_IR(cond, msg, ...) \
+    VCONDCHECK(primitive, create, dispatch, brgemv_ir, (cond), \
+            status::unimplemented, msg, ##__VA_ARGS__)
 
 namespace dnnl {
 namespace impl {
@@ -413,19 +418,28 @@ private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(brgemv_ir_kernel_t);
 };
 
-// Returns true if the descriptor is supported by the GEMV IR kernel.
-bool brgemv_ir_supported(const brgemm_desc_t &brg) {
+// Returns `status::success` if the descriptor is supported by the GEMV IR
+// kernel, otherwise `status::unimplemented`.
+status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     using namespace data_type;
 
-    if (!utils::everyone_is(f32, brg.dt_a, brg.dt_b, brg.dt_c)) return false;
-    if (brg.isa_impl != avx2) return false;
-    if (brg.transA) return false;
+    VCONDCHECK_BRGEMV_IR(utils::everyone_is(f32, brg.dt_a, brg.dt_b, brg.dt_c),
+            VERBOSE_UNSUPPORTED_DT);
+    VCONDCHECK_BRGEMV_IR(brg.isa_impl == avx2, VERBOSE_UNSUPPORTED_ISA);
+    VCONDCHECK_BRGEMV_IR(
+            !brg.transA, VERBOSE_UNSUPPORTED_FEATURE, "transposed A");
 
-    if (brg.are_post_ops_applicable()) return false;
-    if (brg.alpha != 1.0f) return false;
-    if (brg.beta != 0.0f) return false;
+    VCONDCHECK_BRGEMV_IR(
+            !brg.are_post_ops_applicable(), VERBOSE_UNSUPPORTED_POSTOP);
+    VCONDCHECK_BRGEMV_IR(
+            brg.alpha == 1.0f, VERBOSE_UNSUPPORTED_FEATURE, "alpha != 1");
+    VCONDCHECK_BRGEMV_IR(
+            brg.beta == 0.0f, VERBOSE_UNSUPPORTED_FEATURE, "beta != 0");
 
-    if (brg.is_runtime_lda || brg.is_runtime_ldc) return false;
+    VCONDCHECK_BRGEMV_IR(
+            !brg.is_runtime_lda, VERBOSE_UNSUPPORTED_FEATURE, "runtime lda");
+    VCONDCHECK_BRGEMV_IR(
+            !brg.is_runtime_ldc, VERBOSE_UNSUPPORTED_FEATURE, "runtime ldc");
 
     const int m_block = brg.gemv_bd_block();
     const int dt_sz_a = brg.typesize_A;
@@ -435,14 +449,16 @@ bool brgemv_ir_supported(const brgemm_desc_t &brg) {
     // Ensure indexed displacements fit in 32-bit
     auto fits = [](dim_t v) { return v <= INT32_MAX && v >= INT32_MIN; };
 
-    if (!fits(dt_sz_a * (dim_t)m_block * brg.LDA)) return false;
-    if (!fits(dt_sz_y * (dim_t)m_block * incy)) return false;
+    VCONDCHECK_BRGEMV_IR(fits(dt_sz_a * (dim_t)m_block * brg.LDA),
+            VERBOSE_UNSUPPORTED_FEATURE, "A block offset overflows int32");
+    VCONDCHECK_BRGEMV_IR(fits(dt_sz_y * (dim_t)m_block * incy),
+            VERBOSE_UNSUPPORTED_FEATURE, "y block offset overflows int32");
 
-    return true;
+    return status::success;
 }
 
 brgemm_kernel_t *create_brgemv_ir_kernel(const brgemm_desc_t &brg) {
-    if (!brgemv_ir_supported(brg)) return nullptr;
+    if (brgemv_ir_supported(brg) != status::success) return nullptr;
     return new brgemv_ir_kernel_t(brg);
 }
 

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -349,7 +349,7 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
 
     void generate() override {
         // Build IR for non-transposed GEMV kernel
-        ir::ir_t ir {};
+        ir::ir_t ir;
         nontrans::build_gemv(brg_, ir);
 
         // Scratch registers (2 gpr + 3 vec) reserved for spill code.

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -1,0 +1,450 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+// The IR-based GEMV kernel converts a brgemm descriptor into IR, then runs the
+// register allocator and code emitter.
+//
+// This is the only file that knows about GEMV-specific math and data layout.
+// Everything in IR is generic infrastructure that can be reused for other
+// problems.
+//
+// The brgemv_ir_supported() function checks whether a problem matches the
+// current requirements.
+
+#include <cstdint>
+#include <vector>
+
+#include "common/c_types_map.hpp"
+#include "common/nstl.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/x64/brgemm/brgemv_ir.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/ir/emitter/emitter.hpp"
+#include "cpu/x64/ir/ir.hpp"
+#include "cpu/x64/ir/reg_alloc.hpp"
+#include "cpu/x64/jit_generator.hpp"
+
+#define GET_OFF(field) offsetof(brgemm_kernel_params_t, field)
+#define GET_OFF_BATCH_ELEMENT(field) offsetof(brgemm_batch_element_t, field)
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+namespace {
+
+// Fixed configuration used during IR generation for the GEMV builder.
+//
+//   m / k        - dimensions of matrix A (GEMV always has n = 1)
+//   lda / incy   - leading dimensions of A and stride between elements of `y`
+//   max_bs       - maximum batch size known at IR generation time
+//   m_block      - M rows per full block
+//   k_block      - K elements reduced per K block
+//   dt_sz_a/x/y  - element size in bytes of A, x, and y
+//   dt_a/x/y     - element data type of A, x, and y. Tags the vec vregs so the
+//                  emitter lowers each op to its dtype-specific instruction.
+//   dt_acc       - accumulation data type
+//   m_blocks     - number of full M blocks
+//   m_tail       - remaining M rows after the full blocks
+//   k_blocks     - number of full K blocks
+//   k_tail       - remaining K elements after the full blocks
+//   mblk_*_off   - byte offset to advance A/y pointers between M blocks
+//   kblk_*_off   - byte offset to advance A/x pointers between K blocks
+struct brgemv_ir_conf_t {
+    brgemv_ir_conf_t(const brgemm_desc_t &brg)
+        : m(brg.bcast_dim)
+        , k(brg.reduce_dim)
+        , lda(brg.LDA)
+        , incy(brg.LDC)
+        , max_bs(brg.brgattr.max_bs)
+        , m_block(brg.gemv_bd_block())
+        , k_block(brg.rd_block)
+        , dt_sz_a(brg.typesize_A)
+        , dt_sz_x(brg.typesize_B)
+        , dt_sz_y(brg.typesize_C)
+        , dt_a(brg.dt_a)
+        , dt_x(brg.dt_b)
+        , dt_y(brg.dt_c)
+        , dt_acc(data_type::f32)
+        , m_blocks(m / m_block)
+        , m_tail(m % m_block)
+        , k_blocks(k / k_block)
+        , k_tail(k % k_block)
+        , mblk_a_off(dt_sz_a * m_block * lda)
+        , mblk_y_off(dt_sz_y * m_block * incy)
+        , kblk_a_off(dt_sz_a * k_block)
+        , kblk_x_off(dt_sz_x * k_block) {}
+
+    const dim_t m, k, lda, incy;
+    const int max_bs;
+    const int m_block, k_block;
+    const int dt_sz_a, dt_sz_x, dt_sz_y;
+    const data_type_t dt_a, dt_x, dt_y, dt_acc;
+    const dim_t m_blocks, m_tail, k_blocks, k_tail;
+    const dim_t mblk_a_off, mblk_y_off;
+    const dim_t kblk_a_off, kblk_x_off;
+};
+
+// M-loop input register classification
+//
+// These structs describe registers used by the M-block loop, split by
+// whether their values advance each iteration or remain constant.
+//
+// Design rule:
+// - A field's vreg ID never changes after assignment.
+// - Because of this, these structs are passed by const reference.
+//
+// Note:
+// - Registers created inside the M-block loop (acc, batch_ptr, ws, a_ptr,
+//   x_ptr) are local temporaries and are not included here.
+
+// Registers that advance each M-block iteration by a fixed byte offset.
+struct advancing_regs_t {
+    // Current output pointer. Advances by `mblk_y_off` per M-block.
+    int y_ptr = -1;
+    // Byte offset into A for the current M-block. Starts at 0 and advances by
+    // `mblk_a_off` each iteration.
+    int a_off = -1;
+};
+
+// Registers that remain constant for the entire M-loop.
+struct invariant_regs_t {
+    // Base pointer of the batch-element array.
+    int batch = -1;
+    // Batch size loop count. Set to -1 when max_bs == 1 (single batch element).
+    int bs = -1;
+    // K-tail mask, shared by every masked tail load. It's only required when
+    // `k_tail` is greater than 1.
+    int k_tail_mask = -1;
+};
+
+// Complete input register set for the M-loop, partitioned by whether values
+// advance across iterations.
+struct m_loop_input_regs_t {
+    advancing_regs_t advancing;
+    invariant_regs_t invariant;
+};
+
+// Sets up the M-loop input registers.
+//
+// Loads kernel argument pointers and the batch count, and initializes the
+// running A offset to zero.
+//
+// Optional arguments are only initialized when the configuration specifies
+// their presence. Otherwise, they remain set to -1.
+m_loop_input_regs_t init_m_loop_input_regs(
+        ir::ir_t &ir, const brgemv_ir_conf_t &cfg) {
+    m_loop_input_regs_t regs;
+
+    regs.advancing.y_ptr = ir.new_gpr();
+    ir.load_param(regs.advancing.y_ptr, GET_OFF(ptr_C));
+
+    regs.invariant.batch = ir.new_gpr();
+    ir.load_param(regs.invariant.batch, GET_OFF(batch));
+
+    if (cfg.max_bs > 1) {
+        regs.invariant.bs = ir.new_gpr();
+        ir.load_param(regs.invariant.bs, GET_OFF(BS));
+    }
+
+    regs.advancing.a_off = ir.new_gpr();
+    ir.mov_imm(regs.advancing.a_off, 0);
+
+    if (cfg.k_tail > 1) {
+        // We only need to set the mask once per kernel. It's lifetime is
+        // managed automatically by the allocator.
+        regs.invariant.k_tail_mask = ir.new_mask();
+        ir.set_mask_imm(regs.invariant.k_tail_mask, (int)cfg.k_tail);
+    }
+
+    return regs;
+}
+
+} // namespace
+
+namespace nontrans {
+
+// Innermost reduction step.
+//
+// Loads one k_block-wide chunk of `x`, then performs a multiply-add into each
+// accumulator in `acc` using the corresponding chunk of its A row.
+//
+// Each accumulator holds a partial dot product for one output. The number of
+// accumulators is the number of rows in the current M block or M tail.
+void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        const std::vector<int> &acc, int a_ptr, int x_ptr) {
+    const int x = ir.new_vec(cfg.dt_x);
+    const int a = ir.new_vec(cfg.dt_a);
+    ir.vload(x, x_ptr, 0);
+    for (int i = 0; i < (int)acc.size(); i++) {
+        ir.vload(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda);
+        ir.vfma(acc[i], a, x);
+    }
+}
+
+// Innermost reduction step for K tail.
+//
+// Same shape as emit_microkernel, but uses masked loads.
+void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        const std::vector<int> &acc, int a_ptr, int x_ptr, int mask) {
+    const int x = ir.new_vec(cfg.dt_x);
+    const int a = ir.new_vec(cfg.dt_a);
+    ir.vload_masked(x, x_ptr, 0, mask, (int)cfg.k_tail);
+    for (int i = 0; i < (int)acc.size(); i++) {
+        ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda, mask,
+                (int)cfg.k_tail);
+        ir.vfma(acc[i], a, x);
+    }
+}
+
+// One batch element.
+//
+// Loads A and x pointers, then runs the reduction loop over k.
+// Each iteration processes one `k_block` chunk and advances the pointers.
+void emit_bs_body(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        const std::vector<int> &acc, int batch_ptr, int a_off,
+        int k_tail_mask) {
+    const int a_ptr = ir.new_gpr();
+    const int x_ptr = ir.new_gpr();
+
+    ir.load(a_ptr, batch_ptr, GET_OFF_BATCH_ELEMENT(ptr.A));
+    ir.add_reg(a_ptr, a_off);
+    ir.load(x_ptr, batch_ptr, GET_OFF_BATCH_ELEMENT(ptr.B));
+    ir.add_imm(batch_ptr, sizeof(brgemm_batch_element_t));
+
+    // Advance the A and x pointers by one K block.
+    auto advance_ptrs = [&]() {
+        ir.add_imm(a_ptr, cfg.kblk_a_off);
+        ir.add_imm(x_ptr, cfg.kblk_x_off);
+    };
+
+    // Reduce the full K blocks, then the tail if any. Cases by `k_blocks`.
+    // k > 0 guarantees k_blocks and k_tail are never both zero.
+    //   *  == 0  whole reduction is the tail
+    //   *  == 1  one block, advance by hand only if a tail follows
+    //   *  >= 2  loop, advancing per iteration
+    if (cfg.k_blocks >= 2) {
+        ir::emit_loop_imm(ir, cfg.k_blocks, [&]() {
+            emit_microkernel(ir, cfg, acc, a_ptr, x_ptr);
+        }, advance_ptrs);
+    } else if (cfg.k_blocks == 1) {
+        emit_microkernel(ir, cfg, acc, a_ptr, x_ptr);
+        if (cfg.k_tail > 0) advance_ptrs();
+    }
+    if (cfg.k_tail > 0)
+        emit_microkernel_tail(ir, cfg, acc, a_ptr, x_ptr, k_tail_mask);
+}
+
+// One M block.
+//
+// Contains `m_block` independent accumulators, reduced across the batch.
+// They are then horizontally reduced to a single scalar each and stored.
+//
+// Finally, advances the A and x pointers to the next M block.
+void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        const m_loop_input_regs_t &regs, int m_block) {
+    std::vector<int> acc(m_block);
+    for (int r = 0; r < m_block; r++) {
+        acc[r] = ir.new_vec(cfg.dt_acc);
+        ir.vzero(acc[r]);
+    }
+
+    // Batch reduction over bs dimension
+    const int batch_ptr = ir.new_gpr();
+    ir.mov_reg(batch_ptr, regs.invariant.batch);
+
+    if (cfg.max_bs > 1) {
+        ir::emit_loop_reg(ir, regs.invariant.bs, [&]() {
+            emit_bs_body(ir, cfg, acc, batch_ptr, regs.advancing.a_off,
+                    regs.invariant.k_tail_mask);
+        });
+    } else {
+        ir::emit_loop_imm(ir, 1, [&]() {
+            emit_bs_body(ir, cfg, acc, batch_ptr, regs.advancing.a_off,
+                    regs.invariant.k_tail_mask);
+        });
+    }
+
+    // Horizontal reduction + store
+    const int ws = ir.new_vec(cfg.dt_acc);
+    for (int r = 0; r < m_block; r++)
+        ir.vhreduce(acc[r], ws);
+
+    for (int r = 0; r < m_block; r++)
+        ir.vstore_masked(regs.advancing.y_ptr,
+                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], -1, 1);
+
+    // Advance to next M block
+    ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);
+    ir.add_imm(regs.advancing.y_ptr, cfg.mblk_y_off);
+}
+
+// Builds IR for GEMV with a non-transposed A matrix.
+//
+// Computes:
+//   y[i] = sum_k A[i][k] * x[k]
+//   (m = brg.bcast_dim, k = brg.reduce_dim, n = 1)
+//
+// The output is partitioned into full M blocks of `m_block` rows each, with a
+// final partial block of `m_tail` rows when m is not a multiple of m_block.
+//
+// Each M block:
+// - Maintains one independent accumulator per row
+// - Accumulates over k in k_block-wide chunks across the batch
+// - Horizontally reduces each accumulator to a scalar output value
+//   and stores it to memory
+void build_gemv(const brgemm_desc_t &brg, ir::ir_t &ir) {
+    const brgemv_ir_conf_t cfg(brg);
+    const m_loop_input_regs_t regs = init_m_loop_input_regs(ir, cfg);
+
+    if (cfg.m_blocks > 0)
+        ir::emit_loop_imm(ir, cfg.m_blocks,
+                [&]() { emit_m_block(ir, cfg, regs, cfg.m_block); });
+
+    if (cfg.m_tail > 0) emit_m_block(ir, cfg, regs, (int)cfg.m_tail);
+}
+
+} // namespace nontrans
+
+// generate() runs the full IR pipeline:
+//
+// - Build IR for the given `brgemm_desc_t` descriptor
+// - Allocate registers
+// - Emit code
+// - Wrap in standard preamble, stack frame, and postamble
+//
+// TODO: Generalize the IR pipeline runner so it is shared across all kernels,
+// while allowing different builder implementations to plug into the same
+// fixed sequence:
+// IR build -> register allocation -> preamble -> codegen -> postamble).
+struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemv_ir_kernel_t)
+
+    jit_brgemv_ir_kernel_t(const brgemm_desc_t &abrg)
+        : jit_base_brgemm_kernel_t(jit_name(), abrg.isa_impl), brg_(abrg) {}
+
+    const brgemm_desc_t &get_brg() const override { return brg_; }
+
+    void generate() override {
+        // Build IR for non-transposed GEMV kernel
+        ir::ir_t ir {};
+        nontrans::build_gemv(brg_, ir);
+
+        // Scratch registers (2 gpr + 3 vec) reserved for spill code.
+        const int gpr_scratch0 = 10, gpr_scratch1 = 11;
+        const int vec_scratch0 = 13, vec_scratch1 = 14, vec_scratch2 = 15;
+
+        const int rsp_idx = Xbyak::Operand::RSP;
+        const int param_idx = abi_param1.getIdx();
+
+        // Build register configuration for code emission
+        const ir::reg_config_t reg_cfg = ir::make_reg_config(brg_.isa_impl,
+                param_idx, rsp_idx, {gpr_scratch0, gpr_scratch1},
+                {vec_scratch0, vec_scratch1, vec_scratch2});
+
+        // Register allocation
+        ir::reg_alloc_result_t alloc = allocate_registers(ir, reg_cfg.pools);
+
+        preamble();
+
+        // Stack frame setup
+        if (alloc.frame_bytes > 0) sub(rsp, (uint32_t)alloc.frame_bytes);
+
+        // Code generation. `ir::emit` dispatches to the ISA-specific emitter
+        // based on `brg_.isa_impl`.
+        // The emitter may accumulate static data (e.g. the mask table) that we
+        // need to write down after the postamble.
+        ir::data_section_t data;
+        ir::emit(*this, ir, alloc, reg_cfg, data);
+
+        // Stack cleanup
+        if (alloc.frame_bytes > 0) add(rsp, (uint32_t)alloc.frame_bytes);
+
+        postamble();
+
+        // Emit any static data the emitter accumulated.
+        ir::emit_data_section(*this, data);
+    }
+
+private:
+    brgemm_desc_t brg_;
+};
+
+// TODO: Reorganize `brgemm_kernel_t` to avoid redundant inheritance.
+struct brgemv_ir_kernel_t : public brgemm_kernel_t {
+    brgemv_ir_kernel_t(const brgemm_desc_t &abrd)
+        : kernel_(new jit_brgemv_ir_kernel_t(abrd)) {}
+    ~brgemv_ir_kernel_t() override = default;
+
+    status_t create_kernel() override {
+        if (!kernel_) return status::out_of_memory;
+        return kernel_->create_kernel();
+    }
+
+    void operator()(const brgemm_kernel_params_t *params) const override {
+        (*kernel_)(params);
+    }
+
+    const jit_generator_t *get_jit_generator() const override {
+        return kernel_.get();
+    }
+
+    const brgemm_desc_t &get_brg() const override { return kernel_->get_brg(); }
+
+private:
+    std::unique_ptr<jit_brgemv_ir_kernel_t> kernel_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(brgemv_ir_kernel_t);
+};
+
+// Returns true if the descriptor is supported by the GEMV IR kernel.
+bool brgemv_ir_supported(const brgemm_desc_t &brg) {
+    using namespace data_type;
+
+    if (!utils::everyone_is(f32, brg.dt_a, brg.dt_b, brg.dt_c)) return false;
+    if (brg.isa_impl != avx2) return false;
+    if (brg.transA) return false;
+
+    if (brg.are_post_ops_applicable()) return false;
+    if (brg.alpha != 1.0f) return false;
+    if (brg.beta != 0.0f) return false;
+
+    if (brg.is_runtime_lda || brg.is_runtime_ldc) return false;
+
+    const int m_block = brg.gemv_bd_block();
+    const int dt_sz_a = brg.typesize_A;
+    const int dt_sz_y = brg.typesize_C;
+    const int incy = brg.LDC;
+
+    // Ensure indexed displacements fit in 32-bit
+    auto fits = [](dim_t v) { return v <= INT32_MAX && v >= INT32_MIN; };
+
+    if (!fits(dt_sz_a * (dim_t)m_block * brg.LDA)) return false;
+    if (!fits(dt_sz_y * (dim_t)m_block * incy)) return false;
+
+    return true;
+}
+
+brgemm_kernel_t *create_brgemv_ir_kernel(const brgemm_desc_t &brg) {
+    if (!brgemv_ir_supported(brg)) return nullptr;
+    return new brgemv_ir_kernel_t(brg);
+}
+
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -194,11 +194,18 @@ namespace nontrans {
 void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         const std::vector<ir::vreg_t> &acc, ir::vreg_t a_ptr,
         ir::vreg_t x_ptr) {
+    // GEMV is bandwidth-bound, so SW-prefetch ahead of each load: the x vector
+    // once and every A row. The distance is empirically tuned.
+    constexpr dim_t gemv_pf_dist = 512; // bytes = 8 cache lines
+
     const ir::vreg_t x = ir.new_vec(cfg.dt_x);
     const ir::vreg_t a = ir.new_vec(cfg.dt_a);
+    ir.prefetch(x_ptr, gemv_pf_dist);
     ir.vload(x, x_ptr, 0);
     for (int i = 0; i < (int)acc.size(); i++) {
-        ir.vload(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda);
+        const dim_t a_off = cfg.dt_sz_a * (dim_t)i * cfg.lda;
+        ir.prefetch(a_ptr, a_off + gemv_pf_dist);
+        ir.vload(a, a_ptr, a_off);
         ir.vdot(acc[i], a, x);
     }
 }

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -116,21 +116,21 @@ struct brgemv_ir_conf_t {
 // Registers that advance each M-block iteration by a fixed byte offset.
 struct advancing_regs_t {
     // Current output pointer. Advances by `mblk_y_off` per M-block.
-    int y_ptr = -1;
+    ir::vreg_t y_ptr = ir::vreg_t::none;
     // Byte offset into A for the current M-block. Starts at 0 and advances by
     // `mblk_a_off` each iteration.
-    int a_off = -1;
+    ir::vreg_t a_off = ir::vreg_t::none;
 };
 
 // Registers that remain constant for the entire M-loop.
 struct invariant_regs_t {
     // Base pointer of the batch-element array.
-    int batch = -1;
-    // Batch size loop count. Set to -1 when max_bs == 1 (single batch element).
-    int bs = -1;
+    ir::vreg_t batch = ir::vreg_t::none;
+    // Batch size loop count. `none` when max_bs == 1 (single batch element).
+    ir::vreg_t bs = ir::vreg_t::none;
     // K-tail mask, shared by every masked tail load. It's only required when
     // `k_tail` is greater than 1.
-    int k_tail_mask = -1;
+    ir::vreg_t k_tail_mask = ir::vreg_t::none;
 };
 
 // Complete input register set for the M-loop, partitioned by whether values
@@ -146,7 +146,7 @@ struct m_loop_input_regs_t {
 // running A offset to zero.
 //
 // Optional arguments are only initialized when the configuration specifies
-// their presence. Otherwise, they remain set to -1.
+// their presence. Otherwise, they remain `none`.
 m_loop_input_regs_t init_m_loop_input_regs(
         ir::ir_t &ir, const brgemv_ir_conf_t &cfg) {
     m_loop_input_regs_t regs;
@@ -187,9 +187,10 @@ namespace nontrans {
 // Each accumulator holds a partial dot product for one output. The number of
 // accumulators is the number of rows in the current M block or M tail.
 void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
-        const std::vector<int> &acc, int a_ptr, int x_ptr) {
-    const int x = ir.new_vec(cfg.dt_x);
-    const int a = ir.new_vec(cfg.dt_a);
+        const std::vector<ir::vreg_t> &acc, ir::vreg_t a_ptr,
+        ir::vreg_t x_ptr) {
+    const ir::vreg_t x = ir.new_vec(cfg.dt_x);
+    const ir::vreg_t a = ir.new_vec(cfg.dt_a);
     ir.vload(x, x_ptr, 0);
     for (int i = 0; i < (int)acc.size(); i++) {
         ir.vload(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda);
@@ -201,9 +202,10 @@ void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
 //
 // Same shape as emit_microkernel, but uses masked loads.
 void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
-        const std::vector<int> &acc, int a_ptr, int x_ptr, int mask) {
-    const int x = ir.new_vec(cfg.dt_x);
-    const int a = ir.new_vec(cfg.dt_a);
+        const std::vector<ir::vreg_t> &acc, ir::vreg_t a_ptr, ir::vreg_t x_ptr,
+        ir::vreg_t mask) {
+    const ir::vreg_t x = ir.new_vec(cfg.dt_x);
+    const ir::vreg_t a = ir.new_vec(cfg.dt_a);
     ir.vload_masked(x, x_ptr, 0, mask, (int)cfg.k_tail);
     for (int i = 0; i < (int)acc.size(); i++) {
         ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda, mask,
@@ -217,10 +219,10 @@ void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
 // Loads A and x pointers, then runs the reduction loop over k.
 // Each iteration processes one `k_block` chunk and advances the pointers.
 void emit_bs_body(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
-        const std::vector<int> &acc, int batch_ptr, int a_off,
-        int k_tail_mask) {
-    const int a_ptr = ir.new_gpr();
-    const int x_ptr = ir.new_gpr();
+        const std::vector<ir::vreg_t> &acc, ir::vreg_t batch_ptr,
+        ir::vreg_t a_off, ir::vreg_t k_tail_mask) {
+    const ir::vreg_t a_ptr = ir.new_gpr();
+    const ir::vreg_t x_ptr = ir.new_gpr();
 
     ir.load(a_ptr, batch_ptr, GET_OFF_BATCH_ELEMENT(ptr.A));
     ir.add_reg(a_ptr, a_off);
@@ -258,14 +260,14 @@ void emit_bs_body(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
 // Finally, advances the A and x pointers to the next M block.
 void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         const m_loop_input_regs_t &regs, int m_block) {
-    std::vector<int> acc(m_block);
+    std::vector<ir::vreg_t> acc(m_block, ir::vreg_t::none);
     for (int r = 0; r < m_block; r++) {
         acc[r] = ir.new_vec(cfg.dt_acc);
         ir.vzero(acc[r]);
     }
 
     // Batch reduction over bs dimension
-    const int batch_ptr = ir.new_gpr();
+    const ir::vreg_t batch_ptr = ir.new_gpr();
     ir.mov_reg(batch_ptr, regs.invariant.batch);
 
     if (cfg.max_bs > 1) {
@@ -281,13 +283,13 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     }
 
     // Horizontal reduction + store
-    const int ws = ir.new_vec(cfg.dt_acc);
+    const ir::vreg_t ws = ir.new_vec(cfg.dt_acc);
     for (int r = 0; r < m_block; r++)
         ir.vhreduce(acc[r], ws);
 
     for (int r = 0; r < m_block; r++)
         ir.vstore_masked(regs.advancing.y_ptr,
-                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], -1, 1);
+                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], ir::vreg_t::none, 1);
 
     // Advance to next M block
     ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -194,7 +194,7 @@ void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     ir.vload(x, x_ptr, 0);
     for (int i = 0; i < (int)acc.size(); i++) {
         ir.vload(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda);
-        ir.vfma(acc[i], a, x);
+        ir.vdot(acc[i], a, x);
     }
 }
 
@@ -210,7 +210,7 @@ void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     for (int i = 0; i < (int)acc.size(); i++) {
         ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda, mask,
                 (int)cfg.k_tail);
-        ir.vfma(acc[i], a, x);
+        ir.vdot(acc[i], a, x);
     }
 }
 

--- a/src/cpu/x64/brgemm/brgemv_ir.hpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.hpp
@@ -26,8 +26,9 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-// True when the IR GEMV kernel can generate code for `brg`.
-bool brgemv_ir_supported(const brgemm_desc_t &brg);
+// Returns `status::success` when the IR GEMV kernel can generate code for
+// `brg`, otherwise `status::unimplemented`.
+status_t brgemv_ir_supported(const brgemm_desc_t &brg);
 
 // Creates an IR-based GEMV kernel. Caller owns the pointer.
 // Returns `nullptr` on failure.

--- a/src/cpu/x64/brgemm/brgemv_ir.hpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_BRGEMM_BRGEMV_IR_HPP
+#define CPU_X64_BRGEMM_BRGEMV_IR_HPP
+
+// IR-based GEMV kernel.
+
+#include "cpu/x64/brgemm/brgemm_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+// True when the IR GEMV kernel can generate code for `brg`.
+bool brgemv_ir_supported(const brgemm_desc_t &brg);
+
+// Creates an IR-based GEMV kernel. Caller owns the pointer.
+// Returns `nullptr` on failure.
+brgemm_kernel_t *create_brgemv_ir_kernel(const brgemm_desc_t &brg);
+
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -1,0 +1,187 @@
+# IR-Based JIT Kernel Generation for x64
+
+This directory holds an intermediate representation (IR) for x64 JIT CPU kernels
+and the shared passes that lower it to machine code. A kernel is written as
+target-neutral operations over virtual registers. The shared pipeline allocates
+registers and an ISA-specific emitter lowers the IR to instructions. Kernel code
+carries no manual register management and no data-type or ISA branching.
+
+IR-based kernels coexist with the existing Xbyak generators and are enabled
+incrementally. It is not an optimizing compiler, has no IR-to-IR passes, and
+does not target non-x64 backends.
+
+## Architecture
+
+The kernel is a class derived from `jit_generator_t`. It knows the concrete ISA
+and data types and can use them directly, for example to set up post-op
+callbacks. Its `generate()` calls the stages below in order. Only the *builder* stage is
+kernel-specific. Everything else is shared.
+
+```
+generate()
+|
+|   kernel-specific
++-> +-------------+
+|   | Builder     |  emits target-neutral IR: param loads, loops, math
+|   +-------------+
+|
+|   shared
++-> +-------------+
+|   | Reg config  |  builds ISA-agnostic register pools
+|   +-------------+
+|
++-> +-------------+
+|   | Reg alloc   |  liveness and linear scan over gpr/vec/mask
+|   +-------------+
+|
++-> +-------------+
+|   | Emitter     |  lowers IR to instructions, one backend per ISA
+|   +-------------+
+|
++-> +-------------+
+    | Static data |  mask and post-op tables, after the postamble
+    +-------------+
+```
+
+The ABI preamble, the spill-frame reservation, and the postamble wrap the emit
+step. They are omitted above for clarity.
+
+### Components
+
+* **Builder.** The only kernel-specific part. It loads parameters, builds the
+  loop nest, and expresses the math in target-neutral operations. It is data-type
+  agnostic (the type is only a tag on vector values) and ISA agnostic (masks,
+  vector, and general-purpose registers are abstract).
+* **IR.** A linear list of operations over *virtual registers*. One fixed
+  struct represents every operation, and an `op` kind selects which fields it
+  uses. Every virtual register has a kind (`gpr`, `vec`, or `mask`), and a `vec`
+  register also carries the element data type of the values it holds.
+* **Register configuration.** An ISA-aware step that produces ISA-agnostic
+  register pools (integer indices per register kind) plus the reserved registers:
+  the stack pointer, the kernel-argument pointer, and a few scratch registers the
+  emitter uses for spilled values. It encodes per-ISA facts such as register
+  counts and whether the target has dedicated mask (k) registers.
+* **Register allocator.** Maps unlimited virtual registers onto physical ones,
+  spilling to the stack under pressure. It knows only register kinds and control
+  flow. Liveness analysis (which values are still needed at each operation) is
+  backward data-flow over the IR's trivial control-flow graph, iterated to a fixed
+  point so loop back-edges propagate. Linear scan then
+  reduces each value to a single live interval and spills to the stack when the
+  active set outgrows the register file.
+* **Emitter.** The only part aware of the ISA and data types, because it produces
+  the code. It walks the allocated IR once and lowers each operation to
+  instructions using the physical registers the allocator chose. Spilled values
+  are loaded into scratch registers around each use. There is one backend per ISA
+  family (for example, AVX2\* and AVX-512\*), and a dispatch step selects the
+  matching backend.
+* **Static data.** Some lowerings need constants, such as the AVX2 mask tables,
+  that must live after the ABI postamble, though the references to them are
+  emitted during lowering. The emitter fills a data-section structure with the
+  bytes and an unresolved label. After the postamble, the bytes are written and
+  the labels are bound.
+* **Post-ops injector.** The existing Xbyak post-ops injector is reused unchanged,
+  plugged in as a single `inject_postops` operation. Its variable-length argument
+  list is stored in a side table indexed from the operation's immediate field, so
+  the IR core carries only virtual-register ids. The injector saves and restores
+  its own registers and does not participate in IR allocation.
+
+### Control and Data Flow
+
+The IR is produced in full, then consumed read-only by the allocator and the
+emitter. `generate()` runs a fixed sequence: build the IR, build the register
+configuration, allocate registers, emit the ABI preamble, reserve the spill
+frame, emit the lowered code, tear down the frame, emit the postamble, and write
+the static data. Each kernel assembles this sequence in its own `generate()`
+today. A shared runner for the fixed part is a follow-up.
+
+## Design Principles
+
+* **The whole kernel exists before lowering.** This is what distinguishes the
+  approach from single-pass generation and what makes global register allocation
+  possible.
+* **Flat, fixed-struct IR.** Instructions do not nest, and one struct fits every
+  operation. This keeps the builder, allocator, and emitter simple and avoids any
+  rewrite-pass machinery.
+* **No IR-to-IR optimization passes.** The developer writes the structural
+  optimizations (blocking, unrolling, loop order), which are emitted as written.
+  The IR only takes over register allocation.
+* **Mutable virtual registers.** A virtual register is a named value that may be
+  written more than once (for example, a pointer advanced each
+  iteration), and it occupies a single physical location for its entire live
+  range. The cost is that live-range splitting is ruled out.
+* **Single-register addressing.** A memory operand is a base register plus a
+  build-time constant displacement, with no index and no scale. Any distance known
+  only at run time is folded into the base pointer with an explicit `add`. Every
+  memory operation then reads at most one pointer, which lowers register pressure
+  and simplifies spilling.
+* **Structured loops.** Loops are explicit nodes with a runtime counter.
+* **Separation of concerns is the invariant to protect.** The builder is
+  target-neutral, ISA and data-type knowledge lives only in the emitter and the
+  register configuration, and the allocator knows only kinds and control flow.
+* **`def_use()` must match the emitter.** Liveness is computed from the reads and
+  writes reported by `def_use()`. If a lowering reads or writes a virtual register
+  that `def_use()` does not report, allocation is wrong, so the two must stay in
+  sync.
+
+## Directory Structure
+
+* `ir.hpp`, `ir.cpp`: the IR itself, that is, the operation kinds, virtual
+  registers, the builder helpers, `def_use()`, and the loop-emission helpers.
+* `reg_config.hpp`, `reg_config.cpp`: builds the per-ISA register configuration,
+  that is, the allocatable pools plus the reserved and scratch registers.
+* `reg_alloc.hpp`, `reg_alloc.cpp`: liveness analysis and the linear-scan
+  allocator, producing the assignment for each virtual register and the size of
+  the spill frame.
+* `emitter/emitter.hpp`, `emitter/emitter.cpp`: the lowering pass, which walks the
+  allocated IR, dispatches by ISA family, and manages the static-data section.
+* `emitter/backend_avx2.hpp`: the AVX2-family backend, the reference example of
+  per-operation instruction selection.
+
+The kernel-specific builders live outside this directory. For example,
+`src/cpu/x64/brgemm/brgemv_ir.{hpp,cpp}` holds the GEMV builder and shows how
+`generate()` runs the full pipeline.
+
+## Developer Guidelines
+
+New functionality maps to a specific layer. The IR infrastructure grows by adding
+data types, ISAs, and the fused instructions each ISA supports, and each kind of
+change belongs in one place.
+
+1. **A new data type** is a tag on a `vec` register. The builder stays the same,
+   and the emitter maps the operation and data type to the right instruction.
+2. **A new ISA** adds a new emitter backend or extends an existing one, along with
+   the matching register-configuration facts.
+3. **A new variant of an existing instruction** is a lowering rule in the emitter,
+   not a new IR operation, and is invisible to the builder. For example,
+   `vload_masked` already lowers to `vmovss`, `vmovups`, or `vmaskmovps` depending
+   on how many elements are active.
+4. **A new behavior** that no existing operation can express becomes a new IR
+   operation, with its own definition, `def_use()` entry, and lowering.
+
+To tell the third from the fourth, look at `def_use()`. If the reads and writes
+stay the same and only the emitted instructions differ (by data type, element
+count, or ISA), it is a lowering rule. If the behavior needs different reads or
+writes, it is a new operation. This keeps the set of operations target-neutral.
+
+Additional rules to follow.
+
+* Keep the builder target-neutral. No ISA or data-type conditionals in builder
+  code, since that is exactly the branching this design removes.
+* Update `def_use()` with every change to an operation so liveness stays correct.
+* Confine ISA and data-type knowledge to the emitter and the register
+  configuration.
+* Prefer a running pointer over a computed index, to respect single-register
+  addressing.
+* The public entry points in these headers are exported for unit testing.
+
+## Tests
+
+The IR, allocator, and emitter have dedicated unit tests
+(`test_internals_cpu_ir`). IR-based kernels are also tested through benchdnn.
+
+## References
+
+* Design document (RFC): *IR-Based JIT Kernel Generation for x64 CPUs*, at
+  https://github.com/uxlfoundation/oneDNN/pull/5460
+  (`rfcs/20260630-ir-x64/README.md`). It covers the motivation, goals, and
+  design rationale.

--- a/src/cpu/x64/ir/emitter/backend_avx2.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx2.hpp
@@ -73,12 +73,12 @@ struct avx2_backend_t {
 
     // dst += a * b. The multiplicand dtype `src_dt` selects the instruction.
     // f32 inputs use `vfmadd231ps`. The accumulator (dst) is always f32.
-    void vfma(int d, int a, int b, data_type_t src_dt) {
+    void vdot(int d, int a, int b, data_type_t src_dt) {
         if (src_dt == data_type::f32)
             gen().vfmadd231ps(Xbyak::Ymm(d), Xbyak::Ymm(a), Xbyak::Ymm(b));
         else
             // Only f32 is supported on AVX2 today.
-            assert(!"vfma: dtype not implemented");
+            assert(!"vdot: dtype not implemented");
     }
 
     void vhreduce(int d, int ws, data_type_t dt) {

--- a/src/cpu/x64/ir/emitter/backend_avx2.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx2.hpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_IR_EMITTER_BACKEND_AVX2_HPP
+#define CPU_X64_IR_EMITTER_BACKEND_AVX2_HPP
+
+// AVX2-family backend for the emitter (see `emit()` in `emitter.cpp`).
+//
+// This backend contains every vector and mask instruction for one ISA family
+// and covers all AVX2 extensions (avx2, avx2_vnni, avx2_vnni_2, and so on). The
+// generic emitter iterates over the IR and resolves each virtual register to a
+// physical register index. The backend is the only code on this path that
+// constructs Xbyak `Ymm` registers, so each operation builds its own registers
+// from the indices it is given.
+
+#include <cassert>
+#include <utility>
+#include <vector>
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "cpu/x64/ir/emitter/emitter.hpp"
+#include "cpu/x64/jit_generator.hpp"
+#include "cpu/x64/utils/jit_regops.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+struct avx2_backend_t {
+    avx2_backend_t(jit_generator_t &gen, cpu_isa_t isa) : gen_(gen), isa(isa) {
+        // `isa` is stored for future ISA-specific dispatch (e.g. avx2_vnni_2)
+        // but is not read yet.
+        MAYBE_UNUSED(this->isa);
+    }
+
+    jit_generator_t &gen() { return gen_; }
+
+    // Plain vector ops.
+    void vzero(int d) { // dst = 0
+        gen().vxorps(Xbyak::Ymm(d), Xbyak::Ymm(d), Xbyak::Ymm(d));
+    }
+
+    void vload(int d, int base, dim_t disp) { // dst = [base + disp]
+        gen().vmovups(Xbyak::Ymm(d), gen().ptr[Xbyak::Reg64(base) + (int)disp]);
+    }
+
+    void vstore(int base, dim_t disp, int s) { // [base + disp] = src
+        gen().vmovups(gen().ptr[Xbyak::Reg64(base) + (int)disp], Xbyak::Ymm(s));
+    }
+
+    void vadd(int d, int s, data_type_t dt) { // dst += s0
+        if (dt == data_type::f32)
+            gen().vaddps(Xbyak::Ymm(d), Xbyak::Ymm(d), Xbyak::Ymm(s));
+        else
+            assert(!"vadd: dtype not implemented");
+    }
+
+    // dst += a * b. The multiplicand dtype `src_dt` selects the instruction.
+    // f32 inputs use `vfmadd231ps`. The accumulator (dst) is always f32.
+    void vfma(int d, int a, int b, data_type_t src_dt) {
+        if (src_dt == data_type::f32)
+            gen().vfmadd231ps(Xbyak::Ymm(d), Xbyak::Ymm(a), Xbyak::Ymm(b));
+        else
+            // Only f32 is supported on AVX2 today.
+            assert(!"vfma: dtype not implemented");
+    }
+
+    void vhreduce(int d, int ws, data_type_t dt) {
+        if (dt == data_type::f32)
+            regops::horizontal_add_ps(&gen(), Xbyak::Ymm(d), Xbyak::Ymm(ws));
+        else
+            assert(!"vhreduce: dtype not implemented");
+    }
+
+    // Masked vector ops. On AVX2 a mask is a vector.
+    //
+    // Create a mask for `n_elems` active elements. The mask bytes are written
+    // to the data section and loaded once. A vector mask is a constant, so the
+    // builder emits `set_mask_imm` a single time and the mask is reused across
+    // all masked ops.
+    void set_mask_imm(int d, int n_elems, data_section_t &data) {
+        const int elem_bytes = (int)sizeof(float);
+        const unsigned char active_byte = 0xff;
+
+        std::vector<unsigned char> bytes((size_t)vlen, 0);
+        const int active_bytes = n_elems * elem_bytes;
+        for (int i = 0; i < active_bytes; i++)
+            bytes[i] = active_byte;
+
+        // This label is the memory location of the mask in the data section.
+        data.constants.emplace_back(std::move(bytes), Xbyak::Label());
+        Xbyak::Label &lbl = data.constants.back().second;
+        gen().vmovups(Xbyak::Ymm(d), gen().ptr[gen().rip + lbl]);
+    }
+
+    // Load `n_elems` f32 elements. The count selects the simplest form:
+    //   n_elems == 1:       vmovss (no mask register needed)
+    //   n_elems == simd_w:  vmovups (no mask register needed)
+    //   otherwise:          vmaskmovps with the mask in `mask`
+    void vload_masked(int d, int base, dim_t disp, int mask, int n_elems,
+            data_type_t dt, data_section_t & /*data*/) {
+        const int simd_w = vlen / (int)types::data_type_size(dt);
+        assert(n_elems <= simd_w);
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+
+        if (dt == data_type::f32) {
+            if (n_elems == 1)
+                gen().vmovss(Xbyak::Xmm(d), addr);
+            else if (n_elems == simd_w)
+                gen().vmovups(Xbyak::Ymm(d), addr);
+            else
+                gen().vmaskmovps(Xbyak::Ymm(d), Xbyak::Ymm(mask), addr);
+        } else
+            // vmaskmovps applies only to f32. Other precisions need a different
+            // mechanism here.
+            assert(!"vload_masked: dtype not implemented");
+    }
+
+    // Store `n_elems` f32 elements. Same case split as `vload_masked()`.
+    void vstore_masked(int base, dim_t disp, int s, int mask, int n_elems,
+            data_type_t dt, data_section_t & /*data*/) {
+        const int simd_w = vlen / (int)types::data_type_size(dt);
+        assert(n_elems <= simd_w);
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+
+        if (dt == data_type::f32) {
+            if (n_elems == 1)
+                gen().vmovss(addr, Xbyak::Xmm(s));
+            else if (n_elems == simd_w)
+                gen().vmovups(addr, Xbyak::Ymm(s));
+            else
+                gen().vmaskmovps(addr, Xbyak::Ymm(mask), Xbyak::Ymm(s));
+        } else
+            assert(!"vstore_masked: dtype not implemented");
+    }
+
+private:
+    // The backend is used during the emitter step, which is called from an
+    // IR-based kernel during kernel generation. The kernel owns `gen_`.
+    jit_generator_t &gen_;
+
+    // ISA is used to dispatch ISA-specific instructions (e.g. on avx2_vnni_2).
+    cpu_isa_t isa;
+
+    // Vector register width in bytes.
+    const int vlen = cpu_isa_traits_t<avx2>::vlen;
+};
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/ir/emitter/backend_avx2.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx2.hpp
@@ -67,8 +67,7 @@ struct avx2_backend_t {
     void vadd(int d, int s, data_type_t dt) { // dst += s0
         if (dt == data_type::f32)
             gen().vaddps(Xbyak::Ymm(d), Xbyak::Ymm(d), Xbyak::Ymm(s));
-        else
-            assert(!"vadd: dtype not implemented");
+        else { JIT_ASSERT(!"vadd: dtype not implemented"); }
     }
 
     // dst += a * b. The multiplicand dtype `src_dt` selects the instruction.
@@ -76,16 +75,16 @@ struct avx2_backend_t {
     void vdot(int d, int a, int b, data_type_t src_dt) {
         if (src_dt == data_type::f32)
             gen().vfmadd231ps(Xbyak::Ymm(d), Xbyak::Ymm(a), Xbyak::Ymm(b));
-        else
+        else {
             // Only f32 is supported on AVX2 today.
-            assert(!"vdot: dtype not implemented");
+            JIT_ASSERT(!"vdot: dtype not implemented");
+        }
     }
 
     void vhreduce(int d, int ws, data_type_t dt) {
         if (dt == data_type::f32)
             regops::horizontal_add_ps(&gen(), Xbyak::Ymm(d), Xbyak::Ymm(ws));
-        else
-            assert(!"vhreduce: dtype not implemented");
+        else { JIT_ASSERT(!"vhreduce: dtype not implemented"); }
     }
 
     // Masked vector ops. On AVX2 a mask is a vector.
@@ -126,10 +125,11 @@ struct avx2_backend_t {
                 gen().vmovups(Xbyak::Ymm(d), addr);
             else
                 gen().vmaskmovps(Xbyak::Ymm(d), Xbyak::Ymm(mask), addr);
-        } else
+        } else {
             // vmaskmovps applies only to f32. Other precisions need a different
             // mechanism here.
-            assert(!"vload_masked: dtype not implemented");
+            JIT_ASSERT(!"vload_masked: dtype not implemented");
+        }
     }
 
     // Store `n_elems` f32 elements. Same case split as `vload_masked()`.
@@ -146,8 +146,9 @@ struct avx2_backend_t {
                 gen().vmovups(addr, Xbyak::Ymm(s));
             else
                 gen().vmaskmovps(addr, Xbyak::Ymm(mask), Xbyak::Ymm(s));
-        } else
-            assert(!"vstore_masked: dtype not implemented");
+        } else {
+            JIT_ASSERT(!"vstore_masked: dtype not implemented");
+        }
     }
 
 private:

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -243,6 +243,13 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 break;
             }
 
+            // prefetcht0 is base x86-64, so emit it directly.
+            case op_kind_t::prefetch: {
+                Xbyak::Reg64 base = gpr_use(op.mem.base, gpr_scratch0);
+                gen.prefetcht0(gen.ptr[base + (int)op.mem.disp]);
+                break;
+            }
+
             // Control flow. ISA-neutral, emitted directly.
             case op_kind_t::loop_begin: {
                 Xbyak::Reg64 c = spilled(op.dst) ? gpr_scratch0

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -295,7 +295,7 @@ void emit(jit_generator_t &gen, const ir_t &ir, const reg_alloc_result_t &alloc,
         const reg_config_t &reg_cfg, data_section_t &data) {
     const cpu_isa_t isa = gen.max_cpu_isa();
     if (is_superset(isa, avx512_core)) {
-        assert(!"avx512 emitter is not supported");
+        JIT_ASSERT(!"avx512 emitter is not supported");
     } else {
         avx2_backend_t be(gen, isa);
         emit(be, ir, alloc, reg_cfg, data);

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -195,12 +195,12 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
-            case op_kind_t::vfma: { // rmw: reads and writes dst
+            case op_kind_t::vdot: { // rmw: reads and writes dst
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
                 if (spilled(op.dst)) spill_reload(op.dst, d);
                 int a = vec_use(op.s0, vec_scratch1);
                 int b = vec_use(op.s1, vec_scratch2);
-                be.vfma(d, a, b, dt_of(op.s0));
+                be.vdot(d, a, b, dt_of(op.s0));
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -43,17 +43,19 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
     std::vector<Xbyak::Label> label_id_to_label(ir.n_labels());
 
     // if vreg needs to be spilled
-    auto spilled = [&](int vr) { return alloc.assignments[vr].spilled; };
+    auto spilled
+            = [&](vreg_t vr) { return alloc.assignments[(int)vr].spilled; };
     // get a physical register from a virtual one
-    auto phys = [&](int vr) { return alloc.assignments[vr].phys; };
+    auto phys = [&](vreg_t vr) { return alloc.assignments[(int)vr].phys; };
     // get a stack slot for a virtual register
-    auto slot = [&](int vr) {
-        return gen.ptr[gen.rsp + (int)alloc.assignments[vr].slot];
+    auto slot = [&](vreg_t vr) {
+        return gen.ptr[gen.rsp + (int)alloc.assignments[(int)vr].slot];
     };
     // stack slot byte offset for a vec spill
-    auto slot_off = [&](int vr) { return (int)alloc.assignments[vr].slot; };
+    auto slot_off
+            = [&](vreg_t vr) { return (int)alloc.assignments[(int)vr].slot; };
     // Data type of a vec vreg.
-    auto dt_of = [&](int vr) { return ir.vreg_info()[vr].dt; };
+    auto dt_of = [&](vreg_t vr) { return ir.vreg_info()[(int)vr].dt; };
 
     // Reserve scratch registers for the spills.
     const Xbyak::Reg64 gpr_scratch0(rc.gpr_scratch[0]);
@@ -66,9 +68,9 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
     // as a vector load/store against the stack frame (rsp).
     const int rsp_idx = gen.rsp.getIdx();
     auto spill_reload
-            = [&](int vr, int p) { be.vload(p, rsp_idx, slot_off(vr)); };
+            = [&](vreg_t vr, int p) { be.vload(p, rsp_idx, slot_off(vr)); };
     auto spill_store
-            = [&](int vr, int p) { be.vstore(rsp_idx, slot_off(vr), p); };
+            = [&](vreg_t vr, int p) { be.vstore(rsp_idx, slot_off(vr), p); };
 
     // Resolve a virtual register that an instruction READS (use) to a
     // concrete physical register, hiding whether the allocator spilled it:
@@ -92,14 +94,14 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
     // directly. A spilled vec source is reloaded through the backend, since the
     // reload instruction is ISA-specific. The `vec_use` returns a physical
     // index rather than a typed register.
-    auto gpr_use = [&](int vr, const Xbyak::Reg64 &scr) -> Xbyak::Reg64 {
+    auto gpr_use = [&](vreg_t vr, const Xbyak::Reg64 &scr) -> Xbyak::Reg64 {
         if (!spilled(vr)) return Xbyak::Reg64(phys(vr));
         // reload the spilled gpr from its stack slot
         gen.mov(scr, slot(vr));
         return scr;
     };
 
-    auto vec_use = [&](int vr, int scr_idx) -> int {
+    auto vec_use = [&](vreg_t vr, int scr_idx) -> int {
         if (!spilled(vr)) return phys(vr);
         // reload the spilled vector register from its stack slot
         spill_reload(vr, scr_idx);
@@ -222,9 +224,9 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
             case op_kind_t::vload_masked: { // overwrites dst
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
-                assert((op.s1 < 0 || !spilled(op.s1))
+                assert((op.s1 == vreg_t::none || !spilled(op.s1))
                         && "vload_masked: mask spilled");
-                int mask = (op.s1 >= 0) ? phys(op.s1) : -1;
+                int mask = (op.s1 != vreg_t::none) ? phys(op.s1) : -1;
                 be.vload_masked(d, base, op.mem.disp, mask, (int)op.imm,
                         dt_of(op.dst), data);
                 if (spilled(op.dst)) spill_store(op.dst, d);
@@ -233,9 +235,9 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
             case op_kind_t::vstore_masked: {
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int s = vec_use(op.s0, vec_scratch0);
-                assert((op.s1 < 0 || !spilled(op.s1))
+                assert((op.s1 == vreg_t::none || !spilled(op.s1))
                         && "vstore_masked: mask spilled");
-                int mask = (op.s1 >= 0) ? phys(op.s1) : -1;
+                int mask = (op.s1 != vreg_t::none) ? phys(op.s1) : -1;
                 be.vstore_masked(base, op.mem.disp, s, mask, (int)op.imm,
                         dt_of(op.s0), data);
                 break;

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -270,18 +270,18 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 break;
             }
             case op_kind_t::label: {
-                gen.L(label_id_to_label[op.label_id]);
+                gen.L(label_id_to_label[(int)op.label_id]);
                 break;
             }
             case op_kind_t::jmp: {
-                gen.jmp(label_id_to_label[op.label_id],
+                gen.jmp(label_id_to_label[(int)op.label_id],
                         Xbyak::CodeGenerator::T_NEAR);
                 break;
             }
             case op_kind_t::jz: {
                 Xbyak::Reg64 c = gpr_use(op.s0, gpr_scratch0);
                 gen.cmp(c, 0);
-                gen.jz(label_id_to_label[op.label_id],
+                gen.jz(label_id_to_label[(int)op.label_id],
                         Xbyak::CodeGenerator::T_NEAR);
                 break;
             }

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -270,18 +270,18 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 break;
             }
             case op_kind_t::label: {
-                gen.L(label_id_to_label[(int)op.imm]);
+                gen.L(label_id_to_label[op.label_id]);
                 break;
             }
             case op_kind_t::jmp: {
-                gen.jmp(label_id_to_label[(int)op.imm],
+                gen.jmp(label_id_to_label[op.label_id],
                         Xbyak::CodeGenerator::T_NEAR);
                 break;
             }
             case op_kind_t::jz: {
                 Xbyak::Reg64 c = gpr_use(op.s0, gpr_scratch0);
                 gen.cmp(c, 0);
-                gen.jz(label_id_to_label[(int)op.imm],
+                gen.jz(label_id_to_label[op.label_id],
                         Xbyak::CodeGenerator::T_NEAR);
                 break;
             }

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -1,0 +1,316 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cassert>
+#include <vector>
+#include <unordered_map>
+
+#include "cpu/x64/ir/emitter/backend_avx2.hpp"
+#include "cpu/x64/ir/emitter/emitter.hpp"
+#include "cpu/x64/utils/jit_regops.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+template <typename backend_t>
+void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
+        const reg_config_t &rc, data_section_t &data) {
+
+    // The backend holds the generator.
+    jit_generator_t &gen = be.gen();
+
+    // One label per loop, keyed by the `loop_begin` instruction index. A
+    // `loop_end` jumps back to `labels[op.match]`. A map, so only loops get an
+    // entry.
+    std::unordered_map<int, Xbyak::Label> labels;
+    // One label per `label` id, for `label`/`jmp`/`jz`.
+    std::vector<Xbyak::Label> label_id_to_label(ir.n_labels());
+
+    // if vreg needs to be spilled
+    auto spilled = [&](int vr) { return alloc.assignments[vr].spilled; };
+    // get a physical register from a virtual one
+    auto phys = [&](int vr) { return alloc.assignments[vr].phys; };
+    // get a stack slot for a virtual register
+    auto slot = [&](int vr) {
+        return gen.ptr[gen.rsp + (int)alloc.assignments[vr].slot];
+    };
+    // stack slot byte offset for a vec spill
+    auto slot_off = [&](int vr) { return (int)alloc.assignments[vr].slot; };
+    // Data type of a vec vreg.
+    auto dt_of = [&](int vr) { return ir.vreg_info()[vr].dt; };
+
+    // Reserve scratch registers for the spills.
+    const Xbyak::Reg64 gpr_scratch0(rc.gpr_scratch[0]);
+    const Xbyak::Reg64 gpr_scratch1(rc.gpr_scratch[1]);
+    const int vec_scratch0 = rc.vec_scratch[0];
+    const int vec_scratch1 = rc.vec_scratch[1];
+    const int vec_scratch2 = rc.vec_scratch[2];
+
+    // Move a spilled vec value between its stack slot and a scratch register,
+    // as a vector load/store against the stack frame (rsp).
+    const int rsp_idx = gen.rsp.getIdx();
+    auto spill_reload
+            = [&](int vr, int p) { be.vload(p, rsp_idx, slot_off(vr)); };
+    auto spill_store
+            = [&](int vr, int p) { be.vstore(rsp_idx, slot_off(vr), p); };
+
+    // Resolve a virtual register that an instruction READS (use) to a
+    // concrete physical register, hiding whether the allocator spilled it:
+    //   - not spilled: the value is already in a physical register, so just
+    //     return that register (no extra instruction).
+    //   - spilled: the value lives on the stack slot, so emit a reload into the
+    //     caller-provided scratch register `scr` and return it.
+    // The caller picks `scr` (gpr_scratch0/1 for gpr, vec_scratch0/1/2 for
+    // vec) so that an instruction with several spilled operands reloads each
+    // into a different scratch and they do not clobber one another. The
+    // returned register is valid only until the next reload into the same
+    // scratch, so use it right away. These helpers handle only reads. Writing
+    // a spilled result back is done by the defining instruction (compute into
+    // scratch, then store to the slot).
+    //
+    // TODO: introduce loop-depth spill weights to optimize spills. Currently,
+    // the spilling strategy is naive and is only good for low pressure kernels
+    // (e.g. GEMV).
+    //
+    // gpr reloads are ISA-neutral (a plain `mov`), so `gpr_use` emits them
+    // directly. A spilled vec source is reloaded through the backend, since the
+    // reload instruction is ISA-specific. The `vec_use` returns a physical
+    // index rather than a typed register.
+    auto gpr_use = [&](int vr, const Xbyak::Reg64 &scr) -> Xbyak::Reg64 {
+        if (!spilled(vr)) return Xbyak::Reg64(phys(vr));
+        // reload the spilled gpr from its stack slot
+        gen.mov(scr, slot(vr));
+        return scr;
+    };
+
+    auto vec_use = [&](int vr, int scr_idx) -> int {
+        if (!spilled(vr)) return phys(vr);
+        // reload the spilled vector register from its stack slot
+        spill_reload(vr, scr_idx);
+        return scr_idx;
+    };
+
+    // Lower each IR instruction. Spilled operands are handled as follows:
+    //
+    // - Inputs that an instruction reads are accessed through gpr_use/vec_use.
+    //   These return the register directly, or reload the value from its spill
+    //   slot into a scratch register if needed.
+    //
+    // - The output that an instruction writes is handled separately inside each
+    //   case. If the destination is spilled, we reload it first (for
+    //   read-modify-write operations), perform the operation, and then store
+    //   the result back to its spill slot.
+    //
+    // Scratch register usage:
+    // - gpr_scratch0/vec_scratch0: scratch register for destinations
+    // - gpr_scratch1/vec_scratch1/vec_scratch2: scratch registers for sources
+    //
+    // This separation ensures that spilled source and destination values never
+    // use the same scratch register.
+    for (int i = 0; i < ir.n_ops(); i++) {
+        const op_t &op = ir.ops()[i];
+        switch (op.kind) {
+            // General-purpose register ops. ISA-neutral, emitted directly.
+            case op_kind_t::mov_imm: {
+                if (!spilled(op.dst)) {
+                    gen.mov(Xbyak::Reg64(phys(op.dst)), op.imm);
+                } else {
+                    gen.mov(gpr_scratch0, op.imm);
+                    gen.mov(slot(op.dst), gpr_scratch0);
+                }
+                break;
+            }
+            case op_kind_t::mov_reg: {
+                Xbyak::Reg64 s = gpr_use(op.s0, gpr_scratch1);
+                if (!spilled(op.dst))
+                    gen.mov(Xbyak::Reg64(phys(op.dst)), s);
+                else
+                    gen.mov(slot(op.dst), s);
+                break;
+            }
+            case op_kind_t::add_imm: {
+                if (!spilled(op.dst)) {
+                    gen.add(Xbyak::Reg64(phys(op.dst)), op.imm);
+                } else {
+                    gen.mov(gpr_scratch0, slot(op.dst));
+                    gen.add(gpr_scratch0, op.imm);
+                    gen.mov(slot(op.dst), gpr_scratch0);
+                }
+                break;
+            }
+            case op_kind_t::add_reg: {
+                Xbyak::Reg64 s = gpr_use(op.s0, gpr_scratch1);
+                if (!spilled(op.dst)) {
+                    gen.add(Xbyak::Reg64(phys(op.dst)), s);
+                } else {
+                    gen.mov(gpr_scratch0, slot(op.dst));
+                    gen.add(gpr_scratch0, s);
+                    gen.mov(slot(op.dst), gpr_scratch0);
+                }
+                break;
+            }
+            case op_kind_t::load: {
+                Xbyak::Reg64 base = op.mem.is_param
+                        ? Xbyak::Reg64(rc.param_reg)
+                        : gpr_use(op.mem.base, gpr_scratch1);
+                Xbyak::Reg64 d = spilled(op.dst) ? gpr_scratch0
+                                                 : Xbyak::Reg64(phys(op.dst));
+                gen.mov(d, gen.ptr[base + (int)op.mem.disp]);
+                if (spilled(op.dst)) gen.mov(slot(op.dst), d);
+                break;
+            }
+
+            // Vector ops. Emitting the instruction is the backend's job. A
+            // spilled dst is always stored back to its slot after the op.
+            // A read-modify-write (`rmw`) op also reloads a spilled dst before
+            // the op. An op that overwrites dst does not.
+            case op_kind_t::vzero: { // overwrites dst
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                be.vzero(d);
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
+            case op_kind_t::vload: { // overwrites dst
+                int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                be.vload(d, base, op.mem.disp);
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
+            case op_kind_t::vfma: { // rmw: reads and writes dst
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                if (spilled(op.dst)) spill_reload(op.dst, d);
+                int a = vec_use(op.s0, vec_scratch1);
+                int b = vec_use(op.s1, vec_scratch2);
+                be.vfma(d, a, b, dt_of(op.s0));
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
+            case op_kind_t::vhreduce: { // reads and writes dst
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                if (spilled(op.dst)) spill_reload(op.dst, d);
+                int ws = vec_use(op.s0, vec_scratch1);
+                be.vhreduce(d, ws, dt_of(op.dst));
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
+
+            // Mask ops. Emitting the instruction is the backend's job.
+            // Spilling is not supported for mask vreg for now so we assert
+            // `no spills`.
+            case op_kind_t::set_mask_imm: {
+                assert(!spilled(op.dst) && "set_mask_imm: mask spilled");
+                be.set_mask_imm(phys(op.dst), (int)op.imm, data);
+                break;
+            }
+            case op_kind_t::vload_masked: { // overwrites dst
+                int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                assert((op.s1 < 0 || !spilled(op.s1))
+                        && "vload_masked: mask spilled");
+                int mask = (op.s1 >= 0) ? phys(op.s1) : -1;
+                be.vload_masked(d, base, op.mem.disp, mask, (int)op.imm,
+                        dt_of(op.dst), data);
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
+            case op_kind_t::vstore_masked: {
+                int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
+                int s = vec_use(op.s0, vec_scratch0);
+                assert((op.s1 < 0 || !spilled(op.s1))
+                        && "vstore_masked: mask spilled");
+                int mask = (op.s1 >= 0) ? phys(op.s1) : -1;
+                be.vstore_masked(base, op.mem.disp, s, mask, (int)op.imm,
+                        dt_of(op.s0), data);
+                break;
+            }
+
+            // Control flow. ISA-neutral, emitted directly.
+            case op_kind_t::loop_begin: {
+                Xbyak::Reg64 c = spilled(op.dst) ? gpr_scratch0
+                                                 : Xbyak::Reg64(phys(op.dst));
+                if (op.init_is_reg) {
+                    Xbyak::Reg64 iv = gpr_use(op.s0, gpr_scratch1);
+                    gen.mov(c, iv);
+                } else {
+                    gen.mov(c, op.imm);
+                }
+                if (spilled(op.dst)) gen.mov(slot(op.dst), c);
+                gen.L(labels[i]); // body start
+                break;
+            }
+            case op_kind_t::loop_end: {
+                // dec sets ZF, so the back-edge is a plain jnz with no cmp. The
+                // counter starts >= 1 and lands on exactly 0, so jnz matches jg.
+                if (!spilled(op.dst)) {
+                    Xbyak::Reg64 c(phys(op.dst));
+                    gen.dec(c);
+                } else {
+                    gen.mov(gpr_scratch0, slot(op.dst));
+                    gen.dec(gpr_scratch0);
+                    gen.mov(slot(op.dst), gpr_scratch0);
+                }
+                gen.jnz(labels[op.match]); // back-edge to the matching loop_begin
+                break;
+            }
+            case op_kind_t::label: {
+                gen.L(label_id_to_label[(int)op.imm]);
+                break;
+            }
+            case op_kind_t::jmp: {
+                gen.jmp(label_id_to_label[(int)op.imm],
+                        Xbyak::CodeGenerator::T_NEAR);
+                break;
+            }
+            case op_kind_t::jz: {
+                Xbyak::Reg64 c = gpr_use(op.s0, gpr_scratch0);
+                gen.cmp(c, 0);
+                gen.jz(label_id_to_label[(int)op.imm],
+                        Xbyak::CodeGenerator::T_NEAR);
+                break;
+            }
+        }
+    }
+}
+
+void emit(jit_generator_t &gen, const ir_t &ir, const reg_alloc_result_t &alloc,
+        const reg_config_t &reg_cfg, data_section_t &data) {
+    const cpu_isa_t isa = gen.max_cpu_isa();
+    if (is_superset(isa, avx512_core)) {
+        assert(!"avx512 emitter is not supported");
+    } else {
+        avx2_backend_t be(gen, isa);
+        emit(be, ir, alloc, reg_cfg, data);
+    }
+}
+
+void emit_data_section(jit_generator_t &gen, data_section_t &data) {
+    for (auto &c : data.constants) {
+        gen.align(data_section_t::alignment);
+        gen.L(c.second);
+        for (unsigned char byte : c.first)
+            gen.db(byte);
+    }
+}
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/ir/emitter/emitter.hpp
+++ b/src/cpu/x64/ir/emitter/emitter.hpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_IR_EMITTER_EMITTER_HPP
+#define CPU_X64_IR_EMITTER_EMITTER_HPP
+
+// Lowers an IR along with its register allocation into target machine code,
+// using a `jit_generator`.
+
+#include <deque>
+#include <utility>
+#include <vector>
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/ir/ir.hpp"
+#include "cpu/x64/ir/reg_alloc.hpp"
+#include "cpu/x64/ir/reg_config.hpp"
+#include "cpu/x64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+// Static data the emitter returns to be used after the kernel code
+// (after postamble). For example: AVX2 mask tables.
+//
+// A `std::deque` keeps element addresses stable. A label is referenced while
+// the emitter goes through the IR and is only bound later by
+// `emit_data_section`, so the addresses must stay valid as more constants are
+// appended.
+struct data_section_t {
+    std::deque<std::pair<std::vector<unsigned char>, Xbyak::Label>> constants;
+    static constexpr int alignment = 32;
+};
+
+// Lowering/code emission pass. Walks the IR once and turns each abstract
+// operation into target-specific instructions, using the physical registers
+// chosen by the allocator.
+//
+// Values that cannot stay in a register are spilled on the stack. This is
+// handled by loading spilled inputs into reserved scratch registers before use,
+// and storing results back on stack after use. These scratch registers are
+// excluded from allocation so they are always available for spill handling.
+//
+// Supporting another target ISA mainly requires providing a similar backend
+// (see `emitter/backend_avx2.hpp`) or extending an existing one, then adding a
+// dispatch branch in `emit()`.
+//
+// `data` collects static constants the lowering needs (e.g. mask tables). The
+// emitter appends to it and references each entry rip-relative. The caller
+// then emits the bytes with `emit_data_section()` after the `postamble()`.
+//
+// This is the main entry point for the emitter. It dispatches by ISA family to
+// the matching backend.
+//
+// Export for testing.
+void DNNL_API emit(jit_generator_t &gen, const ir_t &ir,
+        const reg_alloc_result_t &alloc, const reg_config_t &reg_cfg,
+        data_section_t &data);
+
+// Emit the accumulated static data after the kernel's postamble. It aligns,
+// binds each label and then write the data bytes with `db`.
+// Must be called once, after the emitter and the postamble.
+void DNNL_API emit_data_section(jit_generator_t &gen, data_section_t &data);
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -173,21 +173,21 @@ void ir_t::loop_end(int counter, int begin_idx) {
     ops_.push_back(op);
 }
 
-void ir_t::label(int label_id) {
+void ir_t::label(label_t label_id) {
     op_t op;
     op.kind = op_kind_t::label;
     op.label_id = label_id;
     ops_.push_back(op);
 }
 
-void ir_t::jmp(int label_id) {
+void ir_t::jmp(label_t label_id) {
     op_t op;
     op.kind = op_kind_t::jmp;
     op.label_id = label_id;
     ops_.push_back(op);
 }
 
-void ir_t::jz(int cond, int label_id) {
+void ir_t::jz(int cond, label_t label_id) {
     op_t op;
     op.kind = op_kind_t::jz;
     op.s0 = cond;

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -22,15 +22,15 @@ namespace cpu {
 namespace x64 {
 namespace ir {
 
-int ir_t::new_vreg(reg_kind_t k, data_type_t dt) {
+vreg_t ir_t::new_vreg(reg_kind_t k, data_type_t dt) {
     vreg_info_t info {};
     info.kind = k;
     info.dt = dt;
     vreg_info_.push_back(info);
-    return (int)vreg_info_.size() - 1;
+    return static_cast<vreg_t>((int)vreg_info_.size() - 1);
 }
 
-int ir_t::mov_imm(int dst, dim_t imm) {
+int ir_t::mov_imm(vreg_t dst, dim_t imm) {
     op_t op;
     op.kind = op_kind_t::mov_imm;
     op.dst = dst;
@@ -39,7 +39,7 @@ int ir_t::mov_imm(int dst, dim_t imm) {
     return (int)ops_.size() - 1;
 }
 
-void ir_t::mov_reg(int dst, int src) {
+void ir_t::mov_reg(vreg_t dst, vreg_t src) {
     op_t op;
     op.kind = op_kind_t::mov_reg;
     op.dst = dst;
@@ -47,7 +47,7 @@ void ir_t::mov_reg(int dst, int src) {
     ops_.push_back(op);
 }
 
-void ir_t::add_imm(int dst, dim_t imm) {
+void ir_t::add_imm(vreg_t dst, dim_t imm) {
     op_t op;
     op.kind = op_kind_t::add_imm;
     op.dst = dst;
@@ -55,7 +55,7 @@ void ir_t::add_imm(int dst, dim_t imm) {
     ops_.push_back(op);
 }
 
-void ir_t::add_reg(int dst, int src) {
+void ir_t::add_reg(vreg_t dst, vreg_t src) {
     op_t op;
     op.kind = op_kind_t::add_reg;
     op.dst = dst;
@@ -63,7 +63,7 @@ void ir_t::add_reg(int dst, int src) {
     ops_.push_back(op);
 }
 
-void ir_t::load_param(int dst, dim_t disp) {
+void ir_t::load_param(vreg_t dst, dim_t disp) {
     op_t op;
     op.kind = op_kind_t::load;
     op.dst = dst;
@@ -72,7 +72,7 @@ void ir_t::load_param(int dst, dim_t disp) {
     ops_.push_back(op);
 }
 
-void ir_t::load(int dst, int base, dim_t disp) {
+void ir_t::load(vreg_t dst, vreg_t base, dim_t disp) {
     op_t op;
     op.kind = op_kind_t::load;
     op.dst = dst;
@@ -81,14 +81,14 @@ void ir_t::load(int dst, int base, dim_t disp) {
     ops_.push_back(op);
 }
 
-void ir_t::vzero(int dst) {
+void ir_t::vzero(vreg_t dst) {
     op_t op;
     op.kind = op_kind_t::vzero;
     op.dst = dst;
     ops_.push_back(op);
 }
 
-void ir_t::vload(int dst, int base, dim_t disp) {
+void ir_t::vload(vreg_t dst, vreg_t base, dim_t disp) {
     op_t op;
     op.kind = op_kind_t::vload;
     op.dst = dst;
@@ -97,7 +97,7 @@ void ir_t::vload(int dst, int base, dim_t disp) {
     ops_.push_back(op);
 }
 
-void ir_t::vfma(int dst, int a, int b) {
+void ir_t::vfma(vreg_t dst, vreg_t a, vreg_t b) {
     op_t op;
     op.kind = op_kind_t::vfma;
     op.dst = dst;
@@ -106,7 +106,7 @@ void ir_t::vfma(int dst, int a, int b) {
     ops_.push_back(op);
 }
 
-void ir_t::vhreduce(int dst, int workspace) {
+void ir_t::vhreduce(vreg_t dst, vreg_t workspace) {
     op_t op;
     op.kind = op_kind_t::vhreduce;
     op.dst = dst;
@@ -114,7 +114,7 @@ void ir_t::vhreduce(int dst, int workspace) {
     ops_.push_back(op);
 }
 
-void ir_t::set_mask_imm(int mask, int n_elems) {
+void ir_t::set_mask_imm(vreg_t mask, int n_elems) {
     op_t op;
     op.kind = op_kind_t::set_mask_imm;
     op.dst = mask;
@@ -122,11 +122,12 @@ void ir_t::set_mask_imm(int mask, int n_elems) {
     ops_.push_back(op);
 }
 
-void ir_t::vload_masked(int dst, int base, dim_t disp, int mask, int elems) {
+void ir_t::vload_masked(
+        vreg_t dst, vreg_t base, dim_t disp, vreg_t mask, int elems) {
     op_t op;
     op.kind = op_kind_t::vload_masked;
     op.dst = dst;
-    // -1 when no mask register is needed
+    // `none` when no mask register is needed
     op.s1 = mask;
     op.imm = elems;
     op.mem.base = base;
@@ -134,11 +135,12 @@ void ir_t::vload_masked(int dst, int base, dim_t disp, int mask, int elems) {
     ops_.push_back(op);
 }
 
-void ir_t::vstore_masked(int base, dim_t disp, int src, int mask, int elems) {
+void ir_t::vstore_masked(
+        vreg_t base, dim_t disp, vreg_t src, vreg_t mask, int elems) {
     op_t op;
     op.kind = op_kind_t::vstore_masked;
     op.s0 = src;
-    // -1 when no mask register is needed
+    // `none` when no mask register is needed
     op.s1 = mask;
     op.imm = elems;
     op.mem.base = base;
@@ -146,7 +148,7 @@ void ir_t::vstore_masked(int base, dim_t disp, int src, int mask, int elems) {
     ops_.push_back(op);
 }
 
-int ir_t::loop_begin_imm(int counter, dim_t count) {
+int ir_t::loop_begin_imm(vreg_t counter, dim_t count) {
     op_t op;
     op.kind = op_kind_t::loop_begin;
     op.dst = counter;
@@ -155,7 +157,7 @@ int ir_t::loop_begin_imm(int counter, dim_t count) {
     return (int)ops_.size() - 1;
 }
 
-int ir_t::loop_begin_reg(int counter, int init) {
+int ir_t::loop_begin_reg(vreg_t counter, vreg_t init) {
     op_t op;
     op.kind = op_kind_t::loop_begin;
     op.dst = counter;
@@ -165,7 +167,7 @@ int ir_t::loop_begin_reg(int counter, int init) {
     return (int)ops_.size() - 1;
 }
 
-void ir_t::loop_end(int counter, int begin_idx) {
+void ir_t::loop_end(vreg_t counter, int begin_idx) {
     op_t op;
     op.kind = op_kind_t::loop_end;
     op.dst = counter;
@@ -187,7 +189,7 @@ void ir_t::jmp(label_t label_id) {
     ops_.push_back(op);
 }
 
-void ir_t::jz(int cond, label_t label_id) {
+void ir_t::jz(vreg_t cond, label_t label_id) {
     op_t op;
     op.kind = op_kind_t::jz;
     op.s0 = cond;
@@ -213,11 +215,11 @@ void ir_t::def_use(
     defs.clear();
     uses.clear();
 
-    auto u = [&](int v) {
-        if (v >= 0) uses.push_back(v);
+    auto u = [&](vreg_t v) {
+        if (v != vreg_t::none) uses.push_back((int)v);
     };
-    auto d = [&](int v) {
-        if (v >= 0) defs.push_back(v);
+    auto d = [&](vreg_t v) {
+        if (v != vreg_t::none) defs.push_back((int)v);
     };
 
     switch (op.kind) {

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -97,9 +97,9 @@ void ir_t::vload(vreg_t dst, vreg_t base, dim_t disp) {
     ops_.push_back(op);
 }
 
-void ir_t::vfma(vreg_t dst, vreg_t a, vreg_t b) {
+void ir_t::vdot(vreg_t dst, vreg_t a, vreg_t b) {
     op_t op;
-    op.kind = op_kind_t::vfma;
+    op.kind = op_kind_t::vdot;
     op.dst = dst;
     op.s0 = a;
     op.s1 = b;
@@ -203,7 +203,7 @@ void ir_t::jz(vreg_t cond, label_t label_id) {
 //
 // Some tricky cases:
 // - Operations that both read and write the same register (like add_imm,
-//   vfma) count as both a use and a def, because they read the old value
+//   vdot) count as both a use and a def, because they read the old value
 //   and then overwrite it.
 // - vhreduce uses its temporary register (s0) as both read and written,
 //   so the register allocator keeps it separate from the accumulator.
@@ -246,7 +246,7 @@ void ir_t::def_use(
             u(op.mem.base);
             d(op.dst);
             break;
-        case op_kind_t::vfma:
+        case op_kind_t::vdot:
             u(op.dst);
             u(op.s0);
             u(op.s1);

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -176,14 +176,14 @@ void ir_t::loop_end(int counter, int begin_idx) {
 void ir_t::label(int label_id) {
     op_t op;
     op.kind = op_kind_t::label;
-    op.imm = label_id;
+    op.label_id = label_id;
     ops_.push_back(op);
 }
 
 void ir_t::jmp(int label_id) {
     op_t op;
     op.kind = op_kind_t::jmp;
-    op.imm = label_id;
+    op.label_id = label_id;
     ops_.push_back(op);
 }
 
@@ -191,7 +191,7 @@ void ir_t::jz(int cond, int label_id) {
     op_t op;
     op.kind = op_kind_t::jz;
     op.s0 = cond;
-    op.imm = label_id;
+    op.label_id = label_id;
     ops_.push_back(op);
 }
 

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -148,6 +148,14 @@ void ir_t::vstore_masked(
     ops_.push_back(op);
 }
 
+void ir_t::prefetch(vreg_t base, dim_t disp) {
+    op_t op;
+    op.kind = op_kind_t::prefetch;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
 int ir_t::loop_begin_imm(vreg_t counter, dim_t count) {
     op_t op;
     op.kind = op_kind_t::loop_begin;
@@ -269,6 +277,7 @@ void ir_t::def_use(
             u(op.s1); // mask (-1 -> not counted, dropped by u())
             u(op.mem.base);
             break;
+        case op_kind_t::prefetch: u(op.mem.base); break;
         case op_kind_t::loop_begin:
             if (op.init_is_reg) u(op.s0);
             d(op.dst);

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -1,0 +1,288 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/x64/ir/ir.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+int ir_t::new_vreg(reg_kind_t k, data_type_t dt) {
+    vreg_info_t info {};
+    info.kind = k;
+    info.dt = dt;
+    vreg_info_.push_back(info);
+    return (int)vreg_info_.size() - 1;
+}
+
+int ir_t::mov_imm(int dst, dim_t imm) {
+    op_t op;
+    op.kind = op_kind_t::mov_imm;
+    op.dst = dst;
+    op.imm = imm;
+    ops_.push_back(op);
+    return (int)ops_.size() - 1;
+}
+
+void ir_t::mov_reg(int dst, int src) {
+    op_t op;
+    op.kind = op_kind_t::mov_reg;
+    op.dst = dst;
+    op.s0 = src;
+    ops_.push_back(op);
+}
+
+void ir_t::add_imm(int dst, dim_t imm) {
+    op_t op;
+    op.kind = op_kind_t::add_imm;
+    op.dst = dst;
+    op.imm = imm;
+    ops_.push_back(op);
+}
+
+void ir_t::add_reg(int dst, int src) {
+    op_t op;
+    op.kind = op_kind_t::add_reg;
+    op.dst = dst;
+    op.s0 = src;
+    ops_.push_back(op);
+}
+
+void ir_t::load_param(int dst, dim_t disp) {
+    op_t op;
+    op.kind = op_kind_t::load;
+    op.dst = dst;
+    op.mem.is_param = true;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
+void ir_t::load(int dst, int base, dim_t disp) {
+    op_t op;
+    op.kind = op_kind_t::load;
+    op.dst = dst;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
+void ir_t::vzero(int dst) {
+    op_t op;
+    op.kind = op_kind_t::vzero;
+    op.dst = dst;
+    ops_.push_back(op);
+}
+
+void ir_t::vload(int dst, int base, dim_t disp) {
+    op_t op;
+    op.kind = op_kind_t::vload;
+    op.dst = dst;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
+void ir_t::vfma(int dst, int a, int b) {
+    op_t op;
+    op.kind = op_kind_t::vfma;
+    op.dst = dst;
+    op.s0 = a;
+    op.s1 = b;
+    ops_.push_back(op);
+}
+
+void ir_t::vhreduce(int dst, int workspace) {
+    op_t op;
+    op.kind = op_kind_t::vhreduce;
+    op.dst = dst;
+    op.s0 = workspace;
+    ops_.push_back(op);
+}
+
+void ir_t::set_mask_imm(int mask, int n_elems) {
+    op_t op;
+    op.kind = op_kind_t::set_mask_imm;
+    op.dst = mask;
+    op.imm = n_elems;
+    ops_.push_back(op);
+}
+
+void ir_t::vload_masked(int dst, int base, dim_t disp, int mask, int elems) {
+    op_t op;
+    op.kind = op_kind_t::vload_masked;
+    op.dst = dst;
+    // -1 when no mask register is needed
+    op.s1 = mask;
+    op.imm = elems;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
+void ir_t::vstore_masked(int base, dim_t disp, int src, int mask, int elems) {
+    op_t op;
+    op.kind = op_kind_t::vstore_masked;
+    op.s0 = src;
+    // -1 when no mask register is needed
+    op.s1 = mask;
+    op.imm = elems;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
+int ir_t::loop_begin_imm(int counter, dim_t count) {
+    op_t op;
+    op.kind = op_kind_t::loop_begin;
+    op.dst = counter;
+    op.imm = count;
+    ops_.push_back(op);
+    return (int)ops_.size() - 1;
+}
+
+int ir_t::loop_begin_reg(int counter, int init) {
+    op_t op;
+    op.kind = op_kind_t::loop_begin;
+    op.dst = counter;
+    op.s0 = init;
+    op.init_is_reg = true;
+    ops_.push_back(op);
+    return (int)ops_.size() - 1;
+}
+
+void ir_t::loop_end(int counter, int begin_idx) {
+    op_t op;
+    op.kind = op_kind_t::loop_end;
+    op.dst = counter;
+    op.match = begin_idx;
+    ops_.push_back(op);
+}
+
+void ir_t::label(int label_id) {
+    op_t op;
+    op.kind = op_kind_t::label;
+    op.imm = label_id;
+    ops_.push_back(op);
+}
+
+void ir_t::jmp(int label_id) {
+    op_t op;
+    op.kind = op_kind_t::jmp;
+    op.imm = label_id;
+    ops_.push_back(op);
+}
+
+void ir_t::jz(int cond, int label_id) {
+    op_t op;
+    op.kind = op_kind_t::jz;
+    op.s0 = cond;
+    op.imm = label_id;
+    ops_.push_back(op);
+}
+
+// For each operation, we record which virtual registers it reads (uses)
+// and which ones it writes (defs). This info is the basis for liveness
+// analysis, so it must accurately reflect what the operation really does.
+//
+// Some tricky cases:
+// - Operations that both read and write the same register (like add_imm,
+//   vfma) count as both a use and a def, because they read the old value
+//   and then overwrite it.
+// - vhreduce uses its temporary register (s0) as both read and written,
+//   so the register allocator keeps it separate from the accumulator.
+// - A base register used for memory access counts as a read (use),
+//   unless it's a fixed parameter register.
+// - Control operations like loop_end both read and write the loop counter.
+void ir_t::def_use(
+        const op_t &op, std::vector<int> &defs, std::vector<int> &uses) const {
+    defs.clear();
+    uses.clear();
+
+    auto u = [&](int v) {
+        if (v >= 0) uses.push_back(v);
+    };
+    auto d = [&](int v) {
+        if (v >= 0) defs.push_back(v);
+    };
+
+    switch (op.kind) {
+        case op_kind_t::mov_imm: d(op.dst); break;
+        case op_kind_t::mov_reg:
+            d(op.dst);
+            u(op.s0);
+            break;
+        case op_kind_t::add_imm: // read-modify-write
+            u(op.dst);
+            d(op.dst);
+            break;
+        case op_kind_t::add_reg:
+            u(op.dst);
+            u(op.s0);
+            d(op.dst);
+            break;
+        case op_kind_t::load:
+            if (!op.mem.is_param) u(op.mem.base);
+            d(op.dst);
+            break;
+        case op_kind_t::vzero: d(op.dst); break;
+        case op_kind_t::vload:
+            u(op.mem.base);
+            d(op.dst);
+            break;
+        case op_kind_t::vfma:
+            u(op.dst);
+            u(op.s0);
+            u(op.s1);
+            d(op.dst);
+            break;
+        case op_kind_t::vhreduce: // dst and workspace are both read and written
+            u(op.dst);
+            u(op.s0);
+            d(op.dst);
+            d(op.s0);
+            break;
+        case op_kind_t::set_mask_imm: d(op.dst); break;
+        case op_kind_t::vload_masked:
+            u(op.mem.base);
+            u(op.s1); // mask (-1 -> not counted, dropped by u())
+            d(op.dst);
+            break;
+        case op_kind_t::vstore_masked:
+            u(op.s0);
+            u(op.s1); // mask (-1 -> not counted, dropped by u())
+            u(op.mem.base);
+            break;
+        case op_kind_t::loop_begin:
+            if (op.init_is_reg) u(op.s0);
+            d(op.dst);
+            break;
+        case op_kind_t::loop_end:
+            u(op.dst);
+            d(op.dst);
+            break;
+        case op_kind_t::label:
+        case op_kind_t::jmp: break;
+        case op_kind_t::jz: u(op.s0); break;
+    }
+}
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -67,6 +67,13 @@ namespace ir {
 
 enum class reg_kind_t { gpr, vec, mask };
 
+// A label id names a jump target for label/jmp/jz.
+//
+// Strong alias for `int`. Prevents implicit conversion to or from `int` (or a
+// vreg id) so labels and vregs cannot be mixed up accidentally. Cast to
+// `int` when a raw index is needed.
+enum class label_t : int { none = -1 };
+
 enum class op_kind_t {
     // General-purpose register operations
 
@@ -158,7 +165,7 @@ struct mem_t {
 //         * vload_masked / vstore_masked -> active element count
 // mem   - memory address used only by load/store operations.
 // match - for loop_end, index of matching loop_begin operation.
-// label_id - target label id for label/jmp/jz. When unused it's -1.
+// label_id - target label id for label/jmp/jz. When unused it's `none`.
 // init_is_reg - for loop_begin, if true, initialize loop counter from s0
 //                (runtime value) instead of imm.
 struct op_t {
@@ -168,7 +175,7 @@ struct op_t {
     dim_t imm = 0;
     mem_t mem;
     int match = -1;
-    int label_id = -1;
+    label_t label_id = label_t::none;
     bool init_is_reg = false;
 };
 
@@ -211,7 +218,7 @@ struct DNNL_API ir_t {
     int new_mask() { return new_vreg(reg_kind_t::mask); }
 
     // Add a new label and return its id
-    int new_label() { return n_labels_++; }
+    label_t new_label() { return static_cast<label_t>(n_labels_++); }
     int n_vregs() const { return (int)vreg_info_.size(); }
     int n_ops() const { return (int)ops_.size(); }
 
@@ -245,9 +252,9 @@ struct DNNL_API ir_t {
     int loop_begin_imm(int counter, dim_t count);
     int loop_begin_reg(int counter, int init);
     void loop_end(int counter, int begin_idx);
-    void label(int label_id);
-    void jmp(int label_id);
-    void jz(int cond, int label_id);
+    void label(label_t label_id);
+    void jmp(label_t label_id);
+    void jz(int cond, label_t label_id);
 
     // Fill defs/uses with the vregs this operation writes/reads. Liveness and
     // the allocator depend on it, so it must match what the emitter emits.

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -67,11 +67,17 @@ namespace ir {
 
 enum class reg_kind_t { gpr, vec, mask };
 
+// vreg_t and label_t are strong aliases for `int`. They are distinct id types
+// that do not implicitly convert to or from `int`, or to each other, so a
+// vreg, a label, and a raw int cannot be mixed up by accident. `none` marks an
+// unset id. Cast to `int` where a raw index is needed.
+
+// A virtual register id. A placeholder the allocator later maps to a physical
+// register or a spill slot. Its kind (gpr/vec/mask) and, for a vec, element
+// data type live separately in vreg_info_.
+enum class vreg_t : int { none = -1 };
+
 // A label id names a jump target for label/jmp/jz.
-//
-// Strong alias for `int`. Prevents implicit conversion to or from `int` (or a
-// vreg id) so labels and vregs cannot be mixed up accidentally. Cast to
-// `int` when a raw index is needed.
 enum class label_t : int { none = -1 };
 
 enum class op_kind_t {
@@ -138,7 +144,7 @@ enum class op_kind_t {
 //              manage it, so it is not counted as a virtual-register use.
 struct mem_t {
     // virtual gpr holding the pointer (ignored when is_param)
-    int base = -1;
+    vreg_t base = vreg_t::none;
     // constant byte offset
     dim_t disp = 0;
     // base is the kernel-argument pointer
@@ -155,9 +161,9 @@ struct mem_t {
 // is clearly defined in ir_t::def_use().
 //
 // kind - which operation this is. Determines how other fields are used.
-// dst  - virtual register that is written to, or -1 if none is written.
+// dst  - virtual register that is written to, or `none` if none is written.
 //        Some ops (e.g. vfma/vadd) both read from and write to dst.
-// s0,s1 - source virtual registers (inputs), or -1 if not used.
+// s0,s1 - source virtual registers (inputs), or `none` if not used.
 // imm   - immediate value whose meaning depends on the kind:
 //         * mov_imm        -> literal constant
 //         * loop_begin     -> loop trip count
@@ -170,8 +176,8 @@ struct mem_t {
 //                (runtime value) instead of imm.
 struct op_t {
     op_kind_t kind;
-    int dst = -1;
-    int s0 = -1, s1 = -1;
+    vreg_t dst = vreg_t::none;
+    vreg_t s0 = vreg_t::none, s1 = vreg_t::none;
     dim_t imm = 0;
     mem_t mem;
     int match = -1;
@@ -210,12 +216,12 @@ struct DNNL_API ir_t {
 
     // Add a vreg of kind `k` and, for a vec, element data type `dt`.
     // Return its id.
-    int new_vreg(reg_kind_t k, data_type_t dt = data_type::undef);
+    vreg_t new_vreg(reg_kind_t k, data_type_t dt = data_type::undef);
 
     // Convenience wrappers around `new_vreg` for the specific kinds.
-    int new_gpr() { return new_vreg(reg_kind_t::gpr); }
-    int new_vec(data_type_t dt) { return new_vreg(reg_kind_t::vec, dt); }
-    int new_mask() { return new_vreg(reg_kind_t::mask); }
+    vreg_t new_gpr() { return new_vreg(reg_kind_t::gpr); }
+    vreg_t new_vec(data_type_t dt) { return new_vreg(reg_kind_t::vec, dt); }
+    vreg_t new_mask() { return new_vreg(reg_kind_t::mask); }
 
     // Add a new label and return its id
     label_t new_label() { return static_cast<label_t>(n_labels_++); }
@@ -228,33 +234,35 @@ struct DNNL_API ir_t {
     // Refer to documentation for `op_kind_t` for each helper.
 
     // gpr
-    int mov_imm(int dst, dim_t imm);
-    void mov_reg(int dst, int src);
-    void add_imm(int dst, dim_t imm);
-    void add_reg(int dst, int src);
-    void load_param(int dst, dim_t disp);
-    void load(int dst, int base, dim_t disp);
+    int mov_imm(vreg_t dst, dim_t imm);
+    void mov_reg(vreg_t dst, vreg_t src);
+    void add_imm(vreg_t dst, dim_t imm);
+    void add_reg(vreg_t dst, vreg_t src);
+    void load_param(vreg_t dst, dim_t disp);
+    void load(vreg_t dst, vreg_t base, dim_t disp);
 
     // vec
-    void vzero(int dst);
-    void vload(int dst, int base, dim_t disp);
-    void vfma(int dst, int a, int b);
-    void vhreduce(int dst, int workspace);
+    void vzero(vreg_t dst);
+    void vload(vreg_t dst, vreg_t base, dim_t disp);
+    void vfma(vreg_t dst, vreg_t a, vreg_t b);
+    void vhreduce(vreg_t dst, vreg_t workspace);
 
     // vec (masked)
-    void vload_masked(int dst, int base, dim_t disp, int mask, int elems);
-    void vstore_masked(int base, dim_t disp, int src, int mask, int elems);
+    void vload_masked(
+            vreg_t dst, vreg_t base, dim_t disp, vreg_t mask, int elems);
+    void vstore_masked(
+            vreg_t base, dim_t disp, vreg_t src, vreg_t mask, int elems);
 
     // mask
-    void set_mask_imm(int mask, int n_elems);
+    void set_mask_imm(vreg_t mask, int n_elems);
 
     // control flow
-    int loop_begin_imm(int counter, dim_t count);
-    int loop_begin_reg(int counter, int init);
-    void loop_end(int counter, int begin_idx);
+    int loop_begin_imm(vreg_t counter, dim_t count);
+    int loop_begin_reg(vreg_t counter, vreg_t init);
+    void loop_end(vreg_t counter, int begin_idx);
     void label(label_t label_id);
     void jmp(label_t label_id);
-    void jz(int cond, label_t label_id);
+    void jz(vreg_t cond, label_t label_id);
 
     // Fill defs/uses with the vregs this operation writes/reads. Liveness and
     // the allocator depend on it, so it must match what the emitter emits.
@@ -296,7 +304,7 @@ void emit_loop_imm(ir_t &ir, dim_t count_imm, body_t body) {
         body();
         return;
     }
-    const int counter = ir.new_gpr();
+    const vreg_t counter = ir.new_gpr();
     const int begin = ir.loop_begin_imm(counter, count_imm);
     body();
     ir.loop_end(counter, begin);
@@ -312,7 +320,7 @@ void emit_loop_imm(ir_t &ir, dim_t count_imm, body_t body, step_t step) {
         body();
         return;
     }
-    const int counter = ir.new_gpr();
+    const vreg_t counter = ir.new_gpr();
     const int begin = ir.loop_begin_imm(counter, count_imm);
     body();
     step();
@@ -324,9 +332,9 @@ void emit_loop_imm(ir_t &ir, dim_t count_imm, body_t body, step_t step) {
 // loop. A negative count never reaches 0 and gets stuck, so the caller must
 // ensure count_reg >= 0.
 template <typename body_t>
-void emit_loop_reg(ir_t &ir, int count_reg, body_t body) {
-    const int counter = ir.new_gpr();
-    const int skip = ir.new_label();
+void emit_loop_reg(ir_t &ir, vreg_t count_reg, body_t body) {
+    const vreg_t counter = ir.new_gpr();
+    const label_t skip = ir.new_label();
     ir.jz(count_reg, skip); // zero-trip guard. A negative count gets stuck.
     const int begin = ir.loop_begin_reg(counter, count_reg);
     body();

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -214,10 +214,6 @@ struct DNNL_API ir_t {
     const std::vector<op_t> &ops() const { return ops_; }
     int n_labels() const { return n_labels_; }
 
-    // Add a vreg of kind `k` and, for a vec, element data type `dt`.
-    // Return its id.
-    vreg_t new_vreg(reg_kind_t k, data_type_t dt = data_type::undef);
-
     // Convenience wrappers around `new_vreg` for the specific kinds.
     vreg_t new_gpr() { return new_vreg(reg_kind_t::gpr); }
     vreg_t new_vec(data_type_t dt) { return new_vreg(reg_kind_t::vec, dt); }
@@ -270,6 +266,10 @@ struct DNNL_API ir_t {
             std::vector<int> &uses) const;
 
 private:
+    // Add a vreg of kind `k` and, for a vec, element data type `dt`.
+    // Return its id.
+    vreg_t new_vreg(reg_kind_t k, data_type_t dt = data_type::undef);
+
     // Info for each vreg, indexed by its id
     std::vector<vreg_info_t> vreg_info_;
     // All operations, in order

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -1,0 +1,334 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_IR_IR_HPP
+#define CPU_X64_IR_IR_HPP
+
+// Minimal linear IR for JIT kernels.
+//
+// An `ir_t` is a flat list of operations. Each operation reads and writes
+// virtual registers: integer-named placeholders for the values a kernel works
+// with, used instead of physical registers until the allocator assigns them.
+// Every virtual register belongs to one of three kinds (gpr/vec/mask), which
+// defines the kind of physical register it can later land in. Operations are
+// target-neutral. The concrete instructions are chosen later by the emitter.
+//
+// A vec vreg also carries the element data type of the values it holds. The
+// operations stay data-type generic. The builder tags each vec vreg with a
+// dtype and the emitter lowers each op to the instruction for that dtype.
+//
+// The virtual registers are mutable. A virtual register is a named value that
+// may be written more than once. In this IR we deliberately allow reassignment,
+// e.g. a pointer register is loaded and then advanced with `add` each loop
+// iteration, reusing the same name. Each virtual register occupies one physical
+// location (register or spill slot) for the whole of its live range, so a write
+// overwrites that location in place. This keeps the builder and the register
+// allocator simple. The allocator relies only on liveness.
+//
+// Memory operands are base register + displacement, where the displacement is
+// a single constant offset known at build time and encoded directly into the
+// instruction (`[reg + disp]`). There is no second index register and no
+// scale. Any distance that is only known at run time is not a displacement, the
+// builder instead folds it into the base pointer with an explicit `add` (a
+// running pointer that is advanced each iteration instead of recomputing an
+// index). Restricting addresses to one register keeps every memory op reading
+// at most one pointer, which lowers register pressure and simplifies spilling.
+//
+// Loops are explicit structured nodes with a runtime counter register
+// (loop_begin/loop_end). Compile-time loops are unrolled by the builder.
+
+#include <vector>
+
+#include "common/c_types_map.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+// gpr  - General-purpose register
+// vec  - Vector register
+// mask - Mask register (emitter decides whether lower it to k or vector
+//        register)
+
+enum class reg_kind_t { gpr, vec, mask };
+
+enum class op_kind_t {
+    // General-purpose register operations
+
+    // dst = immediate value
+    mov_imm,
+    // dst = source register (s0)
+    mov_reg,
+    // dst += immediate value
+    add_imm,
+    // dst += source register (s0)
+    add_reg,
+    // dst = [base + disp], base is the parameter register if is_param
+    load,
+
+    // Vector operations
+    //
+    // dst = 0 (clear vector)
+    vzero,
+    // dst = [base + disp] (load full vector)
+    vload,
+    // dst += s0 * s1 (fused multiply-add, e.g., vfmadd231ps)
+    vfma,
+    // horizontal reduction of dst; result in element 0. s0 is scratch
+    // (overwritten).
+    vhreduce,
+
+    // Mask operations
+    //
+    // set_mask_imm creates a mask for `imm` active elements.
+    set_mask_imm,
+
+    // Masked vector load/store
+    //
+    // loads `imm` elements. Mask vreg = s1 or -1.
+    vload_masked,
+    // stores `imm` elements. Mmask vreg = s1 or -1.
+    vstore_masked,
+
+    // Control flow
+    //
+    // initialize loop counter (dst = imm or s0 if init_is_reg)
+    loop_begin,
+    // decrement counter and jump to matching loop_begin if not zero
+    loop_end,
+    // bind label id `imm`
+    label,
+    // jump to label id `imm`
+    jmp,
+    // if s0 == 0 jump to label id `imm`
+    jz,
+};
+
+// A memory address of the form base register + displacement.
+//   base     - virtual gpr holding the pointer. Runtime offsets are folded into
+//              it by the builder (incrementing the pointer), so the only
+//              non-register part of an address is a build-time constant.
+//   disp     - that constant byte offset, encoded directly in the instruction
+//              There is no index register and no scale.
+//   is_param - when true the base is not `base` but the kernel's argument
+//              pointer (a fixed register set by the ABI). Used to read fields
+//              of the kernel-parameter struct. The register allocator does not
+//              manage it, so it is not counted as a virtual-register use.
+struct mem_t {
+    // virtual gpr holding the pointer (ignored when is_param)
+    int base = -1;
+    // constant byte offset
+    dim_t disp = 0;
+    // base is the kernel-argument pointer
+    bool is_param = false;
+};
+
+// An `op_t` is a single IR operation. One fixed struct represents every
+// operation and works like a tagged union, where the `kind` field decides which
+// operation it is. Each operation only uses the fields it needs and ignores the
+// rest, which stay at default values.
+//
+// The meaning of each field for a specific operation is explained in the
+// `op_kind_t` comments. Whether dst, s0, and s1 are used for reading or writing
+// is clearly defined in ir_t::def_use().
+//
+// kind - which operation this is. Determines how other fields are used.
+// dst  - virtual register that is written to, or -1 if none is written.
+//        Some ops (e.g. vfma/vadd) both read from and write to dst.
+// s0,s1 - source virtual registers (inputs), or -1 if not used.
+// imm   - immediate value whose meaning depends on the kind:
+//         * mov_imm        -> literal constant
+//         * loop_begin     -> loop trip count
+//         * set_mask_imm   -> active element count
+//         * vload_masked / vstore_masked -> active element count
+// mem   - memory address used only by load/store operations.
+// match - for loop_end, index of matching loop_begin operation.
+// init_is_reg - for loop_begin, if true, initialize loop counter from s0
+//                (runtime value) instead of imm.
+struct op_t {
+    op_kind_t kind;
+    int dst = -1;
+    int s0 = -1, s1 = -1;
+    dim_t imm = 0;
+    mem_t mem;
+    int match = -1;
+    bool init_is_reg = false;
+};
+
+// Metadata for virtual registers that contains the register kind and the
+// data type of the values it holds. `dt` is `undef` for gpr and mask.
+struct vreg_info_t {
+    reg_kind_t kind;
+    data_type_t dt = data_type::undef;
+};
+
+// An `ir_t` is the operation list plus, for each virtual register, its info
+// (kind and for a vec its element data type) so the allocator knows which
+// physical registers it can use and the emitter knows which dtype-specific
+// instruction to lower each op to.
+//
+// * The builder fills it through the helpers below
+// * The allocator and emitter read it
+//
+// Export for testing.
+#ifdef _MSC_VER
+// ir_t is exported whole so that new member functions are covered automatically
+// without annotating each one. It has std::vector members, which triggers
+// C4251. The library and the tests are build by the same compiler, so no
+// mismatch is possible. Silence it.
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+struct DNNL_API ir_t {
+    const std::vector<vreg_info_t> &vreg_info() const { return vreg_info_; }
+    const std::vector<op_t> &ops() const { return ops_; }
+    int n_labels() const { return n_labels_; }
+
+    // Add a vreg of kind `k` and, for a vec, element data type `dt`.
+    // Return its id.
+    int new_vreg(reg_kind_t k, data_type_t dt = data_type::undef);
+
+    // Convenience wrappers around `new_vreg` for the specific kinds.
+    int new_gpr() { return new_vreg(reg_kind_t::gpr); }
+    int new_vec(data_type_t dt) { return new_vreg(reg_kind_t::vec, dt); }
+    int new_mask() { return new_vreg(reg_kind_t::mask); }
+
+    // Add a new label and return its id
+    int new_label() { return n_labels_++; }
+    int n_vregs() const { return (int)vreg_info_.size(); }
+    int n_ops() const { return (int)ops_.size(); }
+
+    // Each helper appends one operation and names registers by `id`. The ones
+    // returning `int` return the new operation's index.
+    //
+    // Refer to documentation for `op_kind_t` for each helper.
+
+    // gpr
+    int mov_imm(int dst, dim_t imm);
+    void mov_reg(int dst, int src);
+    void add_imm(int dst, dim_t imm);
+    void add_reg(int dst, int src);
+    void load_param(int dst, dim_t disp);
+    void load(int dst, int base, dim_t disp);
+
+    // vec
+    void vzero(int dst);
+    void vload(int dst, int base, dim_t disp);
+    void vfma(int dst, int a, int b);
+    void vhreduce(int dst, int workspace);
+
+    // vec (masked)
+    void vload_masked(int dst, int base, dim_t disp, int mask, int elems);
+    void vstore_masked(int base, dim_t disp, int src, int mask, int elems);
+
+    // mask
+    void set_mask_imm(int mask, int n_elems);
+
+    // control flow
+    int loop_begin_imm(int counter, dim_t count);
+    int loop_begin_reg(int counter, int init);
+    void loop_end(int counter, int begin_idx);
+    void label(int label_id);
+    void jmp(int label_id);
+    void jz(int cond, int label_id);
+
+    // Fill defs/uses with the vregs this operation writes/reads. Liveness and
+    // the allocator depend on it, so it must match what the emitter emits.
+    void def_use(const op_t &op, std::vector<int> &defs,
+            std::vector<int> &uses) const;
+
+private:
+    // Info for each vreg, indexed by its id
+    std::vector<vreg_info_t> vreg_info_;
+    // All operations, in order
+    std::vector<op_t> ops_;
+
+    // Label counter.
+    int n_labels_ = 0;
+};
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+// Loop helpers shared by IR builders.
+//
+// If the loop count is known at build time and is 1, don't generate a loop.
+// Just emit `body` once.
+//
+// These helpers either:
+// - generate a runtime loop (creating the loop counter internally), or
+// - inline `body` once when only one iteration is needed.
+//
+// This avoids repeating:
+//   if (count > 1) { loop_begin; ...; loop_end; } else { ... }
+// in every builder.
+
+// Emit a runtime loop with `count_imm` as the iteration count.
+// count_imm == 0 emits nothing, == 1 inlines `body` once, > 1 builds a loop.
+template <typename body_t>
+void emit_loop_imm(ir_t &ir, dim_t count_imm, body_t body) {
+    if (count_imm == 0) return;
+    if (count_imm == 1) {
+        body();
+        return;
+    }
+    const int counter = ir.new_gpr();
+    const int begin = ir.loop_begin_imm(counter, count_imm);
+    body();
+    ir.loop_end(counter, begin);
+}
+
+// Like the helper above, but `step` runs after `body` on each loop iteration.
+// A single inlined iteration (count_imm == 1) skips `step`. Use this for
+// per-iteration pointer updates not needed for a single iteration.
+template <typename body_t, typename step_t>
+void emit_loop_imm(ir_t &ir, dim_t count_imm, body_t body, step_t step) {
+    if (count_imm == 0) return;
+    if (count_imm == 1) {
+        body();
+        return;
+    }
+    const int counter = ir.new_gpr();
+    const int begin = ir.loop_begin_imm(counter, count_imm);
+    body();
+    step();
+    ir.loop_end(counter, begin);
+}
+
+// Loop with a runtime iteration count held in `count_reg`. Use this when the
+// iteration count is not known at IR generation time. A count of 0 skips the
+// loop. A negative count never reaches 0 and gets stuck, so the caller must
+// ensure count_reg >= 0.
+template <typename body_t>
+void emit_loop_reg(ir_t &ir, int count_reg, body_t body) {
+    const int counter = ir.new_gpr();
+    const int skip = ir.new_label();
+    ir.jz(count_reg, skip); // zero-trip guard. A negative count gets stuck.
+    const int begin = ir.loop_begin_reg(counter, count_reg);
+    body();
+    ir.loop_end(counter, begin);
+    ir.label(skip);
+}
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -118,6 +118,9 @@ enum class op_kind_t {
     // stores `imm` elements. Mmask vreg = s1 or -1.
     vstore_masked,
 
+    // prefetch [base + disp] into cache. Reads base, writes nothing.
+    prefetch,
+
     // Control flow
     //
     // initialize loop counter (dst = imm or s0 if init_is_reg)
@@ -259,6 +262,8 @@ struct DNNL_API ir_t {
     // of loading.
     void vstore_masked(
             vreg_t base, dim_t disp, vreg_t src, vreg_t mask, int elems);
+
+    void prefetch(vreg_t base, dim_t disp);
 
     // mask
     void set_mask_imm(vreg_t mask, int n_elems);

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -100,8 +100,8 @@ enum class op_kind_t {
     vzero,
     // dst = [base + disp] (load full vector)
     vload,
-    // dst += s0 * s1 (fused multiply-add, e.g., vfmadd231ps)
-    vfma,
+    // dst += sum_{i=0}^{N-1} (s0[i] * s1[i]), where N is the dot length
+    vdot,
     // horizontal reduction of dst; result in element 0. s0 is scratch
     // (overwritten).
     vhreduce,
@@ -162,7 +162,7 @@ struct mem_t {
 //
 // kind - which operation this is. Determines how other fields are used.
 // dst  - virtual register that is written to, or `none` if none is written.
-//        Some ops (e.g. vfma/vadd) both read from and write to dst.
+//        Some ops (e.g. vdot/vadd) both read from and write to dst.
 // s0,s1 - source virtual registers (inputs), or `none` if not used.
 // imm   - immediate value whose meaning depends on the kind:
 //         * mov_imm        -> literal constant
@@ -244,7 +244,7 @@ struct DNNL_API ir_t {
     // vec
     void vzero(vreg_t dst);
     void vload(vreg_t dst, vreg_t base, dim_t disp);
-    void vfma(vreg_t dst, vreg_t a, vreg_t b);
+    void vdot(vreg_t dst, vreg_t a, vreg_t b);
     void vhreduce(vreg_t dst, vreg_t workspace);
 
     // vec (masked)

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -224,16 +224,20 @@ struct DNNL_API ir_t {
     int n_vregs() const { return (int)vreg_info_.size(); }
     int n_ops() const { return (int)ops_.size(); }
 
-    // Each helper appends one operation and names registers by `id`. The ones
-    // returning `int` return the new operation's index.
+    // Each interface appends one operation and names registers by `id`. The
+    // ones returning `int` return the new operation's index.
     //
-    // Refer to documentation for `op_kind_t` for each helper.
+    // Refer to documentation for `op_kind_t` for each interface. The notes here
+    // add only the parameter-level details that are not obvious from the
+    // signature.
 
     // gpr
     int mov_imm(vreg_t dst, dim_t imm);
     void mov_reg(vreg_t dst, vreg_t src);
     void add_imm(vreg_t dst, dim_t imm);
     void add_reg(vreg_t dst, vreg_t src);
+    // Like `load`, but reads a field of the kernel-argument struct through the
+    // ABI parameter pointer instead of a virtual base register.
     void load_param(vreg_t dst, dim_t disp);
     void load(vreg_t dst, vreg_t base, dim_t disp);
 
@@ -241,11 +245,18 @@ struct DNNL_API ir_t {
     void vzero(vreg_t dst);
     void vload(vreg_t dst, vreg_t base, dim_t disp);
     void vdot(vreg_t dst, vreg_t a, vreg_t b);
+    // `workspace` is scratch. It is overwritten by this call, so pass a vreg
+    // whose value is not needed afterwards.
     void vhreduce(vreg_t dst, vreg_t workspace);
 
     // vec (masked)
+    // `elems` is the number of active elements. `mask` is the mask register
+    // holding that pattern (from `set_mask_imm`), or `vreg_t::none` for a
+    // single element or a full vector, where no mask register is needed.
     void vload_masked(
             vreg_t dst, vreg_t base, dim_t disp, vreg_t mask, int elems);
+    // Same shape as `vload_masked`, but stores `src` to [base + disp] instead
+    // of loading.
     void vstore_masked(
             vreg_t base, dim_t disp, vreg_t src, vreg_t mask, int elems);
 
@@ -253,8 +264,13 @@ struct DNNL_API ir_t {
     void set_mask_imm(vreg_t mask, int n_elems);
 
     // control flow
+    // Pass the returned op index to `loop_end` to close the loop.
     int loop_begin_imm(vreg_t counter, dim_t count);
+    // Like `loop_begin_imm`, but the iteration count is the runtime value in
+    // `init` rather than the compile-time `count`.
     int loop_begin_reg(vreg_t counter, vreg_t init);
+    // Close the loop opened by `loop_begin_imm` or `loop_begin_reg`, passing
+    // the op index it returned as `begin_idx`.
     void loop_end(vreg_t counter, int begin_idx);
     void label(label_t label_id);
     void jmp(label_t label_id);

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -111,11 +111,11 @@ enum class op_kind_t {
     loop_begin,
     // decrement counter and jump to matching loop_begin if not zero
     loop_end,
-    // bind label id `imm`
+    // bind label id `label_id`
     label,
-    // jump to label id `imm`
+    // jump to label id `label_id`
     jmp,
-    // if s0 == 0 jump to label id `imm`
+    // if s0 == 0 jump to label id `label_id`
     jz,
 };
 
@@ -158,6 +158,7 @@ struct mem_t {
 //         * vload_masked / vstore_masked -> active element count
 // mem   - memory address used only by load/store operations.
 // match - for loop_end, index of matching loop_begin operation.
+// label_id - target label id for label/jmp/jz. When unused it's -1.
 // init_is_reg - for loop_begin, if true, initialize loop counter from s0
 //                (runtime value) instead of imm.
 struct op_t {
@@ -167,6 +168,7 @@ struct op_t {
     dim_t imm = 0;
     mem_t mem;
     int match = -1;
+    int label_id = -1;
     bool init_is_reg = false;
 };
 

--- a/src/cpu/x64/ir/reg_alloc.cpp
+++ b/src/cpu/x64/ir/reg_alloc.cpp
@@ -176,7 +176,7 @@ void compute_liveness(
     std::vector<int> label_to_op(ir.n_labels(), -1);
     for (int i = 0; i < n_ops; i++)
         if (ir.ops()[i].kind == op_kind_t::label)
-            label_to_op[(int)ir.ops()[i].imm] = i;
+            label_to_op[ir.ops()[i].label_id] = i;
 
     for (int i = 0; i < n_ops; i++) {
         const op_t &op = ir.ops()[i];
@@ -193,10 +193,10 @@ void compute_liveness(
             if (i + 1 < n_ops) successors[i].push_back(i + 1);
             successors[i].push_back(op.match + 1);
         } else if (op.kind == op_kind_t::jmp) {
-            successors[i].push_back(label_to_op[(int)op.imm]);
+            successors[i].push_back(label_to_op[op.label_id]);
         } else if (op.kind == op_kind_t::jz) {
             if (i + 1 < n_ops) successors[i].push_back(i + 1);
-            successors[i].push_back(label_to_op[(int)op.imm]);
+            successors[i].push_back(label_to_op[op.label_id]);
         } else if (i + 1 < n_ops) {
             successors[i].push_back(i + 1);
         }

--- a/src/cpu/x64/ir/reg_alloc.cpp
+++ b/src/cpu/x64/ir/reg_alloc.cpp
@@ -176,7 +176,7 @@ void compute_liveness(
     std::vector<int> label_to_op(ir.n_labels(), -1);
     for (int i = 0; i < n_ops; i++)
         if (ir.ops()[i].kind == op_kind_t::label)
-            label_to_op[ir.ops()[i].label_id] = i;
+            label_to_op[(int)ir.ops()[i].label_id] = i;
 
     for (int i = 0; i < n_ops; i++) {
         const op_t &op = ir.ops()[i];
@@ -193,10 +193,10 @@ void compute_liveness(
             if (i + 1 < n_ops) successors[i].push_back(i + 1);
             successors[i].push_back(op.match + 1);
         } else if (op.kind == op_kind_t::jmp) {
-            successors[i].push_back(label_to_op[op.label_id]);
+            successors[i].push_back(label_to_op[(int)op.label_id]);
         } else if (op.kind == op_kind_t::jz) {
             if (i + 1 < n_ops) successors[i].push_back(i + 1);
-            successors[i].push_back(label_to_op[op.label_id]);
+            successors[i].push_back(label_to_op[(int)op.label_id]);
         } else if (i + 1 < n_ops) {
             successors[i].push_back(i + 1);
         }

--- a/src/cpu/x64/ir/reg_alloc.cpp
+++ b/src/cpu/x64/ir/reg_alloc.cpp
@@ -1,0 +1,452 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+// The register allocator.
+//
+// Turns the IR's unlimited virtual registers into the CPU's real ones, spilling
+// to the stack when more values are live at once than there are registers. It
+// replaces the original brgemm kernel's hand-managed register numbering. The
+// allocator is responsible for deciding WHO to spill, which relies on three
+// ideas:
+//   1. liveness
+//   2. control-flow graph
+//   3. linear scan
+//
+// It is designed to be generic. It knows only register kinds and control
+// flow, nothing about the computation (brgemm, brgemv, copy, etc.) or the ISA.
+//
+// 1. Liveness
+//
+// A value is `live` at a point if it will be read again before being
+// overwritten. Two values that are live at the same point interfere. They
+// cannot share a register. So the allocator's input is each value's live span,
+// and its job is to pack non-interfering spans onto the same register.
+//
+// 2. The Control-Flow Graph
+//
+// To know what is read later we must know what runs after what. In this IR
+// that is nearly trivial. Each operation flows to the next, with three
+// exceptions:
+//   1. loop_end has two successors. It can fall through, or jump back to the
+//      body start (`back-edge`).
+//   2. jz has two successors. It can fall through, or jump to its label
+//      (`forward-edge`).
+//   3. jmp has one successor. It redirects to its label (`forward edge`).
+//
+//     Back-edge example:
+//
+//     0  loop_begin      <- back-edge returns here
+//     1    v = load [ptr]
+//     2    acc += v * x
+//     3    ptr += stride
+//     4  loop_end        -> 5, or jump back to 0
+//     5  store acc
+//
+// So both branches and the back-edge depart from a straight list. The back-edge
+// is special because it forms a cycle. A cycle is the one thing that forces the
+// liveness pass to repeat, as the next section explains. Forward branches do
+// not. There are no basic blocks. Every operation is a node.
+//
+// Backward Liveness Analysis
+//
+// Liveness is computed backwards and iterated. Needed here depends on uses
+// later, so we go through the list back to front. Each operation keeps alive
+// whatever its successors need, minus what it overwrites, plus what it reads.
+//
+// The back-edge makes this take more than one pass. Iterate to a fixed point
+// is a static analysis of the program text. We don't need to know the loop
+// counter values. We re-iterate over the operation list until a pass changes
+// nothing. That stable result is the `fixed point`.
+//
+// Why a second pass is ever needed: a `ptr` read at the top of the body
+// (see the back-edge example) and advanced at the bottom is, through the
+// back-edge, the value the next iteration reads at the top. So it must be live
+// across the whole body. The first pass does not yet know the loop start needs
+// it. The next pass propagates that, and it appears. This settles in a handful
+// of passes. The count scales with loop nesting depth, not with how many times
+// the loop runs. The result is liveness valid for every possible execution at
+// once.
+//
+// 3. Linear Scan
+//
+// Collapse each value's liveness to one [start, end] interval, ignoring holes.
+// That simplification is what keeps this cheap. If we need, we can enable
+// intervals split to improve register allocation under pressure.
+// Per register kind, sort by start and go through them, keeping the live
+// (`active`) intervals:
+//
+//     v0 |=================|   (0..9)
+//     v1   |===|               (1..3)
+//     v2         |=======|     (4..8)
+//     v3           |=====|     (5..8)
+//        0 1 2 3 4 5 6 7 8 9
+//
+// Free a register when its interval ends. When none is free, spill the interval
+// whose end is furthest away. In the picture, at t=5 both registers are taken
+// by v0 and v2. v0 ends at 9 and v2 ends at 8, so spill v0 and give its
+// register to the newcomer. If the newcomer itself ends furthest, it is the one
+// spilled. Furthest-end frees a register for the longest stretch. A heavier
+// kernel will want to weight this by loop depth so hot values stay put. The
+// mechanism stays the same.
+//
+// TODO: Enable weights based on the loop depth.
+
+#include <algorithm>
+#include <climits>
+
+#include "cpu/x64/ir/reg_alloc.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+namespace {
+
+// Compute liveness for each operation `i`.
+//
+// A value is `live` at operation `i` if some future operation may still
+// read it before it is overwritten. In other words, the value must be kept
+// available because it might be needed later.
+//
+// Two values that are live at the same operation cannot share a register.
+//
+// Backward data-flow to a fixed point. For each operation `i`:
+//
+//   1. Computing `live_in` at operation `i`:
+//      A variable is live before `i` if `i` uses it, or if it is needed
+//      later and not overwritten by `i`.
+//      Formula: live_in[i] = use[i] U (live_out[i] - def[i])
+//
+//   2. Computing `live_out` at operation `i`:
+//      A variable is live after `i` if any successor may need it.
+//      Formula: live_out[i] = union of live_in over all successors of `i`
+//
+// Scan each `i` from last to first, and repeat the whole scan until nothing
+// changes (the fixed point). Successors are `i+1` for a plain operation, the
+// label for jmp/jz, and `i+1` plus the loop body start for loop_end
+// (the back-edge).
+//
+// Small example: `p` is read at the top of a loop body and rewritten at the
+// bottom:
+//
+//   0  loop_begin
+//   1    v = load [p]      (p read)
+//   2    p = p + stride    (p rewritten)
+//   3  loop_end            (back-edge to 0)
+//
+// `p` must be live across the whole body, because the value written at 2 is
+// read at 1 on the next turn. One backward pass finds most of it. The entry to
+// loop_end needs the back-edge, so it appears only on the second pass. A third
+// pass changes nothing, which is the fixed point.
+void compute_liveness(
+        const ir_t &ir, std::vector<std::vector<int8_t>> &live_in) {
+    const int n_ops = ir.n_ops();
+    const int n_vregs = ir.n_vregs();
+
+    // Phase 1: build per-operation def/use sets and the control-flow graph.
+    //
+    // def_at[i][v] is 1 if operation `i` defines (writes) vreg `v`.
+    // use_at[i][v] is 1 if operation `i` uses (reads) vreg `v`.
+    // successors[i] lists all operations that may execute immediately after i.
+    std::vector<std::vector<int8_t>> def_at(
+            n_ops, std::vector<int8_t>(n_vregs, 0));
+    std::vector<std::vector<int8_t>> use_at(
+            n_ops, std::vector<int8_t>(n_vregs, 0));
+
+    std::vector<std::vector<int>> successors(n_ops);
+    std::vector<int> def_vregs, use_vregs;
+
+    // Map label IDs to operation indices so jmp/jz can resolve their target
+    // locations when building the control-flow graph.
+    std::vector<int> label_to_op(ir.n_labels(), -1);
+    for (int i = 0; i < n_ops; i++)
+        if (ir.ops()[i].kind == op_kind_t::label)
+            label_to_op[(int)ir.ops()[i].imm] = i;
+
+    for (int i = 0; i < n_ops; i++) {
+        const op_t &op = ir.ops()[i];
+        ir.def_use(op, def_vregs, use_vregs);
+
+        for (int v : def_vregs)
+            def_at[i][v] = 1;
+        for (int v : use_vregs)
+            use_at[i][v] = 1;
+
+        // Successor edges include fall-through to `i+1` and any explicit
+        // control-flow transfers (branches and loop back-edges).
+        if (op.kind == op_kind_t::loop_end) {
+            if (i + 1 < n_ops) successors[i].push_back(i + 1);
+            successors[i].push_back(op.match + 1);
+        } else if (op.kind == op_kind_t::jmp) {
+            successors[i].push_back(label_to_op[(int)op.imm]);
+        } else if (op.kind == op_kind_t::jz) {
+            if (i + 1 < n_ops) successors[i].push_back(i + 1);
+            successors[i].push_back(label_to_op[(int)op.imm]);
+        } else if (i + 1 < n_ops) {
+            successors[i].push_back(i + 1);
+        }
+    }
+
+    // Phase 2: compute `live_in` and `live_out` using backward dataflow
+    // analysis. Iterate until reaching a fixed point (no changes in a full
+    // pass).
+    live_in.assign(n_ops, std::vector<int8_t>(n_vregs, 0));
+    std::vector<std::vector<int8_t>> live_out(
+            n_ops, std::vector<int8_t>(n_vregs, 0));
+
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (int i = n_ops - 1; i >= 0; i--) {
+            // live_out[i] = OR over successors `s` of live_in[s]
+            for (int v = 0; v < n_vregs; v++) {
+                int8_t live_out_v = 0;
+                for (int s : successors[i])
+                    live_out_v |= live_in[s][v];
+                if (live_out_v != live_out[i][v]) {
+                    live_out[i][v] = live_out_v;
+                    changed = true;
+                }
+            }
+            // live_in[i] = use[i] OR (live_out[i] AND NOT def[i])
+            for (int v = 0; v < n_vregs; v++) {
+                const char live_in_v
+                        = use_at[i][v] || (live_out[i][v] && !def_at[i][v]);
+                if (live_in_v != live_in[i][v]) {
+                    live_in[i][v] = live_in_v;
+                    changed = true;
+                }
+            }
+        }
+    }
+}
+
+// Assign physical registers to virtual registers within a single physical
+// register file using linear-scan register allocation. A file may serve more
+// than one register kind (e.g. vec and mask on AVX2*).
+//
+// Each virtual register is represented as an interval [start, end].
+// Intervals are sorted by start and processed left to right, maintaining an
+// `active` set of intervals currently holding registers.
+//
+// For each interval `v`:
+//   1. Expire old intervals:
+//      Remove any active interval `a` where end[a] < start[v], freeing its
+//      register.
+//
+//   2. Allocate register:
+//      If a register is free, assign it to `v`.
+//
+//   3. Spill if necessary:
+//      Otherwise select the active interval with the latest end
+//      (the `farthest live` interval).
+//      If end[victim] > end[v], spill victim and reuse its register for `v`,
+//      otherwise spill `v`.
+//
+// Spilled values are assigned stack slots starting at `frame`, increasing by
+// `slot_size` per spill.
+//
+// Example (2 registers: r0, r1):
+//
+//   v0 [0..9]   v1 [1..3]   v2 [4..8]   v3 [5..8]
+//
+//   v0 -> r0
+//   v1 -> r1
+//
+//   v2: v1 expires (3 < 4), r1 is free, so v2 -> r1
+//
+//   v3: no free registers.
+//       active ends: v0=9, v2=8 -> victim = v0
+//       since 9 > 8, spill v0 and assign r0 to v3
+void alloc_file(const ir_t &ir, int file_idx,
+        const std::vector<int> &kind_to_file, const std::vector<int> &pool,
+        const std::vector<int> &start, const std::vector<int> &end,
+        size_t slot_size, reg_alloc_result_t &res, size_t &frame) {
+
+    const int n_vregs = ir.n_vregs();
+
+    // Collect intervals belonging to this register file
+    // (end[v] >= 0 means v is used) and sort by start time, since linear scan
+    // processes intervals in increasing start order.
+    std::vector<int> scan_order;
+
+    for (int v = 0; v < n_vregs; v++) {
+        if (kind_to_file[(int)ir.vreg_info()[v].kind] == file_idx
+                && end[v] >= 0)
+            scan_order.push_back(v);
+    }
+
+    std::sort(scan_order.begin(), scan_order.end(),
+            [&](int lhs, int rhs) { return start[lhs] < start[rhs]; });
+
+    // free_regs: pool of available physical registers.
+    // active: intervals currently holding registers, sorted by increasing end.
+    // still_active: intervals that survive expiry each iteration.
+    std::vector<int> free_regs(pool.rbegin(), pool.rend());
+    std::vector<int> active;
+    std::vector<int> still_active;
+
+    for (int v : scan_order) {
+        // Expire intervals that end before the current interval starts,
+        // returning their registers to the free pool.
+        still_active.clear();
+        for (int a : active) {
+            if (end[a] < start[v]) {
+                if (!res.assignments[a].spilled)
+                    free_regs.push_back(res.assignments[a].phys);
+            } else {
+                still_active.push_back(a);
+            }
+        }
+        active.swap(still_active);
+
+        if (!free_regs.empty()) {
+            // A register is available so assign it.
+            res.assignments[v].phys = free_regs.back();
+            free_regs.pop_back();
+        } else {
+            // No free register so choose a spill candidate
+            // (farthest-live interval).
+            int victim = -1;
+            for (int a : active) {
+                if (!res.assignments[a].spilled
+                        && (victim < 0 || end[a] > end[victim])) {
+                    victim = a;
+                }
+            }
+
+            if (victim >= 0 && end[victim] > end[v]) {
+                // Victim outlives `v` so spill victim and reuse its register.
+                res.assignments[v].phys = res.assignments[victim].phys;
+                res.assignments[victim].spilled = true;
+                res.assignments[victim].slot = frame;
+                frame += slot_size;
+                res.any_spill = true;
+            } else {
+                // `v` itself ends furthest so spill `v`. It lives on the stack
+                // and is not added to the active set.
+                res.assignments[v].spilled = true;
+                res.assignments[v].slot = frame;
+                frame += slot_size;
+                res.any_spill = true;
+                continue;
+            }
+        }
+        // `v` now holds a register. Insert it into the active set, keeping the
+        // set sorted by increasing end.
+        const auto pos = std::lower_bound(active.begin(), active.end(), v,
+                [&](int lhs, int rhs) { return end[lhs] < end[rhs]; });
+        active.insert(pos, v);
+    }
+}
+
+} // namespace
+
+// Run full register allocation pipeline.
+// Returns, for each virtual register, either a physical register or a spill
+// slot.
+//
+// The pipeline:
+//   1. Compute liveness (live_in for each operation).
+//   2. Convert liveness into a single interval per virtual register:
+//        start[v] = first operation where `v` is defined, used, or live_in
+//        end[v]   = last such operation
+//   3. Run linear-scan allocation per physical register file, sharing a single
+//      stack frame across all files.
+//
+// Interval construction is intentionally conservative. If a value is live in
+// disjoint regions (e.g. 3-7 and 20-25), it is merged into [3-25]. This
+// ignores holes but guarantees correctness and keeps the algorithm simple.
+//
+// This approximation is usually acceptable because the most important values
+// are hot loop-invariant pointers (e.g. base pointers for C and batch data),
+// which are intended to remain in registers for the entire kernel anyway.
+// For these cases, merging gaps has no practical cost. The only downside
+// appears when a value has a true dead region while registers are scarce,
+// where the gap could otherwise be reused.
+//
+// TODO: improve allocation quality in two stages (in order):
+//
+//   1. Add loop-depth spill weighting.
+//      The current `farthest end wins` rule may incorrectly spill hot values
+//      (e.g. loop-invariant pointers) simply because they live long.
+//      Weighting by loop nesting depth biases spills toward cold values.
+//      This is a local change to alloc_kind.
+//
+//   2. Add hole-aware live-range splitting.
+//      Required only under register pressure when intervals cannot all fit.
+//      Splits must respect spill weights and must not break hot loop-carried
+//      values inside loops.
+reg_alloc_result_t allocate_registers(
+        const ir_t &ir, const reg_pools_t &pools) {
+    const int n_ops = ir.n_ops();
+    const int n_vregs = ir.n_vregs();
+
+    // Step 1: compute operation-level liveness.
+    // live_in[i][v] is 1 when virtual register `v` is needed on entry to
+    // operation `i`.
+    std::vector<std::vector<int8_t>> live_in;
+    compute_liveness(ir, live_in);
+
+    // Step 2: build a single live interval per virtual register.
+    // Each interval [start[v], end[v]] approximates all points where `v` is
+    // live.
+    //
+    // extend_interval(v) expands the interval to include operation `i`
+    // whenever `v` is defined, used, or live on entry to `i`.
+    std::vector<int> start(n_vregs, INT_MAX), end(n_vregs, -1);
+    std::vector<int> def_vregs, use_vregs;
+
+    for (int i = 0; i < n_ops; i++) {
+        auto extend_interval = [&](int v) {
+            if (v < 0) return;
+            start[v] = std::min(start[v], i);
+            end[v] = std::max(end[v], i);
+        };
+
+        ir.def_use(ir.ops()[i], def_vregs, use_vregs);
+        for (int v : def_vregs)
+            extend_interval(v);
+        for (int v : use_vregs)
+            extend_interval(v);
+        for (int v = 0; v < n_vregs; v++)
+            if (live_in[i][v]) extend_interval(v);
+    }
+
+    // Step 3: run linear-scan register allocation per physical register file,
+    // sharing a single stack frame so spill slots do not overlap across files.
+    reg_alloc_result_t res;
+    res.assignments.assign(n_vregs, assignment_t());
+
+    size_t frame = 0;
+    for (int f = 0; f < (int)pools.files.size(); f++) {
+        alloc_file(ir, f, pools.kind_to_file, pools.files[f].regs, start, end,
+                pools.files[f].slot_size, res, frame);
+    }
+
+    constexpr size_t stack_alignment = 16;
+    res.frame_bytes = utils::rnd_up(frame, stack_alignment);
+
+    return res;
+}
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/ir/reg_alloc.hpp
+++ b/src/cpu/x64/ir/reg_alloc.hpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_IR_REG_ALLOC_HPP
+#define CPU_X64_IR_REG_ALLOC_HPP
+
+#include <vector>
+
+#include "common/utils.hpp"
+
+#include "cpu/x64/ir/ir.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+// Describes where a virtual register was assigned by the allocator.
+// The location is determined by `spilled`:
+//
+// - If `spilled == false`, the value is stored in the physical register
+//   `phys`. The number is the register index within its group
+//   (for example: gpr 0=rax, ..., 15=r15 and vec 0=ymm0, ..., 15=ymm15).
+//   In this case, `slot` is not used.
+//
+// - If `spilled == true`, the value is stored on the stack at byte offset
+//   `slot` in the spill area. In this case, `phys` is not used.
+//   Whenever the value is needed, the emitter loads it into a scratch
+//   register before using it.
+struct assignment_t {
+    bool spilled = false;
+    int phys = -1;
+    size_t slot = 0;
+};
+
+// The final allocation result.
+//
+// - `assignments` contains one `assignment_t` for each virtual register,
+//   indexed by virtual register id.
+// - `frame_bytes` is the total amount of stack space needed for spilled
+//   values. The kernel reserves this space with a single `sub rsp`.
+// - `any_spill` is true if any virtual register was spilled to the stack.
+struct reg_alloc_result_t {
+    std::vector<assignment_t> assignments;
+    size_t frame_bytes = 0;
+    bool any_spill = false;
+};
+
+// A register file contains physical registers the allocator may assign, and the
+// stack-slot size used when a spill is needed.
+//
+// `regs` holds the register indices available for allocation (for example, all
+// general-purpose registers except reserved ones such as `rsp`, the argument
+// pointer, and scratch registers).
+//
+// `slot_size` is how many bytes a spilled value needs on the stack
+// (8 for a GPR, 32 for a YMM, 64 for a ZMM).
+struct reg_file_t {
+    std::vector<int> regs;
+    size_t slot_size = 0;
+};
+
+// The register files plus a map from each register kind to the file it
+// allocates from. Two kinds may share one file, e.g. on AVX2* a mask is a
+// vector register, so `vec` and `mask` kinds map to the same file and compete
+// for the same pool. On AVX-512 a mask is a k-register and has its own file.
+//
+// `kind_to_file` is indexed by `(int)reg_kind_t`.
+//
+// This structure is created and filled by make_reg_config() based on the target
+// ISA and later used by allocate_registers() during allocation.
+struct reg_pools_t {
+    std::vector<reg_file_t> files;
+    std::vector<int> kind_to_file;
+};
+
+// Export for testing.
+reg_alloc_result_t DNNL_API allocate_registers(
+        const ir_t &ir, const reg_pools_t &pools);
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/ir/reg_config.cpp
+++ b/src/cpu/x64/ir/reg_config.cpp
@@ -1,0 +1,80 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+
+#include "cpu/x64/ir/reg_config.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+reg_config_t make_reg_config(cpu_isa_t isa, int param_reg, int rsp_reg,
+        const std::vector<int> &gpr_scratch,
+        const std::vector<int> &vec_scratch) {
+    reg_config_t rc;
+    rc.param_reg = param_reg;
+    rc.gpr_scratch = gpr_scratch;
+    rc.vec_scratch = vec_scratch;
+
+    // TODO: enable Intel APX.
+    const int n_gpr = 16;
+    const int n_vec = isa_num_vregs(isa);
+
+    auto contains = [](const std::vector<int> &v, int i) {
+        return std::find(v.begin(), v.end(), i) != v.end();
+    };
+
+    // GPR file includes every gpr except the stack pointer (`rsp`), the
+    // argument pointer, and the scratch registers. The spill slot size is
+    // 8 bytes.
+    reg_file_t gpr_file;
+    gpr_file.slot_size = 8;
+    for (int i = 0; i < n_gpr; i++) {
+        if (i != rsp_reg && i != param_reg && !contains(gpr_scratch, i))
+            gpr_file.regs.push_back(i);
+    }
+
+    // Vector file includes every vector register except the scratch registers.
+    // On AVX2* a mask is a vector register, so masks allocate from this same
+    // file (see `kind_to_file` below). Spill slot is the vector size 32 for
+    // ymm and 64 for zmm.
+    reg_file_t vec_file;
+    vec_file.slot_size = isa_max_vlen(isa);
+    for (int i = 0; i < n_vec; i++) {
+        if (!contains(vec_scratch, i)) vec_file.regs.push_back(i);
+    }
+
+    rc.pools.files = {gpr_file, vec_file};
+
+    // Map each register kind to a file. `reg_kind_t` order is
+    // { gpr, vec, mask }.
+    //  * gpr: file 0
+    //  * vec and mask: file 1 (a mask is a vector register on AVX2*).
+    //
+    // TODO: on AVX-512 add a third file of k-registers and map mask to file 2.
+    rc.pools.kind_to_file = {0, 1, 1};
+
+    return rc;
+}
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/ir/reg_config.hpp
+++ b/src/cpu/x64/ir/reg_config.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_IR_REG_CONFIG_HPP
+#define CPU_X64_IR_REG_CONFIG_HPP
+
+#include <vector>
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/ir/reg_alloc.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+// A few physical registers are selected before the emitter runs and passed in.
+// The register allocator avoids using them, so they are always available for
+// these specific purposes:
+//  - param_reg: stores a pointer to the kernel's input arguments.
+//  - gpr_scratch / vec_scratch: temporary registers that the emitter can use
+//    whenever needed. If a value could not stay in a register and was spilled,
+//    the emitter loads it into one of these registers, performs the required
+//    work, and then stores it back.
+//
+// `pools` contains the registers that are available for allocation for each
+// register kind, along with the stack space needed when a value for that
+// kind is spilled.
+//
+// TODO: Consider adding a second pass. The first pass could determine how many
+// registers need to be spilled, giving a more accurate estimate of the register
+// scratch size. Now we always book a constant size during the `generate()`
+// call.
+struct reg_config_t {
+    reg_pools_t pools;
+    std::vector<int> gpr_scratch; // >= 2 entries
+    std::vector<int> vec_scratch; // >= 3 entries
+    int param_reg = 0;
+};
+
+// Creates the register config for the given ISA.
+//
+// The number of vector registers and their spill-slot size are inferred
+// directly from the ISA. For example, AVX2 uses 16 vector registers with
+// 32-byte spill slots, while AVX-512 uses 32 vector registers with 64-byte
+// spill slots.
+//
+// Some registers are reserved and are not included in the allocatable pools:
+// - `rsp_reg` (stack pointer)
+// - `param_reg` (parameter pointer)
+// - `gpr_scratch` registers
+// - `vec_scratch` registers
+//
+// The emitter uses these scratch registers when loading and storing spilled
+// values.
+//
+// Export for testing.
+reg_config_t DNNL_API make_reg_config(cpu_isa_t isa, int param_reg, int rsp_reg,
+        const std::vector<int> &gpr_scratch,
+        const std::vector<int> &vec_scratch);
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -56,12 +56,18 @@
 #define JIT_ASSERT(condition) \
     do { \
         assert(condition); \
-        if (!(condition)) XBYAK_THROW(Xbyak::ERR_INTERNAL); \
+        if (!(condition)) { \
+            using namespace Xbyak; \
+            XBYAK_THROW(Xbyak::ERR_INTERNAL); \
+        } \
     } while (false)
 #define JIT_ASSERT_RET(condition, ret) \
     do { \
         assert(condition); \
-        if (!(condition)) XBYAK_THROW_RET(Xbyak::ERR_INTERNAL, ret); \
+        if (!(condition)) { \
+            using namespace Xbyak; \
+            XBYAK_THROW_RET(Xbyak::ERR_INTERNAL, ret); \
+        } \
     } while (false)
 
 namespace dnnl {

--- a/tests/gtests/internals/CMakeLists.txt
+++ b/tests/gtests/internals/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND TEST_SOURCES ${MAIN_SRC_GTEST})
 if(NOT DNNL_TARGET_ARCH STREQUAL "X64" OR DNNL_CPU_RUNTIME STREQUAL "NONE")
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_brgemm.cpp)
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_float8.cpp)
+    list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_ir.cpp)
 endif()
 
 if(DNNL_ENABLE_MAX_CPU_ISA)
@@ -61,5 +62,13 @@ register_exe(${TEST_EXE}_sdpa
         "${MAIN_SRC_GTEST};${CMAKE_CURRENT_SOURCE_DIR}/test_sdpa.cpp;${CMAKE_CURRENT_SOURCE_DIR}/test_utils.cpp"
         "test" "dnnl_gtest")
 list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_sdpa.cpp)
+
+# Register CPU IR tests as a separate executable (X64 only)
+if(DNNL_TARGET_ARCH STREQUAL "X64" AND NOT DNNL_CPU_RUNTIME STREQUAL "NONE")
+    register_exe(${TEST_EXE}_cpu_ir
+            "${MAIN_SRC_GTEST};${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_ir.cpp"
+            "test" "dnnl_gtest")
+    list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_ir.cpp)
+endif()
 
 register_exe(${TEST_EXE} "${TEST_SOURCES}" "test" "dnnl_gtest")

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -22,6 +23,7 @@
 #include "common/c_types_map.hpp"
 
 #include "cpu/x64/ir/ir.hpp"
+#include "cpu/x64/ir/reg_alloc.hpp"
 
 namespace dnnl {
 
@@ -30,6 +32,119 @@ using namespace impl::cpu::x64;
 using namespace impl::cpu::x64::ir;
 
 // Helpers shared by the tests
+
+// Build a register pool with `n_gpr` GPRs plus all available vector registers.
+reg_pools_t make_pools(int n_gpr) {
+    reg_pools_t pools {};
+
+    reg_file_t gpr_file {};
+    // Spill slot size for GPR in bytes.
+    gpr_file.slot_size = 8;
+    for (int i = 0; i < n_gpr; i++)
+        gpr_file.regs.push_back(i);
+
+    reg_file_t vec_file {};
+    // Spill slot size for vector registers in bytes. AVX2 only.
+    vec_file.slot_size = 32;
+    for (int i = 0; i < 16; i++)
+        vec_file.regs.push_back(i);
+
+    pools.files = {gpr_file, vec_file};
+    // reg_kind_t order is { gpr, vec, mask }. A mask and vec kinds share the
+    // same register file on AVX2.
+    pools.kind_to_file = {/* gpr */ 0, /*vec*/ 1, /*mask*/ 1};
+
+    return pools;
+}
+
+// A virtual register's (vreg) live interval. Defined as [start, end]
+// operation indices in IR.
+struct interval_t {
+    int start = std::numeric_limits<int>::max();
+    int end = -1;
+    bool used() const { return end >= 0; }
+};
+
+// Reconstruct each vreg's live interval for branch-free IR.
+//
+// In linear code, a value is considered live from the first time it is
+// used until the last time it is used. So, we define its live interval using
+// the recorded reads and writes, without running liveness analysis again. This
+// allows the allocator tests to check for interference using the same approach
+// as the allocator itself.
+std::vector<interval_t> linear_code_intervals(const ir_t &ir) {
+    std::vector<interval_t> iv(ir.n_vregs());
+    std::vector<int> defs, uses;
+
+    for (int i = 0; i < ir.n_ops(); i++) {
+        ir.def_use(ir.ops()[i], defs, uses);
+
+        auto update_interval = [&](int v) {
+            if (v < 0) return;
+            iv[v].start = std::min(iv[v].start, i);
+            iv[v].end = std::max(iv[v].end, i);
+        };
+
+        for (int v : defs)
+            update_interval(v);
+        for (int v : uses)
+            update_interval(v);
+    }
+    return iv;
+}
+
+// Check the allocator's main rule. Two overlapping vregs targeting the same
+// register file must not be assigned the same physical register.
+// Spilled values are stored on the stack, so this rule does not apply to them.
+void expect_no_reg_conflicts(const ir_t &ir, const reg_pools_t &pools,
+        const reg_alloc_result_t &res) {
+    const auto iv = linear_code_intervals(ir);
+    const int n = ir.n_vregs();
+
+    for (int a = 0; a < n; a++) {
+        if (!iv[a].used()) continue;
+        for (int b = a + 1; b < n; b++) {
+            if (!iv[b].used()) continue;
+
+            const int file_a = pools.kind_to_file[(int)ir.vreg_info()[a].kind];
+            const int file_b = pools.kind_to_file[(int)ir.vreg_info()[b].kind];
+            if (file_a != file_b) continue;
+
+            const bool overlap
+                    = iv[a].start <= iv[b].end && iv[b].start <= iv[a].end;
+            if (!overlap) continue;
+
+            const assignment_t &aa = res.assignments[a];
+            const assignment_t &ab = res.assignments[b];
+
+            if (!aa.spilled && !ab.spilled) {
+                EXPECT_NE(aa.phys, ab.phys)
+                        << "vregs " << a << " and " << b
+                        << " overlap but share physical register " << aa.phys;
+            }
+        }
+    }
+}
+
+// Build an IR where all GPRs in the live set are live at the same time.
+// Each register is initialized first, then they are all used together by adding
+// them into an accumulator. The live set size controls the register pressure to
+// exercise register allocation and spilling.
+ir_t build_gpr_live_set(int live_set_size) {
+    ir_t ir;
+    const int acc = ir.new_gpr();
+    ir.mov_imm(acc, 0);
+
+    std::vector<int> live_set(live_set_size);
+    for (int i = 0; i < live_set_size; i++) {
+        live_set[i] = ir.new_gpr();
+        ir.mov_imm(live_set[i], i + 1);
+    }
+    for (int i = 0; i < live_set_size; i++)
+        ir.add_reg(acc, live_set[i]);
+
+    return ir;
+}
 
 // Find the index of the first operation with the given opcode. Otherwise
 // return -1.
@@ -221,6 +336,137 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
 
     // The then block's jmp precedes the else label it jumps over.
     EXPECT_LT(jmp_idx, bound[lbl_else]);
+
+    // The IR that contains branches can be handled by the allocator.
+    // It assigns a location to every value that is read somewhere.
+    const reg_pools_t pools = make_pools(/*n_gpr=*/8);
+    const reg_alloc_result_t res = allocate_registers(ir, pools);
+    // All virtual registers have been assigned.
+    ASSERT_EQ((int)res.assignments.size(), ir.n_vregs());
+
+    for (int v : {cond, base, a, acc}) {
+        const assignment_t &as = res.assignments[v];
+        // Each value is either spilled or has a physical register assigned.
+        EXPECT_TRUE(as.spilled || as.phys >= 0);
+    }
+}
+
+// Allocator tests
+//
+// Checks that there are no register collisions. If all values are live at the
+// same time and there are enough registers, each value gets its own register
+// and no values are spilled.
+TEST(AllocatorTests, DoesNotDoubleAllocateSimultaneouslyLiveValues) {
+    const int live_set_size = 6;
+    // Create an IR that uses `live_set_size` GPRs for values plus 1 additional
+    // GPR for an accumulator.
+    const ir_t ir = build_gpr_live_set(live_set_size);
+
+    // Create a pool for the exact number of required GPRs.
+    const reg_pools_t pools = make_pools(/*n_gpr=*/live_set_size + 1);
+
+    const reg_alloc_result_t res = allocate_registers(ir, pools);
+
+    EXPECT_FALSE(res.any_spill);
+    EXPECT_EQ(res.frame_bytes, 0u);
+    expect_no_reg_conflicts(ir, pools, res);
+}
+
+// Checks that registers are reused correctly. A temporary that is no longer
+// needed gives up its register, which is then used by a later temporary.
+// A value that is still in use keeps its own register.
+TEST(AllocatorTests, ReusesRegisterOfExpiredTemporary) {
+    ir_t ir {};
+
+    const int acc = ir.new_gpr();
+    ir.mov_imm(acc, 0);
+
+    const int t0 = ir.new_gpr();
+    ir.mov_imm(t0, 5);
+    ir.add_reg(acc, t0); // t0 dies here
+
+    const int t1 = ir.new_gpr();
+    ir.mov_imm(t1, 7);
+    ir.add_reg(acc, t1); // t1 is used only after t0 is dead
+
+    // Two registers are sufficient. One for the accumulator and one reused by
+    // t0 then t1.
+    const reg_pools_t pools = make_pools(/*n_gpr=*/2);
+    const reg_alloc_result_t res = allocate_registers(ir, pools);
+
+    EXPECT_FALSE(res.any_spill);
+    EXPECT_FALSE(res.assignments[t0].spilled);
+    EXPECT_FALSE(res.assignments[t1].spilled);
+    // t0 and t1 reuse the same physical register.
+    EXPECT_EQ(res.assignments[t0].phys, res.assignments[t1].phys);
+    // The accumulator, live across both, does not collide with them.
+    EXPECT_NE(res.assignments[acc].phys, res.assignments[t0].phys);
+}
+
+// Checks allocator behavior under register pressure. If the pool doesn't have
+// enough registers for all active values, the allocator spills some values to
+// the stack. It also reserves frame space, keeps the remaining values from
+// overlapping, and assigns each spilled value its own slot offset.
+TEST(AllocatorTests, SpillsUnderRegisterPressure) {
+    const int live_set_size = 6;
+    // Create an IR that uses `live_set_size` GPRs for values plus 1 additional
+    // GPR for an accumulator.
+    const ir_t ir = build_gpr_live_set(live_set_size);
+
+    // Create pool that has fewer registers than live values.
+    const int gpr_pool_size = 4;
+    const reg_pools_t pools = make_pools(/*n_gpr=*/gpr_pool_size);
+
+    const reg_alloc_result_t res = allocate_registers(ir, pools);
+
+    // Expect some spills and non-zero stack frame size.
+    EXPECT_TRUE(res.any_spill);
+    EXPECT_GT(res.frame_bytes, 0u);
+
+    // Check that non-spilled registers do not share the same register.
+    expect_no_reg_conflicts(ir, pools, res);
+
+    // Collect spill slots and check that they are unique, slot-aligned, and
+    // inside the reserved frame.
+    std::vector<size_t> slots;
+    for (const auto &as : res.assignments) {
+        if (as.spilled) {
+            // Check alignment.
+            EXPECT_EQ(as.slot % pools.files[0].slot_size, 0u);
+            // The slot is within the frame.
+            EXPECT_LT(as.slot, res.frame_bytes);
+            slots.push_back(as.slot);
+        }
+    }
+
+    ASSERT_FALSE(slots.empty());
+
+    // Check that each spilled register has a unique slot.
+    std::sort(slots.begin(), slots.end());
+    EXPECT_EQ(std::unique(slots.begin(), slots.end()), slots.end())
+            << "two spilled values were given the same stack slot";
+}
+
+// Checks that allocation depends only on its inputs. The same IR and register
+// pool produces identical register assignments, spill decisions, and stack
+// size, which makes the emitted code reproducible.
+TEST(AllocatorTests, AllocatesDeterministically) {
+    const ir_t ir = build_gpr_live_set(6);
+    // Create smaller GPR register pool to put pressure.
+    const reg_pools_t pools = make_pools(4);
+
+    const reg_alloc_result_t a = allocate_registers(ir, pools);
+    const reg_alloc_result_t b = allocate_registers(ir, pools);
+
+    ASSERT_EQ(a.assignments.size(), b.assignments.size());
+    EXPECT_EQ(a.frame_bytes, b.frame_bytes);
+    EXPECT_EQ(a.any_spill, b.any_spill);
+
+    for (size_t v = 0; v < a.assignments.size(); v++) {
+        EXPECT_EQ(a.assignments[v].spilled, b.assignments[v].spilled);
+        EXPECT_EQ(a.assignments[v].phys, b.assignments[v].phys);
+        EXPECT_EQ(a.assignments[v].slot, b.assignments[v].slot);
+    }
 }
 
 } // namespace dnnl

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -285,7 +285,7 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
     // AVX2 only.
     ir.vload(b, ptr, simd_w * (dim_t)sizeof(float));
 
-    ir.vfma(acc, a, b);
+    ir.vdot(acc, a, b);
 
     // Instructions appear in the exact order they were built.
     ASSERT_EQ(ir.n_ops(), 5);
@@ -293,7 +293,7 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
     EXPECT_EQ(ir.ops()[1].kind, op_kind_t::vzero);
     EXPECT_EQ(ir.ops()[2].kind, op_kind_t::vload);
     EXPECT_EQ(ir.ops()[3].kind, op_kind_t::vload);
-    EXPECT_EQ(ir.ops()[4].kind, op_kind_t::vfma);
+    EXPECT_EQ(ir.ops()[4].kind, op_kind_t::vdot);
 
     // Register kinds and data type are recorded for the allocator and emitter.
     EXPECT_EQ(ir.vreg_info()[(int)ptr].kind, reg_kind_t::gpr);
@@ -320,7 +320,7 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
     EXPECT_EQ(defs, std::vector<int>({(int)a}));
     EXPECT_EQ(uses, std::vector<int>({(int)ptr}));
 
-    // vfma accumulates in place so the destination is read and written, both
+    // vdot accumulates in place so the destination is read and written, both
     // sources are read.
     ir.def_use(ir.ops()[4], defs, uses);
     EXPECT_EQ(defs, std::vector<int>({(int)acc}));
@@ -407,7 +407,7 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
 
     // then:
     ir.vzero(acc);
-    ir.vfma(acc, a, a); // arbitrary work, just to populate the block
+    ir.vdot(acc, a, a); // arbitrary work, just to populate the block
     ir.jmp(lbl_end);
 
     // else:
@@ -605,7 +605,7 @@ ir_t build_dot_ir() {
     const vreg_t b = ir.new_vec(data_type::f32);
     ir.vload(b, b_ptr, 0);
 
-    ir.vfma(acc, a, b);
+    ir.vdot(acc, a, b);
 
     const vreg_t ws = ir.new_vec(data_type::f32);
     ir.vhreduce(acc, ws);
@@ -660,7 +660,7 @@ TEST(EmitterTests, EmitsValidCodeForSpilledAllocation) {
     for (int r = 0; r < 6; r++) {
         const vreg_t a = ir.new_vec(data_type::f32);
         ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
-        ir.vfma(acc[r], a, b);
+        ir.vdot(acc[r], a, b);
     }
 
     ir_kernel_t k(ir, /*vec_regs_limit=*/4);
@@ -709,7 +709,7 @@ TEST(IntegrationTests, BuildsLoopReduction) {
         ir.vload(a, a_ptr, 0);
         const vreg_t b = ir.new_vec(data_type::f32);
         ir.vload(b, b_ptr, 0);
-        ir.vfma(acc, a, b);
+        ir.vdot(acc, a, b);
     }, [&]() {
         ir.add_imm(a_ptr, simd_w * (dim_t)sizeof(float));
         ir.add_imm(b_ptr, simd_w * (dim_t)sizeof(float));
@@ -761,7 +761,7 @@ ir_t build_shared_vector_dot_ir(int n) {
         const vreg_t a = ir.new_vec(data_type::f32);
         ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
 
-        ir.vfma(acc[r], a, b);
+        ir.vdot(acc[r], a, b);
     }
 
     const vreg_t ws = ir.new_vec(data_type::f32);

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -1,0 +1,226 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "common/c_types_map.hpp"
+
+#include "cpu/x64/ir/ir.hpp"
+
+namespace dnnl {
+
+using namespace impl;
+using namespace impl::cpu::x64;
+using namespace impl::cpu::x64::ir;
+
+// Helpers shared by the tests
+
+// Find the index of the first operation with the given opcode. Otherwise
+// return -1.
+int find_op(const ir_t &ir, op_kind_t op) {
+    for (int i = 0; i < ir.n_ops(); i++)
+        if (ir.ops()[i].kind == op) return i;
+    return -1;
+}
+
+// IR builder tests
+//
+// Checks that the builder records an IR correctly. Operations stay in the right
+// order. Each virtual register has the correct kind and data type. Every
+// operation has the right inputs and outputs. The fused multiply add is an
+// important example. It must treat its accumulator as both read and written or
+// the system would incorrectly think a value is no longer needed even though it
+// is still in use.
+TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
+    ir_t ir {};
+    const int ptr = ir.new_gpr();
+    ir.load_param(ptr, 0);
+
+    const int acc = ir.new_vec(data_type::f32);
+    ir.vzero(acc);
+
+    const int a = ir.new_vec(data_type::f32);
+    ir.vload(a, ptr, 0);
+
+    const int b = ir.new_vec(data_type::f32);
+    // AVX2 only.
+    ir.vload(b, ptr, simd_w * (dim_t)sizeof(float));
+
+    ir.vfma(acc, a, b);
+
+    // Instructions appear in the exact order they were built.
+    ASSERT_EQ(ir.n_ops(), 5);
+    EXPECT_EQ(ir.ops()[0].kind, op_kind_t::load);
+    EXPECT_EQ(ir.ops()[1].kind, op_kind_t::vzero);
+    EXPECT_EQ(ir.ops()[2].kind, op_kind_t::vload);
+    EXPECT_EQ(ir.ops()[3].kind, op_kind_t::vload);
+    EXPECT_EQ(ir.ops()[4].kind, op_kind_t::vfma);
+
+    // Register kinds and data type are recorded for the allocator and emitter.
+    EXPECT_EQ(ir.vreg_info()[ptr].kind, reg_kind_t::gpr);
+    EXPECT_EQ(ir.vreg_info()[ptr].dt, data_type::undef);
+
+    EXPECT_EQ(ir.vreg_info()[a].kind, reg_kind_t::vec);
+    EXPECT_EQ(ir.vreg_info()[a].dt, data_type::f32);
+
+    EXPECT_EQ(ir.vreg_info()[b].kind, reg_kind_t::vec);
+    EXPECT_EQ(ir.vreg_info()[b].dt, data_type::f32);
+
+    EXPECT_EQ(ir.vreg_info()[acc].kind, reg_kind_t::vec);
+    EXPECT_EQ(ir.vreg_info()[acc].dt, data_type::f32);
+
+    std::vector<int> defs, uses;
+
+    // vzero writes its destination and reads nothing.
+    ir.def_use(ir.ops()[1], defs, uses);
+    EXPECT_EQ(defs, std::vector<int>({acc}));
+    EXPECT_TRUE(uses.empty());
+
+    // vload reads the base pointer and writes the loaded vector.
+    ir.def_use(ir.ops()[2], defs, uses);
+    EXPECT_EQ(defs, std::vector<int>({a}));
+    EXPECT_EQ(uses, std::vector<int>({ptr}));
+
+    // vfma accumulates in place so the destination is read and written, both
+    // sources are read.
+    ir.def_use(ir.ops()[4], defs, uses);
+    EXPECT_EQ(defs, std::vector<int>({acc}));
+    ASSERT_EQ(uses.size(), 3u);
+    EXPECT_NE(std::find(uses.begin(), uses.end(), a), uses.end());
+    EXPECT_NE(std::find(uses.begin(), uses.end(), b), uses.end());
+    EXPECT_NE(std::find(uses.begin(), uses.end(), acc), uses.end());
+}
+
+// Validates loop construction. A real loop links its end back to its begin and
+// shares one counter register, while a loop that would run only once is inlined
+// rather than emitted as a branch that is never taken.
+TEST(IRBuilderTests, LoopLinkageAndSingleIterationInlining) {
+    {
+        ir_t ir {};
+        const int acc = ir.new_gpr();
+        ir.mov_imm(acc, 0);
+        emit_loop_imm(ir, 4, [&]() { ir.add_imm(acc, 1); });
+
+        const int begin = find_op(ir, op_kind_t::loop_begin);
+        const int end = find_op(ir, op_kind_t::loop_end);
+        ASSERT_NE(begin, -1);
+        ASSERT_NE(end, -1);
+
+        // The back-edge is linked and the body sits between the two markers.
+        EXPECT_EQ(ir.ops()[end].match, begin);
+        EXPECT_LT(begin, end);
+        // loop_begin and loop_end operate on the same counter register.
+        EXPECT_EQ(ir.ops()[begin].dst, ir.ops()[end].dst);
+        // The counter is a general-purpose register created for the loop.
+        EXPECT_EQ(ir.vreg_info()[ir.ops()[begin].dst].kind, reg_kind_t::gpr);
+    }
+
+    {
+        // A single-iteration loop is inlined so no loop markers are emitted.
+        ir_t ir {};
+        const int acc = ir.new_gpr();
+        ir.mov_imm(acc, 0);
+        emit_loop_imm(ir, 1, [&]() { ir.add_imm(acc, 1); });
+
+        EXPECT_EQ(find_op(ir, op_kind_t::loop_begin), -1);
+        EXPECT_EQ(find_op(ir, op_kind_t::loop_end), -1);
+        EXPECT_EQ(ir.n_ops(), 2);
+    }
+}
+
+// Validates that an if/else is well-formed. Labels are distinct and bound, and
+// each jump targets the right label. This proves the forward-edge control flow
+// is constructed correctly.
+TEST(IRBuilderTests, ForwardEdgeControlFlow) {
+    ir_t ir {};
+
+    const int cond = ir.new_gpr();
+    ir.load_param(cond, 0);
+
+    const int a = ir.new_vec(data_type::f32);
+    const int acc = ir.new_vec(data_type::f32);
+
+    const int base = ir.new_gpr();
+
+    ir.load_param(base, sizeof(int));
+    ir.vload(a, base, 0);
+
+    const int lbl_else = ir.new_label();
+    const int lbl_end = ir.new_label();
+
+    // Build an IR for the following control flow:
+    //
+    //     if (cond != 0) { acc += a * a; }  // then block
+    //     else           { acc = 0; }       // else block
+    //
+    // which lowers to a forward-branch skeleton:
+    //
+    //     jz cond -> else      ; fall through to 'then' when cond != 0
+    //   then:
+    //     ...work...
+    //     jmp -> end           ; skip the else block
+    //   else:
+    //     ...
+    //   end:
+
+    ir.jz(cond, lbl_else);
+
+    // then:
+    ir.vzero(acc);
+    ir.vfma(acc, a, a); // arbitrary work, just to populate the block
+    ir.jmp(lbl_end);
+
+    // else:
+    ir.label(lbl_else);
+    ir.vzero(acc);
+
+    // end:
+    ir.label(lbl_end);
+
+    // The two labels have distinct ids.
+    EXPECT_NE(lbl_else, lbl_end);
+    EXPECT_EQ(ir.n_labels(), 2);
+
+    // Every branch target points to a label that exists in the IR.
+    std::vector<int> bound(ir.n_labels(), -1);
+    for (int i = 0; i < ir.n_ops(); i++) {
+        if (ir.ops()[i].kind == op_kind_t::label) {
+            // Save the position of the label (`i`).
+            bound[(int)ir.ops()[i].imm] = i;
+        }
+    }
+    // >= 0 means it's bound.
+    EXPECT_GE(bound[lbl_else], -1);
+    EXPECT_GE(bound[lbl_end], -1);
+
+    const int jz_idx = find_op(ir, op_kind_t::jz);
+    const int jmp_idx = find_op(ir, op_kind_t::jmp);
+    ASSERT_NE(jz_idx, -1);
+    ASSERT_NE(jmp_idx, -1);
+
+    // The conditional jump targets the else label. The unconditional jump jumps
+    // over the else block to the end label.
+    EXPECT_EQ(ir.ops()[jz_idx].imm, lbl_else);
+    EXPECT_EQ(ir.ops()[jmp_idx].imm, lbl_end);
+
+    // The then block's jmp precedes the else label it jumps over.
+    EXPECT_LT(jmp_idx, bound[lbl_else]);
+}
+
+} // namespace dnnl

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -271,7 +271,7 @@ private:
 // the system would incorrectly think a value is no longer needed even though it
 // is still in use.
 TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
-    ir_t ir {};
+    ir_t ir;
     const vreg_t ptr = ir.new_gpr();
     ir.load_param(ptr, 0);
 
@@ -335,7 +335,7 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
 // rather than emitted as a branch that is never taken.
 TEST(IRBuilderTests, LoopLinkageAndSingleIterationInlining) {
     {
-        ir_t ir {};
+        ir_t ir;
         const vreg_t acc = ir.new_gpr();
         ir.mov_imm(acc, 0);
         emit_loop_imm(ir, 4, [&]() { ir.add_imm(acc, 1); });
@@ -357,7 +357,7 @@ TEST(IRBuilderTests, LoopLinkageAndSingleIterationInlining) {
 
     {
         // A single-iteration loop is inlined so no loop markers are emitted.
-        ir_t ir {};
+        ir_t ir;
         const vreg_t acc = ir.new_gpr();
         ir.mov_imm(acc, 0);
         emit_loop_imm(ir, 1, [&]() { ir.add_imm(acc, 1); });
@@ -372,7 +372,7 @@ TEST(IRBuilderTests, LoopLinkageAndSingleIterationInlining) {
 // each jump targets the right label. This proves the forward-edge control flow
 // is constructed correctly.
 TEST(IRBuilderTests, ForwardEdgeControlFlow) {
-    ir_t ir {};
+    ir_t ir;
 
     const vreg_t cond = ir.new_gpr();
     ir.load_param(cond, 0);
@@ -486,7 +486,7 @@ TEST(AllocatorTests, DoesNotDoubleAllocateSimultaneouslyLiveValues) {
 // needed gives up its register, which is then used by a later temporary.
 // A value that is still in use keeps its own register.
 TEST(AllocatorTests, ReusesRegisterOfExpiredTemporary) {
-    ir_t ir {};
+    ir_t ir;
 
     const vreg_t acc = ir.new_gpr();
     ir.mov_imm(acc, 0);
@@ -584,7 +584,7 @@ TEST(AllocatorTests, AllocatesDeterministically) {
 // Builds a small reduction IR (dot product of one vector pair) used by the
 // emitter and integration tests.
 ir_t build_dot_ir() {
-    ir_t ir {};
+    ir_t ir;
 
     // Load pointers for a, b, c.
     const vreg_t a_ptr = ir.new_gpr();
@@ -640,7 +640,7 @@ TEST(EmitterTests, EmitsValidCodeForSpilledAllocation) {
 
     // Six independent accumulators plus temporaries exceed a four-register
     // vector file, so the allocator must spill.
-    ir_t ir {};
+    ir_t ir;
 
     const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, 0);
@@ -689,7 +689,7 @@ TEST(IntegrationTests, BuildsLoopReduction) {
     constexpr int k_blocks = 2;
     constexpr int k = k_blocks * simd_w; // 16 elements
 
-    ir_t ir {};
+    ir_t ir;
 
     const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, offsetof(dot_args_t, a));
@@ -738,7 +738,7 @@ TEST(IntegrationTests, BuildsLoopReduction) {
 // Computes a dot product where one vector is multiplied by n vectors into
 // n independent accumulators, each of which is reduced and stored.
 ir_t build_shared_vector_dot_ir(int n) {
-    ir_t ir {};
+    ir_t ir;
 
     const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, offsetof(dot_args_t, a));
@@ -831,7 +831,7 @@ struct select_args_t {
 TEST(IntegrationTests, BranchSelectsCorrectValue) {
     SKIP_IF_NO_AVX2();
 
-    ir_t ir {};
+    ir_t ir;
 
     const vreg_t cond = ir.new_gpr();
     ir.load_param(cond, offsetof(select_args_t, cond));

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -384,8 +384,8 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
     ir.load_param(base, sizeof(int));
     ir.vload(a, base, 0);
 
-    const int lbl_else = ir.new_label();
-    const int lbl_end = ir.new_label();
+    const label_t lbl_else = ir.new_label();
+    const label_t lbl_end = ir.new_label();
 
     // Build an IR for the following control flow:
     //
@@ -425,12 +425,13 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
     for (int i = 0; i < ir.n_ops(); i++) {
         if (ir.ops()[i].kind == op_kind_t::label) {
             // Save the position of the label (`i`).
-            bound[ir.ops()[i].label_id] = i;
+            bound[(int)ir.ops()[i].label_id] = i;
         }
     }
-    // >= 0 means it's bound.
-    EXPECT_GE(bound[lbl_else], -1);
-    EXPECT_GE(bound[lbl_end], -1);
+
+    // != -1 means it's bound.
+    EXPECT_NE(bound[(int)lbl_else], -1);
+    EXPECT_NE(bound[(int)lbl_end], -1);
 
     const int jz_idx = find_op(ir, op_kind_t::jz);
     const int jmp_idx = find_op(ir, op_kind_t::jmp);
@@ -443,7 +444,7 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
     EXPECT_EQ(ir.ops()[jmp_idx].label_id, lbl_end);
 
     // The then block's jmp precedes the else label it jumps over.
-    EXPECT_LT(jmp_idx, bound[lbl_else]);
+    EXPECT_LT(jmp_idx, bound[(int)lbl_else]);
 
     // The IR that contains branches can be handled by the allocator.
     // It assigns a location to every value that is read somewhere.
@@ -848,8 +849,8 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     const int b = ir.new_vec(data_type::f32);
     ir.vload(b, b_ptr, 0);
 
-    const int lbl_else = ir.new_label();
-    const int lbl_end = ir.new_label();
+    const label_t lbl_else = ir.new_label();
+    const label_t lbl_end = ir.new_label();
 
     //     if (cond != 0) { c = a; }  // then block
     //     else           { c = b; }  // else block

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -143,10 +143,10 @@ void expect_no_reg_conflicts(const ir_t &ir, const reg_pools_t &pools,
 // exercise register allocation and spilling.
 ir_t build_gpr_live_set(int live_set_size) {
     ir_t ir;
-    const int acc = ir.new_gpr();
+    const vreg_t acc = ir.new_gpr();
     ir.mov_imm(acc, 0);
 
-    std::vector<int> live_set(live_set_size);
+    std::vector<vreg_t> live_set(live_set_size, vreg_t::none);
     for (int i = 0; i < live_set_size; i++) {
         live_set[i] = ir.new_gpr();
         ir.mov_imm(live_set[i], i + 1);
@@ -272,16 +272,16 @@ private:
 // is still in use.
 TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
     ir_t ir {};
-    const int ptr = ir.new_gpr();
+    const vreg_t ptr = ir.new_gpr();
     ir.load_param(ptr, 0);
 
-    const int acc = ir.new_vec(data_type::f32);
+    const vreg_t acc = ir.new_vec(data_type::f32);
     ir.vzero(acc);
 
-    const int a = ir.new_vec(data_type::f32);
+    const vreg_t a = ir.new_vec(data_type::f32);
     ir.vload(a, ptr, 0);
 
-    const int b = ir.new_vec(data_type::f32);
+    const vreg_t b = ir.new_vec(data_type::f32);
     // AVX2 only.
     ir.vload(b, ptr, simd_w * (dim_t)sizeof(float));
 
@@ -296,38 +296,38 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
     EXPECT_EQ(ir.ops()[4].kind, op_kind_t::vfma);
 
     // Register kinds and data type are recorded for the allocator and emitter.
-    EXPECT_EQ(ir.vreg_info()[ptr].kind, reg_kind_t::gpr);
-    EXPECT_EQ(ir.vreg_info()[ptr].dt, data_type::undef);
+    EXPECT_EQ(ir.vreg_info()[(int)ptr].kind, reg_kind_t::gpr);
+    EXPECT_EQ(ir.vreg_info()[(int)ptr].dt, data_type::undef);
 
-    EXPECT_EQ(ir.vreg_info()[a].kind, reg_kind_t::vec);
-    EXPECT_EQ(ir.vreg_info()[a].dt, data_type::f32);
+    EXPECT_EQ(ir.vreg_info()[(int)a].kind, reg_kind_t::vec);
+    EXPECT_EQ(ir.vreg_info()[(int)a].dt, data_type::f32);
 
-    EXPECT_EQ(ir.vreg_info()[b].kind, reg_kind_t::vec);
-    EXPECT_EQ(ir.vreg_info()[b].dt, data_type::f32);
+    EXPECT_EQ(ir.vreg_info()[(int)b].kind, reg_kind_t::vec);
+    EXPECT_EQ(ir.vreg_info()[(int)b].dt, data_type::f32);
 
-    EXPECT_EQ(ir.vreg_info()[acc].kind, reg_kind_t::vec);
-    EXPECT_EQ(ir.vreg_info()[acc].dt, data_type::f32);
+    EXPECT_EQ(ir.vreg_info()[(int)acc].kind, reg_kind_t::vec);
+    EXPECT_EQ(ir.vreg_info()[(int)acc].dt, data_type::f32);
 
     std::vector<int> defs, uses;
 
     // vzero writes its destination and reads nothing.
     ir.def_use(ir.ops()[1], defs, uses);
-    EXPECT_EQ(defs, std::vector<int>({acc}));
+    EXPECT_EQ(defs, std::vector<int>({(int)acc}));
     EXPECT_TRUE(uses.empty());
 
     // vload reads the base pointer and writes the loaded vector.
     ir.def_use(ir.ops()[2], defs, uses);
-    EXPECT_EQ(defs, std::vector<int>({a}));
-    EXPECT_EQ(uses, std::vector<int>({ptr}));
+    EXPECT_EQ(defs, std::vector<int>({(int)a}));
+    EXPECT_EQ(uses, std::vector<int>({(int)ptr}));
 
     // vfma accumulates in place so the destination is read and written, both
     // sources are read.
     ir.def_use(ir.ops()[4], defs, uses);
-    EXPECT_EQ(defs, std::vector<int>({acc}));
+    EXPECT_EQ(defs, std::vector<int>({(int)acc}));
     ASSERT_EQ(uses.size(), 3u);
-    EXPECT_NE(std::find(uses.begin(), uses.end(), a), uses.end());
-    EXPECT_NE(std::find(uses.begin(), uses.end(), b), uses.end());
-    EXPECT_NE(std::find(uses.begin(), uses.end(), acc), uses.end());
+    EXPECT_NE(std::find(uses.begin(), uses.end(), (int)a), uses.end());
+    EXPECT_NE(std::find(uses.begin(), uses.end(), (int)b), uses.end());
+    EXPECT_NE(std::find(uses.begin(), uses.end(), (int)acc), uses.end());
 }
 
 // Validates loop construction. A real loop links its end back to its begin and
@@ -336,7 +336,7 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
 TEST(IRBuilderTests, LoopLinkageAndSingleIterationInlining) {
     {
         ir_t ir {};
-        const int acc = ir.new_gpr();
+        const vreg_t acc = ir.new_gpr();
         ir.mov_imm(acc, 0);
         emit_loop_imm(ir, 4, [&]() { ir.add_imm(acc, 1); });
 
@@ -351,13 +351,14 @@ TEST(IRBuilderTests, LoopLinkageAndSingleIterationInlining) {
         // loop_begin and loop_end operate on the same counter register.
         EXPECT_EQ(ir.ops()[begin].dst, ir.ops()[end].dst);
         // The counter is a general-purpose register created for the loop.
-        EXPECT_EQ(ir.vreg_info()[ir.ops()[begin].dst].kind, reg_kind_t::gpr);
+        EXPECT_EQ(
+                ir.vreg_info()[(int)ir.ops()[begin].dst].kind, reg_kind_t::gpr);
     }
 
     {
         // A single-iteration loop is inlined so no loop markers are emitted.
         ir_t ir {};
-        const int acc = ir.new_gpr();
+        const vreg_t acc = ir.new_gpr();
         ir.mov_imm(acc, 0);
         emit_loop_imm(ir, 1, [&]() { ir.add_imm(acc, 1); });
 
@@ -373,13 +374,13 @@ TEST(IRBuilderTests, LoopLinkageAndSingleIterationInlining) {
 TEST(IRBuilderTests, ForwardEdgeControlFlow) {
     ir_t ir {};
 
-    const int cond = ir.new_gpr();
+    const vreg_t cond = ir.new_gpr();
     ir.load_param(cond, 0);
 
-    const int a = ir.new_vec(data_type::f32);
-    const int acc = ir.new_vec(data_type::f32);
+    const vreg_t a = ir.new_vec(data_type::f32);
+    const vreg_t acc = ir.new_vec(data_type::f32);
 
-    const int base = ir.new_gpr();
+    const vreg_t base = ir.new_gpr();
 
     ir.load_param(base, sizeof(int));
     ir.vload(a, base, 0);
@@ -453,8 +454,8 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
     // All virtual registers have been assigned.
     ASSERT_EQ((int)res.assignments.size(), ir.n_vregs());
 
-    for (int v : {cond, base, a, acc}) {
-        const assignment_t &as = res.assignments[v];
+    for (vreg_t v : {cond, base, a, acc}) {
+        const assignment_t &as = res.assignments[(int)v];
         // Each value is either spilled or has a physical register assigned.
         EXPECT_TRUE(as.spilled || as.phys >= 0);
     }
@@ -487,14 +488,14 @@ TEST(AllocatorTests, DoesNotDoubleAllocateSimultaneouslyLiveValues) {
 TEST(AllocatorTests, ReusesRegisterOfExpiredTemporary) {
     ir_t ir {};
 
-    const int acc = ir.new_gpr();
+    const vreg_t acc = ir.new_gpr();
     ir.mov_imm(acc, 0);
 
-    const int t0 = ir.new_gpr();
+    const vreg_t t0 = ir.new_gpr();
     ir.mov_imm(t0, 5);
     ir.add_reg(acc, t0); // t0 dies here
 
-    const int t1 = ir.new_gpr();
+    const vreg_t t1 = ir.new_gpr();
     ir.mov_imm(t1, 7);
     ir.add_reg(acc, t1); // t1 is used only after t0 is dead
 
@@ -504,12 +505,12 @@ TEST(AllocatorTests, ReusesRegisterOfExpiredTemporary) {
     const reg_alloc_result_t res = allocate_registers(ir, pools);
 
     EXPECT_FALSE(res.any_spill);
-    EXPECT_FALSE(res.assignments[t0].spilled);
-    EXPECT_FALSE(res.assignments[t1].spilled);
+    EXPECT_FALSE(res.assignments[(int)t0].spilled);
+    EXPECT_FALSE(res.assignments[(int)t1].spilled);
     // t0 and t1 reuse the same physical register.
-    EXPECT_EQ(res.assignments[t0].phys, res.assignments[t1].phys);
+    EXPECT_EQ(res.assignments[(int)t0].phys, res.assignments[(int)t1].phys);
     // The accumulator, live across both, does not collide with them.
-    EXPECT_NE(res.assignments[acc].phys, res.assignments[t0].phys);
+    EXPECT_NE(res.assignments[(int)acc].phys, res.assignments[(int)t0].phys);
 }
 
 // Checks allocator behavior under register pressure. If the pool doesn't have
@@ -586,31 +587,31 @@ ir_t build_dot_ir() {
     ir_t ir {};
 
     // Load pointers for a, b, c.
-    const int a_ptr = ir.new_gpr();
+    const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, 0);
 
-    const int b_ptr = ir.new_gpr();
+    const vreg_t b_ptr = ir.new_gpr();
     ir.load_param(b_ptr, sizeof(void *));
 
-    const int c_ptr = ir.new_gpr();
+    const vreg_t c_ptr = ir.new_gpr();
     ir.load_param(c_ptr, 2 * sizeof(void *));
 
-    const int acc = ir.new_vec(data_type::f32);
+    const vreg_t acc = ir.new_vec(data_type::f32);
     ir.vzero(acc);
 
-    const int a = ir.new_vec(data_type::f32);
+    const vreg_t a = ir.new_vec(data_type::f32);
     ir.vload(a, a_ptr, 0);
 
-    const int b = ir.new_vec(data_type::f32);
+    const vreg_t b = ir.new_vec(data_type::f32);
     ir.vload(b, b_ptr, 0);
 
     ir.vfma(acc, a, b);
 
-    const int ws = ir.new_vec(data_type::f32);
+    const vreg_t ws = ir.new_vec(data_type::f32);
     ir.vhreduce(acc, ws);
 
     // store the reduced scalar
-    ir.vstore_masked(c_ptr, 0, acc, -1, 1);
+    ir.vstore_masked(c_ptr, 0, acc, vreg_t::none, 1);
 
     return ir;
 }
@@ -641,23 +642,23 @@ TEST(EmitterTests, EmitsValidCodeForSpilledAllocation) {
     // vector file, so the allocator must spill.
     ir_t ir {};
 
-    const int a_ptr = ir.new_gpr();
+    const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, 0);
 
-    const int b_ptr = ir.new_gpr();
+    const vreg_t b_ptr = ir.new_gpr();
     ir.load_param(b_ptr, sizeof(void *));
 
-    const int b = ir.new_vec(data_type::f32);
+    const vreg_t b = ir.new_vec(data_type::f32);
     ir.vload(b, b_ptr, 0);
 
-    std::vector<int> acc(6);
+    std::vector<vreg_t> acc(6, vreg_t::none);
     for (int r = 0; r < 6; r++) {
         acc[r] = ir.new_vec(data_type::f32);
         ir.vzero(acc[r]);
     }
 
     for (int r = 0; r < 6; r++) {
-        const int a = ir.new_vec(data_type::f32);
+        const vreg_t a = ir.new_vec(data_type::f32);
         ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
         ir.vfma(acc[r], a, b);
     }
@@ -690,23 +691,23 @@ TEST(IntegrationTests, BuildsLoopReduction) {
 
     ir_t ir {};
 
-    const int a_ptr = ir.new_gpr();
+    const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, offsetof(dot_args_t, a));
 
-    const int b_ptr = ir.new_gpr();
+    const vreg_t b_ptr = ir.new_gpr();
     ir.load_param(b_ptr, offsetof(dot_args_t, b));
 
-    const int c_ptr = ir.new_gpr();
+    const vreg_t c_ptr = ir.new_gpr();
     ir.load_param(c_ptr, offsetof(dot_args_t, c));
 
-    const int acc = ir.new_vec(data_type::f32);
+    const vreg_t acc = ir.new_vec(data_type::f32);
     ir.vzero(acc);
 
     // Reduce one simd_w-wide chunk per iteration and advance the pointers.
     emit_loop_imm(ir, k_blocks, [&]() {
-        const int a = ir.new_vec(data_type::f32);
+        const vreg_t a = ir.new_vec(data_type::f32);
         ir.vload(a, a_ptr, 0);
-        const int b = ir.new_vec(data_type::f32);
+        const vreg_t b = ir.new_vec(data_type::f32);
         ir.vload(b, b_ptr, 0);
         ir.vfma(acc, a, b);
     }, [&]() {
@@ -714,9 +715,9 @@ TEST(IntegrationTests, BuildsLoopReduction) {
         ir.add_imm(b_ptr, simd_w * (dim_t)sizeof(float));
     });
 
-    const int ws = ir.new_vec(data_type::f32);
+    const vreg_t ws = ir.new_vec(data_type::f32);
     ir.vhreduce(acc, ws);
-    ir.vstore_masked(c_ptr, 0, acc, -1, 1);
+    ir.vstore_masked(c_ptr, 0, acc, vreg_t::none, 1);
 
     ir_kernel_t kernel(ir);
     ASSERT_TRUE(kernel.run_ir_pipeline());
@@ -739,36 +740,37 @@ TEST(IntegrationTests, BuildsLoopReduction) {
 ir_t build_shared_vector_dot_ir(int n) {
     ir_t ir {};
 
-    const int a_ptr = ir.new_gpr();
+    const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, offsetof(dot_args_t, a));
 
-    const int b_ptr = ir.new_gpr();
+    const vreg_t b_ptr = ir.new_gpr();
     ir.load_param(b_ptr, offsetof(dot_args_t, b));
 
-    const int c_ptr = ir.new_gpr();
+    const vreg_t c_ptr = ir.new_gpr();
     ir.load_param(c_ptr, offsetof(dot_args_t, c));
 
-    const int b = ir.new_vec(data_type::f32);
+    const vreg_t b = ir.new_vec(data_type::f32);
     // Load shared vector.
     ir.vload(b, b_ptr, 0);
 
-    std::vector<int> acc(n);
+    std::vector<vreg_t> acc(n, vreg_t::none);
     for (int r = 0; r < n; r++) {
         acc[r] = ir.new_vec(data_type::f32);
         ir.vzero(acc[r]);
 
-        const int a = ir.new_vec(data_type::f32);
+        const vreg_t a = ir.new_vec(data_type::f32);
         ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
 
         ir.vfma(acc[r], a, b);
     }
 
-    const int ws = ir.new_vec(data_type::f32);
+    const vreg_t ws = ir.new_vec(data_type::f32);
     for (int r = 0; r < n; r++)
         ir.vhreduce(acc[r], ws);
 
     for (int r = 0; r < n; r++)
-        ir.vstore_masked(c_ptr, r * (dim_t)sizeof(float), acc[r], -1, 1);
+        ir.vstore_masked(
+                c_ptr, r * (dim_t)sizeof(float), acc[r], vreg_t::none, 1);
 
     return ir;
 }
@@ -831,22 +833,22 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
 
     ir_t ir {};
 
-    const int cond = ir.new_gpr();
+    const vreg_t cond = ir.new_gpr();
     ir.load_param(cond, offsetof(select_args_t, cond));
 
-    const int a_ptr = ir.new_gpr();
+    const vreg_t a_ptr = ir.new_gpr();
     ir.load_param(a_ptr, offsetof(select_args_t, a));
 
-    const int b_ptr = ir.new_gpr();
+    const vreg_t b_ptr = ir.new_gpr();
     ir.load_param(b_ptr, offsetof(select_args_t, b));
 
-    const int c_ptr = ir.new_gpr();
+    const vreg_t c_ptr = ir.new_gpr();
     ir.load_param(c_ptr, offsetof(select_args_t, c));
 
-    const int a = ir.new_vec(data_type::f32);
+    const vreg_t a = ir.new_vec(data_type::f32);
     ir.vload(a, a_ptr, 0);
 
-    const int b = ir.new_vec(data_type::f32);
+    const vreg_t b = ir.new_vec(data_type::f32);
     ir.vload(b, b_ptr, 0);
 
     const label_t lbl_else = ir.new_label();
@@ -865,10 +867,10 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     //     store b -> c
     //   end:
     ir.jz(cond, lbl_else);
-    ir.vstore_masked(c_ptr, 0, a, -1, simd_w); // then: c = a
+    ir.vstore_masked(c_ptr, 0, a, vreg_t::none, simd_w); // then: c = a
     ir.jmp(lbl_end);
     ir.label(lbl_else);
-    ir.vstore_masked(c_ptr, 0, b, -1, simd_w); // else: c = b
+    ir.vstore_masked(c_ptr, 0, b, vreg_t::none, simd_w); // else: c = b
     ir.label(lbl_end);
 
     ir_kernel_t kernel(ir);

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -425,7 +425,7 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
     for (int i = 0; i < ir.n_ops(); i++) {
         if (ir.ops()[i].kind == op_kind_t::label) {
             // Save the position of the label (`i`).
-            bound[(int)ir.ops()[i].imm] = i;
+            bound[ir.ops()[i].label_id] = i;
         }
     }
     // >= 0 means it's bound.
@@ -439,8 +439,8 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
 
     // The conditional jump targets the else label. The unconditional jump jumps
     // over the else block to the end label.
-    EXPECT_EQ(ir.ops()[jz_idx].imm, lbl_else);
-    EXPECT_EQ(ir.ops()[jmp_idx].imm, lbl_end);
+    EXPECT_EQ(ir.ops()[jz_idx].label_id, lbl_else);
+    EXPECT_EQ(ir.ops()[jmp_idx].label_id, lbl_end);
 
     // The then block's jmp precedes the else label it jumps over.
     EXPECT_LT(jmp_idx, bound[lbl_else]);

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -22,8 +22,11 @@
 
 #include "common/c_types_map.hpp"
 
+#include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/ir/ir.hpp"
 #include "cpu/x64/ir/reg_alloc.hpp"
+#include "cpu/x64/ir/reg_config.hpp"
+#include "cpu/x64/jit_generator.hpp"
 
 namespace dnnl {
 
@@ -31,7 +34,15 @@ using namespace impl;
 using namespace impl::cpu::x64;
 using namespace impl::cpu::x64::ir;
 
+// Tests that require generating a kernel require AVX2.
+#define SKIP_IF_NO_AVX2() \
+    do { \
+        if (!mayiuse(avx2)) GTEST_SKIP() << "IR emitter require AVX2"; \
+    } while (0)
+
 // Helpers shared by the tests
+
+constexpr int simd_w = 8;
 
 // Build a register pool with `n_gpr` GPRs plus all available vector registers.
 reg_pools_t make_pools(int n_gpr) {
@@ -153,6 +164,103 @@ int find_op(const ir_t &ir, op_kind_t op) {
         if (ir.ops()[i].kind == op) return i;
     return -1;
 }
+
+// Reference dot product over `n` f32 elements.
+float ref_dot(const float *a, const float *b, int n) {
+    float acc = 0.f;
+    for (int i = 0; i < n; i++)
+        acc += a[i] * b[i];
+    return acc;
+}
+
+// IR-based kernel.
+class ir_kernel_t : public impl::cpu::x64::jit_generator_t {
+public:
+    ir_kernel_t(ir_t ir, int vec_regs_limit = -1)
+        // Only AVX2 is currently supported.
+        : jit_generator_t("ir_run_kernel", cpu::x64::avx2)
+        , ir_(std::move(ir))
+        , vec_regs_limit_(vec_regs_limit) {}
+
+    const char *name() const override { return "ir_kernel"; }
+    const char *source_file() const override { return __FILE__; }
+
+    // Build and finalize the code. Return false on any Xbyak error.
+    bool run_ir_pipeline() {
+        generate();
+        this->ready();
+        return Xbyak::GetError() == Xbyak::ERR_NONE;
+    }
+
+    // Get generated code.
+    const uint8_t *code_ptr() { return this->Xbyak::CodeGenerator::getCode(); }
+    // Get generated code size.
+    size_t code_size() { return this->Xbyak::CodeGenerator::getSize(); }
+
+    // Calls the generated kernel.
+    template <typename arg_t>
+    void run(const arg_t *args) {
+        auto fn = reinterpret_cast<void (*)(const arg_t *)>(
+                const_cast<uint8_t *>(code_ptr()));
+        fn(args);
+    }
+
+    // Allocation outcome. Becomes valid after `run_ir_pipeline()`.
+    //
+    // True if the generated kernel has any spills.
+    bool spilled() const { return spilled_; }
+    // The stack size required by the allocator for spilling.
+    size_t stack_size() const { return stack_size_; }
+
+protected:
+    void generate() override {
+        const int rsp_idx = Xbyak::Operand::RSP;
+        const int param_idx = abi_param1.getIdx();
+
+        // Scratch registers the emitter reserves for spill handling. They are
+        // not part of the register pool. The indices of the registers are
+        // irrelevant. Should work fine for AVX2 and AVX-512.
+        const int gpr_scratch0 = 10, gpr_scratch1 = 11;
+        const int vec_scratch0 = 13, vec_scratch1 = 14, vec_scratch2 = 15;
+
+        reg_config_t reg_cfg = make_reg_config(avx2, param_idx, rsp_idx,
+                {gpr_scratch0, gpr_scratch1},
+                {vec_scratch0, vec_scratch1, vec_scratch2});
+
+        // Shrink the vector register pool to force spills when requested.
+        if (vec_regs_limit_ >= 0) {
+            const int vec_reg_pool_idx = 1;
+            auto &vec_regs = reg_cfg.pools.files[vec_reg_pool_idx].regs;
+            if ((int)vec_regs.size() > vec_regs_limit_)
+                vec_regs.resize(vec_regs_limit_);
+        }
+
+        // Run allocator.
+        const reg_alloc_result_t alloc = allocate_registers(ir_, reg_cfg.pools);
+        spilled_ = alloc.any_spill;
+        stack_size_ = alloc.frame_bytes;
+
+        preamble();
+
+        const int frame = (int)utils::rnd_up(alloc.frame_bytes, 16);
+        if (frame > 0) sub(rsp, frame);
+
+        data_section_t data;
+        emit(*this, ir_, alloc, reg_cfg, data);
+
+        if (frame > 0) add(rsp, frame);
+
+        postamble();
+
+        emit_data_section(*this, data);
+    }
+
+private:
+    ir_t ir_ {};
+    int vec_regs_limit_ = 0;
+    bool spilled_ = false;
+    size_t stack_size_ = 0;
+};
 
 // IR builder tests
 //
@@ -467,6 +575,322 @@ TEST(AllocatorTests, AllocatesDeterministically) {
         EXPECT_EQ(a.assignments[v].phys, b.assignments[v].phys);
         EXPECT_EQ(a.assignments[v].slot, b.assignments[v].slot);
     }
+}
+
+// Emitter tests
+//
+// Builds a small reduction IR (dot product of one vector pair) used by the
+// emitter and integration tests.
+ir_t build_dot_ir() {
+    ir_t ir {};
+
+    // Load pointers for a, b, c.
+    const int a_ptr = ir.new_gpr();
+    ir.load_param(a_ptr, 0);
+
+    const int b_ptr = ir.new_gpr();
+    ir.load_param(b_ptr, sizeof(void *));
+
+    const int c_ptr = ir.new_gpr();
+    ir.load_param(c_ptr, 2 * sizeof(void *));
+
+    const int acc = ir.new_vec(data_type::f32);
+    ir.vzero(acc);
+
+    const int a = ir.new_vec(data_type::f32);
+    ir.vload(a, a_ptr, 0);
+
+    const int b = ir.new_vec(data_type::f32);
+    ir.vload(b, b_ptr, 0);
+
+    ir.vfma(acc, a, b);
+
+    const int ws = ir.new_vec(data_type::f32);
+    ir.vhreduce(acc, ws);
+
+    // store the reduced scalar
+    ir.vstore_masked(c_ptr, 0, acc, -1, 1);
+
+    return ir;
+}
+
+// Validates emitter determinism. Emitting the same program twice produces
+// byte-for-byte identical machine code. The encoding is position independent
+// (relative branches, rip-relative constants), so equal bytes is a valid check.
+TEST(EmitterTests, EmitsDeterministicCodeForIdenticalIr) {
+    SKIP_IF_NO_AVX2();
+    ir_kernel_t k1(build_dot_ir());
+    ir_kernel_t k2(build_dot_ir());
+
+    ASSERT_TRUE(k1.run_ir_pipeline());
+    ASSERT_TRUE(k2.run_ir_pipeline());
+
+    ASSERT_GT(k1.code_size(), 0u);
+    ASSERT_EQ(k1.code_size(), k2.code_size());
+    EXPECT_EQ(0, std::memcmp(k1.code_ptr(), k2.code_ptr(), k1.code_size()));
+}
+
+// Validates the emitter's spill path. When the allocation spills, the
+// reload-compute-store sequence must lower with no assembler error, and a stack
+// frame must be reserved for the spilled values.
+TEST(EmitterTests, EmitsValidCodeForSpilledAllocation) {
+    SKIP_IF_NO_AVX2();
+
+    // Six independent accumulators plus temporaries exceed a four-register
+    // vector file, so the allocator must spill.
+    ir_t ir {};
+
+    const int a_ptr = ir.new_gpr();
+    ir.load_param(a_ptr, 0);
+
+    const int b_ptr = ir.new_gpr();
+    ir.load_param(b_ptr, sizeof(void *));
+
+    const int b = ir.new_vec(data_type::f32);
+    ir.vload(b, b_ptr, 0);
+
+    std::vector<int> acc(6);
+    for (int r = 0; r < 6; r++) {
+        acc[r] = ir.new_vec(data_type::f32);
+        ir.vzero(acc[r]);
+    }
+
+    for (int r = 0; r < 6; r++) {
+        const int a = ir.new_vec(data_type::f32);
+        ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
+        ir.vfma(acc[r], a, b);
+    }
+
+    ir_kernel_t k(ir, /*vec_regs_limit=*/4);
+    ASSERT_TRUE(k.run_ir_pipeline());
+    EXPECT_TRUE(k.spilled());
+    EXPECT_GT(k.stack_size(), 0u);
+    EXPECT_GT(k.code_size(), 0u);
+}
+
+// Integration tests
+
+// Arguments for the dot-product kernels.
+struct dot_args_t {
+    const float *a;
+    const float *b;
+    float *c;
+};
+
+// Pipeline test. A dot product over sixteen elements, expressed as a
+// two-iteration loop, is built, allocated, emitted, run, and checked against
+// a reference. Passing it means the whole pipeline computes the right number,
+// including loop control flow and values kept live across the back-edge.
+TEST(IntegrationTests, BuildsLoopReduction) {
+    SKIP_IF_NO_AVX2();
+
+    constexpr int k_blocks = 2;
+    constexpr int k = k_blocks * simd_w; // 16 elements
+
+    ir_t ir {};
+
+    const int a_ptr = ir.new_gpr();
+    ir.load_param(a_ptr, offsetof(dot_args_t, a));
+
+    const int b_ptr = ir.new_gpr();
+    ir.load_param(b_ptr, offsetof(dot_args_t, b));
+
+    const int c_ptr = ir.new_gpr();
+    ir.load_param(c_ptr, offsetof(dot_args_t, c));
+
+    const int acc = ir.new_vec(data_type::f32);
+    ir.vzero(acc);
+
+    // Reduce one simd_w-wide chunk per iteration and advance the pointers.
+    emit_loop_imm(ir, k_blocks, [&]() {
+        const int a = ir.new_vec(data_type::f32);
+        ir.vload(a, a_ptr, 0);
+        const int b = ir.new_vec(data_type::f32);
+        ir.vload(b, b_ptr, 0);
+        ir.vfma(acc, a, b);
+    }, [&]() {
+        ir.add_imm(a_ptr, simd_w * (dim_t)sizeof(float));
+        ir.add_imm(b_ptr, simd_w * (dim_t)sizeof(float));
+    });
+
+    const int ws = ir.new_vec(data_type::f32);
+    ir.vhreduce(acc, ws);
+    ir.vstore_masked(c_ptr, 0, acc, -1, 1);
+
+    ir_kernel_t kernel(ir);
+    ASSERT_TRUE(kernel.run_ir_pipeline());
+
+    std::vector<float> a(k), b(k);
+    for (int i = 0; i < k; i++) {
+        a[i] = (float)(i + 1);
+        b[i] = (float)(2 * i - 3);
+    }
+
+    float c = -12345.f;
+    dot_args_t args {a.data(), b.data(), &c};
+    kernel.run(&args);
+
+    EXPECT_FLOAT_EQ(c, ref_dot(a.data(), b.data(), k));
+}
+
+// Computes a dot product where one vector is multiplied by n vectors into
+// n independent accumulators, each of which is reduced and stored.
+ir_t build_shared_vector_dot_ir(int n) {
+    ir_t ir {};
+
+    const int a_ptr = ir.new_gpr();
+    ir.load_param(a_ptr, offsetof(dot_args_t, a));
+
+    const int b_ptr = ir.new_gpr();
+    ir.load_param(b_ptr, offsetof(dot_args_t, b));
+
+    const int c_ptr = ir.new_gpr();
+    ir.load_param(c_ptr, offsetof(dot_args_t, c));
+
+    const int b = ir.new_vec(data_type::f32);
+    // Load shared vector.
+    ir.vload(b, b_ptr, 0);
+
+    std::vector<int> acc(n);
+    for (int r = 0; r < n; r++) {
+        acc[r] = ir.new_vec(data_type::f32);
+        ir.vzero(acc[r]);
+
+        const int a = ir.new_vec(data_type::f32);
+        ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
+
+        ir.vfma(acc[r], a, b);
+    }
+
+    const int ws = ir.new_vec(data_type::f32);
+    for (int r = 0; r < n; r++)
+        ir.vhreduce(acc[r], ws);
+
+    for (int r = 0; r < n; r++)
+        ir.vstore_masked(c_ptr, r * (dim_t)sizeof(float), acc[r], -1, 1);
+
+    return ir;
+}
+
+// Validates that register allocator decisions never change results. The same
+// computation is run with a full register file and with one too small to avoid
+// spills. Both must produce identical results.
+TEST(IntegrationTests, SpillProducesEquivalentResults) {
+    SKIP_IF_NO_AVX2();
+
+    constexpr int n = 6;
+
+    ir_kernel_t full(build_shared_vector_dot_ir(n));
+    ir_kernel_t limited(build_shared_vector_dot_ir(n), /*vec_regs_cap=*/4);
+
+    ASSERT_TRUE(full.run_ir_pipeline());
+    ASSERT_TRUE(limited.run_ir_pipeline());
+
+    // The full file fits everything. The limited file must spill.
+    EXPECT_FALSE(full.spilled());
+    EXPECT_TRUE(limited.spilled());
+
+    std::vector<float> a(n * simd_w), b(simd_w);
+    for (int i = 0; i < n * simd_w; i++)
+        a[i] = (float)(i % 7) - 3.f;
+
+    for (int i = 0; i < simd_w; i++)
+        b[i] = (float)(i - 2);
+
+    std::vector<float> c_full(n, 0.f), c_limited(n, 0.f);
+
+    dot_args_t args_full {a.data(), b.data(), c_full.data()};
+    dot_args_t args_limited {a.data(), b.data(), c_limited.data()};
+
+    full.run(&args_full);
+    limited.run(&args_limited);
+
+    for (int r = 0; r < n; r++) {
+        const float expected = ref_dot(&a[r * simd_w], b.data(), simd_w);
+        EXPECT_FLOAT_EQ(c_full[r], expected) << "row " << r;
+        EXPECT_FLOAT_EQ(c_limited[r], expected) << "row " << r;
+    }
+}
+
+// Arguments for the branch-selection kernel. A runtime flag plus two candidate
+// input vectors and one output vector.
+struct select_args_t {
+    int64_t cond;
+    const float *a;
+    const float *b;
+    float *c;
+};
+
+// Validates forward branches end to end. A runtime flag selects which of two
+// inputs to store, and each flag value produces the expected output. This check
+// that emitted control flow works and both candidates stayed live across the
+// branching.
+TEST(IntegrationTests, BranchSelectsCorrectValue) {
+    SKIP_IF_NO_AVX2();
+
+    ir_t ir {};
+
+    const int cond = ir.new_gpr();
+    ir.load_param(cond, offsetof(select_args_t, cond));
+
+    const int a_ptr = ir.new_gpr();
+    ir.load_param(a_ptr, offsetof(select_args_t, a));
+
+    const int b_ptr = ir.new_gpr();
+    ir.load_param(b_ptr, offsetof(select_args_t, b));
+
+    const int c_ptr = ir.new_gpr();
+    ir.load_param(c_ptr, offsetof(select_args_t, c));
+
+    const int a = ir.new_vec(data_type::f32);
+    ir.vload(a, a_ptr, 0);
+
+    const int b = ir.new_vec(data_type::f32);
+    ir.vload(b, b_ptr, 0);
+
+    const int lbl_else = ir.new_label();
+    const int lbl_end = ir.new_label();
+
+    //     if (cond != 0) { c = a; }  // then block
+    //     else           { c = b; }  // else block
+    //
+    // which lowers to a forward-branch skeleton:
+    //
+    //     jz cond -> else      ; fall through to 'then' when cond != 0
+    //   then:
+    //     store a -> c
+    //     jmp -> end           ; skip the else block
+    //   else:
+    //     store b -> c
+    //   end:
+    ir.jz(cond, lbl_else);
+    ir.vstore_masked(c_ptr, 0, a, -1, simd_w); // then: c = a
+    ir.jmp(lbl_end);
+    ir.label(lbl_else);
+    ir.vstore_masked(c_ptr, 0, b, -1, simd_w); // else: c = b
+    ir.label(lbl_end);
+
+    ir_kernel_t kernel(ir);
+    ASSERT_TRUE(kernel.run_ir_pipeline());
+
+    std::vector<float> a_data(simd_w), b_data(simd_w), c_data(simd_w, 0.f);
+    for (int i = 0; i < simd_w; i++) {
+        a_data[i] = (float)(10 + i);
+        b_data[i] = (float)(100 + i);
+    }
+
+    // cond != 0 selects a.
+    select_args_t args_a {1, a_data.data(), b_data.data(), c_data.data()};
+    kernel.run(&args_a);
+    for (int i = 0; i < simd_w; i++)
+        EXPECT_FLOAT_EQ(c_data[i], a_data[i]) << "lane " << i;
+
+    // cond == 0 selects b.
+    std::fill(c_data.begin(), c_data.end(), 0.f);
+    select_args_t args_b {0, a_data.data(), b_data.data(), c_data.data()};
+    kernel.run(&args_b);
+    for (int i = 0; i < simd_w; i++)
+        EXPECT_FLOAT_EQ(c_data[i], b_data[i]) << "lane " << i;
 }
 
 } // namespace dnnl


### PR DESCRIPTION
This is a large pull request that provides the minimum starting point for introducing IR-based kernel generation for CPU x64. It is based on the proposal: https://github.com/uxlfoundation/oneDNN/pull/5460

* The pull request is split into logically reviewable commits. Each commit introduces one pipeline stage in the IR pipeline (builder -> register allocator -> emitter), finishing  with the first kernel. Each commit also includes its own gtests, making it self-contained.
* Approximately 900 lines of the code are gtests.
* Most of the pull request consists of new code. Only a few existing files are modified.
* The new kernel is an IR-based GEMV kernel with a minimal supported feature set:
  * f32
  * AVX2
  * All tail cases
  * alpha = 1, beta = 0
  * No bias
  * No post-ops
  * No scales
  * `A` must be in row-major layout
* The new kernel is enabled by default whenever it supports the given problem. It generates byte-identical code to the existing GEMV kernel within BRGEMM, so no performance degradation is expected.
* No additional benchdnn coverage is required, as GEMV cases are already covered.


Note: I have also implemented support for bias, post-ops via the injector, scales, AVX-512, BF16, and other features. However, I want to focus on introducing the infrastructure first and then add these features in separate pull requests. This makes it easier to see the cost of extending the kernels and the infrastructure, and it also simplifies the review process.