### PR TITLE
cmake: add XLA source fallback for EIGEN_ASYNC

### DIFF
--- a/cmake/Threading.cmake
+++ b/cmake/Threading.cmake
@@ -1,5 +1,6 @@
 #===============================================================================
 # Copyright 2018 Intel Corporation
+# Copyright 2026 Arm Ltd. and affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/Threadpool.cmake
+++ b/cmake/Threadpool.cmake
@@ -48,10 +48,53 @@ if("${DNNL_CPU_THREADING_RUNTIME}" STREQUAL "THREADPOOL")
         endif()
 
         if("${_DNNL_TEST_THREADPOOL_IMPL}" STREQUAL "EIGEN_ASYNC")
-            find_package(xla REQUIRED CONFIG PATH_SUFFIXES "lib64/cmake/xla")
+            find_package(xla QUIET CONFIG PATH_SUFFIXES "lib64/cmake/xla")
             if(xla_FOUND)
                 list(APPEND EXTRA_STATIC_LIBS xla)
                 message(STATUS "Found XLA: ${PACKAGE_PREFIX_DIR}")
+            else()
+                if("${DNNL_XLA_SOURCE_DIR}" STREQUAL "")
+                    message(FATAL_ERROR
+                        "Could not find XLA package configuration. Set "
+                        "xla_DIR to an XLA package or ONEDNN_XLA_SOURCE_DIR "
+                        "to an OpenXLA/XLA source tree.")
+                endif()
+
+                foreach(_xla_src
+                        "xla/tsl/platform/logging.cc"
+                        "xla/tsl/concurrency/async_value.cc"
+                        "xla/tsl/concurrency/async_value_ref.cc"
+                        "xla/backends/cpu/runtime/work_queue.h")
+                    if(NOT EXISTS "${DNNL_XLA_SOURCE_DIR}/${_xla_src}")
+                        message(FATAL_ERROR
+                            "ONEDNN_XLA_SOURCE_DIR does not look like an "
+                            "OpenXLA/XLA source tree. Missing: "
+                            "${DNNL_XLA_SOURCE_DIR}/${_xla_src}")
+                    endif()
+                endforeach()
+
+                add_library(xla STATIC
+                    "${DNNL_XLA_SOURCE_DIR}/xla/tsl/platform/logging.cc"
+                    "${DNNL_XLA_SOURCE_DIR}/xla/tsl/concurrency/async_value.cc"
+                    "${DNNL_XLA_SOURCE_DIR}/xla/tsl/concurrency/async_value_ref.cc")
+                target_include_directories(xla PUBLIC
+                    "${DNNL_XLA_SOURCE_DIR}"
+                    "${DNNL_XLA_SOURCE_DIR}/third_party/tsl")
+                target_compile_features(xla PUBLIC cxx_std_17)
+                target_link_libraries(xla PUBLIC
+                    absl::any_invocable
+                    absl::base
+                    absl::check
+                    absl::core_headers
+                    absl::inlined_vector
+                    absl::log
+                    absl::span
+                    absl::status
+                    absl::statusor
+                    absl::strings
+                    absl::synchronization)
+                list(APPEND EXTRA_STATIC_LIBS xla)
+                message(STATUS "Using XLA sources: ${DNNL_XLA_SOURCE_DIR}")
             endif()
         endif()
     endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,7 @@
 #===============================================================================
 # Copyright 2018 Intel Corporation
 # Copyright 2026 Advanced Micro Devices, Inc.
+# Copyright 2026 Arm Ltd. and affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -319,6 +320,11 @@ if(NOT "${_DNNL_TEST_THREADPOOL_IMPL}" MATCHES "^(STANDALONE|TBB|EIGEN|EIGEN_ASY
     message(FATAL_ERROR
         "Unsupported threadpool implementation: ${_DNNL_TEST_THREADPOOL_IMPL}")
 endif()
