### PR TITLE
x64: binary: fix implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -80,7 +80,7 @@ void brgemm_desc_t::cleanup_dst_md() {
     dst_md_ = nullptr;
 }
 
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
     brgemm_kernel_params_t brgemm_p;
@@ -108,7 +108,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
@@ -136,7 +136,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
@@ -179,7 +179,7 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -637,7 +637,7 @@ status_t brgemm_desc_set_attr(
 status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     if (brg == nullptr) return status::invalid_arguments;
 
-    const int max_vpad = nstl::max(
+    const dim_t max_vpad = nstl::max(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
     if (brg->is_dgmm)
@@ -648,7 +648,7 @@ status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     if (!brg->is_dgmm) {
         // virtual padding is restricted by bd_block size due to
         // brgemm_kernel implementation. TODO: remove this restriction
-        const int min_bd_block
+        const dim_t min_bd_block
                 = brg->bdb_tail > 0 ? brg->bdb_tail : brg->bd_block;
         if ((max_vpad > min_bd_block)) return status::unimplemented;
     }
@@ -742,12 +742,12 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
     for (int i = 0; i < max_palette_size_in_bytes; i++)
         _tc[i] = 0;
 
-    const int typesize_A
+    const dim_t typesize_A
             = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_A;
-    const int typesize_B
+    const dim_t typesize_B
             = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_B;
 
-    const int rd_step = 4 / typesize_A;
+    const dim_t rd_step = 4 / typesize_A;
 
     const auto Ac = typesize_A * rd_block;
 

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -213,7 +213,7 @@ status_t DNNL_API brgemm_kernel_destroy(brgemm_kernel_t *brg_kernel);
 ///     * In rest scenarios is not used.
 /// @param dynamic_values TODO: missing doc
 ///
-void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C,
         void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);
@@ -240,7 +240,7 @@ void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
 ///     * In rest scenarios is not used.
 /// @param dynamic_values TODO: missing doc
 ///
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C,
         void *scratch = nullptr,
@@ -269,7 +269,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
 /// @param dynamic_values TODO: missing doc
 ///
 void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
-        int bs, const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
+        dim_t bs, const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);
 
@@ -299,7 +299,7 @@ void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
 /// @param dynamic_values TODO: missing doc
 ///
 void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
-        int bs, const void *addr_A, const void *addr_B,
+        dim_t bs, const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -39,7 +39,7 @@ brgemm_kernel_container_t::get_set() {
     return set_;
 }
 
-bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
+bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
         const std::vector<char> &bd_mask,
         const std::vector<brgemm_batch_element_t> &static_offsets) {
     bd_mask_list_.push_back(bd_mask);
@@ -100,7 +100,7 @@ bool brgemm_kernel_container_t::brgemm_kernel_cmp(
     return (std::memcmp(lcode, rcode, lsz) < 0);
 }
 
-status_t brgemm_kernel_container_t::insert(int idx, const brgemm_desc_t *brg) {
+status_t brgemm_kernel_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
     // Use two level hashing of brgemm kernels:
     // 1. Try to find entry in local brgemm_map_ using brgemm descriptor as a
     // key (we can check if brgemm descriptor is unique inside brgemm primitive)
@@ -123,7 +123,7 @@ status_t brgemm_kernel_container_t::insert(int idx, const brgemm_desc_t *brg) {
     return status::success;
 }
 
-bool brgemm_palette_container_t::insert(int idx, const brgemm_desc_t *brg) {
+bool brgemm_palette_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
     S_t kernel_palette;
     auto status = brgemm_init_tiles(*brg, kernel_palette.data());
     if (status != status::success) return false;

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -49,7 +49,7 @@ bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
 
     const auto ret = map_.insert({brg, idx});
-    const int ref_size = refs_.size();
+    const dim_t ref_size = refs_.size();
     if (idx > ref_size - 1) { refs_.resize(idx + 1); }
     refs_[idx] = &(ret.first->first);
     // if there was no insertion then clean bd_mask and static_offsets
@@ -60,7 +60,7 @@ bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
     return ret.second;
 }
 
-int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
+dim_t brgemm_desc_container_t::insert(brgemm_desc_t &brg,
         const std::vector<char> &bd_mask,
         const std::vector<brgemm_batch_element_t> &static_offsets) {
     bd_mask_list_.push_back(bd_mask);
@@ -68,7 +68,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
 
     static_offsets_list_.push_back(static_offsets);
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
-    const int ref_size = refs_.size();
+    const dim_t ref_size = refs_.size();
     const auto ret = map_.insert({brg, -1});
     if (!ret.second) {
         // if there was no insertion then clean bd_mask and static_offsets
@@ -77,7 +77,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
         return ret.first->second;
     }
 
-    int idx = map_.size() - 1;
+    const dim_t idx = map_.size() - 1;
     if (idx > ref_size - 1) {
         if (ref_size == 0)
             refs_.resize(1);
@@ -100,7 +100,8 @@ bool brgemm_kernel_container_t::brgemm_kernel_cmp(
     return (std::memcmp(lcode, rcode, lsz) < 0);
 }
 
-status_t brgemm_kernel_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
+status_t brgemm_kernel_container_t::insert(
+        dim_t idx, const brgemm_desc_t *brg) {
     // Use two level hashing of brgemm kernels:
     // 1. Try to find entry in local brgemm_map_ using brgemm descriptor as a
     // key (we can check if brgemm descriptor is unique inside brgemm primitive)

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -39,13 +39,13 @@ public:
     void resize(size_t ns) { refs_.resize(ns); }
     inline const brgemm_desc_t *operator[](int idx) const { return refs_[idx]; }
 
-    bool insert(int idx, brgemm_desc_t &brg) {
+    bool insert(dim_t idx, brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
         std::vector<brgemm_batch_element_t> dummy_static_offsets;
         return insert(idx, brg, dummy_bd_mask, dummy_static_offsets);
     }
 
-    bool insert(int idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
+    bool insert(dim_t idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
     int insert(brgemm_desc_t &brg) {
@@ -78,7 +78,7 @@ struct brgemm_kernel_container_t {
         return refs_[idx];
     }
 
-    status_t insert(int idx, const brgemm_desc_t *brg);
+    status_t insert(dim_t idx, const brgemm_desc_t *brg);
     static bool brgemm_kernel_cmp(const std::shared_ptr<brgemm_kernel_t> &lhs,
             const std::shared_ptr<brgemm_kernel_t> &rhs);
 
@@ -117,12 +117,12 @@ struct brgemm_palette_container_t {
     brgemm_palette_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
 
-    inline const char *operator[](int idx) const { return refs_[idx]->data(); }
+    inline const char *operator[](dim_t idx) const { return refs_[idx]->data(); }
 
-    bool insert(int idx, const brgemm_desc_t *brg);
-    bool insert(int idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
+    bool insert(dim_t idx, const brgemm_desc_t *brg);
+    bool insert(dim_t idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
 
-    inline void maybe_tile_configure(bool is_amx, int &idx, int new_idx) const {
+    inline void maybe_tile_configure(bool is_amx, dim_t &idx, dim_t new_idx) const {
         if (idx == new_idx) return;
         if (is_amx && (idx < 0 || refs_[idx] != refs_[new_idx]))
             amx_tile_configure(refs_[new_idx]->data());

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -37,7 +37,10 @@ public:
     brgemm_desc_container_t() = default;
     brgemm_desc_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
-    inline const brgemm_desc_t *operator[](int idx) const { return refs_[idx]; }
+    inline const brgemm_desc_t *operator[](dim_t idx) const {
+        assert(idx >= 0);
+        return refs_[idx];
+    }
 
     bool insert(dim_t idx, brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
@@ -48,13 +51,13 @@ public:
     bool insert(dim_t idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
-    int insert(brgemm_desc_t &brg) {
+    dim_t insert(brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
         std::vector<brgemm_batch_element_t> dummy_static_offsets;
         return insert(brg, dummy_bd_mask, dummy_static_offsets);
     }
 
-    int insert(brgemm_desc_t &brg, const std::vector<char> &bd_mask,
+    dim_t insert(brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
     size_t refs_size() { return refs_.size(); }
@@ -62,7 +65,7 @@ public:
 private:
     std::vector<const brgemm_desc_t *> refs_;
 
-    std::map<brgemm_desc_t, int> map_;
+    std::map<brgemm_desc_t, dim_t> map_;
     std::vector<std::vector<char>> bd_mask_list_;
     std::vector<std::vector<brgemm_batch_element_t>> static_offsets_list_;
 };
@@ -74,7 +77,8 @@ struct brgemm_kernel_container_t {
     brgemm_kernel_container_t() = default;
     brgemm_kernel_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
-    inline const brgemm_kernel_t *operator[](int idx) const {
+    inline const brgemm_kernel_t *operator[](dim_t idx) const {
+        assert(idx >= 0);
         return refs_[idx];
     }
 
@@ -117,12 +121,18 @@ struct brgemm_palette_container_t {
     brgemm_palette_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
 
-    inline const char *operator[](dim_t idx) const { return refs_[idx]->data(); }
+    inline const char *operator[](dim_t idx) const {
+        assert(idx >= 0);
+        return refs_[idx]->data();
+    }
 
     bool insert(dim_t idx, const brgemm_desc_t *brg);
-    bool insert(dim_t idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
+    bool insert(dim_t idx, const brgemm_desc_t &brg) {
+        return insert(idx, &brg);
+    }
 
-    inline void maybe_tile_configure(bool is_amx, dim_t &idx, dim_t new_idx) const {
+    inline void maybe_tile_configure(
+            bool is_amx, dim_t &idx, dim_t new_idx) const {
         if (idx == new_idx) return;
         if (is_amx && (idx < 0 || refs_[idx] != refs_[new_idx]))
             amx_tile_configure(refs_[new_idx]->data());

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -168,8 +168,8 @@ struct DNNL_API brgemm_attr_t {
     // then "max_bs" is the the only batch size that can be used on kernel call
     // else "max_bs" is the maximum batch size that can be used
     dim_t max_bs;
-    int max_top_vpad, max_bottom_vpad;
-    int max_top_bpad, max_bottom_bpad;
+    dim_t max_top_vpad, max_bottom_vpad;
+    dim_t max_top_bpad, max_bottom_bpad;
     dim_t hint_expected_A_size, hint_expected_B_size, hint_expected_C_size;
     brgemm_kernel_innermost_loop_t hint_innermost_loop
             = brgemm_ld_loop_innermost;
@@ -201,7 +201,7 @@ struct DNNL_API brgemm_attr_t {
     // 0 – bd_mask is not used
     // 1 – bd_mask is used on storing stage only
     // 2 – bd_mask used both on reading and storing stages
-    int bd_mask_level;
+    dim_t bd_mask_level;
     // use_uker is a boolean value that determines whether to use the unrolled
     // kernel or not
     bool use_uker;
@@ -221,12 +221,12 @@ struct DNNL_API brgemm_attr_t {
     bool var_bs {false};
     bool postops_only {false};
     // Hint for bs_group value in brgemm_desc_t
-    int hint_bs_group {0};
+    dim_t hint_bs_group {0};
 
-    int hint_bd_block {0};
-    int hint_ld_block {0};
-    int hint_bd_block2 {0};
-    int hint_ld_block2 {0};
+    dim_t hint_bd_block {0};
+    dim_t hint_ld_block {0};
+    dim_t hint_bd_block2 {0};
+    dim_t hint_ld_block2 {0};
     bool hint_ununroll_bd_loop {false};
 
     brgemm_kernel_hint_mem_advice_t mem_advice {brgemm_hint_mem_advice_undef};
@@ -260,10 +260,10 @@ struct brgemm_desc_t {
     dim_t bcast_dim = 0; // M;
     dim_t load_dim = 0; // N;
     dim_t reduce_dim = 0; // K;
-    int LDA = 0;
-    int LDB = 0;
-    int LDC = 0;
-    int LDD = 0;
+    dim_t LDA = 0;
+    dim_t LDB = 0;
+    dim_t LDC = 0;
+    dim_t LDD = 0;
 
     bool fused_copy_a = false;
     // we use two isa_ variables
@@ -329,7 +329,7 @@ struct brgemm_desc_t {
     bool with_dst_scales = false;
     data_type_t dt_wei_scales = data_type::undef;
     // Grouping in batch used by brdgmm kernel
-    int bs_group {0};
+    dim_t bs_group {0};
 
     brgemm_attr_t brgattr;
 
@@ -337,18 +337,18 @@ struct brgemm_desc_t {
     dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     bool is_blocked = false;
 
-    int bdb = 0, bd_block = 0, bdb_tail = 0;
-    int bdb2 = 0, bd_block2 = 0, bdb2_tail = 0;
-    int ldb = 0, ld_block = 0, ldb_tail = 0;
-    int ldb2 = 0, ld_block2 = 0, ldb2_tail = 0;
-    int rdb = 0, rd_block = 0, rdb_tail = 0;
-    int rd_step = 0, ld_step = 0;
+    dim_t bdb = 0, bd_block = 0, bdb_tail = 0;
+    dim_t bdb2 = 0, bd_block2 = 0, bdb2_tail = 0;
+    dim_t ldb = 0, ld_block = 0, ldb_tail = 0;
+    dim_t ldb2 = 0, ld_block2 = 0, ldb2_tail = 0;
+    dim_t rdb = 0, rd_block = 0, rdb_tail = 0;
+    dim_t rd_step = 0, ld_step = 0;
 
-    int typesize_A = 0;
-    int typesize_B = 0;
-    int typesize_C = 0;
-    int typesize_D = 0;
-    int typesize_bias = 0;
+    dim_t typesize_A = 0;
+    dim_t typesize_B = 0;
+    dim_t typesize_C = 0;
+    dim_t typesize_D = 0;
+    dim_t typesize_bias = 0;
 
     bool is_ymm = false;
     bool is_zmm = false;
@@ -374,7 +374,7 @@ struct brgemm_desc_t {
     // by kernel API.
     bool with_weights_scale_adjust = false;
     brgemm_kernel_innermost_loop_t innermost_loop = brgemm_ld_loop_innermost;
-    int is_M_tail = false;
+    dim_t is_M_tail = false;
     bool interleave_tilestores_ = false;
     brgemm_prf_t prfA, prfB, prfC;
     bool is_runtime_lda = false;
@@ -391,10 +391,10 @@ struct brgemm_desc_t {
     // Controls whether y is treated as a row in GEMV-specific code paths.
     bool treat_y_as_row = false;
     // GEMV transA register-blocking unroll factor.
-    int gemv_transa_bd_unroll = 0;
+    dim_t gemv_transa_bd_unroll = 0;
     // non-transA: tail along the reduction dimension.
     // transA:     number of valid elements in the final vector accumulator.
-    int gemv_tail = 0;
+    dim_t gemv_tail = 0;
 
     static constexpr int MAX_VPAD = 100;
     static constexpr int AMX_TILES_NUM = 8;
@@ -431,7 +431,7 @@ struct brgemm_desc_t {
     dim_t gemv_bdb_tail() const {
         assert(is_gemv);
         if (!is_gemv) return 0;
-        const int gemv_transa_simd_w
+        const dim_t gemv_transa_simd_w
                 = transA ? bd_block / gemv_transa_bd_unroll : 1;
         assert(IMPLICATION(transA, gemv_transa_simd_w != 1));
         return transA ? bdb_tail / gemv_transa_simd_w : bdb_tail;
@@ -520,67 +520,65 @@ struct brgemm_desc_t {
     }
 
     // Tile register decomposition
-    int get_bd_block2() const noexcept {
-        auto res = (bdb <= bd_block2) ? bdb : (bd_block2 + (bdb_tail ? 1 : 0));
-        return res;
+    dim_t get_bd_block2() const noexcept {
+        return (bdb <= bd_block2) ? bdb : (bd_block2 + (bdb_tail ? 1 : 0));
     }
 
-    int get_ld_block2() const noexcept {
-        auto res = (ldb <= ld_block2) ? ldb : (ld_block2 + (ldb_tail ? 1 : 0));
-        return res;
+    dim_t get_ld_block2() const noexcept {
+        return (ldb <= ld_block2) ? ldb : (ld_block2 + (ldb_tail ? 1 : 0));
     }
 
-    int get_num_C_tiles() const noexcept {
+    dim_t get_num_C_tiles() const noexcept {
         return get_bd_block2() * get_ld_block2();
     }
-    int get_C_tensor(int m, int n, bool m_tail = false,
+    dim_t get_C_tensor(dim_t m, dim_t n, bool m_tail = false,
             bool n_tail = false) const noexcept {
         auto M = m_tail ? get_bd_block2() - 1 : m;
         auto N = n_tail ? get_ld_block2() - 1 : n;
         return (M * get_ld_block2() + N);
     }
 
-    int get_num_A_tiles() const noexcept {
+    dim_t get_num_A_tiles() const noexcept {
         const auto req_tiles = (bdb_tail && bdb > 1) ? 2 : 1;
         const auto max_tiles = AMX_TILES_NUM - get_num_C_tiles() - 1;
         const auto n_tiles = nstl::min(get_bd_block2(), max_tiles);
         assert(n_tiles >= req_tiles);
-        return nstl::max(req_tiles, n_tiles);
+        return nstl::max<dim_t>(req_tiles, n_tiles);
     }
 
-    int get_A_tensor(int m, bool m_tail = false) const noexcept {
+    dim_t get_A_tensor(dim_t m, bool m_tail = false) const noexcept {
         const auto full_A_tiles = get_num_A_tiles() - (bdb_tail ? 1 : 0);
         auto M = (m_tail || full_A_tiles == 0) ? get_num_A_tiles() - 1
                                                : m % full_A_tiles;
         return (get_num_C_tiles() + M);
     }
 
-    int get_num_B_tiles() const noexcept {
+    dim_t get_num_B_tiles() const noexcept {
         const auto req_tiles = (ldb_tail && ldb > 1) ? 2 : 1;
         const auto max_tiles
                 = AMX_TILES_NUM - get_num_C_tiles() - get_num_A_tiles();
         const auto n_tiles = nstl::min(get_ld_block2(), max_tiles);
         assert(n_tiles >= req_tiles);
-        return nstl::max(req_tiles, n_tiles);
+        return nstl::max<dim_t>(req_tiles, n_tiles);
     }
 
-    int get_B_tensor(int n, bool n_tail = false) const noexcept {
+    dim_t get_B_tensor(dim_t n, bool n_tail = false) const noexcept {
         const auto full_B_tiles = get_num_B_tiles() - (ldb_tail ? 1 : 0);
         auto N = (n_tail || full_B_tiles == 0) ? get_num_B_tiles() - 1
                                                : n % full_B_tiles;
         return (get_num_C_tiles() + get_num_A_tiles() + N);
     }
 
-    int get_convert_wsp_buffer_size() const noexcept {
+    dim_t get_convert_wsp_buffer_size() const noexcept {
         if (!is_input_convert()) return 0;
-        const int n_bdb = bd_block2;
-        const int n_rdb = rdb + (rdb_tail != 0);
-        const int n_ldb = ldb + (ldb_tail != 0);
-        const int downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
+        const dim_t n_bdb = bd_block2;
+        const dim_t n_rdb = rdb + (rdb_tail != 0);
+        const dim_t n_ldb = ldb + (ldb_tail != 0);
+        const dim_t downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
         return downcvt_tiles * tilesize;
     }
 
-    int get_fused_copy_a_wsp_buffer_size() const noexcept {
+    dim_t get_fused_copy_a_wsp_buffer_size() const noexcept {
         if (fused_copy_a)
             return brgattr.max_bs * bcast_dim
                     * dnnl::impl::utils::rnd_up(reduce_dim, max_rd_block())
@@ -588,8 +586,8 @@ struct brgemm_desc_t {
         return 0;
     }
 
-    int get_wsp_buffer_size() const noexcept {
-        int sz = 0;
+    dim_t get_wsp_buffer_size() const noexcept {
+        dim_t sz = 0;
         if (is_tmm) {
             sz = get_num_C_tiles() * tilesize; // postops buffer
             sz += get_convert_wsp_buffer_size();

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -167,7 +167,7 @@ struct DNNL_API brgemm_attr_t {
     // if unrolled kernel is used (use_uker == true)
     // then "max_bs" is the the only batch size that can be used on kernel call
     // else "max_bs" is the maximum batch size that can be used
-    int max_bs;
+    dim_t max_bs;
     int max_top_vpad, max_bottom_vpad;
     int max_top_bpad, max_bottom_bpad;
     dim_t hint_expected_A_size, hint_expected_B_size, hint_expected_C_size;
@@ -215,7 +215,7 @@ struct DNNL_API brgemm_attr_t {
     // bd block. By default are equal to regular leading dimension parameters
     // specified on brgemm creation.
     // Supported by brgemm unrolled kernel for now.
-    int LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
+    dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     // If "true" then batchsize is allowed to change on each kernel call
     // and there is no unrolling by batchsize in kernel
     bool var_bs {false};
@@ -257,9 +257,9 @@ struct brgemm_desc_t {
 
     // Note: new added parameters must be taken into account in the brgemm
     // comparison function
-    int bcast_dim = 0; // M;
-    int load_dim = 0; // N;
-    int reduce_dim = 0; // K;
+    dim_t bcast_dim = 0; // M;
+    dim_t load_dim = 0; // N;
+    dim_t reduce_dim = 0; // K;
     int LDA = 0;
     int LDB = 0;
     int LDC = 0;
@@ -334,7 +334,7 @@ struct brgemm_desc_t {
     brgemm_attr_t brgattr;
 
     // Derived  parameters
-    int LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
+    dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     bool is_blocked = false;
 
     int bdb = 0, bd_block = 0, bdb_tail = 0;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -346,7 +346,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) return false;
 
         auto min_bdb = INT_MAX;
-        const auto start_bd_block = nstl::min(max_width, BD);
+        const auto start_bd_block = nstl::min<dim_t>(max_width, BD);
         auto best_bd_block = start_bd_block;
         for (auto bd_block = start_bd_block; bd_block > 0; bd_block--) {
             int bdb = 0;
@@ -419,7 +419,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 }
             }
             if (brg->bd_block == 1) {
-                brg->bd_block = nstl::min(max_width, BD);
+                brg->bd_block = nstl::min<dim_t>(max_width, BD);
                 brg->bdb_tail = BD % max_width;
                 for (int i = max_width; i >= min_width; i--) {
                     const auto i_tail = BD % i;
@@ -595,7 +595,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
         } else if (BD <= 16) {
             // Have to call recalc_blocking twice to calculate ldb
             recalc_blocking(BD, 16, 0, 0);
-            const auto ld_block2 = nstl::min(
+            const auto ld_block2 = nstl::min<dim_t>(
                     ldb_tail_16 ? ((brg->ldb > 4) ? 3 : 4) : 5, div_up(LD, 16));
             recalc_blocking(0, 0, 1, ld_block2);
         } else if (bdb_tail_only && weak_bdb && BD > 64) {
@@ -611,7 +611,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
             // Have to call recalc_blocking twice to calculate bdb
             // we can't use ld_block other than 16
             recalc_blocking(16, 16, 0, 0);
-            const auto bd_block2 = nstl::min(
+            const auto bd_block2 = nstl::min<dim_t>(
                     brg->bdb_tail ? (brg->bdb > 4 ? 3 : 4) : 5, div_up(BD, 16));
             recalc_blocking(0, 0, bd_block2, 1);
         } else if (bdb_block_tail && ldb_tail_16 && BD_R16 == 32 && LD_R16 == 32
@@ -660,7 +660,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     const auto rd_block_step = brg->rd_block_step();
     const auto max_rd_block = brg->max_rd_block();
     if (brg->amx_may_extend_k()) {
-        brg->rd_block = nstl::min(
+        brg->rd_block = nstl::min<dim_t>(
                 rnd_up(brg->reduce_dim, brg->rd_step), max_rd_block);
     } else if (brg->fused_copy_a) {
         brg->rd_block = max_rd_block;
@@ -1119,9 +1119,9 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     CHECK(safe_dim_to_int(brg->LDD, LDC));
     brg->is_runtime_ldc = brg->is_runtime_ldd = is_runtime_value(LDC);
 
-    CHECK(safe_dim_to_int(brg->bcast_dim, (brg->is_row_major()) ? M : N));
-    CHECK(safe_dim_to_int(brg->load_dim, (brg->is_row_major()) ? N : M));
-    CHECK(safe_dim_to_int(brg->reduce_dim, K));
+    brg->bcast_dim = (brg->is_row_major()) ? M : N;
+    brg->load_dim = (brg->is_row_major()) ? N : M;
+    brg->reduce_dim = K;
 
     brg->bd_block2 = 0;
     brg->bdb2 = 0;
@@ -1185,8 +1185,8 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     CHECK(safe_dim_to_int(brg->LDC, LDC));
     CHECK(safe_dim_to_int(brg->LDD, LDC));
 
-    CHECK(safe_dim_to_int(brg->bcast_dim, M));
-    CHECK(safe_dim_to_int(brg->load_dim, N));
+    brg->bcast_dim = M;
+    brg->load_dim = N;
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -209,30 +209,30 @@ void set_brg_vmm(brgemm_desc_t *brg) {
             = !brg->is_zmm && mayiuse(avx2) && is_superset(brg->isa_impl, avx2);
 }
 
-int calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
+dim_t calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
     brg->ld_block2 = try_ld_block2;
     brg->ldb2 = brg->ldb / brg->ld_block2;
     brg->ldb2_tail = brg->ldb % brg->ld_block2;
 
-    if (brg->ldb2 == 0) brg->ld_block2 = nstl::max(1, brg->ldb2_tail);
+    if (brg->ldb2 == 0) brg->ld_block2 = nstl::max<dim_t>(1, brg->ldb2_tail);
     brg->embd_bcst = brg->is_f32
             && (brg->ldb2_tail <= 1 && brg->ldb2 == 0)
             /*only avx512 or more can bcast*/
             && is_superset(brg->isa_impl, avx512_core);
 
-    const int adj_ld_block2
+    const dim_t adj_ld_block2
             = (brg->ldb2 != 0) ? brg->ld_block2 : brg->ldb2_tail;
-    return nstl::max(1, adj_ld_block2);
+    return nstl::max<dim_t>(1, adj_ld_block2);
 }
 
-int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
+dim_t calculate_max_bcast_block(brgemm_desc_t *brg, const dim_t adj_ld_block2) {
 
     // TODO: Calculating the number of available registers should be re-factored
     // to use one code here and in brgemm kernel generator on
     // "max_effective_vregs" calculation
     int max_isa_regs = isa_num_vregs(brg->isa_impl);
-    const int max_bcst_regs = brg->n_bcast_1_load ? 0 : 1;
-    const int load_regs = brg->n_bcast_1_load ? 1 : adj_ld_block2;
+    const dim_t max_bcst_regs = brg->n_bcast_1_load ? 0 : 1;
+    const dim_t load_regs = brg->n_bcast_1_load ? 1 : adj_ld_block2;
     const bool req_zp_a_comp_pads
             = (brg->req_cal_comp_pads || brg->brgattr.max_top_vpad > 0
                       || brg->brgattr.max_bottom_vpad > 0)
@@ -258,15 +258,16 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
 
     // --------------- microkernel ---------------
     // see vmm_inp_shift() in brgemm kernel
-    const int compensation_regs = brg->req_src_s8_shift
+    // see vmm_inp_shift() in brgemm kernel
+    const dim_t compensation_regs = brg->req_src_s8_shift
                     || brg->zp_type_a != brgemm_broadcast_t::none
             ? 1
             : 0;
 
     // see vmm_zp_a_shift(), vmm_one_bytes() in brgemm kernel
-    const int zp_a_comp_pads_regs = req_zp_a_comp_pads ? 2 : 0;
+    const dim_t zp_a_comp_pads_regs = req_zp_a_comp_pads ? 2 : 0;
 
-    const int microkernel_regs = zp_a_comp_pads_regs + compensation_regs;
+    const dim_t microkernel_regs = zp_a_comp_pads_regs + compensation_regs;
 
     const auto microkernel_max_reg_count
             = max_isa_regs - microkernel_regs - load_regs - max_bcst_regs;
@@ -275,9 +276,9 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
             = microkernel_max_reg_count / (adj_ld_block2 + brg->n_bcast_1_load);
 
     // ----- post-ops and store accumulators -----
-    const int beta_regs = !one_of(brg->beta, 1.f, 0.f);
+    const dim_t beta_regs = !one_of(brg->beta, 1.f, 0.f);
 
-    const int postops_regs = brg->attr()
+    const dim_t postops_regs = brg->attr()
             ? injector::aux_vec_count(
                       brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;
@@ -287,7 +288,7 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     // registers related to 'max_bcast_block'
     assert(IMPLICATION(
             brg->is_bf16_emu, is_superset(brg->isa_impl, avx512_core)));
-    const int bf16_emu_regs = brg->is_bf16_emu ? 4 : 0;
+    const dim_t bf16_emu_regs = brg->is_bf16_emu ? 4 : 0;
 
     const auto store_regs = nstl::max(beta_regs,
             nstl::max(
@@ -313,12 +314,12 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     const auto LD = brg->load_dim;
     const auto LD_R16 = rnd_up(LD, 16);
 
-    const int max_width = 16, min_width = 1;
+    const dim_t max_width = 16, min_width = 1;
     brg->ld_block = 16;
     brg->ldb = LD / brg->ld_block;
     brg->ldb_tail = LD % brg->ld_block;
 
-    auto find_bdb_bd_mask = [&](int bd_block, int &bdb, int &bdb_tail) {
+    auto find_bdb_bd_mask = [&](dim_t bd_block, dim_t &bdb, dim_t &bdb_tail) {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) {
             bdb = div_up(BD, bd_block);
             bdb_tail = BD % bd_block;
@@ -345,12 +346,12 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     auto find_bd_block_for_bd_mask = [&]() {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) return false;
 
-        auto min_bdb = INT_MAX;
+        dim_t min_bdb = INT_MAX;
         const auto start_bd_block = nstl::min<dim_t>(max_width, BD);
         auto best_bd_block = start_bd_block;
         for (auto bd_block = start_bd_block; bd_block > 0; bd_block--) {
-            int bdb = 0;
-            int bdb_tail = 0;
+            dim_t bdb = 0;
+            dim_t bdb_tail = 0;
             find_bdb_bd_mask(bd_block, bdb, bdb_tail);
             // bcast_dim should be divided by bd_block
             if (bdb < min_bdb && bdb_tail == 0) {
@@ -447,8 +448,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 || brg->bd_block < 8);
     };
 
-    auto recalc_blocking = [&](int new_bd_block, int new_ld_block,
-                                   int new_bd_block2, int new_ld_block2) {
+    auto recalc_blocking = [&](dim_t new_bd_block, dim_t new_ld_block,
+                                   dim_t new_bd_block2, dim_t new_ld_block2) {
         if (new_bd_block != 0) {
             brg->bd_block = new_bd_block;
             find_bdb_bd_mask(brg->bd_block, brg->bdb, brg->bdb_tail);
@@ -853,12 +854,12 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     brg->ldb = brg->load_dim / brg->ld_block;
     brg->ldb_tail = brg->load_dim % brg->ld_block;
 
-    const int max_vpad = nstl::max(
+    const dim_t max_vpad = nstl::max<dim_t>(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
     // iterate ld_block2 starting from 4 to allow bd_block larger than
     // virtual padding
-    int max_bcast_block {0}, min_bcast_block {0}, adj_ld_block2 {0};
+    dim_t max_bcast_block {0}, min_bcast_block {0}, adj_ld_block2 {0};
     bool few_regs = utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2);
     bool hint_n_bcast_1_load
             = brg->brgattr.hint_loop_order == brgemm_lo_bl_1load;
@@ -875,11 +876,11 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     // padding to avoid possible functional issues
     if (min_bcast_block < max_vpad) return status::unimplemented;
 
-    const int min_block = nstl::max(1, max_vpad);
+    const dim_t min_block = nstl::max<dim_t>(1, max_vpad);
 
     float best_bd_block_eff = 0.f;
     brg->bd_block = max_bcast_block;
-    for (int bd_block = max_bcast_block; bd_block >= min_block; bd_block--) {
+    for (dim_t bd_block = max_bcast_block; bd_block >= min_block; bd_block--) {
         // avoid msvc warning 'potential divide by zero'
         const auto bd_block_disb = (brg->bcast_dim <= 0 || bd_block == 0)
                 ? 0.f
@@ -905,7 +906,7 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     const data_type_t rd_block_dt = get_mac_emu_data_type(
             brg->dt_a, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
     if (rd_block_dt == dnnl_data_type_undef) return status::unimplemented;
-    const int vnni_granularity = data_type_vnni_granularity(rd_block_dt);
+    const dim_t vnni_granularity = data_type_vnni_granularity(rd_block_dt);
     brg->rd_block = rd_unroll * vnni_granularity;
     brg->rdb = brg->reduce_dim / brg->rd_block;
     brg->rdb_tail = brg->reduce_dim % brg->rd_block;
@@ -965,7 +966,7 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
     if (brg->isa_impl == isa_undef) return status::unimplemented;
 
     set_brg_vmm(brg); // Needed to dispatch into the right kernel later.
-    const int max_vregs = isa_num_vregs(brg->isa_impl);
+    const dim_t max_vregs = isa_num_vregs(brg->isa_impl);
 
     const int simd_w = isa_max_vlen(brg->isa_impl) / brg->typesize_C;
     const bool is_avx2_vnni_2_xf16
@@ -999,19 +1000,19 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
 
     const int max_n_block2_vmms = 4;
     const int max_n_block2 = max_n_block2_vmms / n_block1_num_steps;
-    n_block2 = nstl::min(max_n_block2, nb_n_block1);
+    n_block2 = nstl::min<dim_t>(max_n_block2, nb_n_block1);
 
-    const int aux_vregs
+    const dim_t aux_vregs
             = jit_brdgmm_kernel_base_t<Xbyak::Zmm>::get_aux_vmm_count(*brg);
-    const int compute_vregs
+    const dim_t compute_vregs
             = jit_brdgmm_kernel_base_t<Xbyak::Zmm>::get_compute_vmm_count(*brg);
-    const int bf16_emu_vregs = brg->is_bf16_emu * 4;
-    const int postops_regs = brg->attr()
+    const dim_t bf16_emu_vregs = brg->is_bf16_emu * 4;
+    const dim_t postops_regs = brg->attr()
             ? injector::aux_vec_count(
                       brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;
 
-    const int max_acc_vmms = max_vregs
+    const dim_t max_acc_vmms = max_vregs
             - nstl::max(postops_regs,
                     nstl::max(compute_vregs + aux_vregs, bf16_emu_vregs));
 
@@ -1109,14 +1110,14 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->req_s8s8_compensation
             = brg->req_src_s8_shift && !brg->with_per_mn_compensation;
 
-    CHECK(safe_dim_to_int(brg->LDA, (brg->is_row_major()) ? LDA : LDB));
+    brg->LDA = (brg->is_row_major()) ? LDA : LDB;
     brg->is_runtime_lda = (brg->is_row_major()) ? is_runtime_value(LDA)
                                                 : is_runtime_value(LDB);
-    CHECK(safe_dim_to_int(brg->LDB, (brg->is_row_major()) ? LDB : LDA));
+    brg->LDB = (brg->is_row_major()) ? LDB : LDA;
     brg->is_runtime_ldb = (brg->is_row_major()) ? is_runtime_value(LDB)
                                                 : is_runtime_value(LDA);
-    CHECK(safe_dim_to_int(brg->LDC, LDC));
-    CHECK(safe_dim_to_int(brg->LDD, LDC));
+    brg->LDC = LDC;
+    brg->LDD = LDC;
     brg->is_runtime_ldc = brg->is_runtime_ldd = is_runtime_value(LDC);
 
     brg->bcast_dim = (brg->is_row_major()) ? M : N;
@@ -1181,9 +1182,9 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
 
     brg->is_dgmm = true;
 
-    CHECK(safe_dim_to_int(brg->LDA, LDA));
-    CHECK(safe_dim_to_int(brg->LDC, LDC));
-    CHECK(safe_dim_to_int(brg->LDD, LDC));
+    brg->LDA = LDA;
+    brg->LDC = LDC;
+    brg->LDD = LDC;
 
     brg->bcast_dim = M;
     brg->load_dim = N;

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -173,7 +173,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_permute_vmm() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::load_accumulators(
-        int m_blocks, int n_blocks) {
+        dim_t m_blocks, dim_t n_blocks) {
     const int v_substep = vnni_substep();
     for_(int v = 0; v < v_substep; ++v)
     for_(int m = 0; m < m_blocks; ++m)
@@ -228,7 +228,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::set_A_B_matrices() {
     }
 
     add(reg_aux_A, reg_a_offset);
-    lea(reg_aux_B, ptr[reg_aux_B + reg_aux_N * brg.typesize_B]);
+    lea(reg_aux_B,
+            ptr[reg_aux_B + reg_aux_N * xbyak_address_scale(brg.typesize_B)]);
 }
 
 template <typename Wmm>
@@ -242,7 +243,7 @@ template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::cvt2ps(data_type_t type_in,
         const Vmm vmm_in, const Xbyak::Operand &op, bool mask_flag,
         bool store) {
-    const int tail_size = tail_length();
+    const int tail_size = xbyak_register_index(tail_length());
     const bool is_load_tail = op.isMEM() && mask_flag && tail_size > 0
             && (tail_size < static_cast<int>(
                         vreg_traits_t<Vmm>::vlen / sizeof(float)));
@@ -268,7 +269,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::cvt2ps(data_type_t type_in,
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::apply_post_ops(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     injector_utils::vmm_index_set_t vmm_idxs_param;
@@ -367,7 +368,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::apply_post_ops(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     const bool dq2ps_required = brg.is_int8;
     const int v_substep = vnni_substep();
@@ -459,7 +460,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     if (brg.with_bias) {
         reg_aux_bias.restore();
-        lea(reg_aux_bias, ptr[reg_aux_bias + reg_aux_N * brg.typesize_bias]);
+        lea(reg_aux_bias,
+                ptr[reg_aux_bias
+                        + reg_aux_N * xbyak_address_scale(brg.typesize_bias)]);
     }
 
     for_(int v_i = 0; v_i < v_substep; ++v_i)
@@ -615,7 +618,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_without_post_ops(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     const bool dt_requires_saturation
             = brg.is_int8 && brg.dt_c != data_type::s32;
@@ -654,13 +657,13 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_without_post_ops(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::maybe_transpose_interleaved_vnni_to_plain(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     if (vnni_substep() == 1) return;
 
     // The tail block is always processed as plain.
     // No need to transpose it here.
-    const int n_blocks_e = n_blocks - has_n_tail;
+    const dim_t n_blocks_e = n_blocks - has_n_tail;
 
     auto ymm_aux0 = vmm_tmp(0);
     for_(int m_i = 0; m_i < m_blocks; m_i++)
@@ -690,7 +693,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_src_zp() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     const int v_substep = vnni_substep();
 
@@ -710,7 +713,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
     for (int n = 0; n < n_blocks; n++) {
         const int substep_simd = get_substep_simd(n, v_i, has_n_tail);
         if (substep_simd <= 0) continue;
-        const size_t offset = comp_offset(n);
+        const dim_t offset = comp_offset(n);
         if (brg.req_s8s8_compensation) {
             const Vmm vmm_comp = vmm_s8s8_comp();
             uni_vmovups(vmm_comp,
@@ -737,7 +740,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
                     vpmulld(vmm_zp, vmm_zp,
                             maybe_EVEX_compress_addr(reg_aux_src_zp, offset));
             } else {
-                const int tail_size = tail_length();
+                const int tail_size = xbyak_register_index(tail_length());
                 const Vmm ymm_tmp
                         = vmm_bcast(); // used for bcast or tail processing in avx2
                 load_data(data_type::s32, vmm_zp, ptr[reg_aux_zp_comp + offset],
@@ -758,7 +761,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     maybe_transpose_interleaved_vnni_to_plain(m_blocks, n_blocks, has_n_tail);
 
@@ -788,10 +791,10 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::load_a(
-        Vmm vmma, int m_i, int n_i, int v_i, bool has_n_tail) {
-    const int n_blocks
+        Vmm vmma, dim_t m_i, dim_t n_i, dim_t v_i, bool has_n_tail) {
+    const dim_t n_blocks
             = has_n_tail && n_block2_tail() > 0 ? n_block2_tail() : n_block2();
-    const int substep_simd = get_substep_simd(n_i, v_i, has_n_tail);
+    const dim_t substep_simd = get_substep_simd(n_i, v_i, has_n_tail);
     const bool is_tail_block = has_n_tail && n_i + 1 == n_blocks;
     const bool mask_flag = substep_simd < simd_w_;
     const auto addr = ptr[reg_aux_A + A_offset(m_i, n_i)
@@ -840,11 +843,11 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_a(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::load_b(
-        Vmm vmmb, int n_i, int v_i, bool has_n_tail, bool wei_zp) {
+        Vmm vmmb, dim_t n_i, dim_t v_i, bool has_n_tail, bool wei_zp) {
     assert(IMPLICATION(wei_zp, brg.is_int8 && compute_src_zp_));
     // for B matrix we assume memory is padded and it is safe to load simd
     // elements. is_tail only used during avx_ne_convert tail optimization.
-    const int n_blocks
+    const dim_t n_blocks
             = has_n_tail && n_block2_tail() > 0 ? n_block2_tail() : n_block2();
     const bool is_tail_block = has_n_tail && (n_i + 1 == n_blocks);
     const auto addr = ptr[reg_aux_B + B_offset(n_i)
@@ -892,7 +895,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_b(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
-        compute_pad_kernel_t kernel_type, Vmm vmm_acc, Vmm vmmb, int n,
+        compute_pad_kernel_t kernel_type, Vmm vmm_acc, Vmm vmmb, dim_t n,
         bool is_tail_block) {
     switch (kernel_type) {
         case compute_pad_kernel_t::s8s8_kernel:
@@ -902,7 +905,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
             const Vmm vmm_zp = isa_has_masks(brg.isa_impl)
                     ? maybe_mask(vmm_zp_comp(), is_tail_block, false)
                     : vmm_zp_comp();
-            const size_t offset = comp_offset(n);
+            const dim_t offset = comp_offset(n);
             if (IMPLICATION(is_tail_block, isa_has_masks(brg.isa_impl))) {
                 if (is_src_zp_bcast_) {
                     if (is_superset(brg.isa_impl, avx512_core))
@@ -937,22 +940,22 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::pad_comp_kernel(
-        compute_pad_kernel_t kernel_type, int m_blocks, int n_blocks,
-        int padding, const Xbyak::Reg64 reg_pad,
-        const std::function<int(int)> &get_mi, bool has_tail) {
+        compute_pad_kernel_t kernel_type, dim_t m_blocks, dim_t n_blocks,
+        dim_t padding, const Xbyak::Reg64 reg_pad,
+        const std::function<dim_t(dim_t)> &get_mi, bool has_tail) {
     assert(vnni_substep() == 1);
-    const int max_m_unroll = padding;
+    const dim_t max_m_unroll = padding;
     const bool is_zero_point_kernel
             = kernel_type == compute_pad_kernel_t::zero_point_kernel;
-    const int max_bvmms
+    const dim_t max_bvmms
             = accm(m_blocks, n_blocks, 0, 0, 0).getIdx() - vmm_b(0).getIdx();
-    const int n_preload_b_vmms = max_bvmms >= n_blocks
+    const dim_t n_preload_b_vmms = max_bvmms >= n_blocks
             ? n_blocks
             : max_bvmms - 1 /*for ad-hoc load*/;
     const bool load_broadcast_wei = is_zero_point_kernel;
-    for (int i = 0; i < n_preload_b_vmms; ++i) {
-        const int n_i = i % n_blocks;
-        const int v_i = i / n_blocks;
+    for (dim_t i = 0; i < n_preload_b_vmms; ++i) {
+        const dim_t n_i = i % n_blocks;
+        const dim_t v_i = i / n_blocks;
         if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
         load_b(vmm_b(i), n_i, v_i, has_tail, load_broadcast_wei);
     }
@@ -965,17 +968,17 @@ void jit_brdgmm_kernel_base_t<Wmm>::pad_comp_kernel(
     jmp(ptr[reg_table_base], T_NEAR);
     align(8);
     L(jmp_table_base);
-    for (int m_i = 0; m_i <= max_m_unroll; ++m_i) {
+    for (dim_t m_i = 0; m_i <= max_m_unroll; ++m_i) {
         putL(jmp_table_labels[m_i]);
     }
 
-    for (int pad_i = max_m_unroll; pad_i > 0; --pad_i) {
+    for (dim_t pad_i = max_m_unroll; pad_i > 0; --pad_i) {
         L(jmp_table_labels[pad_i]);
         if (is_zero_point_kernel) load_src_zp();
         if (pad_i > m_blocks) continue;
-        const int m_i = get_mi(pad_i);
-        int p_b_i = 0;
-        for (int n_i = 0; n_i < n_blocks; ++n_i, ++p_b_i) {
+        const dim_t m_i = get_mi(pad_i);
+        dim_t p_b_i = 0;
+        for (dim_t n_i = 0; n_i < n_blocks; ++n_i, ++p_b_i) {
             const int substep_simd = get_substep_simd(n_i, 0, has_tail);
             if (substep_simd <= 0) continue;
             const Vmm vmm_acc = accm(m_blocks, n_blocks, m_i, n_i, 0);
@@ -998,27 +1001,27 @@ void jit_brdgmm_kernel_base_t<Wmm>::pad_comp_kernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::batch_pad_kernel(
-        int m_blocks, int n_blocks, bool has_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_tail) {
 
     assert(vnni_substep() == 1);
-    const int max_bvmms
+    const dim_t max_bvmms
             = accm(m_blocks, n_blocks, 0, 0, 0).getIdx() - vmm_b(0).getIdx();
 
     auto kernel_body = [&](compute_pad_kernel_t kernel_type) {
         const bool is_zero_point_kernel
                 = kernel_type == compute_pad_kernel_t::zero_point_kernel;
         if (is_zero_point_kernel) load_src_zp();
-        for (int nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
-            const int n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+        for (dim_t nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
+            const dim_t n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 if (get_substep_simd(n_i, 0, has_tail) <= 0) continue;
                 const bool load_broadcast_wei = is_zero_point_kernel;
                 load_b(vmm_b(i), n_i, 0, has_tail, load_broadcast_wei);
             }
-            for_(int m_i = 0; m_i < m_blocks; ++m_i)
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+            for_(dim_t m_i = 0; m_i < m_blocks; ++m_i)
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 const int substep_simd = get_substep_simd(n_i, 0, has_tail);
                 if (substep_simd <= 0) continue;
                 const Vmm vmm_acc = accm(m_blocks, n_blocks, m_i, n_i, 0);
@@ -1036,17 +1039,18 @@ void jit_brdgmm_kernel_base_t<Wmm>::batch_pad_kernel(
 }
 
 template <typename Wmm>
-void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
-        int n_blocks, bool has_top_padding, bool has_bottom_padding,
-        bool has_tail, int shift_a) {
+void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(dim_t m_blocks,
+        dim_t n_blocks, bool has_top_padding, bool has_bottom_padding,
+        bool has_tail, dim_t shift_a) {
 
     const bool has_padding = has_top_padding || has_bottom_padding;
-    const int max_bvmms
+    const dim_t max_bvmms
             = accm(m_blocks, n_blocks, 0, 0, 0).getIdx() - vmm_b(0).getIdx();
     const int v_substep = vnni_substep();
     assert(max_bvmms > 0);
 
-    auto dot_product = [&](Vmm vmma, Vmm vmmb, int m_i, int n_i, int v_i) {
+    auto dot_product
+            = [&](Vmm vmma, Vmm vmmb, dim_t m_i, dim_t n_i, dim_t v_i) {
         auto vmm_acc = accm(m_blocks, n_blocks, m_i, n_i, v_i);
         if (brg.is_f32) {
             if (is_fma_embd()) {
@@ -1074,18 +1078,18 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
 
     if (!has_padding) {
         // preload vmm_b if possible.
-        for_(int v_i = 0; v_i < v_substep; ++v_i)
-        for (int nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
-            const int n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+        for_(dim_t v_i = 0; v_i < v_substep; ++v_i)
+        for (dim_t nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
+            const dim_t n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
                 load_b(vmm_b(i), n_i, v_i, has_tail);
             }
             if (grouped_bs()) {
-                for_(int m_i = 0; m_i < m_blocks; ++m_i)
-                for (int i = 0; i < n_e; ++i) {
-                    const int n_i = nb_i + i;
+                for_(dim_t m_i = 0; m_i < m_blocks; ++m_i)
+                for (dim_t i = 0; i < n_e; ++i) {
+                    const dim_t n_i = nb_i + i;
                     if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
                     const auto vmm_A = vmm_a(m_i + shift_a, i);
                     if (shift_a == 0 || m_i == m_blocks - 1) {
@@ -1097,9 +1101,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
                 }
             }
 
-            for_(int m_i = 0; m_i < m_blocks; ++m_i)
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+            for_(dim_t m_i = 0; m_i < m_blocks; ++m_i)
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
                 const auto vmm_A = vmm_a(m_i + shift_a, i);
                 if (!grouped_bs() && (shift_a == 0 || m_i == m_blocks - 1)) {
@@ -1111,13 +1115,13 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
             }
         }
     } else {
-        const int max_req_preload_vmms = n_blocks * vnni_substep();
-        const int n_preload_b_vmms = max_bvmms >= max_req_preload_vmms
+        const dim_t max_req_preload_vmms = n_blocks * vnni_substep();
+        const dim_t n_preload_b_vmms = max_bvmms >= max_req_preload_vmms
                 ? max_req_preload_vmms
                 : max_bvmms - 1 /*for ad-hoc load*/;
-        for (int i = 0; i < n_preload_b_vmms; ++i) {
-            const int n_i = i % n_blocks;
-            const int v_i = i / n_blocks;
+        for (dim_t i = 0; i < n_preload_b_vmms; ++i) {
+            const dim_t n_i = i % n_blocks;
+            const dim_t v_i = i / n_blocks;
             if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
             load_b(vmm_b(i), n_i, v_i, has_tail);
         }
@@ -1174,7 +1178,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
                     dot_product(vmm_A, vmm_b(p_b_i), m_i, n_i, v_i);
                 } else {
                     // preloaded vmm_b not available
-                    const int b_idx = max_bvmms - 1;
+                    const dim_t b_idx = max_bvmms - 1;
                     load_b(vmm_b(b_idx), n_i, v_i, has_tail);
                     dot_product(vmm_A, vmm_b(b_idx), m_i, n_i, v_i);
                 }
@@ -1185,8 +1189,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
 }
 
 template <typename Wmm>
-void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
-        const int m_blocks) {
+void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(dim_t m_blocks) {
     const bool do_check_effective_padding = check_effective_padding();
     Label no_top_padding;
 
@@ -1194,7 +1197,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
         if (do_check_effective_padding) {
             Label done_adjust_bottom_padding;
             mov(reg_aux_A_vpad_bottom, reg_aux_M);
-            add(reg_aux_A_vpad_bottom, m_blocks - M());
+            sub(reg_aux_A_vpad_bottom, M() - m_blocks);
             add(reg_aux_A_vpad_bottom,
                     ptr[reg_aux_batch_addr
                             + GET_OFF_BATCH_ELEMENT(vvpad.bottom)]);
@@ -1235,11 +1238,11 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_batch_padding_info() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
-    const int tpad = brg.brgattr.max_top_vpad;
-    const int bpad = brg.brgattr.max_bottom_vpad;
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
+    const dim_t tpad = brg.brgattr.max_top_vpad;
+    const dim_t bpad = brg.brgattr.max_bottom_vpad;
     if (tpad > 0) {
-        auto get_mi = [=](int pad_i) { return pad_i - 1; };
+        auto get_mi = [=](dim_t pad_i) { return pad_i - 1; };
         if (brg.req_s8s8_compensation)
             pad_comp_kernel(compute_pad_kernel_t::s8s8_kernel, m_blocks,
                     n_blocks, brg.brgattr.max_top_vpad, reg_aux_A_vpad_top,
@@ -1250,7 +1253,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
                     get_mi, has_n_tail);
     }
     if (bpad > 0) {
-        auto get_mi = [=](int pad_i) { return m_blocks - pad_i; };
+        auto get_mi = [=](dim_t pad_i) { return m_blocks - pad_i; };
         if (brg.req_s8s8_compensation)
             pad_comp_kernel(compute_pad_kernel_t::s8s8_kernel, m_blocks,
                     n_blocks, brg.brgattr.max_bottom_vpad,
@@ -1264,11 +1267,11 @@ void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail, int shift_a) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail, dim_t shift_a) {
 
     // padding for vertical dimensions
-    const int tpad = brg.brgattr.max_top_vpad;
-    const int bpad = brg.brgattr.max_bottom_vpad;
+    const dim_t tpad = brg.brgattr.max_top_vpad;
+    const dim_t bpad = brg.brgattr.max_bottom_vpad;
     Label microkernel_with_padding, done_microkernel, skip_microkernel_l;
 
     if (has_vpad_) {
@@ -1294,7 +1297,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     Label bs_loop_label, done_bs_loop;
     load_accumulators(m_blocks, n_blocks);
@@ -1304,7 +1307,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
     mov(reg_BS_loop, reg_BS);
     restore_A_B_matrices();
 
-    auto bs_iteration = [&](int shift_a) {
+    auto bs_iteration = [&](dim_t shift_a) {
         Label compute_brdgemm_l, end_batch_loop_l;
         set_A_B_matrices();
         if (compute_compensation_ && has_bpad_) {
@@ -1323,7 +1326,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
 
     L(bs_loop_label);
     {
-        for (int sh = 0; sh < bs_group(); sh++) {
+        for (dim_t sh = 0; sh < bs_group(); sh++) {
             bs_iteration(sh);
             advance_A_B_matrices();
         }
@@ -1340,23 +1343,23 @@ template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
     const bool has_m_block2_tail = m_block2_tail() > 0;
-    const int loop_m = (nb_m_block2() - has_m_block2_tail);
+    const dim_t loop_m = nb_m_block2() - has_m_block2_tail;
     const bool do_loop_m = loop_m > 1;
 
     const bool has_n_block2_tail = n_block2_tail() > 0;
     const bool need_separate_n_block1_tail_block = n_block1_tail() != 0
             && !has_n_block2_tail && nb_n_block2() > 1
             && !isa_has_masks(brg.isa_impl);
-    const int loop_n = nb_n_block2() - has_n_block2_tail
+    const dim_t loop_n = nb_n_block2() - has_n_block2_tail
             - need_separate_n_block1_tail_block;
     const bool do_loop_n = loop_n > 1;
     const bool loop_n_update_aux_ptrs = do_loop_n || (loop_n < nb_n_block2());
 
-    auto n_loop = [&](int m_blocks) {
+    auto n_loop = [&](dim_t m_blocks) {
         Label n_loop_label;
-        const int n_blocks = n_block2();
-        const int n_loop_step = oc_logical_offset(n_blocks);
-        const int n_loop_work = loop_n * n_blocks * n_block1();
+        const dim_t n_blocks = n_block2();
+        const dim_t n_loop_step = oc_logical_offset(n_blocks);
+        const dim_t n_loop_work = loop_n * n_blocks * n_block1();
         const bool vlen_tail_in_loop = n_block1_tail() != 0
                 && !need_separate_n_block1_tail_block && !has_n_block2_tail;
 
@@ -1404,7 +1407,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
     auto m_loop = [&]() {
         Label m_loop_label;
-        const int m_blocks = m_block2();
+        const dim_t m_blocks = m_block2();
         const bool reset_mask = isa_has_masks(brg.isa_impl)
                 && n_block1_tail() != 0 && do_loop_n && !has_n_block2_tail;
 
@@ -1418,13 +1421,19 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
             if (do_loop_m || has_m_block2_tail) {
                 add(reg_aux_M, m_blocks);
-                const int n_loop_offset
+                const dim_t n_loop_offset
                         = loop_n_update_aux_ptrs * loop_n * n_block2();
-                add(reg_a_offset, A_offset(m_blocks, -n_loop_offset));
+                const dim_t a_shift
+                        = A_offset(m_blocks, 0) - A_offset(0, n_loop_offset);
+                const dim_t c_shift = C_offset(m_blocks, 0, 0)
+                        - C_offset(0, n_loop_offset, 0);
+                const dim_t d_shift = D_offset(m_blocks, 0, 0)
+                        - D_offset(0, n_loop_offset, 0);
+                add(reg_a_offset, a_shift);
                 reg_aux_C.restore();
-                add(reg_aux_C, C_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_C, c_shift);
                 reg_aux_C.save();
-                add(reg_aux_D, D_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_D, d_shift);
             }
 
             if (do_loop_m) {

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -51,9 +51,10 @@ struct jit_brdgmm_kernel_base_t : public jit_base_brgemm_kernel_t {
             : aux_vmm_count_(0)
             , vmm_tmp_count_(0)
             , compute_vmm_base_idx_(-1)
-            , compute_vmm_count_((grouped_bs(brg) ? 0 : 1)
+            , compute_vmm_count_(jit_generator_t::xbyak_register_index(
+                      (grouped_bs(brg) ? 0 : 1)
                       + (!is_fma_embd(brg))
-                              * brg.ld_block2 /*n_block*/) // vmm_a + vmm_b
+                              * brg.ld_block2 /*n_block*/)) // vmm_a + vmm_b
             , idx_vmm_a_(-1)
             , idx_vmm_b_(-1)
             , idx_vmm_permute_(-1)
@@ -88,19 +89,20 @@ struct jit_brdgmm_kernel_base_t : public jit_base_brgemm_kernel_t {
 
             // assign compute vmms
             idx_vmm_a_ = compute_vmm_base_idx_;
-            const int max_m = brg.bd_block2 + brg.bs_group - 1;
-            const int max_n = brg.ld_block2;
+            const dim_t max_m = brg.bd_block2 + brg.bs_group - 1;
+            const dim_t max_n = brg.ld_block2;
             idx_vmm_b_
                     = vmm_a_idx(brg, max_m - 1, max_n - 1) + !is_fma_embd(brg);
         }
         int vnni_substep(const brgemm_desc_t &brg) const {
             return brg.isa_impl == avx2_vnni_2 && brg.is_xf16() ? 2 : 1;
         }
-        int vmm_a_idx(const brgemm_desc_t &brg, int m, int n) const {
+        int vmm_a_idx(const brgemm_desc_t &brg, dim_t m, dim_t n) const {
             const auto idx_offset = grouped_bs(brg)
                     ? (m * brg.ld_block2 + n) * vnni_substep(brg)
                     : 0;
-            return idx_vmm_a_ + idx_offset;
+            return jit_generator_t::xbyak_register_index(
+                    idx_vmm_a_ + idx_offset);
         }
 
         int get_compute_vmm_count() { return compute_vmm_count_; }
@@ -258,8 +260,8 @@ private:
     // note 2: zmm0 collides with vmm_permute, hence need to write this value
     // before every loop.
 
-    const int simd_w_;
-    const int max_vmms_;
+    const dim_t simd_w_;
+    const dim_t max_vmms_;
     const bool compute_dst_zp_, compute_src_zp_;
     const bool is_src_zp_bcast_;
     const bool compute_compensation_; // code-path for either s8s8 or src_zp
@@ -271,21 +273,21 @@ private:
 
     bool with_binary_non_scalar_bcast_ = false;
 
-    inline int M() { return brg.bcast_dim; }
-    inline int N() { return brg.load_dim; }
-    inline int m_block2() { return brg.bd_block2; }
-    inline int nb_m_block2() { return brg.bdb2; }
-    inline int m_block2_tail() { return brg.bdb2_tail; }
+    inline dim_t M() { return brg.bcast_dim; }
+    inline dim_t N() { return brg.load_dim; }
+    inline dim_t m_block2() { return brg.bd_block2; }
+    inline dim_t nb_m_block2() { return brg.bdb2; }
+    inline dim_t m_block2_tail() { return brg.bdb2_tail; }
 
-    inline int n_block1() { return brg.ld_block; }
-    inline int nb_n_block1() { return brg.ldb; }
-    inline int n_block1_tail() { return brg.ldb_tail; }
-    inline int n_block2() { return brg.ld_block2; }
-    inline int nb_n_block2() { return brg.ldb2; }
-    inline int n_block2_tail() { return brg.ldb2_tail; }
-    int tail_length() { return n_block1_tail() % simd_w_; }
+    inline dim_t n_block1() { return brg.ld_block; }
+    inline dim_t nb_n_block1() { return brg.ldb; }
+    inline dim_t n_block1_tail() { return brg.ldb_tail; }
+    inline dim_t n_block2() { return brg.ld_block2; }
+    inline dim_t nb_n_block2() { return brg.ldb2; }
+    inline dim_t n_block2_tail() { return brg.ldb2_tail; }
+    dim_t tail_length() { return n_block1_tail() % simd_w_; }
 
-    inline int bs_group() const { return brg.bs_group; }
+    inline dim_t bs_group() const { return brg.bs_group; }
     static bool grouped_bs(const brgemm_desc_t &brg) {
         return brg.bs_group > 1;
     }
@@ -308,30 +310,34 @@ private:
 
     int vnni_substep() { return vmm_alloc.vnni_substep(brg); }
 
-    int get_substep_simd(int n_i, int v_i, bool has_n_tail) {
-        const int last_n_block_sz
+    int get_substep_simd(dim_t n_i, dim_t v_i, bool has_n_tail) {
+        const dim_t last_n_block_sz
                 = n_block2_tail() > 0 ? n_block2_tail() : n_block2();
         if (has_n_tail && n_i + 1 == last_n_block_sz) {
-            return nstl::min(simd_w_, n_block1_tail() - v_i * simd_w_);
+            return xbyak_register_index(
+                    nstl::min<dim_t>(simd_w_, n_block1_tail() - v_i * simd_w_));
         } else {
             return simd_w_;
         }
     }
-    Vmm vmm_a(int m, int n) {
+    Vmm vmm_a(dim_t m, dim_t n) {
         const auto idx_a = vmm_alloc.vmm_a_idx(brg, m, n);
         assert(idx_a < (vmm_alloc.get_idx_vmm_b() + is_fma_embd()));
         return Vmm(idx_a);
     }
-    Vmm vmm_b(int bi = 0) { return Vmm(vmm_alloc.get_idx_vmm_b() + bi); }
-    Vmm accm(int m_blocks, int n_blocks, int m, int n, int vnni_idx) {
+    Vmm vmm_b(dim_t bi = 0) {
+        return Vmm(xbyak_register_index(vmm_alloc.get_idx_vmm_b() + bi));
+    }
+    Vmm accm(dim_t m_blocks, dim_t n_blocks, dim_t m, dim_t n, dim_t vnni_idx) {
         assert(m_blocks <= m_block2() && m < m_blocks);
         assert(n_blocks <= n_block2() && n < n_blocks);
-        const int accm_start = max_vmms_ - m_blocks * n_blocks * vnni_substep();
-        const int accm_rel_idx
+        const dim_t accm_start
+                = max_vmms_ - m_blocks * n_blocks * vnni_substep();
+        const dim_t accm_rel_idx
                 = m * n_blocks * vnni_substep() + n * vnni_substep() + vnni_idx;
-        const int idx = accm_start + accm_rel_idx;
+        const dim_t idx = accm_start + accm_rel_idx;
         assert(idx < max_vmms_ && idx > vmm_b(0).getIdx());
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
     Vmm vmm_permute() { return Vmm(vmm_alloc.get_idx_vmm_permute()); }
     Vmm vmm_shift() { // -128's
@@ -340,11 +346,11 @@ private:
     Vmm vmm_s8s8_comp() { return Vmm(vmm_alloc.get_idx_vmm_s8s8_comp()); }
     Vmm vmm_zp_comp() { return Vmm(vmm_alloc.get_idx_vmm_zp_comp()); }
     Vmm vmm_bcast() { return Vmm(vmm_alloc.get_idx_vmm_bcast()); }
-    Vmm vmm_tmp(int i) {
-        const int idx
+    Vmm vmm_tmp(dim_t i) {
+        const dim_t idx
                 = max_vmms_ - m_block2() * n_block2() * vnni_substep() - 1 - i;
         assert(idx > (is_fast_vnni_int8() - 1));
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
 
     template <typename U>
@@ -352,61 +358,64 @@ private:
     void init_masks();
     void read_params();
     void load_permute_vmm();
-    void load_accumulators(int m_blocks, int n_blocks);
+    void load_accumulators(dim_t m_blocks, dim_t n_blocks);
     void restore_A_B_matrices();
     void set_A_B_matrices();
     void advance_A_B_matrices();
-    void load_a(Vmm vmma, int m_i, int n_i, int v_i, bool has_n_tail);
-    void load_b(
-            Vmm vmmb, int n_i, int v_i, bool has_n_tail, bool wei_zp = false);
+    void load_a(Vmm vmma, dim_t m_i, dim_t n_i, dim_t v_i, bool has_n_tail);
+    void load_b(Vmm vmmb, dim_t n_i, dim_t v_i, bool has_n_tail,
+            bool wei_zp = false);
     void comp_dot_product(compute_pad_kernel_t kernel_type, Vmm vmm_acc,
-            Vmm vmmb, int n,
+            Vmm vmmb, dim_t n,
             bool is_tail_block); // int8 compensation dot_product (zp and s8s8)
-    void pad_comp_kernel(compute_pad_kernel_t kernel_type, int m_blocks,
-            int n_blocks, int padding, const Xbyak::Reg64 reg_pad,
-            const std::function<int(int)> &get_mi, bool has_tail = false);
-    void vertical_pad_kernel(int m_blocks, int n_blocks, bool has_tail);
-    void batch_pad_kernel(int m_blocks, int n_blocks, bool has_tail = false);
-    void brdgmm_microkernel(int m_blocks, int n_blocks, bool has_top_padding,
-            bool has_bottom_padding, bool has_tail, int shift_a);
+    void pad_comp_kernel(compute_pad_kernel_t kernel_type, dim_t m_blocks,
+            dim_t n_blocks, dim_t padding, const Xbyak::Reg64 reg_pad,
+            const std::function<dim_t(dim_t)> &get_mi, bool has_tail = false);
+    void vertical_pad_kernel(dim_t m_blocks, dim_t n_blocks, bool has_tail);
+    void batch_pad_kernel(
+            dim_t m_blocks, dim_t n_blocks, bool has_tail = false);
+    void brdgmm_microkernel(dim_t m_blocks, dim_t n_blocks,
+            bool has_top_padding, bool has_bottom_padding, bool has_tail,
+            dim_t shift_a);
     void compute_loop();
     void get_batch_padding_info();
-    void get_vertical_padding_info(const int m_blocks);
-    void call_brdgmm_microkernel(const int m_blocks, const int n_blocks,
-            bool has_n_tail, int shift_a);
-    void batch_loop(const int m_blocks, const int n_blocks, bool has_n_tail);
+    void get_vertical_padding_info(dim_t m_blocks);
+    void call_brdgmm_microkernel(
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail, dim_t shift_a);
+    void batch_loop(dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag, bool store);
-    void apply_post_ops(int m_blocks, int n_blocks, bool has_n_tail);
+    void apply_post_ops(dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void maybe_transpose_interleaved_vnni_to_plain(
-            int m_blocks, int n_blocks, bool has_n_tail);
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void load_src_zp();
-    void compute_int8_compensation(int m_blocks, int n_blocks, bool has_n_tail);
-    void store_accumulators(int m_blocks, int n_blocks, bool has_n_tail);
+    void compute_int8_compensation(
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
+    void store_accumulators(dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void store_accumulators_without_post_ops(
-            int m_blocks, int n_blocks, bool has_n_tail);
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void store_accumulators_apply_post_ops(
-            int m_blocks, int n_blocks, bool has_n_tail);
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     bool check_effective_padding() { return has_vpad_ && M() > m_block2(); }
-    int oc_logical_offset(int n) { return n * n_block1(); }
-    int A_offset(int m, int n) {
+    dim_t oc_logical_offset(dim_t n) { return n * n_block1(); }
+    dim_t A_offset(dim_t m, dim_t n) {
         return brg.typesize_A * (m * brg.LDA + n * n_block1());
     }
-    int B_offset(int n) { return brg.typesize_B * n * n_block1(); }
-    int C_offset(int m, int n, int v) {
+    dim_t B_offset(dim_t n) { return brg.typesize_B * n * n_block1(); }
+    dim_t C_offset(dim_t m, dim_t n, dim_t v) {
         return brg.typesize_C * (m * brg.LDC + n * n_block1() + v * simd_w_);
     }
-    int D_offset(int m, int n, int v) {
+    dim_t D_offset(dim_t m, dim_t n, dim_t v) {
         return brg.typesize_D * (m * brg.LDD + n * n_block1() + v * simd_w_);
     }
-    int bias_offset(int n, int v) {
+    dim_t bias_offset(dim_t n, dim_t v) {
         return brg.typesize_bias * (n * n_block1() + v * simd_w_);
     }
-    int wei_scales_offset(int n, int v) {
-        return sizeof(float) * brg.is_per_n_wei_scales
+    dim_t wei_scales_offset(dim_t n, dim_t v) {
+        return static_cast<dim_t>(sizeof(float)) * brg.is_per_n_wei_scales
                 * (n * n_block1() + v * simd_w_);
     }
-    size_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
+    dim_t comp_offset(dim_t n) { return sizeof(int32_t) * n * n_block1(); }
 
     void generate() override;
 };

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -3035,7 +3035,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
 
 void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
     was_prev_bi_ = false;
-    const auto bdb2_to_unroll = nstl::max(0,
+    const auto bdb2_to_unroll = nstl::max<dim_t>(0,
             brg.bdb2
                     - (actual_ils(bi.apply_postops, bi.skip_accumulation) ? 1
                                                                           : 0));

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -253,10 +253,10 @@ private:
     // iteration_map_t) describe the structure of cycles and are used for
     // JIT code generation
     struct iteration_block_t {
-        int block = 0;
+        dim_t block = 0;
         dim_t pos = 0;
         bool is_tail = false;
-        iteration_block_t(dim_t pos_, int block_, bool is_tail_ = false)
+        iteration_block_t(dim_t pos_, dim_t block_, bool is_tail_ = false)
             : block(block_), pos(pos_), is_tail(is_tail_) {}
         bool operator==(const iteration_block_t &rhs) const {
             return block == rhs.block && is_tail == rhs.is_tail;
@@ -283,7 +283,7 @@ private:
             return (blocks[b].pos - blocks[0].pos);
         }
 
-        int block(size_t b) const {
+        dim_t block(size_t b) const {
             assert(b < blocks.size());
             return blocks[b].block;
         }
@@ -293,11 +293,11 @@ private:
             return blocks[b].is_tail;
         }
 
-        int block2() const { return static_cast<int>(blocks.size()); }
+        dim_t block2() const { return static_cast<dim_t>(blocks.size()); }
 
-        int length() const {
+        dim_t length() const {
             if (blocks.empty()) return 0;
-            auto n = blocks.size();
+            const dim_t n = blocks.size();
             // only last block may be different
             return ((n - 1) * blocks[0].block + blocks[n - 1].block);
         }
@@ -374,9 +374,9 @@ private:
 
     struct prf_t {
         brgemm_kernel_prefetching_t pft = brgemm_prf_default;
-        int dist = -1;
-        int vec = 0;
-        void set(brgemm_kernel_prefetching_t pft_, int dist_) {
+        dim_t dist = -1;
+        dim_t vec = 0;
+        void set(brgemm_kernel_prefetching_t pft_, dim_t dist_) {
             pft = pft_;
             dist = dist_;
             vec = 0;
@@ -405,8 +405,8 @@ private:
     // saved parameters for storing
     brgemm_iteration_t prev_bi_;
     // current storing coordinates
-    int ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
-    int ils_bd_step_ = 3; // heuristic value
+    dim_t ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
+    dim_t ils_bd_step_ = 3; // heuristic value
     prf_t prf0A, prf1A, prf2A, prfntaA, prf0B, prf1B, prf2B, prfntaB, prf0C,
             prf1C;
 
@@ -441,22 +441,22 @@ private:
     const Xbyak::Zmm zmm_ubound = zmm9;
 
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
-    Xbyak::Zmm accm(int bd) const {
+    Xbyak::Zmm accm(dim_t bd) const {
         assert(bd < 16);
-        return Xbyak::Zmm(31 - (bd % ils_bd_step_));
+        return Xbyak::Zmm(xbyak_register_index(31 - (bd % ils_bd_step_)));
     }
 
-    Xbyak::Zmm zmm_bias(int ldb) const {
+    Xbyak::Zmm zmm_bias(dim_t ldb) const {
         assert(ldb < 5);
         // zmm10 - zmm14
-        return Xbyak::Zmm(10 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(10 + ldb));
     }
 
-    Xbyak::Zmm zmm_scales(int ldb) const {
+    Xbyak::Zmm zmm_scales(dim_t ldb) const {
         assert(ldb < 5);
         assert(ils_bd_step_ < 10);
         // zmm15 - zmm19
-        return Xbyak::Zmm(15 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(15 + ldb));
     }
 
     template <typename U>
@@ -473,26 +473,26 @@ private:
     void maybe_saturation(Xbyak::Zmm &zmm);
     void apply_alpha_beta_to_vector(
             int idx, const Address &addr, bool is_ld_tail);
-    void apply_post_ops_to_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void apply_post_ops_to_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_with_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, int ldb);
+    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, dim_t ldb);
     void prepare_post_ops_registers(brgemm_iteration_t &bi);
 
     bool bi_shift_output(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_A(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_B(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
 
     void uni_prefetch(const Address &addr, brgemm_kernel_prefetching_t pft,
             bool for_write);
     void prefetch_CD_range(brgemm_iteration_t &bi,
-            brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish,
-            int bdb, int ldb);
-    int calc_ops_CD(brgemm_iteration_t &bi) const noexcept;
+            brgemm_kernel_prefetching_t pft, dim_t bd_start, dim_t bd_finish,
+            dim_t bdb, dim_t ldb);
+    dim_t calc_ops_CD(brgemm_iteration_t &bi) const noexcept;
     void prefetch_CD(brgemm_iteration_t &bi, brgemm_iteration_t &pfo_bi,
             prf_t &prf, bool prefetch_all);
 
@@ -502,58 +502,58 @@ private:
             prf_t &prf, bool prefetch_all);
     void prefetching(brgemm_iteration_t &bi, bool prefetch_all);
 
-    void process_output_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void process_output_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_without_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void store_vector(brgemm_iteration_t &bi, int bdb, int bd, int ldb);
-    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb, const int idx);
+    void store_vector(brgemm_iteration_t &bi, dim_t bdb, dim_t bd, dim_t ldb);
+    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb, const int idx);
 
     void interleave_store(brgemm_iteration_t &bi, bool store_all);
 
     void store_accumulators(brgemm_iteration_t &bi);
 
-    void set_A_B_matrices(int bs);
+    void set_A_B_matrices(dim_t bs);
     void set_A_B_matrices();
 
     void bf32_downconvert(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf);
     void fp8_to_f16_upconvert(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt);
 
     void fp8_to_f16_upconvert_to_vnni(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt);
 
     void bf32_downconvert_to_vnni(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf);
 
     void maybe_pre_process_data(brgemm_iteration_t &bi, const Tmm &t1,
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
 
-    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
+    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk, bool use_memadvice);
 
     bool process_k_tail_only_last_tile();
 
-    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
+    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset_src, dim_t offset_dst,
             bool mem_advice_A);
 
     void maybe_tileloadd_nt(
-            brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset);
+            brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset);
 
-    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
+    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, dim_t bdb);
 
     void maybe_sprinkle_prefetches();
 
-    void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
     void gemm_microkernel_amx(brgemm_iteration_t &bi);
@@ -573,7 +573,7 @@ private:
     void generate() override;
 
     void prepare_bd_mask() noexcept;
-    int skipped_bd_mask(int inp_bd) noexcept;
+    dim_t skipped_bd_mask(dim_t inp_bd) noexcept;
 
     bool get_store_by_vectors(bool apply_post_ops) const {
         const bool need_to_apply_post_ops
@@ -588,46 +588,46 @@ private:
                 && !skip_accumulation);
     }
 
-    dim_t A_offset(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_wsp(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset_wsp(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
-            int bd_elem_idx = 0) const noexcept;
+    dim_t A_offset_line(const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb = 0,
+            dim_t bd_elem_idx = 0) const noexcept;
 
-    dim_t B_offset(
-            const brgemm_iteration_t &bi, int ldb, int rdb = 0) const noexcept;
+    dim_t B_offset(const brgemm_iteration_t &bi, dim_t ldb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t B_offset_line(const brgemm_iteration_t &bi, int ldb, int rdb = 0,
-            int rd_elem_idx = 0) const noexcept;
+    dim_t B_offset_line(const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb = 0,
+            dim_t rd_elem_idx = 0) const noexcept;
 
-    dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
+    dim_t C_offset(const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+            dim_t ldb) const noexcept;
 
-    dim_t D_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
+    dim_t D_offset(const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+            dim_t ldb) const noexcept;
 
     dim_t lda() const noexcept;
     dim_t ldb() const noexcept;
 
-    dim_t bias_offset(int ldb) const noexcept;
+    dim_t bias_offset(dim_t ldb) const noexcept;
 
-    dim_t scales_offset(int ldb) const noexcept;
-    dim_t zp_comp_a_offset(int ldb) const noexcept;
-    dim_t zp_comp_pad_a_offset(const brgemm_iteration_t &bi, int bdb,
-            int inp_bd, int ldb) const noexcept;
-    dim_t zp_comp_b_offset(int bd) const noexcept;
-    dim_t zp_c_values_offset(brgemm_iteration_t &bi, int ldb) const noexcept;
-    dim_t per_mn_comp_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
-    bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
-    int get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
+    dim_t scales_offset(dim_t ldb) const noexcept;
+    dim_t zp_comp_a_offset(dim_t ldb) const noexcept;
+    dim_t zp_comp_pad_a_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb) const noexcept;
+    dim_t zp_comp_b_offset(dim_t bd) const noexcept;
+    dim_t zp_c_values_offset(brgemm_iteration_t &bi, dim_t ldb) const noexcept;
+    dim_t per_mn_comp_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb) const noexcept;
+    bool is_out_bd(const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const;
+    dim_t get_out_bd(const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const;
 
-    void maybe_tilestore(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void maybe_tilestore(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
-    int get_C_tensor(brgemm_iteration_t &bi, int m, int n) const noexcept;
+    dim_t get_C_tensor(brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept;
     void top_loop(brgemm_iteration_t &bi);
     bd_iteration_t *find_similar(const bd_iteration_t *bdi, bool apply_postops);
 
@@ -639,7 +639,7 @@ private:
 };
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_output(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     if (shift == 0) return true;
 
@@ -669,7 +669,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_output(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_A(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nbdis = tloop.bdis.size();
@@ -689,7 +689,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_A(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_B(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nldis = tloop.ldis.size();
@@ -708,8 +708,8 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_B(
     return true;
 }
 
-int jit_brgemm_amx_uker_base_t::get_C_tensor(
-        brgemm_iteration_t &bi, int m, int n) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::get_C_tensor(
+        brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept {
     return brg.get_C_tensor(m, n, bi.bdi->is_tail(m), bi.ldi->is_tail(n));
 }
 
@@ -720,8 +720,8 @@ void jit_brgemm_amx_uker_base_t::prepare_bd_mask() noexcept {
     adj_bd_mask_buffer_.resize(bd_mask_size);
     skipped_bd_mask_buffer_.resize(bd_mask_size);
     if (bd_mask_buffer_ptr_ != nullptr) {
-        int out_ibd = 0;
-        for (int i = 0; i < bd_mask_size; i++) {
+        dim_t out_ibd = 0;
+        for (dim_t i = 0; i < bd_mask_size; i++) {
             adj_bd_mask_buffer_[i] = out_ibd;
             out_ibd += bd_mask_buffer_ptr_[i];
             skipped_bd_mask_buffer_[i] = i;
@@ -736,7 +736,7 @@ void jit_brgemm_amx_uker_base_t::prepare_bd_mask() noexcept {
         assert(!"struct nullptr error");
 }
 
-int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
+dim_t jit_brgemm_amx_uker_base_t::skipped_bd_mask(dim_t inp_bd) noexcept {
     if (brg.brgattr.bd_mask_level != 2)
         return inp_bd;
     else
@@ -744,7 +744,7 @@ int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     // Full WSP buffer layout:
     //   1. partial C results.
     //   2. data type conversion.
@@ -764,7 +764,7 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.A
             : 0;
@@ -775,12 +775,12 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
-        int bdb, int rdb, int bd_elem_idx) const noexcept {
+        dim_t bdb, dim_t rdb, dim_t bd_elem_idx) const noexcept {
     return A_offset(bi, bdb, rdb) + bd_elem_idx * LDA2_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset(
-        const brgemm_iteration_t &bi, int ldb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.B
             : 0;
@@ -796,12 +796,12 @@ dim_t jit_brgemm_amx_uker_base_t::B_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
-        int ldb, int rdb, int rd_elem_idx) const noexcept {
+        dim_t ldb, dim_t rdb, dim_t rd_elem_idx) const noexcept {
     return B_offset(bi, ldb, rdb) + rd_elem_idx * LDB_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
-        int bdb, int inp_bd, int ldb) const noexcept {
+        dim_t bdb, dim_t inp_bd, dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -814,7 +814,7 @@ dim_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
 }
 
 dim_t jit_brgemm_amx_uker_base_t::D_offset(const brgemm_iteration_t &bi,
-        int bdb, int inp_bd, int ldb) const noexcept {
+        dim_t bdb, dim_t inp_bd, dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -829,21 +829,21 @@ dim_t jit_brgemm_amx_uker_base_t::ldb() const noexcept {
     return LDB_size_ * brg.rd_step;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::bias_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::bias_offset(dim_t ldb) const noexcept {
     return ldb * ld_block_bias_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::scales_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::scales_offset(dim_t ldb) const noexcept {
     return brg.is_per_n_wei_scales * ldb * ld_block_scales_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(dim_t ldb) const noexcept {
     return ldb * ld_block_zp_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_comp_pad_a_offset(
-        const brgemm_iteration_t &bi, int bdb, int inp_bd,
-        int ldb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+        dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -851,12 +851,12 @@ dim_t jit_brgemm_amx_uker_base_t::zp_comp_pad_a_offset(
             + (dim_t)ldb * ld_block_zp_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(int bd) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(dim_t bd) const noexcept {
     return sizeof(int32_t) * bd;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
-        brgemm_iteration_t &bi, int ldb) const noexcept {
+        brgemm_iteration_t &bi, dim_t ldb) const noexcept {
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         return (bi.ldi->is_tail(ldb)) ? ldb_tail_zp_size_
                                       : bi.ldi->pos(ldb) * ld_block_zp_size_;
@@ -866,8 +866,8 @@ dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
-        const brgemm_iteration_t &bi, int bdb, int inp_bd,
-        int ldb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+        dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     assert(bd >= 0);
@@ -881,14 +881,14 @@ dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
 }
 
 bool jit_brgemm_amx_uker_base_t::is_out_bd(
-        const bd_iteration_t *bdi, int bdb, int inp_bd) const {
+        const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const {
     const auto bd = bdi->pos(bdb) + inp_bd;
     return IMPLICATION(
             brg.brgattr.bd_mask_level, bdi->bd_mask[bd - bdi->pos(0)] != 0);
 }
 
-int jit_brgemm_amx_uker_base_t::get_out_bd(
-        const bd_iteration_t *bdi, int bdb, int inp_bd) const {
+dim_t jit_brgemm_amx_uker_base_t::get_out_bd(
+        const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const {
     if (!is_out_bd(bdi, bdb, inp_bd)) return -1;
     const auto bd = bdi->pos(bdb) + inp_bd;
     if (brg.brgattr.bd_mask_level) {
@@ -978,17 +978,17 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
         ils_shift = need_ils_shift ? bi.bdi->C_shift : 0;
     }
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
-            tileloadd(Tmm(get_C_tensor(bi, bdb, ldb)),
+            tileloadd(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))),
                     ptr[reg_C + c_offset + reg_stride_ld_block]);
         } else {
             // call tilezero on very first iteration
             if (!brg.interleave_tilestores_
                     || everyone_is(0u, bi.bdi->idx, bi.ldi->idx))
-                tilezero(Tmm(get_C_tensor(bi, bdb, ldb)));
+                tilezero(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -1035,8 +1035,8 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     }
 }
 
-void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
@@ -1127,7 +1127,7 @@ void jit_brgemm_amx_uker_base_t::maybe_saturation(Xbyak::Zmm &zmm) {
 }
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
-        brgemm_iteration_t &bi, int ldb) {
+        brgemm_iteration_t &bi, dim_t ldb) {
     if (!bi.apply_postops) return;
     auto k_mask = (!bi.ldi->is_tail(ldb)) ? ld_full_mask : ld_tail_mask;
 
@@ -1168,7 +1168,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     // This must happen for both apply_postops and non-apply_postops paths.
     if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1212,7 +1212,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 case data_type::f32:
                 default: vbroadcastss(zmm_src_sc, src_sc_addr); break;
             }
-            for (int ldb = 0; ldb < ldi->block2(); ldb++)
+            for (dim_t ldb = 0; ldb < ldi->block2(); ldb++)
                 vmulps(zmm_scales(ldb), zmm_scales(ldb), zmm_src_sc);
         }
     }
@@ -1222,7 +1222,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
 
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto ptr_bias
                     = EVEX_compress_addr(reg_bias, bias_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1233,7 +1233,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_src_scales && !brg.is_per_k_src_scales
             && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
@@ -1261,7 +1261,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
 
     if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1345,10 +1345,10 @@ void jit_brgemm_amx_uker_base_t::uni_prefetch(
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
-        brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish, int bdb,
-        int ldb) {
+        brgemm_kernel_prefetching_t pft, dim_t bd_start, dim_t bd_finish,
+        dim_t bdb, dim_t ldb) {
     const auto ldb_pos = bi.ldi->pos(ldb);
-    for (int bd = bd_start; bd < bd_finish; bd++) {
+    for (dim_t bd = bd_start; bd < bd_finish; bd++) {
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
         if (bi.apply_postops) {
             const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
@@ -1371,11 +1371,11 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
     }
 }
 
-int jit_brgemm_amx_uker_base_t::calc_ops_CD(
+dim_t jit_brgemm_amx_uker_base_t::calc_ops_CD(
         brgemm_iteration_t &bi) const noexcept {
     const auto &tloop = imap_[bi.apply_postops];
-    return tloop.rdis.size() * bi.ldi->block2() * bi.bdi->block2()
-            * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs);
+    return static_cast<dim_t>(tloop.rdis.size()) * bi.ldi->block2()
+            * bi.bdi->block2() * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs);
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
@@ -1394,7 +1394,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
             = (are_post_ops_applicable_ && !prev_bi_.apply_postops)
             ? brg.typesize_C
             : brg.typesize_D;
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / bdb_row;
         const auto vec_in_bdb_row = prf.vec - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / pfo_bi.bdi->block(bdb);
@@ -1418,7 +1418,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_A(brgemm_iteration_t &bi,
             ? tot_vecs
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / pfo_bi.bdi->block(0);
         const auto bd = prf.vec % pfo_bi.bdi->block(0);
 
@@ -1442,7 +1442,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_B(brgemm_iteration_t &bi,
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
     // TODO: check these addressing for correctness
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
 
         const auto ldb = prf.vec / pfo_bi.rdi->block(0);
         const auto rb = prf.vec % pfo_bi.rdi->block(0);
@@ -1505,7 +1505,8 @@ void jit_brgemm_amx_uker_base_t::prefetching(
 }
 
 void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb, const int idx) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb,
+        const int idx) {
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     auto zmm = Zmm(idx);
@@ -1526,8 +1527,8 @@ void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
     vaddps(zmm_masked, zmm, zmm_zp_comp_a);
 }
 
-void jit_brgemm_amx_uker_base_t::process_output_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::process_output_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
 
     const auto k_mask = bi.ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
@@ -1778,7 +1779,7 @@ void jit_brgemm_amx_uker_base_t::store_vector_without_post_ops(
 }
 
 void jit_brgemm_amx_uker_base_t::store_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb) {
 
     if (!is_out_bd(bi.bdi, bdb, inp_bd)) return;
 
@@ -1838,7 +1839,7 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
     const auto bdb_row = prev_bi_.bdi->block(0) * prev_bi_.ldi->block2();
     const auto total_vectors = prev_bi_.bdi->length() * prev_bi_.ldi->block2();
     const auto nvecs = store_all ? total_vectors : ils_vecs_per_store;
-    for (int vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
+    for (dim_t vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
         const auto bdb = ils_vec_ / bdb_row;
         const auto vec_in_bdb_row = ils_vec_ - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / prev_bi_.bdi->block(bdb);
@@ -1887,8 +1888,8 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
     if (store_by_vectors && !real_ils && !prepare_post_ops_registers_once_)
         prepare_post_ops_registers(bi);
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (store_by_vectors) {
             if (!brg.interleave_tilestores_ && !bi.skip_accumulation) {
                 const auto wsp_offset = use_ils_
@@ -1896,13 +1897,13 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
                                 * ld_block_C_size_
                         : 0;
                 tilestored(ptr[reg_buf + reg_stride_ld_block + wsp_offset],
-                        Tmm(get_C_tensor(bi, bdb, ldb)));
+                        Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
             }
             if (real_ils) continue;
 
             prepare_post_ops_registers_ldb(bi, ldb);
 
-            for (int bd_step = 0; bd_step < bi.bdi->block(bdb);
+            for (dim_t bd_step = 0; bd_step < bi.bdi->block(bdb);
                     bd_step += ils_bd_step_) {
                 auto bd_finish
                         = nstl::min(bd_step + ils_bd_step_, bi.bdi->block(bdb));
@@ -1914,12 +1915,12 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
         } else if (!brg.interleave_tilestores_) {
             const auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb));
             tilestored(ptr[reg_C + reg_stride_ld_block + c_offset],
-                    Tmm(get_C_tensor(bi, bdb, ldb)));
+                    Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
 
-void jit_brgemm_amx_uker_base_t::set_A_B_matrices(int bs) {
+void jit_brgemm_amx_uker_base_t::set_A_B_matrices(dim_t bs) {
     if (one_of(brg.type, brgemm_static_offs)) return;
     assert(one_of(brg.type, brgemm_addr, brgemm_offs));
     if (brg.brgattr.max_bs == 1) return;
@@ -2025,13 +2026,14 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
     current_num_amx_ops++;
 }
 void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
-        brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset) {
+        brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset) {
 
     const bool is_A = mk == matrix_kind_t::matrix_A;
     bool load_nt = is_A ? brg.load_nt_A : brg.load_nt_B;
 
-    auto t1 = Tmm(is_A ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
-                       : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb)));
+    auto t1 = Tmm(xbyak_register_index(is_A
+                    ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
+                    : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb))));
     auto reg_base = is_A ? reg_A : reg_B;
     auto reg_stride = is_A ? reg_stride_lda : reg_stride_ldb;
 
@@ -2066,8 +2068,9 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 }
 
 void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
-        brgemm_iteration_t &bi, int bdb) {
-    auto t1 = Tmm(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb)));
+        brgemm_iteration_t &bi, dim_t bdb) {
+    auto t1 = Tmm(
+            xbyak_register_index(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
 
     auto load_a_tile_from_wsp = [&]() {
         if (brg.load_nt_A) {
@@ -2106,7 +2109,7 @@ void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
     };
 }
 void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
-        int bdb_idx, int ldb_idx, bool do_pre_tilestore,
+        dim_t bdb_idx, dim_t ldb_idx, bool do_pre_tilestore,
         bool do_post_tilestore) {
     if (bi.skip_accumulation) return;
     auto current_tensor_idx = get_C_tensor(bi, bdb_idx, ldb_idx);
@@ -2120,8 +2123,8 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     const auto store_tensor_number = current_tensor_number + store_tensor_shift;
 
     const auto &store_bi = do_pre_tilestore ? prev_bi_ : bi;
-    const int max_store_tensor_number
-            = store_bi.bdi->blocks.size() * store_bi.ldi->blocks.size();
+    const dim_t max_store_tensor_number
+            = store_bi.bdi->block2() * store_bi.ldi->block2();
     bool perform_store
             = (do_pre_tilestore
                       && (store_tensor_number >= 2
@@ -2134,7 +2137,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
         ldb_idx = store_tensor_idx % bi.ldi->block2();
     }
     const bool store_by_vectors = get_store_by_vectors(bi.apply_postops);
-    Tmm acc = Tmm(store_tensor_idx);
+    Tmm acc = Tmm(xbyak_register_index(store_tensor_idx));
     if (store_by_vectors) {
         const auto wsp_offset = (use_ils_ || brg.interleave_tilestores_)
                 ? (bdb_idx * bi.ldi->block2() + ldb_idx) * bi.bdi->block(0)
@@ -2151,14 +2154,17 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     tilezero(acc);
 }
 
-void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
-        int ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
+void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx,
+        dim_t ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
     prefetching(bi, false);
     maybe_tilestore(bi, bdb_idx, ldb_idx, do_pre_tilestore, false);
 
-    const Tmm &x1 = Tmm(get_C_tensor(bi, bdb_idx, ldb_idx));
-    const Tmm &x2 = Tmm(brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx)));
-    const Tmm &x3 = Tmm(brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx)));
+    const Tmm &x1
+            = Tmm(xbyak_register_index(get_C_tensor(bi, bdb_idx, ldb_idx)));
+    const Tmm &x2 = Tmm(xbyak_register_index(
+            brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx))));
+    const Tmm &x3 = Tmm(xbyak_register_index(
+            brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx))));
 
     using namespace data_type;
     if (brg.is_tf32) {
@@ -2195,12 +2201,12 @@ void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
-        int num_rows, int tile_num_col_bytes, reg64_t reg_data, int offset,
+        int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt) {
     const auto rd_block = bi.rdi->block(0);
-    const int max_num_cols
-            = nstl::min<int>(tile_num_col_bytes / sizeof(float16_t), rd_block);
-    const int col_tail = max_num_cols % 32;
+    const dim_t max_num_cols = nstl::min<dim_t>(
+            tile_num_col_bytes / sizeof(float16_t), rd_block);
+    const dim_t col_tail = max_num_cols % 32;
     auto zmm_1 = zmm_tmp_1();
     auto zmm_1_masked = col_tail ? zmm_1 | fp_col_mask | T_z : zmm_1;
 
@@ -2232,11 +2238,11 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
 // This method down-converts the data from f32 to bf16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 void jit_brgemm_amx_uker_base_t::bf32_downconvert(brgemm_iteration_t &bi,
-        int num_rows, int tile_num_col_bytes, reg64_t reg_data, int offset,
+        int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf) {
     const auto rd_block = bi.rdi->block(0);
-    const auto max_num_cols
-            = nstl::min<int>(tile_num_col_bytes / sizeof(bfloat16_t), rd_block);
+    const auto max_num_cols = nstl::min<dim_t>(
+            tile_num_col_bytes / sizeof(bfloat16_t), rd_block);
     const auto col_tail = max_num_cols % simd_w;
     auto zmm_1 = zmm_tmp_1();
     auto zmm_2 = zmm_tmp_2();
@@ -2276,8 +2282,8 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert(brgemm_iteration_t &bi,
 // format. Generally used by matrix_B.
 void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
         brgemm_iteration_t &bi, int num_rows, int tile_num_col_bytes,
-        reg64_t reg_data, int offset, reg64_t reg_data_stride, reg64_t reg_buf,
-        data_type_t dt) {
+        reg64_t reg_data, dim_t offset, reg64_t reg_data_stride,
+        reg64_t reg_buf, data_type_t dt) {
     const int num_cols_ele = tile_num_col_bytes / 2; // 32 for full tile
     const int num_N = num_cols_ele / 2; // 16 for full tile
     const auto zmm_2 = zmm_tmp_2();
@@ -2290,22 +2296,22 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
     lea(reg_data_aux, ptr[reg_data + offset]);
 
     const int vnni_granularity = 2;
-    const int r_end = utils::div_up(rd_block, vnni_granularity);
+    const dim_t r_end = utils::div_up(rd_block, vnni_granularity);
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else
         assert(!"unsupported data type");
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2314,7 +2320,7 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
 // format. Generally used by matrix_B.
 void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         brgemm_iteration_t &bi, int num_rows, int tile_num_col_bytes,
-        reg64_t reg_data, int offset, reg64_t reg_data_stride,
+        reg64_t reg_data, dim_t offset, reg64_t reg_data_stride,
         reg64_t reg_buf) {
     const auto num_cols_ele = tile_num_col_bytes / sizeof(bfloat16_t);
     const auto num_N = num_cols_ele / sizeof(bfloat16_t);
@@ -2342,12 +2348,12 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
     lea(reg_data_aux, ptr[reg_data + offset]);
 
     const auto rd_block = bi.rdi->block(0);
-    const int vnni_granularity
+    const auto vnni_granularity
             = data_type_vnni_granularity(data_type_t::dnnl_bf16);
-    const auto r_end
-            = nstl::min(utils::div_up(rd_block, vnni_granularity), num_rows);
+    const dim_t r_end = nstl::min<dim_t>(
+            utils::div_up(rd_block, vnni_granularity), num_rows);
 
-    for (int r = 0; r < r_end; ++r) {
+    for (dim_t r = 0; r < r_end; ++r) {
         load(zmm_1, ptr[reg_data_aux]);
 
         if (r * vnni_granularity + 1 >= rd_block) {
@@ -2360,13 +2366,15 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         vpermw(zmm_1, zmm_bf32_permute, zmm_1);
         vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_1);
         lea(reg_data_aux,
-                ptr[reg_data_aux + vnni_granularity * reg_data_stride]);
+                ptr[reg_data_aux
+                        + reg_data_stride
+                                * xbyak_address_scale(vnni_granularity)]);
     }
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2401,9 +2409,9 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
     const auto matrix_a_offset = transform_offset;
     const auto matrix_b_offset = transform_offset
             + brgemm_desc_t::tilesize
-                    * (nstl::max<int>(should_save_transform(mk),
+                    * nstl::max<dim_t>(should_save_transform(mk),
                             should_save_transform(matrix_A) * brg.brgattr.max_bs
-                                    * max_bdb2 * max_rdb));
+                                    * max_bdb2 * static_cast<dim_t>(max_rdb));
     const auto matrix_offset = is_A ? matrix_a_offset : matrix_b_offset;
     const std::string key
             = std::to_string(bi.bsi->pos) + "_" + std::to_string(offset);
@@ -2454,7 +2462,7 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 }
 
 void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset_src, dim_t offset_dst, bool mem_advice_A) {
     if (offset_dst) add(reg_buf, offset_dst);
     copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
@@ -2466,12 +2474,12 @@ bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
     // The check is on the last tile on K dim and tile before last on M dim. If
     // loading that tile exceeds the A matrix, then we need to process K tail
     // on every M tile.
-    int last_bd_block = brg.bdb_tail == 0 ? brg.bd_block : brg.bdb_tail;
+    const dim_t last_bd_block = brg.bdb_tail == 0 ? brg.bd_block : brg.bdb_tail;
     return brg.rd_block - brg.rdb_tail <= last_bd_block * brg.reduce_dim;
 }
 
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset, reg64_t reg_stride, matrix_kind_t mk,
         bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
@@ -2513,7 +2521,7 @@ void jit_brgemm_amx_uker_base_t::copy_k_tail_to_wsp(const Tmm &t1,
     const auto num_col_bytes = palette_.cols[t1.getIdx()];
 
     const auto max_num_cols
-            = nstl::min<int>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
+            = nstl::min<dim_t>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
     const size_t col_tail
             = max_num_cols % (zmm_width_in_bytes / brg.typesize_A);
     if (col_tail) {
@@ -2577,7 +2585,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
     else
         mov(reg_stride_ld_block, LDC_size_);
 
-    for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+    for (dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++) {
         if (brg.fused_copy_a) {
             maybe_fused_copy_A_nt_load(bi, bdb);
         } else {
@@ -2585,7 +2593,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
                     bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
         }
 
-        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
             if (bdb == 0)
                 maybe_tileloadd_nt(
                         bi, matrix_kind_t::matrix_B, ldb, B_offset(bi, ldb));
@@ -2713,7 +2721,7 @@ void jit_brgemm_amx_uker_base_t::bs_loop(brgemm_iteration_t &bi) {
         store_accumulators(bi);
     } else {
         if (brg.alpha != 0.f) {
-            for (int bs = 0; bs < brg.brgattr.max_bs; bs++) {
+            for (dim_t bs = 0; bs < brg.brgattr.max_bs; bs++) {
                 bi.bsi = &(tloop.bsis[bs]);
                 bi.first_bsi = bi.bsi->is_first;
                 bi.last_bsi = bi.bsi->is_last;
@@ -2832,8 +2840,8 @@ void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
     if (brg.interleave_tilestores_) {
         prev_bi_ = bi;
         was_prev_bi_ = true;
-        for_(int bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
-        for (int ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
+        for_(dim_t bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
+        for (dim_t ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
             maybe_tilestore(prev_bi_, bdb, ldb, true, false);
         }
     }
@@ -2867,13 +2875,13 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         auto bdi_pos = skipped_bd_mask(0);
         bd_iteration_t bdi;
         bdi.blocks.reserve(brg.bd_block2);
-        int prefetch_distance_m = brg.bcast_dim;
+        dim_t prefetch_distance_m = brg.bcast_dim;
         bd_iteration_t bdi_prefetch;
         bi_prefetch.bdi = &bdi_prefetch;
 
-        for (int bdb = 0; bdb < brg.bdb; bdb += brg.bd_block2) {
+        for (dim_t bdb = 0; bdb < brg.bdb; bdb += brg.bd_block2) {
             bdi.blocks.clear();
-            for (int ibdb = 0; ibdb < brg.bd_block2; ibdb++) {
+            for (dim_t ibdb = 0; ibdb < brg.bd_block2; ibdb++) {
                 auto abdb = bdb + ibdb;
                 if (abdb >= brg.bdb) break;
                 if (brg.bdb_tail && abdb == brg.bdb - 1) {
@@ -2920,16 +2928,16 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
             tloop.bdis.push_back(bdi);
         }
 
-        size_t ldi_pos = 0;
+        dim_t ldi_pos = 0;
         dim_iteration_t ldi;
         ldi.blocks.reserve(brg.ld_block2);
-        size_t prefetch_distance_n = (size_t)brg.ldb;
+        dim_t prefetch_distance_n = brg.ldb;
         bd_iteration_t ldi_prefetch;
         bi_prefetch.ldi = &ldi_prefetch;
 
-        for (int ldb = 0; ldb < brg.ldb; ldb += brg.ld_block2) {
+        for (dim_t ldb = 0; ldb < brg.ldb; ldb += brg.ld_block2) {
             ldi.blocks.clear();
-            for (int ildb = 0; ildb < brg.ld_block2; ildb++) {
+            for (dim_t ildb = 0; ildb < brg.ld_block2; ildb++) {
                 auto aldb = ldb + ildb;
                 if (aldb >= brg.ldb) break;
                 if (brg.ldb_tail && aldb == brg.ldb - 1) {
@@ -2952,13 +2960,13 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
             tloop.ldis.push_back(ldi);
         }
 
-        size_t rdi_pos = 0;
+        dim_t rdi_pos = 0;
         dim_iteration_t rdi;
         rdi.blocks.reserve(1);
         dim_iteration_t rdi_prefetch;
         bi_prefetch.rdi = &rdi_prefetch;
 
-        for (int rdb = 0; rdb < brg.rdb; rdb++) {
+        for (dim_t rdb = 0; rdb < brg.rdb; rdb++) {
             rdi.blocks.clear();
             rdi.blocks.emplace_back(rdi_pos, brg.rd_block);
             if (brg.prfA.sprinkled || brg.prfB.sprinkled) {
@@ -2982,7 +2990,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         // is not supported. In order to support prefetches in this case,
         // current_num_amx_ops needs to be an array per bs in bs_max.
         bs_iteration_t bsi;
-        for (int bs = 0; bs < brg.brgattr.max_bs; bs++) {
+        for (dim_t bs = 0; bs < brg.brgattr.max_bs; bs++) {
             bsi.pos = bs;
             bsi.is_first = (bs == 0);
             bsi.is_last = (bs == brg.brgattr.max_bs - 1);
@@ -2996,7 +3004,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                         = find_similar(&(tloop.bdis[ibdi]), apply_postops);
             }
         }
-        size_t rdb_including_tail = brg.rdb + (brg.rdb_tail > 0 ? 1 : 0);
+        const dim_t rdb_including_tail = brg.rdb + (brg.rdb_tail > 0 ? 1 : 0);
         num_amx_ops = brg.bdb * rdb_including_tail * brg.ldb;
         current_num_amx_ops = 0;
         // Calculate the offsets of A's cache lines to prefetch
@@ -3004,8 +3012,8 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         if (brg.prfA.sprinkled) {
             for (size_t bdb = 0; bdb < bdi_prefetch.blocks.size(); ++bdb) {
                 for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
-                    int bd_block_size = bdi_prefetch.blocks[bdb].block;
-                    for (int bd = 0; bd < bd_block_size; bd++) {
+                    const dim_t bd_block_size = bdi_prefetch.blocks[bdb].block;
+                    for (dim_t bd = 0; bd < bd_block_size; bd++) {
                         prf_sprinkled_a.prefetch_offsets.push_back(
                                 A_offset_line(bi_prefetch, bdb, rdb, bd));
                     }
@@ -3020,8 +3028,8 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         if (brg.prfB.sprinkled) {
             for (size_t ldb = 0; ldb < ldi_prefetch.blocks.size(); ++ldb) {
                 for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
-                    int rd_block_size = rdi_prefetch.blocks[rdb].block;
-                    for (int rd = 0; rd < rd_block_size; rd += brg.rd_step) {
+                    const dim_t rd_block_size = rdi_prefetch.blocks[rdb].block;
+                    for (dim_t rd = 0; rd < rd_block_size; rd += brg.rd_step) {
                         prf_sprinkled_b.prefetch_offsets.push_back(
                                 B_offset_line(bi_prefetch, ldb, rdb, rd));
                     }

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -305,7 +305,8 @@ private:
     }
 
     Vmm accm(dim_t ld_block, dim_t bd, dim_t ld) const noexcept {
-        return Vmm(max_effective_vregs - 1 - (bd * ld_block + ld));
+        return Vmm(xbyak_register_index(
+                max_effective_vregs - 1 - (bd * ld_block + ld)));
     }
 
     Vmm bcst(dim_t bd = 0) const noexcept {
@@ -313,7 +314,7 @@ private:
             dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - bd;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         } else
             return Vmm(0);
     }
@@ -325,20 +326,20 @@ private:
             dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - ld;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         }
     }
 
     Vmm gemv_load_a() const noexcept {
         assert(brg.is_gemv);
         const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm gemv_load_b() const noexcept {
         assert(brg.is_gemv);
         const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm vmm_tmp(dim_t i) const noexcept {
@@ -346,7 +347,7 @@ private:
         MAYBE_UNUSED(bd_block);
         assert(IMPLICATION(!brg.is_tmm,
                 i >= 0 && i < max_effective_vregs - bd_block * brg.ld_block2));
-        return Vmm(i);
+        return Vmm(xbyak_register_index(i));
     }
 
     Vmm vmm_tail_mask() const noexcept { return vmm_tmp(1); }
@@ -1168,7 +1169,8 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
         for_(dim_t bdb = 0; bdb < bd_block2; bdb++)
         for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
             dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
-            tilezero(Tmm(brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail)));
+            tilezero(Tmm(xbyak_register_index(
+                    brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail))));
         }
     } else if (brg.is_gemv) {
         for (dim_t bd = 0; bd < brg.gemv_bd_block(); bd++) {
@@ -1246,11 +1248,11 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else
         assert(!"unsupported data type");
 
@@ -2431,7 +2433,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
             for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
                 for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
                     const dim_t idx = is_ld_tail ? brg.ld_block2 : ldb;
-                    const int c_tensor = brg.get_C_tensor(
+                    const dim_t c_tensor = brg.get_C_tensor(
                             bdb, idx, is_bdb_tail, is_ld_tail);
                     if (do_accum_ops) {
                         if (skip_accumulation) {
@@ -2441,7 +2443,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                             }
                         } else {
                             tilestored(ptr[reg_buf + reg_stride_ld_block],
-                                    Tmm(c_tensor));
+                                    Tmm(xbyak_register_index(c_tensor)));
                             for (dim_t bd = 0; bd < adj_bd_block; bd++) {
                                 const size_t buf_offset
                                         = (bd * brg.ld_block) * brg.typesize_C;
@@ -2481,7 +2483,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
                         reg_buf.restore();
                     } else {
-                        auto tmm = Tmm(c_tensor);
+                        auto tmm = Tmm(xbyak_register_index(c_tensor));
                         if (skip_accumulation) tilezero(tmm);
                         tilestored(ptr[reg_aux_C + reg_stride_ld_block], tmm);
                         if (ldb < ld_block2 - 1)
@@ -2735,7 +2737,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
 
     const dim_t tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
                                : brg.get_B_tensor(idx, is_tail);
-    auto t1 = Tmm(tmm_idx);
+    auto t1 = Tmm(xbyak_register_index(tmm_idx));
 
     auto reg_base = is_A ? reg_aux_A : reg_aux_B;
 
@@ -2752,7 +2754,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
         dim_t rd_block
                 = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
         if (brg.is_input_convert()) {
-            const int vnni_granularity
+            const auto vnni_granularity
                     = data_type_vnni_granularity(data_type::f16);
             rd_block = utils::rnd_up(rd_block, vnni_granularity);
         }
@@ -2901,10 +2903,12 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
                     is_ld_tail, false);
             for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
-                tdpbxxd(Tmm(brg.get_C_tensor(
-                                bdb, idx, is_bdb_tail, is_ld_tail)),
-                        Tmm(brg.get_A_tensor(bdb, is_bdb_tail)),
-                        Tmm(brg.get_B_tensor(idx, is_ld_tail)));
+                tdpbxxd(Tmm(xbyak_register_index(brg.get_C_tensor(
+                                bdb, idx, is_bdb_tail, is_ld_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_A_tensor(bdb, is_bdb_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_B_tensor(idx, is_ld_tail))));
             }
         }
     }
@@ -3940,7 +3944,7 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
         L(sum_zp_scale_data_);
         const dim_t scale_int = float2int(brg.sum_scale);
         for (dim_t i = 0; i < simd; ++i)
-            dd(scale_int);
+            dd(static_cast<uint32_t>(scale_int));
     }
 
     if (brg.is_fp8_via_convert()) {

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -23,16 +23,16 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-static std::size_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
+static dim_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
     static constexpr int byte_size_bits = 8;
     return vmm.getBit() / byte_size_bits;
 }
 
-static std::size_t calc_vmm_to_preserve_size_bytes(
+static dim_t calc_vmm_to_preserve_size_bytes(
         const std::initializer_list<Xbyak::Xmm> &vmm_to_preserve) {
 
     return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
-            std::size_t(0u), [](std::size_t accum, const Xbyak::Xmm &vmm) {
+            dim_t(0), [](dim_t accum, const Xbyak::Xmm &vmm) {
         return accum + get_vmm_size_bytes(vmm);
     });
 }
@@ -214,7 +214,7 @@ void reg64_savable_t::addTo(const Xbyak::Reg64 &reg) const {
         regscratchpad_.jit().add(reg, *this);
 }
 
-void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, int imm) const {
+void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, dim_t imm) const {
     if (booking_ >= 0)
         regscratchpad_.jit().imul(reg, getStoragePtr(), imm);
     else

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -67,7 +67,7 @@ private:
     jit_generator_t *host_;
     std::stack<Xbyak::Reg64> reg64_stack_;
     std::stack<Xbyak::Xmm> vmm_stack_;
-    size_t vmm_to_preserve_size_bytes_;
+    dim_t vmm_to_preserve_size_bytes_;
 };
 
 class conditional_register_preserve_guard_t : public register_preserve_guard_t {
@@ -151,7 +151,7 @@ public:
     void restoreTo(const Xbyak::Reg64 &reg) const;
     void restoreTo(const Xbyak::Reg32 &reg32) const;
     void addTo(const Xbyak::Reg64 &reg) const;
-    void imulTo(const Xbyak::Reg64 &reg, int imm) const;
+    void imulTo(const Xbyak::Reg64 &reg, dim_t imm) const;
     Xbyak::Address getStoragePtr() const {
         return regscratchpad_.getPtr(booking_);
     }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -425,8 +425,9 @@ static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_binary_injector_t<isa, Vmm>::adjust_temp_vmm_hint(
-        int user_hint, int start_idx, int end_idx, int max_vmm_idx) const {
+size_t jit_uni_binary_injector_t<isa, Vmm>::adjust_temp_vmm_hint(
+        size_t user_hint, size_t start_idx, size_t end_idx,
+        size_t max_vmm_idx) const {
     const bool user_hint_in_vector_range
             = user_hint >= start_idx && user_hint <= end_idx;
     const bool user_hint_exceeded_limit = user_hint > max_vmm_idx;
@@ -483,9 +484,9 @@ static void restore_stack(jit_generator_t *host, const Vmm &vmm) {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-std::pair<bool, int> jit_uni_binary_injector_t<isa, Vmm>::should_preserve_vmm(
-        int curr_idx, int vmm_hint, int max_vmm_idx,
-        bool dt_helper_vmm_needed) const {
+std::pair<bool, size_t>
+jit_uni_binary_injector_t<isa, Vmm>::should_preserve_vmm(size_t curr_idx,
+        size_t vmm_hint, size_t max_vmm_idx, bool dt_helper_vmm_needed) const {
     if (dt_helper_vmm_needed && vmm_hint == curr_idx) {
         if (curr_idx == 0)
             return std::make_pair(true, max_vmm_idx);
@@ -547,7 +548,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const dim_t blk_size = dst_d.blocking_desc().inner_blks[0];
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
                     || !rhs_arg_params.vmm_idx_to_out_reg.empty());
@@ -870,7 +871,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
         if (is_first || !cache_addr) {
             calculate_no_broadcast_base(out_addr, tmp_reg);
             if (elem_size_bytes > 1) {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->sal(tmp_reg, shift_val);
             }
             host_->add(addr_reg, tmp_reg);
@@ -898,7 +899,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_base(
     host_->sub(out_reg,
             host_->ptr[param1_ + rhs_arg_static_params_.dst_orig_offset]);
     host_->shr(out_reg,
-            std::log2(types::data_type_size(
+            math::ilog2q(types::data_type_size(
                     rhs_arg_static_params_.dst_d.data_type())));
 }
 
@@ -971,7 +972,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1047,7 +1048,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const dim_t blk_size = dst_d.blocking_desc().inner_blks[0];
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
     const auto r8 = host_->r8;
@@ -1076,7 +1077,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_partial(
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const dim_t blk_size = dst_d.blocking_desc().inner_blks[0];
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     const auto offset_adj = ((offset_shr % strides[0]) / strides[1]) * blk_size
@@ -1190,7 +1191,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1328,7 +1329,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
                 if (elem_size_bytes == 1) {
                     host_->add(addr_reg, rax);
                 } else {
-                    const int shift_val = std::log2(elem_size_bytes);
+                    const int shift_val = math::ilog2q(elem_size_bytes);
                     host_->mov(tmp_reg, rax);
                     host_->sal(tmp_reg, shift_val);
                     host_->add(addr_reg, tmp_reg);
@@ -1448,7 +1449,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, r8);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = math::ilog2q(elem_size_bytes);
         host_->mov(tmp_reg, r8);
         host_->sal(tmp_reg, shift_val);
         host_->add(addr_reg, tmp_reg);
@@ -1469,7 +1470,7 @@ void jit_uni_binary_injector_t<isa,
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, rhs_offset);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = math::ilog2q(elem_size_bytes);
         const uint64_t rhs_offset_bytes = static_cast<uint64_t>(rhs_offset)
                 << shift_val;
         host_->mov(tmp_reg, rhs_offset_bytes);
@@ -1555,7 +1556,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const dim_t blk_size = dst_d.blocking_desc().inner_blks[0];
 
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1587,7 +1588,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
     const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
     const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
     const auto W = (ndims >= 3) ? dst_d.dims()[ndims - 1] : 1;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const dim_t blk_size = dst_d.blocking_desc().inner_blks[0];
 
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
@@ -1724,7 +1725,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2034,7 +2035,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2168,7 +2169,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2378,7 +2379,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2555,7 +2556,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2726,7 +2727,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -3316,7 +3317,8 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
 
 static Xbyak::uint8 MM_SHUFFLE(
         Xbyak::uint8 z, Xbyak::uint8 y, Xbyak::uint8 x, Xbyak::uint8 w) {
-    return (((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
+    return static_cast<Xbyak::uint8>(
+            (((z) << 6) | ((y) << 4) | ((x) << 2) | (w)));
 }
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -239,7 +239,7 @@ struct rhs_arg_dynamic_params_t {
     std::map<int, Xbyak::Reg64> vmm_idx_to_out_reg;
     std::map<int, size_t> vmm_idx_to_out_elem_off_val;
 
-    std::unordered_set<int> vmm_tail_idx_;
+    std::unordered_set<size_t> vmm_tail_idx_;
     tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT;
 };
 
@@ -311,8 +311,8 @@ private:
      * <start_idx, end_idx>). If not it returns new vmm idx value that will be
      * used as temporary vmm in future computations.
      */
-    int adjust_temp_vmm_hint(
-            int user_hint, int start_idx, int end_idx, int max_vmm_idx) const;
+    size_t adjust_temp_vmm_hint(size_t user_hint, size_t start_idx,
+            size_t end_idx, size_t max_vmm_idx) const;
     /*
      * Taking into account rhs_broadcasting_strategy and information from user
      * about tensor slice (rhs_arg_params) stored in Vmm(vmm_idx) calculates
@@ -621,8 +621,9 @@ private:
      * index in second member that should be used as temporary vmm inside inject
      * binary.
      */
-    std::pair<bool, int> should_preserve_vmm(int curr_idx, int vmm_hint,
-            int max_vmm_idx, bool dt_helper_vmm_needed) const;
+    std::pair<bool, size_t> should_preserve_vmm(size_t curr_idx,
+            size_t vmm_hint, size_t max_vmm_idx,
+            bool dt_helper_vmm_needed) const;
     /*
      * Used in isa != avx512 where m32bcst is not supported, replaces ptr_b
      * with ptr.

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -594,7 +594,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
             is_bf32, is_tf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     if (ur == 0) return status::invalid_arguments;
     ur_block = brg.bd_block;
     if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -668,9 +668,9 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     ur_block = brg.bd_block;
-    adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
+    adj_ocblock = nstl::max<dim_t>(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
     if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {
         brgemm_desc_t brg_sp_tail;
 

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -713,7 +713,7 @@ status_t jit_brgemm_ip_fwd_conf_t::init_conf(cpu_isa_t isa,
         if (st == success) st = brgemm_desc_finalize(&brg_desc);
 
         if (st == success) {
-            int bd_block = brg_desc.bd_block;
+            dim_t bd_block = brg_desc.bd_block;
 
             if (jbgp.oc_block == 64 && bd_block != 6) jbgp.os_block = 6;
             if (jbgp.oc_block == 48 && bd_block != 8) jbgp.os_block = 8;

--- a/src/cpu/x64/jit_brgemm_primitive_conf.cpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.cpp
@@ -23,11 +23,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-int jit_brgemm_primitive_conf_t::ks() const {
+dim_t jit_brgemm_primitive_conf_t::ks() const {
     return kd * kh * kw;
 }
 
-int jit_brgemm_primitive_conf_t::get_weights_oc_block() const {
+dim_t jit_brgemm_primitive_conf_t::get_weights_oc_block() const {
     using namespace format_tag;
 
     assert(wei_tag != undef && "Weights tag not defined!");

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -30,15 +30,15 @@ struct jit_brgemm_primitive_conf_t {
     conv_harness_t harness;
     int simd_w;
     int ndims;
-    int mb, os;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
-    int id = 1, ih = 1, iw = 1;
-    int od = 1, oh = 1, ow = 1;
-    int kd = 1, kh = 1, kw = 1;
-    int f_pad, l_pad, t_pad;
-    int back_pad, r_pad, b_pad;
-    int stride_d, stride_h, stride_w;
-    int dilate_d, dilate_h, dilate_w;
+    dim_t mb, os;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t id = 1, ih = 1, iw = 1;
+    dim_t od = 1, oh = 1, ow = 1;
+    dim_t kd = 1, kh = 1, kw = 1;
+    dim_t f_pad, l_pad, t_pad;
+    dim_t back_pad, r_pad, b_pad;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t dilate_d, dilate_h, dilate_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool is_wei_layout_any;
     bool with_bias;
@@ -46,14 +46,14 @@ struct jit_brgemm_primitive_conf_t {
     bool with_eltwise;
     bool with_binary;
     bool req_s8s8_compensation;
-    int nb_ic, ic_block, ic_block_ext;
-    int nb_oc, oc_block, oc_block_ext;
-    int nb_iw, iw_block;
-    int nb_ow, ow_block;
-    int nb_os, os_block;
-    int nb_oc_blocking;
-    int nb_ic_blocking;
-    int nb_os_blocking;
+    dim_t nb_ic, ic_block, ic_block_ext;
+    dim_t nb_oc, oc_block, oc_block_ext;
+    dim_t nb_iw, iw_block;
+    dim_t nb_ow, ow_block;
+    dim_t nb_os, os_block;
+    dim_t nb_oc_blocking;
+    dim_t nb_ic_blocking;
+    dim_t nb_os_blocking;
 
     data_type_t src_dt;
     data_type_t dst_dt;
@@ -73,9 +73,9 @@ struct jit_brgemm_primitive_conf_t {
     bool with_dst_scales;
     int is_oc_scale;
 
-    int LDA, LDB, LDC, LDD;
-    int M, N, K, M_tail, N_tail, K_tail;
-    int gemm_batch_size, adjusted_batch_size;
+    dim_t LDA, LDB, LDC, LDD;
+    dim_t M, N, K, M_tail, N_tail, K_tail;
+    dim_t gemm_batch_size, adjusted_batch_size;
     brgemm_batch_kind_t brg_type;
     int num_gemm_kernels;
     int nthr, nthr_mb, nthr_oc_b, nthr_ic_b;
@@ -88,10 +88,10 @@ struct jit_brgemm_primitive_conf_t {
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
 
     // Compute kernel-spatial dimension size.
-    int ks() const;
+    dim_t ks() const;
 
     // Compute foward weights oc-block.
-    int get_weights_oc_block() const;
+    dim_t get_weights_oc_block() const;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -83,7 +83,7 @@ struct jit_brgemm_primitive_conf_t {
     cpu_isa_t isa;
     bool use_uker;
     bool use_interleave_stores;
-    int amx_buf_size_per_thread;
+    dim_t amx_buf_size_per_thread;
     brgemm_kernel_prefetching_t hint_prefetching
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -84,12 +84,19 @@ inline int float2int(float x) {
     return utils::bit_cast<int>(x);
 }
 
-inline void tc_configure_tile(palette_config_t *tc, int t, int rows, int cols) {
-    const bool rows_ok = (size_t)t < sizeof(tc->rows) / sizeof(tc->rows[0]);
-    const bool cols_ok = (size_t)t < sizeof(tc->cols) / sizeof(tc->cols[0]);
-    if (rows_ok && cols_ok) {
-        tc->rows[t] = rows;
-        tc->cols[t] = cols;
+inline void tc_configure_tile(
+        palette_config_t *tc, dim_t t, dim_t rows, dim_t cols) {
+    // AMX tile config is a fixed hardware register layout (tile index
+    // bounded by palette_config_t::max_size, uint8_t rows, uint16_t cols)
+    // - narrowing here is unavoidable, so it's consolidated in this single
+    // boundary helper with bounds checks, rather than scattered across
+    // call sites.
+    const bool idx_ok = t >= 0 && t < palette_config_t::max_size;
+    const bool rows_ok = rows >= 0 && rows <= UINT8_MAX;
+    const bool cols_ok = cols >= 0 && cols <= UINT16_MAX;
+    if (idx_ok && rows_ok && cols_ok) {
+        tc->rows[t] = static_cast<uint8_t>(rows);
+        tc->cols[t] = static_cast<uint16_t>(cols);
     } else {
         assert(!"out of range");
     }

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -214,6 +214,7 @@ public:
     using Xbyak::CodeGenerator::pinsrb;
     using Xbyak::CodeGenerator::shl;
     using Xbyak::CodeGenerator::sub;
+    using Xbyak::CodeGenerator::vcmpps;
     using Xbyak::CodeGenerator::vpblendd;
     using Xbyak::CodeGenerator::vpermq;
     using Xbyak::CodeGenerator::vpextrb;
@@ -319,6 +320,15 @@ public:
             const Xbyak::Operand &op, T imm) {
         JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
         Xbyak::CodeGenerator::vpblendd(x1, x2, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vcmpps(const Xbyak::Opmask &k, const Xbyak::Xmm &x,
+            const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vcmpps(k, x, op, static_cast<uint8_t>(imm));
     }
 
     static int xbyak_register_index(dim_t index) {

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -19,6 +19,7 @@
 
 #include <limits.h>
 #include <vector>
+#include <type_traits>
 
 #include "common/bit_cast.hpp"
 #include "common/compiler_workarounds.hpp"
@@ -74,6 +75,11 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace x64 {
+
+// Required so XBYAK_THROW's unqualified 'Error' resolves in this namespace.
+#ifndef XBYAK_NO_EXCEPTION
+using Xbyak::Error;
+#endif
 
 // TODO: move this to jit_generator_t class?
 namespace {
@@ -200,6 +206,73 @@ public:
         _op_floor = 1u,
         _op_mxcsr = 4u,
     };
+
+    using Xbyak::CodeGenerator::add;
+    using Xbyak::CodeGenerator::cmp;
+    using Xbyak::CodeGenerator::imul;
+    using Xbyak::CodeGenerator::shl;
+    using Xbyak::CodeGenerator::sub;
+
+    // These are the dim_t immediate forms used by brgemm. x86 accepts at
+    // most a 32-bit immediate. Offsets and shifts are non-negative; cmp also
+    // supports the verified negative-vpad case.
+    // TODO: Use a scratch register or rebase a pointer for values > INT_MAX.
+    // Note: the enable_if constrains this to T == dim_t exactly, so int/
+    // uint32_t call sites keep resolving to the native Xbyak overloads above
+    // instead of becoming ambiguous with these dim_t ones.
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void add(const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::add(op, static_cast<uint32_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void sub(const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::sub(op, static_cast<uint32_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void cmp(const Xbyak::Operand &op, T imm) {
+        // Negative virtual padding is compared by brgemm kernels.
+        JIT_ASSERT(imm >= INT_MIN && imm <= INT_MAX);
+        Xbyak::CodeGenerator::cmp(
+                op, static_cast<uint32_t>(static_cast<int32_t>(imm)));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void shl(const Xbyak::Operand &op, T count) {
+        JIT_ASSERT(count >= 0 && count <= UINT8_MAX);
+        Xbyak::CodeGenerator::shl(op, static_cast<int>(count));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void imul(const Xbyak::Reg64 &dst, const Xbyak::Operand &src, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::imul(dst, src, static_cast<int>(imm));
+    }
+
+    static int xbyak_register_index(dim_t index) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        return static_cast<int>(index);
+    }
+
+    static int xbyak_address_scale(dim_t scale) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(utils::one_of(scale, 1, 2, 4, 8), 0);
+        return static_cast<int>(scale);
+    }
 
     Xbyak::Reg64 param1 = abi_param1;
     const int EVEX_max_8b_offt = 0x200;
@@ -2224,7 +2297,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Address &src_addr,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2233,7 +2306,7 @@ public:
             return;
         }
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[src_addr.getRegExp()
                     + Xbyak::RegExp(bytes_offset * sizeof(int8_t))];
         };
@@ -2243,7 +2316,7 @@ public:
 
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2255,7 +2328,7 @@ public:
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[reg + offset + bytes_offset * sizeof(int8_t)];
         };
 
@@ -2264,8 +2337,8 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void helper_load_bytes(const Vmm &vmm, int load_size, const AddrFunc &addr,
-            const bool zero_vmm = true) {
+    void helper_load_bytes(const Vmm &vmm, dim_t load_size,
+            const AddrFunc &addr, const bool zero_vmm = true) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2297,8 +2370,8 @@ private:
         // use clean execution sequence
         if (zero_vmm) uni_vpxor(vmm, vmm, vmm);
 
-        int start_bytes = 0;
-        int bytes_to_load = load_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_load = load_size;
 
         if (load_size > 16) {
             // Prepare to insert to upper bits of ymm
@@ -2385,8 +2458,8 @@ private:
 public:
     template <typename Vmm>
     void store_bytes(
-            const Vmm &vmm, const Xbyak::Address &dst_addr, int store_size) {
-        const auto addr = [&](int bytes_offset) {
+            const Vmm &vmm, const Xbyak::Address &dst_addr, dim_t store_size) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[dst_addr.getRegExp()
                     + Xbyak::RegExp(bytes_offset * sizeof(int8_t))];
         };
@@ -2395,12 +2468,12 @@ public:
 
     template <typename Vmm>
     void store_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int store_size) {
+            dim_t store_size) {
 
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[reg + offset + bytes_offset * sizeof(int8_t)];
         };
 
@@ -2409,7 +2482,7 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void store_bytes(const Vmm &vmm, int store_size, const AddrFunc &addr) {
+    void store_bytes(const Vmm &vmm, dim_t store_size, const AddrFunc &addr) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2439,8 +2512,8 @@ private:
             return;
         }
 
-        int start_bytes = 0;
-        int bytes_to_store = store_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_store = store_size;
 
         if (store_size > 16) {
             vmovdqu(addr(0), xmm); // load lower bits from ymm
@@ -2523,7 +2596,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, bool is_signed, int load_size,
+            int64_t offset, bool is_signed, dim_t load_size,
             const bool zero_vmm) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2533,7 +2606,7 @@ public:
 
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm,
-            const Xbyak::Address &src_addr, bool is_signed, int load_size,
+            const Xbyak::Address &src_addr, bool is_signed, dim_t load_size,
             const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
@@ -2593,7 +2666,7 @@ public:
      */
     template <typename Vmm>
     void store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
         using supported_vmm_t = typename utils::conditional<is_vmm_supported,
@@ -2610,7 +2683,7 @@ public:
 private:
     template <typename Vmm>
     void helper_store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
 
         assert(is_valid_isa(sse41)
                 && "routine is not supported for the current isa");
@@ -2670,7 +2743,7 @@ public:
      */
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, int load_size, const bool zero_vmm = true) {
+            int64_t offset, dim_t load_size, const bool zero_vmm = true) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
         load_data(type_in, vmm, ptr[reg + offset], load_size, zero_vmm);
@@ -2678,7 +2751,7 @@ public:
 
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm,
-            const Xbyak::Address &src_addr, int load_size,
+            const Xbyak::Address &src_addr, dim_t load_size,
             const bool zero_vmm = true) {
 
         assert(is_valid_isa(sse41)

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -210,8 +210,14 @@ public:
     using Xbyak::CodeGenerator::add;
     using Xbyak::CodeGenerator::cmp;
     using Xbyak::CodeGenerator::imul;
+    using Xbyak::CodeGenerator::pextrb;
+    using Xbyak::CodeGenerator::pinsrb;
     using Xbyak::CodeGenerator::shl;
     using Xbyak::CodeGenerator::sub;
+    using Xbyak::CodeGenerator::vpblendd;
+    using Xbyak::CodeGenerator::vpermq;
+    using Xbyak::CodeGenerator::vpextrb;
+    using Xbyak::CodeGenerator::vpinsrb;
 
     // These are the dim_t immediate forms used by brgemm. x86 accepts at
     // most a 32-bit immediate. Offsets and shifts are non-negative; cmp also
@@ -262,9 +268,66 @@ public:
         Xbyak::CodeGenerator::imul(dst, src, static_cast<int>(imm));
     }
 
+    // dim_t forms of the 8-bit-immediate emit methods, so kernels can pass
+    // dim_t lane indices / blend masks directly. The narrowing to uint8_t and
+    // the bounds check are consolidated here at the XByak boundary.
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void pinsrb(const Xbyak::Xmm &xmm, const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::pinsrb(xmm, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void pextrb(const Xbyak::Operand &op, const Xbyak::Xmm &xmm, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::pextrb(op, xmm, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpinsrb(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
+            const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpinsrb(x1, x2, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpextrb(const Xbyak::Operand &op, const Xbyak::Xmm &x, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpextrb(op, x, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpermq(const Xbyak::Ymm &y, const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpermq(y, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpblendd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
+            const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpblendd(x1, x2, op, static_cast<uint8_t>(imm));
+    }
+
     static int xbyak_register_index(dim_t index) {
-        // The fallback is returned only after XByak records the error.
-        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        // The fallback is returned only after XByak records the error,
+        // INT_MIN is used, because some primitives(e.g. pooling)
+        // are creating registers with invlid index, but never uses it,
+        // currently those objects are gracefully die without assertion.
+        // TODO: refactor pooling primitive in order to follow the contract.
+        JIT_ASSERT_RET(index >= INT_MIN && index <= INT_MAX, 0);
         return static_cast<int>(index);
     }
 

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -844,7 +844,7 @@ struct jit_brgemm_conv_conf_t {
 
     int max_batch;
     int max_vpad;
-    int amx_buf_size_per_thread;
+    dim_t amx_buf_size_per_thread;
 
     bool wei_plain;
     bool is_rd_padded_to_block {false}, is_rd_padded_to_vnni {false},

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -964,7 +964,7 @@ struct jit_binary_conf_t {
     bool is_ternary_op = false;
     bool is_src_different_layouts = false;
     dim_t outer_dims = 1;
-    int src1_stride = 1;
+    dim_t src1_stride = 1;
     int not_bcasted_sp_dims = 0;
     cpu_isa_t isa = isa_undef;
 

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -984,8 +984,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
                               : 0);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = utils::div_up(src0_d.padded_dims()[1], simd_w);
         // Compute strategy:
         // Each block is individual - parallel over MB and C_blocks safely.
 
@@ -1110,8 +1109,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
             = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = utils::div_up(src0_d.padded_dims()[1], simd_w);
         // Compute strategy:
         // Each line of channels is individual, parallel over MB, C_blocks
         // and spatial (broadcasted and not broadcasted spatial dims

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -347,7 +347,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::perform_op(
     else if (cmp_op) {
         const unsigned int predicate = cmp_predicate(alg);
         if (is_avx512) {
-            vcmpps(cmp_mask, v0, v1, predicate);
+            vcmpps(cmp_mask, v0, v1, static_cast<dim_t>(predicate));
             vmovups(v0 | cmp_mask | T_z, vreg_one_);
         } else {
             uni_vcmpps(v0, v0, v1, predicate);


### PR DESCRIPTION
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Affected only on binary primitive.