### PR TITLE
benchdnn: propagate res into service reorder to obtain status

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -35,11 +35,11 @@
 
 namespace binary {
 
-int fill_mem(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_mem(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -88,7 +88,7 @@ int fill_mem(
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -254,29 +254,29 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC_0:
-                SAFE(fill_mem(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_mem(exec_arg, prb, mem, ref_mem, res), WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
                     auto &src_copy = mem_map.at(-exec_arg);
                     SAFE(bool(src_copy) ? OK : FAIL, WARN);
-                    SAFE(src_copy.reorder(mem), WARN);
+                    SAFE(src_copy.reorder(mem, res), WARN);
                 }
                 break;
             case DNNL_ARG_SRC_1:
-                SAFE(fill_mem(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_mem(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_SRC_2:
-                SAFE(fill_mem(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_mem(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_DST:
                 if (prb->attr.post_ops.find(alg_t::SUM) >= 0) {
-                    SAFE(fill_mem(exec_arg, prb, mem, ref_mem), WARN);
+                    SAFE(fill_mem(exec_arg, prb, mem, ref_mem, res), WARN);
 
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
                 break;
@@ -321,7 +321,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -38,8 +38,8 @@
 namespace bnorm {
 
 int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
-        dnn_mem_t &mem_dt) {
-    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
+        dnn_mem_t &mem_dt, res_t *res) {
+    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // If the library doesn't expect input mean, don't fill it.
@@ -60,14 +60,14 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_mean, res_t *res) {
-    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         return fill_random_real(mem_dt, mem_fp, res);
@@ -115,15 +115,15 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         }
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_variance(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
-        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src,
-        const dnn_mem_t &ref_mean) {
-    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
+        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src, const dnn_mem_t &ref_mean,
+        res_t *res) {
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // If the library doesn't expect input variance, don't fill it.
@@ -162,17 +162,17 @@ int fill_variance(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_src_add(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
-        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src,
-        const dnn_mem_t &ref_mean) {
+        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src, const dnn_mem_t &ref_mean,
+        res_t *res) {
     const bool fill_src_add = prb->fuse_add_relu();
     if (!fill_src_add) return OK;
-    if (fill_from_file(DNNL_ARG_SRC_1, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SRC_1, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -215,15 +215,16 @@ int fill_src_add(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
                 offset, round_to_nearest_representable(prb->dt, val));
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_scale(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const bool use_sc = prb->use_sc();
     if (!use_sc) return OK;
-    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -240,15 +241,16 @@ int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_shift(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const bool use_sh = prb->use_sh();
     if (!use_sh) return OK;
-    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -265,7 +267,7 @@ int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -276,7 +278,7 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
 
     auto &mean = mem_map.at(DNNL_ARG_MEAN);
     auto &ref_mean = ref_mem_map.at(DNNL_ARG_MEAN);
-    SAFE(fill_mean(prb, cfg, ref_mean, mean), WARN);
+    SAFE(fill_mean(prb, cfg, ref_mean, mean, res), WARN);
 
     auto &src = mem_map.at(DNNL_ARG_SRC);
     auto &ref_src = ref_mem_map.at(DNNL_ARG_SRC);
@@ -286,36 +288,37 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
     if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
         auto &src_copy = mem_map.at(-DNNL_ARG_SRC);
         SAFE(bool(src_copy) ? OK : FAIL, WARN);
-        SAFE(src_copy.reorder(src), WARN);
+        SAFE(src_copy.reorder(src, res), WARN);
     }
 
     auto &var = mem_map.at(DNNL_ARG_VARIANCE);
     auto &ref_var = ref_mem_map.at(DNNL_ARG_VARIANCE);
-    SAFE(fill_variance(prb, cfg, ref_var, var, ref_src, ref_mean), WARN);
+    SAFE(fill_variance(prb, cfg, ref_var, var, ref_src, ref_mean, res), WARN);
 
     auto &src_add = mem_map.at(DNNL_ARG_SRC_1);
     auto &ref_src_add = ref_mem_map.at(DNNL_ARG_SRC_1);
-    SAFE(fill_src_add(prb, cfg, ref_src_add, src_add, ref_src, ref_mean), WARN);
+    SAFE(fill_src_add(prb, cfg, ref_src_add, src_add, ref_src, ref_mean, res),
+            WARN);
 
     auto &scale = mem_map.at(DNNL_ARG_SCALE);
     auto &ref_scale = ref_mem_map.at(DNNL_ARG_SCALE);
-    SAFE(fill_scale(prb, ref_scale, scale), WARN);
+    SAFE(fill_scale(prb, ref_scale, scale, res), WARN);
 
     auto &shift = mem_map.at(DNNL_ARG_SHIFT);
     auto &ref_shift = ref_mem_map.at(DNNL_ARG_SHIFT);
-    SAFE(fill_shift(prb, ref_shift, shift), WARN);
+    SAFE(fill_shift(prb, ref_shift, shift, res), WARN);
 
     return OK;
 }
 
-int prepare_bwd(
-        const prb_t *prb, dnn_mem_map_t &mem_map, dnn_mem_map_t &ref_mem_map) {
+int prepare_bwd(const prb_t *prb, dnn_mem_map_t &mem_map,
+        dnn_mem_map_t &ref_mem_map, res_t *res) {
     auto &mem_fp = ref_mem_map.at(DNNL_ARG_DIFF_DST);
     auto &mem_dt = mem_map.at(DNNL_ARG_DIFF_DST);
 
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -325,7 +328,7 @@ int prepare_bwd(
         if (prb->inplace) {
             auto &diff_dst_copy = mem_map.at(-DNNL_ARG_DIFF_DST);
             SAFE(bool(diff_dst_copy) ? OK : FAIL, WARN);
-            SAFE(diff_dst_copy.reorder(mem_dt), WARN);
+            SAFE(diff_dst_copy.reorder(mem_dt, res), WARN);
         }
 
         return OK;
@@ -368,7 +371,7 @@ int prepare_bwd(
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -671,7 +674,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
     if (is_fwd_prim) {
         SAFE(prepare_fwd(prb, mem_map, ref_mem_map, res), WARN);
     } else {
-        SAFE(prepare_bwd(prb, mem_map, ref_mem_map), WARN);
+        SAFE(prepare_bwd(prb, mem_map, ref_mem_map, res), WARN);
     }
 
     // Don't keep reference memory if it is not used further.
@@ -749,7 +752,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = prb->dir & FLAG_FWD ? v_prim[0] : v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, v_prim[0], /*override_dir_with_fwd=*/true);
+    init_memory_args(
+            mem_map, prb, v_prim[0], res, /*override_dir_with_fwd=*/true);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], prb, res),
             WARN));
@@ -768,7 +772,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     if (prb->dir & FLAG_BWD) {
         // Pass same memory map as we need data from forward on backward.
-        init_memory_args(mem_map, prb, v_prim[1]);
+        init_memory_args(mem_map, prb, v_prim[1], res);
         TIME_FILL(SAFE(
                 init_ref_memory_args(ref_mem_map, mem_map, v_prim[1], prb, res),
                 WARN));

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -219,7 +219,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
 
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     assert(mem_dt.nelems() == mem_fp.nelems());
 
@@ -275,14 +275,14 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 // An object to pass information between different modules of the flow.
 struct kernel_args_t {
-    kernel_args_t(const prb_t *prb, res_t *res)
+    kernel_args_t(const prb_t *prb)
         :
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
         brgemm_kernel_(nullptr)
@@ -297,8 +297,7 @@ struct kernel_args_t {
 #endif
         , scratchpad_size_(0)
         , generate_skip_accumulation_(false)
-        , prb_(prb)
-        , res_(res) {
+        , prb_(prb) {
     }
 
     // Output members
@@ -318,12 +317,10 @@ struct kernel_args_t {
 
     // Input members
     const prb_t *prb_;
-    res_t *res_;
 };
 
-int init_kernel(kernel_args_t &kernel_args) {
+int init_kernel(kernel_args_t &kernel_args, res_t *res) {
     const prb_t *prb = kernel_args.prb_;
-    res_t *res = kernel_args.res_;
 
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
     using namespace namespace_impl;
@@ -852,8 +849,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             auto &dst_fp = ref_mem_map.at(DNNL_ARG_DST);
             auto &dst_dt = mem_map.at(DNNL_ARG_DST);
 
-            SAFE(dst_fp.reorder(acc_fp), WARN);
-            SAFE(dst_dt.reorder(dst_fp), WARN);
+            SAFE(dst_fp.reorder(acc_fp, res), WARN);
+            SAFE(dst_dt.reorder(dst_fp, res), WARN);
         }
     }
 
@@ -1030,8 +1027,8 @@ int doit(const prb_t *prb, res_t *res) {
     prb->skip_invalid(res);
     if (res->state == SKIPPED) return OK;
 
-    kernel_args_t kernel_args(prb, res);
-    SAFE(init_kernel(kernel_args), WARN);
+    kernel_args_t kernel_args(prb);
+    SAFE(init_kernel(kernel_args, res), WARN);
     if (res->state == SKIPPED) return OK;
     if (bench_mode == bench_mode_t::init) return res->state = INITIALIZED, OK;
 
@@ -1195,7 +1192,7 @@ int doit(const prb_t *prb, res_t *res) {
     } else {
         const auto &wei_dt = mem_map.at(DNNL_ARG_WEIGHTS);
         auto &wei_packed_dt = mem_map.at(DNNL_ARG_WEIGHTS_1);
-        SAFE(wei_packed_dt.reorder(wei_dt), WARN);
+        SAFE(wei_packed_dt.reorder(wei_dt, res), WARN);
     }
 
     std::vector<dnnl_dim_t> offsets(2 * prb->batch_size);

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -61,6 +61,7 @@ std::string reason2str(reason_t reason) {
         case reason_t::graph_untested_rewriter_error: return "Rewriter failed";
         case reason_t::invalid: return "Invalid case";
         case reason_t::failed_ref_not_expected: return "Ref Impl Not Expected";
+        case reason_t::failed_service_reorder: return "Service Reorder Error";
         case reason_t::skip_not_enough_ram: return "Not enough RAM";
         case reason_t::skip_impl_hit: return "Skip-impl option hit";
         case reason_t::skip_start: return "Skip-start option hit";

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -65,10 +65,10 @@ dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
 }
 
 int fill_src(int exec_arg, dnnl_data_type_t dt, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -110,7 +110,7 @@ int fill_src(int exec_arg, dnnl_data_type_t dt, dnn_mem_t &mem_dt,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -184,7 +184,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // filtered out and re-directed to a common call.
         if ((exec_arg & DNNL_ARG_MULTIPLE_SRC)
                 && !(exec_arg & DNNL_ARG_ATTR_SCALES)) {
-            SAFE(fill_src(exec_arg, prb->ddt, mem, ref_mem), WARN);
+            SAFE(fill_src(exec_arg, prb->ddt, mem, ref_mem, res), WARN);
         } else {
             SAFE(init_ref_memory_args_default_case(
                          exec_arg, mem, ref_mem, prb->attr, res),
@@ -238,7 +238,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -126,8 +126,8 @@ int check_reorder_presence(
                 /* prefill = */ true);
         dnn_mem_t mem_dt_s8(
                 mem_dt.md_, get_test_engine(), /* prefill = */ true);
-        SAFE(mem_fp_s8.reorder(mem_fp), WARN);
-        SAFE(mem_dt_s8.reorder(mem_fp_s8), WARN);
+        SAFE(mem_fp_s8.reorder(mem_fp, res), WARN);
+        SAFE(mem_dt_s8.reorder(mem_fp_s8, res), WARN);
         SAFE(mem_dt.size() == mem_dt_s8.size() ? OK : FAIL, WARN);
         int rc = std::memcmp((void *)mem_dt, (void *)mem_dt_s8, mem_dt.size());
         SAFE(rc == 0 ? OK : FAIL, WARN);
@@ -148,7 +148,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -230,7 +230,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res, cfg.get_swapped_dt(kind)), WARN);
 
     if (kind == WEI)
         SAFE(check_reorder_presence(prb, mem_dt, mem_fp, res), WARN);
@@ -559,7 +559,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
                 break;
@@ -575,7 +575,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         }
 
         update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)));
+                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
@@ -654,7 +654,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim_ref = v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(init_ref_memory_args(
                            ref_mem_map, mem_map, prim, prb, res, prim_ref),
             WARN));

--- a/tests/benchdnn/conv/conv_dw_fusion.cpp
+++ b/tests/benchdnn/conv/conv_dw_fusion.cpp
@@ -34,7 +34,7 @@ namespace conv_dw_fusion {
 
 int fill_scales(int exec_arg, const attr_t &attr, int arg, dnn_mem_t &mem_dt,
         dnn_mem_t &mem_fp, res_t *res) {
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
     return fill_scales(attr, arg, mem_dt, mem_fp, res);
 }
 
@@ -168,31 +168,33 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
                 SAFE(fill_data(SRC, exec_arg, prb0, cfg, mem, ref_mem, res),
                         WARN);
                 if (has_bench_mode_bit(mode_bit_t::corr))
-                    SAFE(mem_map0.at(exec_arg).reorder(ref_mem), WARN);
+                    SAFE(mem_map0.at(exec_arg).reorder(ref_mem, res), WARN);
                 break;
             case DNNL_ARG_WEIGHTS:
                 SAFE(fill_data(WEI, exec_arg, prb0, cfg, mem, ref_mem, res),
                         WARN);
                 if (has_bench_mode_bit(mode_bit_t::corr))
-                    SAFE(mem_map0.at(exec_arg).reorder(ref_mem), WARN);
+                    SAFE(mem_map0.at(exec_arg).reorder(ref_mem, res), WARN);
                 break;
             case DNNL_ARG_BIAS:
                 SAFE(fill_data(BIA, exec_arg, prb0, cfg, mem, ref_mem, res),
                         WARN);
                 if (has_bench_mode_bit(mode_bit_t::corr))
-                    SAFE(mem_map0.at(exec_arg).reorder(ref_mem), WARN);
+                    SAFE(mem_map0.at(exec_arg).reorder(ref_mem, res), WARN);
                 break;
             case (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS):
                 SAFE(fill_data(WEI, exec_arg, prb1, cfg, mem, ref_mem, res),
                         WARN);
                 if (has_bench_mode_bit(mode_bit_t::corr))
-                    SAFE(mem_map1.at(DNNL_ARG_WEIGHTS).reorder(ref_mem), WARN);
+                    SAFE(mem_map1.at(DNNL_ARG_WEIGHTS).reorder(ref_mem, res),
+                            WARN);
                 break;
             case (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS):
                 SAFE(fill_data(BIA, exec_arg, prb1, cfg, mem, ref_mem, res),
                         WARN);
                 if (has_bench_mode_bit(mode_bit_t::corr))
-                    SAFE(mem_map1.at(DNNL_ARG_BIAS).reorder(ref_mem), WARN);
+                    SAFE(mem_map1.at(DNNL_ARG_BIAS).reorder(ref_mem, res),
+                            WARN);
                 break;
             default: { // Process all attributes here
                 int pre_dw_post_ops_range
@@ -214,18 +216,18 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
                             /* int = */ true, attr_t::post_ops_t::kind_t::ADD,
                             "binary post-op");
                     if (exec_arg & DNNL_ARG_SRC_1) {
-                        if (!fill_from_file(exec_arg, mem, ref_mem))
+                        if (!fill_from_file(exec_arg, mem, ref_mem, res))
                             SAFE(fill_random_real(
                                          mem, ref_mem, res, binary_fill_cfg),
                                     WARN);
-                        SAFE(mem_map0.at(exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map0.at(exec_arg).reorder(ref_mem, res), WARN);
                     }
                 } else if (is_pre_dw_scales_arg && !is_post_dw_scales_arg) {
                     int local_exec_arg = exec_arg ^ DNNL_ARG_ATTR_SCALES;
                     SAFE(fill_scales(exec_arg, prb0->attr, local_exec_arg, mem,
                                  ref_mem, res),
                             WARN);
-                    SAFE(mem_map0.at(exec_arg).reorder(mem), WARN);
+                    SAFE(mem_map0.at(exec_arg).reorder(mem, res), WARN);
                 }
             } break;
         }
@@ -249,7 +251,7 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
             // Binary post-op filling config.
             fill_cfg_t binary_fill_cfg(mem.dt(), -16.f, 16.f, /* int = */ true,
                     attr_t::post_ops_t::kind_t::ADD, "binary post-op");
-            if (!fill_from_file(orig_idx, mem, ref_mem))
+            if (!fill_from_file(orig_idx, mem, ref_mem, res))
                 SAFE(fill_random_real(mem, ref_mem, res, binary_fill_cfg),
                         WARN);
         }
@@ -347,21 +349,21 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim1 = v_prim[2];
 
     dnn_mem_map_t mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
 
     // Fill first convolution
     std::unique_ptr<prb_t> prb0 = get_first_conv_prb(prb);
     if (!prb0) SAFE(FAIL, WARN);
 
     dnn_mem_map_t mem_map0;
-    init_memory_args(mem_map0, prb0.get(), prim0);
+    init_memory_args(mem_map0, prb0.get(), prim0, res);
 
     // Fill next convolution
     std::unique_ptr<prb_t> prb1 = get_fused_conv_prb(prb);
     if (!prb1) SAFE(FAIL, WARN);
 
     dnn_mem_map_t mem_map1;
-    init_memory_args(mem_map1, prb1.get(), prim1);
+    init_memory_args(mem_map1, prb1.get(), prim1, res);
 
     TIME_FILL(SAFE(init_ref_memory_args(mem_map0, mem_map1, mem_map, prim0,
                            prb0.get(), prb1.get(), prb, res, prb->dir),
@@ -374,7 +376,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
         if (has_bench_mode_bit(mode_bit_t::corr)) {
             SAFE(execute_and_wait(prim0, args0), WARN);
-            SAFE(mem_map1.at(DNNL_ARG_SRC).reorder(mem_map0.at(DNNL_ARG_DST)),
+            SAFE(mem_map1.at(DNNL_ARG_SRC)
+                            .reorder(mem_map0.at(DNNL_ARG_DST), res),
                     WARN);
             SAFE(execute_and_wait(prim1, args1), WARN);
 

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -127,8 +127,8 @@ int check_reorder_presence(
                 /* prefill = */ true);
         dnn_mem_t mem_dt_s8(
                 mem_dt.md_, get_test_engine(), /* prefill = */ true);
-        SAFE(mem_fp_s8.reorder(mem_fp), WARN);
-        SAFE(mem_dt_s8.reorder(mem_fp_s8), WARN);
+        SAFE(mem_fp_s8.reorder(mem_fp, res), WARN);
+        SAFE(mem_dt_s8.reorder(mem_fp_s8, res), WARN);
         SAFE(mem_dt.size() == mem_dt_s8.size() ? OK : FAIL, WARN);
         int rc = std::memcmp((void *)mem_dt, (void *)mem_dt_s8, mem_dt.size());
         SAFE(rc == 0 ? OK : FAIL, WARN);
@@ -141,7 +141,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -215,7 +215,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res, cfg.get_swapped_dt(kind)), WARN);
 
     if (kind == WEI)
         SAFE(check_reorder_presence(prb, mem_dt, mem_fp, res), WARN);
@@ -486,7 +486,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
                 break;
@@ -517,7 +517,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         }
 
         update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)));
+                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
@@ -589,7 +589,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim_ref = v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(init_ref_memory_args(
                            ref_mem_map, mem_map, prim, prb, res, prim_ref),
             WARN));

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -744,7 +744,7 @@ int measure_perf(const thr_ctx_t &ctx, res_t *res, perf_function_t &perf_func,
             // numbers.
             mem_map[j].emplace(
                     arg, dnn_mem_t(m.md_, engine, /* prefill = */ true));
-            SAFE(mem_map[j].at(arg).reorder(m), WARN);
+            SAFE(mem_map[j].at(arg).reorder(m, res), WARN);
         }
         v_args[j] = args_t(mem_map[j]);
         execute_unmap_args(v_args[j], dnnl_args[j]);
@@ -1863,7 +1863,7 @@ void get_kinds_to_check_shared(
 // consider passing `cfg` directly.
 int update_ref_mem_map_from_prim(dnnl_primitive_t prim_ref,
         const dnn_mem_t &library_mem, dnn_mem_map_t &ref_mem_map, int exec_arg,
-        dnnl_data_type_t swapped_dt) {
+        dnnl_data_type_t swapped_dt, res_t *res) {
     if (!prim_ref) return OK;
 
     const auto &ref_mem = ref_mem_map.at(exec_arg);
@@ -1929,7 +1929,7 @@ int update_ref_mem_map_from_prim(dnnl_primitive_t prim_ref,
         const auto prim_ref_swapped_dt = query_md_data_type(ref_md) == dnnl_f32
                 ? dnnl_data_type_undef
                 : swapped_dt;
-        SAFE(prim_ref_mem.reorder(ref_mem, prim_ref_swapped_dt), WARN);
+        SAFE(prim_ref_mem.reorder(ref_mem, res, prim_ref_swapped_dt), WARN);
     }
     ref_mem_map[exec_arg] = std::move(prim_ref_mem);
 
@@ -1948,7 +1948,7 @@ int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
         dnn_mem_t &ref_mem, const attr_t &attr, res_t *res,
         const std::unordered_map<int, fill_cfg_t> &fill_cfg_map) {
     assert(exec_arg > 0); // Negative values will produce false-positive `true`.
-    if (fill_from_file(exec_arg, mem, ref_mem)) return OK;
+    if (fill_from_file(exec_arg, mem, ref_mem, res)) return OK;
 
     const int post_ops_range = DNNL_ARG_ATTR_MULTIPLE_POST_OP(31)
             - DNNL_ARG_ATTR_MULTIPLE_POST_OP(0);
@@ -2013,8 +2013,9 @@ int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
                 fill_scales(attr, local_exec_arg, mem, ref_mem, res), WARN));
     } else if (is_zero_point_arg) {
         int local_exec_arg = exec_arg ^ DNNL_ARG_ATTR_ZERO_POINTS;
-        TIME_FILL(SAFE(
-                fill_zero_points(attr, local_exec_arg, mem, ref_mem), WARN));
+        TIME_FILL(
+                SAFE(fill_zero_points(attr, local_exec_arg, mem, ref_mem, res),
+                        WARN));
     } else if (is_dropout_p) {
         ref_mem.set_f32_elem(0, attr.dropout.p);
         mem.set_elem(0, attr.dropout.p);
@@ -2032,7 +2033,7 @@ int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
         mem.set_s64_elem(0, attr.dropout.offset);
     } else if (is_rounding_seed) {
         ref_mem.set_elem(0, attr.rounding_mode.seed);
-        TIME_FILL(SAFE(mem.reorder(ref_mem), WARN));
+        TIME_FILL(SAFE(mem.reorder(ref_mem, res), WARN));
     }
 
     return OK;
@@ -2081,7 +2082,7 @@ int check_bitwise(dnnl_primitive_t prim, const std::vector<data_kind_t> &kinds,
         run1_mem_map.emplace(arg,
                 dnn_mem_t(mem.md_, dnnl_f32, tag::abx, get_cpu_engine(),
                         /* prefill = */ false));
-        SAFE(run1_mem_map.at(arg).reorder(mem), WARN);
+        SAFE(run1_mem_map.at(arg).reorder(mem, res), WARN);
     }
 
     // Put original data into DST tensor if sum post-op is present.
@@ -2090,7 +2091,7 @@ int check_bitwise(dnnl_primitive_t prim, const std::vector<data_kind_t> &kinds,
         auto &dst_mem = const_cast<dnn_mem_t &>(args.find(query_arg));
         const auto &orig_dst_mem = args.find(-query_arg);
         SAFE_V(bool(orig_dst_mem) && bool(dst_mem) ? OK : FAIL);
-        SAFE(dst_mem.reorder(orig_dst_mem), WARN);
+        SAFE(dst_mem.reorder(orig_dst_mem, res), WARN);
     }
 
     // Put original data into SRC if inplace mode was specified.
@@ -2115,7 +2116,7 @@ int check_bitwise(dnnl_primitive_t prim, const std::vector<data_kind_t> &kinds,
             res->state = FAILED;
             return FAIL;
         }
-        SAFE(in_mem.reorder(orig_in_mem), WARN);
+        SAFE(in_mem.reorder(orig_in_mem, res), WARN);
     }
 
     // Perform a second run.
@@ -2414,7 +2415,7 @@ void check_correctness(const base_prb_t *base_prb,
 }
 
 void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
-        dnnl_primitive_t prim, bool override_dir_with_fwd,
+        dnnl_primitive_t prim, res_t *res, bool override_dir_with_fwd,
         const engine_t &test_engine) {
     const std::vector<int> supported_exec_args
             = base_prb->supported_exec_args(override_dir_with_fwd);
@@ -2511,7 +2512,7 @@ void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
                         dnn_mem_t new_mem(
                                 md, test_engine, /* prefill = */ true);
                         // Reorder user's data from the old memory to the new one.
-                        auto st = new_mem.reorder(mem_map.at(exec_arg));
+                        auto st = new_mem.reorder(mem_map.at(exec_arg), res);
                         assert(st == OK);
                         if (st != OK) return;
                         mem_map[exec_arg] = std::move(new_mem);

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -321,7 +321,7 @@ dnnl_data_type_t deduce_cfg_data_type(
 // internally, while map doesn't not invalidate its references when adding a new
 // element which simplifies an implementation.
 void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
-        dnnl_primitive_t prim, bool override_dir_with_fwd = false,
+        dnnl_primitive_t prim, res_t *res, bool override_dir_with_fwd = false,
         const engine_t &test_engine = get_test_engine());
 
 void erase_unused_args(
@@ -332,7 +332,7 @@ void get_kinds_to_check_shared(
 
 int update_ref_mem_map_from_prim(dnnl_primitive_t prim_ref,
         const dnn_mem_t &library_mem, dnn_mem_map_t &ref_mem_map, int exec_arg,
-        dnnl_data_type_t swapped_dt);
+        dnnl_data_type_t swapped_dt, res_t *res);
 
 int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
         dnn_mem_t &ref_mem, const attr_t &attr, res_t *res,

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -115,7 +115,7 @@ dnn_mem_t::dnn_mem_t(const dnn_mem_t &rhs, dnnl_data_type_t dt,
     : dnn_mem_t(rhs.md_, dt, tag, engine, /* prefill = */ true) {
     // Prefill is `true` unconditionally because of reorder involved.
     if (active_) {
-        int status = reorder(rhs);
+        int status = reorder(rhs, nullptr);
         if (status != OK) {
             BENCHDNN_PRINT(
                     0, "%s\n", "Error: reorder in memory constructor failed.");
@@ -123,11 +123,12 @@ dnn_mem_t::dnn_mem_t(const dnn_mem_t &rhs, dnnl_data_type_t dt,
     }
 }
 
-int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
+int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst, res_t *res,
         const_dnnl_primitive_attr_t attr) {
     std::shared_ptr<const dnn_mem_t> r_src(&src, [](const dnn_mem_t *) {});
     std::shared_ptr<dnn_mem_t> r_dst(&dst, [](dnn_mem_t *) {});
 
+    dnnl_status_t status = dnnl_success;
     dnnl_primitive_desc_t r_pd_ {};
     dnnl_primitive_t prim_ {};
 
@@ -148,7 +149,7 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
     const auto &cpu_engine = get_cpu_engine();
     if (src.engine().is_gpu() || dst.engine().is_gpu()) {
 
-        dnnl_status_t status = dnnl_reorder_primitive_desc_create(
+        status = dnnl_reorder_primitive_desc_create(
                 &r_pd_, src.md_, cpu_engine, dst.md_, cpu_engine, attr);
         if (status == dnnl_success) {
             // Create CPU memory objects wrapping mapped pointers of source and
@@ -163,7 +164,7 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
 
     while (!r_pd_) {
         // Fallback to GPU reorder.
-        auto status = dnnl_reorder_primitive_desc_create(
+        status = dnnl_reorder_primitive_desc_create(
                 &r_pd_, src.md_, src.engine(), dst.md_, dst.engine(), attr);
         if (status == dnnl_success) break;
         // If fail to create reorder pd, use plain data copy for identical
@@ -194,8 +195,9 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
             });
             return OK;
         }
-        BENCHDNN_PRINT(0, "%s\n", "Error: failed to create a reorder.");
-        return FAIL;
+        if (res) res->state = FAILED;
+        if (res) res->reason = reason_t::failed_service_reorder;
+        DNN_SAFE(status, WARN);
     }
 
     auto r_pd = make_benchdnn_dnnl_wrapper(r_pd_);
@@ -216,7 +218,13 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
     dnn_mem_t scratchpad(
             scratchpad_md, scratchpad_engine, /* prefill = */ true);
 
-    DNN_SAFE(dnnl_primitive_create(&prim_, r_pd), CRIT);
+    status = dnnl_primitive_create(&prim_, r_pd);
+    if (status != dnnl_success) {
+        if (res) res->state = FAILED;
+        if (res) res->reason = reason_t::failed_service_reorder;
+        DNN_SAFE(status, WARN);
+    }
+
     auto prim = make_benchdnn_dnnl_wrapper(prim_);
 
     args_t args;
@@ -249,7 +257,7 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
     }
 
     stream_staller_t staller(stream);
-    auto status = dnnl_primitive_execute(
+    status = dnnl_primitive_execute(
             prim, stream, static_cast<int>(dnnl_args.size()), dnnl_args.data());
     staller.release();
     DNN_SAFE(dnnl_stream_wait(stream), CRIT);
@@ -259,13 +267,19 @@ int execute_reorder(const dnn_mem_t &src, dnn_mem_t &dst,
     for (int i = 0; i < args.size(); ++i)
         if (!args.dnn_mem(i).is_mapped()) args.dnn_mem(i).map();
 
-    return status != dnnl_success ? FAIL : OK;
+    if (status != dnnl_success) {
+        if (res) res->state = FAILED;
+        if (res) res->reason = reason_t::failed_service_reorder;
+        DNN_SAFE(status, WARN);
+    }
+
+    return OK;
 }
 
 // `swap_dt` changes `this` data type which may be needed for
 // different sum data type or fpmath mode specified.
-int dnn_mem_t::reorder(const dnn_mem_t &rhs, const_dnnl_primitive_attr_t attr,
-        dnnl_data_type_t swap_dt) {
+int dnn_mem_t::reorder(const dnn_mem_t &rhs, res_t *res,
+        const_dnnl_primitive_attr_t attr, dnnl_data_type_t swap_dt) {
     if (this == &rhs) return OK;
 
     // When `rhs` object is empty, it's illigal to execute a reorder over it.
@@ -285,7 +299,7 @@ int dnn_mem_t::reorder(const dnn_mem_t &rhs, const_dnnl_primitive_attr_t attr,
     const bool do_swap_dt = swap_dt != dnnl_data_type_undef;
     dnnl_data_type_t orig_dt = this->dt();
     if (do_swap_dt) this->set_dt(swap_dt);
-    auto status = execute_reorder(rhs, *this, attr);
+    auto status = execute_reorder(rhs, *this, res, attr);
     if (do_swap_dt) this->set_dt(orig_dt);
     return status;
 }

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -85,11 +85,12 @@ struct dnn_mem_t {
 
     ~dnn_mem_t() { cleanup(); }
 
-    int reorder(const dnn_mem_t &rhs, const_dnnl_primitive_attr_t attr,
+    int reorder(const dnn_mem_t &rhs, res_t *res,
+            const_dnnl_primitive_attr_t attr,
             dnnl_data_type_t swap_dt = dnnl_data_type_undef);
-    int reorder(const dnn_mem_t &rhs,
+    int reorder(const dnn_mem_t &rhs, res_t *res,
             dnnl_data_type_t swap_dt = dnnl_data_type_undef) {
-        return reorder(rhs, nullptr, swap_dt);
+        return reorder(rhs, res, nullptr, swap_dt);
     }
 
     size_t size(int index = 0) const;

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -197,10 +197,10 @@ static float get_eltwise_zero_trust_percent(const prb_t *prb) {
 }
 
 int fill_data(int exec_arg, const prb_t *prb, data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -282,7 +282,7 @@ int fill_data(int exec_arg, const prb_t *prb, data_kind_t kind,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -451,23 +451,24 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         switch (exec_arg) {
             case DNNL_ARG_SRC:
                 if (is_fwd_prim)
-                    SAFE(fill_data(exec_arg, prb, SRC, mem, ref_mem), WARN);
+                    SAFE(fill_data(exec_arg, prb, SRC, mem, ref_mem, res),
+                            WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
                     auto &src_copy = mem_map.at(-exec_arg);
                     SAFE(bool(src_copy) ? OK : FAIL, WARN);
-                    SAFE(src_copy.reorder(mem), WARN);
+                    SAFE(src_copy.reorder(mem, res), WARN);
                 }
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_data(exec_arg, prb, DST, mem, ref_mem), WARN);
+                SAFE(fill_data(exec_arg, prb, DST, mem, ref_mem, res), WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
                     auto &diff_dst_copy = mem_map.at(-exec_arg);
                     SAFE(bool(diff_dst_copy) ? OK : FAIL, WARN);
-                    SAFE(diff_dst_copy.reorder(mem), WARN);
+                    SAFE(diff_dst_copy.reorder(mem, res), WARN);
                 }
                 break;
             default:
@@ -543,7 +544,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = prb->dir & FLAG_FWD ? v_prim[0] : v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, v_prim[0], /*override_dir_with_fwd=*/true);
+    init_memory_args(
+            mem_map, prb, v_prim[0], res, /*override_dir_with_fwd=*/true);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], prb, res),
             WARN));
@@ -560,7 +562,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     if (prb->dir & FLAG_BWD) {
         // Pass same memory map as we need data from forward on backward.
-        init_memory_args(mem_map, prb, v_prim[1]);
+        init_memory_args(mem_map, prb, v_prim[1], res);
         TIME_FILL(SAFE(
                 init_ref_memory_args(ref_mem_map, mem_map, v_prim[1], prb, res),
                 WARN));

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -34,8 +34,8 @@ using namespace bnorm;
 namespace gnorm {
 
 int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
-        dnn_mem_t &mem_dt) {
-    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
+        dnn_mem_t &mem_dt, res_t *res) {
+    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // If the library doesn't expect input mean, don't fill it.
@@ -63,14 +63,14 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     });
 
     if (mem_dt && IMPLICATION(prb->dir & FLAG_FWD, prb->use_stats()))
-        SAFE(mem_dt.reorder(mem_fp), WARN);
+        SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_mean, res_t *res) {
-    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         return fill_random_real(mem_dt, mem_fp, res);
@@ -178,15 +178,15 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         }
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
-        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src,
-        const dnn_mem_t &ref_mean) {
-    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
+        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src, const dnn_mem_t &ref_mean,
+        res_t *res) {
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // If the library doesn't expect input variance, don't fill it.
@@ -228,15 +228,16 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         mem_fp.set_f32_elem(idx, val);
     });
 
-    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_scale(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const bool use_sc = prb->use_sc();
     if (!use_sc) return OK;
-    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -253,15 +254,16 @@ int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_shift(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const bool use_sh = prb->use_sh();
     if (!use_sh) return OK;
-    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -278,7 +280,7 @@ int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -289,7 +291,7 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
 
     auto &mean = mem_map.at(DNNL_ARG_MEAN);
     auto &ref_mean = ref_mem_map.at(DNNL_ARG_MEAN);
-    SAFE(fill_mean(prb, cfg, ref_mean, mean), WARN);
+    SAFE(fill_mean(prb, cfg, ref_mean, mean, res), WARN);
 
     auto &src = mem_map.at(DNNL_ARG_SRC);
     auto &ref_src = ref_mem_map.at(DNNL_ARG_SRC);
@@ -299,28 +301,30 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
     if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
         auto &src_copy = mem_map.at(-DNNL_ARG_SRC);
         SAFE(bool(src_copy) ? OK : FAIL, WARN);
-        SAFE(src_copy.reorder(src), WARN);
+        SAFE(src_copy.reorder(src, res), WARN);
     }
 
     auto &var = mem_map.at(DNNL_ARG_VARIANCE);
     auto &ref_var = ref_mem_map.at(DNNL_ARG_VARIANCE);
-    SAFE(fill_variance_fwd(prb, cfg, ref_var, var, ref_src, ref_mean), WARN);
+    SAFE(fill_variance_fwd(prb, cfg, ref_var, var, ref_src, ref_mean, res),
+            WARN);
 
     auto &scale = mem_map.at(DNNL_ARG_SCALE);
     auto &ref_scale = ref_mem_map.at(DNNL_ARG_SCALE);
-    SAFE(fill_scale(prb, ref_scale, scale), WARN);
+    SAFE(fill_scale(prb, ref_scale, scale, res), WARN);
 
     auto &shift = mem_map.at(DNNL_ARG_SHIFT);
     auto &ref_shift = ref_mem_map.at(DNNL_ARG_SHIFT);
-    SAFE(fill_shift(prb, ref_shift, shift), WARN);
+    SAFE(fill_shift(prb, ref_shift, shift, res), WARN);
 
     return OK;
 }
 
-int fill_variance_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_variance_bwd(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -341,7 +345,7 @@ int fill_variance_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(idx, val - prb->eps);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -350,7 +354,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         const dnn_mem_t &ref_mean, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -381,7 +385,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         }
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -390,7 +394,7 @@ int fill_diff_dst_bwd(
         const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -428,7 +432,7 @@ int fill_diff_dst_bwd(
         }
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -439,11 +443,11 @@ int prepare_bwd(const prb_t *prb, dnn_mem_map_t &mem_map,
 
     auto &mean = mem_map.at(DNNL_ARG_MEAN);
     auto &ref_mean = ref_mem_map.at(DNNL_ARG_MEAN);
-    SAFE(fill_mean(prb, cfg, ref_mean, mean), WARN);
+    SAFE(fill_mean(prb, cfg, ref_mean, mean, res), WARN);
 
     auto &var = mem_map.at(DNNL_ARG_VARIANCE);
     auto &ref_var = ref_mem_map.at(DNNL_ARG_VARIANCE);
-    SAFE(fill_variance_bwd(prb, ref_var, var), WARN);
+    SAFE(fill_variance_bwd(prb, ref_var, var, res), WARN);
 
     auto &src = mem_map.at(DNNL_ARG_SRC);
     auto &ref_src = ref_mem_map.at(DNNL_ARG_SRC);
@@ -457,12 +461,12 @@ int prepare_bwd(const prb_t *prb, dnn_mem_map_t &mem_map,
     if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
         auto &d_dst_copy = mem_map.at(-DNNL_ARG_DIFF_DST);
         SAFE(bool(d_dst_copy) ? OK : FAIL, WARN);
-        SAFE(d_dst_copy.reorder(d_dst), WARN);
+        SAFE(d_dst_copy.reorder(d_dst, res), WARN);
     }
 
     auto &scale = mem_map.at(DNNL_ARG_SCALE);
     auto &ref_scale = ref_mem_map.at(DNNL_ARG_SCALE);
-    SAFE(fill_scale(prb, ref_scale, scale), WARN);
+    SAFE(fill_scale(prb, ref_scale, scale, res), WARN);
 
     return OK;
 }
@@ -755,7 +759,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/graph/custom_driver.cpp
+++ b/tests/benchdnn/graph/custom_driver.cpp
@@ -60,7 +60,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             case DNNL_ARG_SRC:
                 // For GenIndex op, the input value doesn't affect the output
                 // value, it doesn't matter what value we fill in.
-                SAFE(::custom::fill_mem(mem, ref_mem, 0, 0), WARN);
+                SAFE(::custom::fill_mem(mem, ref_mem, 0, 0, res), WARN);
                 break;
             default: break;
         }
@@ -125,7 +125,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             case DNNL_ARG_SRC:
                 // Use `7` not to mess with scales for s8 which may create a
                 // `8 * 8 (= 128) = -128` for s8.
-                SAFE(::custom::fill_mem(mem, ref_mem, -8, 7), WARN);
+                SAFE(::custom::fill_mem(mem, ref_mem, -8, 7, res), WARN);
                 break;
             default: break;
         }
@@ -138,9 +138,7 @@ int execute(const prb_t *prb, const args_t &args, res_t *res) {
     const auto &tag = ::std::get<0>(prb->arg_mds_.at(DNNL_ARG_SRC));
     dnn_mem_t pad(src, src.dt(), tag, get_test_engine());
     ::graph::permute_md(pad, prb->order);
-    int ret = const_cast<dnn_mem_t &>(args.find(DNNL_ARG_DST)).reorder(pad);
-    if (ret != OK) { res->state = FAILED; }
-    return ret;
+    return const_cast<dnn_mem_t &>(args.find(DNNL_ARG_DST)).reorder(pad, res);
 }
 } // namespace transpose
 
@@ -172,7 +170,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             case DNNL_ARG_SRC:
                 // Use `7` not to mess with scales for s8 which may create a
                 // `8 * 8 (= 128) = -128` for s8.
-                SAFE(::custom::fill_mem(mem, ref_mem, -8, 7), WARN);
+                SAFE(::custom::fill_mem(mem, ref_mem, -8, 7, res), WARN);
                 break;
             default: break;
         }
@@ -186,15 +184,13 @@ int execute(const prb_t *prb, const args_t &args, res_t *res) {
     // generate dense stride
     dnn_mem_t pad(src.md_, src.dt(), tag::abx, get_test_engine(),
             /* prefill = */ true);
-    int ret = pad.reorder(src);
-    if (ret != OK) { res->state = FAILED; }
+    SAFE(pad.reorder(src, res), WARN);
+
     // update output shape with dense stride
     dnnl_memory_desc_destroy(pad.md_);
     dnnl_memory_desc_create_with_string_tag(&pad.md_, dst.ndims(), dst.dims(),
             dst.dt(), normalize_tag(tag::abx, dst.ndims()).c_str());
-    ret = dst.reorder(pad);
-    if (ret != OK) { res->state = FAILED; }
-    return ret;
+    return dst.reorder(pad, res);
 }
 } // namespace reshape
 
@@ -224,7 +220,8 @@ void setup_cmp(compare::compare_t &cmp, const base_prb_t *base_prb,
     }
 }
 
-int fill_mem(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int f_min, int f_max) {
+int fill_mem(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int f_min, int f_max,
+        res_t *res) {
 
     const auto dt = mem_dt.dt();
     if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
@@ -253,13 +250,13 @@ int fill_mem(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int f_min, int f_max) {
             mem_fp.set_elem(idx, round_to_nearest_representable(dt, value));
         }
     });
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
-        bool override_dir_with_fwd, const engine_t &test_engine) {
+        bool override_dir_with_fwd, res_t *, const engine_t &test_engine) {
     const auto *prb = prb_t::from(base_prb);
     const auto &supported_exec_args
             = base_prb->supported_exec_args(override_dir_with_fwd);
@@ -284,8 +281,8 @@ void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
 
 void init_memory_args_native(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
         const graph::deserialized_op_t &, const engine_t &ref_eng) {
-    init_memory_args(
-            mem_map, base_prb, /*override_dir_with_fwd=*/false, ref_eng);
+    init_memory_args(mem_map, base_prb, /*override_dir_with_fwd=*/false,
+            nullptr, ref_eng);
 }
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,

--- a/tests/benchdnn/graph/custom_driver.hpp
+++ b/tests/benchdnn/graph/custom_driver.hpp
@@ -78,12 +78,13 @@ private:
 
 dnnl_status_t init_pd(init_pd_args_t &init_pd_args);
 
-int fill_mem(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int f_min, int f_max);
+int fill_mem(
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int f_min, int f_max, res_t *res);
 void setup_cmp(compare::compare_t &cmp, const base_prb_t *prb, data_kind_t kind,
         const args_t &ref_args);
 
 void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
-        bool override_dir_with_fwd = false,
+        bool override_dir_with_fwd = false, res_t *res = nullptr,
         const engine_t &test_engine = get_test_engine());
 
 void init_memory_args_native(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -246,7 +246,7 @@ int map_unmap_partition_mem(graph::partition_mem_map_t &partition_mem_map,
 int make_input_tensors(std::vector<dnnl::graph::tensor> &input_ts,
         const graph::partition_mem_map_t &partition_mem_map,
         const graph::op_ref_list_t &ops,
-        const std::vector<dnnl::graph::logical_tensor> &ins) {
+        const std::vector<dnnl::graph::logical_tensor> &ins, res_t *res) {
     for (size_t idx = 0; idx < ins.size(); ++idx) {
         // find the op id of the input logical tensor
         const auto &in = ins[idx];
@@ -263,7 +263,7 @@ int make_input_tensors(std::vector<dnnl::graph::tensor> &input_ts,
         const auto iter = partition_mem_map.find(lt_id);
         if (iter != partition_mem_map.end()) {
             const auto &graph_mem = iter->second;
-            input_ts[idx] = graph_mem.make_graph_tensor(lt);
+            input_ts[idx] = graph_mem.make_graph_tensor(lt, res);
         } else {
             BENCHDNN_PRINT(0,
                     "FAIL: Cannot find graph memory with lt id %zu! \n", lt_id);
@@ -284,7 +284,8 @@ int make_output_tensors(std::vector<dnnl::graph::tensor> &output_ts,
         const graph::partition_mem_map_t &partition_mem_map,
         const graph::op_ref_list_t &ops,
         const std::vector<dnnl::graph::logical_tensor> &outs,
-        const std::vector<std::pair<size_t, size_t>> &inplace_ports) {
+        const std::vector<std::pair<size_t, size_t>> &inplace_ports,
+        res_t *res) {
 
     for (size_t idx = 0; idx < outs.size(); ++idx) {
         // find the op id of the output logical tensor
@@ -307,7 +308,7 @@ int make_output_tensors(std::vector<dnnl::graph::tensor> &output_ts,
         }
         const auto &graph_mem = iter->second;
         if (has_bench_mode_bit(mode_bit_t::corr)) {
-            output_ts[idx] = graph_mem.make_graph_tensor(lt);
+            output_ts[idx] = graph_mem.make_graph_tensor(lt, res);
         } else {
             // For performance mode, we need special handling for graph
             // with in-place ports by using the graph memory of input
@@ -323,7 +324,8 @@ int make_output_tensors(std::vector<dnnl::graph::tensor> &output_ts,
                 const auto inplace_iter = partition_mem_map.find(inplace_lt_id);
                 if (inplace_iter != partition_mem_map.end()) {
                     const auto &inplace_graph_mem = inplace_iter->second;
-                    output_ts[idx] = inplace_graph_mem.make_graph_tensor(lt);
+                    output_ts[idx]
+                            = inplace_graph_mem.make_graph_tensor(lt, res);
                 } else {
                     BENCHDNN_PRINT(0,
                             "FAIL: Cannot find logical tensor with id %zu! "
@@ -333,7 +335,7 @@ int make_output_tensors(std::vector<dnnl::graph::tensor> &output_ts,
                 }
 
             } else {
-                output_ts[idx] = graph_mem.make_graph_tensor(lt);
+                output_ts[idx] = graph_mem.make_graph_tensor(lt, res);
             }
         }
     }
@@ -772,7 +774,7 @@ int doit(const prb_t *prb, res_t *res) {
         const auto &inplace_ports
                 = c_partitions[i - idx_offset].get_inplace_ports();
         if (make_input_tensors(
-                    input_ts, partition_mem_map_v[i], op_list, inputs)
+                    input_ts, partition_mem_map_v[i], op_list, inputs, res)
                 != OK) {
             BENCHDNN_PRINT(0,
                     "FAIL: Fail to construct input tesnors for partition "
@@ -781,7 +783,7 @@ int doit(const prb_t *prb, res_t *res) {
             return res->state = FAILED, FAIL;
         }
         if (make_output_tensors(output_ts, partition_mem_map_v[i], op_list,
-                    outputs, inplace_ports)
+                    outputs, inplace_ports, res)
                 != OK) {
             BENCHDNN_PRINT(0,
                     "FAIL: Fail to construct output tesnors for partition "

--- a/tests/benchdnn/graph/graph_memory.cpp
+++ b/tests/benchdnn/graph/graph_memory.cpp
@@ -46,7 +46,7 @@ size_t get_benchdnn_device_limit() {
 
 // Constructs memories for all inputs and outputs needed for comparison.
 dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
-        const deserialized_lt_t &lt, const bool is_op_input,
+        const deserialized_lt_t &lt, const bool is_op_input, res_t *res,
         const bool use_graph_layout)
     : graph_dims_(lt.shape_), graph_strides_(lt.stride_) {
     const auto &g_eng = lt.is_host_scalar()
@@ -80,7 +80,7 @@ dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
 
         if (!has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
             // Fill data from reference memories.
-            fill_mem_with_data(mem, g_eng);
+            fill_mem_with_data(mem, g_eng, res);
         }
 
     } else {
@@ -134,7 +134,7 @@ dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
 }
 
 int dnn_graph_mem_t::fill_mem_with_data(
-        const dnn_mem_t &mem, const dnnl::engine &eng) {
+        const dnn_mem_t &mem, const dnnl::engine &eng, res_t *res) {
     // If `mem` comes empty, don't update the underlying `mem_` then.
     if (!mem) return OK;
 
@@ -162,7 +162,7 @@ int dnn_graph_mem_t::fill_mem_with_data(
         // engine to perform a data copy.
         dnn_mem_t c_mem(ndims, mem.dims(), dst_dt, mem.strides(), dst_eng,
                 /* prefill = */ true);
-        SAFE_V(c_mem.reorder(mem));
+        SAFE_V(c_mem.reorder(mem, res));
         prim_to_graph_memcpy(mem_, c_mem);
     } else {
         prim_to_graph_memcpy(mem_, mem);
@@ -172,7 +172,7 @@ int dnn_graph_mem_t::fill_mem_with_data(
 }
 
 dnnl::graph::tensor dnn_graph_mem_t::make_graph_tensor(
-        const deserialized_lt_t &lt) const {
+        const deserialized_lt_t &lt, res_t *) const {
     void *data_handle;
     dnnl_memory_get_data_handle(mem_.m_, &data_handle);
     dnnl::graph::logical_tensor graph_lt = lt.create();

--- a/tests/benchdnn/graph/graph_memory.hpp
+++ b/tests/benchdnn/graph/graph_memory.hpp
@@ -161,9 +161,11 @@ public:
     // value is false.
     //
     dnn_graph_mem_t(const dnn_mem_t &mem, const deserialized_lt_t &lt,
-            const bool is_op_input, const bool use_graph_layout = false);
+            const bool is_op_input, res_t *res,
+            const bool use_graph_layout = false);
 
-    dnnl::graph::tensor make_graph_tensor(const deserialized_lt_t &lt) const;
+    dnnl::graph::tensor make_graph_tensor(
+            const deserialized_lt_t &lt, res_t *res) const;
 
     const dnn_mem_t &get_mem() const { return mem_; }
 
@@ -171,7 +173,8 @@ public:
     void unmap_mem() { mem_.unmap(); }
 
 private:
-    int fill_mem_with_data(const dnn_mem_t &mem, const dnnl::engine &eng);
+    int fill_mem_with_data(
+            const dnn_mem_t &mem, const dnnl::engine &eng, res_t *res);
 
     dnn_mem_t mem_;
     std::shared_ptr<void> buffer_;

--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -75,7 +75,7 @@ void handle_special_dt_set(
     ref_prim->init_prim(::get_test_engine(), res, /* force_override = */ true);
     if (res->state == SKIPPED || res->state == UNIMPLEMENTED) return nullptr;
 
-    ref_prim->init_memory_args(::get_test_engine());
+    ref_prim->init_memory_args(::get_test_engine(), res);
     ref_prim->init_ref_memory_args(::get_test_engine(), res);
     if (res->state == SKIPPED || res->state == UNIMPLEMENTED
             || res->state == DEFERRED)
@@ -621,7 +621,7 @@ int partition_data_displacer_t::displace_input_data(size_t lt_id,
         SAFE_V(ref_prim.init_prim(
                 get_cpu_engine(), &res, /* force_override = */ true));
 
-        ref_prim.init_memory_args(get_cpu_engine());
+        ref_prim.init_memory_args(get_cpu_engine(), &res);
         SAFE_V(ref_prim.init_ref_memory_args(get_cpu_engine(), &res));
 
         const auto &src_mem = ref_prim.get_arg(DNNL_ARG_SRC);
@@ -650,7 +650,7 @@ int partition_data_displacer_t::displace_input_data(size_t lt_id,
         const bool mds_are_equal
                 = dnnl_memory_desc_equal(mem_replace.md_, mem.md_) == 1;
         if (mds_are_equal) {
-            SAFE(mem.reorder(mem_replace), WARN);
+            SAFE(mem.reorder(mem_replace, res), WARN);
             break;
         }
 
@@ -668,7 +668,7 @@ int partition_data_displacer_t::displace_input_data(size_t lt_id,
         if (mds_are_int8 || mds_are_fp8) {
             dnnl_memory_desc_destroy(mem_replace.md_);
             dnnl_memory_desc_clone(&mem_replace.md_, mem.md_);
-            SAFE(mem.reorder(mem_replace), WARN);
+            SAFE(mem.reorder(mem_replace, res), WARN);
             break;
         }
 
@@ -680,7 +680,7 @@ int partition_data_displacer_t::displace_input_data(size_t lt_id,
             if (groups > 1) {
                 dnnl_memory_desc_destroy(mem_replace.md_);
                 dnnl_memory_desc_clone(&mem_replace.md_, mem.md_);
-                SAFE(mem.reorder(mem_replace), WARN);
+                SAFE(mem.reorder(mem_replace, res), WARN);
                 break;
             }
         }
@@ -697,7 +697,7 @@ int partition_data_displacer_t::displace_input_data(size_t lt_id,
             dnnl_memory_desc_destroy(mem_replace.md_);
             dnnl_memory_desc_clone(&mem_replace.md_, new_replace_md);
             dnnl_memory_desc_destroy(new_replace_md);
-            SAFE(mem.reorder(mem_replace), WARN);
+            SAFE(mem.reorder(mem_replace, res), WARN);
             break;
         }
 
@@ -715,7 +715,7 @@ int partition_data_displacer_t::displace_input_data(size_t lt_id,
             dnnl_memory_desc_destroy(mem_replace.md_);
             dnnl_memory_desc_clone(&mem_replace.md_, new_replace_md);
             dnnl_memory_desc_destroy(new_replace_md);
-            SAFE(mem.reorder(mem_replace), WARN);
+            SAFE(mem.reorder(mem_replace, res), WARN);
             break;
         }
 

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -104,7 +104,7 @@ int ref_partition_t::init_ref(
         SAFE_V(check_partition_total_size(par_op_ref.get(), res));
         if (res->state == SKIPPED) return OK;
 
-        ref_prim->init_memory_args(::get_test_engine());
+        ref_prim->init_memory_args(::get_test_engine(), res);
         SAFE_V(ref_prim->init_ref_memory_args(::get_test_engine(), res));
 
         // store the memory for each logical tensor
@@ -170,11 +170,11 @@ int ref_partition_t::init_graph_mem(
             }
             partition_mem_map.emplace(id,
                     dnn_graph_mem_t(lt_id_2_mems_.at(id), lt_id_2_lt_.at(id),
-                            /*is_op_input=*/true));
+                            /*is_op_input=*/true, res));
         } else
             partition_mem_map.emplace(id,
                     dnn_graph_mem_t({}, lt_id_2_lt_.at(id),
-                            /*is_op_input=*/true));
+                            /*is_op_input=*/true, res));
     }
 
     for (const auto &id : partition_out_ids_) {
@@ -183,7 +183,8 @@ int ref_partition_t::init_graph_mem(
                 || has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
             partition_mem_map.emplace(id,
                     dnn_graph_mem_t({}, lt_id_2_lt_.at(id),
-                            /*is_op_input=*/false, /*use_graph_layout=*/true));
+                            /*is_op_input=*/false, res,
+                            /*use_graph_layout=*/true));
         } else if (lt_id_2_mems_.find(id) != lt_id_2_mems_.end()) {
             // For output memories of graph, they need to be in compliance with
             // the reference memories regarding the shapes and memory tags, as
@@ -191,7 +192,7 @@ int ref_partition_t::init_graph_mem(
             // comparison.
             partition_mem_map.emplace(id,
                     dnn_graph_mem_t(lt_id_2_mems_.at(id), lt_id_2_lt_.at(id),
-                            /*is_op_input=*/false));
+                            /*is_op_input=*/false, res));
         } else {
             BENCHDNN_PRINT(0, "Fail: cannot find memory for %zu\n", id);
             res->state = FAILED;
@@ -234,7 +235,7 @@ void ref_partition_t::exec_ops(res_t *res) {
                 dnn_mem_t &dst_i
                         = const_cast<dnn_mem_t &>(ref_prim->get_arg(arg));
                 const auto &src_i = lt_id_2_mems_.at(lt.id_);
-                SAFE_V(dst_i.reorder(src_i));
+                SAFE_V(dst_i.reorder(src_i, res));
                 continue;
             }
             ref_prim->replace_arg(arg, lt_id_2_mems_.at(lt.id_));
@@ -308,7 +309,7 @@ void ref_partition_t::exec_ops(res_t *res) {
                 dnn_mem_t &src_i
                         = const_cast<dnn_mem_t &>(ref_prim->get_arg(arg));
                 dnn_mem_t src_low_dt(src_i, dt, tag::abx, src_i.engine());
-                SAFE_V(src_i.reorder(src_low_dt));
+                SAFE_V(src_i.reorder(src_low_dt, res));
             }
         }
 
@@ -333,7 +334,7 @@ void ref_partition_t::exec_ops(res_t *res) {
                 dnn_mem_t &dst_i
                         = const_cast<dnn_mem_t &>(ref_prim->get_arg(arg));
                 dnn_mem_t dst_low_dt(dst_i, dt, tag::abx, dst_i.engine());
-                SAFE_V(dst_i.reorder(dst_low_dt));
+                SAFE_V(dst_i.reorder(dst_low_dt, res));
             }
         }
     }

--- a/tests/benchdnn/graph/ref_primitive.cpp
+++ b/tests/benchdnn/graph/ref_primitive.cpp
@@ -79,24 +79,24 @@ int execute(const base_prb_t *base_prb, const args_t &args, res_t *res) {
     args_t ref_args;
     const dnn_mem_t &src = args.find(DNNL_ARG_SRC);
     dnn_mem_t src_f32_abx(src, dnnl_f32, tag::abx, src.engine());
-    SAFE_V(src_f32_abx.reorder(src));
+    SAFE_V(src_f32_abx.reorder(src, res));
     ref_args.set(DNNL_ARG_SRC, src_f32_abx);
 
     dnn_mem_t &dst = const_cast<dnn_mem_t &>(args.find(DNNL_ARG_DST));
     dnn_mem_t dst_f32_abx(dst, dnnl_f32, tag::abx, dst.engine());
-    SAFE_V(dst_f32_abx.reorder(dst));
+    SAFE_V(dst_f32_abx.reorder(dst, res));
     ref_args.set(DNNL_ARG_DST, dst_f32_abx);
 
     dnn_mem_t &stats = const_cast<dnn_mem_t &>(args.find(DNNL_ARG_DST_1));
     dnn_mem_t stats_f32_abx(stats, dnnl_f32, tag::abx, stats.engine());
-    SAFE_V(stats_f32_abx.reorder(stats));
+    SAFE_V(stats_f32_abx.reorder(stats, res));
     ref_args.set(DNNL_ARG_DST_1, stats_f32_abx);
 
     ::softmax::compute_ref(prb, prb->dir, ref_args);
 
     // restore original memory format after ::softmax::compute_ref
-    SAFE_V(dst.reorder(dst_f32_abx));
-    SAFE_V(stats.reorder(stats_f32_abx));
+    SAFE_V(dst.reorder(dst_f32_abx, res));
+    SAFE_V(stats.reorder(stats_f32_abx, res));
 
     res->state = EXECUTED;
     return OK;
@@ -195,7 +195,7 @@ int ref_primitive_t::init_prim(
                      force_f32_prim_dt, /*is_graph_ref=*/true),
                 WARN);
         if (res->state == SKIPPED || res->state == UNIMPLEMENTED) return OK;
-        ::init_memory_args(mems_, prb, fwd_prim_,
+        ::init_memory_args(mems_, prb, fwd_prim_, res,
                 /*override_dir_with_fwd=*/true, ref_eng);
         SAFE(init_ref_memory_args_func_(
                      ref_mems, mems_, fwd_prim_, prb, res, nullptr),
@@ -214,11 +214,11 @@ int ref_primitive_t::init_prim(
     return OK;
 }
 
-void ref_primitive_t::init_memory_args(const engine_t &ref_eng) {
+void ref_primitive_t::init_memory_args(const engine_t &ref_eng, res_t *res) {
     if (!prb_) return;
 
     if (prim_) {
-        ::init_memory_args(mems_, prb_.get(), prim_,
+        ::init_memory_args(mems_, prb_.get(), prim_, res,
                 /*override_dir_with_fwd=*/false, ref_eng);
     } else {
         // handle an empty primitive through a driver's reference

--- a/tests/benchdnn/graph/ref_primitive.hpp
+++ b/tests/benchdnn/graph/ref_primitive.hpp
@@ -55,7 +55,7 @@ public:
     // memories with int8 data. `force_override` flag restricts forcing f32
     // data type primarily for this use case.
     int init_prim(const engine_t &eng, res_t *res, bool force_override = false);
-    void init_memory_args(const engine_t &eng);
+    void init_memory_args(const engine_t &eng, res_t *res);
     int init_ref_memory_args(const engine_t &eng, res_t *res);
     int execute_prim(res_t *res) const;
     void check_correctness(const args_t &args, bool has_eltwise, bool has_nans,

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -162,8 +162,8 @@ int check_reorder_presence(
                 /* prefill = */ true);
         dnn_mem_t mem_dt_s8(
                 mem_dt.md_, get_test_engine(), /* prefill = */ true);
-        SAFE(mem_fp_s8.reorder(mem_fp), WARN);
-        SAFE(mem_dt_s8.reorder(mem_fp_s8), WARN);
+        SAFE(mem_fp_s8.reorder(mem_fp, res), WARN);
+        SAFE(mem_dt_s8.reorder(mem_fp_s8, res), WARN);
         SAFE(mem_dt.size() == mem_dt_s8.size() ? OK : FAIL, WARN);
         int rc = std::memcmp((void *)mem_dt, (void *)mem_dt_s8, mem_dt.size());
         SAFE(rc == 0 ? OK : FAIL, WARN);
@@ -176,7 +176,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -234,7 +234,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res, cfg.get_swapped_dt(kind)), WARN);
 
     if (kind == WEI)
         SAFE(check_reorder_presence(prb, mem_dt, mem_fp, res), WARN);
@@ -361,7 +361,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
                 break;
@@ -377,7 +377,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         }
 
         update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)));
+                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
@@ -449,7 +449,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim_ref = v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(init_ref_memory_args(
                            ref_mem_map, mem_map, prim, prb, res, prim_ref),
             WARN));

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -41,8 +41,8 @@ using namespace bnorm;
 namespace lnorm {
 
 int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
-        dnn_mem_t &mem_dt) {
-    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
+        dnn_mem_t &mem_dt, res_t *res) {
+    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // If the library doesn't expect input mean, don't fill it.
@@ -71,14 +71,14 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     });
 
     if (mem_dt && IMPLICATION(prb->dir & FLAG_FWD, prb->use_stats()))
-        SAFE(mem_dt.reorder(mem_fp), WARN);
+        SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_mean, res_t *res) {
-    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         return fill_random_real(mem_dt, mem_fp, res);
@@ -140,15 +140,15 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         }
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
-        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src,
-        const dnn_mem_t &ref_mean) {
-    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
+        dnn_mem_t &mem_dt, const dnn_mem_t &ref_src, const dnn_mem_t &ref_mean,
+        res_t *res) {
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp, res)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // If the library doesn't expect input variance, don't fill it.
@@ -183,15 +183,16 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         mem_fp.set_f32_elem(n, val);
     });
 
-    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_scale(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const bool use_sc = prb->use_sc();
     if (!use_sc) return OK;
-    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -208,15 +209,16 @@ int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_shift(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const bool use_sh = prb->use_sh();
     if (!use_sh) return OK;
-    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -233,7 +235,7 @@ int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(c, val);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -244,7 +246,7 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
 
     auto &mean = mem_map.at(DNNL_ARG_MEAN);
     auto &ref_mean = ref_mem_map.at(DNNL_ARG_MEAN);
-    SAFE(fill_mean(prb, cfg, ref_mean, mean), WARN);
+    SAFE(fill_mean(prb, cfg, ref_mean, mean, res), WARN);
 
     auto &src = mem_map.at(DNNL_ARG_SRC);
     auto &ref_src = ref_mem_map.at(DNNL_ARG_SRC);
@@ -254,28 +256,30 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
     if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
         auto &src_copy = mem_map.at(-DNNL_ARG_SRC);
         SAFE(bool(src_copy) ? OK : FAIL, WARN);
-        SAFE(src_copy.reorder(src), WARN);
+        SAFE(src_copy.reorder(src, res), WARN);
     }
 
     auto &var = mem_map.at(DNNL_ARG_VARIANCE);
     auto &ref_var = ref_mem_map.at(DNNL_ARG_VARIANCE);
-    SAFE(fill_variance_fwd(prb, cfg, ref_var, var, ref_src, ref_mean), WARN);
+    SAFE(fill_variance_fwd(prb, cfg, ref_var, var, ref_src, ref_mean, res),
+            WARN);
 
     auto &scale = mem_map.at(DNNL_ARG_SCALE);
     auto &ref_scale = ref_mem_map.at(DNNL_ARG_SCALE);
-    SAFE(fill_scale(prb, ref_scale, scale), WARN);
+    SAFE(fill_scale(prb, ref_scale, scale, res), WARN);
 
     auto &shift = mem_map.at(DNNL_ARG_SHIFT);
     auto &ref_shift = ref_mem_map.at(DNNL_ARG_SHIFT);
-    SAFE(fill_shift(prb, ref_shift, shift), WARN);
+    SAFE(fill_shift(prb, ref_shift, shift, res), WARN);
 
     return OK;
 }
 
-int fill_variance_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
+int fill_variance_bwd(
+        const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -295,7 +299,7 @@ int fill_variance_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
         mem_fp.set_f32_elem(n, val - prb->eps);
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -304,7 +308,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         const dnn_mem_t &ref_mean, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -331,7 +335,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         }
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -340,7 +344,7 @@ int fill_diff_dst_bwd(
         const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -375,7 +379,7 @@ int fill_diff_dst_bwd(
         }
     });
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -386,11 +390,11 @@ int prepare_bwd(const prb_t *prb, dnn_mem_map_t &mem_map,
 
     auto &mean = mem_map.at(DNNL_ARG_MEAN);
     auto &ref_mean = ref_mem_map.at(DNNL_ARG_MEAN);
-    SAFE(fill_mean(prb, cfg, ref_mean, mean), WARN);
+    SAFE(fill_mean(prb, cfg, ref_mean, mean, res), WARN);
 
     auto &var = mem_map.at(DNNL_ARG_VARIANCE);
     auto &ref_var = ref_mem_map.at(DNNL_ARG_VARIANCE);
-    SAFE(fill_variance_bwd(prb, ref_var, var), WARN);
+    SAFE(fill_variance_bwd(prb, ref_var, var, res), WARN);
 
     auto &src = mem_map.at(DNNL_ARG_SRC);
     auto &ref_src = ref_mem_map.at(DNNL_ARG_SRC);
@@ -404,12 +408,12 @@ int prepare_bwd(const prb_t *prb, dnn_mem_map_t &mem_map,
     if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
         auto &d_dst_copy = mem_map.at(-DNNL_ARG_DIFF_DST);
         SAFE(bool(d_dst_copy) ? OK : FAIL, WARN);
-        SAFE(d_dst_copy.reorder(d_dst), WARN);
+        SAFE(d_dst_copy.reorder(d_dst, res), WARN);
     }
 
     auto &scale = mem_map.at(DNNL_ARG_SCALE);
     auto &ref_scale = ref_mem_map.at(DNNL_ARG_SCALE);
-    SAFE(fill_scale(prb, ref_scale, scale), WARN);
+    SAFE(fill_scale(prb, ref_scale, scale, res), WARN);
 
     return OK;
 }
@@ -718,7 +722,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -35,10 +35,10 @@
 namespace lrn {
 
 int fill_dat(int exec_arg, const prb_t *prb, data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -58,19 +58,19 @@ int fill_dat(int exec_arg, const prb_t *prb, data_kind_t kind,
         mem_fp.set_f32_elem(i, value);
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_src(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
-    return fill_dat(exec_arg, prb, SRC, mem_dt, mem_fp);
+int fill_src(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
+    return fill_dat(exec_arg, prb, SRC, mem_dt, mem_fp, res);
 }
 
-int fill_dst(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
-    return fill_dat(exec_arg, prb, DST, mem_dt, mem_fp);
+int fill_dst(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
+    return fill_dat(exec_arg, prb, DST, mem_dt, mem_fp, res);
 }
 
 dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
@@ -183,10 +183,10 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_dst(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_dst(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             default: break;
         }
@@ -247,7 +247,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = prb->dir & FLAG_FWD ? v_prim[0] : v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, v_prim[0], /*override_dir_with_fwd=*/true);
+    init_memory_args(
+            mem_map, prb, v_prim[0], res, /*override_dir_with_fwd=*/true);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], prb, res),
             WARN));
@@ -264,7 +265,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     if (prb->dir & FLAG_BWD) {
         // Pass same memory map as we need data from forward on backward.
-        init_memory_args(mem_map, prb, v_prim[1]);
+        init_memory_args(mem_map, prb, v_prim[1], res);
         TIME_FILL(SAFE(
                 init_ref_memory_args(ref_mem_map, mem_map, v_prim[1], prb, res),
                 WARN));

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -529,7 +529,7 @@ static int fill_grouped_offsets(
 // The values buffer is filled as a contiguous 2D
 // tensor (offsets describe per-group slicing, not value placement)
 static int fill_grouped_data(data_kind_t kind, const prb_t *prb,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     if (kind != SRC && kind != WEI) {
         BENCHDNN_PRINT(0,
                 "Error: grouped filling only supports SRC or WEI, got "
@@ -568,7 +568,7 @@ static int fill_grouped_data(data_kind_t kind, const prb_t *prb,
             = dnn_mem_t::init_md(2, g_dims, mem_dt.dt(), tag::any, val_strides);
     dnn_mem_t vals_view(val_md, mem_fp.engine(), /* prefill = */ false,
             {true, mem_dt.get_mapped_pointer<void>(0)});
-    SAFE(vals_view.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    SAFE(vals_view.reorder(mem_fp, res, cfg.get_swapped_dt(kind)), WARN);
 
     return OK;
 }
@@ -578,7 +578,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
 
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     bool is_sparse_packed = false;
     bool is_any_sparse = false;
@@ -595,7 +595,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
     }
 
     if (prb->sparse_options.is_grouped(exec_arg)) {
-        SAFE(fill_grouped_data(kind, prb, mem_dt, mem_fp), WARN);
+        SAFE(fill_grouped_data(kind, prb, mem_dt, mem_fp, res), WARN);
         return OK;
     }
 
@@ -655,7 +655,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         fill_dense_fp_values(kind, prb, cfg, mem_fp);
     }
 
-    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res, cfg.get_swapped_dt(kind)), WARN);
 
     return OK;
 }
@@ -927,7 +927,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
             } break;
@@ -959,7 +959,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         }
 
         update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)));
+                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
@@ -974,7 +974,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // TODO: will be handled by `init_ref_memory_args_default_case` once
         // memory argument dependency is resolved.
         if (fill_from_file(DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS | DNNL_ARG_SRC,
-                    mem, ref_mem))
+                    mem, ref_mem, res))
             return OK;
         const auto &ref_mem_src = ref_mem_map.at(DNNL_ARG_SRC);
         const auto src_precomputed_reductions_gs
@@ -995,7 +995,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             ref_mem.set_elem(i, val);
         }
 
-        SAFE(mem.reorder(ref_mem), WARN);
+        SAFE(mem.reorder(ref_mem, res), WARN);
     }
 
     return OK;
@@ -1053,7 +1053,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim_ref = v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(init_ref_memory_args(
                            ref_mem_map, mem_map, prim, prb, res, prim_ref),
             WARN));

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -38,7 +38,7 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -85,23 +85,23 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 // fill ws with big numbers to reliably cause a correctness issue (and not
 // anything else) in case of a bug in the library
-int fill_ws(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_ws(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const size_t nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     benchdnn_parallel_nd(
             nelems, [&](int64_t i) { mem_fp.set_elem(i, (1 << 24) - 1); });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -323,7 +323,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                             = is_integral_dt(mem.dt()) ? dnnl_s32 : dnnl_f32;
                     ref_mem_map[exec_arg] = dnn_mem_t(mem.md_, ws_dt, tag::abx,
                             ref_engine, /* prefill = */ false);
-                    SAFE(fill_ws(exec_arg, prb, mem, ref_mem), WARN);
+                    SAFE(fill_ws(exec_arg, prb, mem, ref_mem, res), WARN);
                 }
                 break;
             case DNNL_ARG_DST:
@@ -394,7 +394,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = prb->dir & FLAG_FWD ? v_prim[0] : v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, v_prim[0], /*override_dir_with_fwd=*/true);
+    init_memory_args(
+            mem_map, prb, v_prim[0], res, /*override_dir_with_fwd=*/true);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], prb, res),
             WARN));
