### PR TITLE
tests: benchdnn: rnn: add missing header

### DIFF
--- a/tests/benchdnn/rnn/rnn.cpp
+++ b/tests/benchdnn/rnn/rnn.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +36,10 @@
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
 #include "oneapi/dnnl/dnnl_threadpool.hpp"
 #include "tests/test_thread_decl.hpp"
+#endif
+
+#if defined(DNNL_AARCH64_USE_ACL)
+#include "tests/test_isa_common.hpp"
 #endif
 
 // Using hidden attr API for testing RNN
@@ -834,7 +839,7 @@ void prb_t::skip_unimplemented(res_t *res) const {
             return;
         }
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL)
         const bool is_acl_f16_not_ok = prb.cfg[SRC_LAYER].dt == dnnl_f16
                 && dnnl::impl::cpu::platform::has_data_type_support(dnnl_f16);
         if (is_acl_f16_not_ok) {


### PR DESCRIPTION
# Description

Was left out of the last round of fixups (https://github.com/uxlfoundation/oneDNN/commit/7249845e502839f519a741286c6dc7509653cd20)

Example failing nightly: https://github.com/uxlfoundation/oneDNN/actions/runs/28921073206

```
FAILED: tests/benchdnn/CMakeFiles/benchdnn.dir/rnn/rnn.cpp.o 
/usr/bin/g++-13 -DBUILD_GRAPH -DCL_TARGET_OPENCL_VERSION=120 -DDNNL_AARCH64=1 -DDNNL_AARCH64_USE_ACL -DDNNL_DLL -DNOMINMAX -DWIN32_LEAN_AND_MEAN -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/home/runner/work/oneDNN/oneDNN/oneDNN_build/build/include -I/home/runner/work/oneDNN/oneDNN/oneDNN_build/include -I/home/runner/work/oneDNN/oneDNN/oneDNN_build/third_party/opencl -I/home/runner/work/oneDNN/oneDNN/oneDNN_pkg/ComputeLibrary -I/home/runner/work/oneDNN/oneDNN/oneDNN_pkg/ComputeLibrary/include -I/home/runner/work/oneDNN/oneDNN/oneDNN_build/third_party/xbyak_aarch64 -I/home/runner/work/oneDNN/oneDNN/oneDNN_build -I/home/runner/work/oneDNN/oneDNN/oneDNN_build/src -I/home/runner/work/oneDNN/oneDNN/oneDNN_build/tests/benchdnn -I/home/runner/work/oneDNN/oneDNN/oneDNN_build/src/../include -fopenmp -fvisibility-inlines-hidden  -Wall -Wno-unknown-pragmas -Wundef -Werror -fvisibility=internal -O3 -mcpu=generic  -fPIC -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong     -Wno-strict-overflow -Wno-maybe-uninitialized -Wno-stringop-overflow -Wno-array-bounds -O3 -DNDEBUG -std=c++14 -MD -MT tests/benchdnn/CMakeFiles/benchdnn.dir/rnn/rnn.cpp.o -MF tests/benchdnn/CMakeFiles/benchdnn.dir/rnn/rnn.cpp.o.d -o tests/benchdnn/CMakeFiles/benchdnn.dir/rnn/rnn.cpp.o -c /home/runner/work/oneDNN/oneDNN/oneDNN_build/tests/benchdnn/rnn/rnn.cpp
/home/runner/work/oneDNN/oneDNN/oneDNN_build/tests/benchdnn/rnn/rnn.cpp: In member function ‘virtual void rnn::prb_t::skip_unimplemented(res_t*) const’:
/home/runner/work/oneDNN/oneDNN/oneDNN_build/tests/benchdnn/rnn/rnn.cpp:839:26: error: ‘dnnl::impl’ has not been declared
  839 |                 && dnnl::impl::cpu::platform::has_data_type_support(dnnl_f16);
      |                          ^~~~

```

cc: @dzarukin 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?