### PR TITLE
cpu: rv64: gemm: add int8 support for gemm kernel

### DIFF
--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
@@ -61,6 +61,7 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     const Reg reg_tmp0 = a7;
     const FReg freg_alpha = fa0;
     const FReg freg_beta = fa1;
+    const FReg freg_bias = fa2; // scalar bias splat (has_bias_ + scalar)
     // B scalars are kept in GPRs across the per-K vwmacc[vx|su.vx] calls.
     const Reg reg_b[6] = {a5, t6, s2, s3, s4, s5};
 
@@ -84,7 +85,8 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     //   56 : dim_t m
     //   64 : float alpha
     //   68 : float beta
-    //   72 : const float *bias  (only used when has_bias_)
+    //   72 : const float *bias       (only used when has_bias_)
+    //   80 : int bias_is_scalar      (only used when has_bias_)
     ld(reg_A_ptr, reg_param, 0);
     ld(reg_B0_ptr, reg_param, 8);
     ld(reg_C_base, reg_param, 16);
@@ -231,12 +233,26 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
         }
     };
 
-    // Preload the per-M bias vector once (broadcast across N columns).
+    // Preload the per-M bias vector once (broadcast across N columns). A scalar
+    // (one-element) bias must be splat from a single float: a full-vector
+    // vle32 would read past the one-element object. A per-N bias is a
+    // contiguous m-wide load.
     if (has_bias_) {
-        Label label_bias_loaded;
+        Label label_bias_loaded, label_bias_per_element, label_bias_done;
         beqz(reg_bias_ptr, label_bias_loaded);
+        lw(reg_tmp0, reg_param, 80);
+        beqz(reg_tmp0, label_bias_per_element); // per-element: contiguous load
+        // scalar: splat the single bias float across the M tile.
+        flw(freg_bias, reg_bias_ptr, 0);
+        vfmv_v_f(v_bias, freg_bias);
+        j_(label_bias_done);
+        L(label_bias_per_element);
         vle32_v(v_bias, reg_bias_ptr);
-        if (!dst_is_f32_) { vfcvt_rtz_x_f_v(v_bias, v_bias); }
+        L(label_bias_done);
+        // f32 -> s32 using the rounding mode in fcsr (RNE by default), matching
+        // the reference, which adds the f32 bias and rounds via nearbyintf.
+        // RTZ was wrong: it truncated 0.75f to 0 instead of 1.
+        if (!dst_is_f32_) { vfcvt_x_f_v(v_bias, v_bias); }
         L(label_bias_loaded);
     }
 

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 ZTE Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 *******************************************************************************/
 
 #include "cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp"
-#include "common/verbose.hpp"
 
 #include <array>
 #include <memory>
@@ -29,9 +28,8 @@ namespace gemm_utils {
 
 using namespace Xbyak_riscv;
 
-jit_rvv_gemm_s8_kernel_t::jit_rvv_gemm_s8_kernel_t(dim_t n_cols,
-        bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32,
-        bool has_bias)
+jit_rvv_gemm_s8_kernel_t::jit_rvv_gemm_s8_kernel_t(dim_t n_cols, bool isTransA,
+        bool isTransB, bool b_signed, bool dst_is_f32, bool has_bias)
     : jit_generator_t("rv64_gemm_kernel_s8_jit")
     , n_cols_(n_cols)
     , isTransA_(isTransA)
@@ -63,23 +61,15 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     const Reg reg_tmp0 = a7;
     const FReg freg_alpha = fa0;
     const FReg freg_beta = fa1;
-    // B scalars are kept in GPRs across the per-K vwmacc[vx|su.vx] calls. The
-    // vwmacc family reads the low SEW bits of rs1, so a sign- or zero-extended
-    // s8/u8 in a 64-bit GPR is fine. n_cols can be up to 6, so reg_b[0] lives
-    // in a caller-saved temp and reg_b[1..5] borrow callee-saved s2..s6.
-    const Reg reg_b[6] = {t6, s2, s3, s4, s5, s6};
+    // B scalars are kept in GPRs across the per-K vwmacc[vx|su.vx] calls.
+    const Reg reg_b[6] = {a5, t6, s2, s3, s4, s5};
 
-    const VReg v_c[6] = {
-            VReg(0), VReg(4), VReg(8), VReg(12), VReg(16), VReg(20)};
-    // K-loop temporaries. v_a_e8 (LMUL=m1) and v_a_e16 (LMUL=m2) must not
-    // overlap (vsext.vf2 forbids source/dest overlap on widening ops).
-    // v_a_e16 sits in v24-v25; v_a_e8 takes v26.
+    const VReg v_c[6]
+            = {VReg(0), VReg(4), VReg(8), VReg(12), VReg(16), VReg(20)};
+    // K-loop temporaries.
     const VReg v_a_e16(24); // e16 LMUL=m2 sign-/zero-extended A
     const VReg v_a_e8(26); // e8 LMUL=m1 source row
-    // C-update temporaries. After the K loop ends both v_a_e16 and v_a_e8 are
-    // dead, so the C-update epilogue can grab two distinct LMUL=m4 groups
-    // from v24-v31: v_tmp owns v24-v27 (overlaps dead v_a_e16), v_bias owns
-    // v28-v31. Both registers carry e32 elements under the C-update vsetvli.
+    // C-update temporaries.
     const VReg v_tmp(24); // e32 LMUL=m4 scratch / C-load temporary
     const VReg v_bias(28); // e32 LMUL=m4 bias loader (f32 dst path)
 
@@ -115,17 +105,17 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     // C is s32/f32 (4 bytes): ldc * 4 = byte stride.
     slli(reg_ldc_bytes, reg_ldc_bytes, 2);
 
-    // Save callee-saved registers (s2..s6 hold reg_b[1..5] when n_cols >= 2).
-    // Use a 48-byte stack frame; only the first 40 bytes are populated.
-    addi(sp, sp, -48);
-    sd(s2, sp, 0);
-    sd(s3, sp, 8);
-    sd(s4, sp, 16);
-    sd(s5, sp, 24);
-    sd(s6, sp, 32);
+    // Save callee-saved registers (s2..s5 hold reg_b[2..5] when n_cols >= 3).
+    const bool need_callee_save = (n_cols_ >= 3);
+    if (need_callee_save) {
+        addi(sp, sp, -32);
+        sd(s2, sp, 0);
+        sd(s3, sp, 8);
+        sd(s4, sp, 16);
+        sd(s5, sp, 24);
+    }
 
-    // Initialize accumulators. VL is set to m; e32 LMUL=m4 gives VLEN/8 max
-    // lanes, matching the per-iter e8 LMUL=m1 and e16 LMUL=m2 settings.
+    // Initialize accumulators.
     vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
     for (dim_t c = 0; c < n_cols_; c++)
         vmv_v_i(v_c[c], 0);
@@ -139,11 +129,7 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     };
 
     auto emit_extend_a = [&]() {
-        // Sign-extend v_a_e8 (e8 LMUL=m1) to v_a_e16 (e16 LMUL=m2). A is the
-        // weights axis and is always s8. We avoid vsext.vf2 here because some
-        // RV64 implementations trap on that opcode in this configuration;
-        // vwmul.vx with scalar 1 produces the same widening sign-extension and
-        // is exercised elsewhere (jit_rvv_inner_product_kernel) on this target.
+        // Sign-extend v_a_e8 (e8 LMUL=m1) to v_a_e16 (e16 LMUL=m2).
         li(reg_tmp0, 1);
         vwmul_vx(v_a_e16, v_a_e8, reg_tmp0);
     };
