### PR TITLE
[rls-v3.13] xe: sdpa: perf fix on xe2 for h64,second-token

### DIFF
--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -440,7 +440,7 @@ static std::vector<fwd_config_record_t> sorted_configs = []() {
         {{compute::gpu_arch_t::xe2, 64},                   {16, 64, 32, 16, 8, 2, 2, 8}},
         {{compute::gpu_arch_t::xe2, 64, 64},               {32, 32, 32, 16, 4, 2, 2, 4}},
         {{compute::gpu_arch_t::xe2, 64, 32},               {16, 16, 16, 16, 4, 2, 4, 2}},
-        {{compute::gpu_arch_t::xe2, 64,     second_token}, {32, 32, 32, 16, 4, 2, 2, 4}},
+        {{compute::gpu_arch_t::xe2, 64,     second_token}, {64, 16, 16, 16, 8, 1, 4, 1}},
         {{compute::gpu_arch_t::xe2, 64, 64, second_token}, {16, 16, 16, 16, 4, 2, 4, 2}},
 
         {{compute::gpu_arch_t::xe2, 64,       quantized}, {16, 64, 16, 32, 16, 1, 8, 2}},


### PR DESCRIPTION
# Description

Fixes a performance regression introduced by the fix in https://github.com/uxlfoundation/oneDNN/pull/5534. This PR adjusts the SDPA config to perform better on xe2 for the small head size.

Fixes [MFDNN-15328](https://jira.devtools.intel.com/browse/MFDNN-15328)
Backports: #5581