### PR TITLE
benchdnn: de-macroing graph driver

### DIFF
--- a/tests/benchdnn/graph/allocator.cpp
+++ b/tests/benchdnn/graph/allocator.cpp
@@ -14,9 +14,16 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <functional>
 #include "allocator.hpp"
 #include "graph_memory.hpp"
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+#include "oneapi/dnnl/dnnl_graph_sycl.hpp"
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include "oneapi/dnnl/dnnl_graph_ocl.hpp"
+#endif
 
 // Throw an exception for not enough memory, which will be caught in
 // DNN_GRAPH_SAFE.

--- a/tests/benchdnn/graph/allocator.hpp
+++ b/tests/benchdnn/graph/allocator.hpp
@@ -17,16 +17,9 @@
 #ifndef BENCHDNN_GRAPH_ALLOCATOR_HPP
 #define BENCHDNN_GRAPH_ALLOCATOR_HPP
 
-#include <unordered_set>
+#include "graph/memory_pool.hpp"
 
-#include "dnnl_common.hpp"
-#include "memory_pool.hpp"
 #include "oneapi/dnnl/dnnl_graph.hpp"
-
-#ifdef DNNL_WITH_SYCL
-#include "oneapi/dnnl/dnnl_graph_sycl.hpp"
-#include "oneapi/dnnl/dnnl_sycl.hpp"
-#endif
 
 namespace graph {
 

--- a/tests/benchdnn/graph/custom_driver.cpp
+++ b/tests/benchdnn/graph/custom_driver.cpp
@@ -202,9 +202,9 @@ dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
     return dnnl_success;
 }
 