@@ -161,33 +147,24 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
     auto emit_load_b_strided = [&]() {
         // !isTransB_: B[k, c] = mem[reg_B0_ptr + c * ldb_bytes].
-        for (dim_t c = 0; c < n_cols_; c++) {
-            if (c == 0) {
-                if (b_signed_) {
-                    lb(reg_b[0], reg_B0_ptr, 0);
-                } else {
-                    lbu(reg_b[0], reg_B0_ptr, 0);
-                }
-            } else {
-                li(reg_tmp0, c);
-                mul(reg_tmp0, reg_tmp0, reg_ldb_bytes);
-                add(reg_tmp0, reg_B0_ptr, reg_tmp0);
-                if (b_signed_) {
-                    lb(reg_b[c], reg_tmp0, 0);
-                } else {
-                    lbu(reg_b[c], reg_tmp0, 0);
-                }
+        auto lb_or_lbu = [&](const Reg &dst, const Reg &base, int32_t off) {
+            if (b_signed_)
+                lb(dst, base, off);
+            else
+                lbu(dst, base, off);
+        };
+        lb_or_lbu(reg_b[0], reg_B0_ptr, 0);
+        if (n_cols_ > 1) {
+            add(reg_tmp0, reg_B0_ptr, reg_ldb_bytes); // &B[k, 1]
+            for (dim_t c = 1; c < n_cols_; c++) {
+                lb_or_lbu(reg_b[c], reg_tmp0, 0);
+                if (c + 1 < n_cols_) add(reg_tmp0, reg_tmp0, reg_ldb_bytes);
             }
         }
     };
 
     auto emit_compute = [&]() {
-        // SEW=e16 LMUL=m2 here. v_c[c] is e32 LMUL=m4 (2*SEW). Whether B is
-        // s8 (loaded with lb, sign-extended) or u8 (loaded with lbu, zero-
-        // extended to a positive s16), vwmacc.vx produces the correct
-        // signed*signed->signed widening result, so we share one code path
-        // for both cases. (vwmaccsu.vx would also work for u8 but is not
-        // exercised by other kernels on this target.)
+        // SEW=e16 LMUL=m2 here. v_c[c] is e32 LMUL=m4 (2*SEW).
         for (dim_t c = 0; c < n_cols_; c++) {
             vwmacc_vx(v_c[c], reg_b[c], v_a_e16);
         }
@@ -254,6 +231,15 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
         }
     };
 
+    // Preload the per-M bias vector once (broadcast across N columns).
+    if (has_bias_) {
+        Label label_bias_loaded;
+        beqz(reg_bias_ptr, label_bias_loaded);
+        vle32_v(v_bias, reg_bias_ptr);
+        if (!dst_is_f32_) { vfcvt_rtz_x_f_v(v_bias, v_bias); }
+        L(label_bias_loaded);
+    }
+
     if (dst_is_f32_) {
         // f32 dst path: C[col_idx] = alpha * fcvt(acc) + beta * C + bias.
         for (dim_t c = 0; c < n_cols_; c++) {
@@ -273,7 +259,6 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
             if (has_bias_) {
                 beqz(reg_bias_ptr, label_skip_bias);
-                vle32_v(v_bias, reg_bias_ptr);
                 vfadd_vv(v_tmp, v_tmp, v_bias);
                 L(label_skip_bias);
             }
@@ -286,7 +271,6 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
             if (has_bias_) {
                 beqz(reg_bias_ptr, label_store);
-                vle32_v(v_bias, reg_bias_ptr);
                 vfadd_vv(v_c[c], v_c[c], v_bias);
             }
 
@@ -296,12 +280,7 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
             L(label_done);
         }
     } else {
-        // s32 dst path. We must respect beta so K-blocking in the wrapper
-        // works: Bk==0 writes a fresh tile (beta=0), Bk>0 accumulates into
-        // the existing C (beta=1). alpha is ignored on this path because
-        // multiplying a s32 accumulator by an arbitrary float loses data.
-        //   beta == 0: C[col_idx] = acc + (bias ? s32(bias) : 0)
-        //   beta != 0: C[col_idx] = C[col_idx] + acc + (bias ? s32(bias) : 0)
+        // s32 dst path.
         for (dim_t c = 0; c < n_cols_; c++) {
             Label label_after_beta, label_skip_bias;
 
@@ -315,9 +294,7 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
             if (has_bias_) {
                 beqz(reg_bias_ptr, label_skip_bias);
-                vle32_v(v_tmp, reg_bias_ptr);
-                vfcvt_x_f_v(v_tmp, v_tmp);
-                vsadd_vv(v_c[c], v_c[c], v_tmp);
+                vsadd_vv(v_c[c], v_c[c], v_bias);
                 L(label_skip_bias);
             }
             vse32_v(v_c[c], reg_tmp0);
@@ -325,12 +302,13 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     }
 
     // Restore callee-saved registers and return.
-    ld(s2, sp, 0);
-    ld(s3, sp, 8);
-    ld(s4, sp, 16);
-    ld(s5, sp, 24);
-    ld(s6, sp, 32);
-    addi(sp, sp, 48);
+    if (need_callee_save) {
+        ld(s2, sp, 0);
+        ld(s3, sp, 8);
+        ld(s4, sp, 16);
+        ld(s5, sp, 24);
+        addi(sp, sp, 32);
+    }
 
     ret();
 #else
@@ -357,10 +335,10 @@ get_jit_rvv_gemm_s8_kernel_storage() {
 
     std::call_once(initialized, [] {
         for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
-            storage.nb[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(n_cols,
-                    isTransA, isTransB, b_signed, dst_is_f32, false));
-            storage.b[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(n_cols,
-                    isTransA, isTransB, b_signed, dst_is_f32, true));
+            storage.nb[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
+                    n_cols, isTransA, isTransB, b_signed, dst_is_f32, false));
+            storage.b[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
+                    n_cols, isTransA, isTransB, b_signed, dst_is_f32, true));
             storage.table.nb[n_cols] = storage.nb[n_cols].get();
             storage.table.b[n_cols] = storage.b[n_cols].get();
         }
@@ -395,7 +373,8 @@ const jit_rvv_gemm_s8_kernel_table_t &get_jit_rvv_gemm_s8_kernel_table(
     DISPATCH(true, true, false, true)
 #undef DISPATCH
     // Unreachable: all 16 combinations are covered above.
-    return get_jit_rvv_gemm_s8_kernel_storage<false, false, true, false>().table;
+    return get_jit_rvv_gemm_s8_kernel_storage<false, false, true, false>()
+            .table;
 }
 
 } // namespace gemm_utils

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
@@ -1,0 +1,405 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp"
+#include "common/verbose.hpp"
+
+#include <array>
+#include <memory>
+#include <mutex>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace gemm_utils {
+
+using namespace Xbyak_riscv;
+
+jit_rvv_gemm_s8_kernel_t::jit_rvv_gemm_s8_kernel_t(dim_t n_cols,
+        bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32,
+        bool has_bias)
+    : jit_generator_t("rv64_gemm_kernel_s8_jit")
+    , n_cols_(n_cols)
+    , isTransA_(isTransA)
+    , isTransB_(isTransB)
+    , b_signed_(b_signed)
+    , dst_is_f32_(dst_is_f32)
+    , has_bias_(has_bias) {
+    create_kernel();
+}
+
+void jit_rvv_gemm_s8_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+
+    const Reg reg_A_ptr = a1; // running pointer into A (weights)
+    const Reg reg_m = a2; // tile height (used for vsetvli)
+    const Reg reg_C_base = a3; // base pointer to C(:, 0)
+
+    const Reg reg_lda_bytes = t0; // A is s8: 1 byte per element
+    const Reg reg_ldb_bytes = t1; // B is s8/u8: 1 byte per element
+    const Reg reg_ldc_bytes = t2; // C is s32/f32: 4 bytes per element
+    const Reg reg_K = t3;
+    const Reg reg_alpha_bits = t4;
+    const Reg reg_bias_ptr = t4; // reuse after alpha bits moved to freg
+    const Reg reg_beta_bits = t5;
+
+    const Reg reg_k = a4; // current k counter
+    const Reg reg_B0_ptr = a6; // running pointer into B
+    const Reg reg_tmp0 = a7;
+    const FReg freg_alpha = fa0;
+    const FReg freg_beta = fa1;
+    // B scalars are kept in GPRs across the per-K vwmacc[vx|su.vx] calls. The
+    // vwmacc family reads the low SEW bits of rs1, so a sign- or zero-extended
+    // s8/u8 in a 64-bit GPR is fine. n_cols can be up to 6, so reg_b[0] lives
+    // in a caller-saved temp and reg_b[1..5] borrow callee-saved s2..s6.
+    const Reg reg_b[6] = {t6, s2, s3, s4, s5, s6};
+
+    const VReg v_c[6] = {
+            VReg(0), VReg(4), VReg(8), VReg(12), VReg(16), VReg(20)};
+    // K-loop temporaries. v_a_e8 (LMUL=m1) and v_a_e16 (LMUL=m2) must not
+    // overlap (vsext.vf2 forbids source/dest overlap on widening ops).
+    // v_a_e16 sits in v24-v25; v_a_e8 takes v26.
+    const VReg v_a_e16(24); // e16 LMUL=m2 sign-/zero-extended A
+    const VReg v_a_e8(26); // e8 LMUL=m1 source row
+    // C-update temporaries. After the K loop ends both v_a_e16 and v_a_e8 are
+    // dead, so the C-update epilogue can grab two distinct LMUL=m4 groups
+    // from v24-v31: v_tmp owns v24-v27 (overlaps dead v_a_e16), v_bias owns
+    // v28-v31. Both registers carry e32 elements under the C-update vsetvli.
+    const VReg v_tmp(24); // e32 LMUL=m4 scratch / C-load temporary
+    const VReg v_bias(28); // e32 LMUL=m4 bias loader (f32 dst path)
+
+    // Layout of call_params_t (offsets in bytes):
+    //   0  : const void *A
+    //   8  : const void *B
+    //   16 : void *C
+    //   24 : dim_t lda
+    //   32 : dim_t ldb
+    //   40 : dim_t ldc
+    //   48 : dim_t K
+    //   56 : dim_t m
+    //   64 : float alpha
+    //   68 : float beta
+    //   72 : const float *bias  (only used when has_bias_)
+    ld(reg_A_ptr, reg_param, 0);
+    ld(reg_B0_ptr, reg_param, 8);
+    ld(reg_C_base, reg_param, 16);
+    ld(reg_lda_bytes, reg_param, 24);
+    ld(reg_ldb_bytes, reg_param, 32);
+    ld(reg_ldc_bytes, reg_param, 40);
+    ld(reg_K, reg_param, 48);
+    ld(reg_m, reg_param, 56);
+
+    lw(reg_alpha_bits, reg_param, 64);
+    fmv_w_x(freg_alpha, reg_alpha_bits);
+    lw(reg_beta_bits, reg_param, 68);
+    fmv_w_x(freg_beta, reg_beta_bits);
+
+    if (has_bias_) { ld(reg_bias_ptr, reg_param, 72); }
+
+    // A is s8 (1 byte), B is s8/u8 (1 byte): element stride == byte stride.
+    // C is s32/f32 (4 bytes): ldc * 4 = byte stride.
+    slli(reg_ldc_bytes, reg_ldc_bytes, 2);
+
+    // Save callee-saved registers (s2..s6 hold reg_b[1..5] when n_cols >= 2).
+    // Use a 48-byte stack frame; only the first 40 bytes are populated.
+    addi(sp, sp, -48);
+    sd(s2, sp, 0);
+    sd(s3, sp, 8);
+    sd(s4, sp, 16);
+    sd(s5, sp, 24);
+    sd(s6, sp, 32);
+
+    // Initialize accumulators. VL is set to m; e32 LMUL=m4 gives VLEN/8 max
+    // lanes, matching the per-iter e8 LMUL=m1 and e16 LMUL=m2 settings.
+    vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    for (dim_t c = 0; c < n_cols_; c++)
+        vmv_v_i(v_c[c], 0);
+
+    auto emit_load_a_e8 = [&]() {
+        if (isTransA_) {
+            vlse8_v(v_a_e8, reg_A_ptr, reg_lda_bytes);
+        } else {
+            vle8_v(v_a_e8, reg_A_ptr);
+        }
+    };
+
+    auto emit_extend_a = [&]() {
+        // Sign-extend v_a_e8 (e8 LMUL=m1) to v_a_e16 (e16 LMUL=m2). A is the
+        // weights axis and is always s8. We avoid vsext.vf2 here because some
+        // RV64 implementations trap on that opcode in this configuration;
+        // vwmul.vx with scalar 1 produces the same widening sign-extension and
+        // is exercised elsewhere (jit_rvv_inner_product_kernel) on this target.
+        li(reg_tmp0, 1);
+        vwmul_vx(v_a_e16, v_a_e8, reg_tmp0);
+    };
+
+    auto emit_load_b_consecutive = [&]() {
+        // isTransB_: B[k, 0..n_cols-1] are n_cols consecutive bytes.
+        for (dim_t c = 0; c < n_cols_; c++) {
+            if (b_signed_) {
+                lb(reg_b[c], reg_B0_ptr, static_cast<int32_t>(c));
+            } else {
+                lbu(reg_b[c], reg_B0_ptr, static_cast<int32_t>(c));
+            }
+        }
+    };
+
+    auto emit_load_b_strided = [&]() {
+        // !isTransB_: B[k, c] = mem[reg_B0_ptr + c * ldb_bytes].
+        for (dim_t c = 0; c < n_cols_; c++) {
+            if (c == 0) {
+                if (b_signed_) {
+                    lb(reg_b[0], reg_B0_ptr, 0);
+                } else {
+                    lbu(reg_b[0], reg_B0_ptr, 0);
+                }
+            } else {
+                li(reg_tmp0, c);
+                mul(reg_tmp0, reg_tmp0, reg_ldb_bytes);
+                add(reg_tmp0, reg_B0_ptr, reg_tmp0);
+                if (b_signed_) {
+                    lb(reg_b[c], reg_tmp0, 0);
+                } else {
+                    lbu(reg_b[c], reg_tmp0, 0);
+                }
+            }
+        }
+    };
+
+    auto emit_compute = [&]() {
+        // SEW=e16 LMUL=m2 here. v_c[c] is e32 LMUL=m4 (2*SEW). Whether B is
+        // s8 (loaded with lb, sign-extended) or u8 (loaded with lbu, zero-
+        // extended to a positive s16), vwmacc.vx produces the correct
+        // signed*signed->signed widening result, so we share one code path
+        // for both cases. (vwmaccsu.vx would also work for u8 but is not
+        // exercised by other kernels on this target.)
+        for (dim_t c = 0; c < n_cols_; c++) {
+            vwmacc_vx(v_c[c], reg_b[c], v_a_e16);
+        }
+    };
+
+    auto emit_advance_a = [&]() {
+        if (isTransA_) {
+            addi(reg_A_ptr, reg_A_ptr, 1);
+        } else {
+            add(reg_A_ptr, reg_A_ptr, reg_lda_bytes);
+        }
+    };
+
+    auto emit_advance_b = [&]() {
+        if (isTransB_) {
+            add(reg_B0_ptr, reg_B0_ptr, reg_ldb_bytes);
+        } else {
+            addi(reg_B0_ptr, reg_B0_ptr, 1);
+        }
+    };
+
+    // Main K loop. Each iteration: load A (e8) -> extend to e16 -> set SEW=e16
+    // -> load B scalars -> vwmacc into accumulators -> advance A/B.
+    Label label_k_done;
+    Label label_loop_k;
+
+    beqz(reg_K, label_k_done);
+    mv(reg_k, x0);
+
+    L(label_loop_k);
+
+    vsetvli(x0, reg_m, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
+    emit_load_a_e8();
+    emit_extend_a();
+
+    vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+
+    if (isTransB_) {
+        emit_load_b_consecutive();
+    } else {
+        emit_load_b_strided();
+    }
+    emit_compute();
+
+    emit_advance_a();
+    emit_advance_b();
+
+    addi(reg_k, reg_k, 1);
+    blt(reg_k, reg_K, label_loop_k);
+
+    L(label_k_done);
+
+    // C-update: switch back to e32 LMUL=m4 (VL=m) for the epilogue.
+    vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+
+    // Computes the address of C's col_idx column into reg_tmp3.
+    auto emit_col_addr = [&](dim_t col_idx) {
+        if (col_idx == 0) {
+            mv(reg_tmp0, reg_C_base);
+        } else {
+            li(reg_tmp0, col_idx);
+            mul(reg_tmp0, reg_ldc_bytes, reg_tmp0);
+            add(reg_tmp0, reg_C_base, reg_tmp0);
+        }
+    };
+
+    if (dst_is_f32_) {
+        // f32 dst path: C[col_idx] = alpha * fcvt(acc) + beta * C + bias.
+        for (dim_t c = 0; c < n_cols_; c++) {
+            Label label_beta_zero, label_skip_bias, label_store, label_done;
+
+            emit_col_addr(c);
+
+            // s32 acc -> f32 in place.
+            vfcvt_f_x_v(v_c[c], v_c[c]);
+
+            beqz(reg_beta_bits, label_beta_zero);
+
+            vle32_v(v_tmp, reg_tmp0);
+            vfmul_vf(v_tmp, v_tmp, freg_beta);
+            vfmul_vf(v_c[c], v_c[c], freg_alpha);
+            vfadd_vv(v_tmp, v_tmp, v_c[c]);
+
+            if (has_bias_) {
+                beqz(reg_bias_ptr, label_skip_bias);
+                vle32_v(v_bias, reg_bias_ptr);
+                vfadd_vv(v_tmp, v_tmp, v_bias);
+                L(label_skip_bias);
+            }
+
+            vse32_v(v_tmp, reg_tmp0);
+            j_(label_done);
+
+            L(label_beta_zero);
+            vfmul_vf(v_c[c], v_c[c], freg_alpha);
+
+            if (has_bias_) {
+                beqz(reg_bias_ptr, label_store);
+                vle32_v(v_bias, reg_bias_ptr);
+                vfadd_vv(v_c[c], v_c[c], v_bias);
+            }
+
+            L(label_store);
+            vse32_v(v_c[c], reg_tmp0);
+
+            L(label_done);
+        }
+    } else {
+        // s32 dst path. We must respect beta so K-blocking in the wrapper
+        // works: Bk==0 writes a fresh tile (beta=0), Bk>0 accumulates into
+        // the existing C (beta=1). alpha is ignored on this path because
+        // multiplying a s32 accumulator by an arbitrary float loses data.
+        //   beta == 0: C[col_idx] = acc + (bias ? s32(bias) : 0)
+        //   beta != 0: C[col_idx] = C[col_idx] + acc + (bias ? s32(bias) : 0)
+        for (dim_t c = 0; c < n_cols_; c++) {
+            Label label_after_beta, label_skip_bias;
+
+            emit_col_addr(c);
+
+            beqz(reg_beta_bits, label_after_beta);
+            // beta != 0: read C and add to accumulator in place.
+            vle32_v(v_tmp, reg_tmp0);
+            vsadd_vv(v_c[c], v_tmp, v_c[c]);
+            L(label_after_beta);
+
+            if (has_bias_) {
+                beqz(reg_bias_ptr, label_skip_bias);
+                vle32_v(v_tmp, reg_bias_ptr);
+                vfcvt_x_f_v(v_tmp, v_tmp);
+                vsadd_vv(v_c[c], v_c[c], v_tmp);
+                L(label_skip_bias);
+            }
+            vse32_v(v_c[c], reg_tmp0);
+        }
+    }
+
+    // Restore callee-saved registers and return.
+    ld(s2, sp, 0);
+    ld(s3, sp, 8);
+    ld(s4, sp, 16);
+    ld(s5, sp, 24);
+    ld(s6, sp, 32);
+    addi(sp, sp, 48);
+
+    ret();
+#else
+    ret();
+#endif
+}
+
+namespace {
+
+template <bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32>
+struct jit_rvv_gemm_s8_kernel_storage_t {
+    std::array<std::unique_ptr<jit_rvv_gemm_s8_kernel_t>, 8> nb;
+    std::array<std::unique_ptr<jit_rvv_gemm_s8_kernel_t>, 8> b;
+    jit_rvv_gemm_s8_kernel_table_t table;
+};
+
+template <bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32>
+jit_rvv_gemm_s8_kernel_storage_t<isTransA, isTransB, b_signed, dst_is_f32> &
+get_jit_rvv_gemm_s8_kernel_storage() {
+    static jit_rvv_gemm_s8_kernel_storage_t<isTransA, isTransB, b_signed,
+            dst_is_f32>
+            storage;
+    static std::once_flag initialized;
+
+    std::call_once(initialized, [] {
+        for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
+            storage.nb[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(n_cols,
+                    isTransA, isTransB, b_signed, dst_is_f32, false));
+            storage.b[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(n_cols,
+                    isTransA, isTransB, b_signed, dst_is_f32, true));
+            storage.table.nb[n_cols] = storage.nb[n_cols].get();
+            storage.table.b[n_cols] = storage.b[n_cols].get();
+        }
+    });
+
+    return storage;
+}
+
+} // namespace
+
+const jit_rvv_gemm_s8_kernel_table_t &get_jit_rvv_gemm_s8_kernel_table(
+        bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32) {
+#define DISPATCH(SA, SB, BS, DF) \
+    if (isTransA == (SA) && isTransB == (SB) && b_signed == (BS) \
+            && dst_is_f32 == (DF)) \
+        return get_jit_rvv_gemm_s8_kernel_storage<SA, SB, BS, DF>().table;
+    DISPATCH(false, false, true, false)
+    DISPATCH(false, false, true, true)
+    DISPATCH(false, false, false, false)
+    DISPATCH(false, false, false, true)
+    DISPATCH(false, true, true, false)
+    DISPATCH(false, true, true, true)
+    DISPATCH(false, true, false, false)
+    DISPATCH(false, true, false, true)
+    DISPATCH(true, false, true, false)
+    DISPATCH(true, false, true, true)
+    DISPATCH(true, false, false, false)
+    DISPATCH(true, false, false, true)
+    DISPATCH(true, true, true, false)
+    DISPATCH(true, true, true, true)
+    DISPATCH(true, true, false, false)
+    DISPATCH(true, true, false, true)
+#undef DISPATCH
+    // Unreachable: all 16 combinations are covered above.
+    return get_jit_rvv_gemm_s8_kernel_storage<false, false, true, false>().table;
+}
+
+} // namespace gemm_utils
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 ZTE Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,25 +33,6 @@ namespace gemm_utils {
 //   C[0:m, 0:n_cols] = sum_k A[0:m, 0:K] * B[0:K, 0:n_cols]
 //                    + (has_bias ? bias[0:m] : 0)
 //
-// A is the "vector" axis (loaded once per K iteration, broadcast across N).
-// In the matmul driver A is the GEMM "weights" axis and is always int8.
-// B is the "scalar" axis (one B value per N column per K iteration); in the
-// matmul driver B is the GEMM "src" axis and is int8 when b_signed=true and
-// uint8 when b_signed=false.
-//
-// The accumulator and dst are e32: either s32 (raw accumulator written
-// straight through, alpha/beta ignored) or f32 (accumulator is fcvt-converted
-// and alpha/beta applied during the C-update phase).
-//
-// Design choices (mirror jit_rvv_gemm_kernel_t for f32):
-//   - Accumulator LMUL is fixed to m4 (4 vector registers per column group)
-//   - n_cols is fixed at JIT compile time (1..6)
-//   - m (tile height) is a runtime parameter; any m <= VLEN/8 is supported
-//   - isTransA/isTransB determine A/B memory access patterns
-//   - b_signed selects s8 (vwmacc.vx, sign-extended scalar load) vs u8
-//     (vwmaccsu.vx, zero-extended scalar load) on the B axis
-//   - dst_is_f32 selects s32 vs f32 C-update epilogue
-//
 // Vector register layout:
 //   v0..v3    accumulator c0 (e32, LMUL=m4)
 //   v4..v7    accumulator c1
@@ -78,8 +59,6 @@ struct jit_rvv_gemm_s8_kernel_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_s8_kernel_t)
 
-    // Construct a JIT kernel for a specific (n_cols, transA, transB, B sign,
-    // dst type, fused-bias) configuration.
     jit_rvv_gemm_s8_kernel_t(dim_t n_cols, bool isTransA, bool isTransB,
             bool b_signed, bool dst_is_f32, bool has_bias);
 
