### PR TITLE
x64: resampling: fix implicit narrowing conversions

### DIFF
--- a/src/cpu/simple_resampling.cpp
+++ b/src/cpu/simple_resampling.cpp
@@ -82,13 +82,13 @@ status_t simple_resampling_kernel_t::init() {
 }
 
 status_t simple_resampling_kernel_t::execute(const exec_ctx_t &ctx) const {
-    const int OD = pd_->OD();
-    const int OH = pd_->OH();
-    const int OW = pd_->OW();
-    const int ID = pd_->ID();
-    const int IH = pd_->IH();
-    const int IW = pd_->IW();
-    const int NB_CH = utils::div_up(pd_->C(), inner_stride_);
+    const dim_t OD = pd_->OD();
+    const dim_t OH = pd_->OH();
+    const dim_t OW = pd_->OW();
+    const dim_t ID = pd_->ID();
+    const dim_t IH = pd_->IH();
+    const dim_t IW = pd_->IW();
+    const dim_t NB_CH = utils::div_up(pd_->C(), inner_stride_);
 
     if (pd_->is_fwd()) {
         const auto src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -623,16 +623,16 @@ struct jit_uni_pooling_args_t {
 };
 
 struct jit_resampling_conf_t {
-    unsigned ndims = 0;
+    dim_t ndims = 0;
 
-    unsigned c = 0;
-    unsigned id = 0, ih = 0, iw = 0;
-    unsigned od = 0, oh = 0, ow = 0;
+    dim_t c = 0;
+    dim_t id = 0, ih = 0, iw = 0;
+    dim_t od = 0, oh = 0, ow = 0;
 
-    unsigned stride_d = 0;
-    unsigned stride_h = 0;
-    unsigned stride_w = 0;
-    unsigned inner_stride = 0;
+    dim_t stride_d = 0;
+    dim_t stride_h = 0;
+    dim_t stride_w = 0;
+    dim_t inner_stride = 0;
 
     // The linear algorithm is an approximation of the point
     // value based on the limit values. For one dimension,

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -35,6 +35,13 @@ namespace x64 {
 
 using namespace resampling_utils;
 
+// Offsets are stored in the 32-bit gather-index buffer
+// This function safely casts the offset.
+static unsigned to_gather_index(dim_t offset) {
+    assert(offset >= 0 && offset <= UINT32_MAX);
+    return static_cast<unsigned>(offset);
+}
+
 static cpu_isa_t get_supported_isa(bool is_plain) {
     if (is_plain && mayiuse(avx512_core_fp16)) return avx512_core_fp16;
     if (mayiuse(avx512_core_bf16)) return avx512_core_bf16;
@@ -109,7 +116,7 @@ status_t jit_uni_resampling_fwd_t::pd_t::init(engine_t *engine) {
     conf_.ndims = ndims();
 
     if (conf_.alg == alg_kind::resampling_linear)
-        conf_.number_of_corners = pow(2, conf_.ndims - 2);
+        conf_.number_of_corners = 1u << (conf_.ndims - 2);
 
     conf_.src_dt_size = types::data_type_size(conf_.src_data_type);
     conf_.dst_dt_size = types::data_type_size(conf_.dst_data_type);
@@ -301,18 +308,21 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_nearest() {
             + utils::rnd_up(pd()->OW(), kernel_->get_simd_w()));
 
     for (dim_t od = 0; od < pd()->OD(); od++) {
-        const int offset_id = nearest_idx(od, pd()->OD(), pd()->ID())
-                * pd()->get_conf().stride_d;
+        const unsigned offset_id
+                = to_gather_index(nearest_idx(od, pd()->OD(), pd()->ID())
+                        * pd()->get_conf().stride_d);
         indices_.emplace_back(offset_id);
     }
     for (dim_t oh = 0; oh < pd()->OH(); oh++) {
-        const int offset_ih = nearest_idx(oh, pd()->OH(), pd()->IH())
-                * pd()->get_conf().stride_h;
+        const unsigned offset_ih
+                = to_gather_index(nearest_idx(oh, pd()->OH(), pd()->IH())
+                        * pd()->get_conf().stride_h);
         indices_.emplace_back(offset_ih);
     }
     for (dim_t ow = 0; ow < pd()->OW(); ow++) {
-        const int offset_iw = nearest_idx(ow, pd()->OW(), pd()->IW())
-                * pd()->get_conf().stride_w;
+        const unsigned offset_iw
+                = to_gather_index(nearest_idx(ow, pd()->OW(), pd()->IW())
+                        * pd()->get_conf().stride_w);
         indices_.emplace_back(offset_iw);
     }
 
@@ -322,12 +332,12 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_nearest() {
 status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
     using namespace resampling_utils;
 
-    const unsigned number_of_corners = pd()->get_conf().number_of_corners;
-    const unsigned stride_w = pd()->get_conf().stride_w;
-    const unsigned stride_h = pd()->get_conf().stride_h;
-    const unsigned stride_d = pd()->get_conf().stride_d;
+    const dim_t number_of_corners = pd()->get_conf().number_of_corners;
+    const dim_t stride_w = pd()->get_conf().stride_w;
+    const dim_t stride_h = pd()->get_conf().stride_h;
+    const dim_t stride_d = pd()->get_conf().stride_d;
 
-    unsigned num_of_elements = 0;
+    dim_t num_of_elements = 0;
     if (pd()->get_conf().tag_kind == jit_memory_tag_kind_t::ncsp) {
         // In kernel is used vmovdqu to get indices. This instruction don't have
         // tail processing possibilities on sse41 and avx. To avoid problems
@@ -356,10 +366,10 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
                 for (unsigned i = 0; i < number_of_corners; i++) {
                     std::bitset<3> corners(i);
-                    indices_[i * indices_stride + offset]
-                            = coeffs_id.idx[corners.test(2)] * stride_d
+                    indices_[i * indices_stride + offset] = to_gather_index(
+                            coeffs_id.idx[corners.test(2)] * stride_d
                             + coeffs_ih.idx[corners.test(1)] * stride_h
-                            + coeffs_iw.idx[corners.test(0)] * stride_w;
+                            + coeffs_iw.idx[corners.test(0)] * stride_w);
                     weights_[i * weights_stride + offset]
                             = coeffs_id.wei[corners.test(2)]
                             * coeffs_ih.wei[corners.test(1)]
@@ -390,8 +400,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
             // to read and makes the operation faster.
             weights_w[2 * ow] = coeffs_iw.wei[0];
             weights_w[2 * ow + 1] = coeffs_iw.wei[1];
-            indices_w[2 * ow] = coeffs_iw.idx[0] * stride_w;
-            indices_w[2 * ow + 1] = coeffs_iw.idx[1] * stride_w;
+            indices_w[2 * ow] = to_gather_index(coeffs_iw.idx[0] * stride_w);
+            indices_w[2 * ow + 1]
+                    = to_gather_index(coeffs_iw.idx[1] * stride_w);
         }
 
         for (dim_t oh = 0; oh < pd()->OH(); oh++) {
@@ -399,8 +410,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_h[oh] = coeffs_ih.wei[0];
             weights_h[pd()->OH() + oh] = coeffs_ih.wei[1];
-            indices_h[oh] = coeffs_ih.idx[0] * stride_h;
-            indices_h[pd()->OH() + oh] = coeffs_ih.idx[1] * stride_h;
+            indices_h[oh] = to_gather_index(coeffs_ih.idx[0] * stride_h);
+            indices_h[pd()->OH() + oh]
+                    = to_gather_index(coeffs_ih.idx[1] * stride_h);
         }
 
         for (dim_t od = 0; od < pd()->OD(); od++) {
@@ -408,8 +420,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_d[od] = coeffs_id.wei[0];
             weights_d[pd()->OD() + od] = coeffs_id.wei[1];
-            indices_d[od] = coeffs_id.idx[0] * stride_d;
-            indices_d[pd()->OD() + od] = coeffs_id.idx[1] * stride_d;
+            indices_d[od] = to_gather_index(coeffs_id.idx[0] * stride_d);
+            indices_d[pd()->OD() + od]
+                    = to_gather_index(coeffs_id.idx[1] * stride_d);
         }
     } else {
         assert(!"Invalid memory format kind.");

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -146,12 +146,13 @@ std::size_t jit_uni_resampling_kernel_t<isa, Vmm>::calculate_tail_size() const {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_resampling_kernel_t<isa, Vmm>::get_channels_to_compute_without_tail(
-        const bool is_tail_in_blocked_format) const {
+dim_t jit_uni_resampling_kernel_t<isa,
+        Vmm>::get_channels_to_compute_without_tail(const bool
+                is_tail_in_blocked_format) const {
     assert(utils::one_of(conf_.tag_kind, tag_kind::blocked, tag_kind::nspc)
             && "Incorrect memory tag.");
 
-    int c_to_compute_without_tail = 0;
+    dim_t c_to_compute_without_tail = 0;
 
     if (conf_.tag_kind == tag_kind::blocked && is_tail_in_blocked_format) {
         // Example:
@@ -301,17 +302,17 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::apply_postops(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
-        const int c_to_compute_without_tail, const bool is_tail) {
-    const int c_to_compute_with_tail
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
+    const dim_t c_to_compute_with_tail
             = is_tail ? utils::rnd_up(tail_size_, simd_w_) : 0;
-    const int c_to_zeroing = conf_.inner_stride - c_to_compute_without_tail
+    const dim_t c_to_zeroing = conf_.inner_stride - c_to_compute_without_tail
             - c_to_compute_with_tail;
 
     if (c_to_zeroing > 0) {
         assert(c_to_zeroing % simd_w_ == 0);
         const Vmm vmm_zeros(vmm_tmp_.getIdx());
 
-        for (int c = 0; c < c_to_zeroing; c += simd_w_) {
+        for (dim_t c = 0; c < c_to_zeroing; c += simd_w_) {
             uni_vxorps(vmm_zeros, vmm_zeros, vmm_zeros);
             const auto dst_address = ptr[reg_dst_ + c * conf_.dst_dt_size];
             io_.at(conf_.dst_data_type)->store(vmm_zeros, dst_address, false);
@@ -324,8 +325,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::interpolate_c_oriented_format(
         const c_oriented_generation_fn_t &generation_fn) {
-    const unsigned c_with_padding = utils::rnd_up(conf_.c, conf_.inner_stride);
-    const unsigned padding_size_to_preserve = c_with_padding - conf_.c;
+    const dim_t c_with_padding = utils::rnd_up(conf_.c, conf_.inner_stride);
+    const dim_t padding_size_to_preserve = c_with_padding - conf_.c;
 
     if (padding_size_to_preserve > 0 && conf_.tag_kind == tag_kind::blocked) {
         Label tail_label;
@@ -410,7 +411,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_ncsp_format() {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
-        const int c_to_compute_without_tail, const bool is_tail) {
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
     const Reg64 &reg_c = reg_tmp_;
     const Reg64 &reg_src_shifted = reg_aux_src_0_;
 
@@ -454,7 +455,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa,
-        Vmm>::compute_ne_xf16_nearest_c_interpolate(const int
+        Vmm>::compute_ne_xf16_nearest_c_interpolate(const dim_t
                 c_to_compute_without_tail) {
     const Reg64 &reg_c = reg_tmp_;
     const Reg64 &reg_src_shifted = reg_aux_src_0_;
@@ -501,12 +502,12 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
     const bool has_ne_xf16_supported = isa == avx2_vnni_2
             && utils::one_of(
                     conf_.src_data_type, data_type::bf16, data_type::f16);
-    const int total_c_to_compute_without_tail
+    const dim_t total_c_to_compute_without_tail
             = get_channels_to_compute_without_tail(is_tail_in_blocked_format);
-    const int c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
+    const dim_t c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
             ? utils::rnd_dn(total_c_to_compute_without_tail, 2 * simd_w_)
             : 0;
-    const int c_to_compute_without_tail = total_c_to_compute_without_tail
+    const dim_t c_to_compute_without_tail = total_c_to_compute_without_tail
             - c_to_compute_ne_xf16_without_tail;
     const bool insert_tail_processsing_code
             = (conf_.tag_kind == tag_kind::nspc && tail_size_ > 0)
@@ -549,10 +550,9 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
-    const unsigned indices_stride
+    const dim_t indices_stride
             = conf_.ow * conf_.oh * conf_.od * conf_.el_size_of_indices;
-    const unsigned weights_stride
-            = conf_.ow * conf_.oh * conf_.od * sizeof(float);
+    const dim_t weights_stride = conf_.ow * conf_.oh * conf_.od * sizeof(float);
 
     auto linear_interpolation = [&](const bool is_tail) {
         const Vmm vmm_dst(vmm_idx(0));
@@ -608,7 +608,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa,
-        Vmm>::compute_ne_xf16_linear_c_interpolate(const int
+        Vmm>::compute_ne_xf16_linear_c_interpolate(const dim_t
                 c_to_compute_without_tail) {
     const Reg64 &reg_c = reg_tmp_;
 
@@ -692,7 +692,7 @@ void jit_uni_resampling_kernel_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::compute_linear_c_interpolate(
-        const int c_to_compute_without_tail, const bool is_tail) {
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
     const Reg64 &reg_c = reg_tmp_;
 
     const std::vector<std::reference_wrapper<const Vmm>> src_vmms
@@ -786,12 +786,12 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_c_oriented_format(
     const bool has_ne_xf16_supported = isa == avx2_vnni_2 && conf_.ndims <= 4
             && utils::one_of(
                     conf_.src_data_type, data_type::bf16, data_type::f16);
-    const int total_c_to_compute_without_tail
+    const dim_t total_c_to_compute_without_tail
             = get_channels_to_compute_without_tail(is_tail_in_blocked_format);
-    const int c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
+    const dim_t c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
             ? utils::rnd_dn(total_c_to_compute_without_tail, 2 * simd_w_)
             : 0;
-    const int c_to_compute_without_tail = total_c_to_compute_without_tail
+    const dim_t c_to_compute_without_tail = total_c_to_compute_without_tail
             - c_to_compute_ne_xf16_without_tail;
     const bool insert_tail_processsing_code
             = (conf_.tag_kind == tag_kind::nspc && tail_size_ > 0)

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -75,7 +75,7 @@ private:
 
     bool can_movntps_be_used() const;
     std::size_t calculate_tail_size() const;
-    int get_channels_to_compute_without_tail(
+    dim_t get_channels_to_compute_without_tail(
             bool is_tail_in_blocked_format) const;
 
     std::map<data_type_t, io::io_saturation_conf_t>
@@ -90,7 +90,7 @@ private:
             const int data_idx, const bool is_tail, const size_t offset = 0);
 
     void preserve_zero_padding(
-            int c_to_compute_without_tail, const bool is_tail);
+            dim_t c_to_compute_without_tail, const bool is_tail);
 
     void interpolate_c_oriented_format(
             const c_oriented_generation_fn_t &generation_fn);
@@ -99,13 +99,13 @@ private:
     void linear_ncsp_format();
     void linear_c_oriented_format(const bool is_tail_in_blocked_format);
     void compute_nearest_c_interpolate(
-            const int c_to_compute_without_tail, const bool is_tail);
+            const dim_t c_to_compute_without_tail, const bool is_tail);
     void compute_ne_xf16_nearest_c_interpolate(
-            const int c_to_compute_without_tail);
+            const dim_t c_to_compute_without_tail);
     void compute_linear_c_interpolate(
-            const int c_to_compute_without_tail, const bool is_tail);
+            const dim_t c_to_compute_without_tail, const bool is_tail);
     void compute_ne_xf16_linear_c_interpolate(
-            const int c_to_compute_without_tail);
+            const dim_t c_to_compute_without_tail);
 
     void generate() override;
 


### PR DESCRIPTION
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Affected only on **resampling**. 
