### PR TITLE
cpu: x64: matmul: fix batch offset for padded batch strides

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -1828,9 +1828,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                         = helper.get_a_stride(bgmmc.ndims - 1) * bgmmc.a_dt_sz;
 
             is_A_batch_layout_trivial_
-                    = is_batch_layout_trivial(src_d_, bgmmc.batch);
+                    = is_batch_layout_trivial(src_d_);
             is_C_batch_layout_trivial_
-                    = is_batch_layout_trivial(dst_d_, bgmmc.batch);
+                    = is_batch_layout_trivial(dst_d_);
         } else {
             M_ = bgmmc.M;
             M_chunks_ = bgmmc.M_chunks;
@@ -1891,9 +1891,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                         * helper.get_b_stride(bgmmc.ndims - 1 - dim_idx);
 
             is_B_batch_layout_trivial_
-                    = is_batch_layout_trivial(wei_d_, bgmmc.batch);
+                    = is_batch_layout_trivial(wei_d_);
             is_C_batch_layout_trivial_
-                    = is_batch_layout_trivial(dst_d_, bgmmc.batch);
+                    = is_batch_layout_trivial(dst_d_);
         } else {
             N_ = bgmmc.N;
             N_chunks_ = bgmmc.N_chunks;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -209,25 +209,29 @@ bool post_ops_ok(brgemm_matmul_conf_t &bgmmc, const primitive_attr_t &attr,
 
 // Trivial: The motivation is to compute batch offset for a memory
 // (src or wei or dst) with minimal overhead, by using
-// `batch_offset = b * b_stride`.
-// This is possible when the batch layout is contiguous.
-bool is_batch_layout_trivial(
-        const memory_desc_wrapper &mdw, const dim_t batch) {
+// `batch_offset = b * b_stride`, where `b` is the flattened batch index
+// iterated in logical (row-major) order and `b_stride` is the stride of
+// the innermost batch dimension (strides[ndims - 3]).
+// This is only valid when the batch dimensions form a contiguous
+// row-major nesting, i.e. every batch dimension `d` satisfies
+// `strides[d] == b_stride * prod(dims[d + 1 .. ndims - 3])`.
+bool is_batch_layout_trivial(const memory_desc_wrapper &mdw) {
     const int ndims = mdw.ndims();
     if (ndims <= 3) return true;
 
+    const auto &dims = mdw.dims();
     const auto &strides = mdw.strides();
-    const int batch_start_idx = ndims - 3;
-    dim_t cur_stride = strides[batch_start_idx];
-    dim_t min_batch_stride = cur_stride;
-    dim_t max_batch_stride = cur_stride;
-    for (int d = batch_start_idx - 1; d >= 0; --d) {
-        cur_stride = strides[d];
-        min_batch_stride = nstl::min(min_batch_stride, cur_stride);
-        max_batch_stride = nstl::max(max_batch_stride, cur_stride);
+    const int innermost_batch_idx = ndims - 3;
+    dim_t expected_stride = strides[innermost_batch_idx];
+    if (expected_stride == 0) return false;
+    for (int d = innermost_batch_idx; d >= 0; --d) {
+        // Dimensions of size 1 do not contribute to the batch offset and
+        // their stride is irrelevant.
+        if (dims[d] == 1) continue;
+        if (strides[d] != expected_stride) return false;
+        expected_stride *= dims[d];
     }
-    if (min_batch_stride == 0) return false;
-    return max_batch_stride / min_batch_stride == batch;
+    return true;
 }
 
 bool dims_adjacent(const memory_desc_wrapper &mdw, const int outer_dim,
@@ -2357,11 +2361,11 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     }
 
     bgmmc.is_src_batch_layout_trivial
-            = is_batch_layout_trivial(src_d, bgmmc.batch);
+            = is_batch_layout_trivial(src_d);
     bgmmc.is_wei_batch_layout_trivial
-            = is_batch_layout_trivial(weights_d, bgmmc.batch);
+            = is_batch_layout_trivial(weights_d);
     bgmmc.is_dst_batch_layout_trivial
-            = is_batch_layout_trivial(dst_d, bgmmc.batch);
+            = is_batch_layout_trivial(dst_d);
 
     // Sets things related to chunks and others
     init_aux_values(bgmmc, src_d, weights_d, dst_d);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -540,7 +540,7 @@ int get_n_block_from_tag(format_tag_t matrix_b_tag);
 
 void mem_advice_init(brgemm_matmul_conf_t &bgmmc);
 
-bool is_batch_layout_trivial(const memory_desc_wrapper &mdw, const dim_t batch);
+bool is_batch_layout_trivial(const memory_desc_wrapper &mdw);
 
 // Returns true if logical dimension `inner_dim` is nested immediately inside
 // `outer_dim` in memory, i.e. no other dimension is physically interleaved


### PR DESCRIPTION
Fixes [MFDNN-15317](https://jira.devtools.intel.com/browse/MFDNN-15317)

brgemm matmul uses `is_batch_layout_trivial()` to decide whether the batch offset can be computed with the fast path `offset = b * stride[ndims - 3]`.

The previous check only verified `max_batch_stride / min_batch_stride == batch`, which is necessary but not sufficient: it can accidentally hold for padded/non-contiguous batch layouts. For example a dst tensor 4x8x1x1964 with batch strides 63488 (dim0) and 1984 (dim1) satisfies 63488 / 1984 == 32 == batch, so it was wrongly treated as trivial even though a contiguous nesting requires dim0 stride 1984 * 8 == 15872. As a result the batch offset for every slice with dim0 > 0 was computed incorrectly, so those outputs were never written and remained NaN.

Replace the ratio heuristic with an exact verification that the batch dimensions form a contiguous row-major nesting (each batch dim stride equals the innermost batch stride times the product of the inner batch extents). Dimensions of size 1 are skipped since they do not contribute to the batch offset. Non-contiguous layouts now correctly fall back to the accurate `off_l()` path.

Found by new tests from #5317