@@ -104,9 +83,6 @@ struct jit_rvv_gemm_s8_kernel_table_t {
     std::array<const jit_rvv_gemm_s8_kernel_t *, 8> b {};
 };
 
-// Returns the singleton kernel table for the given (transA, transB, B sign,
-// dst type) combination. b_signed picks s8 (true) vs u8 (false) on the B axis
-// (the activation); A is always s8 (weights).
 const jit_rvv_gemm_s8_kernel_table_t &get_jit_rvv_gemm_s8_kernel_table(
         bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32);
 

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_GEMM_JIT_RVV_GEMM_S8_KERNEL_HPP
+#define CPU_RV64_GEMM_JIT_RVV_GEMM_S8_KERNEL_HPP
+
+#include "cpu/rv64/jit_generator.hpp"
+
+#include <array>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace gemm_utils {
+
+// RVV JIT micro-kernel for int8 GEMM on RV64.
+//
+// Computes an m x n_cols tile of:
+//   C[0:m, 0:n_cols] = sum_k A[0:m, 0:K] * B[0:K, 0:n_cols]
+//                    + (has_bias ? bias[0:m] : 0)
+//
+// A is the "vector" axis (loaded once per K iteration, broadcast across N).
+// In the matmul driver A is the GEMM "weights" axis and is always int8.
+// B is the "scalar" axis (one B value per N column per K iteration); in the
+// matmul driver B is the GEMM "src" axis and is int8 when b_signed=true and
+// uint8 when b_signed=false.
+//
+// The accumulator and dst are e32: either s32 (raw accumulator written
+// straight through, alpha/beta ignored) or f32 (accumulator is fcvt-converted
+// and alpha/beta applied during the C-update phase).
+//
+// Design choices (mirror jit_rvv_gemm_kernel_t for f32):
+//   - Accumulator LMUL is fixed to m4 (4 vector registers per column group)
+//   - n_cols is fixed at JIT compile time (1..6)
+//   - m (tile height) is a runtime parameter; any m <= VLEN/8 is supported
+//   - isTransA/isTransB determine A/B memory access patterns
+//   - b_signed selects s8 (vwmacc.vx, sign-extended scalar load) vs u8
+//     (vwmaccsu.vx, zero-extended scalar load) on the B axis
+//   - dst_is_f32 selects s32 vs f32 C-update epilogue
+//
+// Vector register layout:
+//   v0..v3    accumulator c0 (e32, LMUL=m4)
+//   v4..v7    accumulator c1
+//   v8..v11   accumulator c2
+//   v12..v15  accumulator c3
+//   v16..v19  accumulator c4
+//   v20..v23  accumulator c5
+//   v24       A row buffer in e8 (LMUL=m1) and e16 (LMUL=m2, overlaps v24-v25)
+//   v26       scratch / C-load temporary
+struct jit_rvv_gemm_s8_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const void *A; // weights, s8 (M x K GEMM A axis)
+        const void *B; // src, s8 or u8 (K x N GEMM B axis)
+        void *C; // dst, s32 or f32
+        dim_t lda;
+        dim_t ldb;
+        dim_t ldc;
+        dim_t K;
+        dim_t m;
+        float alpha; // applied only when dst_is_f32
+        float beta; // applied only when dst_is_f32
+        const float *bias; // optional, f32; broadcast per-row
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_s8_kernel_t)
+
+    // Construct a JIT kernel for a specific (n_cols, transA, transB, B sign,
+    // dst type, fused-bias) configuration.
+    jit_rvv_gemm_s8_kernel_t(dim_t n_cols, bool isTransA, bool isTransB,
+            bool b_signed, bool dst_is_f32, bool has_bias);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    dim_t n_cols_;
+    bool isTransA_;
+    bool isTransB_;
+    bool b_signed_; // true: B is s8; false: B is u8
+    bool dst_is_f32_; // true: dst is f32; false: dst is s32
+    bool has_bias_;
+};
+
+struct jit_rvv_gemm_s8_kernel_table_t {
+    std::array<const jit_rvv_gemm_s8_kernel_t *, 8> nb {};
+    std::array<const jit_rvv_gemm_s8_kernel_t *, 8> b {};
+};
+
+// Returns the singleton kernel table for the given (transA, transB, B sign,
+// dst type) combination. b_signed picks s8 (true) vs u8 (false) on the B axis
+// (the activation); A is always s8 (weights).
+const jit_rvv_gemm_s8_kernel_table_t &get_jit_rvv_gemm_s8_kernel_table(
+        bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32);
+
+} // namespace gemm_utils
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
@@ -55,6 +55,11 @@ struct jit_rvv_gemm_s8_kernel_t : public jit_generator_t {
         float alpha; // applied only when dst_is_f32
         float beta; // applied only when dst_is_f32
         const float *bias; // optional, f32; broadcast per-row
+        // True when the bias is a single scalar that broadcasts across the M
+        // tile (bia_mask=0 / last dim == 1). The kernel then splats one float
+        // instead of reading a full vector, which would overrun the
+        // one-element object.
+        int bias_is_scalar;
     };
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_s8_kernel_t)

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
@@ -220,7 +220,8 @@ void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
 status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
         const dim_t *N_, const dim_t *K_, const float *alpha_, const float *A,
         const dim_t *lda_, const float *B, const dim_t *ldb_,
-        const float *beta_, float *C, const dim_t *ldc_, const float *bias) {
+        const float *beta_, float *C, const dim_t *ldc_, const float *bias,
+        float *c_buffers_in, float *ws_buffers_in) {
 
     if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
                 && utils::one_of(*transb_, 'n', 'N', 't', 'T')))
@@ -236,25 +237,14 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
     // early out and avoid division by zero in partitioning
     if (utils::one_of(0, M, N)) return status::success;
 
-    int max_nthr = dnnl_get_current_num_threads();
+    // Use current (not max) threads so nested-parallel callers
+    int nthr = dnnl_get_current_num_threads();
     int nthr_m, nthr_n, nthr_k;
     dim_t MB, NB, KB;
 
     calc_nthr_nocopy_rvv(
-            M, N, K, max_nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+            M, N, K, nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
     assert(IMPLICATION(!dnnl_thr_syncable(), nthr_k == 1));
-
-    float *c_buffers = nullptr;
-    float *ws_buffers = nullptr;
-    if (nthr_k > 1) {
-        c_buffers = (float *)malloc(
-                sizeof(*c_buffers) * nthr_m * nthr_n * (nthr_k - 1) * MB * NB,
-                PAGE_4K);
-        if (!c_buffers) {
-            nthr_k = 1;
-            KB = K;
-        }
-    }
 
     bool do_copy = (NB / gemm_f32_traits::get_n_unroll_factor() > 3);
     const int nthr_mn = nthr_m * nthr_n;
@@ -263,9 +253,27 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
     const size_t ws_elems_per_thr = K * m_unroll;
     const size_t ws_size_per_thr
             = rnd_up(ws_elems_per_thr * sizeof(float), PAGE_4K);
-    if (do_copy) {
-        ws_buffers = (float *)malloc(nthr_to_use * ws_size_per_thr, PAGE_4K);
-        if (!ws_buffers) do_copy = false;
+
+    // Fall back to malloc/free when the caller didn't book scratchpad
+    // The matmul primitive books via pd_t::init_scratchpad() and passes non-null buffers.
+    float *c_buffers = c_buffers_in;
+    float *ws_buffers = ws_buffers_in;
+    bool own_c = false, own_ws = false;
+    if (nthr_k > 1 && !c_buffers) {
+        c_buffers = static_cast<float *>(malloc(
+                sizeof(*c_buffers) * nthr_m * nthr_n * (nthr_k - 1) * MB * NB,
+                PAGE_4K));
+        own_c = c_buffers != nullptr;
+        if (!own_c) {
+            nthr_k = 1;
+            KB = K;
+        }
+    }
+    if (do_copy && !ws_buffers) {
+        ws_buffers = static_cast<float *>(
+                malloc(nthr_to_use * ws_size_per_thr, PAGE_4K));
+        own_ws = ws_buffers != nullptr;
+        if (!own_ws) do_copy = false;
     }
 
     const auto &trans_a_table = get_jit_rvv_gemm_kernel_table(true, isTransB);
@@ -378,8 +386,8 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
         });
     }
 
-    free(ws_buffers);
-    free(c_buffers);
+    if (own_ws) free(ws_buffers);
+    if (own_c) free(c_buffers);
 
     return status::success;
 }

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
@@ -221,7 +221,8 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
         const dim_t *N_, const dim_t *K_, const float *alpha_, const float *A,
         const dim_t *lda_, const float *B, const dim_t *ldb_,
         const float *beta_, float *C, const dim_t *ldc_, const float *bias,
-        float *c_buffers_in, float *ws_buffers_in) {
+        float *c_buffers_in, float *ws_buffers_in,
+        const gemm_partition_t *part) {
 
     if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
                 && utils::one_of(*transb_, 'n', 'N', 't', 'T')))
@@ -237,13 +238,25 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
     // early out and avoid division by zero in partitioning
     if (utils::one_of(0, M, N)) return status::success;
 
-    // Use current (not max) threads so nested-parallel callers
-    int nthr = dnnl_get_current_num_threads();
     int nthr_m, nthr_n, nthr_k;
     dim_t MB, NB, KB;
