### PR TITLE
xe: gemm: align post-op vs alpha conditions for host dst scale

### DIFF
--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -523,7 +523,7 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
         }
     }
 
-    // Get host scalar zero-poins values
+    // Get host scalar zero-point values
     if (pd()->with_a_zero_points() || pd()->with_b_zero_points()) {
         ao = &GEMM_CTX_ARG_STORAGE(a_zero_point);
         bo = &GEMM_CTX_ARG_STORAGE(b_zero_point);
@@ -541,7 +541,6 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
     if (pd()->attr()->scales_.has_host_scalars()) {
         const auto &a_scales = pd()->attr()->scales_.get(DNNL_ARG_A);
         const auto &b_scales = pd()->attr()->scales_.get(DNNL_ARG_B);
-        const auto &c_scales = pd()->attr()->scales_.get(DNNL_ARG_C);
         const auto &a_scales_storage = GEMM_CTX_ARG_STORAGE(a_scales);
         const auto &b_scales_storage = GEMM_CTX_ARG_STORAGE(b_scales);
         const auto &c_scales_storage = GEMM_CTX_ARG_STORAGE(c_scales);
@@ -556,7 +555,7 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
             alpha *= scale_val;
         }
         // Limited support of host scalar dst scales
-        if (c_scales.is_host_scalar() && pd()->attr()->post_ops_.len() == 0) {
+        if (pd()->with_inlined_c_scale()) {
             CHECK(maybe_get_host_scalar_value(c_scales_storage, scale_val));
             gpu_assert(scale_val != 0);
             alpha /= scale_val;

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -21,7 +21,6 @@
 #include "gpu/intel/gemm/jit/gen_kernel.hpp"
 #include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/jit/eltwise_injector.hpp"
-#include "gpu/intel/jit/utils/type_bridge.hpp"
 #include "gpu/intel/utils.hpp"
 
 namespace dnnl {
@@ -80,7 +79,6 @@ status_t pd_t::init_post_ops(impl::engine_t *engine) {
 
     bool ok = true;
     int prelu_count = 0;
-    const int num_orig_postops = post_ops_.len();
     for (int i = 0; i < post_ops_.len(); i++) {
         const auto &e = post_ops_.entry_[i];
         switch (e.kind) {
@@ -150,8 +148,7 @@ status_t pd_t::init_post_ops(impl::engine_t *engine) {
     if (bias_via_binary_) {
         VDISPATCH_GEMM_SC(post_ops_.prepend_binary(binary_add, &d->bias_desc),
                 "%s: bias via binary post-op", VERBOSE_UNSUPPORTED_POSTOP);
-        binary_srcs_.insert(
-                binary_srcs_.begin(), binary_src_t {binary_src_t::bias, 0});
+        binary_srcs_.emplace(binary_srcs_.begin(), binary_src_t::bias, 0);
     }
     non_scale_po_ |= bias_via_binary_;
 
@@ -172,15 +169,14 @@ status_t pd_t::init_post_ops(impl::engine_t *engine) {
                         post_ops_.append_binary(binary_div, &scale_md),
                         "%s: %s scales via binary post-op",
                         VERBOSE_UNSUPPORTED_POSTOP, arg2str(arg).c_str());
-                binary_srcs_.push_back(
-                        binary_src_t {binary_src_t::scales, arg});
+                binary_srcs_.emplace_back(binary_src_t::scales, arg);
             } else {
                 VDISPATCH_GEMM_SC(
                         post_ops_.prepend_binary(binary_mul, &scale_md),
                         "%s: %s scales via binary post-op",
                         VERBOSE_UNSUPPORTED_POSTOP, arg2str(arg).c_str());
-                binary_srcs_.insert(binary_srcs_.begin(),
-                        binary_src_t {binary_src_t::scales, arg});
+                binary_srcs_.emplace(
+                        binary_srcs_.begin(), binary_src_t::scales, arg);
             }
             converted = true;
         }
@@ -202,8 +198,7 @@ status_t pd_t::init_post_ops(impl::engine_t *engine) {
         if (converted) b_quant.scale_ndims = -1;
     }
 
-    bool try_c_scale = !c_scales.is_host_scalar()
-            || (c_scales.is_host_scalar() && num_orig_postops > 0);
+    bool try_c_scale = !c_scales.is_host_scalar() || with_inlined_c_scale();
     if (!c_scales.has_default_values() && try_c_scale) {
         bool converted;
         CHECK(maybe_convert_scales_to_postop(c_scale_md_, DNNL_ARG_C,
@@ -217,7 +212,14 @@ status_t pd_t::init_post_ops(impl::engine_t *engine) {
     return status::success;
 }
 
-bool pd_t::dy_quant_enabled() {
+bool pd_t::with_inlined_c_scale() const {
+    if (!with_c_scales()) return false;
+    const auto &c_scales = attr()->scales_.get(DNNL_ARG_C);
+    if (!c_scales.is_host_scalar()) return false;
+    return !non_scale_po_ && !with_sum_;
+}
+
+bool pd_t::dy_quant_enabled() const {
     const auto d = desc();
     using namespace data_type;
     bool all_f8 = (utils::one_of(d->a_type(), f8_e5m2, f8_e4m3)
@@ -229,7 +231,7 @@ bool pd_t::dy_quant_enabled() {
             || all_f8;
 }
 
-bool pd_t::wei_decomp() {
+bool pd_t::wei_decomp() const {
     const auto d = desc();
     using namespace data_type;
     return (utils::one_of(d->c_type(), f32, f16, bf16, f8_e5m2, f8_e4m3)
@@ -242,7 +244,7 @@ bool pd_t::wei_decomp() {
             && attr()->mayiconvert(d->a_type(), f32);
 }
 
-bool pd_t::quant_enabled() {
+bool pd_t::quant_enabled() const {
     return wei_decomp() || dy_quant_enabled();
 }
 

--- a/src/gpu/intel/gemm/jit/pd.hpp
+++ b/src/gpu/intel/gemm/jit/pd.hpp
@@ -197,6 +197,7 @@ struct pd_t : public gemm::pd_t {
     bool with_c_scales() const {
         return !attr()->scales_.has_default_values(DNNL_ARG_DST);
     }
+    bool with_inlined_c_scale() const;
 
     bool with_a_zero_points() const { return (a_quant.zp_ndims >= 0); }
     bool with_b_zero_points() const { return (b_quant.zp_ndims >= 0); }
@@ -214,9 +215,9 @@ struct pd_t : public gemm::pd_t {
     bool b_scales_2d() const { return b_quant.scale_ndims > 1; }
     bool c_scales_2d() const { return c_quant.scale_ndims > 1; }
 
-    bool dy_quant_enabled();
-    bool wei_decomp();
-    bool quant_enabled();
+    bool dy_quant_enabled() const;
+    bool wei_decomp() const;
+    bool quant_enabled() const;
 
     bool swap_ab() const { return swap_ab_; }
 


### PR DESCRIPTION
Addresses the remaining failure in [MFDNN-15209](https://jira.devtools.intel.com/browse/MFDNN-15209).

The conditions for inlining a dst host scalar scale depended on there being no post-ops, ignoring the situation where bias is later implemented via post-op. This resulted in the scale being inlined and the scale and bias being applied in the wrong order.