@@ -412,7 +413,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     if (prb->dir & FLAG_BWD) {
         // Pass same memory map as we need data from forward on backward.
-        init_memory_args(mem_map, prb, v_prim[1]);
+        init_memory_args(mem_map, prb, v_prim[1], res);
         TIME_FILL(SAFE(
                 init_ref_memory_args(ref_mem_map, mem_map, v_prim[1], prb, res),
                 WARN));

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -32,11 +32,11 @@
 
 namespace prelu {
 
-int fill_data(
-        data_kind_t kind, int exec_arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_data(data_kind_t kind, int exec_arg, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -94,7 +94,7 @@ int fill_data(
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -208,13 +208,13 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data(SRC, exec_arg, mem, ref_mem), WARN);
+                SAFE(fill_data(SRC, exec_arg, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_WEIGHTS:
-                SAFE(fill_data(WEI, exec_arg, mem, ref_mem), WARN);
+                SAFE(fill_data(WEI, exec_arg, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_data(DST, exec_arg, mem, ref_mem), WARN);
+                SAFE(fill_data(DST, exec_arg, mem, ref_mem, res), WARN);
                 break;
             default: break;
         }
@@ -267,7 +267,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -109,8 +109,8 @@ bool is_norm_alg(const alg_t alg) {
 }
 
 int fill_mem(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp,
-        float non_neutral_prob, bool expanded_range,
-        bool only_positive_values) {
+        float non_neutral_prob, bool expanded_range, bool only_positive_values,
+        res_t *res) {
     // Refer to modes documentation for filling principles.
     // Multiply alg overflows extremely fast. Exclude it from validation.
     if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->alg != alg_t::mul) {
@@ -172,15 +172,15 @@ int fill_mem(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp,
                     idx, round_to_nearest_representable(sdt, value));
         }
     });
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
     return OK;
 }
 
-int fill_src(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_src(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (!nelems) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     int nelems_to_reduce = 1;
     for (int dim = 0; dim < prb->ndims; dim++) {
@@ -196,14 +196,14 @@ int fill_src(
     const float non_neutral_prob
             = 1.f * safe_to_reduce_elems / nelems_to_reduce;
 
-    return fill_mem(prb, mem_dt, mem_fp, non_neutral_prob, false, false);
+    return fill_mem(prb, mem_dt, mem_fp, non_neutral_prob, false, false, res);
 }
 
-int fill_dst(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+int fill_dst(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
     const bool only_positive_values = is_norm_alg(prb->alg);
-    return fill_mem(prb, mem_dt, mem_fp, 1.0f, true, only_positive_values);
+    return fill_mem(prb, mem_dt, mem_fp, 1.0f, true, only_positive_values, res);
 }
 
 void prb_t::skip_unimplemented(res_t *res) const {
@@ -305,16 +305,16 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_DST:
                 if (prb->attr.post_ops.find(attr_t::post_ops_t::kind_t::SUM)
                         >= 0) {
-                    SAFE(fill_dst(exec_arg, prb, mem, ref_mem), WARN);
+                    SAFE(fill_dst(exec_arg, prb, mem, ref_mem, res), WARN);
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
                 break;
@@ -361,7 +361,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -37,10 +37,10 @@
 namespace reorder {
 
 int fill_mem(int exec_arg, const prb_t *prb, data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -78,7 +78,7 @@ int fill_mem(int exec_arg, const prb_t *prb, data_kind_t kind,
         if (zero_out_wa) mem_dt.set_elem(i, 0);
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -550,7 +550,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_FROM: {
-                SAFE(fill_mem(exec_arg, prb, SRC, mem, ref_mem), WARN);
+                SAFE(fill_mem(exec_arg, prb, SRC, mem, ref_mem, res), WARN);
                 // Additional inputs to compare compensation buffers.
                 ref_mem_map.emplace(DNNL_ARG_SRC_1,
                         setup_compensation_memory(prb, FLAG_S8S8_COMP));
@@ -562,12 +562,12 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 const int sum_idx = po.find(attr_t::post_ops_t::SUM);
                 // MIOpen doesn't work properly when tensors are filled with 0xFF.
                 if (sum_idx >= 0 || is_amd_gpu()) {
-                    SAFE(fill_mem(exec_arg, prb, DST, mem, ref_mem), WARN);
+                    SAFE(fill_mem(exec_arg, prb, DST, mem, ref_mem, res), WARN);
 
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
             } break;
@@ -612,7 +612,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -33,10 +33,10 @@
 namespace resampling {
 
 int fill_dat(int exec_arg, const prb_t *prb, data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -60,19 +60,19 @@ int fill_dat(int exec_arg, const prb_t *prb, data_kind_t kind,
         mem_fp.set_f32_elem(i, round_to_nearest_representable(dt, value));
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_src(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
-    return fill_dat(exec_arg, prb, SRC, mem_dt, mem_fp);
+int fill_src(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
+    return fill_dat(exec_arg, prb, SRC, mem_dt, mem_fp, res);
 }
 
-int fill_dst(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
-    return fill_dat(exec_arg, prb, DST, mem_dt, mem_fp);
+int fill_dst(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
+    return fill_dat(exec_arg, prb, DST, mem_dt, mem_fp, res);
 }
 
 dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
@@ -212,22 +212,22 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_DST:
                 if (prb->attr.post_ops.find(attr_t::post_ops_t::kind_t::SUM)
                         >= 0) {
-                    SAFE(fill_dst(exec_arg, prb, mem, ref_mem), WARN);
+                    SAFE(fill_dst(exec_arg, prb, mem, ref_mem, res), WARN);
 
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem), WARN);
+                        SAFE(mem_map.at(-exec_arg).reorder(ref_mem, res), WARN);
                     }
                 }
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_dst(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_dst(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             default: {
                 std::unordered_map<int, fill_cfg_t> fill_cfg_map;
@@ -286,7 +286,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/rnn/rnn.cpp
+++ b/tests/benchdnn/rnn/rnn.cpp
@@ -128,7 +128,7 @@ dnnl_primitive_attr_t create_dnnl_rnn_attr(const prb_t &prb) {
 }
 
 int check_s8s8_reorder(const prb_t &prb, rnn_data_kind_t kind,
-        const dnn_mem_t &mem_dt, const dnn_mem_t &mem_fp) {
+        const dnn_mem_t &mem_dt, const dnn_mem_t &mem_fp, res_t *res) {
     // TODO: enable for all cpu_kind when supported
     if (is_gpu()) return OK;
 
@@ -198,7 +198,7 @@ int check_s8s8_reorder(const prb_t &prb, rnn_data_kind_t kind,
     }
 
     /* 2. compute s8_plain_quantized --reorder--> s8_packed_quantized */
-    SAFE(mem_s8_dst.reorder(mem_s8_src), WARN);
+    SAFE(mem_s8_dst.reorder(mem_s8_src, res), WARN);
 
     /* 3. we check that the two memory are bitwise identical. */
     auto sz = mem_dt.size();
@@ -219,11 +219,11 @@ int check_s8s8_reorder(const prb_t &prb, rnn_data_kind_t kind,
 
 int fill_memory(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
         dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, dnnl_data_type_t dt, float mean,
-        float stddev, float min, float max,
+        float stddev, float min, float max, res_t *res,
         const_dnnl_primitive_attr_t attr = nullptr, bool flip_sign = false) {
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     assert(mem_dt.nelems() == mem_fp.nelems());
 
@@ -298,9 +298,10 @@ int fill_memory(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
     }
 
     // 3. We reorder the data for the DNNL RNN primitive
-    SAFE(mem_dt.reorder(mem_fp, reorder_attr), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res, reorder_attr), WARN);
     if ((reorder_attr != nullptr) && (dt == dnnl_s8))
-        if (check_s8s8_reorder(prb, kind, mem_dt, mem_fp) != OK) return FAIL;
+        if (check_s8s8_reorder(prb, kind, mem_dt, mem_fp, res) != OK)
+            return FAIL;
 
     // Bullet 4.a holds: quantize weights for int8 benchdnn reference RNN
     if (prb.is_int8()) {
@@ -337,15 +338,15 @@ int fill_memory(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
 }
 
 int fill_memory(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp,
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res,
         const_dnnl_primitive_attr_t attr = nullptr, bool flip_sign = false) {
     const dt_conf_t::entry_t &c = prb.cfg[kind];
     return fill_memory(exec_arg, prb, kind, mem_dt, mem_fp, c.dt, c.f_mean,
-            c.f_stddev, c.f_min, c.f_max, attr, flip_sign);
+            c.f_stddev, c.f_min, c.f_max, res, attr, flip_sign);
 }
 
 int fill_activation(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp,
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res,
         const_dnnl_primitive_attr_t attr = nullptr) {
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
@@ -361,17 +362,20 @@ int fill_activation(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
     bool flip_sign = prb.skip_nonlinear == false && prb.alg == VANILLA_RNN
             && prb.activation == RELU
             && (kind == SRC_LAYER || kind == SRC_ITER);
-    return fill_memory(exec_arg, prb, kind, mem_dt, mem_fp, attr, flip_sign);
+    return fill_memory(
+            exec_arg, prb, kind, mem_dt, mem_fp, res, attr, flip_sign);
 }
 
 int fill_src_iter_c(int exec_arg, const prb_t &prb, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp, const_dnnl_primitive_attr_t attr = nullptr) {
+        dnn_mem_t &mem_fp, res_t *res,
+        const_dnnl_primitive_attr_t attr = nullptr) {
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
 
     const bool special_case = prb.prop == dnnl_backward && prb.skip_nonlinear;
     if (!special_case)
-        return fill_memory(exec_arg, prb, SRC_ITER_C, mem_dt, mem_fp, attr);
+        return fill_memory(
+                exec_arg, prb, SRC_ITER_C, mem_dt, mem_fp, res, attr);
 
     // The scaling factors in tparams when testing backward are common for
     // for forward and backward passes, and computed as 1 over maximum of
@@ -437,15 +441,15 @@ int fill_src_iter_c(int exec_arg, const prb_t &prb, dnn_mem_t &mem_dt,
     const dt_conf_t::entry_t &c = prb.cfg[SRC_ITER_C];
     return fill_memory(exec_arg, prb, SRC_ITER_C, mem_dt, mem_fp, c.dt,
             c.f_mean * adjust_factor, c.f_stddev * adjust_factor,
-            c.f_min * adjust_factor, c.f_max * adjust_factor, attr);
+            c.f_min * adjust_factor, c.f_max * adjust_factor, res, attr);
 }
 
 int fill_weights(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp,
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res,
         const_dnnl_primitive_attr_t attr = nullptr) {
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     assert(kind == WEIGHTS_PROJECTION ? mem_fp.ndims() == 4
                                       : mem_fp.ndims() == 5);
@@ -489,21 +493,21 @@ int fill_weights(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
     // Pass rnn attributes to f32 -> s8 reorders only
     const_dnnl_primitive_attr_t reorder_attr = nullptr;
     if (prb.is_int8()) reorder_attr = attr;
-    SAFE(mem_dt.reorder(mem_pure_fp, reorder_attr), WARN);
+    SAFE(mem_dt.reorder(mem_pure_fp, res, reorder_attr), WARN);
 
     // Test that s8 -> s8 reorder works correctly
     if ((reorder_attr != nullptr) && (dt == dnnl_s8))
-        return check_s8s8_reorder(prb, kind, mem_dt, mem_pure_fp);
+        return check_s8s8_reorder(prb, kind, mem_dt, mem_pure_fp, res);
     return OK;
 }
 
 // To reduce likelihood of cancellation happening in bwd by bias,
 // (especially for GRU), we want diff_bias to be sparse
 int fill_bias(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     /* Do fixed partitioning to have same filling for any number of threads */
     const int64_t chunk_size = 64;
@@ -534,7 +538,7 @@ int fill_bias(int exec_arg, const prb_t &prb, rnn_data_kind_t kind,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -1160,124 +1164,131 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC_LAYER:
-                SAFE(fill_activation(
-                             exec_arg, prb, SRC_LAYER, mem, ref_mem, rnn_attr),
+                SAFE(fill_activation(exec_arg, prb, SRC_LAYER, mem, ref_mem,
+                             res, rnn_attr),
                         WARN);
                 break;
             case DNNL_ARG_AUGRU_ATTENTION:
                 SAFE(fill_activation(exec_arg, prb, AUGRU_ATTENTION, mem,
-                             ref_mem, rnn_attr),
+                             ref_mem, res, rnn_attr),
                         WARN);
                 break;
             case DNNL_ARG_SRC_ITER:
-                SAFE(fill_activation(
-                             exec_arg, prb, SRC_ITER, mem, ref_mem, rnn_attr),
+                SAFE(fill_activation(exec_arg, prb, SRC_ITER, mem, ref_mem, res,
+                             rnn_attr),
                         WARN);
                 break;
             case DNNL_ARG_SRC_ITER_C:
-                SAFE(fill_src_iter_c(exec_arg, prb, mem, ref_mem, rnn_attr),
+                SAFE(fill_src_iter_c(
+                             exec_arg, prb, mem, ref_mem, res, rnn_attr),
                         WARN);
                 break;
             case DNNL_ARG_WEIGHTS_LAYER:
                 if (is_fwd_prim)
                     SAFE(fill_weights(exec_arg, prb, WEIGHTS_LAYER, mem,
-                                 ref_mem, rnn_attr),
+                                 ref_mem, res, rnn_attr),
                             WARN);
                 break;
             case DNNL_ARG_WEIGHTS_ITER:
                 if (is_fwd_prim)
                     SAFE(fill_weights(exec_arg, prb, WEIGHTS_ITER, mem, ref_mem,
-                                 rnn_attr),
+                                 res, rnn_attr),
                             WARN);
                 break;
             case DNNL_ARG_WEIGHTS_PEEPHOLE:
                 if (is_fwd_prim)
-                    SAFE(fill_memory(
-                                 exec_arg, prb, WEIGHTS_PEEPHOLE, mem, ref_mem),
+                    SAFE(fill_memory(exec_arg, prb, WEIGHTS_PEEPHOLE, mem,
+                                 ref_mem, res),
                             WARN);
                 break;
             case DNNL_ARG_WEIGHTS_PROJECTION:
                 if (is_fwd_prim)
                     SAFE(fill_weights(exec_arg, prb, WEIGHTS_PROJECTION, mem,
-                                 ref_mem, rnn_attr),
+                                 ref_mem, res, rnn_attr),
                             WARN);
                 break;
             case DNNL_ARG_BIAS:
                 if (is_fwd_prim)
-                    SAFE(fill_memory(exec_arg, prb, BIAS, mem, ref_mem), WARN);
+                    SAFE(fill_memory(exec_arg, prb, BIAS, mem, ref_mem, res),
+                            WARN);
                 break;
             case DNNL_ARG_DST_LAYER:
                 if (is_fwd_prim)
                     SAFE(fill_activation(
-                                 exec_arg, prb, DST_LAYER, mem, ref_mem),
+                                 exec_arg, prb, DST_LAYER, mem, ref_mem, res),
                             WARN);
                 break;
             case DNNL_ARG_DST_ITER:
                 if (is_fwd_prim)
-                    SAFE(fill_activation(exec_arg, prb, DST_ITER, mem, ref_mem),
+                    SAFE(fill_activation(
+                                 exec_arg, prb, DST_ITER, mem, ref_mem, res),
                             WARN);
                 break;
             case DNNL_ARG_DST_ITER_C:
                 if (is_fwd_prim)
-                    SAFE(fill_memory(exec_arg, prb, DST_ITER_C, mem, ref_mem),
+                    SAFE(fill_memory(
+                                 exec_arg, prb, DST_ITER_C, mem, ref_mem, res),
                             WARN);
                 break;
             case DNNL_ARG_SCRATCHPAD: /* Put internal allocations here */ break;
             case DNNL_ARG_WORKSPACE: /* Or here... */ break;
             case DNNL_ARG_DIFF_SRC_LAYER:
                 SAFE(fill_activation(
-                             exec_arg, prb, DIFF_SRC_LAYER, mem, ref_mem),
+                             exec_arg, prb, DIFF_SRC_LAYER, mem, ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_AUGRU_ATTENTION:
-                SAFE(fill_activation(
-                             exec_arg, prb, DIFF_AUGRU_ATTENTION, mem, ref_mem),
+                SAFE(fill_activation(exec_arg, prb, DIFF_AUGRU_ATTENTION, mem,
+                             ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_SRC_ITER:
                 SAFE(fill_activation(
-                             exec_arg, prb, DIFF_SRC_ITER, mem, ref_mem),
+                             exec_arg, prb, DIFF_SRC_ITER, mem, ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_SRC_ITER_C:
-                SAFE(fill_memory(exec_arg, prb, DIFF_SRC_ITER_C, mem, ref_mem),
+                SAFE(fill_memory(
+                             exec_arg, prb, DIFF_SRC_ITER_C, mem, ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_WEIGHTS_LAYER:
-                SAFE(fill_weights(
-                             exec_arg, prb, DIFF_WEIGHTS_LAYER, mem, ref_mem),
+                SAFE(fill_weights(exec_arg, prb, DIFF_WEIGHTS_LAYER, mem,
+                             ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_WEIGHTS_ITER:
-                SAFE(fill_weights(
-                             exec_arg, prb, DIFF_WEIGHTS_ITER, mem, ref_mem),
+                SAFE(fill_weights(exec_arg, prb, DIFF_WEIGHTS_ITER, mem,
+                             ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE:
                 SAFE(fill_memory(exec_arg, prb, DIFF_WEIGHTS_PEEPHOLE, mem,
-                             ref_mem),
+                             ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_WEIGHTS_PROJECTION:
                 SAFE(fill_memory(exec_arg, prb, DIFF_WEIGHTS_PROJECTION, mem,
-                             ref_mem),
+                             ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_BIAS:
-                SAFE(fill_bias(exec_arg, prb, DIFF_BIAS, mem, ref_mem), WARN);
+                SAFE(fill_bias(exec_arg, prb, DIFF_BIAS, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_DIFF_DST_LAYER:
                 SAFE(fill_activation(
-                             exec_arg, prb, DIFF_DST_LAYER, mem, ref_mem),
+                             exec_arg, prb, DIFF_DST_LAYER, mem, ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_DST_ITER:
                 SAFE(fill_activation(
-                             exec_arg, prb, DIFF_DST_ITER, mem, ref_mem),
+                             exec_arg, prb, DIFF_DST_ITER, mem, ref_mem, res),
                         WARN);
                 break;
             case DNNL_ARG_DIFF_DST_ITER_C:
-                SAFE(fill_memory(exec_arg, prb, DIFF_DST_ITER_C, mem, ref_mem),
+                SAFE(fill_memory(
+                             exec_arg, prb, DIFF_DST_ITER_C, mem, ref_mem, res),
                         WARN);
                 break;
             default: break;
@@ -1368,7 +1379,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = prb.prop != dnnl_backward ? v_prim[0] : v_prim[1];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, &prb, v_prim[0], /*override_dir_with_fwd=*/true);
+    init_memory_args(
+            mem_map, &prb, v_prim[0], res, /*override_dir_with_fwd=*/true);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], &prb, res),
             WARN));
@@ -1394,7 +1406,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     if (prb.prop == dnnl_backward) {
         // Pass same memory map as we need data from forward on backward.
-        init_memory_args(mem_map, &prb, v_prim[1]);
+        init_memory_args(mem_map, &prb, v_prim[1], res);
         TIME_FILL(SAFE(init_ref_memory_args(
                                ref_mem_map, mem_map, v_prim[1], &prb, res),
                 WARN));

--- a/tests/benchdnn/sdpa/sdpa.cpp
+++ b/tests/benchdnn/sdpa/sdpa.cpp
@@ -136,7 +136,7 @@ int fill_data(int exec_arg, data_kind_t kind, const prb_t *prb,
         const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -190,12 +190,12 @@ int fill_data(int exec_arg, data_kind_t kind, const prb_t *prb,
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res, cfg.get_swapped_dt(kind)), WARN);
     return OK;
 }
 
 // Fill attention mask with realistic 0 / -inf values (~25 % masked).
-int fill_mask(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_mask(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
 
@@ -213,7 +213,7 @@ int fill_mask(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
             mem_fp.set_f32_elem(idx, (rng() % 4 == 0) ? neg_inf : 0.f);
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
     return OK;
 }
 
@@ -391,7 +391,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                         WARN);
                 break;
             case DNNL_ARG_DST: break;
-            case DNNL_ARG_ATTN_MASK: SAFE(fill_mask(mem, ref_mem), WARN); break;
+            case DNNL_ARG_ATTN_MASK:
+                SAFE(fill_mask(mem, ref_mem, res), WARN);
+                break;
             case DNNL_ARG_DIFF_DST:
                 SAFE(fill_data(exec_arg, DST, prb, cfg, mem, ref_mem, res),
                         WARN);
@@ -467,7 +469,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     dnn_mem_map_t mem_map, ref_mem_map;
 
-    init_memory_args(mem_map, prb, v_prim[0], /*override_dir_with_fwd=*/true);
+    init_memory_args(
+            mem_map, prb, v_prim[0], res, /*override_dir_with_fwd=*/true);
 
     {
         auto scale_md = dnn_mem_t::init_host_scalar_md(dnnl_f32);
@@ -497,7 +500,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     if (prb->dir & FLAG_BWD) {
         // Extend memory map with backward args.
-        init_memory_args(mem_map, prb, v_prim[1]);
+        init_memory_args(mem_map, prb, v_prim[1], res);
 
         // Re-add scale (pruned by init_memory_args since SCALE is not in
         // exec_bwd_args; init_ref_memory_args will fill the value).

--- a/tests/benchdnn/self/graph_example.cpp
+++ b/tests/benchdnn/self/graph_example.cpp
@@ -142,7 +142,7 @@ int init_op(std::unordered_map<int, graph_link_t> &op_graph,
     auto &mems = std::get<1>(op_graph[op_idx]);
     auto &ref_mems = std::get<2>(op_graph[op_idx]);
 
-    init_memory_args(mems, prb, prim);
+    init_memory_args(mems, prb, prim, res);
 
     // Initialize reference memories and fill the library memories.
     TIME_FILL(SAFE(init_ref_memory_args(ref_mems, mems, prim, prb, res), WARN));
@@ -218,7 +218,7 @@ int check_correctness(std::unordered_map<int, graph_link_t> &op_graph,
         const auto &mem_fp_md = mem_fp.md_;
         dnn_mem_t mem_fp_golden(mem_fp_md, dnnl_f32, tag::abx, get_cpu_engine(),
                 /* prefill = */ true);
-        SAFE(mem_fp_golden.reorder(mem_fp), WARN);
+        SAFE(mem_fp_golden.reorder(mem_fp, res), WARN);
 
         SAFE(cmp.compare(mem_fp_golden, mem_dt, attr_t(), res), WARN);
     }

--- a/tests/benchdnn/shuffle/shuffle.cpp
+++ b/tests/benchdnn/shuffle/shuffle.cpp
@@ -30,11 +30,11 @@
 
 namespace shuffle {
 
-int fill_src(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_src(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -64,7 +64,7 @@ int fill_src(
         mem_fp.set_f32_elem(i, round_to_nearest_representable(prb->dt, value));
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -156,10 +156,10 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem, res), WARN);
                 break;
             default: break;
         }
@@ -212,7 +212,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -99,11 +99,11 @@ dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
     return dnnl_success;
 }
 
-int fill_data_fwd(
-        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_data_fwd(int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -188,16 +188,16 @@ int fill_data_fwd(
         }
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
 int fill_data_bwd(data_kind_t data_kind, int exec_arg, const prb_t *prb,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int seed) {
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int seed, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -225,7 +225,7 @@ int fill_data_bwd(data_kind_t data_kind, int exec_arg, const prb_t *prb,
         mem_fp.set_f32_elem(i, value);
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -399,36 +399,36 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data_fwd(exec_arg, prb, mem, ref_mem), WARN);
+                SAFE(fill_data_fwd(exec_arg, prb, mem, ref_mem, res), WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
                     auto &src_copy = mem_map.at(-exec_arg);
                     SAFE(bool(src_copy) ? OK : FAIL, WARN);
-                    SAFE(src_copy.reorder(mem), WARN);
+                    SAFE(src_copy.reorder(mem, res), WARN);
                 }
                 break;
             case DNNL_ARG_DST:
                 if (!is_fwd_prim) {
                     const bool neg_sign = prb->alg == SOFTMAX
                             || prb->alg == SOFTMAX_INF_AS_ZERO;
-                    SAFE(fill_data_bwd(
-                                 DST, exec_arg, prb, mem, ref_mem, neg_sign),
+                    SAFE(fill_data_bwd(DST, exec_arg, prb, mem, ref_mem,
+                                 neg_sign, res),
                             WARN);
                 }
                 break;
             case DNNL_ARG_DIFF_DST: {
                 const bool neg_sign = prb->alg == SOFTMAX
                         || prb->alg == SOFTMAX_INF_AS_ZERO;
-                SAFE(fill_data_bwd(
-                             DIFF_DST, exec_arg, prb, mem, ref_mem, !neg_sign),
+                SAFE(fill_data_bwd(DIFF_DST, exec_arg, prb, mem, ref_mem,
+                             !neg_sign, res),
                         WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
                     auto &diff_dst_copy = mem_map.at(-exec_arg);
                     SAFE(bool(diff_dst_copy) ? OK : FAIL, WARN);
-                    SAFE(diff_dst_copy.reorder(mem), WARN);
+                    SAFE(diff_dst_copy.reorder(mem, res), WARN);
                 }
             } break;
             default: {
@@ -489,7 +489,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -65,10 +65,10 @@ dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
     return dnnl_success;
 }
 
-int fill_src(int exec_arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_src(int exec_arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
-    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp, res)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -91,7 +91,7 @@ int fill_src(int exec_arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
         mem_fp.set_f32_elem(i, round_to_nearest_representable(dt, value));
     });
 
-    SAFE(mem_dt.reorder(mem_fp), WARN);
+    SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -158,14 +158,14 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         bool is_src_arg = (exec_arg & DNNL_ARG_MULTIPLE_SRC);
         if (is_src_arg) {
-            SAFE(fill_src(exec_arg, mem, ref_mem), WARN);
+            SAFE(fill_src(exec_arg, mem, ref_mem, res), WARN);
             // Need a copy of source data for inplace mode for bitwise testing.
             // For multiple args, only the first one requires a copy.
             if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace
                     && exec_arg == DNNL_ARG_MULTIPLE_SRC) {
                 auto &src_copy = mem_map.at(-exec_arg);
                 SAFE(bool(src_copy) ? OK : FAIL, WARN);
-                SAFE(src_copy.reorder(mem), WARN);
+                SAFE(src_copy.reorder(mem, res), WARN);
             }
         }
         // Don't keep reference memory if it is not used further.
@@ -203,7 +203,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     const auto &prim = v_prim[0];
 
     dnn_mem_map_t mem_map, ref_mem_map;
-    init_memory_args(mem_map, prb, prim);
+    init_memory_args(mem_map, prb, prim, res);
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
 

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -159,13 +159,13 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
         SAFE(fill_random_real(mem_dt, mem_fp, res, fill_cfg), WARN);
     }
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
 
-int fill_zero_points(
-        const attr_t &attr, int arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_zero_points(const attr_t &attr, int arg, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
 
@@ -201,7 +201,7 @@ int fill_zero_points(
         });
     }
 
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
+    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }
@@ -322,14 +322,7 @@ int fill_random_real_dense(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
                 0, round_to_nearest_representable(round_dt, elem_first_val));
     }
 
-    if (mem) {
-        // TODO: move `res` inside reorder.
-        auto status = mem.reorder(mem_ref);
-        if (status != OK) {
-            if (res) res->state = FAILED;
-            return status;
-        }
-    }
+    if (mem) SAFE(mem.reorder(mem_ref, res), WARN);
 
     return OK;
 }
@@ -493,8 +486,9 @@ std::string execarg2str(int exec_arg) {
 
 std::string buffer_prefix;
 
-bool fill_from_file(int exec_arg, dnn_mem_t &mem, dnn_mem_t &ref_mem) {
-    static const char format[] = "File %s %s; buffer not imported.\n";
+bool fill_from_file(
+        int exec_arg, dnn_mem_t &mem, dnn_mem_t &ref_mem, res_t *res) {
+    static const char format[] = "[FILL]: File %s %s; buffer not imported.\n";
     auto prefix = buffer_prefix;
     if (prefix.empty()) return false;
 
@@ -536,7 +530,7 @@ bool fill_from_file(int exec_arg, dnn_mem_t &mem, dnn_mem_t &ref_mem) {
         SAFE_V(FAIL);
         return false;
     }
-    if (ref_mem && (ref_mem.reorder(mem) != OK)) {
+    if (ref_mem && (ref_mem.reorder(mem, res) != OK)) {
         BENCHDNN_PRINT(0, format, prefix.c_str(), "cannot be reordered");
         SAFE_V(FAIL);
         return false;

--- a/tests/benchdnn/utils/fill.hpp
+++ b/tests/benchdnn/utils/fill.hpp
@@ -88,8 +88,8 @@ int fill_scales(const attr_t &attr, int arg, dnn_mem_t &mem_dt,
 int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
         dnn_mem_t &mem_fp, res_t *res);
 
-int fill_zero_points(
-        const attr_t &attr, int arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp);
+int fill_zero_points(const attr_t &attr, int arg, dnn_mem_t &mem_dt,
+        dnn_mem_t &mem_fp, res_t *res);
 
 int fill_random_real(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
         const fill_cfg_t &fill_cfg = get_default_fill_cfg(),
@@ -101,6 +101,7 @@ int fill_random_real(dnn_mem_t &mem_ref,
 
 extern std::string buffer_prefix;
 
-bool fill_from_file(int exec_arg, dnn_mem_t &mem, dnn_mem_t &ref_mem);
+bool fill_from_file(
+        int exec_arg, dnn_mem_t &mem, dnn_mem_t &ref_mem, res_t *res);
 
 #endif

--- a/tests/benchdnn/utils/res.hpp
+++ b/tests/benchdnn/utils/res.hpp
@@ -131,6 +131,9 @@ enum class reason_t {
     invalid,
     // The library dispatched in ref implementation when it's not anticipated.
     failed_ref_not_expected,
+    // The internal reorder primitive when moving data from on dnn_mem_t object
+    // to another failed for some reason.
+    failed_service_reorder,
     // The problem requires more RAM than the system provides.
     skip_not_enough_ram,
     // The library fetched the implementation that was requested to be skipped.


### PR DESCRIPTION
This is a technical debt.
Basically, the main change is to pass `res_t *res` argument through the stack, mostly from `init_ref_memory_args` to fill functions and below to the `dnn_mem_t::reorder(...)` call. Other changes are supplemental or remove previous logic that tried to ease that pain point.

Before:
```
run: --reorder --sdt=f32 --ddt=f4_e2m1 --stag=bax --dtag=aBx16b 2x64x14x14
Error: failed to create a reorder.
Error: reorder in memory constructor failed.
[   0][DST][0:0:0:0] exp_f32:           6 exp:           6 got:        -nan diff:     nan rdiff:     nan
[   1][DST][0:0:0:1] exp_f32:          -6 exp:          -6 got:        -nan diff:     nan rdiff:     nan
[   2][DST][0:0:0:2] exp_f32:           0 exp:           0 got:        -nan diff:     nan rdiff:     nan
[   3][DST][0:0:0:3] exp_f32:           0 exp:           0 got:        -nan diff:     nan rdiff:     nan
[   4][DST][0:0:0:4] exp_f32:         0.5 exp:         0.5 got:        -nan diff:     nan rdiff:     nan
[   5][DST][0:0:0:5] exp_f32:           1 exp:           1 got:        -nan diff:     nan rdiff:     nan
[   6][DST][0:0:0:6] exp_f32:         1.5 exp:         1.5 got:        -nan diff:     nan rdiff:     nan
[   7][DST][0:0:0:7] exp_f32:           2 exp:           2 got:        -nan diff:     nan rdiff:     nan
[   8][DST][0:0:0:8] exp_f32:           6 exp:           6 got:        -nan diff:     nan rdiff:     nan
[   9][DST][0:0:0:9] exp_f32:           6 exp:           6 got:        -nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=0 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
9770:FAILED (errors:25088 total:25088) (59 ms) __REPRO: --reorder --sdt=f32 --ddt=f4_e2m1 --stag=bax --dtag=aBx16b 2x64x14x14
```

After:
```
run: --reorder --sdt=f32 --ddt=f4_e2m1 --stag=bax --dtag=aBx16b 2x64x14x14
Error: Function 'execute_reorder' at (../tests/benchdnn/dnnl_memory.cpp:200) returned 'unimplemented'
Error: reorder in memory constructor failed.
[   0][DST][0:0:0:0] exp_f32:           6 exp:           6 got:        -nan diff:     nan rdiff:     nan
[   1][DST][0:0:0:1] exp_f32:          -6 exp:          -6 got:        -nan diff:     nan rdiff:     nan
[   2][DST][0:0:0:2] exp_f32:           0 exp:           0 got:        -nan diff:     nan rdiff:     nan
[   3][DST][0:0:0:3] exp_f32:           0 exp:           0 got:        -nan diff:     nan rdiff:     nan
[   4][DST][0:0:0:4] exp_f32:         0.5 exp:         0.5 got:        -nan diff:     nan rdiff:     nan
[   5][DST][0:0:0:5] exp_f32:           1 exp:           1 got:        -nan diff:     nan rdiff:     nan
[   6][DST][0:0:0:6] exp_f32:         1.5 exp:         1.5 got:        -nan diff:     nan rdiff:     nan
[   7][DST][0:0:0:7] exp_f32:           2 exp:           2 got:        -nan diff:     nan rdiff:     nan
[   8][DST][0:0:0:8] exp_f32:           6 exp:           6 got:        -nan diff:     nan rdiff:     nan
[   9][DST][0:0:0:9] exp_f32:           6 exp:           6 got:        -nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=0 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:       0 all_max_rdiff:       0
```