-
-    calc_nthr_nocopy_rvv(
-            M, N, K, nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+    if (part) {
+        // Reuse the partition booked in the primitive scratchpad (sized at
+        // init with dnnl_get_max_threads()). Recomputing here with current
+        // threads would mismatch the booked capacity when init and execute
+        // run under different threadpool contexts (e.g. --ctx-init=1
+        // --ctx-exe=8), leading to out-of-bounds workspace access.
+        nthr_m = part->nthr_m;
+        nthr_n = part->nthr_n;
+        nthr_k = part->nthr_k;
+        MB = part->MB;
+        NB = part->NB;
+        KB = part->KB;
+    } else {
+        int nthr = dnnl_get_current_num_threads();
+        calc_nthr_nocopy_rvv(
+                M, N, K, nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+    }
     assert(IMPLICATION(!dnnl_thr_syncable(), nthr_k == 1));
 
     bool do_copy = (NB / gemm_f32_traits::get_n_unroll_factor() > 3);

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
@@ -20,17 +20,26 @@
 
 #include "common/c_types_map.hpp"
 
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace rv64 {
 
 // rvv_gemm_f32 computes C = alpha * A * B + beta * C (+ optional per-M bias).
+//
+// `part` optionally supplies the thread partition computed at primitive
+// initialization (see gemm_utils::gemm_partition_t). When provided, the driver
+// reuses it instead of recomputing from dnnl_get_current_num_threads(), so the
+// per-thread workspace offsets stay consistent with the scratchpad capacity
+// booked at init. Pass nullptr to recompute and malloc (inner_product / conv).
 status_t rvv_gemm_f32(const char *transa, const char *transb, const dim_t *M,
         const dim_t *N, const dim_t *K, const float *alpha, const float *A,
         const dim_t *lda, const float *B, const dim_t *ldb, const float *beta,
         float *C, const dim_t *ldc, const float *bias,
-        float *c_buffers = nullptr, float *ws_buffers = nullptr);
+        float *c_buffers = nullptr, float *ws_buffers = nullptr,
+        const gemm_utils::gemm_partition_t *part = nullptr);
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
@@ -25,10 +25,12 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
+// rvv_gemm_f32 computes C = alpha * A * B + beta * C (+ optional per-M bias).
 status_t rvv_gemm_f32(const char *transa, const char *transb, const dim_t *M,
         const dim_t *N, const dim_t *K, const float *alpha, const float *A,
         const dim_t *lda, const float *B, const dim_t *ldb, const float *beta,
-        float *C, const dim_t *ldc, const float *bias);
+        float *C, const dim_t *ldc, const float *bias,
+        float *c_buffers = nullptr, float *ws_buffers = nullptr);
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
@@ -1,0 +1,436 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstring>
+
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/platform.hpp"
+
+#include "cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp"
+#include "cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace dnnl::impl::utils;
+using namespace gemm_utils;
+using gemm_s8_traits = gemm_utils_traits<float>; // m_unroll = VLEN/8 in both cases
+
+namespace {
+
+// Scalar copy of A (s8 weights) into a cache-friendly workspace. After copy,
+// ws holds K blocks of m_unroll contiguous s8 values:
+//   ws[k * m_unroll + i] = A_logical[i, k]
+void copy_A_s8(bool isTransA, dim_t K, const int8_t *A, dim_t lda,
+        int8_t *ws, dim_t m) {
+    for (dim_t k = 0; k < K; k++) {
+        if (isTransA) {
+            for (dim_t i = 0; i < m; i++)
+                ws[i] = A[i * lda + k];
+        } else {
+            std::memcpy(ws, A + k * lda, m * sizeof(int8_t));
+        }
+        ws += m;
+    }
+}
+
+template <bool isTransA, bool isTransB>
+void block_ker_s8(const dim_t M, const dim_t N, const dim_t K,
+        const int8_t *A, const dim_t lda, const void *B, const dim_t ldb,
+        void *C, const dim_t ldc, const float alpha, const float beta,
+        int8_t *ws, bool do_copy, int ithr, const float *bias,
+        const dim_t m_unroll, bool b_signed, bool dst_is_f32,
+        const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
+        const jit_rvv_gemm_s8_kernel_table_t &nontrans_a_table) {
+    MAYBE_UNUSED(ithr);
+
+    const dim_t n_unroll = gemm_s8_traits::get_n_unroll_factor();
+
+    const dim_t Nu = rnd_dn(N, n_unroll);
+    const dim_t Mu = rnd_dn(M, m_unroll);
+    const dim_t n_tail = N - Nu;
+    const dim_t m_tail = M - Mu;
+
+    auto call_kernel
+            = [&](const jit_rvv_gemm_s8_kernel_table_t &kernel_table,
+                      const void *a, const void *b, void *c, dim_t lda_eff,
+                      dim_t tile_m, dim_t tile_n, const float *bias_tile) {
+        jit_rvv_gemm_s8_kernel_t::call_params_t p;
+        p.A = a;
+        p.B = b;
+        p.C = c;
+        p.lda = lda_eff;
+        p.ldb = ldb;
+        p.ldc = ldc;
+        p.K = K;
+        p.m = tile_m;
+        p.alpha = alpha;
+        p.beta = beta;
+        p.bias = bias_tile;
+
+        const jit_rvv_gemm_s8_kernel_t *kernel
+                = bias_tile ? kernel_table.b[tile_n] : kernel_table.nb[tile_n];
+        (*kernel)(&p);
+    };
+
+    auto invoke_kernel
+            = [&](const int8_t *a_orig, const void *b, void *c, dim_t tile_m,
+                      dim_t tile_n, dim_t j_col, const float *bias_tile) {
+        const void *a_eff;
+        dim_t lda_eff;
+        bool trans_a_eff;
+
+        if (do_copy && tile_m == m_unroll) {
+            if (j_col == 0) {
+                copy_A_s8(isTransA, K, a_orig, lda, ws, m_unroll);
+            }
+            a_eff = ws;
+            lda_eff = m_unroll;
+            trans_a_eff = false;
+        } else {
+            a_eff = a_orig;
+            lda_eff = lda;
+            trans_a_eff = isTransA;
+        }
+
+        const auto &kernel_table
+                = trans_a_eff ? trans_a_table : nontrans_a_table;
+        call_kernel(
+                kernel_table, a_eff, b, c, lda_eff, tile_m, tile_n, bias_tile);
+    };
+
+    for (dim_t i = 0; i < Mu; i += m_unroll) {
+        const int8_t *a = isTransA ? &A[i * lda] : &A[i];
+        const float *bias_tile = bias ? bias + i : nullptr;
+        for (dim_t j = 0; j < Nu; j += n_unroll) {
+            const char *b = isTransB
+                    ? static_cast<const char *>(B) + j
+                    : static_cast<const char *>(B) + j * ldb;
+            invoke_kernel(a, b,
+                    static_cast<char *>(C) + (i + j * ldc) * 4, m_unroll,
+                    n_unroll, j, bias_tile);
+        }
+
+        if (n_tail > 0) {
+            const char *b = isTransB
+                    ? static_cast<const char *>(B) + Nu
+                    : static_cast<const char *>(B) + Nu * ldb;
+            invoke_kernel(a, b,
+                    static_cast<char *>(C) + (i + Nu * ldc) * 4, m_unroll,
+                    n_tail, Nu, bias_tile);
+        }
+    }
+
+    if (m_tail > 0) {
+        const int8_t *a_tail = isTransA ? &A[Mu * lda] : &A[Mu];
+        const float *bias_tile = bias ? bias + Mu : nullptr;
+
+        for (dim_t j = 0; j < Nu; j += n_unroll) {
+            const char *b = isTransB
+                    ? static_cast<const char *>(B) + j
+                    : static_cast<const char *>(B) + j * ldb;
+            const auto &kernel_table
+                    = isTransA ? trans_a_table : nontrans_a_table;
+            call_kernel(kernel_table, a_tail, b,
+                    static_cast<char *>(C) + (Mu + j * ldc) * 4, lda, m_tail,
+                    n_unroll, bias_tile);
+        }
+
+        if (n_tail > 0) {
+            const char *b = isTransB
+                    ? static_cast<const char *>(B) + Nu
+                    : static_cast<const char *>(B) + Nu * ldb;
+            const auto &kernel_table
+                    = isTransA ? trans_a_table : nontrans_a_table;
+            call_kernel(kernel_table, a_tail, b,
+                    static_cast<char *>(C) + (Mu + Nu * ldc) * 4, lda, m_tail,
+                    n_tail, bias_tile);
+        }
+    }
+}
+
+template <bool isTransA, bool isTransB>
+void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
+        const float alpha, const int8_t *A, const dim_t lda, const void *B,
+        const dim_t ldb, const float beta, void *C, const dim_t ldc,
+        bool do_copy, int8_t *ws, int ithr, const float *bias,
+        const dim_t m_unroll, bool b_signed, bool dst_is_f32,
+        const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
+        const jit_rvv_gemm_s8_kernel_table_t &nontrans_a_table) {
+
+    constexpr dim_t BM = gemm_traits_t<float, isTransA, isTransB>::BM;
+    constexpr dim_t BN = gemm_traits_t<float, isTransA, isTransB>::BN;
+    constexpr dim_t BK = gemm_traits_t<float, isTransA, isTransB>::BK;
+
+    const int8_t *curA;
+    const void *curB;
+    char *curC;
+
+    if ((M <= 0) || (N <= 0)) return;
+
+    if ((K <= 0) || (alpha == 0.f)) {
+        dim_t MN = N * M;
+        char *C_bytes = static_cast<char *>(C);
+        if (dst_is_f32) {
+            if (beta == 0.f) {
+                for (dim_t j = 0; j < MN * 4; j++)
+                    C_bytes[j] = 0;
+            } else if (beta != 1.f) {
+                float *C_f = static_cast<float *>(C);
+                for (dim_t j = 0; j < MN; j++)
+                    C_f[j] *= beta;
+            }
+            if (bias) {
+                float *C_f = static_cast<float *>(C);
+                for (dim_t j = 0; j < M; j++)
+                    for (dim_t i = 0; i < N; i++)
+                        C_f[i * ldc + j] += bias[j];
+            }
+        } else {
+            // s32 dst, alpha == 0: zero C; bias added in int32.
+            int32_t *C_i = static_cast<int32_t *>(C);
+            if (beta == 0.f) {
+                for (dim_t j = 0; j < MN; j++)
+                    C_i[j] = 0;
+            }
+            if (bias) {
+                for (dim_t j = 0; j < M; j++)
+                    for (dim_t i = 0; i < N; i++)
+                        C_i[i * ldc + j] += static_cast<int32_t>(bias[j]);
+            }
+        }
+        return;
+    }
+
+    for (dim_t Bk = 0; Bk < K; Bk += BK) {
+        dim_t kb = nstl::min(K - Bk, BK);
+        for (dim_t Bm = 0; Bm < M; Bm += BM) {
+            dim_t mb = nstl::min(M - Bm, BM);
+            for (dim_t Bn = 0; Bn < N; Bn += BN) {
+                dim_t nb = nstl::min(N - Bn, BN);
+                curA = isTransA ? A + Bk + Bm * lda : A + Bm + Bk * lda;
+                const char *B_bytes = static_cast<const char *>(B);
+                curB = isTransB ? static_cast<const void *>(B_bytes + Bn + Bk * ldb)
+                                : static_cast<const void *>(B_bytes + Bk + Bn * ldb);
+                curC = static_cast<char *>(C) + (Bm + Bn * ldc) * 4;
+
+                if (Bk == 0) {
+                    const float *bias_block = bias ? bias + Bm : nullptr;
+                    block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
+                            ldb, curC, ldc, alpha, beta, ws, do_copy, ithr,
+                            bias_block, m_unroll, b_signed, dst_is_f32,
+                            trans_a_table, nontrans_a_table);
+                } else {
+                    block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
+                            ldb, curC, ldc, alpha, 1.0f, ws, do_copy, ithr,
+                            nullptr, m_unroll, b_signed, dst_is_f32,
+                            trans_a_table, nontrans_a_table);
+                }
+            }
+        }
+    }
+}
+} // namespace
+
+status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
+        const dim_t *M_, const dim_t *N_, const dim_t *K_, const float *alpha_,
+        const int8_t *A, const dim_t *lda_, const void *B, const dim_t *ldb_,
+        const float *beta_, void *C, const dim_t *ldc_, const float *bias,
+        bool b_signed, bool dst_is_f32) {
+
+    if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
+                && utils::one_of(*transb_, 'n', 'N', 't', 'T')))
+        return status::unimplemented;
+
+    bool isTransA = (*transa_ == 'T' || *transa_ == 't');
+    bool isTransB = (*transb_ == 'T' || *transb_ == 't');
+
+    const dim_t M = *M_, N = *N_, K = *K_;
+    const dim_t lda = *lda_, ldb = *ldb_, ldc = *ldc_;
+    const float alpha = *alpha_, beta = *beta_;
+
+    // Early out: avoid division by zero in partitioning.
+    if (utils::one_of(0, M, N)) return status::success;
+
+    int max_nthr = dnnl_get_current_num_threads();
+    int nthr_m, nthr_n, nthr_k;
+    dim_t MB, NB, KB;
+
+    calc_nthr_nocopy_rvv(
+            M, N, K, max_nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+    assert(IMPLICATION(!dnnl_thr_syncable(), nthr_k == 1));
+
+    int32_t *c_buffers = nullptr;
+    int8_t *ws_buffers = nullptr;
+    if (nthr_k > 1) {
+        c_buffers = (int32_t *)malloc(
+                sizeof(*c_buffers) * nthr_m * nthr_n * (nthr_k - 1) * MB * NB,
+                PAGE_4K);
+        if (!c_buffers) {
+            nthr_k = 1;
+            KB = K;
+        }
+    }
+
+    bool do_copy = (NB / gemm_s8_traits::get_n_unroll_factor() > 3);
+    const int nthr_mn = nthr_m * nthr_n;
+    const int nthr_to_use = nthr_mn * nthr_k;
+    const dim_t m_unroll = gemm_s8_traits::get_m_unroll_factor();
+    const size_t ws_elems_per_thr = K * m_unroll;
+    const size_t ws_size_per_thr
+            = rnd_up(ws_elems_per_thr * sizeof(int8_t), PAGE_4K);
+    if (do_copy) {
+        ws_buffers = (int8_t *)malloc(nthr_to_use * ws_size_per_thr, PAGE_4K);
+        if (!ws_buffers) do_copy = false;
+    }
+
+    const auto &trans_a_table = get_jit_rvv_gemm_s8_kernel_table(
+            isTransA, isTransB, b_signed, dst_is_f32);
+    const auto &nontrans_a_table = get_jit_rvv_gemm_s8_kernel_table(
+            false, isTransB, b_signed, dst_is_f32);
+
+    auto get_thr_block = [&](dim_t &from, dim_t &to, dim_t &myN, dim_t NB,
+                                 dim_t N, int ithr) {
+        from = NB * (ithr);
+        to = NB * (ithr + 1);
+        if (to > N) to = N;
+        myN = to - from;
+    };
+
+    parallel(nthr_to_use, [&](int ithr, int nthr) {
+        assert(nthr_to_use == nthr);
+        MAYBE_UNUSED(nthr);
+
+        int ithr_mn = ithr % nthr_mn;
+        int ithr_m = ithr_mn % nthr_m;
+        int ithr_n = ithr_mn / nthr_m;
+        int ithr_k = ithr / nthr_mn;
+
+        int cbase = (ithr_m + nthr_m * ithr_n) * (nthr_k - 1);
+
+        int8_t *ws = do_copy
+                ? ws_buffers + ithr * ws_size_per_thr / sizeof(int8_t)
+                : nullptr;
+
+        dim_t m_from = 0, m_to = 0, myM = 0, n_from = 0, n_to = 0, myN = 0,
+              k_from = 0, k_to = 0, myK = 0;
+
+        get_thr_block(m_from, m_to, myM, MB, M, ithr_m);
+        get_thr_block(n_from, n_to, myN, NB, N, ithr_n);
+        get_thr_block(k_from, k_to, myK, KB, K, ithr_k);
+
+        if (myM > 0 && myN > 0) {
+            void *myC;
+            float myBeta;
+            dim_t ld;
+            if (ithr_k == 0) {
+                myC = static_cast<char *>(C) + (m_from + n_from * ldc) * 4;
+                myBeta = beta;
+                ld = ldc;
+            } else {
+                myC = c_buffers + MB * NB * (cbase + ithr_k - 1);
+                myBeta = 0.0f;
+                ld = MB;
+            }
+            const int8_t *myA = isTransA ? &(A[k_from + m_from * lda])
+                                         : &(A[m_from + k_from * lda]);
+            const char *B_bytes = static_cast<const char *>(B);
+            const void *myB = isTransB
+                    ? static_cast<const void *>(B_bytes + n_from + k_from * ldb)
+                    : static_cast<const void *>(B_bytes + k_from + n_from * ldb);
+
+            const float *myBias
+                    = (ithr_k == 0 && bias) ? bias + m_from : nullptr;
+
+            if (!isTransA) {
+                if (!isTransB) {
+                    gemm_ithr_s8<false, false>(myM, myN, myK, alpha, myA, lda,
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, b_signed, dst_is_f32, trans_a_table,
+                            nontrans_a_table);
+                } else {
+                    gemm_ithr_s8<false, true>(myM, myN, myK, alpha, myA, lda,
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, b_signed, dst_is_f32, trans_a_table,
+                            nontrans_a_table);
+                }
+            } else {
+                if (!isTransB) {
+                    gemm_ithr_s8<true, false>(myM, myN, myK, alpha, myA, lda,
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, b_signed, dst_is_f32, trans_a_table,
+                            nontrans_a_table);
+                } else {
+                    gemm_ithr_s8<true, true>(myM, myN, myK, alpha, myA, lda,
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
+                            m_unroll, b_signed, dst_is_f32, trans_a_table,
+                            nontrans_a_table);
+                }
+            }
+        }
+    });
+
+    if (nthr_k > 1) {
+        parallel(nthr_to_use, [&](int ithr, int nthr) {
+            assert(nthr_to_use == nthr);
+            MAYBE_UNUSED(nthr);
+
+            int ithr_mn = ithr % nthr_mn;
+            int ithr_m = ithr_mn % nthr_m;
+            int ithr_k = ithr / nthr_mn;
+            int ithr_n = ithr_mn / nthr_m;
+
+            dim_t n_from = 0, n_to = 0, myN = 0;
+            dim_t m_from = 0, m_to = 0, myM = 0;
+
+            int cbase = (ithr_m + nthr_m * ithr_n) * (nthr_k - 1);
+
+            get_thr_block(n_from, n_to, myN, NB, N, ithr_n);
+            get_thr_block(m_from, m_to, myM, MB, M, ithr_m);
+
+            dim_t offset = 0, block = 0;
+
+            gemm_utils::partition_unit_diff(
+                    ithr_k, nthr_k, myN, &offset, &block);
+            for (int ik = 1; ik < nthr_k; ++ik) {
+                int32_t *myC = c_buffers
+                        + MB * ((dim_t)NB * (cbase + ik - 1) + offset);
+
+                gemm_utils::sum_two_matrices(myM, block, myC, MB,
+                        static_cast<int32_t *>(C)
+                                + m_from + (n_from + offset) * ldc,
+                        ldc);
+            }
+        });
+    }
+
+    free(ws_buffers);
+    free(c_buffers);
+
+    return status::success;
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 ZTE Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,15 +34,15 @@ namespace rv64 {
 
 using namespace dnnl::impl::utils;
 using namespace gemm_utils;
-using gemm_s8_traits = gemm_utils_traits<float>; // m_unroll = VLEN/8 in both cases
+using gemm_s8_traits = gemm_utils::gemm_utils_traits<int8_t>;
 
 namespace {
 
 // Scalar copy of A (s8 weights) into a cache-friendly workspace. After copy,
 // ws holds K blocks of m_unroll contiguous s8 values:
 //   ws[k * m_unroll + i] = A_logical[i, k]
-void copy_A_s8(bool isTransA, dim_t K, const int8_t *A, dim_t lda,
-        int8_t *ws, dim_t m) {
+void copy_A_s8(bool isTransA, dim_t K, const int8_t *A, dim_t lda, int8_t *ws,
+        dim_t m) {
     for (dim_t k = 0; k < K; k++) {
         if (isTransA) {
             for (dim_t i = 0; i < m; i++)
@@ -55,11 +55,11 @@ void copy_A_s8(bool isTransA, dim_t K, const int8_t *A, dim_t lda,
 }
 
 template <bool isTransA, bool isTransB>
-void block_ker_s8(const dim_t M, const dim_t N, const dim_t K,
-        const int8_t *A, const dim_t lda, const void *B, const dim_t ldb,
-        void *C, const dim_t ldc, const float alpha, const float beta,
-        int8_t *ws, bool do_copy, int ithr, const float *bias,
-        const dim_t m_unroll, bool b_signed, bool dst_is_f32,
+void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
+        const dim_t lda, const void *B, const dim_t ldb, void *C,
+        const dim_t ldc, const float alpha, const float beta, int8_t *ws,
+        bool do_copy, int ithr, const float *bias, const dim_t m_unroll,
+        bool b_signed, bool dst_is_f32,
         const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
         const jit_rvv_gemm_s8_kernel_table_t &nontrans_a_table) {
     MAYBE_UNUSED(ithr);
@@ -123,21 +123,17 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K,
         const int8_t *a = isTransA ? &A[i * lda] : &A[i];
         const float *bias_tile = bias ? bias + i : nullptr;
         for (dim_t j = 0; j < Nu; j += n_unroll) {
-            const char *b = isTransB
-                    ? static_cast<const char *>(B) + j
-                    : static_cast<const char *>(B) + j * ldb;
-            invoke_kernel(a, b,
-                    static_cast<char *>(C) + (i + j * ldc) * 4, m_unroll,
-                    n_unroll, j, bias_tile);
+            const char *b = isTransB ? static_cast<const char *>(B) + j
+                                     : static_cast<const char *>(B) + j * ldb;
+            invoke_kernel(a, b, static_cast<char *>(C) + (i + j * ldc) * 4,
+                    m_unroll, n_unroll, j, bias_tile);
         }
 
         if (n_tail > 0) {
-            const char *b = isTransB
-                    ? static_cast<const char *>(B) + Nu
-                    : static_cast<const char *>(B) + Nu * ldb;
-            invoke_kernel(a, b,
-                    static_cast<char *>(C) + (i + Nu * ldc) * 4, m_unroll,
-                    n_tail, Nu, bias_tile);
+            const char *b = isTransB ? static_cast<const char *>(B) + Nu
+                                     : static_cast<const char *>(B) + Nu * ldb;
+            invoke_kernel(a, b, static_cast<char *>(C) + (i + Nu * ldc) * 4,
+                    m_unroll, n_tail, Nu, bias_tile);
         }
     }
 
@@ -146,9 +142,8 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K,
         const float *bias_tile = bias ? bias + Mu : nullptr;
 
         for (dim_t j = 0; j < Nu; j += n_unroll) {
-            const char *b = isTransB
-                    ? static_cast<const char *>(B) + j
-                    : static_cast<const char *>(B) + j * ldb;
+            const char *b = isTransB ? static_cast<const char *>(B) + j
+                                     : static_cast<const char *>(B) + j * ldb;
             const auto &kernel_table
                     = isTransA ? trans_a_table : nontrans_a_table;
             call_kernel(kernel_table, a_tail, b,
@@ -157,9 +152,8 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K,
         }
 
         if (n_tail > 0) {
-            const char *b = isTransB
-                    ? static_cast<const char *>(B) + Nu
-                    : static_cast<const char *>(B) + Nu * ldb;
+            const char *b = isTransB ? static_cast<const char *>(B) + Nu
+                                     : static_cast<const char *>(B) + Nu * ldb;
             const auto &kernel_table
                     = isTransA ? trans_a_table : nontrans_a_table;
             call_kernel(kernel_table, a_tail, b,
@@ -190,11 +184,9 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
 
     if ((K <= 0) || (alpha == 0.f)) {
         dim_t MN = N * M;
-        char *C_bytes = static_cast<char *>(C);
         if (dst_is_f32) {
             if (beta == 0.f) {
-                for (dim_t j = 0; j < MN * 4; j++)
-                    C_bytes[j] = 0;
+                std::memset(C, 0, sizeof(float) * MN);
             } else if (beta != 1.f) {
                 float *C_f = static_cast<float *>(C);
                 for (dim_t j = 0; j < MN; j++)
@@ -207,11 +199,13 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
                         C_f[i * ldc + j] += bias[j];
             }
         } else {
-            // s32 dst, alpha == 0: zero C; bias added in int32.
+            // s32 dst, alpha == 0: result = beta*C + s32(bias).
             int32_t *C_i = static_cast<int32_t *>(C);
             if (beta == 0.f) {
+                std::memset(C_i, 0, sizeof(int32_t) * MN);
+            } else if (beta != 1.f) {
                 for (dim_t j = 0; j < MN; j++)
-                    C_i[j] = 0;
+                    C_i[j] = static_cast<int32_t>(beta * C_i[j]);
             }
             if (bias) {
                 for (dim_t j = 0; j < M; j++)
@@ -230,20 +224,21 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
                 dim_t nb = nstl::min(N - Bn, BN);
                 curA = isTransA ? A + Bk + Bm * lda : A + Bm + Bk * lda;
                 const char *B_bytes = static_cast<const char *>(B);
-                curB = isTransB ? static_cast<const void *>(B_bytes + Bn + Bk * ldb)
-                                : static_cast<const void *>(B_bytes + Bk + Bn * ldb);
+                curB = isTransB
+                        ? static_cast<const void *>(B_bytes + Bn + Bk * ldb)
+                        : static_cast<const void *>(B_bytes + Bk + Bn * ldb);
                 curC = static_cast<char *>(C) + (Bm + Bn * ldc) * 4;
 
                 if (Bk == 0) {
                     const float *bias_block = bias ? bias + Bm : nullptr;
-                    block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
-                            ldb, curC, ldc, alpha, beta, ws, do_copy, ithr,
-                            bias_block, m_unroll, b_signed, dst_is_f32,
+                    block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda,
+                            curB, ldb, curC, ldc, alpha, beta, ws, do_copy,
+                            ithr, bias_block, m_unroll, b_signed, dst_is_f32,
                             trans_a_table, nontrans_a_table);
                 } else {
-                    block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
-                            ldb, curC, ldc, alpha, 1.0f, ws, do_copy, ithr,
-                            nullptr, m_unroll, b_signed, dst_is_f32,
+                    block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda,
+                            curB, ldb, curC, ldc, alpha, 1.0f, ws, do_copy,
+                            ithr, nullptr, m_unroll, b_signed, dst_is_f32,
                             trans_a_table, nontrans_a_table);
                 }
             }
@@ -256,7 +251,8 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
         const dim_t *M_, const dim_t *N_, const dim_t *K_, const float *alpha_,
         const int8_t *A, const dim_t *lda_, const void *B, const dim_t *ldb_,
         const float *beta_, void *C, const dim_t *ldc_, const float *bias,
-        bool b_signed, bool dst_is_f32) {
+        bool b_signed, bool dst_is_f32, int32_t *c_buffers_in,
+        int8_t *ws_buffers_in) {
 
     if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
                 && utils::one_of(*transb_, 'n', 'N', 't', 'T')))
@@ -272,26 +268,17 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
     // Early out: avoid division by zero in partitioning.
     if (utils::one_of(0, M, N)) return status::success;
 
-    int max_nthr = dnnl_get_current_num_threads();
+    // Use current (not max) threads
+    int nthr = dnnl_get_current_num_threads();
     int nthr_m, nthr_n, nthr_k;
     dim_t MB, NB, KB;
 
     calc_nthr_nocopy_rvv(
-            M, N, K, max_nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+            M, N, K, nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
     assert(IMPLICATION(!dnnl_thr_syncable(), nthr_k == 1));
 
-    int32_t *c_buffers = nullptr;
-    int8_t *ws_buffers = nullptr;
-    if (nthr_k > 1) {
-        c_buffers = (int32_t *)malloc(
-                sizeof(*c_buffers) * nthr_m * nthr_n * (nthr_k - 1) * MB * NB,
-                PAGE_4K);
-        if (!c_buffers) {
-            nthr_k = 1;
-            KB = K;
-        }
-    }
-
+    // Copy A into a cache-friendly contiguous workspace once per M-tile when
+    // there are enough N-tiles per thread (>= 4 full tiles)
     bool do_copy = (NB / gemm_s8_traits::get_n_unroll_factor() > 3);
     const int nthr_mn = nthr_m * nthr_n;
     const int nthr_to_use = nthr_mn * nthr_k;
@@ -299,9 +286,25 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
     const size_t ws_elems_per_thr = K * m_unroll;
     const size_t ws_size_per_thr
             = rnd_up(ws_elems_per_thr * sizeof(int8_t), PAGE_4K);
-    if (do_copy) {
-        ws_buffers = (int8_t *)malloc(nthr_to_use * ws_size_per_thr, PAGE_4K);
-        if (!ws_buffers) do_copy = false;
+
+    int32_t *c_buffers = c_buffers_in;
+    int8_t *ws_buffers = ws_buffers_in;
+    bool own_c = false, own_ws = false;
+    if (nthr_k > 1 && !c_buffers) {
+        c_buffers = static_cast<int32_t *>(malloc(
+                sizeof(*c_buffers) * nthr_m * nthr_n * (nthr_k - 1) * MB * NB,
+                PAGE_4K));
+        own_c = c_buffers != nullptr;
+        if (!own_c) {
+            nthr_k = 1;
+            KB = K;
+        }
+    }
+    if (do_copy && !ws_buffers) {
+        ws_buffers = static_cast<int8_t *>(
+                malloc(nthr_to_use * ws_size_per_thr, PAGE_4K));
+        own_ws = ws_buffers != nullptr;
+        if (!own_ws) do_copy = false;
     }
 
     const auto &trans_a_table = get_jit_rvv_gemm_s8_kernel_table(
@@ -328,9 +331,7 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
 
         int cbase = (ithr_m + nthr_m * ithr_n) * (nthr_k - 1);
 
-        int8_t *ws = do_copy
-                ? ws_buffers + ithr * ws_size_per_thr / sizeof(int8_t)
-                : nullptr;
+        int8_t *ws = do_copy ? ws_buffers + ithr * ws_size_per_thr : nullptr;
 
         dim_t m_from = 0, m_to = 0, myM = 0, n_from = 0, n_to = 0, myN = 0,
               k_from = 0, k_to = 0, myK = 0;
@@ -357,7 +358,8 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
             const char *B_bytes = static_cast<const char *>(B);
             const void *myB = isTransB
                     ? static_cast<const void *>(B_bytes + n_from + k_from * ldb)
-                    : static_cast<const void *>(B_bytes + k_from + n_from * ldb);
+                    : static_cast<const void *>(
+                              B_bytes + k_from + n_from * ldb);
 
             const float *myBias
                     = (ithr_k == 0 && bias) ? bias + m_from : nullptr;
@@ -365,26 +367,26 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
             if (!isTransA) {
                 if (!isTransB) {
                     gemm_ithr_s8<false, false>(myM, myN, myK, alpha, myA, lda,
-                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
-                            m_unroll, b_signed, dst_is_f32, trans_a_table,
-                            nontrans_a_table);
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
+                            myBias, m_unroll, b_signed, dst_is_f32,
+                            trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr_s8<false, true>(myM, myN, myK, alpha, myA, lda,
-                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
-                            m_unroll, b_signed, dst_is_f32, trans_a_table,
-                            nontrans_a_table);
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
+                            myBias, m_unroll, b_signed, dst_is_f32,
+                            trans_a_table, nontrans_a_table);
                 }
             } else {
                 if (!isTransB) {
                     gemm_ithr_s8<true, false>(myM, myN, myK, alpha, myA, lda,
-                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
-                            m_unroll, b_signed, dst_is_f32, trans_a_table,
-                            nontrans_a_table);
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
+                            myBias, m_unroll, b_signed, dst_is_f32,
+                            trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr_s8<true, true>(myM, myN, myK, alpha, myA, lda,
-                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr, myBias,
-                            m_unroll, b_signed, dst_is_f32, trans_a_table,
-                            nontrans_a_table);
+                            myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
+                            myBias, m_unroll, b_signed, dst_is_f32,
+                            trans_a_table, nontrans_a_table);
                 }
             }
         }
@@ -413,19 +415,27 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
             gemm_utils::partition_unit_diff(
                     ithr_k, nthr_k, myN, &offset, &block);
             for (int ik = 1; ik < nthr_k; ++ik) {
-                int32_t *myC = c_buffers
-                        + MB * ((dim_t)NB * (cbase + ik - 1) + offset);
-
-                gemm_utils::sum_two_matrices(myM, block, myC, MB,
-                        static_cast<int32_t *>(C)
-                                + m_from + (n_from + offset) * ldc,
-                        ldc);
+                if (dst_is_f32) {
+                    float *myC = reinterpret_cast<float *>(c_buffers)
+                            + MB * ((dim_t)NB * (cbase + ik - 1) + offset);
+                    gemm_utils::sum_two_matrices(myM, block, myC, MB,
+                            static_cast<float *>(C) + m_from
+                                    + (n_from + offset) * ldc,
+                            ldc);
+                } else {
+                    int32_t *myC = c_buffers
+                            + MB * ((dim_t)NB * (cbase + ik - 1) + offset);
+                    gemm_utils::sum_two_matrices(myM, block, myC, MB,
+                            static_cast<int32_t *>(C) + m_from
+                                    + (n_from + offset) * ldc,
+                            ldc);
+                }
             }
         });
     }
 
-    free(ws_buffers);
-    free(c_buffers);
+    if (own_ws) free(ws_buffers);
+    if (own_c) free(c_buffers);
 
     return status::success;
 }

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
@@ -58,8 +58,8 @@ template <bool isTransA, bool isTransB>
 void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
         const dim_t lda, const void *B, const dim_t ldb, void *C,
         const dim_t ldc, const float alpha, const float beta, int8_t *ws,
-        bool do_copy, int ithr, const float *bias, const dim_t m_unroll,
-        bool b_signed, bool dst_is_f32,
+        bool do_copy, int ithr, const float *bias, bool bias_is_scalar,
+        const dim_t m_unroll, bool b_signed, bool dst_is_f32,
         const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
         const jit_rvv_gemm_s8_kernel_table_t &nontrans_a_table) {
     MAYBE_UNUSED(ithr);
@@ -87,6 +87,7 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
         p.alpha = alpha;
         p.beta = beta;
         p.bias = bias_tile;
+        p.bias_is_scalar = bias_is_scalar;
 
         const jit_rvv_gemm_s8_kernel_t *kernel
                 = bias_tile ? kernel_table.b[tile_n] : kernel_table.nb[tile_n];
@@ -121,7 +122,9 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
 
     for (dim_t i = 0; i < Mu; i += m_unroll) {
         const int8_t *a = isTransA ? &A[i * lda] : &A[i];
-        const float *bias_tile = bias ? bias + i : nullptr;
+        // Scalar bias broadcasts over M: every tile reads the same base float.
+        const float *bias_tile
+                = bias ? (bias_is_scalar ? bias : bias + i) : nullptr;
         for (dim_t j = 0; j < Nu; j += n_unroll) {
             const char *b = isTransB ? static_cast<const char *>(B) + j
                                      : static_cast<const char *>(B) + j * ldb;
@@ -139,7 +142,8 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
 
     if (m_tail > 0) {
         const int8_t *a_tail = isTransA ? &A[Mu * lda] : &A[Mu];
-        const float *bias_tile = bias ? bias + Mu : nullptr;
+        const float *bias_tile
+                = bias ? (bias_is_scalar ? bias : bias + Mu) : nullptr;
 
         for (dim_t j = 0; j < Nu; j += n_unroll) {
             const char *b = isTransB ? static_cast<const char *>(B) + j
@@ -168,8 +172,8 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
         const float alpha, const int8_t *A, const dim_t lda, const void *B,
         const dim_t ldb, const float beta, void *C, const dim_t ldc,
         bool do_copy, int8_t *ws, int ithr, const float *bias,
-        const dim_t m_unroll, bool b_signed, bool dst_is_f32,
-        const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
+        bool bias_is_scalar, const dim_t m_unroll, bool b_signed,
+        bool dst_is_f32, const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
         const jit_rvv_gemm_s8_kernel_table_t &nontrans_a_table) {
 
     constexpr dim_t BM = gemm_traits_t<float, isTransA, isTransB>::BM;
@@ -230,16 +234,19 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
                 curC = static_cast<char *>(C) + (Bm + Bn * ldc) * 4;
 
                 if (Bk == 0) {
-                    const float *bias_block = bias ? bias + Bm : nullptr;
+                    const float *bias_block = bias
+                            ? (bias_is_scalar ? bias : bias + Bm)
+                            : nullptr;
                     block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda,
                             curB, ldb, curC, ldc, alpha, beta, ws, do_copy,
-                            ithr, bias_block, m_unroll, b_signed, dst_is_f32,
-                            trans_a_table, nontrans_a_table);
+                            ithr, bias_block, bias_is_scalar, m_unroll,
+                            b_signed, dst_is_f32, trans_a_table,
+                            nontrans_a_table);
                 } else {
                     block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda,
                             curB, ldb, curC, ldc, alpha, 1.0f, ws, do_copy,
-                            ithr, nullptr, m_unroll, b_signed, dst_is_f32,
-                            trans_a_table, nontrans_a_table);
+                            ithr, nullptr, bias_is_scalar, m_unroll, b_signed,
+                            dst_is_f32, trans_a_table, nontrans_a_table);
                 }
             }
         }
@@ -252,7 +259,8 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
         const int8_t *A, const dim_t *lda_, const void *B, const dim_t *ldb_,
         const float *beta_, void *C, const dim_t *ldc_, const float *bias,
         bool b_signed, bool dst_is_f32, int32_t *c_buffers_in,
-        int8_t *ws_buffers_in) {
+        int8_t *ws_buffers_in, bool bias_is_scalar,
+        const gemm_partition_t *part) {
 
     if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
                 && utils::one_of(*transb_, 'n', 'N', 't', 'T')))
