### PR TITLE
ngen: fixup sendgc/sendgx SWSB

### DIFF
--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -1689,12 +1689,13 @@ bool Instruction12::getARFType(ARFType &arfType, int opNum, HW hw) const
 {
     if (opNum > 1) return false;
 
+    if (isSend(opcode()))
+        return false;
+
     // Only need to support unary/binary, for detecting ce/cr/sr usage.
     switch (opcode()) {
         case Opcode::nop:
         case Opcode::illegal:
-        case Opcode::send:
-        case Opcode::sendc:
         case Opcode::bfe:
         case Opcode::bfi2:
         case Opcode::csel:


### PR DESCRIPTION
Fixes a bug in SWSB where `A@1` was getting added to send instructions due to an implementation error (missed adding these instructions to a switch statement).

Some instructions modify cr/ce/sr "special" registers. These are not tracked by HW, so software is responsible for waiting until the instruction that modifies these registers finishes before accessing them again. We do that by adding `A@1` SWSB to the next instruction that uses/modifies these registers. sendgx and sendgc instructions were not properly marked as "not modifiers or consumers of special registers" so they were getting unnecessary `A@1`. This fixes the issue by correctly exempting all send instructions from this SWSB pattern.