+
+onednn_option(XLA_SOURCE_DIR ""
+    "Path to an OpenXLA/XLA source tree used to build the minimal XLA async
+    runtime subset for _DNNL_TEST_THREADPOOL_IMPL=EIGEN_ASYNC when no XLA
+    CMake package is available.")
 
 custom_option(TBBROOT ""
     "Path to Threading Building Blocks (TBB) package.")

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -297,11 +297,15 @@ discoverable by CMake.
 The `EIGEN_ASYNC` has same requirements as `EIGEN` and additionally requires
 OpenXLA threadpool package, however, additional actions might be required to
 compile tests since this threadpool implementation relies on internal OpenXLA
-headers.
+headers. The OpenXLA dependency can be provided either as an install/package
+prefix with `xlaConfig.cmake`, or by setting `ONEDNN_XLA_SOURCE_DIR` to an
+OpenXLA/XLA source tree. The source-tree path builds the minimal XLA async
+runtime subset required by the tests with the same compiler used for oneDNN.
 
 For example:
 ~~~sh
-$ cmake -DONEDNN_CPU_RUNTIME=THREADPOOL -D_ONEDNN_TEST_THREADPOOL_IMPL=EIGEN -DCMAKE_PREFIX_PATH="/path/to/eigen/share/eigen3/cmake;/path/to/absl/lib64/cmake" ..
+$ cmake -DONEDNN_CPU_RUNTIME=THREADPOOL -D_DNNL_TEST_THREADPOOL_IMPL=EIGEN -DCMAKE_PREFIX_PATH="/path/to/eigen/share/eigen3/cmake;/path/to/absl/lib64/cmake" ..
+$ cmake -DONEDNN_CPU_RUNTIME=THREADPOOL -D_DNNL_TEST_THREADPOOL_IMPL=EIGEN_ASYNC -DEigen3_DIR=/path/to/eigen/share/eigen3/cmake -Dabsl_DIR=/path/to/absl/lib64/cmake/absl -DONEDNN_XLA_SOURCE_DIR=/path/to/xla ..
 ~~~
 
 @anchor opt_blas_vendor


### PR DESCRIPTION
 # Description

  This change adds an optional source-tree fallback for building the XLA async runtime pieces required by `_DNNL_TEST_THREADPOOL_IMPL=EIGEN_ASYNC`.

Today the EIGEN_ASYNC test threadpool path requires an XLA CMake package discoverable through `find_package(xla CONFIG)`.
This is difficult to reproduce in open-source development because XLA does not currently provide a documented build or install export for the subset of headers and `libxla.a` needed by oneDNN’s async Eigen threadpool validation.

 The new behavior keeps the existing packaged XLA flow as the preferred path.
 If that package is found, oneDNN continues to use the imported xla target.

 If no XLA package is found and ONEDNN_XLA_SOURCE_DIR is provided.

This also documents the new build option in the threadpool validation build instructions.

  Fixes [#5499](https://github.com/uxlfoundation/oneDNN/issues/5499)

  # Validation

 Tested on AArch64 with ACL and Eigen async threadpool enabled.

 Configure included:

  -DONEDNN_AARCH64_USE_ACL=ON
  -DONEDNN_CPU_RUNTIME=THREADPOOL
  -D_DNNL_TEST_THREADPOOL_IMPL=EIGEN_ASYNC
  -DONEDNN_XLA_SOURCE_DIR=/path/to/xla
  -DEigen3_DIR=/tmp/eigen-xla-install/share/eigen3/cmake
  -Dabsl_DIR=/tmp/absl-xla-install/lib/cmake/absl


The build produced the fallback libxla.a from:

  xla/tsl/platform/logging.cc.o
  xla/tsl/concurrency/async_value.cc.o
  xla/tsl/concurrency/async_value_ref.cc.o


Also verified the resulting test_reorder binary contains XLA/TSL async symbols such as:

  tsl::AsyncValue
  tsl::BlockUntilReady
  xla::cpu::Worker::Parallelize

  # Checklist

  ## General

  - [x] Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally for each commit?
      - Partial: test_reorder passed locally for the validated AArch64 ACL + THREADPOOL + EIGEN_ASYNC build. 
  - [ ] Have you formatted the code using clang-format?
    
  ## Performance improvements

  - [ ] Have you submitted performance data that demonstrates performance improvements?
      - Not applicable. This is a build/developer workflow change.

  ### New features

  - [ ] Have you published an RFC for the new feature?
      - Not applicable. This is an optional build fallback for existing EIGEN_ASYNC validation support.
  - [ ] Was the RFC approved?
      - Not applicable.
  - [x] Have you added relevant tests?
      - Existing EIGEN_ASYNC threadpool tests are enabled by this build path. test_reorder was built and passed with the
        fallback.

  ### Bug fixes

  - [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
  
  - [ ] Have you added relevant regression tests?
      
  ## RFC (https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

  - [ ] Does RFC document follow the template
    (https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
      - Not applicable.
  - [ ] Have you added a link to the rendered document?
      - Not applicable.