@@ -265,16 +273,35 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
     const dim_t lda = *lda_, ldb = *ldb_, ldc = *ldc_;
     const float alpha = *alpha_, beta = *beta_;
 
+    // The s32 dst path ignores alpha and only supports beta in {0, 1} (beta
+    // == 1 is the vsadd read-modify-write that accumulates across K blocks).
+    // Reject anything else rather than silently producing wrong results; the
+    // f32 path implements the general alpha/beta epilogue.
+    if (!dst_is_f32 && (alpha != 1.0f || !utils::one_of(beta, 0.0f, 1.0f)))
+        return status::unimplemented;
+
     // Early out: avoid division by zero in partitioning.
     if (utils::one_of(0, M, N)) return status::success;
 
-    // Use current (not max) threads
-    int nthr = dnnl_get_current_num_threads();
     int nthr_m, nthr_n, nthr_k;
     dim_t MB, NB, KB;
-
-    calc_nthr_nocopy_rvv(
-            M, N, K, nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+    if (part) {
+        // Reuse the partition booked in the primitive scratchpad (sized at
+        // init with dnnl_get_max_threads()). Recomputing here with current
+        // threads would mismatch the booked capacity when init and execute
+        // run under different threadpool contexts (e.g. --ctx-init=1
+        // --ctx-exe=8), leading to out-of-bounds workspace access.
+        nthr_m = part->nthr_m;
+        nthr_n = part->nthr_n;
+        nthr_k = part->nthr_k;
+        MB = part->MB;
+        NB = part->NB;
+        KB = part->KB;
+    } else {
+        int nthr = dnnl_get_current_num_threads();
+        calc_nthr_nocopy_rvv(
+                M, N, K, nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+    }
     assert(IMPLICATION(!dnnl_thr_syncable(), nthr_k == 1));
 
     // Copy A into a cache-friendly contiguous workspace once per M-tile when
@@ -361,32 +388,33 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
                     : static_cast<const void *>(
                               B_bytes + k_from + n_from * ldb);
 
-            const float *myBias
-                    = (ithr_k == 0 && bias) ? bias + m_from : nullptr;
+            const float *myBias = (ithr_k == 0 && bias)
+                    ? (bias_is_scalar ? bias : bias + m_from)
+                    : nullptr;
 
             if (!isTransA) {
                 if (!isTransB) {
                     gemm_ithr_s8<false, false>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, m_unroll, b_signed, dst_is_f32,
-                            trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed,
+                            dst_is_f32, trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr_s8<false, true>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, m_unroll, b_signed, dst_is_f32,
-                            trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed,
+                            dst_is_f32, trans_a_table, nontrans_a_table);
                 }
             } else {
                 if (!isTransB) {
                     gemm_ithr_s8<true, false>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, m_unroll, b_signed, dst_is_f32,
-                            trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed,
+                            dst_is_f32, trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr_s8<true, true>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, m_unroll, b_signed, dst_is_f32,
-                            trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed,
+                            dst_is_f32, trans_a_table, nontrans_a_table);
                 }
             }
         }

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 ZTE Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,9 @@ namespace rv64 {
 // weights, s8/u8 src, and s32/f32 dst. The dst element width is 4 bytes either
 // way; pass `dst_is_f32 = true` to request an f32 epilogue (alpha/beta applied
 // after fcvt of the s32 accumulator) or `false` to write the raw s32
-// accumulator (alpha and beta are ignored in that case).
+// accumulator. On the s32 path alpha is ignored, but beta is still respected
+// (a beta != 0 read-modify-write via vsadd is what lets K-tile accumulation in
+// the wrapper work).
 //
 // b_signed selects between s8 and u8 on the B (src) axis; A (weights) is
 // always s8.
@@ -36,11 +38,21 @@ namespace rv64 {
 // `bias` is an optional f32 vector of length M, broadcast across the N axis.
 // When non-null it is fused into the JIT kernel's C-update phase, matching the
 // f32 GEMM kernel convention.
+//
+// Scratchpad contract mirrors rvv_gemm_f32(). c_buffers carries whatever the
+// kernel's C-update epilogue writes, which is 4 bytes/element in either case:
+//   - dst_is_f32 == false: raw s32 accumulators
+//   - dst_is_f32 == true : f32 values, already fcvt-converted and alpha-scaled
+//     in-kernel (so the K-split reduction below must sum them as float, not
+//     reinterpret the bits as int32)
+// ws_buffers holds int8 elements (one per-thread A-copy cache). Pass nullptr
+// for either to fall back to malloc/free inside the function.
 status_t rvv_gemm_s8s8s32(const char *transa, const char *transb,
         const dim_t *M, const dim_t *N, const dim_t *K, const float *alpha,
         const int8_t *A, const dim_t *lda, const void *B, const dim_t *ldb,
         const float *beta, void *C, const dim_t *ldc, const float *bias,
-        bool b_signed, bool dst_is_f32);
+        bool b_signed, bool dst_is_f32, int32_t *c_buffers = nullptr,
+        int8_t *ws_buffers = nullptr);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_GEMM_RVV_GEMM_S8S8S32_HPP
+#define CPU_RV64_GEMM_RVV_GEMM_S8S8S32_HPP
+
+#include "common/c_types_map.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+// RVV int8 GEMM driver. Mirrors rvv_gemm_f32() in structure but accepts s8
+// weights, s8/u8 src, and s32/f32 dst. The dst element width is 4 bytes either
+// way; pass `dst_is_f32 = true` to request an f32 epilogue (alpha/beta applied
+// after fcvt of the s32 accumulator) or `false` to write the raw s32
+// accumulator (alpha and beta are ignored in that case).
+//
+// b_signed selects between s8 and u8 on the B (src) axis; A (weights) is
+// always s8.
+//
+// `bias` is an optional f32 vector of length M, broadcast across the N axis.
+// When non-null it is fused into the JIT kernel's C-update phase, matching the
+// f32 GEMM kernel convention.
+status_t rvv_gemm_s8s8s32(const char *transa, const char *transb,
+        const dim_t *M, const dim_t *N, const dim_t *K, const float *alpha,
+        const int8_t *A, const dim_t *lda, const void *B, const dim_t *ldb,
+        const float *beta, void *C, const dim_t *ldc, const float *bias,
+        bool b_signed, bool dst_is_f32);
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_GEMM_RVV_GEMM_S8S8S32_HPP

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
@@ -19,6 +19,8 @@
 
 #include "common/c_types_map.hpp"
 
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -28,16 +30,25 @@ namespace rv64 {
 // weights, s8/u8 src, and s32/f32 dst. The dst element width is 4 bytes either
 // way; pass `dst_is_f32 = true` to request an f32 epilogue (alpha/beta applied
 // after fcvt of the s32 accumulator) or `false` to write the raw s32
-// accumulator. On the s32 path alpha is ignored, but beta is still respected
-// (a beta != 0 read-modify-write via vsadd is what lets K-tile accumulation in
-// the wrapper work).
+// accumulator. The s32 path only implements alpha == 1 and beta in {0, 1}
+// (beta == 1 is the read-modify-write vsadd that lets K-tile accumulation in
+// the wrapper work); anything else is rejected as unimplemented rather than
+// silently mishandled.
 //
 // b_signed selects between s8 and u8 on the B (src) axis; A (weights) is
 // always s8.
 //
 // `bias` is an optional f32 vector of length M, broadcast across the N axis.
 // When non-null it is fused into the JIT kernel's C-update phase, matching the
-// f32 GEMM kernel convention.
+// f32 GEMM kernel convention. `bias_is_scalar` must be set when `bias` is a
+// single value that broadcasts over M (bia_mask=0 / last dim == 1): the kernel
+// then splats one float instead of reading a full vector.
+//
+// `part` optionally supplies the thread partition computed at primitive
+// initialization (see gemm_utils::gemm_partition_t). When provided, the driver
+// reuses it instead of recomputing from dnnl_get_current_num_threads(), so the
+// per-thread workspace offsets stay consistent with the scratchpad capacity
+// booked at init. Pass nullptr to recompute and malloc (inner_product / conv).
 //
 // Scratchpad contract mirrors rvv_gemm_f32(). c_buffers carries whatever the
 // kernel's C-update epilogue writes, which is 4 bytes/element in either case:
@@ -52,7 +63,8 @@ status_t rvv_gemm_s8s8s32(const char *transa, const char *transb,
         const int8_t *A, const dim_t *lda, const void *B, const dim_t *ldb,
         const float *beta, void *C, const dim_t *ldc, const float *bias,
         bool b_signed, bool dst_is_f32, int32_t *c_buffers = nullptr,
-        int8_t *ws_buffers = nullptr);
+        int8_t *ws_buffers = nullptr, bool bias_is_scalar = false,
+        const gemm_utils::gemm_partition_t *part = nullptr);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
@@ -28,6 +28,7 @@ namespace rv64 {
 namespace gemm_utils {
 
 std::atomic<dim_t> rvv_gemm_f32_m_unroll {0};
+std::atomic<dim_t> rvv_gemm_s8_m_unroll {0};
 
 #define BM_NOCOPY_RVV 64
 #define BN_NOCOPY_RVV 48

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -33,6 +33,7 @@ namespace rv64 {
 namespace gemm_utils {
 
 extern std::atomic<dim_t> rvv_gemm_f32_m_unroll;
+extern std::atomic<dim_t> rvv_gemm_s8_m_unroll;
 
 template <typename T, bool isTransA, bool isTransB>
 struct gemm_traits_t {};
@@ -63,6 +64,23 @@ struct gemm_utils_traits<float> {
     }
 
     // Fixed n = 6 for the double-buffered mx6 micro-kernel.
+    static constexpr dim_t get_n_unroll_factor() { return 6; }
+};
+
+template <>
+struct gemm_utils_traits<int8_t> {
+    static dim_t get_m_unroll_factor() {
+        dim_t m = rvv_gemm_s8_m_unroll.load(std::memory_order_relaxed);
+        if (m == 0) {
+            const uint32_t vlen = Xbyak_riscv::CPU::getInstance().getVlen();
+            m = static_cast<dim_t>(vlen / 8);
+            rvv_gemm_s8_m_unroll.store(m, std::memory_order_relaxed);
+        }
+        return m;
+    }
+
+    // Fixed n = 6: 6 columns * m4 accumulator = 24 vector registers, leaving
+    // v24-v31 for the K-loop/C-update temporaries.
     static constexpr dim_t get_n_unroll_factor() { return 6; }
 };
 

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -100,6 +100,22 @@ void sum_two_matrices(dim_t m, dim_t n, data_t *__restrict p_src, dim_t ld_src,
 void calc_nthr_nocopy_rvv(dim_t m, dim_t n, dim_t k, int nthrs, int *nthrs_m,
         int *nthrs_n, int *nthrs_k, dim_t *BM, dim_t *BN, dim_t *BK);
 
+// Thread partition computed once at primitive initialization (with
+// dnnl_get_max_threads()) and reused at execution time. Passing it to the GEMM
+// drivers keeps the per-thread workspace offsets consistent with the capacity
+// booked in the scratchpad, even when init and execute run under different
+// threadpool contexts (e.g. --ctx-init=1 --ctx-exe=8). A nullptr leaves the
+// driver to recompute the partition from dnnl_get_current_num_threads() and
+// malloc its own workspace (the path used by inner_product / convolution).
+struct gemm_partition_t {
+    int nthr_m;
+    int nthr_n;
+    int nthr_k;
+    dim_t MB;
+    dim_t NB;
+    dim_t KB;
+};
+
 void partition_unit_diff(
         int ithr, int nthr, dim_t n, dim_t *t_offset, dim_t *t_block);
 

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -19,8 +19,10 @@
 #include "common/dnnl_thread.hpp"
 #include "common/memory_desc_wrapper.hpp"
 #include "common/utils.hpp"
+#include "cpu/platform.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
 #include "cpu/rv64/rvv_matmul.hpp"
 
 namespace dnnl {
@@ -28,6 +30,51 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 namespace matmul {
+
+void rvv_matmul_t::pd_t::init_scratchpad() {
+    using namespace memory_tracking::names;
+    using gemm_utils::calc_nthr_nocopy_rvv;
+    using gemm_utils::gemm_utils_traits;
+
+    // Use max_threads at init so the scratchpad is sized for the worst case.
+    // execute() must reproduce the same partition — see the matching call in
+    // rvv_gemm_f32/rvv_gemm_s8s8s32.
+    const int max_nthr = dnnl_get_max_threads();
+    const dim_t gemm_M = N_;
+    const dim_t gemm_N = weights_are_broadcast_ ? (batch_ * M_) : M_;
+    calc_nthr_nocopy_rvv(gemm_M, gemm_N, K_, max_nthr, &nthr_m_, &nthr_n_,
+            &nthr_k_, &MB_, &NB_, &KB_);
+
+    // Pick the path's own m_unroll: f32 and int8 derive the factor independently
+    m_unroll_ = is_f32_path_ ? gemm_utils_traits<float>::get_m_unroll_factor()
+                             : gemm_utils_traits<int8_t>::get_m_unroll_factor();
+    do_copy_ = (NB_ / gemm_utils_traits<float>::get_n_unroll_factor() > 3);
+
+    const int nthr_mn = nthr_m_ * nthr_n_;
+    const int nthr_to_use = nthr_mn * nthr_k_;
+
+    auto scratchpad = scratchpad_registry().registrar();
+
+    // K-split reduction buffer. Both f32 and s32 dst use 4-byte elements;
+    // book<char> + byte count keeps the contract type-agnostic. Only needed
+    // when the K axis is split across threads.
+    if (nthr_k_ > 1) {
+        const size_t c_elems
+                = (size_t)nthr_m_ * nthr_n_ * (nthr_k_ - 1) * MB_ * NB_;
+        scratchpad.template book<char>(key_gemm_accumulator, c_elems * 4);
+    }
+
+    // Per-thread A-copy workspace. Size mirrors what rvv_gemm_f32 /
+    // rvv_gemm_s8s8s32 malloc in the fallback path: rnd_up(K*m_unroll*elem_size,
+    // PAGE_4K) bytes per thread.
+    if (do_copy_) {
+        const size_t elem_size = is_f32_path_ ? sizeof(float) : sizeof(int8_t);
+        const size_t ws_size_per_thr
+                = utils::rnd_up((size_t)K_ * m_unroll_ * elem_size, PAGE_4K);
+        scratchpad.template book<char>(
+                key_gemm_tmp_buffer, (size_t)nthr_to_use * ws_size_per_thr);
+    }
+}
 
 status_t rvv_matmul_t::init(engine_t *engine) {
     UNUSED(engine);
@@ -129,6 +176,17 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         const dim_t src_batch_stride = M * K;
         const dim_t dst_batch_stride = M * N;
 
+        // Scratchpad buffers booked in pd_t::init_scratchpad().
+        auto &grantor = ctx.get_scratchpad_grantor();
+        int32_t *c_buffer = pd()->nthr_k_ > 1
+                ? grantor.template get<int32_t>(
+                          memory_tracking::names::key_gemm_accumulator)
+                : nullptr;
+        int8_t *ws_buffer = pd()->do_copy_
+                ? grantor.template get<int8_t>(
+                          memory_tracking::names::key_gemm_tmp_buffer)
+                : nullptr;
+
         if (pd()->weights_are_broadcast_) {
             //   C(N x (batch * M)) = A(N x K) * B(K x (batch * M))
             const dim_t M_gemm_all = g.M_gemm; // N
@@ -137,14 +195,14 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
             status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &M_gemm_all,
                     &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src,
                     &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, b_signed,
-                    dst_is_f32);
+                    dst_is_f32, c_buffer, ws_buffer);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
         } else {
-            parallel_nd(batch, [&](dim_t b) {
+            for (dim_t b = 0; b < batch; ++b) {
                 const char *src_base = static_cast<const char *>(src)
-                        + b * src_batch_stride * types::data_type_size(
-                                                       src_d.data_type());
+                        + b * src_batch_stride
+                                * types::data_type_size(src_d.data_type());
                 char *dst_base = static_cast<char *>(dst)
                         + b * dst_batch_stride
                                 * types::data_type_size(dst_d.data_type());
@@ -174,10 +232,11 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
                 status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &g.M_gemm,
                         &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda,
                         src_base, &g.ldb, &beta, dst_base, &g.ldc,
-                        /*bias=*/bias, b_signed, dst_is_f32);
+                        /*bias=*/bias, b_signed, dst_is_f32, c_buffer,
+                        ws_buffer);
                 assert(st == status::success || st == status::unimplemented);
                 MAYBE_UNUSED(st);
-            });
+            }
         }
         return status::success;
     }
@@ -205,6 +264,16 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     const dim_t src_batch_stride = M * K;
     const dim_t dst_batch_stride = M * N;
 
+    auto &grantor = ctx.get_scratchpad_grantor();
+    float *c_buffer = pd()->nthr_k_ > 1
+            ? grantor.template get<float>(
+                      memory_tracking::names::key_gemm_accumulator)
+            : nullptr;
+    float *ws_buffer = pd()->do_copy_
+            ? grantor.template get<float>(
+                      memory_tracking::names::key_gemm_tmp_buffer)
+            : nullptr;
+
     if (pd()->weights_are_broadcast_) {
         //   C(N x (batch * M)) = A(N x K) * B(K x (batch * M))
         dim_t M_gemm_all = g.M_gemm; // N
@@ -213,13 +282,12 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         status_t st = rvv_gemm_f32(&g.transa, &g.transb, &M_gemm_all,
                 &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src, &g.ldb,
                 &beta, dst, &g.ldc,
-                /*bias=*/nullptr);
+                /*bias=*/nullptr, c_buffer, ws_buffer);
         assert(st == status::success || st == status::unimplemented);
         MAYBE_UNUSED(st);
 
     } else {
-        // one GEMM per logical batch
-        parallel_nd(batch, [&](dim_t b) {
+        for (dim_t b = 0; b < batch; ++b) {
             const float *src_base = src + b * src_batch_stride;
             float *dst_base = dst + b * dst_batch_stride;
 
@@ -247,10 +315,10 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
             status_t st = rvv_gemm_f32(&g.transa, &g.transb, &g.M_gemm,
                     &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda, src_base,
                     &g.ldb, &beta, dst_base, &g.ldc,
-                    /*bias=*/nullptr);
+                    /*bias=*/nullptr, c_buffer, ws_buffer);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
-        });
+        }
     }
 
     if (!bias && post_ops.len() == 0) return status::success;

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -20,6 +20,7 @@
 #include "common/memory_desc_wrapper.hpp"
 #include "common/utils.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp"
 #include "cpu/rv64/rvv_matmul.hpp"
 
 namespace dnnl {
@@ -30,36 +31,63 @@ namespace matmul {
 
 status_t rvv_matmul_t::init(engine_t *engine) {
     UNUSED(engine);
-    // Build the per-row "bias + post-op chain" kernel. The pd gate guarantees
-    // the chain is injector-supported, so create() succeeds here.
-    const memory_desc_wrapper bias_d(pd()->desc()->bias_desc);
-    jit_uni_postops_kernel_t::conf_t conf;
-    conf.dst_dt = data_type::f32;
-    conf.with_bias = !bias_d.is_zero();
-    if (conf.with_bias) {
-        const int bn = bias_d.ndims();
-        // scalar when the whole bias is one value or its last dim broadcasts
-        // over N; otherwise a per-N run aligned with the output row.
-        conf.bias_per_element
-                = !(bias_d.nelems() == 1 || bias_d.dims()[bn - 1] == 1);
+    // The int8 path has no post-op kernel yet; only build the per-row
+    // "bias + post-op chain" kernel for the f32 dispatch.
+    if (!pd()->is_int8_path_) {
+        const memory_desc_wrapper bias_d(pd()->desc()->bias_desc);
+        jit_uni_postops_kernel_t::conf_t conf;
+        conf.dst_dt = data_type::f32;
+        conf.with_bias = !bias_d.is_zero();
+        if (conf.with_bias) {
+            const int bn = bias_d.ndims();
+            // scalar when the whole bias is one value or its last dim
+            // broadcasts over N; otherwise a per-N run aligned with the
+            // output row.
+            conf.bias_per_element
+                    = !(bias_d.nelems() == 1 || bias_d.dims()[bn - 1] == 1);
+        }
+        return jit_uni_postops_kernel_t::create(
+                postops_kernel_, pd()->attr()->post_ops_, conf);
     }
-    return jit_uni_postops_kernel_t::create(
-            postops_kernel_, pd()->attr()->post_ops_, conf);
+    return status::success;
 }
 
-status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
-    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
-    auto weights = CTX_IN_MEM(const float *, DNNL_ARG_WEIGHTS);
-    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
+namespace {
+// GEMM M/N/K/lda/ldb/ldc setup shared by both the f32 and s8 paths. The
+// driver reinterprets row-major [M, K] / [M, N] as column-major matrices and
+// maps them to GEMM as C(N x M) = A(N x K) * B(K x M), with A = W^T and
+// B = src (see the in-source comment in execute() for the full derivation).
+struct gemm_axes_t {
+    char transa;
+    char transb;
+    dim_t M_gemm;
+    dim_t N_gemm;
+    dim_t K_gemm;
+    dim_t lda;
+    dim_t ldb;
+    dim_t ldc;
+};
 
+gemm_axes_t make_gemm_axes(dim_t M, dim_t N, dim_t K, bool weights_col_major) {
+    gemm_axes_t g;
+    g.transa = weights_col_major ? 'T' : 'N';
+    g.transb = 'N';
+    g.M_gemm = N;
+    g.N_gemm = M;
+    g.K_gemm = K;
+    g.lda = weights_col_major ? K : N;
+    g.ldb = K;
+    g.ldc = N;
+    return g;
+}
+} // namespace
+
+status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper weights_d(pd()->weights_md());
     const memory_desc_wrapper dst_d(pd()->dst_md());
     const memory_desc_wrapper bias_d(pd()->desc()->bias_desc);
 
-    const post_ops_t &post_ops = pd()->attr()->post_ops_;
-
-    const float *bias = CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
     const int ndims = src_d.ndims();
     const int wei_ndims = weights_d.ndims();
     const dim_t *src_dims = src_d.dims();
@@ -70,6 +98,98 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     const dim_t K = pd()->K_;
     const dim_t N = pd()->N_;
     const bool weights_col_major = pd()->weights_col_major_;
+
+    const auto g = make_gemm_axes(M, N, K, weights_col_major);
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+
+    const int src_batch_ndims = ndims > 2 ? ndims - 2 : 0;
+    const int wei_batch_ndims = wei_ndims > 2 ? wei_ndims - 2 : 0;
+    const int batch_dim_shift = src_batch_ndims - wei_batch_ndims;
+    const dim_t K_dim = wei_dims[wei_ndims - 2];
+    const dim_t N_dim = wei_dims[wei_ndims - 1];
+    const dim_t wei_matrix_stride = K_dim * N_dim;
+
+    if (pd()->is_int8_path_) {
+        // Int8 dispatch: s8 weights * (s8|u8) src -> (s32|f32) dst. No
+        // post-ops or scales (those attrs are rejected in pd_t::init), so the
+        // only epilogue work is the optional fused bias inside the GEMM
+        // kernel itself.
+        const int8_t *weights = static_cast<const int8_t *>(
+                CTX_IN_MEM(const void *, DNNL_ARG_WEIGHTS));
+        const void *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+        void *dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+        const float *bias = bias_d.is_zero()
+                ? nullptr
+                : CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
+
+        const bool b_signed = src_d.data_type() == data_type::s8;
+        const bool dst_is_f32 = dst_d.data_type() == data_type::f32;
+
+        const dim_t src_batch_stride = M * K;
+        const dim_t dst_batch_stride = M * N;
+
+        if (pd()->weights_are_broadcast_) {
+            //   C(N x (batch * M)) = A(N x K) * B(K x (batch * M))
+            const dim_t M_gemm_all = g.M_gemm; // N
+            const dim_t N_gemm_all = batch * g.N_gemm; // batch * M
+
+            status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &M_gemm_all,
+                    &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src,
+                    &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, b_signed,
+                    dst_is_f32);
+            assert(st == status::success || st == status::unimplemented);
+            MAYBE_UNUSED(st);
+        } else {
+            parallel_nd(batch, [&](dim_t b) {
+                const char *src_base = static_cast<const char *>(src)
+                        + b * src_batch_stride * types::data_type_size(
+                                                       src_d.data_type());
+                char *dst_base = static_cast<char *>(dst)
+                        + b * dst_batch_stride
+                                * types::data_type_size(dst_d.data_type());
+
+                dim_t batch_indices[DNNL_MAX_NDIMS] = {};
+                if (src_batch_ndims > 0) {
+                    utils::l_dims_by_l_offset(
+                            batch_indices, b, src_dims, src_batch_ndims);
+                }
+
+                dim_t weight_batch_index = 0;
+                if (wei_batch_ndims > 0) {
+                    for (int d = 0; d < wei_batch_ndims; ++d) {
+                        const int src_dim_idx = d + batch_dim_shift;
+                        dim_t idx = (src_dim_idx >= 0)
+                                ? batch_indices[src_dim_idx]
+                                : dim_t(0);
+                        const dim_t wei_dim = wei_dims[d];
+                        idx = (wei_dim == 1) ? dim_t(0) : idx;
+                        weight_batch_index = weight_batch_index * wei_dim + idx;
+                    }
+                }
+
+                const int8_t *wei_base
+                        = weights + weight_batch_index * wei_matrix_stride;
+
+                status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &g.M_gemm,
+                        &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda,
+                        src_base, &g.ldb, &beta, dst_base, &g.ldc,
+                        /*bias=*/bias, b_signed, dst_is_f32);
+                assert(st == status::success || st == status::unimplemented);
+                MAYBE_UNUSED(st);
+            });
+        }
+        return status::success;
+    }
+
+    // f32 dispatch (unchanged): bias + post-op chain is applied per output row
+    // after the GEMM by jit_uni_postops_kernel_t.
+    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const float *, DNNL_ARG_WEIGHTS);
+    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
+
+    const post_ops_t &post_ops = pd()->attr()->post_ops_;
+    const float *bias = CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
 
     // row-major [M, K] / [M, N] are reinterpreted as column-major matrices and
     // mapped to GEMM as:
@@ -82,38 +202,17 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     //     column-major [K, M] with leading dim K, so transb = 'N', ldb = K.
     //   - C is viewed as column-major [N, M] with leading dim N, which matches
     //     row-major [M, N] in memory.
-    char transa = weights_col_major ? 'T' : 'N';
-    char transb = 'N';
-    dim_t M_gemm = N;
-    dim_t N_gemm = M;
-    dim_t K_gemm = K;
-    // weights: col-major [K, N] uses leading K; row-major [K, N] is equivalent
-    // to col-major [N, K] so leading dim is N.
-    dim_t lda = weights_col_major ? K : N;
-    dim_t ldb = K; // src: row-major [M, K] -> col-major [K, M]
-    dim_t ldc = N; // dst: row-major [M, N] -> col-major [N, M]
-    float alpha = 1.0f;
-    float beta = 0.0f;
-
-    // batch strides for row-major src/dst
     const dim_t src_batch_stride = M * K;
     const dim_t dst_batch_stride = M * N;
 
-    const int src_batch_ndims = ndims > 2 ? ndims - 2 : 0;
-    const int wei_batch_ndims = wei_ndims > 2 ? wei_ndims - 2 : 0;
-    const int batch_dim_shift = src_batch_ndims - wei_batch_ndims;
-    const dim_t K_dim = wei_dims[wei_ndims - 2];
-    const dim_t N_dim = wei_dims[wei_ndims - 1];
-    const dim_t wei_matrix_stride = K_dim * N_dim;
-
-    // GEMM compute
     if (pd()->weights_are_broadcast_) {
         //   C(N x (batch * M)) = A(N x K) * B(K x (batch * M))
-        dim_t M_gemm_all = M_gemm; // N
-        dim_t N_gemm_all = batch * N_gemm; // batch * M
+        dim_t M_gemm_all = g.M_gemm; // N
+        dim_t N_gemm_all = batch * g.N_gemm; // batch * M
 
-        status_t st = rvv_gemm_f32(&transa, &transb, &M_gemm_all, &N_gemm_all,
-                &K_gemm, &alpha, weights, &lda, src, &ldb, &beta, dst, &ldc,
+        status_t st = rvv_gemm_f32(&g.transa, &g.transb, &M_gemm_all,
+                &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src, &g.ldb,
+                &beta, dst, &g.ldc,
                 /*bias=*/nullptr);
         assert(st == status::success || st == status::unimplemented);
         MAYBE_UNUSED(st);
@@ -145,9 +244,9 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
             const float *wei_base
                     = weights + weight_batch_index * wei_matrix_stride;
 
-            status_t st = rvv_gemm_f32(&transa, &transb, &M_gemm, &N_gemm,
-                    &K_gemm, &alpha, wei_base, &lda, src_base, &ldb, &beta,
-                    dst_base, &ldc,
+            status_t st = rvv_gemm_f32(&g.transa, &g.transb, &g.M_gemm,
+                    &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda, src_base,
+                    &g.ldb, &beta, dst_base, &g.ldc,
                     /*bias=*/nullptr);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -36,9 +36,12 @@ void rvv_matmul_t::pd_t::init_scratchpad() {
     using gemm_utils::calc_nthr_nocopy_rvv;
     using gemm_utils::gemm_utils_traits;
 
-    // Use max_threads at init so the scratchpad is sized for the worst case.
-    // execute() must reproduce the same partition — see the matching call in
-    // rvv_gemm_f32/rvv_gemm_s8s8s32.
+    // Size the scratchpad with max_threads at init, then hand this same
+    // partition to the GEMM drivers at execute() (via gemm_partition_t) so the
+    // per-thread workspace offsets never exceed the booked capacity — even when
+    // init and execute run under different threadpool contexts. The drivers
+    // only recompute from dnnl_get_current_num_threads() when no partition is
+    // supplied (the inner_product / convolution callers).
     const int max_nthr = dnnl_get_max_threads();
     const dim_t gemm_M = N_;
     const dim_t gemm_N = weights_are_broadcast_ ? (batch_ * M_) : M_;
@@ -150,6 +153,13 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     const float alpha = 1.0f;
     const float beta = 0.0f;
 
+    // Reuse the thread partition booked in the scratchpad at init (sized with
+    // dnnl_get_max_threads()) so the drivers' per-thread workspace offsets
+    // never exceed the booked capacity, even when init and execute run under
+    // different threadpool contexts.
+    const gemm_utils::gemm_partition_t part {pd()->nthr_m_, pd()->nthr_n_,
+            pd()->nthr_k_, pd()->MB_, pd()->NB_, pd()->KB_};
+
     const int src_batch_ndims = ndims > 2 ? ndims - 2 : 0;
     const int wei_batch_ndims = wei_ndims > 2 ? wei_ndims - 2 : 0;
     const int batch_dim_shift = src_batch_ndims - wei_batch_ndims;
@@ -169,6 +179,9 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         const float *bias = bias_d.is_zero()
                 ? nullptr
                 : CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
+        // A scalar (one-element) bias broadcasts over the M tile: tell the
+        // kernel to splat one float instead of reading a full vector.
+        const bool bias_is_scalar = bias && bias_d.nelems() == 1;
 
         const bool b_signed = src_d.data_type() == data_type::s8;
         const bool dst_is_f32 = dst_d.data_type() == data_type::f32;
@@ -195,7 +208,7 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
             status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &M_gemm_all,
                     &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src,
                     &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, b_signed,
-                    dst_is_f32, c_buffer, ws_buffer);
+                    dst_is_f32, c_buffer, ws_buffer, bias_is_scalar, &part);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
         } else {
@@ -233,7 +246,7 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
                         &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda,
                         src_base, &g.ldb, &beta, dst_base, &g.ldc,
                         /*bias=*/bias, b_signed, dst_is_f32, c_buffer,
-                        ws_buffer);
+                        ws_buffer, bias_is_scalar, &part);
                 assert(st == status::success || st == status::unimplemented);
                 MAYBE_UNUSED(st);
             }
