### PR TITLE
common: remove c_compatible and clean up nstl

### DIFF
--- a/src/common/engine.hpp
+++ b/src/common/engine.hpp
@@ -46,7 +46,7 @@
  *   - Provide engine specific memory allocation
  *   - Provide engine specific primitive_desc_t creators
  */
-struct dnnl_engine : public dnnl::impl::c_compatible {
+struct dnnl_engine {
     dnnl_engine(dnnl::impl::engine_impl_t *impl) : impl_(impl), counter_(1) {}
 
     /** get kind of the current engine */
@@ -229,7 +229,7 @@ inline runtime_kind_t get_cpu_native_runtime() {
 #endif
 }
 
-struct engine_factory_t : public c_compatible {
+struct engine_factory_t {
     virtual size_t count() const = 0;
     virtual status_t engine_create(engine_t **engine, size_t index) const = 0;
     virtual ~engine_factory_t() = default;

--- a/src/common/memory.hpp
+++ b/src/common/memory.hpp
@@ -41,7 +41,7 @@ enum memory_flags_t {
 } // namespace impl
 } // namespace dnnl
 
-struct dnnl_memory : public dnnl::impl::c_compatible {
+struct dnnl_memory {
     /** XXX: Parameter flags must contain either alloc or use_runtime_ptr from
      * memory_flags_t. */
     dnnl_memory(dnnl::impl::engine_t *engine,

--- a/src/common/memory_desc.hpp
+++ b/src/common/memory_desc.hpp
@@ -334,7 +334,7 @@ status_t memory_desc_permute_axes(memory_desc_t &out_memory_desc,
 // dimensions themselves, plus information about elements type and memory
 // format. Additionally, contains format-specific descriptions of the data
 // layout.
-struct dnnl_memory_desc : public dnnl::impl::c_compatible {
+struct dnnl_memory_desc {
     dnnl_memory_desc()
         : ndims(0)
         , dims {}

--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -37,7 +37,7 @@ namespace impl {
 /** thin wrapper class over \struct memory_desc_t which allows easy
  * manipulations with underlying C structure, which is taken by reference */
 // NOLINTNEXTLINE(readability-identifier-naming)
-struct memory_desc_wrapper : public c_compatible {
+struct memory_desc_wrapper {
     const memory_desc_t *md_;
 
     /** constructor which takes a reference to a constant underlying C memory

--- a/src/common/memory_map_manager.hpp
+++ b/src/common/memory_map_manager.hpp
@@ -30,7 +30,7 @@ namespace impl {
 
 // Service class to support RAII semantics with parameterized "finalization".
 template <typename key_type, typename tag_type = void>
-struct memory_map_manager_t : public c_compatible {
+struct memory_map_manager_t {
     using unmap_func_type = std::function<status_t(stream_t *, void *)>;
 
     memory_map_manager_t() = default;

--- a/src/common/memory_storage.hpp
+++ b/src/common/memory_storage.hpp
@@ -32,7 +32,7 @@ namespace impl {
 //
 // Memory storage is engine-specific and has different implementations for
 // different engines.
-struct memory_storage_t : public c_compatible {
+struct memory_storage_t {
     memory_storage_t(engine_t *engine, const memory_storage_t *root_storage);
     memory_storage_t(engine_t *engine) : memory_storage_t(engine, this) {}
 

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -24,8 +24,6 @@
 #include <array>
 #include <cassert>
 #include <cstdlib>
-#include <map>
-#include <vector>
 
 #include "bfloat16.hpp"
 #include "float16.hpp"
@@ -282,92 +280,6 @@ struct is_integral<int4_t> {
 template <>
 struct is_integral<uint4_t> {
     static constexpr bool value = true;
-};
-
-template <typename T, typename U>
-struct is_same { // NOLINT(readability-identifier-naming)
-    static constexpr bool value = false;
-};
-template <typename T>
-struct is_same<T, T> {
-    static constexpr bool value = true;
-};
-
-// Rationale: oneDNN needs container implementations that do not generate
-// dependencies on C++ run-time libraries.
-//
-// Implementation philosophy: caller is responsible to check if the operation
-// is valid. The only functions that have to return status are those that
-// depend on memory allocation or similar operations.
-//
-// This means that e.g. an operator [] does not have to check for boundaries.
-// The caller should have checked the boundaries. If it did not we crash and
-// burn: this is a bug in oneDNN and throwing an exception would not have been
-// recoverable.
-//
-// On the other hand, insert() or resize() or a similar operation needs to
-// return a status because the outcome depends on factors external to the
-// caller. The situation is probably also not recoverable also, but oneDNN
-// needs to be nice and report "out of memory" to the users.
-
-enum nstl_status_t { success = 0, out_of_memory };
-
-template <typename T>
-class vector { // NOLINT(readability-identifier-naming)
-private:
-    std::vector<T> _impl;
-
-public:
-    using iterator = typename std::vector<T>::iterator;
-    using const_iterator = typename std::vector<T>::const_iterator;
-    using size_type = typename std::vector<T>::size_type;
-    vector() = default;
-    vector(size_type n) : _impl(n) {}
-    vector(size_type n, const T &value) : _impl(n, value) {}
-    template <typename input_iterator>
-    vector(input_iterator first, input_iterator last) : _impl(first, last) {}
-    ~vector() = default;
-    size_type size() const { return _impl.size(); }
-    T &operator[](size_type i) { return _impl[i]; }
-    const T &operator[](size_type i) const { return _impl[i]; }
-    iterator begin() { return _impl.begin(); }
-    const_iterator begin() const { return _impl.begin(); }
-    iterator end() { return _impl.end(); }
-    const_iterator end() const { return _impl.end(); }
-    template <typename input_iterator>
-    nstl_status_t insert(
-            iterator pos, input_iterator begin, input_iterator end) {
-        _impl.insert(pos, begin, end);
-        return success;
-    }
-    void clear() { _impl.clear(); }
-    void push_back(const T &t) { _impl.push_back(t); }
-    void resize(size_type count) { _impl.resize(count); }
-    void reserve(size_type count) { _impl.reserve(count); }
-};
-
-template <typename Key, typename T>
-class map { // NOLINT(readability-identifier-naming)
-private:
-    std::map<Key, T> _impl;
-
-public:
-    using iterator = typename std::map<Key, T>::iterator;
-    using const_iterator = typename std::map<Key, T>::const_iterator;
-    using size_type = typename std::map<Key, T>::size_type;
-    map() = default;
-    ~map() = default;
-    size_type size() const { return _impl.size(); }
-    T &operator[](const Key &k) { return _impl[k]; }
-    const T &operator[](const Key &k) const { return _impl[k]; }
-    iterator begin() { return _impl.begin(); }
-    const_iterator begin() const { return _impl.begin(); }
-    iterator end() { return _impl.end(); }
-    const_iterator end() const { return _impl.end(); }
-    template <typename input_iterator>
-    void clear() {
-        _impl.clear();
-    }
 };
 
 // Compile-time sequence of indices (part of C++14)

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -43,43 +43,10 @@ namespace impl {
 // build) in order to replace it with a custom one from an object file at link
 // time.
 void DNNL_WEAK *malloc(size_t size, int alignment);
-// Use glibc malloc (and, consequently, free) when DNNL_ENABLE_MEM_DEBUG is
-// enabled, such that the operator new doesn't fail during out_of_memory
-// testing.
-#define MALLOC(size, alignment) ::malloc(size)
-#define FREE(ptr) ::free(ptr)
 #else
-void DNNL_API *malloc(size_t size, int alignment);
-#define MALLOC(size, alignment) malloc(size, alignment)
-#define FREE(ptr) free(ptr)
+void *malloc(size_t size, int alignment);
 #endif
-void DNNL_API free(void *p);
-
-struct c_compatible { // NOLINT(readability-identifier-naming)
-    enum { default_alignment = 64 };
-    static void *operator new(size_t sz) {
-        return MALLOC(sz, default_alignment);
-    }
-    static void *operator new(size_t sz, void *p) {
-        UNUSED(sz);
-        return p;
-    }
-    static void *operator new[](size_t sz) {
-        return MALLOC(sz, default_alignment);
-    }
-    static void operator delete(void *p) { FREE(p); }
-    static void operator delete[](void *p) { FREE(p); }
-
-protected:
-    // This member is intended as a check for whether all necessary members in
-    // derived classes have been allocated. Consequently status::out_of_memory
-    // should be returned if a fail occurs. This member should be modified only
-    // in a constructor.
-    bool is_initialized_ = true;
-};
-
-#undef MALLOC
-#undef FREE
+void free(void *p);
 
 namespace nstl {
 
@@ -346,7 +313,7 @@ struct is_same<T, T> {
 enum nstl_status_t { success = 0, out_of_memory };
 
 template <typename T>
-class vector : public c_compatible { // NOLINT(readability-identifier-naming)
+class vector { // NOLINT(readability-identifier-naming)
 private:
     std::vector<T> _impl;
 
@@ -380,7 +347,7 @@ public:
 };
 
 template <typename Key, typename T>
-class map : public c_compatible { // NOLINT(readability-identifier-naming)
+class map { // NOLINT(readability-identifier-naming)
 private:
     std::map<Key, T> _impl;
 

--- a/src/common/primitive.hpp
+++ b/src/common/primitive.hpp
@@ -31,7 +31,7 @@ namespace impl {
 
 struct resource_mapper_t;
 // Primitive implementation
-struct primitive_t : public c_compatible {
+struct primitive_t {
     using primitive_list_t = std::vector<const primitive_t *>;
 
     primitive_t(const primitive_desc_t *pd) : pd_(pd->clone()) {}

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -778,7 +778,7 @@ status_t dnnl_post_ops_clone(
     if (any_null(post_ops, existing_post_ops)) return invalid_arguments;
 
     auto new_post_ops = utils::make_unique<post_ops_t>(*existing_post_ops);
-    if (!new_post_ops->is_initialized()) return out_of_memory;
+    if (!new_post_ops) return out_of_memory;
 
     return safe_ptr_assign(*post_ops, new_post_ops.release());
 }

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -38,7 +38,7 @@ namespace impl {
 
 const primitive_attr_t &default_attr();
 
-struct rnn_data_qparams_t : public c_compatible {
+struct rnn_data_qparams_t {
     rnn_data_qparams_t() : scale_(1.f), shift_(0.f) {}
     bool has_default_values() const { return (scale_ == 1. && shift_ == 0.); }
     bool defined() const {
@@ -61,7 +61,7 @@ struct rnn_data_qparams_t : public c_compatible {
     float shift_;
 };
 
-struct rnn_tparams_t : public c_compatible {
+struct rnn_tparams_t {
     rnn_tparams_t()
         : test_mode_(false), scales_(nullptr), ngates_(0), cscale_(0.0f) {}
 
@@ -128,7 +128,7 @@ private:
 };
 
 // Note: keep for RNN quantization
-struct rnn_create_time_scales_t : public c_compatible {
+struct rnn_create_time_scales_t {
     rnn_create_time_scales_t() : count_(1), mask_(0), scales_(scales_buf_) {
         set_single_scale(1.f);
     }
@@ -184,7 +184,7 @@ private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(rnn_create_time_scales_t);
 };
 
-struct dropout_t : public c_compatible {
+struct dropout_t {
     dropout_t() = default;
 
     bool has_default_values() const {
@@ -217,7 +217,7 @@ struct dropout_t : public c_compatible {
     bool use_host_scalars_ = false;
 };
 
-struct rnd_mode_t : public c_compatible {
+struct rnd_mode_t {
     rnd_mode_t() = default;
 
     bool has_default_values() const { return rounding_modes_map_.empty(); }
@@ -274,7 +274,7 @@ struct primitive_attr_item_t {
     virtual ~primitive_attr_item_t() = default;
 };
 
-struct fpmath_t : public c_compatible {
+struct fpmath_t {
     fpmath_t(dnnl_fpmath_mode_t mode = fpmath_mode::strict,
             bool apply_to_int = false)
         : mode_(mode), apply_to_int_(apply_to_int) {}
@@ -290,7 +290,7 @@ struct fpmath_t : public c_compatible {
 } // namespace impl
 } // namespace dnnl
 
-struct dnnl_post_ops : public dnnl::impl::c_compatible {
+struct dnnl_post_ops {
     struct entry_t {
         entry_t() : kind(dnnl::impl::primitive_kind::undefined) {}
 
@@ -529,8 +529,6 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
         return ret;
     }
 
-    bool is_initialized() const { return is_initialized_; }
-
     std::vector<entry_t> entry_;
 
     // Since binary post op accepts no more than 32 memory arguments by
@@ -549,7 +547,7 @@ private:
             const dnnl::impl::data_type_t dst_dt, const bool is_int8) const;
 };
 
-struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
+struct dnnl_primitive_attr {
     dnnl_primitive_attr()
         : scratchpad_mode_(dnnl::impl::scratchpad_mode::library)
         , fpmath_(dnnl::impl::get_fpmath_mode(), false)
@@ -562,8 +560,7 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
         return new dnnl_primitive_attr(*this);
     }
 
-    dnnl_primitive_attr(const dnnl_primitive_attr &other)
-        : c_compatible(other) {
+    dnnl_primitive_attr(const dnnl_primitive_attr &other) {
         if (copy_from(other) != dnnl::impl::status::success)
             is_initialized_ = false;
     }
@@ -755,6 +752,10 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
     dnnl::impl::rnd_mode_t rounding_mode_;
 
     std::unique_ptr<dnnl::impl::primitive_attr_item_t> gpu_attr_;
+
+    // Set to `false` when copying from another attribute fails, so that
+    // `status::out_of_memory` is reported.
+    bool is_initialized_ = true;
 
     dnnl_primitive_attr &operator=(const dnnl_primitive_attr &other) = delete;
 };

--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -45,7 +45,7 @@ namespace impl {
 struct quant_entry_t;
 const quant_entry_t &default_quant_entry();
 
-struct quant_entry_t : public c_compatible {
+struct quant_entry_t {
     quant_entry_t() = default;
     quant_entry_t(const quant_entry_t &e) = default;
     ~quant_entry_t() = default;
@@ -180,7 +180,7 @@ private:
 
 std::ostream &operator<<(std::ostream &ss, const quant_entry_t &e);
 
-struct quant_entries_t : public c_compatible {
+struct quant_entries_t {
     quant_entries_t(data_type_t default_data_type)
         : default_data_type_(default_data_type) {}
 

--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -35,9 +35,9 @@
 #include "common/utils.hpp"
 
 #include <algorithm>
+#include <map>
 #include <string>
 #include <vector>
-#include <unordered_map>
 
 namespace dnnl {
 namespace impl {

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -54,7 +54,7 @@ struct impl_list_item_t;
 struct primitive_t;
 // Primitive descriptor implementation
 // NOLINTBEGIN(google-default-arguments)
-struct primitive_desc_t : public c_compatible {
+struct primitive_desc_t {
     primitive_desc_t(const primitive_attr_t *attr, primitive_kind_t kind)
         : attr_(*attr), kind_(kind), pd_iterator_offset_(0), skip_idx_(-1) {
         is_initialized_ = is_initialized_ && attr_.is_initialized();
@@ -515,6 +515,10 @@ struct primitive_desc_t : public c_compatible {
     }
 
 protected:
+    // Set to `false` by derived classes (typically in a copy constructor) when
+    // a member allocation fails, so that `status::out_of_memory` is reported.
+    bool is_initialized_ = true;
+
     primitive_attr_t attr_;
     primitive_kind_t kind_;
     int pd_iterator_offset_;

--- a/src/common/primitive_desc_iface.hpp
+++ b/src/common/primitive_desc_iface.hpp
@@ -41,7 +41,7 @@ status_t primitive_desc_create(primitive_desc_iface_t **primitive_desc_iface,
 // can be stored in the primitive cache as part of the primitive implementation
 // to which it belongs
 // 2. engine_t - a dnnl engine
-struct dnnl_primitive_desc : public dnnl::impl::c_compatible {
+struct dnnl_primitive_desc {
     dnnl_primitive_desc(const std::shared_ptr<dnnl::impl::primitive_desc_t> &pd,
             dnnl::impl::engine_t *engine);
 

--- a/src/common/primitive_desc_iterator.hpp
+++ b/src/common/primitive_desc_iterator.hpp
@@ -32,7 +32,7 @@ namespace impl {
 
 struct primitive_desc_t;
 
-struct primitive_desc_iterator_t : public c_compatible {
+struct primitive_desc_iterator_t {
     primitive_desc_iterator_t(engine_t *engine, const op_desc_t *op_desc,
             const primitive_attr_t *attr, const primitive_desc_t *hint_fwd_pd,
             int skip_idx = -1)
@@ -48,7 +48,6 @@ struct primitive_desc_iterator_t : public c_compatible {
 
         while (impl_list_[last_idx_])
             ++last_idx_;
-        is_initialized_ = is_initialized_ && attr_.is_initialized();
     }
 
     engine_t *engine() const { return engine_; }
@@ -97,7 +96,9 @@ struct primitive_desc_iterator_t : public c_compatible {
 
     const primitive_attr_t &attr() const { return attr_; }
 
-    bool is_initialized() const { return is_initialized_; }
+    // The iterator is only usable if the attributes it copied were allocated
+    // successfully; delegate the check to the copied attributes.
+    bool is_initialized() const { return attr_.is_initialized(); }
 
 protected:
     int idx_;

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -23,6 +23,7 @@
 
 #include "dnnl_thread.hpp"
 #include "engine.hpp"
+#include "memory_desc.hpp"
 #include "primitive_hashing.hpp"
 
 namespace dnnl {
@@ -57,9 +58,18 @@ bool key_t::operator==(const key_t &rhs) const {
         && pd_iterator_offset_ == rhs.pd_iterator_offset_
         && impl_nthr_ == rhs.impl_nthr_
         && skip_idx_ == rhs.skip_idx_
-        && (*attr_) == (*rhs.attr_)
-        && std::equal(
-            hint_mds_.begin(), hint_mds_.end(), rhs.hint_mds_.begin());
+        && (*attr_) == (*rhs.attr_);
+    if (!ret) {
+        // ANCHOR: HASHING_DEBUGINFO_16.
+        VDEBUGINFO(16, primitive, hashing, "operator==,ret=%d", ret);
+        return ret;
+    }
+
+    for (size_t i = 0; i < rhs.hint_mds_.size(); i++) {
+        // Note: fast exit on `!ret` secures the same-sized hints. Make sure
+        // there will be no access out-of-bounds for hints on both sides.
+        ret = ret && hint_mds_[i] == rhs.hint_mds_[i];
+    }
 
     if (!ret) {
         // ANCHOR: HASHING_DEBUGINFO_16.

--- a/src/common/primitive_iface.hpp
+++ b/src/common/primitive_iface.hpp
@@ -49,7 +49,7 @@ status_t primitive_execute(
 //
 // Note: primitive_desc_iface_t and impl::primitive_t share the same
 // impl::primitive_desc_t
-struct dnnl_primitive : public dnnl::impl::c_compatible {
+struct dnnl_primitive {
     dnnl_primitive(const std::shared_ptr<dnnl::impl::primitive_t> &primitive,
             dnnl::impl::engine_t *engine);
 

--- a/src/common/resource.hpp
+++ b/src/common/resource.hpp
@@ -42,7 +42,7 @@ namespace impl {
 //
 // This abstraction takes ownership of all content it holds hence it should be
 // responsible for destroying it as well.
-struct resource_t : public c_compatible {
+struct resource_t {
     virtual ~resource_t() = default;
 };
 

--- a/src/common/stream.hpp
+++ b/src/common/stream.hpp
@@ -26,7 +26,7 @@
 #include "common/stream_impl.hpp"
 #include "common/utils.hpp"
 
-struct dnnl_stream : public dnnl::impl::c_compatible {
+struct dnnl_stream {
     dnnl_stream(dnnl::impl::engine_t *engine, dnnl::impl::stream_impl_t *impl)
         : engine_(engine), impl_(impl) {}
     virtual ~dnnl_stream() = default;

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -1270,15 +1270,15 @@ format_tag_t memory_desc_matches_one_of_tag(
     }
     return format_tag::undef;
 }
+inline bool any_memory_desc_host_scalar(const memory_desc_t *md) {
+    return md != nullptr && md->format_kind == format_kind::host_scalar;
+}
+
 template <typename... Args>
 inline bool any_memory_desc_host_scalar(const memory_desc_t *md, Args... mds) {
     if (md != nullptr && md->format_kind == format_kind::host_scalar)
         return true;
     return any_memory_desc_host_scalar(mds...);
-}
-
-inline bool any_memory_desc_host_scalar(const memory_desc_t *md) {
-    return md != nullptr && md->format_kind == format_kind::host_scalar;
 }
 
 } // namespace impl

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -186,8 +186,7 @@ int getpagesize() {
 #endif
 }
 
-// Add DNNL_API to make test_internals_cpu_ir work.
-void DNNL_API *malloc(size_t size, int alignment) {
+void *malloc(size_t size, int alignment) {
     void *ptr;
     if (memory_debug::is_mem_debug())
         return memory_debug::malloc(size, alignment);
@@ -202,8 +201,7 @@ void DNNL_API *malloc(size_t size, int alignment) {
     return (rc == 0) ? ptr : nullptr;
 }
 
-// Add DNNL_API to make test_internals_cpu_ir work.
-void DNNL_API free(void *p) {
+void free(void *p) {
 
     if (memory_debug::is_mem_debug()) return memory_debug::free(p);
 

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -29,6 +29,7 @@
 #include <locale>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <memory>
 #include <string>

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -16,6 +16,7 @@
 *******************************************************************************/
 
 #include <atomic>
+#include <map>
 #include <regex>
 #include <sstream>
 #include <type_traits>
@@ -1767,8 +1768,26 @@ void verbose_printf_impl(const char *raw_fmt_str, verbose_t::flag_kind kind) {
 #ifdef DNNL_EXPERIMENTAL_LOGGING
     const log_manager_t &log_manager = log_manager_t::get_log_manager();
 
-    if (log_manager.is_logger_enabled())
-        log_manager.log(fmt_str.c_str(), align_verbose_mode_to_log_level(kind));
+    if (log_manager.is_logger_enabled()) {
+        static const std::map<verbose_t::flag_kind, log_manager_t::log_level_t>
+                verbose_to_log_map {
+                        {verbose_t::all, log_manager_t::trace},
+                        {verbose_t::debuginfo, log_manager_t::debug},
+                        {verbose_t::level1, log_manager_t::info},
+                        {verbose_t::level2, log_manager_t::info},
+                        {verbose_t::create_dispatch, log_manager_t::info},
+                        {verbose_t::create_check, log_manager_t::info},
+                        {verbose_t::create_profile, log_manager_t::info},
+                        {verbose_t::profile_externals, log_manager_t::info},
+                        {verbose_t::exec_profile, log_manager_t::info},
+                        {verbose_t::exec_check, log_manager_t::error},
+                        {verbose_t::error, log_manager_t::critical},
+                        {verbose_t::warn, log_manager_t::warn},
+                        {verbose_t::none, log_manager_t::off},
+                };
+
+        log_manager.log(fmt_str.c_str(), verbose_to_log_map.at(kind));
+    }
     if (log_manager.is_console_enabled()) {
         printf("%s", fmt_str.c_str());
         fflush(stdout);

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -279,44 +279,6 @@ static inline uint32_t get_verbose_dev_mode(
 
 bool get_verbose_timestamp();
 
-// logging functionality for saving verbose outputs to logfiles
-#ifdef DNNL_EXPERIMENTAL_LOGGING
-inline const std::map<dnnl::impl::verbose_t::flag_kind,
-        log_manager_t::log_level_t> &
-get_verbose_to_log_level_map() {
-    static const std::map<dnnl::impl::verbose_t::flag_kind,
-            log_manager_t::log_level_t>
-            verbose_to_log_map {
-                    {verbose_t::all, log_manager_t::trace},
-                    {verbose_t::debuginfo, log_manager_t::debug},
-                    {verbose_t::level1, log_manager_t::info},
-                    {verbose_t::level2, log_manager_t::info},
-                    {verbose_t::create_dispatch, log_manager_t::info},
-                    {verbose_t::create_check, log_manager_t::info},
-                    {verbose_t::create_profile, log_manager_t::info},
-                    {verbose_t::profile_externals, log_manager_t::info},
-                    {verbose_t::exec_profile, log_manager_t::info},
-                    {verbose_t::exec_check, log_manager_t::error},
-                    {verbose_t::error, log_manager_t::critical},
-                    {verbose_t::warn, log_manager_t::warn},
-                    {verbose_t::none, log_manager_t::off},
-            };
-    return verbose_to_log_map;
-}
-
-// aligns the verbose modes to the logger levels when printing API output
-inline log_manager_t::log_level_t align_verbose_mode_to_log_level(
-        verbose_t::flag_kind kind) {
-    const auto &map = get_verbose_to_log_level_map();
-    auto it = map.find(kind);
-    if (it != map.end()) {
-        return it->second;
-    } else {
-        return log_manager_t::off;
-    }
-}
-#endif
-
 // Helpers to print verbose outputs to the console and the logfiles.
 // when logging is disabled, data is printed only to stdout.
 // when enabled, it is printed to the logfile and to stdout as well if

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -124,14 +124,7 @@ bool is_imm12(T imm) {
 
 } // namespace
 
-class jit_generator_t : public Xbyak_aarch64::CodeGenerator,
-                        public c_compatible {
-public:
-    using c_compatible::operator new;
-    using c_compatible::operator new[];
-    using c_compatible::operator delete;
-    using c_compatible::operator delete[];
-
+class jit_generator_t : public Xbyak_aarch64::CodeGenerator {
 private:
     const size_t xreg_len = 8;
     const size_t vreg_len_preserve = 8; // Only bottom 8byte must be preserved.

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -1991,7 +1991,7 @@ struct jit_bnorm_t : public jit_generator_t {
 namespace bnorm_impl {
 
 template <cpu_isa_t isa>
-struct driver_t : public c_compatible {
+struct driver_t {
     driver_t(const batch_normalization_pd_t *pd, int nthr)
         : pd_(pd), jbp_(pd_, nthr, simd_w_), ker_(pd_, &jbp_) {}
 

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
@@ -357,7 +357,7 @@ struct jit_bnorm_s8_t<sve_512> : public jit_bnorm_base_t<sve_512> {
 namespace bnorm_s8_impl {
 
 template <cpu_isa_t isa>
-struct driver_t : public c_compatible {
+struct driver_t {
     driver_t(const batch_normalization_pd_t *pd) : pd_(pd), ker_(pd_) {}
     ~driver_t() = default;
 

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -1045,7 +1045,7 @@ status_t jit_uni_softmax_bwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 namespace softmax_impl {
 
 template <cpu_isa_t isa>
-struct driver_t : public c_compatible {
+struct driver_t {
 
     driver_t(const softmax_pd_t *pd) : pd_(pd), ker_(pd_) {}
 

--- a/src/cpu/aarch64/ukernel/attr_params.hpp
+++ b/src/cpu/aarch64/ukernel/attr_params.hpp
@@ -24,7 +24,7 @@
 
 #ifdef DNNL_EXPERIMENTAL_UKERNEL
 
-struct dnnl_ukernel_attr_params : public dnnl::impl::c_compatible {
+struct dnnl_ukernel_attr_params {
     dnnl_ukernel_attr_params() = default;
 
     dnnl::impl::status_t set_post_ops_args(const void **post_ops_args);

--- a/src/cpu/aarch64/ukernel/brgemm.hpp
+++ b/src/cpu/aarch64/ukernel/brgemm.hpp
@@ -24,7 +24,7 @@
 
 #ifdef DNNL_EXPERIMENTAL_UKERNEL
 
-struct dnnl_brgemm : public dnnl::impl::c_compatible {
+struct dnnl_brgemm {
     dnnl_brgemm(dnnl::impl::dim_t M, dnnl::impl::dim_t N, dnnl::impl::dim_t K,
             dnnl::impl::dim_t batch_size, dnnl::impl::dim_t lda,
             dnnl::impl::dim_t ldb, dnnl::impl::dim_t ldc,

--- a/src/cpu/aarch64/ukernel/transform.hpp
+++ b/src/cpu/aarch64/ukernel/transform.hpp
@@ -26,7 +26,7 @@
 
 #ifdef DNNL_EXPERIMENTAL_UKERNEL
 
-struct dnnl_transform : public dnnl::impl::c_compatible {
+struct dnnl_transform {
     // Ctor that follows a call to initialize matmul conf struct.
     dnnl_transform(dnnl::impl::dim_t K, dnnl::impl::dim_t N,
             dnnl::impl::cpu::ukernel::pack_type_t in_pack_type,

--- a/src/cpu/rv64/jit_generator.hpp
+++ b/src/cpu/rv64/jit_generator.hpp
@@ -62,13 +62,8 @@ inline bool is_subset(cpu_isa_t isa, cpu_isa_t max_isa) {
 }
 
 // Minimal RV64 JIT generator base class.
-class jit_generator_t : public Xbyak_riscv::CodeGenerator, public c_compatible {
+class jit_generator_t : public Xbyak_riscv::CodeGenerator {
 public:
-    using c_compatible::operator new;
-    using c_compatible::operator new[];
-    using c_compatible::operator delete;
-    using c_compatible::operator delete[];
-
     // All JIT kernels must override these to provide a stable name used for
     // debug/logging and jit code registration.
     virtual const char *name() const = 0;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -23,6 +23,8 @@
 #include "cpu/x64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/x64/jit_brgemm_conv.hpp"
 
+#include <vector>
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -1162,10 +1164,10 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     if (jcp.req_cal_comp_pad && jcp.exec_type != exec_vpad) {
         comp_owb.resize(jcp.nb_ow, -1);
-        vector<int> ow_kw_b(jcp.ow, -1);
-        vector<int> ow_kw_e(jcp.ow, -1);
-        vector<int> comp_ow_kw_s(jcp.comp_ow_size, -1);
-        vector<int> comp_ow_kw_f(jcp.comp_ow_size, -1);
+        std::vector<int> ow_kw_b(jcp.ow, -1);
+        std::vector<int> ow_kw_e(jcp.ow, -1);
+        std::vector<int> comp_ow_kw_s(jcp.comp_ow_size, -1);
+        std::vector<int> comp_ow_kw_f(jcp.comp_ow_size, -1);
         dim_t comp_ow_l = 0;
 
         for (int ow = 0; ow < OW;) {
@@ -1524,8 +1526,8 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
     if (!jcp.req_cal_comp_pad) return status::success;
 
     // TODO: taking them by copy might affect the performance.
-    vector<int> adjusted_k;
-    vector<int> adjusted_k_l;
+    std::vector<int> adjusted_k;
+    std::vector<int> adjusted_k_l;
     int vpad_k = 0;
     const bool has_relo_large_spatial /* heuristic*/
             = is_relo_with_relo_weights && jcp.oc_block * jcp.ow > 10240;

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -17,6 +17,8 @@
 #include "cpu/x64/jit_brgemm_conv_comp_pad_kernel.hpp"
 #include "cpu/x64/jit_brgemm_conv_utils.hpp"
 
+#include <vector>
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -281,8 +283,8 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::bwd_kw_iw_loop(const int icb,
     const auto LP = jcp_.l_pad;
     const auto nb_iw = div_up(jcp_.iw, SW);
 
-    vector<int> ker_kw_ow_b(SW * KW, -1);
-    vector<int> ker_kw_ow_e(SW * KW, -1);
+    std::vector<int> ker_kw_ow_b(SW * KW, -1);
+    std::vector<int> ker_kw_ow_e(SW * KW, -1);
 
     for_(int sw = 0; sw < SW; sw++)
     for (int iwb = 0; iwb < nb_iw; iwb++) {
@@ -331,10 +333,10 @@ template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::fwd_kw_ow_loop(const int icb,
         const int icb_tail, const int ic_step, const int m_block,
         const int mb_tail, const int n_block, const bool use_inversion) {
-    vector<int> kw_ow_b(jcp_.kw, -1);
-    vector<int> kw_ow_e(jcp_.kw, -1);
-    vector<int> comp_ow_kw_s(jcp_.comp_ow_size, -1);
-    vector<int> comp_ow_kw_f(jcp_.comp_ow_size, -1);
+    std::vector<int> kw_ow_b(jcp_.kw, -1);
+    std::vector<int> kw_ow_e(jcp_.kw, -1);
+    std::vector<int> comp_ow_kw_s(jcp_.comp_ow_size, -1);
+    std::vector<int> comp_ow_kw_f(jcp_.comp_ow_size, -1);
     dim_t comp_ow_l = 0;
     const auto DW = jcp_.dilate_w + 1;
 
@@ -607,8 +609,8 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store(
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::kw_loop(
         const int n_block) {
-    vector<int> ow_kw_b(jcp_.ow, -1);
-    vector<int> ow_kw_e(jcp_.ow, -1);
+    std::vector<int> ow_kw_b(jcp_.ow, -1);
+    std::vector<int> ow_kw_e(jcp_.ow, -1);
     int prev_comp_ow = 0;
     const auto DW = jcp_.dilate_w + 1;
     for (int ow = 0; ow < jcp_.ow; ow++) {

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -156,14 +156,7 @@ constexpr Xbyak::Operand::Code abi_not_param_reg =
 #endif
 
 class jit_generator_t : public Xbyak::MmapAllocator,
-                        public Xbyak::CodeGenerator,
-                        public c_compatible {
-public:
-    using c_compatible::operator new;
-    using c_compatible::operator new[];
-    using c_compatible::operator delete;
-    using c_compatible::operator delete[];
-
+                        public Xbyak::CodeGenerator {
 private:
     const size_t xmm_len = 16;
 #ifdef _WIN32

--- a/src/cpu/x64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.cpp
@@ -2117,7 +2117,7 @@ struct jit_bnorm_t : public jit_generator_t {
 namespace bnorm_impl {
 
 template <cpu_isa_t isa>
-struct driver_t : public c_compatible {
+struct driver_t {
     driver_t(const batch_normalization_pd_t *pd, int nthr)
         : pd_(pd), jbp_(pd_, nthr, simd_w), ker_(pd_, &jbp_) {}
 

--- a/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
@@ -643,7 +643,7 @@ struct jit_bnorm_s8_t<sse41> : public jit_bnorm_base_t<sse41> {
 namespace bnorm_s8_impl {
 
 template <cpu_isa_t isa>
-struct driver_t : public c_compatible {
+struct driver_t {
     driver_t(const batch_normalization_pd_t *pd) : pd_(pd), ker_(pd_) {}
     ~driver_t() = default;
 

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -1896,7 +1896,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
 namespace bnorm_tbb_impl {
 
 template <cpu_isa_t isa>
-struct driver_t : public c_compatible {
+struct driver_t {
 private:
     struct bnorm_dims_t {
         dim_t N, C, S;

--- a/src/cpu/x64/ukernel/attr_params.hpp
+++ b/src/cpu/x64/ukernel/attr_params.hpp
@@ -23,7 +23,7 @@
 
 #ifdef DNNL_EXPERIMENTAL_UKERNEL
 
-struct dnnl_ukernel_attr_params : public dnnl::impl::c_compatible {
+struct dnnl_ukernel_attr_params {
     dnnl_ukernel_attr_params() = default;
 
     dnnl::impl::status_t set_post_ops_args(const void **post_ops_args);

--- a/src/cpu/x64/ukernel/brgemm.hpp
+++ b/src/cpu/x64/ukernel/brgemm.hpp
@@ -26,7 +26,7 @@
 
 #ifdef DNNL_EXPERIMENTAL_UKERNEL
 
-struct dnnl_brgemm : public dnnl::impl::c_compatible {
+struct dnnl_brgemm {
     dnnl_brgemm(dnnl::impl::dim_t M, dnnl::impl::dim_t N, dnnl::impl::dim_t K,
             dnnl::impl::dim_t batch_size, dnnl::impl::dim_t lda,
             dnnl::impl::dim_t ldb, dnnl::impl::dim_t ldc,

--- a/src/cpu/x64/ukernel/transform.hpp
+++ b/src/cpu/x64/ukernel/transform.hpp
@@ -26,7 +26,7 @@
 
 #ifdef DNNL_EXPERIMENTAL_UKERNEL
 
-struct dnnl_transform : public dnnl::impl::c_compatible {
+struct dnnl_transform {
     // Ctor that follows a call to initialize matmul conf struct.
     dnnl_transform(dnnl::impl::dim_t K, dnnl::impl::dim_t N,
             dnnl::impl::cpu::ukernel::pack_type_t in_pack_type,


### PR DESCRIPTION
Remove outdated `c_compatible` and `nstl` functionality to simplify the software stack.