### PR TITLE
cpu: x64: binary: fix assertion on permuted src0 layout with broadcast

### DIFF
--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -192,8 +192,9 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     conf_.bcast_type = is_tensor_op() ? bcast_t::none
                                       : get_bcast_type(src1_md_, bcast_dims);
     // op_type only matters for broadcasted operation
-    assert(IMPLICATION(
-            conf_.bcast_type != bcast_t::none, conf_.op_type != op_t::none));
+    VDISPATCH_BINARY(IMPLICATION(conf_.bcast_type != bcast_t::none,
+                             conf_.op_type != op_t::none),
+            "unsupported src0 layout for broadcast operation");
     conf_.broadcast_src1_value = (conf_.op_type == op_t::n_c_spatial
                                          && conf_.bcast_type == bcast_t::per_c)
             || (utils::one_of(conf_.op_type, op_t::n_spatial_c, op_t::c_blocked)
@@ -479,7 +480,8 @@ bool jit_uni_binary_t::pd_t::is_applicable() {
 
     // only nspc and ncsp formats are supported for bcast
     if (src0_d.is_plain() && src1_d.is_plain())
-        return is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d);
+        return is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d)
+                && get_op_type(src0_d) != op_t::none;
 
     // blocked formats
     if (!conf_.is_i8) {

--- a/tests/benchdnn/inputs/binary/harness_binary_regression
+++ b/tests/benchdnn/inputs/binary/harness_binary_regression
@@ -13,3 +13,6 @@
 
 # Post-op with non-broadcast load
 --reset --alg=add --attr-post-ops=binary_div:f32:common 1x4:1x4
+
+# Permuted src0 tag (acbd) with scalar broadcast should not assert (MFDNN-14988)
+--reset --allow-enum-tags-only=0 --alg=mul --sdt=f32:f32 --ddt=f32 --stag=acbd:abcd --dtag=acbd 128x12x1x256:1x1x1x1


### PR DESCRIPTION
Fixes the assertion reported in MFDNN-14988.

When src0 uses a permuted plain tag (e.g. `acbd`) with a unit spatial dimension and src1 is broadcast, `get_op_type()` returns `op_t::none` (the strides match no supported pattern), while `is_format_non_blocked()` still accepts the layout. `is_applicable()` then returns true and the primitive aborts on an assert in `init()`.

This is the minimal fix: it makes the unsupported case fall back to the reference implementation instead of asserting.

- `is_applicable()`: add a `get_op_type(src0_d) != op_t::none` check in the plain-format broadcast path, so an unsupported layout is rejected and handled by ref:any.
- Replace the `assert` with `VDISPATCH_BINARY`, so any remaining unhandled path returns unimplemented instead of aborting.
- Add a regression case to `harness_binary_regression`.

Scope note: this does not extend jit:uni to support these layouts. Adding jit:uni support was explored separately in #5367; per an offline discussion on the low product value of the standalone CPU binary primitive, that approach is not being pursued and #5367 is being closed. This PR restarts from the minimal fix.

Testing: the reported repro no longer asserts (runs on ref:any, correct result). `test_binary_ci` and `harness_binary_regression` pass with no failures.

This replaces the earlier #5354, which could not be reopened after its branch was rebased.