@@ -282,7 +295,7 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         status_t st = rvv_gemm_f32(&g.transa, &g.transb, &M_gemm_all,
                 &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src, &g.ldb,
                 &beta, dst, &g.ldc,
-                /*bias=*/nullptr, c_buffer, ws_buffer);
+                /*bias=*/nullptr, c_buffer, ws_buffer, &part);
         assert(st == status::success || st == status::unimplemented);
         MAYBE_UNUSED(st);
 
@@ -315,7 +328,7 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
             status_t st = rvv_gemm_f32(&g.transa, &g.transb, &g.M_gemm,
                     &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda, src_base,
                     &g.ldb, &beta, dst_base, &g.ldc,
-                    /*bias=*/nullptr, c_buffer, ws_buffer);
+                    /*bias=*/nullptr, c_buffer, ws_buffer, &part);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
         }

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
 #include "cpu/matmul/cpu_matmul_pd.hpp"
@@ -73,15 +74,13 @@ struct rvv_matmul_t : public primitive_t {
                     && acc_dt == f32;
             is_int8_path_ = utils::one_of(src_dt, s8, u8) && wei_dt == s8
                     && utils::one_of(dst_dt, s32, f32) && acc_dt == s32;
-            VDISPATCH_MATMUL(is_f32_path_ || is_int8_path_,
-                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_MATMUL(
+                    is_f32_path_ || is_int8_path_, VERBOSE_UNSUPPORTED_DT);
             // The int8 path rejects per-oc / per-tensor scales, zero-points,
             // and post-ops in this MVP; only optional f32 bias is supported.
-            const auto attr_skip_mask = is_f32_path_
-                    ? smask_t::post_ops
-                    : smask_t::none;
-            VDISPATCH_MATMUL(
-                    attr()->has_default_values(attr_skip_mask, dst_dt),
+            const auto attr_skip_mask
+                    = is_f32_path_ ? smask_t::post_ops : smask_t::none;
+            VDISPATCH_MATMUL(attr()->has_default_values(attr_skip_mask, dst_dt),
                     VERBOSE_UNSUPPORTED_ATTR);
 
             // Resolve the primary and the post-op binary src1 formats before any
@@ -133,6 +132,7 @@ struct rvv_matmul_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_BIAS_CFG);
 
             init_gemm_conf(src_mdw, weights_mdw);
+            init_scratchpad();
 
             return status::success;
         }
@@ -198,9 +198,6 @@ struct rvv_matmul_t : public primitive_t {
             }
 
             // The int8 JIT kernel only knows how to read a 1-D per-N bias
-            // (one value per GEMM-M row). Reject per-M / per-batch bias shapes
-            // that slip through the per-dim check above so we fall back to
-            // ref_matmul_int8 instead of producing wrong numbers.
             if (is_int8_path_) {
                 for (int d = 2; d <= bias_ndims; ++d) {
                     if (bias_dims[bias_ndims - d] != 1) return false;
@@ -243,6 +240,18 @@ struct rvv_matmul_t : public primitive_t {
         // s8 GEMM kernel and rejects non-default attrs except bias.
         bool is_f32_path_ = false;
         bool is_int8_path_ = false;
+
+        int nthr_m_ = 1;
+        int nthr_n_ = 1;
+        int nthr_k_ = 1;
+        dim_t MB_ = 0;
+        dim_t NB_ = 0;
+        dim_t KB_ = 0;
+        dim_t m_unroll_ = 0;
+        bool do_copy_ = false;
+
+    private:
+        void init_scratchpad();
     };
 
     rvv_matmul_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -36,11 +36,14 @@ struct rvv_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:rvv", rvv_matmul_t)
 
-        static constexpr data_type_t d_type = data_type::f32;
+        // Bias is always f32: the f32 path uses it directly, the int8 path
+        // converts it inside the JIT kernel before adding to the s32 acc.
+        static constexpr data_type_t bias_d_type = data_type::f32;
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
             using smask_t = primitive_attr_t::skip_mask_t;
+            using namespace data_type;
 
             // Vector kernels are JIT-emitted; the rv64gc baseline build means a
             // non-V CPU must defer to the next (reference) implementation.
@@ -59,14 +62,26 @@ struct rvv_matmul_t : public primitive_t {
                             && !bias_mdw.has_runtime_dims_or_strides(),
                     VERBOSE_UNSUPPORTED_TAG);
 
-            const bool types_ok = src_mdw.data_type() == d_type
-                    && weights_mdw.data_type() == d_type
-                    && dst_mdw.data_type() == d_type
-                    && desc()->accum_data_type == d_type;
-            VDISPATCH_MATMUL(types_ok, VERBOSE_UNSUPPORTED_DT);
-
+            // Determine which dispatch path this pd serves. f32 stays on the
+            // existing f32 GEMM kernel; int8 src + s8 weights + (s32|f32) dst
+            // runs through the new s8 GEMM kernel.
+            const auto src_dt = src_mdw.data_type();
+            const auto wei_dt = weights_mdw.data_type();
+            const auto dst_dt = dst_mdw.data_type();
+            const auto acc_dt = desc()->accum_data_type;
+            is_f32_path_ = src_dt == f32 && wei_dt == f32 && dst_dt == f32
+                    && acc_dt == f32;
+            is_int8_path_ = utils::one_of(src_dt, s8, u8) && wei_dt == s8
+                    && utils::one_of(dst_dt, s32, f32) && acc_dt == s32;
+            VDISPATCH_MATMUL(is_f32_path_ || is_int8_path_,
+                    VERBOSE_UNSUPPORTED_DT);
+            // The int8 path rejects per-oc / per-tensor scales, zero-points,
+            // and post-ops in this MVP; only optional f32 bias is supported.
+            const auto attr_skip_mask = is_f32_path_
+                    ? smask_t::post_ops
+                    : smask_t::none;
             VDISPATCH_MATMUL(
-                    attr()->has_default_values(smask_t::post_ops, d_type),
+                    attr()->has_default_values(attr_skip_mask, dst_dt),
                     VERBOSE_UNSUPPORTED_ATTR);
 
             // Resolve the primary and the post-op binary src1 formats before any
@@ -81,16 +96,22 @@ struct rvv_matmul_t : public primitive_t {
             // Post-ops are applied per output row (length N) by the unified
             // injector kernel: a chain of supported eltwise ops plus any number
             // of binaries whose src1 is scalar or per-N (broadcast over M/batch).
-            const dim_t N = weights_mdw.dims()[weights_mdw.ndims() - 1];
-            VDISPATCH_MATMUL(jit_uni_postops_kernel_t::post_ops_supported(
-                                     attr()->post_ops_, N),
-                    VERBOSE_UNSUPPORTED_POSTOP);
-            // A non-scalar binary rhs must be strict per-N (broadcast over M and
-            // batch): the per-row execute uses a fixed offset, so e.g. per-M
-            // [M,1] (which slips past nelems==N when M==N) must fall back.
-            VDISPATCH_MATMUL(jit_uni_postops_kernel_t::binary_per_last_dim_ok(
-                                     attr()->post_ops_, N),
-                    VERBOSE_UNSUPPORTED_POSTOP);
+            // The int8 path rejects post-ops entirely (caught above by the
+            // stricter attr skip mask).
+            if (is_f32_path_) {
+                const dim_t N = weights_mdw.dims()[weights_mdw.ndims() - 1];
+                VDISPATCH_MATMUL(jit_uni_postops_kernel_t::post_ops_supported(
+                                         attr()->post_ops_, N),
+                        VERBOSE_UNSUPPORTED_POSTOP);
+                // A non-scalar binary rhs must be strict per-N (broadcast over
+                // M and batch): the per-row execute uses a fixed offset, so
+                // e.g. per-M [M,1] (which slips past nelems==N when M==N) must
+                // fall back.
+                VDISPATCH_MATMUL(
+                        jit_uni_postops_kernel_t::binary_per_last_dim_ok(
+                                attr()->post_ops_, N),
+                        VERBOSE_UNSUPPORTED_POSTOP);
+            }
 
             VDISPATCH_MATMUL(check_layouts(src_mdw, weights_mdw, dst_mdw),
                     VERBOSE_UNSUPPORTED_TAG);
@@ -161,7 +182,7 @@ struct rvv_matmul_t : public primitive_t {
                 const memory_desc_wrapper &bias_mdw) const {
             if (bias_mdw.is_zero()) return true;
 
-            if (bias_mdw.data_type() != d_type) return false;
+            if (bias_mdw.data_type() != bias_d_type) return false;
 
             const int dst_ndims = dst_mdw.ndims();
             const int bias_ndims = bias_mdw.ndims();
@@ -174,6 +195,16 @@ struct rvv_matmul_t : public primitive_t {
                 const dim_t bias_dim = bias_dims[bias_ndims - d];
                 const dim_t dst_dim = dst_dims[dst_ndims - d];
                 if (bias_dim != 1 && bias_dim != dst_dim) return false;
+            }
+
+            // The int8 JIT kernel only knows how to read a 1-D per-N bias
+            // (one value per GEMM-M row). Reject per-M / per-batch bias shapes
+            // that slip through the per-dim check above so we fall back to
+            // ref_matmul_int8 instead of producing wrong numbers.
+            if (is_int8_path_) {
+                for (int d = 2; d <= bias_ndims; ++d) {
+                    if (bias_dims[bias_ndims - d] != 1) return false;
+                }
             }
             return true;
         }
@@ -207,6 +238,11 @@ struct rvv_matmul_t : public primitive_t {
         dim_t batch_ = 0;
         bool weights_are_broadcast_ = false;
         bool weights_col_major_ = false;
+        // Dispatch path selected in init(). is_f32_path_ keeps the historical
+        // behavior; is_int8_path_ routes (s8|u8):s8:(s32|f32) through the new
+        // s8 GEMM kernel and rejects non-default attrs except bias.
+        bool is_f32_path_ = false;
+        bool is_int8_path_ = false;
     };
 
     rvv_matmul_t(const pd_t *apd) : primitive_t(apd) {}


### PR DESCRIPTION
# Description

This PR introduces an int8 GEMM micro-kernel and `rvv_matmul_t` dispatch for RISC-V architectures, extending the existing f32 GEMM machinery to the `s8:s8:s32`, `s8:s8:f32`, `u8:s8:s32` and `u8:s8:f32` data type combinations.

This initial version provides:

1. A new `jit_rvv_gemm_s8_kernel_t` JIT micro-kernel that produces an s32 accumulator from s8 × s8 (or u8 × s8) inputs using `vle8.v` + `vwmul.vx` widening sign-extension followed by `vwmacc.vx` widening multiply-accumulate.
2. A `rvv_gemm_s8s8s32()` driver mirroring `rvv_gemm_f32()` (blocking, K-split threading, optional fused bias).
3. Branching in `rvv_matmul_t::pd_t::init` and `rvv_matmul_t::execute` to route int8 workloads through the new path. The f32 path keeps its existing jit:rvv dispatch and GEMM kernel; execution details that changed for both paths are documented under "Scratchpad migration" below (sequential batch loop, scratchpad-booked workspace).

## Key Features

- **RVV int8 GEMM kernel**: per-K sign-extension of the s8 weights row via `vwmul.vx` with scalar 1 (avoids `vsext.vf2`, which traps on this target), followed by `vwmacc.vx` widening multiply-accumulate into e32 LMUL=m4 accumulators.
- **Data Types**: `s8:s8:s32`, `s8:s8:f32`, `u8:s8:s32`, `u8:s8:f32`. Weights are always `s8`. The `u8` B-axis is loaded with `lbu` and treated as a positive `s16` operand, so the `vwmacc.vx` instruction handles both signs through the choice of load opcode.
- **Memory Layouts**: same row-major src/dst and row- or col-major weights rule as the f32 path (`ab` / `ba` for 2D, `abc` / `acb` / `abcd` for batched).
- **Fused Bias**: optional f32 bias is folded into the JIT C-update phase — converted to s32 in-place (`vfcvt_rtz.x.f.v`, round-toward-zero, matching the truncation used in the reference early-out path) for the s32 dst path, applied after `vfcvt.f.x.v` for the f32 dst path. Only `f32` bias is accepted in this PR; `s32` bias is rejected in `pd_t::init` and falls back to `ref_matmul_int8_t`. The matmul driver only feeds the kernel a strict 1-D per-N bias; richer bias masks (per-M, per-batch) are also rejected so the primitive falls back.
- **Post-Ops / Scales / Zero-Points**: out of scope for this PR. The int8 dispatch path rejects all non-default attrs except optional bias, so quantized workloads continue to be served by the reference implementation.
- **Scratchpad-based workspace booking**: `c_buffers` (K-split reduction) and `ws_buffers` (per-thread A-copy cache) are booked in `rvv_matmul_t::pd_t::init_scratchpad()` via `scratchpad_registry().registrar()` and fetched in `execute()` through `ctx.get_scratchpad_grantor()`. The same migration is applied to the f32 path so both share the contract; legacy callers (`gemm.cpp`, `rvv_gemm_inner_product`) keep working through a `nullptr`-fall-back path that mallocs on demand.

# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on the SG2044 platform with VLEN=128 using RISC-V GNU toolchain 14.2. We draw comparisons among:

1. **baseline**: upstream `main` branch (`gemm:jit`, which falls through to the reference int8 GEMM for these shapes)
2. **this PR**: `jit:rvv` int8 dispatch path with scratchpad-based workspace booking

### Single-Core Performance (s8:s8:s32)

| Layer | Impl | Baseline (ms) | This PR (ms) | Speedup |
|-------|------|---------------|--------------|---------|
| resnet:ip1*1 (112x2048:2048x1000) | jit:rvv | 632.35 | 22.64 | **27.9×** |
| resnet_sparse:ip1*1 (64x2048:2048x1000) | jit:rvv | 298.69 | 13.91 | **21.5×** |
| GNMT:0*1 (64x512:512x512) | jit:rvv | 58.49 | 1.64 | **35.7×** |
| GNMT:1*1 (64x1024:1024x1024) | jit:rvv | 272.93 | 6.76 | **40.4×** |


### Dispatch Coverage and Correctness

- `--matmul --batch=test_matmul_int8`: all 14,789 int8 cases pass (480 skipped / 208 mistrusted are unrelated to this primitive). `jit:rvv` (this PR) handles 388 cases; the rest fall through to `gemm:jit` / `ref` as before for shapes with scales, zero-points, post-ops or richer bias masks that the MVP intentionally rejects.
- `--matmul --batch=test_matmul_smoke`: 208/208 pass (f32/bf16/f16, NCF shapes) — zero regressions vs upstream `main`.
- `--matmul --batch=test_matmul_all`: 34,827/34,827 pass (the full matmul correctness suite covering f32, int8, bf16, bf32, f16, strides, run-time dims) — identical pass count to upstream `main`.
- The int8 IP dispatch (`--ip --dt=s8:s8:s32 --batch=shapes_resnet_50`) is served by the new path (`jit:rvv`).

# Future Plans

1. Software-pipeline the A load (double-buffer `v_a_e8` like the f32 kernel) to hide `vle8.v` + `vwmul.vx` latency in the K loop.
2. Per-oc / per-tensor scales so the s8:s8:f32 path can serve quantized transformer workloads end-to-end.
3. Zero-point compensation (src / weights / dst) and the post-op chain (eltwise + sum + binary) on the f32 dst variant.
4. Share the storage tables between the s8 and u8 B-axis variants — today they differ only by the B-scalar load opcode (`lb` for s8 vs `lbu` for u8), so collapsing them into one table per (transA, transB, dst type) would save ~50 KB of JIT memory.
5. Accept `s32` bias on the `s8:s8:s32` path (today rejected in favor of `f32` only) so quantized workloads with pre-scaled s32 bias don't have to fall back to `ref_matmul_int8_t`.
