### PR TITLE
cpu: x64: injector: fix crash in comparison binary post-ops with tail

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -2904,11 +2904,13 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
             = rhs_addr.isBroadcast() && rhs_arg_data_type == data_type::f32;
     const bool with_tail_not_fusable_to_binary_op
             = with_tail && !isa_has_masks(isa);
+    const bool cmp_op_with_tail_vector_mem_operand
+            = cmp_op && with_tail && !rhs_addr.isBroadcast();
     const bool process_rhs_arg_using_tmp_vmm
             = rhs_arg_data_type != data_type::f32 || (scalar_f32 && !is_avx512_)
             || with_tail_not_fusable_to_binary_op
             || !binary_op_with_unaligned_mem_operand_allowed_
-            || (cmp_op && !is_avx512_);
+            || (cmp_op && !is_avx512_) || cmp_op_with_tail_vector_mem_operand;
 
     if (process_rhs_arg_using_tmp_vmm) {
 


### PR DESCRIPTION
Fixes: [MFDNN-15306](https://jira.devtools.intel.com/browse/MFDNN-15306)
For comparison binary post-ops (ge, gt, le, lt, eq, ne) on avx512, the rhs was passed directly as a memory operand to vcmpps without an accompanying mask. On the tail block this read past the end of the src1 buffer since memory faults were not suppressed, causing a segfault (e.g. matmul with attr-post-ops=ge:f32:per_oc). Regular ops avoid this because the masked dst suppresses the fault, and scalar-broadcast operands only read a single element.

Route comparison ops through a masked load into a temporary vmm when there is a tail and a non-broadcast (vector) memory operand.
