### PR TITLE
x64: matmul: reject grouped per-K weight scales for fp8

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1955,6 +1955,16 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.is_wei_scale_per_k = false;
     }
 
+    // Per-K weight scales are only applied for weight decompression (integer
+    // weights) and int8 grouped quantization. Other types (e.g. fp8) pass the
+    // check above (per_ocic/per_tensor also set the per-N bit) but the
+    // K-grouping would be ignored, so reject them here. A per-K group
+    // spanning all of K was already downgraded to per-N above.
+    VCONDCHECK_BG(IMPLICATION(bgmmc.is_wei_scale_per_k,
+                          bgmmc.with_wei_decompression
+                                  || bgmmc.with_int8_grouped_quantization),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+
     // Batched (3D/4D) per-batch scales/ZP have batch bits set in the mask.
     // Compute the stride (in elements) between consecutive per-batch planes
     // so the matmul driver can offset the scales/ZP pointer per batch index.


### PR DESCRIPTION
Fixes [MFDNN-15323](https://jira.devtools.intel.com/browse/MFDNN-15323).

## Description

`brgemm_matmul` accepted grouped per-K weight scales (`per_ocic`/`per_tensor` with a K-group < K) for fp8 weights but silently ignored the K-grouping, producing wrong results — e.g. the ticket case fails with 100% mismatches:

```
--matmul --dt=bf16:f8_e5m2:bf16 --stag=abx --dtag=abx \
    --attr-scales=wei:per_tensor:f32:64x1 1676x1536:1536x16
```

Per-K weight scales are only applied for integer weight decompression and int8 grouped quantization; for fp8 they were neither applied nor rejected. This reworks the dispatch to return `unimplemented` for such configs.

Only f32 scales reached the affected path; any other scale data type was already rejected by the pre-existing "f32 scales only for non-decompression" check in `check_attr_scales`.

fp8 cases where the reference implementation applies (e.g. `f8_e5m2:f8_e5m2`) remain supported: brgemm dispatches away and they fall back to `ref`, which computes grouped scales correctly.

## Validation

benchdnn (CPU): ticket case now SKIPPED (was FAILED); `f8_e5m2:f8_e5m2` grouped scales pass via `ref`; fp8 `common`/`per_oc` and integer-decompression grouped-K scales still pass.
