### PR TITLE
benchdnn: matmul: support broadcast condition (src2) policy for select

### DIFF
--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -765,11 +765,27 @@ std::vector<std::pair<int, int>> attr_t::post_ops_t::get_po_masks(
         assert(mask >= 0);
         v_masks.emplace_back(DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | arg, mask);
 
-        // there is no broadcasting support for the ternary src2 input, hence
-        // no mask is required.
-        if (e.is_binary_kind_with_ternary_op())
+        // Condition (src2) mask for the ternary select input, derived from its
+        // policy so a broadcast condition is filled accordingly. With no
+        // explicit src2 spec the condition spans the full dst shape (mask -1),
+        // preserving prior behavior.
+        if (e.is_binary_kind_with_ternary_op()) {
+            int src2_mask = -1;
+            switch (e.binary.src2_mask_input) {
+                case attr_t::mask_input_t::none: src2_mask = -1; break;
+                case attr_t::mask_input_t::mask:
+                    src2_mask = e.binary.src2_mask;
+                    break;
+                case attr_t::mask_input_t::policy:
+                    src2_mask = attr_t::policy2mask(DNNL_ARG_SRC_2,
+                            e.binary.src2_policy, ndims, prim_kind);
+                    break;
+                default: assert(!"unknown mask_input value"); break;
+            }
             v_masks.emplace_back(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2, -1);
+                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2,
+                    src2_mask);
+        }
     }
     return v_masks;
 }
@@ -1397,8 +1413,32 @@ int attr_args_t::prepare_post_ops_mds(const attr_t &attr, int ndims,
                     std::move(rhs_tensor_desc));
 
             if (e.is_binary_kind_with_ternary_op()) {
+                // Deduce the condition (src2) dims from its mask/policy so a
+                // broadcast condition (e.g. per_tensor, or broadcast on outer
+                // dims) is expressed as size-1 dims, mirroring src1 above.
+                // With no explicit src2 spec the condition defaults to the full
+                // dst shape (all mask bits set) to preserve prior behavior.
+                const int full_mask = (1 << ndims) - 1;
+                int src2_mask = full_mask;
+                switch (e.binary.src2_mask_input) {
+                    case attr_t::mask_input_t::none:
+                        src2_mask = full_mask;
+                        break;
+                    case attr_t::mask_input_t::mask:
+                        src2_mask = e.binary.src2_mask;
+                        break;
+                    case attr_t::mask_input_t::policy:
+                        src2_mask = attr_t::policy2mask(DNNL_ARG_SRC_2,
+                                e.binary.src2_policy, ndims, prim_kind);
+                        break;
+                    default: assert(!"unknown mask_input value"); break;
+                }
+                dnnl_dims_t src2_tensor_dims = {};
+                for (auto d = 0; d < ndims; ++d)
+                    src2_tensor_dims[d]
+                            = (!(src2_mask & (1 << d))) ? 1 : dims[d];
                 auto rhs_src2_tensor_desc = dnn_mem_t::init_md(
-                        ndims, dims, e.binary.src2_dt, tag::any);
+                        ndims, src2_tensor_dims, e.binary.src2_dt, tag::any);
                 mds.emplace(
                         (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2),
                         std::move(rhs_src2_tensor_desc));

--- a/tests/benchdnn/doc/knobs_attr.md
+++ b/tests/benchdnn/doc/knobs_attr.md
@@ -332,6 +332,14 @@ for the third tensor positioned after that of the second and are separated by `:
 The arguments are optional for the third tensor and the data type value for
 the third tensor is fixed at `s8`.
 
+`S2_MASK_INPUT` follows the same `MASK_INPUT` semantics as above and defines the
+dimensions of the conditional (third) tensor, so it may be broadcast against the
+destination: `common` (`mask = 0`) is a single-value condition applied to the
+whole tensor, while unset (no `S2_MASK_INPUT`) spans the full destination shape.
+Note that a broadcast condition is only supported by the reference
+implementation; optimized implementations that cannot fuse it fall back to the
+reference path.
+
 ### Prelu
 `PRELU` post operation kind applies forward algorithm to the operations result
 and then stores it. Weights `DT` is always implicitly f32.

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -352,13 +352,6 @@ attr_t::post_ops_t str2attr_post_ops(const std::string &s) {
                     } else {
                         e.binary.src2_mask = src_mask;
                         e.binary.src2_mask_input = attr_t::mask_input_t::mask;
-                        if (e.binary.src2_mask > 0)
-                            BENCHDNN_PRINT(0, "%s \'%s\' %s\n",
-                                    "Error: binary post-op policy for the "
-                                    "src2 tensor",
-                                    mask_input_str.c_str(),
-                                    "is not recognized - broadcasting is not "
-                                    "supported for the ternary tensor.");
                     }
                 } else {
                     // Otherwise, re-direct to policy parsing.
@@ -382,13 +375,13 @@ attr_t::post_ops_t str2attr_post_ops(const std::string &s) {
                         e.binary.src2_policy = src_policy;
                         e.binary.src2_mask_input = attr_t::mask_input_t::policy;
 
-                        if (e.binary.src2_policy != attr_t::policy_t::COMMON) {
+                        if (e.binary.src2_policy
+                                == attr_t::policy_t::POLICY_TOTAL) {
                             BENCHDNN_PRINT(0, "%s \'%s\' %s\n",
                                     "Error: binary post-op policy for the "
                                     "src2 tensor",
                                     mask_input_str.c_str(),
-                                    "is not supported - broadcasting is "
-                                    "not supported for the src2 tensor.");
+                                    "is not recognized.");
                             SAFE_V(FAIL);
                         }
                     }


### PR DESCRIPTION
# Description

Implements benchdnn syntax for ternary post-ops properly. Previously, the language was designed but didn't allow to update src2 memory desc settings and didn't check them properly in case they were specified which resulted in successful runs while it shouldn't.

This is a prerequisite for reproducing/testing the broadcast-condition matmul
crash tracked in MFDNN-15313.

Repro (broadcast condition now expressible via the src2 policy):

    benchdnn --matmul --stag=abcd --wtag=abcd --dtag=abcd --dt=f32 \
      --attr-post-ops=select:f32:common 1x16x32x256:1x16x256x33

Relates to: MFDNN-15313

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? (`test_matmul_ci` verified on Granite Rapids AVX-512+AMX, RelWithAssert: 13517 tests, 0 failed)
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