-std::vector<int> supported_exec_args(const prb_t *prb) {
+std::vector<int> prb_t::supported_exec_args(bool) const {
     std::vector<int> exec_args;
-    switch (prb->alg) {
+    switch (alg) {
         case GENINDEX: return ::custom::genindex::exec_args;
         case TRANSPOSE: return ::custom::transpose::exec_args;
         case RESHAPE: return ::custom::reshape::exec_args;
@@ -213,8 +213,9 @@ std::vector<int> supported_exec_args(const prb_t *prb) {
     return exec_args;
 }
 
-void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
-        const args_t &ref_args) {
+void setup_cmp(compare::compare_t &cmp, const base_prb_t *base_prb,
+        data_kind_t kind, const args_t &ref_args) {
+    const auto *prb = prb_t::from(base_prb);
     switch (prb->alg) {
         case GENINDEX:
         case TRANSPOSE:
@@ -257,9 +258,11 @@ int fill_mem(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int f_min, int f_max) {
     return OK;
 }
 
-void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
-        const std::vector<int> &supported_exec_args,
-        const engine_t &test_engine) {
+void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
+        bool override_dir_with_fwd, const engine_t &test_engine) {
+    const auto *prb = prb_t::from(base_prb);
+    const auto &supported_exec_args
+            = base_prb->supported_exec_args(override_dir_with_fwd);
     for (const auto &exec_arg : supported_exec_args) {
         if (prb->arg_mds_.find(exec_arg) == prb->arg_mds_.end()) {
             assert(!"missing required args");
@@ -280,7 +283,9 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
 }
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
-        const prb_t *prb, res_t *res) {
+        dnnl_primitive_t, const base_prb_t *base_prb, res_t *res,
+        dnnl_primitive_t) {
+    const auto *prb = prb_t::from(base_prb);
     switch (prb->alg) {
         case GENINDEX:
             SAFE(::custom::genindex::init_ref_memory_args(
@@ -304,9 +309,10 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
     return OK;
 }
 
-void skip_unimplemented_prb(const prb_t *prb, res_t *res) {}
+void prb_t::skip_unimplemented(res_t *res) const {}
 
-int execute(const prb_t *prb, const args_t &args, res_t *res) {
+int execute(const base_prb_t *base_prb, const args_t &args, res_t *res) {
+    const auto *prb = prb_t::from(base_prb);
     int ret = FAILED;
     switch (prb->alg) {
         case GENINDEX: ret = ::custom::genindex::execute(prb, args, res); break;

--- a/tests/benchdnn/graph/custom_driver.cpp
+++ b/tests/benchdnn/graph/custom_driver.cpp
@@ -282,6 +282,12 @@ void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
     }
 }
 
+void init_memory_args_native(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
+        const graph::deserialized_op_t &, const engine_t &ref_eng) {
+    init_memory_args(
+            mem_map, base_prb, /*override_dir_with_fwd=*/false, ref_eng);
+}
+
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         dnnl_primitive_t, const base_prb_t *base_prb, res_t *res,
         dnnl_primitive_t) {

--- a/tests/benchdnn/graph/custom_driver.hpp
+++ b/tests/benchdnn/graph/custom_driver.hpp
@@ -86,6 +86,9 @@ void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
         bool override_dir_with_fwd = false,
         const engine_t &test_engine = get_test_engine());
 
+void init_memory_args_native(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
+        const graph::deserialized_op_t &base_op_ref, const engine_t &ref_eng);
+
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         dnnl_primitive_t prim, const base_prb_t *base_prb, res_t *res,
         dnnl_primitive_t prim_ref = nullptr);

--- a/tests/benchdnn/graph/custom_driver.hpp
+++ b/tests/benchdnn/graph/custom_driver.hpp
@@ -23,6 +23,7 @@
 #include "deserialize.hpp"
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
+#include "utils/prb.hpp"
 #include "utils/settings.hpp"
 
 namespace custom {
@@ -49,7 +50,7 @@ struct settings_t {
     void finalize() {};
 };
 
-struct prb_t {
+struct prb_t : public base_prb_t {
     prb_t(const settings_t &s) : arg_mds_(s.arg_mds_), alg(s.alg) {
         switch (alg) {
             case GENINDEX: axis = s.axis; break;
@@ -61,27 +62,35 @@ struct prb_t {
     ::std::unordered_map<int, arg_md_t> arg_mds_;
     ::std::vector<int64_t> order;
     int64_t axis = -1;
-    attr_t attr;
     alg_t alg = ALG_UNKNOWN;
+
+    static const prb_t *from(const base_prb_t *base_prb) {
+        return downcast<const prb_t *>(base_prb);
+    }
+
+    void skip_unimplemented(res_t *res) const override;
+    std::vector<int> supported_exec_args(
+            bool override_dir_with_fwd) const override;
+
+private:
+    std::string set_repro_line() override { return std::string(); }
 };
 
 dnnl_status_t init_pd(init_pd_args_t &init_pd_args);
-std::vector<int> supported_exec_args(const prb_t *prb);
 
 int fill_mem(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int f_min, int f_max);
-void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
+void setup_cmp(compare::compare_t &cmp, const base_prb_t *prb, data_kind_t kind,
         const args_t &ref_args);
 
-void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
-        const std::vector<int> &supported_exec_args,
+void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
+        bool override_dir_with_fwd = false,
         const engine_t &test_engine = get_test_engine());
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
-        const prb_t *prb, res_t *res);
+        dnnl_primitive_t prim, const base_prb_t *base_prb, res_t *res,
+        dnnl_primitive_t prim_ref = nullptr);
 
-void skip_unimplemented_prb(const prb_t *prb, res_t *res);
-
-int execute(const prb_t *prb, const args_t &args, res_t *res);
+int execute(const base_prb_t *prb, const args_t &args, res_t *res);
 
 } // namespace custom
 #endif

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -22,6 +22,8 @@
 #include <queue>
 #include <stdexcept>
 
+#include "dnn_types.hpp"
+
 #include "deserialize.hpp"
 #include "utils/stringstream.hpp"
 

--- a/tests/benchdnn/graph/deserialize.hpp
+++ b/tests/benchdnn/graph/deserialize.hpp
@@ -24,7 +24,9 @@
 // It requires user to define an object to parse and `load` routines.
 #include "src/graph/utils/json.hpp"
 
-#include "utils.hpp"
+#include "graph/utils.hpp"
+
+#include <unordered_set>
 
 namespace graph {
 

--- a/tests/benchdnn/graph/graph_memory.hpp
+++ b/tests/benchdnn/graph/graph_memory.hpp
@@ -25,7 +25,6 @@
 #include <type_traits>
 #include <unordered_map>
 
-#include "setting_handler.hpp"
 #include "utils/compare.hpp"
 #include "utils/settings.hpp"
 

--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -14,11 +14,13 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <numeric>
 #include <random>
 
 #include "dnnl_common.hpp"
 #include "input_displacer.hpp"
 #include "ref_partition.hpp"
+#include "ref_primitive.hpp"
 
 #include "utils/parallel.hpp"
 

--- a/tests/benchdnn/graph/input_displacer.hpp
+++ b/tests/benchdnn/graph/input_displacer.hpp
@@ -17,7 +17,7 @@
 #ifndef BENCHDNN_GRAPH_INPUT_DISPLACER_HPP
 #define BENCHDNN_GRAPH_INPUT_DISPLACER_HPP
 
-#include "ref_primitive.hpp"
+#include "deserialize.hpp"
 
 #include "src/common/memory_desc.hpp"
 #include "utils/fill.hpp"

--- a/tests/benchdnn/graph/memory_pool.hpp
+++ b/tests/benchdnn/graph/memory_pool.hpp
@@ -17,17 +17,18 @@
 #ifndef MEMORY_POOL_HPP
 #define MEMORY_POOL_HPP
 
-#include <mutex>
-#include <unordered_set>
+#include "oneapi/dnnl/dnnl_config.h"
 
-#include "oneapi/dnnl/dnnl_graph.hpp"
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-#include "oneapi/dnnl/dnnl_graph_ocl.hpp"
-#include "oneapi/dnnl/dnnl_ocl.hpp"
+#include <CL/cl.h>
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-#include "oneapi/dnnl/dnnl_graph_sycl.hpp"
-#include "oneapi/dnnl/dnnl_sycl.hpp"
+#include <sycl/sycl.hpp>
 #endif
+
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 
 #ifndef UNUSED
 #define UNUSED(x) ((void)(x))

--- a/tests/benchdnn/graph/parser.hpp
+++ b/tests/benchdnn/graph/parser.hpp
@@ -17,15 +17,10 @@
 #ifndef BENCHDNN_GRAPH_PARSER_HPP
 #define BENCHDNN_GRAPH_PARSER_HPP
 
+#include "graph/utils.hpp"
+
 #include <map>
 #include <string>
-
-#include "allocator.hpp"
-#include "dnnl_common.hpp"
-#include "oneapi/dnnl/dnnl_graph.hpp"
-#include "utils.hpp"
-
-extern dnnl_engine_kind_t engine_tgt_kind;
 
 namespace graph {
 

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -17,6 +17,7 @@
 #include "ref_partition.hpp"
 #include "cpu/platform.hpp"
 #include "dnnl_common.hpp"
+#include "setting_handler.hpp"
 
 #include "utils/compare.hpp"
 

--- a/tests/benchdnn/graph/ref_primitive.cpp
+++ b/tests/benchdnn/graph/ref_primitive.cpp
@@ -17,14 +17,11 @@
 #include "ref_primitive.hpp"
 #include "setting_handler.hpp"
 
-namespace graph {
-
 #define DEFINE_REF_PRIM_HELPER_FUNCS(driver) \
     namespace driver { \
-    void init_memory_args_native(const ::driver::prb_t *prb, \
-            const deserialized_op_t &base_op_ref, dnn_mem_map_t &mem_map, \
-            const engine_t &ref_eng) {} \
-    int execute(const ::driver::prb_t *prb, const args_t &args, res_t *res) { \
+    void init_memory_args_native(dnn_mem_map_t &, const base_prb_t *, \
+            const graph::deserialized_op_t &, const engine_t &) {} \
+    int execute(const base_prb_t *, const args_t &, res_t *res) { \
         res->state = UNIMPLEMENTED; \
         return FAIL; \
     } \
@@ -37,7 +34,6 @@ DEFINE_REF_PRIM_HELPER_FUNCS(binary);
 DEFINE_REF_PRIM_HELPER_FUNCS(bnorm);
 DEFINE_REF_PRIM_HELPER_FUNCS(concat);
 DEFINE_REF_PRIM_HELPER_FUNCS(conv);
-DEFINE_REF_PRIM_HELPER_FUNCS(custom);
 DEFINE_REF_PRIM_HELPER_FUNCS(deconv);
 DEFINE_REF_PRIM_HELPER_FUNCS(eltwise);
 DEFINE_REF_PRIM_HELPER_FUNCS(gnorm);
@@ -52,9 +48,9 @@ DEFINE_REF_PRIM_HELPER_FUNCS(resampling);
 
 namespace softmax {
 
-void init_memory_args_native(const ::softmax::prb_t *prb,
-        const deserialized_op_t &base_op_ref, dnn_mem_map_t &mem_map,
-        const engine_t &ref_eng) {
+void init_memory_args_native(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
+        const graph::deserialized_op_t &base_op_ref, const engine_t &ref_eng) {
+    const auto *prb = ::softmax::prb_t::from(base_prb);
     if (base_op_ref.out_lts_.size() != 2) {
         assert(!"softmax should have two outputs to run into "
                 "init_memory_args_native");
@@ -75,7 +71,8 @@ void init_memory_args_native(const ::softmax::prb_t *prb,
                     stats_strides.data(), ref_eng, /* prefill = */ true));
 }
 
-int execute(const ::softmax::prb_t *prb, const args_t &args, res_t *res) {
+int execute(const base_prb_t *base_prb, const args_t &args, res_t *res) {
+    const auto *prb = ::softmax::prb_t::from(base_prb);
     assert(args.find(DNNL_ARG_DST_1).size() != 0);
     // in order to run with ::softmax::compute_ref, we need to
     // construct all memory with abx tag and f32 dt
@@ -106,6 +103,8 @@ int execute(const ::softmax::prb_t *prb, const args_t &args, res_t *res) {
 }
 } // namespace softmax
 
+namespace graph {
+
 ref_primitive_t::ref_primitive_t(const deserialized_op_t &op)
     : op_(op), kind_(opstr2kind(op_.kind_)), driver_(op_.opkind2driver()) {
 
@@ -133,33 +132,6 @@ ref_primitive_t::ref_primitive_t(const deserialized_op_t &op)
             = special_backward_op.find(op_.kind_) != special_backward_op.end();
 }
 
-// a switch skeleton to handle thing for each driver and template code
-// CASE_DRIVER is for primitive driver and CASE_CUSTOM is for custom driver
-// caller should define the behavior for both situation
-#define SWITCH_DRIVER(CASE_DRIVER, CASE_CUSTOM) \
-    switch (driver_) { \
-        CASE_CUSTOM; \
-        CASE_DRIVER(binary); \
-        CASE_DRIVER(bnorm); \
-        CASE_DRIVER(concat); \
-        CASE_DRIVER(conv); \
-        CASE_DRIVER(deconv); \
-        CASE_DRIVER(eltwise); \
-        CASE_DRIVER(gnorm); \
-        CASE_DRIVER(lnorm); \
-        CASE_DRIVER(matmul); \
-        CASE_DRIVER(pool); \
-        CASE_DRIVER(prelu); \
-        CASE_DRIVER(reduction); \
-        CASE_DRIVER(reorder); \
-        CASE_DRIVER(resampling); \
-        CASE_DRIVER(softmax); \
-        default: { \
-            SAFE_V(FAIL); \
-            break; \
-        } \
-    }
-
 int ref_primitive_t::init_prb(res_t *res) {
 #define CASE_INIT_PRB(driver) \
     case dnnl_driver_t::driver: { \
@@ -167,21 +139,46 @@ int ref_primitive_t::init_prb(res_t *res) {
                 = get_setting<::driver::settings_t>(op_, res); \
         if (res->state == INVALID_ARGUMENTS) return FAIL; \
         setting.finalize(); \
-        auto pprb = ::std::make_shared<::driver::prb_t>(setting); \
-        prb_wrapper_ \
-                = ::std::make_shared<prb_wrapper_t<::driver::prb_t>>(pprb); \
+        prb_ = std::make_shared<::driver::prb_t>(setting); \
+        setup_cmp_func_ = ::driver::setup_cmp; \
+        execute_func_ = ::driver::execute; \
+        init_ref_memory_args_func_ = ::driver::init_ref_memory_args; \
+        init_memory_args_native_func_ = ::driver::init_memory_args_native; \
+        init_pd_func_ = ::driver::init_pd; \
         break; \
     }
 
-#define CASE_INIT_CUSTOM_PRB CASE_INIT_PRB(custom);
-
-    SWITCH_DRIVER(CASE_INIT_PRB, CASE_INIT_CUSTOM_PRB);
+    switch (driver_) {
+        CASE_INIT_PRB(custom);
+        CASE_INIT_PRB(binary);
+        CASE_INIT_PRB(bnorm);
+        CASE_INIT_PRB(concat);
+        CASE_INIT_PRB(conv);
+        CASE_INIT_PRB(deconv);
+        CASE_INIT_PRB(eltwise);
+        CASE_INIT_PRB(gnorm);
+        CASE_INIT_PRB(lnorm);
+        CASE_INIT_PRB(matmul);
+        CASE_INIT_PRB(pool);
+        CASE_INIT_PRB(prelu);
+        CASE_INIT_PRB(reduction);
+        CASE_INIT_PRB(reorder);
+        CASE_INIT_PRB(resampling);
+        CASE_INIT_PRB(softmax);
+        default: {
+            SAFE_V(FAIL);
+            break;
+        }
+    }
 
     return OK;
 }
 
 int ref_primitive_t::init_prim(
         const engine_t &ref_eng, res_t *res, bool force_override) {
+    // The custom driver does not contain a primitive, skip this step.
+    if (driver_ == dnnl_driver_t::custom) return OK;
+
     const bool is_quant_or_dequant = kind_ == dnnl::graph::op::kind::Dequantize
             || kind_ == dnnl::graph::op::kind::Quantize
             || kind_ == dnnl::graph::op::kind::DynamicDequantize
@@ -190,126 +187,62 @@ int ref_primitive_t::init_prim(
     // zero-points attribute. Thus, skip them for forcing.
     const bool force_f32_prim_dt = !force_override && !is_quant_or_dequant;
 
-#define CASE_INIT_PRIM(driver) \
-    case dnnl_driver_t::driver: { \
-        const ::driver::prb_t *prb = prb_wrapper_->get<::driver::prb_t>(); \
-        dnn_mem_map_t ref_mems; \
-        if (is_special_backward_op_) { \
-            SAFE(create_primitive(fwd_prim_, ref_eng, ::driver::init_pd, prb, \
-                         res, FLAG_FWD, nullptr, prb->dir &FLAG_BWD, nullptr, \
-                         force_f32_prim_dt, /*is_graph_ref=*/true), \
-                    WARN); \
-            if (res->state == SKIPPED || res->state == UNIMPLEMENTED) \
-                return OK; \
-            ::init_memory_args(mems_, prb, fwd_prim_, \
-                    /*override_dir_with_fwd=*/true, ref_eng); \
-            SAFE(::driver::init_ref_memory_args( \
-                         ref_mems, mems_, fwd_prim_, prb, res), \
-                    WARN); \
-            args_ = args_t(mems_); \
-            SAFE(execute_and_wait(fwd_prim_, args_, res), WARN); \
-        } \
-        SAFE(create_primitive(prim_, ref_eng, ::driver::init_pd, prb, res, \
-                     prb->dir, \
-                     is_special_backward_op_ ? query_pd(fwd_prim_) : nullptr, \
-                     false, nullptr, force_f32_prim_dt, \
-                     /*is_graph_ref=*/true), \
-                WARN); \
-        if (res->state == SKIPPED || res->state == UNIMPLEMENTED \
-                || res->state == DEFERRED) \
-            return OK; \
-        break; \
+    const base_prb_t *prb = prb_.get();
+    dnn_mem_map_t ref_mems;
+    if (is_special_backward_op_) {
+        SAFE(create_primitive(fwd_prim_, ref_eng, init_pd_func_, prb, res,
+                     FLAG_FWD, nullptr, prb->dir & FLAG_BWD, nullptr,
+                     force_f32_prim_dt, /*is_graph_ref=*/true),
+                WARN);
+        if (res->state == SKIPPED || res->state == UNIMPLEMENTED) return OK;
+        ::init_memory_args(mems_, prb, fwd_prim_,
+                /*override_dir_with_fwd=*/true, ref_eng);
+        SAFE(init_ref_memory_args_func_(
+                     ref_mems, mems_, fwd_prim_, prb, res, nullptr),
+                WARN);
+        args_ = args_t(mems_);
+        SAFE(execute_and_wait(fwd_prim_, args_, res), WARN);
     }
-// custom driver does not contain primitive, skip this step
-#define CASE_INIT_CUSTOM_PRIM \
-    case dnnl_driver_t::custom: break;
+    SAFE(create_primitive(prim_, ref_eng, init_pd_func_, prb, res, prb->dir,
+                 is_special_backward_op_ ? query_pd(fwd_prim_) : nullptr, false,
+                 nullptr, force_f32_prim_dt, /*is_graph_ref=*/true),
+            WARN);
+    if (res->state == SKIPPED || res->state == UNIMPLEMENTED
+            || res->state == DEFERRED)
+        return OK;
 
-    SWITCH_DRIVER(CASE_INIT_PRIM, CASE_INIT_CUSTOM_PRIM);
     return OK;
 }
 
 void ref_primitive_t::init_memory_args(const engine_t &ref_eng) {
-#define CASE_INIT_MEMORY_ARGS(driver) \
-    case dnnl_driver_t::driver: { \
-        if (prb_wrapper_) { \
-            const ::driver::prb_t *prb = prb_wrapper_->get<::driver::prb_t>(); \
-            if (prim_) { \
-                ::init_memory_args(mems_, prb, prim_, \
-                        /*override_dir_with_fwd=*/false, ref_eng); \
-            } else { \
-                /* handle an empty primitive through a driver's reference */ \
-                driver::init_memory_args_native(prb, op_, mems_, ref_eng); \
-            } \
-        } \
-        break; \
-    }
+    if (!prb_) return;
 
-#define CASE_INIT_CUSTOM_MEMORY_ARGS \
-    case dnnl_driver_t::custom: { \
-        if (prb_wrapper_) { \
-            const ::custom::prb_t *prb = prb_wrapper_->get<::custom::prb_t>(); \
-            ::custom::init_memory_args( \
-                    mems_, prb, /*override_dir_with_fwd=*/false, ref_eng); \
-        } \
-        break; \
+    if (prim_) {
+        ::init_memory_args(mems_, prb_.get(), prim_,
+                /*override_dir_with_fwd=*/false, ref_eng);
+    } else {
+        // handle an empty primitive through a driver's reference
+        init_memory_args_native_func_(mems_, prb_.get(), op_, ref_eng);
     }
-
-    SWITCH_DRIVER(CASE_INIT_MEMORY_ARGS, CASE_INIT_CUSTOM_MEMORY_ARGS);
 }
 
 int ref_primitive_t::init_ref_memory_args(const engine_t &ref_eng, res_t *res) {
-#define CASE_INIT_REF_MEMORY_ARGS(driver) \
-    case dnnl_driver_t::driver: { \
-        dnn_mem_map_t ref_mems; \
-        if (prb_wrapper_) { \
-            const ::driver::prb_t *prb = prb_wrapper_->get<::driver::prb_t>(); \
-            SAFE(::driver::init_ref_memory_args( \
-                         ref_mems, mems_, prim_, prb, res), \
-                    WARN); \
-            args_ = args_t(mems_); \
-        } \
-        break; \
+    dnn_mem_map_t ref_mems;
+    if (prb_) {
+        SAFE(init_ref_memory_args_func_(
+                     ref_mems, mems_, prim_, prb_.get(), res, nullptr),
+                WARN);
+        args_ = args_t(mems_);
     }
-
-#define CASE_INIT_CUSTOM_REF_MEMORY_ARGS \
-    case dnnl_driver_t::custom: { \
-        dnn_mem_map_t ref_mems; \
-        if (prb_wrapper_) { \
-            const ::custom::prb_t *prb = prb_wrapper_->get<::custom::prb_t>(); \
-            SAFE(::custom::init_ref_memory_args( \
-                         ref_mems, mems_, nullptr, prb, res), \
-                    WARN); \
-            args_ = args_t(mems_); \
-        } \
-        break; \
-    }
-
-    SWITCH_DRIVER(CASE_INIT_REF_MEMORY_ARGS, CASE_INIT_CUSTOM_REF_MEMORY_ARGS);
     return OK;
 }
 
 int ref_primitive_t::execute_prim(res_t *res) const {
-#define CASE_EXECUTE(driver) \
-    case dnnl_driver_t::driver: { \
-        if (prim_) { \
-            SAFE(execute_and_wait(prim_, args_, res), WARN); \
-        } else if (prb_wrapper_) { \
-            const ::driver::prb_t *prb = prb_wrapper_->get<::driver::prb_t>(); \
-            SAFE(driver::execute(prb, args_, res), WARN); \
-        } \
-        break; \
+    if (prim_) {
+        SAFE(execute_and_wait(prim_, args_, res), WARN);
+    } else if (prb_) {
+        SAFE(execute_func_(prb_.get(), args_, res), WARN);
     }
-
-#define CASE_CUSTOM_EXECUTE \
-    case dnnl_driver_t::custom: { \
-        if (prb_wrapper_) { \
-            const ::custom::prb_t *prb = prb_wrapper_->get<::custom::prb_t>(); \
-            SAFE(::custom::execute(prb, args_, res), WARN); \
-        } \
-        break; \
-    }
-
-    SWITCH_DRIVER(CASE_EXECUTE, CASE_CUSTOM_EXECUTE);
     return OK;
 }
 
@@ -335,16 +268,6 @@ void ref_primitive_t::check_correctness(
                     {DNNL_ARG_DIFF_SHIFT, SH},
             };
 
-#define CASE_CHECK_CORRECTNESS(driver) \
-    case dnnl_driver_t::driver: { \
-        const ::driver::prb_t *prb = prb_wrapper_->get<::driver::prb_t>(); \
-        setup_cmp(cmp, prb, dnnl_arg_2_data_kind_map.at(arg), args_); \
-        attr = prb->attr; \
-        break; \
-    }
-
-#define CASE_CUSTOM_CHECK_CORRECTNESS CASE_CHECK_CORRECTNESS(custom)
-
     // args is the result from graph side
     // args_ is the reference result under this context
     // only check the arg contained in args, compare args with args_
@@ -363,8 +286,8 @@ void ref_primitive_t::check_correctness(
             return;
         }
         compare::compare_t cmp;
-        attr_t attr;
-        SWITCH_DRIVER(CASE_CHECK_CORRECTNESS, CASE_CUSTOM_CHECK_CORRECTNESS);
+        setup_cmp_func_(cmp, prb_.get(), it->second, args_);
+        const attr_t &attr = prb_->attr;
 
         cmp.set_data_kind(it->second);
         cmp.set_has_eltwise_post_op(has_eltwise);

--- a/tests/benchdnn/graph/ref_primitive.cpp
+++ b/tests/benchdnn/graph/ref_primitive.cpp
@@ -249,7 +249,7 @@ void ref_primitive_t::init_memory_args(const engine_t &ref_eng) {
         if (prb_wrapper_) { \
             const ::custom::prb_t *prb = prb_wrapper_->get<::custom::prb_t>(); \
             ::custom::init_memory_args( \
-                    mems_, prb, ::custom::supported_exec_args(prb), ref_eng); \
+                    mems_, prb, /*override_dir_with_fwd=*/false, ref_eng); \
         } \
         break; \
     }
@@ -276,7 +276,8 @@ int ref_primitive_t::init_ref_memory_args(const engine_t &ref_eng, res_t *res) {
         dnn_mem_map_t ref_mems; \
         if (prb_wrapper_) { \
             const ::custom::prb_t *prb = prb_wrapper_->get<::custom::prb_t>(); \
-            SAFE(::custom::init_ref_memory_args(ref_mems, mems_, prb, res), \
+            SAFE(::custom::init_ref_memory_args( \
+                         ref_mems, mems_, nullptr, prb, res), \
                     WARN); \
             args_ = args_t(mems_); \
         } \

--- a/tests/benchdnn/graph/ref_primitive.hpp
+++ b/tests/benchdnn/graph/ref_primitive.hpp
@@ -17,6 +17,8 @@
 #ifndef BENCHDNN_GRAPH_REF_PRIMITIVE_HPP
 #define BENCHDNN_GRAPH_REF_PRIMITIVE_HPP
 
+#include "dnnl_common.hpp"
+
 #include "deserialize.hpp"
 
 #include "utils/dnnl_query.hpp"

--- a/tests/benchdnn/graph/ref_primitive.hpp
+++ b/tests/benchdnn/graph/ref_primitive.hpp
@@ -23,43 +23,25 @@
 
 namespace graph {
 
-// `prb_wrapper_base_t` and `prb_wrapper_t` defined to wrap `prb_t` object
-// because C++11 doesn't support templated member variables, and there is no
-// common base type for `prb_t` types, thus, it's impossible to put a shared
-// pointer of `prb_t` or its base object directly into `ref_prims_` member of
-// `ref_partition_t` object. Shared pointer of wrapper base object will be put
-// into `ref_prims_`. These wrappers could be removed after moving to C++14.
-class prb_wrapper_base_t {
-public:
-    virtual ~prb_wrapper_base_t() = default;
-    template <typename prb_t>
-    const prb_t *get() const;
-};
+// A function that executes a graph reference path for a driver that has no
+// primitive (or a custom driver).
+using execute_func_t
+        = std::function<int(const base_prb_t *, const args_t &, res_t *)>;
 
-// A template class to wrap shared pointer of prb obj
-template <typename prb_t>
-class prb_wrapper_t : public prb_wrapper_base_t {
-public:
-    prb_wrapper_t(const std::shared_ptr<prb_t> &prb) : prb_(prb) {}
-    // get raw pointer of prb object
-    const prb_t *get() const { return prb_.get(); }
+// A function that initializes the reference memory arguments for a driver
+// that runs through its own reference (an empty primitive or a custom driver).
+using init_memory_args_native_func_t = std::function<void(dnn_mem_map_t &,
+        const base_prb_t *, const deserialized_op_t &, const engine_t &)>;
 
-private:
-    std::shared_ptr<prb_t> prb_;
-};
-
-// A template function in base wrapper, which dynamic cast from base object to
-// derived object and return raw pointer of prb obj
-template <typename prb_t>
-inline const prb_t *prb_wrapper_base_t::get() const {
-    return dynamic_cast<const prb_wrapper_t<prb_t> &>(*this).get();
-}
+// A function that initializes the reference memory arguments for a driver.
+using init_ref_memory_args_func_t
+        = std::function<int(dnn_mem_map_t &, dnn_mem_map_t &, dnnl_primitive_t,
+                const base_prb_t *, res_t *, dnnl_primitive_t)>;
 
 // `ref_primitive_t` is an abstraction to connect a graph op and a primitive
 // driver. Its purpose is to translate a graph op into a primitive and execute
 // it. Any primitive driver with template programming work should be done
 // through this class.
-// Note: non-templated functions are exposed to simplify the logic.
 class ref_primitive_t {
 public:
     ref_primitive_t() = default;
@@ -102,10 +84,23 @@ private:
     BENCHDNN_DISALLOW_COPY_AND_ASSIGN(ref_primitive_t);
 
     deserialized_op_t op_;
-    ::dnnl::graph::op::kind kind_;
+    dnnl::graph::op::kind kind_;
     dnnl_driver_t driver_;
     bool is_special_backward_op_;
-    ::std::shared_ptr<prb_wrapper_base_t> prb_wrapper_;
+    std::shared_ptr<const base_prb_t> prb_;
+    // Driver-specific compare object setup function, assigned in `init_prb`.
+    setup_cmp_func_t setup_cmp_func_ = nullptr;
+    // Driver-specific reference execute function, assigned in `init_prb`.
+    execute_func_t execute_func_ = nullptr;
+    // Driver-specific reference memory args init function, assigned in
+    // `init_prb`.
+    init_ref_memory_args_func_t init_ref_memory_args_func_ = nullptr;
+    // Driver-specific native memory args init function (used when there's no
+    // primitive), assigned in `init_prb`.
+    init_memory_args_native_func_t init_memory_args_native_func_ = nullptr;
+    // Driver-specific primitive descriptor init function, assigned in
+    // `init_prb`. Not used for the custom driver as it has no primitive.
+    init_pd_func_t init_pd_func_ = nullptr;
     benchdnn_dnnl_wrapper_t<dnnl_primitive_t> fwd_prim_, prim_;
     dnn_mem_map_t mems_;
     args_t args_;

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -18,14 +18,22 @@
 #include <set>
 #include <vector>
 
-#include "cpu/platform.hpp"
+#include "graph/allocator.hpp"
+#include "graph/utils.hpp"
 
-#include "allocator.hpp"
 #include "dnnl_common.hpp"
-#include "utils.hpp"
+
 #include "utils/stream_kind.hpp"
 #include "utils/stringstream.hpp"
 #include "utils/timer.hpp"
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+#include "oneapi/dnnl/dnnl_graph_sycl.hpp"
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include "oneapi/dnnl/dnnl_graph_ocl.hpp"
+#endif
 
 namespace graph {
 

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -17,36 +17,15 @@
 #ifndef BENCHDNN_GRAPH_UTILS_HPP
 #define BENCHDNN_GRAPH_UTILS_HPP
 
-#include <algorithm>
-#include <cctype>
-#include <cstddef>
-#include <future> // for std::promise and std::future
-#include <map>
-#include <numeric>
+#include "dnnl_memory.hpp"
+#include "utils/engine.hpp"
+#include "utils/timer.hpp"
+
+#include "oneapi/dnnl/dnnl_graph.hpp"
+
 #include <string>
 #include <utility>
 #include <vector>
-#include <unordered_map>
-#include <unordered_set>
-
-#include "oneapi/dnnl/dnnl.hpp"
-#include "oneapi/dnnl/dnnl_graph.hpp"
-
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
-#include "oneapi/dnnl/dnnl_threadpool.hpp"
-#endif
-
-#ifdef DNNL_WITH_SYCL
-#include "dnnl_sycl.hpp"
-#include "oneapi/dnnl/dnnl_graph_sycl.hpp"
-#endif
-
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-#include "oneapi/dnnl/dnnl_graph_ocl.hpp"
-#endif
-
-#include "common.hpp"
-#include "dnnl_common.hpp"
 
 namespace graph {
 


### PR DESCRIPTION
This is concluding PR in the latest series around `base_prb_t` and de-templating main benchdnn functions. With simplified signatures and a common prb class it became possible to simplify graph codes responsible to setup reference path for a graph object.

It also partially cleans up header dependencies though this work is not fully completed (can it ever be completed?).