### PR TITLE
cpu: aarch64: jit_generator: use xzr instead of tmp reg in set_preg

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
@@ -916,11 +916,11 @@ void jit_brdgmm_kernel_base_t::init_masks() {
         const bool has_n_block2_tail = n_block2_tail() > 0;
         if (has_n_block2_tail || nb_n_block2() <= 1) {
             // The mask can be set only once.
-            set_preg(k_mask.s, n_block1_tail(), X_TMP_0, X_TMP_1);
+            set_preg(k_mask.s, n_block1_tail(), X_TMP_0);
         } else {
             // Need to adjust mask, and set only when needed.
             // So store it temporarily in k_tail_mask.
-            set_preg(k_tail_mask.s, n_block1_tail(), X_TMP_0, X_TMP_1);
+            set_preg(k_tail_mask.s, n_block1_tail(), X_TMP_0);
         }
     } else if (brg.with_binary) {
         // the post-ops injector seems to use mask unconditionally

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -1820,14 +1820,14 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
                         const int rd_block_quadtail
                                 = brg.rd_block % (16 / brg.typesize_A);
                         if (brg.typesize_A == 1)
-                            set_preg(rd_tail_mask.b, rd_block_quadtail, X_TMP_0,
-                                    X_TMP_1);
+                            set_preg(
+                                    rd_tail_mask.b, rd_block_quadtail, X_TMP_0);
                         if (brg.typesize_A == 2)
-                            set_preg(rd_tail_mask.h, rd_block_quadtail, X_TMP_0,
-                                    X_TMP_1);
+                            set_preg(
+                                    rd_tail_mask.h, rd_block_quadtail, X_TMP_0);
                         if (brg.typesize_A == 4)
-                            set_preg(rd_tail_mask.s, rd_block_quadtail, X_TMP_0,
-                                    X_TMP_1);
+                            set_preg(
+                                    rd_tail_mask.s, rd_block_quadtail, X_TMP_0);
                     }
 
                     gemm_microkernel(bd_block2, is_bdb_tail, ld_block2,
@@ -1850,7 +1850,7 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
                 // GEMV loads whole vector from left hand side
                 const int k_tail
                         = brg.LDA % simd_elems(data_type::f32, brg.isa_impl);
-                set_preg(rd_tail_mask.s, k_tail, X_TMP_0, X_TMP_1);
+                set_preg(rd_tail_mask.s, k_tail, X_TMP_0);
 
                 gemv_microkernel(is_bdb_tail, ld_block2, is_rd_tail, vpad);
             } else {
@@ -1860,28 +1860,22 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
                     const int rd_tail_quadtail
                             = brg.rdb_tail == 16 ? 16 : (brg.rdb_tail % 16);
                     if (brg.typesize_A == 1)
-                        set_preg(rd_tail_mask.b, rd_tail_quadtail, X_TMP_0,
-                                X_TMP_1);
+                        set_preg(rd_tail_mask.b, rd_tail_quadtail, X_TMP_0);
                     if (brg.typesize_A == 2)
-                        set_preg(rd_tail_mask.h, rd_tail_quadtail, X_TMP_0,
-                                X_TMP_1);
+                        set_preg(rd_tail_mask.h, rd_tail_quadtail, X_TMP_0);
                     if (brg.typesize_A == 4)
-                        set_preg(rd_tail_mask.s, rd_tail_quadtail, X_TMP_0,
-                                X_TMP_1);
+                        set_preg(rd_tail_mask.s, rd_tail_quadtail, X_TMP_0);
                     // Note that n_bcast_1_load may still need to deal with the tail
                 } else {
                     // n_load_1_bcast loads at most a word, but we may need to predicate the
                     // last word load to avoid overstepping the A buffer
                     const auto rd_tail_size = brg.rdb_tail % brg.rd_step;
                     if (brg.typesize_A == 1)
-                        set_preg(
-                                rd_tail_mask.b, rd_tail_size, X_TMP_0, X_TMP_1);
+                        set_preg(rd_tail_mask.b, rd_tail_size, X_TMP_0);
                     if (brg.typesize_A == 2)
-                        set_preg(
-                                rd_tail_mask.h, rd_tail_size, X_TMP_0, X_TMP_1);
+                        set_preg(rd_tail_mask.h, rd_tail_size, X_TMP_0);
                     if (brg.typesize_A == 4)
-                        set_preg(
-                                rd_tail_mask.s, rd_tail_size, X_TMP_0, X_TMP_1);
+                        set_preg(rd_tail_mask.s, rd_tail_size, X_TMP_0);
                 }
 
                 gemm_microkernel(bd_block2, is_bdb_tail, ld_block2, is_rd_tail,
@@ -2225,7 +2219,7 @@ void jit_brgemm_kernel_t::generate() {
 
     // Can we remove this?
     if (simd_w_ != cpu_sveLen / sizeof(float)) {
-        set_preg(P_ALL_ONE.b, simd_w_ * 4, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.b, simd_w_ * 4, X_TMP_0);
     }
 
     mov(x7, x0);
@@ -2241,7 +2235,7 @@ void jit_brgemm_kernel_t::generate() {
                              brg.req_s8s8_compensation)
             && IMPLICATION(!vpad_exist, brg.req_cal_comp_pads);
 
-    set_preg(ld_tail_mask.s, brg.ldb_tail, X_TMP_0, X_TMP_1);
+    set_preg(ld_tail_mask.s, brg.ldb_tail, X_TMP_0);
     if (brg.is_int8 && !brg.has_int8_vnni) { assert(!"unsupported\n"); }
 
     read_params();

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1753,7 +1753,7 @@ static void load_bytes(jit_generator_t *host, const Xbyak_aarch64::ZReg &vmm,
     if (load_size == 0) {
         return;
     } else {
-        host->set_preg(host->P_TMP.b, load_size);
+        host->set_preg(host->P_TMP.b, load_size, host->X_TMP_3);
         host->ld1b(vmm.b, host->P_TMP / Xbyak_aarch64::T_z,
                 Xbyak_aarch64::ptr(reg_addr));
     }

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -207,12 +207,12 @@ void jit_sve_core_brgemm_conv_trans_kernel_t::generate() {
 
     if (jcp.ic_without_padding % jcp.ic_block) {
         int tail_size = (jcp.ic_without_padding % jcp.ic_block) % jcp.simd_w;
-        set_preg(ktail_mask.s, tail_size, X_TMP_0, X_TMP_1);
+        set_preg(ktail_mask.s, tail_size, X_TMP_0);
     }
 
     if (jcp.ic_block % jcp.simd_w) {
         int block_tail_size = jcp.ic_block % jcp.simd_w;
-        set_preg(kblock_tail_mask.s, block_tail_size, X_TMP_0, X_TMP_1);
+        set_preg(kblock_tail_mask.s, block_tail_size, X_TMP_0);
     }
 
     auto icb_loop_body = [&](bool is_ic_tail) {
@@ -457,12 +457,12 @@ void jit_sve_core_brgemm_conv_rtus_kernel_t::generate() {
 
     if (jcp.ic_without_padding % jcp.ic_block) {
         int tail_size = (jcp.ic_without_padding % jcp.ic_block) % jcp.simd_w;
-        set_preg(ktail_mask.s, tail_size, X_TMP_0, X_TMP_1);
+        set_preg(ktail_mask.s, tail_size, X_TMP_0);
     }
 
     if (jcp.ic_block % jcp.simd_w) {
         int block_tail_size = jcp.ic_block % jcp.simd_w;
-        set_preg(kblock_tail_mask.s, block_tail_size, X_TMP_0, X_TMP_1);
+        set_preg(kblock_tail_mask.s, block_tail_size, X_TMP_0);
     }
 
     assert(jcp.nb_ic_blocking == 1 && "TODO: support multi-batch case");

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -690,8 +690,8 @@ private:
         sub_imm(sp, sp, utils::rnd_up(stack_space_needed_, 16), X_TMP_0);
 
         if (simd_w_ != cpu_sveLen / sizeof(float)) {
-            set_preg(P_ALL_ONE.b, simd_w_ * 4, X_TMP_0, X_TMP_1);
-            set_preg(k_full_mask.b, simd_w_ * 4, X_TMP_0, X_TMP_1);
+            set_preg(P_ALL_ONE.b, simd_w_ * 4, X_TMP_0);
+            set_preg(k_full_mask.b, simd_w_ * 4, X_TMP_0);
         } else
             ptrue(k_full_mask.b);
 
@@ -716,7 +716,7 @@ private:
         int mb = brg.bcast_dim / m_block;
         int mb_tail = brg.bcast_dim % m_block;
 
-        set_preg(k_tail_mask.s, nb_tail, X_TMP_0, X_TMP_1);
+        set_preg(k_tail_mask.s, nb_tail, X_TMP_0);
 
         if (brg.alpha != 0) {
             add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_in), X_TMP_0);

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2024-2025 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
 
     auto kmovw = [=](PReg k, unsigned w) {
         mov_imm(regw_tmp, w);
-        set_preg(k.h, w, X_TMP_0, X_TMP_1);
+        set_preg(k.h, w, X_TMP_0);
     };
 
     kmovw(k3333, 0x3333); // 0011001100110011
@@ -310,8 +310,7 @@ void jit_brgemm_copy_to_coarse_t::set_last_row_tail_masks() {
     assert(row_tail > 0 && "kernel is meant to be used with tail processing");
 
     // Set load mask
-    set_preg(
-            reg_m_last_row_tail_load.d, typesize_ * row_tail, X_TMP_0, X_TMP_1);
+    set_preg(reg_m_last_row_tail_load.d, typesize_ * row_tail, X_TMP_0);
 
     // Caution: Since size of ZMM equals 64 bytes therefore we need
     // different masks to store tails with smaller row_block_size_
@@ -329,10 +328,10 @@ void jit_brgemm_copy_to_coarse_t::set_last_row_tail_masks() {
     if (row_tail_store_size >= num_bytes(full_mask)) {
         ptrue(reg_m_last_row_tail_load.b);
     } else if (row_tail_store_size >= num_bytes(half_mask))
-        set_preg(reg_m_last_row_tail_load.b, half_mask, X_TMP_0, X_TMP_1);
+        set_preg(reg_m_last_row_tail_load.b, half_mask, X_TMP_0);
     else {
         assert(row_tail_store_size == num_bytes(quad_mask));
-        set_preg(reg_m_last_row_tail_load.b, quad_mask, X_TMP_0, X_TMP_1);
+        set_preg(reg_m_last_row_tail_load.b, quad_mask, X_TMP_0);
     }
 }
 
@@ -344,8 +343,8 @@ void jit_brgemm_copy_to_coarse_t::set_full_row_tail_masks() {
             ? size_t {0x00000000ffffffff}
             : size_t {0x000000000000ffff};
 
-    set_preg(reg_m_full_row_tail_store.b, tail_mask, X_TMP_0, X_TMP_1);
-    set_preg(reg_m_full_row_tail_load.b, tail_mask, X_TMP_0, X_TMP_1);
+    set_preg(reg_m_full_row_tail_store.b, tail_mask, X_TMP_0);
+    set_preg(reg_m_full_row_tail_load.b, tail_mask, X_TMP_0);
 }
 
 void jit_brgemm_copy_to_coarse_t::generate() {
@@ -647,8 +646,7 @@ void jit_brgemm_trans_wei_f32_t::generate() {
     add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_K), X_TMP_0);
     ldr(reg_loop_K, ptr(X_DEFAULT_ADDR));
 
-    auto kmovw
-            = [=](PReg k, unsigned w) { set_preg(k.h, w, X_TMP_0, X_TMP_1); };
+    auto kmovw = [=](PReg k, unsigned w) { set_preg(k.h, w, X_TMP_0); };
 
     kmovw(k3333, 0x3333); // 0011001100110011
     kmovw(k5555, 0x5555); // 0101010101010101

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -335,13 +335,10 @@ public:
         }
     }
 
-    template <typename PRegBHSD, typename T>
-    void set_preg(const PRegBHSD &p, T tail_size,
-            const Xbyak_aarch64::XReg x_tmp0 = Xbyak_aarch64::XReg(DUMMY_IDX),
-            const Xbyak_aarch64::XReg x_tmp1 = Xbyak_aarch64::XReg(DUMMY_IDX)) {
+    template <typename PRegBHSD>
+    void set_preg(const PRegBHSD &p, size_t tail_size,
+            const Xbyak_aarch64::XReg x_tmp) {
         using namespace Xbyak_aarch64;
-
-        assert(tail_size <= 64); // Implemented only for "SVE size <=  512"
 
         switch (tail_size) {
             case 0: pfalse(PRegB(p.getIdx())); return;
@@ -358,10 +355,8 @@ public:
             case 64: ptrue(p, VL64); return;
         }
 
-        assert(x_tmp0.getIdx() != DUMMY_IDX && x_tmp1.getIdx() != DUMMY_IDX);
-        mov_imm(x_tmp0, 0);
-        mov_imm(x_tmp1, tail_size);
-        whilelt(p, x_tmp0, x_tmp1);
+        mov_imm(x_tmp, tail_size);
+        whilelo(p, xzr, x_tmp);
     }
 
     template <typename T>

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2022-2025 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1287,7 +1287,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::generate() {
             bne(skip_tail_mask);
         }
         assert(tail_size <= 16);
-        set_preg(ktail_mask.s, tail_size);
+        set_preg(ktail_mask.s, tail_size, X_TMP_0);
         L(skip_tail_mask);
     }
 

--- a/src/cpu/aarch64/jit_sve_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.cpp
@@ -624,7 +624,7 @@ void jit_sve_conv_fwd_kernel_t<isa>::generate() {
 
     //TO DO : renaming predicate register (P_ALL_ONE)
     if (simd_w_ != cpu_sveLen / sizeof(float))
-        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0);
 
     ldr(reg_inp, ptr(abi_param1, GET_OFF(src)));
     ldr(reg_out, ptr(abi_param1, GET_OFF(dst)));
@@ -1971,7 +1971,7 @@ void jit_sve_conv_bwd_data_kernel_f32_t<isa>::generate() {
     preamble();
 
     if (simd_w_ != cpu_sveLen / sizeof(float))
-        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0);
     ldr(reg_src, ptr(param, GET_OFF(src)));
     ldr(reg_dst, ptr(param, GET_OFF(dst)));
     ldr(reg_ker, ptr(param, GET_OFF(filt)));
@@ -4055,7 +4055,7 @@ void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::generate_kernel() {
     preamble();
 
     if (simd_w_ != cpu_sveLen / sizeof(float))
-        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0);
 
     ldr(reg_input, ptr(param, GET_OFF(src)));
     ldr(reg_output, ptr(param, GET_OFF(dst)));

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -462,7 +462,7 @@ struct jit_bnorm_t : public jit_generator_t {
     void prepare_tail_mask() {
         if (!is_c_padded()) return;
         const int tail = pd_->C() % (int)(vlen / sizeof(float));
-        set_preg(ktail_mask.s, tail, X_TMP_0, X_TMP_1);
+        set_preg(ktail_mask.s, tail, X_TMP_0);
     }
 
     void prepare_relu() {

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021-2023 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -252,7 +252,7 @@ struct jit_bnorm_s8_t<sve_512> : public jit_bnorm_base_t<sve_512> {
     void prepare_tail_mask() override {
         if (!c_tail_) return;
 
-        set_preg(tail_opmask.s, c_tail_, X_TMP_0, X_TMP_1);
+        set_preg(tail_opmask.s, c_tail_, X_TMP_0);
     }
 
     void load_mean_and_var(const ZReg &vmean, const ZReg &vsqrtvar, size_t offt,
@@ -309,7 +309,7 @@ struct jit_bnorm_s8_t<sve_512> : public jit_bnorm_base_t<sve_512> {
             L(mb_sp_loop);
             {
                 if (need_tail) {
-                    set_preg(p_tmp0.s, c_tail_, X_TMP_0, X_TMP_1);
+                    set_preg(p_tmp0.s, c_tail_, X_TMP_0);
                     ld1sb(v.s, p_tmp0 / T_z, ptr(src_ptr()));
                 } else {
                     ld1sb(v.s, P_ALL_ONE / T_z, ptr(src_ptr()));

--- a/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2022-2025 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ void jit_uni_deconv_zp_pad_str_kernel_t<isa>::init() {
     else
         assert(!"unreachable");
 
-    set_preg(ktail_mask_.s, tail_size_);
+    set_preg(ktail_mask_.s, tail_size_, X_TMP_0);
 
     if (!jcp_.is_depthwise) // fill register byte ones
         dup(vmm_one_bytes_.b, 0x01);

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
@@ -459,7 +459,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
     this->preamble();
     //TO DO : renaming predicate register (P_ALL_ONE)
     if (isa != asimd && simd_w_ != cpu_sveLen / sizeof(float))
-        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0);
     if (jcp.is_fused_conv) {
         ldr(reg_input_buffer_ptr, ptr(abi_param1, GET_OFF(src)));
         mov(reg_iw_offset, 0);
@@ -1240,7 +1240,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::generate() {
     preamble();
     //TO DO : renaming predicate register (P_ALL_ONE)
     if (simd_w_ != cpu_sveLen / sizeof(float)) {
-        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0);
     }
 
     if (simd_w_ != 16 && simd_w_ != 8) {

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -345,8 +345,8 @@ template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::prepare_tail_mask() {
     /* PRegS(k_c_tail_mask) keeps flags in the context
            of 8-bit elements. */
-    set_preg(k_c_tail_mask_b.b, jpp.c_tail, X_TMP_0, X_TMP_1);
-    set_preg(k_c_tail_mask_s.s, jpp.c_tail, X_TMP_0, X_TMP_1);
+    set_preg(k_c_tail_mask_b.b, jpp.c_tail, X_TMP_0);
+    set_preg(k_c_tail_mask_s.s, jpp.c_tail, X_TMP_0);
     not_(k_c_tail_mask_s_not.b, P_ALL_ONE / T_z, k_c_tail_mask_s.b);
 }
 
@@ -892,7 +892,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
     size_t simd_w_ = simd_elems(data_type_t::dnnl_f32, isa);
 
     if (simd_w_ != cpu_sveLen / sizeof(float))
-        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0);
 
     Label idx_table;
 

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -467,7 +467,7 @@ void jit_softmax_sve_t::load(
 }
 
 void jit_softmax_sve_t::prepare_tail_mask() {
-    set_preg(tail_opmask.s, axis_simd_tail_, X_TMP_0, X_TMP_1);
+    set_preg(tail_opmask.s, axis_simd_tail_, X_TMP_0);
 }
 
 void jit_softmax_sve_t::get_horizontal_op(const ZReg &v, op_t op) {
@@ -652,7 +652,7 @@ void jit_softmax_sve_t::prepare_mask() {
     }
 
     if (simd_w_ != cpu_sveLen / sizeof(float))
-        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0);
 }
 
 void jit_softmax_sve_t::restore_mask() {

--- a/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -572,8 +572,7 @@ void jit_brgemm_matmul_copy_b_f32_t::copy_16_8_x_n_block(
 
     const int columns_tail = ncolumns % n_blk_step;
 
-    if (columns_tail < n_blk_step)
-        set_preg(kTail.s, columns_tail, X_TMP_0, X_TMP_1);
+    if (columns_tail < n_blk_step) set_preg(kTail.s, columns_tail, X_TMP_0);
 
     int iter = 0;
     for_(int k = 0; k < nrows; k++) //nrows = unroll
@@ -805,7 +804,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<sve_256>::copy_row_x_col(
         }
         if (columns_tail > 0) {
             add_imm(X_DEFAULT_ADDR, reg_src, i * src_stride_, X_TMP_0);
-            set_preg(P_TMP.b, columns_tail * typesize_, X_TMP_0, X_TMP_1);
+            set_preg(P_TMP.b, columns_tail * typesize_, X_TMP_0);
             ld1b(vmm_src.b, P_TMP / T_z, ptr(X_DEFAULT_ADDR));
         } else {
             add_imm(X_DEFAULT_ADDR, reg_src, i * src_stride_, X_TMP_0);
@@ -838,7 +837,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<sve_256>::copy_row_x_col(
         splice(tmp0.s, p_E0, tmp0.s);
 
         if (next_src_idx1 < nrows && load_next) { load(next_src_idx1); }
-        set_preg(p_tmp_0.s, 1, X_TMP_0, X_TMP_1);
+        set_preg(p_tmp_0.s, 1, X_TMP_0);
         mov(tmp1.d, src1.d);
         splice(tmp1.s, p_tmp_0, tmp1.s);
 
@@ -981,9 +980,9 @@ void jit_brgemm_matmul_copy_b_transposed_t<isa>::generate() {
     preamble();
 
     ptrue(p_FF.s);
-    set_preg(p_0F.s, 4, X_TMP_0, X_TMP_1);
+    set_preg(p_0F.s, 4, X_TMP_0);
     rev(p_F0.s, p_0F.s);
-    set_preg(p_33.s, 2, X_TMP_0, X_TMP_1);
+    set_preg(p_33.s, 2, X_TMP_0);
     rev(p_tmp_0.s, p_33.s);
     orr(p_33.b, p_FF, p_33.b, p_F0.b);
     eor(p_33.b, p_FF, p_33.b, p_tmp_0.b);
@@ -992,9 +991,9 @@ void jit_brgemm_matmul_copy_b_transposed_t<isa>::generate() {
     ptrue(p_tmp_0.s);
     trn1(p_AA.s, p_AA.s, p_tmp_0.s);
     rev(p_55.s, p_AA.s);
-    set_preg(p_E0.s, 3, X_TMP_0, X_TMP_1);
+    set_preg(p_E0.s, 3, X_TMP_0);
     rev(p_E0.s, p_E0.s);
-    set_preg(p_02.s, 2, X_TMP_0, X_TMP_1);
+    set_preg(p_02.s, 2, X_TMP_0);
 
     LDR_IMM(reg_src_base, param1, GET_OFF(src));
     LDR_IMM(reg_tr_src_base, param1, GET_OFF(tr_src));

--- a/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
@@ -242,7 +242,7 @@ struct jit_bf16_matmul_kernel_t : public jit_generator_t {
                         : (brg.n_tail % brg.n_blk);
             }
         }
-        set_preg(prd_st.s, pred_st, X_TMP_0, X_TMP_1);
+        set_preg(prd_st.s, pred_st, X_TMP_0);
     }
 
     void generate() override {

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -787,8 +787,8 @@ struct jit_int8_matmul_kernel_t : public jit_generator_t {
 
         const int pred_zp_b_tl
                 = (n_cols % sv_len == 0) ? sv_len : n_cols % sv_len;
-        set_preg(prd_8.b, sv_len, X_TMP_0, X_TMP_1);
-        set_preg(prd_zp_b_tl.b, pred_zp_b_tl, X_TMP_0, X_TMP_1);
+        set_preg(prd_8.b, sv_len, X_TMP_0);
+        set_preg(prd_zp_b_tl.b, pred_zp_b_tl, X_TMP_0);
 
         if (brg_.is_n_tail) {
             pred_b = (brg_.n_tail % sv_len == 0) ? sv_len
@@ -804,9 +804,9 @@ struct jit_int8_matmul_kernel_t : public jit_generator_t {
                         : (brg_.n_tail % brg_.n_blk);
             }
         }
-        set_preg(prd_ld.b, pred_ld, X_TMP_0, X_TMP_1);
-        set_preg(prd_st.s, pred_st, X_TMP_0, X_TMP_1);
-        set_preg(prd_b.s, pred_b, X_TMP_0, X_TMP_1);
+        set_preg(prd_ld.b, pred_ld, X_TMP_0);
+        set_preg(prd_st.s, pred_st, X_TMP_0);
+        set_preg(prd_b.s, pred_b, X_TMP_0);
     }
 
     void generate() override {

--- a/src/cpu/aarch64/matmul/jit_int8_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul_utils.cpp
@@ -118,8 +118,8 @@ void jit_int8_matmul_utils_kernel_t::reo_B_8xN(int lp, int nt) {
 void jit_int8_matmul_utils_kernel_t::gen_reo_a() {
     const int ktl = (dyn_.ktail) ? dyn_.ktail : dyn_.k_blk;
 
-    set_preg(prd_ld.b, ktl, X_TMP_0, X_TMP_1);
-    set_preg(prd_st.b, dyn_.k_blk, X_TMP_0, X_TMP_1);
+    set_preg(prd_ld.b, ktl, X_TMP_0);
+    set_preg(prd_st.b, dyn_.k_blk, X_TMP_0);
 
     ldr_imm(reg_max, reg_param, GET_OFF(nk));
     ldr_imm(reg_min, reg_param, GET_OFF(nm));
@@ -181,8 +181,8 @@ void jit_int8_matmul_utils_kernel_t::gen_reo_a() {
 
 void jit_int8_matmul_utils_kernel_t::gen_reo_b() {
 
-    set_preg(prd_ld.b, dyn_.n_blk, X_TMP_4, X_TMP_1);
-    set_preg(prd_p3.b, dyn_.ntail, X_TMP_4, X_TMP_1);
+    set_preg(prd_ld.b, dyn_.n_blk, X_TMP_4);
+    set_preg(prd_p3.b, dyn_.ntail, X_TMP_4);
 
     ldr_imm(reg_max, reg_param, GET_OFF(nn));
     ldr_imm(reg_min, reg_param, GET_OFF(nk));

--- a/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
@@ -116,7 +116,7 @@ void jit_single_blk_kernel_t::generate() {
 
     Label tail_processing;
 
-    set_preg(p_tmp2.s, 4, X_TMP_0, X_TMP_1);
+    set_preg(p_tmp2.s, 4, X_TMP_0);
     rev(p_tmp1.s, p_tmp2.s);
 
     preamble();
@@ -300,7 +300,7 @@ void jit_single_blk_kernel_t::gen_transpose_8x8() {
 // keep order nchw -> nChw()C
 // or nChw()C -> nchw
 void jit_single_blk_kernel_t::gen_setmask(int mask) {
-    set_preg(p_mask.s, mask, x_tmp_0, x_tmp_1);
+    set_preg(p_mask.s, mask, x_tmp_0);
 }
 
 void jit_single_blk_kernel_t::gen_transpose_4x4() {


### PR DESCRIPTION
# Description

Using the isa-provided `xzr` register saves the unnecessary temporary register that was being used to simply hold `0`.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?