### PR TITLE
fix undefined behavior in loops with int counter and dim_t bound

### DIFF
--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -122,7 +122,7 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
         }
 
-        for (int od = 0; od < jcp.od; od++) {
+        for (dim_t od = 0; od < jcp.od; od++) {
             data_t *__restrict dst = dst_base + n * dst_mb_stride
                     + g * dst_g_stride
                     + ((od * jcp.oh + oh) * jcp.ow + ow) * dst_os_stride;
@@ -325,7 +325,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                                                          : 0;
                                 data_t *d_ = _dst + oc * M;
                                 PRAGMA_OMP_SIMD()
-                                for (int oS = 0; oS < m; ++oS) {
+                                for (dim_t oS = 0; oS < m; ++oS) {
                                     d_[oS] += b;
                                     if (d_[oS] < 0) d_[oS] *= eltwise.alpha;
                                     d_[oS] *= eltwise.scale;
@@ -344,7 +344,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                             args.dst_md = pd()->dst_md();
                             args.l_offset = d_ - dst;
 
-                            for (int oS = 0; oS < m; ++oS) {
+                            for (dim_t oS = 0; oS < m; ++oS) {
                                 d_[oS] += b;
                                 post_ops_->execute(d_[oS], args);
                                 args.l_offset++;
@@ -357,7 +357,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                         data_t b = bias[oc_start + oc];
                         data_t *d_ = _dst + oc * M;
                         PRAGMA_OMP_SIMD()
-                        for (int oS = 0; oS < m; ++oS) {
+                        for (dim_t oS = 0; oS < m; ++oS) {
                             d_[oS] += b;
                         }
                     });
@@ -389,7 +389,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
 
         if (jcp.loop_order == gemm_loop_rlb)
             for (curr.ic = 0; curr.ic < jcp.ic; curr.ic += step.ic)
-                for (int spatial = start.sp; spatial < end.sp;
+                for (dim_t spatial = start.sp; spatial < end.sp;
                         spatial += step.sp) {
                     nd_iterator_init(spatial, curr.n, jcp.mb, curr.g,
                             jcp.ngroups, curr.od, jcp.od, curr.sp, jcp.os);
@@ -404,7 +404,8 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                     }
                 }
         else if (jcp.loop_order == gemm_loop_lrb)
-            for (int spatial = start.sp; spatial < end.sp; spatial += step.sp) {
+            for (dim_t spatial = start.sp; spatial < end.sp;
+                    spatial += step.sp) {
                 nd_iterator_init(spatial, curr.n, jcp.mb, curr.g, jcp.ngroups,
                         curr.od, jcp.od, curr.sp, jcp.os);
                 for (curr.ic = 0; curr.ic < jcp.ic; curr.ic += step.ic)
@@ -512,7 +513,7 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_thr_nspc(
                         = diff_src + is * diff_src_os_stride;
                 const data_t *__restrict acc_arr = acc + is * jcp.ic;
                 PRAGMA_OMP_SIMD()
-                for (int ic = 0; ic < jcp.ic; ic++) {
+                for (dim_t ic = 0; ic < jcp.ic; ic++) {
                     diff_src_arr[ic] = acc_arr[ic];
                 }
             });
@@ -571,8 +572,8 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_ncsp(
             }
 
             const data_t *_weights = weights + g * weights_g_size;
-            for_(int od = 0; od < jcp.od; ++od)
-            for (int os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
+            for_(dim_t od = 0; od < jcp.od; ++od)
+            for (dim_t os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
                 auto out_off = os_nb * m + od * jcp.os;
                 const data_t *_diff_dst
                         = diff_dst + (n * jcp.ngroups + g) * dst_step + out_off;
@@ -679,7 +680,7 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                     if (jcp.im2col_sz && is_problem_3d)
                         jit_gemm_convolution_utils::transpose_dt(
                                 jcp, _src, imtr);
-                    for (int od = 0; od < jcp.od; ++od) {
+                    for (dim_t od = 0; od < jcp.od; ++od) {
                         const data_t *_diff_dst = diff_dst
                                 + mb * jcp.ngroups * dst_step
                                 + od * k * jcp.ngroups * jcp.oc + g * jcp.oc;
@@ -767,7 +768,7 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                 const int width_stride = jcp.ngroups * jcp.oc;
 
                 PRAGMA_OMP_SIMD(reduction(+ : db))
-                for (int ow = 0; ow < jcp.ow; ++ow) {
+                for (dim_t ow = 0; ow < jcp.ow; ++ow) {
                     db += diff_dst_arr[ow * width_stride];
                 }
             }
@@ -839,8 +840,8 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
                 for (size_t mb = mb_start; mb < mb_end; ++mb) {
                     const data_t *_src
                             = src + (mb * jcp.ngroups + g) * src_step;
-                    for_(int od = 0; od < jcp.od; ++od)
-                    for (int os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
+                    for_(dim_t od = 0; od < jcp.od; ++od)
+                    for (dim_t os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
                         auto out_off = os_nb * k + od * jcp.os;
                         const dim_t os_block = nstl::min(
                                 (dim_t)jcp.os_block, jcp.os - os_nb * k);

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -2188,12 +2188,12 @@ void bwd_weights_reduction_par_nspc(int ithr, int nthr, size_t g_start,
             const float *__restrict ws_ptr = ws_base + w * jcp.oc;
             if (tidx == 0) {
                 PRAGMA_OMP_SIMD()
-                for (auto oc = 0; oc < jcp.oc; ++oc) {
+                for (dim_t oc = 0; oc < jcp.oc; ++oc) {
                     dwei_ptr[oc] = ws_ptr[oc];
                 }
             } else {
                 PRAGMA_OMP_SIMD()
-                for (auto oc = 0; oc < jcp.oc; ++oc) {
+                for (dim_t oc = 0; oc < jcp.oc; ++oc) {
                     dwei_ptr[oc] += ws_ptr[oc];
                 }
             }

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -240,7 +240,7 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt<char>(jcp, src, imtr);
 
-        for (int od = 0; od < jcp.od; od++) {
+        for (dim_t od = 0; od < jcp.od; od++) {
             const auto dst_off = n * dst_mb_stride + g * dst_g_stride
                     + ((od * jcp.oh + oh) * jcp.ow + ow) * jcp.dst_os_stride;
             char *__restrict dst = (char *)dst_base
@@ -435,7 +435,7 @@ status_t gemm_x8s8s32x_convolution_bwd_data_t::execute_backward_data_thr(
             const int *__restrict acc_loc = acc + is * jcp.ic;
             const float *__restrict scales_loc
                     = scales + g * jcp.ic * scale_idx_mult;
-            for (int ic = 0; ic < jcp.ic; ic++) {
+            for (dim_t ic = 0; ic < jcp.ic; ic++) {
                 float d = static_cast<float>(acc_loc[ic]);
                 d *= scales_loc[ic * scale_idx_mult];
                 if (jcp.with_bias) {

--- a/src/cpu/nspc_batch_normalization.cpp
+++ b/src/cpu/nspc_batch_normalization.cpp
@@ -110,7 +110,7 @@ status_t nspc_batch_normalization_fwd_t<d_type>::execute_forward(
                                 src + s_off);
                     }
                     PRAGMA_OMP_SIMD()
-                    for (int c = 0; c < C; c++) {
+                    for (dim_t c = 0; c < C; c++) {
                         ws_reduce[C * ithr + c] += _src[c];
                     }
                 }
@@ -150,7 +150,7 @@ status_t nspc_batch_normalization_fwd_t<d_type>::execute_forward(
                                 src + s_off);
                     }
                     PRAGMA_OMP_SIMD()
-                    for (int c = 0; c < C; c++) {
+                    for (dim_t c = 0; c < C; c++) {
                         acc_data_t m = _src[c] - mean_loc[c];
                         ws_reduce[C * ithr + c] += m * m;
                     }
@@ -204,7 +204,7 @@ status_t nspc_batch_normalization_fwd_t<d_type>::execute_forward(
 #if CLANG_WA_02_SAFE_TO_USE_OMP_SIMD
                 PRAGMA_OMP_SIMD()
 #endif
-                for (int c = 0; c < C; c++) {
+                for (dim_t c = 0; c < C; c++) {
                     const size_t c_off = s_off + c;
                     acc_data_t sqrt_variance = static_cast<acc_data_t>(
                             sqrtf(variance_loc[c] + eps));

--- a/src/cpu/ref_batch_normalization.cpp
+++ b/src/cpu/ref_batch_normalization.cpp
@@ -120,19 +120,19 @@ status_t ref_batch_normalization_fwd_t<d_type>::execute_forward(
         acc_data_t v_variance = calculate_stats ? 0 : variance[c];
 
         if (calculate_stats) {
-            for_(int n = 0; n < N; ++n)
-            for_(int d = 0; d < D; ++d)
-            for_(int h = 0; h < H; ++h)
-            for (int w = 0; w < W; ++w) {
+            for_(dim_t n = 0; n < N; ++n)
+            for_(dim_t d = 0; d < D; ++d)
+            for_(dim_t h = 0; h < H; ++h)
+            for (dim_t w = 0; w < W; ++w) {
                 v_mean += maybe_up_convert(
                         src[DATA_OFF(data_d, n, c, d, h, w)]);
             }
             v_mean /= W * N * H * D;
 
-            for_(int n = 0; n < N; ++n)
-            for_(int d = 0; d < D; ++d)
-            for_(int h = 0; h < H; ++h)
-            for (int w = 0; w < W; ++w) {
+            for_(dim_t n = 0; n < N; ++n)
+            for_(dim_t d = 0; d < D; ++d)
+            for_(dim_t h = 0; h < H; ++h)
+            for (dim_t w = 0; w < W; ++w) {
                 acc_data_t m = src[DATA_OFF(data_d, n, c, d, h, w)] - v_mean;
                 v_variance += m * m;
             }

--- a/src/cpu/ref_group_normalization.cpp
+++ b/src/cpu/ref_group_normalization.cpp
@@ -100,20 +100,20 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
         float v_variance = calculate_stats ? 0 : variance[stat_off];
 
         if (calculate_stats) {
-            for_(int c = get_c_start(g); c < get_c_start(g + 1); ++c)
-            for_(int d = 0; d < D; ++d)
-            for_(int h = 0; h < H; ++h)
-            for (int w = 0; w < W; ++w) {
+            for_(dim_t c = get_c_start(g); c < get_c_start(g + 1); ++c)
+            for_(dim_t d = 0; d < D; ++d)
+            for_(dim_t h = 0; h < H; ++h)
+            for (dim_t w = 0; w < W; ++w) {
                 const auto s_off = DATA_OFF(src_d, n, c, d, h, w);
                 float s = io::load_float_value(src_d.data_type(), src, s_off);
                 v_mean += s;
             }
             v_mean /= C_PER_G * W * H * D;
 
-            for_(int c = get_c_start(g); c < get_c_start(g + 1); ++c)
-            for_(int d = 0; d < D; ++d)
-            for_(int h = 0; h < H; ++h)
-            for (int w = 0; w < W; ++w) {
+            for_(dim_t c = get_c_start(g); c < get_c_start(g + 1); ++c)
+            for_(dim_t d = 0; d < D; ++d)
+            for_(dim_t h = 0; h < H; ++h)
+            for (dim_t w = 0; w < W; ++w) {
                 const auto s_off = DATA_OFF(src_d, n, c, d, h, w);
                 float s = io::load_float_value(src_d.data_type(), src, s_off);
                 float m = s - v_mean;
@@ -123,7 +123,7 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
         }
         float sqrt_variance = sqrtf(v_variance + eps);
 
-        for (int c = get_c_start(g); c < get_c_start(g + 1); ++c) {
+        for (dim_t c = get_c_start(g); c < get_c_start(g + 1); ++c) {
             float sm = (scale ? scale[ss_d.off(c)] : 1.0f) / sqrt_variance;
             float sv = shift ? shift[ss_d.off(c)] : 0;
 
@@ -308,7 +308,7 @@ status_t ref_group_normalization_bwd_t::execute(const exec_ctx_t &ctx) const {
                 }
             }
         } else {
-            for (int c = get_c_start(g); c < get_c_start(g + 1); ++c) {
+            for (dim_t c = get_c_start(g); c < get_c_start(g + 1); ++c) {
                 float gamma = scale ? scale[ss_d.off(c)] : 1.0f;
                 for_(dim_t d = 0; d < D; ++d)
                 for_(dim_t h = 0; h < H; ++h)

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -340,7 +340,7 @@ status_t ref_pooling_bwd_t::execute(const exec_ctx_t &ctx) const {
         balance211(diff_src_d.nelems(true), nthr, ithr, start, end);
         if (start == end) return;
 
-        for (int i = start; i < end; i++)
+        for (dim_t i = start; i < end; i++)
             io::store_float_value(data_type::f32, 0, diff_src, i);
     });
 

--- a/src/cpu/ref_softmax.cpp
+++ b/src/cpu/ref_softmax.cpp
@@ -220,7 +220,7 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
         if (zero_padding) {
             const auto tail = src_d.padded_dims()[axis] - src_d.dims()[axis];
             PRAGMA_OMP_SIMD()
-            for (int i = 0; i < tail; i++)
+            for (dim_t i = 0; i < tail; i++)
                 io::store_float_value(
                         dst_d.data_type(), 0, dst_data, channels_ + i);
         }

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -1141,7 +1141,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
     (ndims == 3 ? (md).blk_off((batch), (d0), (d1)) : (md).blk_off((d0), (d1)))
 
         parallel_nd(batch_dim, NB_D1dim, [=](dim_t batch, dim_t D1) {
-            for (int D0 = 0; D0 < NB_D0dim; D0++) {
+            for (dim_t D0 = 0; D0 < NB_D0dim; D0++) {
                 auto i = &input[get_blk_off(
                         input_d, batch, D0_blksize * D0, D1_blksize * D1)];
                 auto o = &output[get_blk_off(output_d, batch, D0, D1)];
@@ -1352,7 +1352,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
 
                     if (zero_padding_needed) {
                         PRAGMA_OMP_SIMD()
-                        for (int off = g_block; off < blksize; off++)
+                        for (dim_t off = g_block; off < blksize; off++)
                             out[off] = 0;
                     }
                 }
@@ -1654,7 +1654,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                         const auto pad_start = block_i + o_off;
                         const auto pad_end = pad_size + o_off;
                         PRAGMA_OMP_SIMD()
-                        for (int i = pad_start; i < pad_end; i++) {
+                        for (ptrdiff_t i = pad_start; i < pad_end; i++) {
                             o[i] = 0;
                         }
                     }
@@ -1679,7 +1679,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                         const auto pad_start = block_i + o_off;
                         const auto pad_end = pad_size + o_off;
                         PRAGMA_OMP_SIMD()
-                        for (int i = pad_start; i < pad_end; i++) {
+                        for (ptrdiff_t i = pad_start; i < pad_end; i++) {
                             o[i] = 0;
                         }
                     }
@@ -1786,7 +1786,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [=](const data_t<type_i> *i, data_t<type_o> *o, int block) {
             if (alpha == 1.0 && beta == 0.0) {
-                for (int l = 0; l < L; ++l) {
+                for (dim_t l = 0; l < L; ++l) {
                     for (int blk = 0; blk < block; ++blk) {
                         const dim_t flat_off
                                 = blk * blk_flat_stride + l * l_flat_stride;
@@ -1802,13 +1802,13 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                         const auto pad_start = block + l * l_blk_stride;
                         const auto pad_end = blksize + l * l_blk_stride;
                         PRAGMA_OMP_SIMD()
-                        for (int i = pad_start; i < pad_end; ++i) {
+                        for (dim_t i = pad_start; i < pad_end; ++i) {
                             o[i] = 0;
                         }
                     }
                 }
             } else {
-                for (int l = 0; l < L; ++l) {
+                for (dim_t l = 0; l < L; ++l) {
                     for (int blk = 0; blk < block; ++blk) {
                         const dim_t flat_off
                                 = blk * blk_flat_stride + l * l_flat_stride;
@@ -1823,7 +1823,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                         const auto pad_start = block + l * l_blk_stride;
                         const auto pad_end = blksize + l * l_blk_stride;
                         PRAGMA_OMP_SIMD()
-                        for (int i = pad_start; i < pad_end; ++i) {
+                        for (dim_t i = pad_start; i < pad_end; ++i) {
                             o[i] = 0;
                         }
                     }
@@ -1979,16 +1979,16 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                     if (order_keep && block_h1 < blksize_1) {
                         // zero padding
                         PRAGMA_OMP_SIMD()
-                        for (int h1 = block_h1; h1 < blksize_1; h1++) {
+                        for (dim_t h1 = block_h1; h1 < blksize_1; h1++) {
                             o[blk_off(h0, h1)] = 0;
                         }
                     }
                 }
                 if (order_keep && block_h0 < blksize_0) {
                     // zero padding
-                    for (int h0 = block_h0; h0 < blksize_0; h0++) {
+                    for (dim_t h0 = block_h0; h0 < blksize_0; h0++) {
                         PRAGMA_OMP_SIMD()
-                        for (int h1 = 0; h1 < blksize_1; ++h1) {
+                        for (dim_t h1 = 0; h1 < blksize_1; ++h1) {
                             o[blk_off(h0, h1)] = 0;
                         }
                     }
@@ -2008,16 +2008,16 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                     if (order_keep && block_h1 < blksize_1) {
                         // zero padding
                         PRAGMA_OMP_SIMD()
-                        for (int h1 = block_h1; h1 < blksize_1; h1++) {
+                        for (dim_t h1 = block_h1; h1 < blksize_1; h1++) {
                             o[blk_off(h0, h1)] = 0;
                         }
                     }
                 }
                 if (order_keep && block_h0 < blksize_0) {
                     // zero padding
-                    for (int h0 = block_h0; h0 < blksize_0; h0++) {
+                    for (dim_t h0 = block_h0; h0 < blksize_0; h0++) {
                         PRAGMA_OMP_SIMD()
-                        for (int h1 = 0; h1 < blksize_1; ++h1) {
+                        for (dim_t h1 = 0; h1 < blksize_1; ++h1) {
                             o[blk_off(h0, h1)] = 0;
                         }
                     }

--- a/src/cpu/rnn/ref_postgemm_gru.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru.cpp
@@ -92,7 +92,7 @@ void gru_fwd_part1_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
     };
 
     if (rnn.is_brgemm && !rnn.unfused_post_gemm) {
-        for (int i = 0; i < rnn.m_block; i++)
+        for (dim_t i = 0; i < rnn.m_block; i++)
             postgemm_call(i);
     } else {
         parallel_nd(rnn.mb, [&](dim_t i) { postgemm_call(i); });
@@ -156,7 +156,7 @@ void gru_fwd_part2_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
     };
 
     if (rnn.is_brgemm && !rnn.unfused_post_gemm) {
-        for (int i = 0; i < rnn.m_block; i++)
+        for (dim_t i = 0; i < rnn.m_block; i++)
             postgemm_call(i);
     } else {
         parallel_nd(rnn.mb, [&](dim_t i) { postgemm_call(i); });

--- a/src/cpu/rnn/ref_postgemm_lstm.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm.cpp
@@ -141,7 +141,7 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
     };
 
     if (rnn.is_brgemm && !rnn.unfused_post_gemm) {
-        for (int i = 0; i < rnn.m_block; i++)
+        for (dim_t i = 0; i < rnn.m_block; i++)
             postgemm_call(i);
     } else {
         parallel_nd(rnn.mb, [&](dim_t i) { postgemm_call(i); });

--- a/src/cpu/rnn/ref_postgemm_lstm_projection.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm_projection.cpp
@@ -47,7 +47,7 @@ void proj_dst_copy(const rnn_utils::rnn_conf_t &rnn,
     // If dst_iter is not nullptr, we need to copy the state to dst_iter
     if (dst_iter_ != nullptr) {
         if (rnn.is_brgemm && !rnn.unfused_post_gemm) {
-            for (int i = 0; i < rnn.m_block; i++)
+            for (dim_t i = 0; i < rnn.m_block; i++)
                 std::memcpy(dst_iter_ + i * dst_iter_ld,
                         dst_layer_ + i * dst_layer_ld, block_step);
         } else {
@@ -129,7 +129,7 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::lstm_projection_postgemm) {
         }
     };
     if (rnn.is_brgemm && !rnn.unfused_post_gemm) {
-        for (int i = 0; i < rnn.m_block; i++)
+        for (dim_t i = 0; i < rnn.m_block; i++)
             postgemm_call(i);
     } else {
         parallel_nd(rnn.mb, [&](dim_t i) { postgemm_call(i); });
@@ -173,7 +173,7 @@ rnn_postgemm_sig(rnn_postgemm_fwd_s8_t::lstm_projection_postgemm) {
         }
     };
     if (rnn.is_brgemm && !rnn.unfused_post_gemm) {
-        for (int i = 0; i < rnn.m_block; i++)
+        for (dim_t i = 0; i < rnn.m_block; i++)
             postgemm_call(i);
     } else {
         parallel_nd(rnn.mb, [&](dim_t i) { postgemm_call(i); });

--- a/src/cpu/rnn/ref_postgemm_rnn.cpp
+++ b/src/cpu/rnn/ref_postgemm_rnn.cpp
@@ -98,7 +98,7 @@ void rnn_fwd_postgemm_template(T func1, const float *scales, float alpha,
     };
 
     if (rnn.is_brgemm && !rnn.unfused_post_gemm) {
-        for (int i = 0; i < rnn.m_block; i++)
+        for (dim_t i = 0; i < rnn.m_block; i++)
             postgemm_call(i);
     } else
         parallel_nd(rnn.mb, postgemm_call);

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -72,8 +72,8 @@ static inline void quantize_igo(int8_t *scratch_quantized,
     parallel(0, [=](const int ithr, const int nthr) {
         dim_t start {0}, end {0};
         balance211(L * D * I, nthr, ithr, start, end);
-        for (int ldi = start; ldi < end; ldi++) {
-            for (int go = 0; go < G * O; go++) {
+        for (dim_t ldi = start; ldi < end; ldi++) {
+            for (dim_t go = 0; go < G * O; go++) {
                 const float s = scales[(mask == 0) ? 0 : go];
                 scratch_quantized[ldi * G * O + go]
                         = q10n::qz_b0_t<in_data_t, int8_t>()(
@@ -132,29 +132,29 @@ static inline void compensate_igo(float *compensation,
         }
         int32_t *compensation_s32
                 = scratch_compensation + ithr * scratch_comp_sz;
-        for (int ld = LD_s; ld < LD_e; ld++) {
+        for (dim_t ld = LD_s; ld < LD_e; ld++) {
             if (I == 1) {
                 PRAGMA_OMP_SIMD()
-                for (int go = GO_s; go < GO_e; go++)
+                for (dim_t go = GO_s; go < GO_e; go++)
                     compensation[ld * G * O + go] = q10n::saturate<float>(
                             scratch_quantized[ld * I * G * O + go]);
             } else {
                 // We split the loop on I in three to avoid conditionals or zeroing compensation
-                int i = 0;
+                dim_t i = 0;
                 PRAGMA_OMP_SIMD()
-                for (int go = GO_s; go < GO_e; go++)
+                for (dim_t go = GO_s; go < GO_e; go++)
                     compensation_s32[go]
                             = scratch_quantized[go + G * O * (i + I * (ld))];
                 // 1 <= i < I-1
                 for (i = 1; i < I - 1; i++) {
                     PRAGMA_OMP_SIMD()
-                    for (int go = GO_s; go < GO_e; go++)
+                    for (dim_t go = GO_s; go < GO_e; go++)
                         compensation_s32[go] += scratch_quantized[go
                                 + G * O * (i + I * (ld))];
                 }
                 // i = I-1
                 PRAGMA_OMP_SIMD()
-                for (int go = GO_s; go < GO_e; go++)
+                for (dim_t go = GO_s; go < GO_e; go++)
                     compensation[ld * G * O + go] = q10n::saturate<float>(
                             compensation_s32[go]
                             + scratch_quantized[go + G * O * (i + I * (ld))]);
@@ -263,13 +263,13 @@ private:
         parallel(0, [=](const int ithr, const int nthr) {
             dim_t start {0}, end {0};
             balance211(outer_dim, nthr, ithr, start, end);
-            for (int i = start; i < end; ++i) {
+            for (dim_t i = start; i < end; ++i) {
                 const dim_t off_in = input_d.off_l(i * inner_dim);
                 const dim_t off_out = output_d.off_l(i * inner_dim);
                 const in_data_t *__restrict i_ = input + off_in;
                 out_data_t *__restrict o_ = output + off_out;
                 PRAGMA_OMP_SIMD()
-                for (int j = 0; j < inner_dim; ++j) {
+                for (dim_t j = 0; j < inner_dim; ++j) {
                     const float in = (float)i_[j] * scale + shift;
                     o_[j] = q10n::qz_a1b0_t<float, out_data_t>()(in);
                 }

--- a/src/cpu/scale_utils.cpp
+++ b/src/cpu/scale_utils.cpp
@@ -115,8 +115,8 @@ const float *precompute_scales(const memory_tracking::grantor_t &scratchpad,
                 const auto wei_scale_stride_oc = wei_scale_per_oc ? 1 : 0;
                 assert(count == wei_scale_count);
                 PRAGMA_OMP_SIMD()
-                for_(int ic = 0; ic < IC; ic++)
-                for (int oc = 0; oc < wei_scale_stride_ic; oc++) {
+                for_(dim_t ic = 0; ic < IC; ic++)
+                for (dim_t oc = 0; oc < wei_scale_stride_ic; oc++) {
                     const auto wei_scale_idx = wei_scale_stride_oc * oc
                             + wei_scale_stride_ic * (ic / wei_scale_groups_ic);
                     const auto loc_scale_idx

--- a/src/cpu/x64/gemm/gemm_driver.cpp
+++ b/src/cpu/x64/gemm/gemm_driver.cpp
@@ -273,7 +273,7 @@ static void sum_matrices(dim_t m, dim_t n, mat_t *__restrict dst, dim_t ld_dst,
 
     for (dim_t j = 0; j < n; j++) {
         PRAGMA_OMP_SIMD()
-        for (int i = 0; i < m; i++)
+        for (dim_t i = 0; i < m; i++)
             dst[i + j * ld_dst] += src[i + j * ld_src];
     }
 }

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -454,7 +454,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
 
-        for (int od = 0; od < jcp.od; od++) {
+        for (dim_t od = 0; od < jcp.od; od++) {
             dst_data_t *__restrict dst = dst_base + n * dst_mb_stride
                     + g * dst_g_stride
                     + ((od * jcp.oh + oh) * jcp.ow + ow) * dst_os_stride;
@@ -763,7 +763,7 @@ status_t gemm_bf16_convolution_bwd_data_t<
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
                 PRAGMA_OMP_SIMD()
-                for (int ic = 0; ic < jcp.ic; ++ic)
+                for (dim_t ic = 0; ic < jcp.ic; ++ic)
                     diff_src_loc[ic] = acc_loc[ic];
             });
         }
@@ -825,8 +825,8 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
             }
 
             const wei_data_t *_weights = weights + g * weights_g_size;
-            for_(int od = 0; od < jcp.od; ++od)
-            for (int os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
+            for_(dim_t od = 0; od < jcp.od; ++od)
+            for (dim_t os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
                 auto out_off = os_nb * m + od * jcp.os;
                 const diff_dst_data_t *_diff_dst
                         = diff_dst + (n * jcp.ngroups + g) * dst_step + out_off;
@@ -1042,7 +1042,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                     if (jcp.im2col_sz && is_problem_3d)
                         jit_gemm_convolution_utils::transpose_dt(
                                 jcp, _src, imtr);
-                    for (int od = 0; od < jcp.od; ++od) {
+                    for (dim_t od = 0; od < jcp.od; ++od) {
                         const diff_dst_data_t *_diff_dst = diff_dst
                                 + mb * jcp.ngroups * dst_step
                                 + od * k * jcp.ngroups * jcp.oc + g * jcp.oc;
@@ -1226,8 +1226,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 for (size_t mb = mb_start; mb < mb_end; ++mb) {
                     const src_data_t *_src
                             = src + (mb * jcp.ngroups + g) * src_step;
-                    for_(int od = 0; od < jcp.od; ++od)
-                    for (int os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
+                    for_(dim_t od = 0; od < jcp.od; ++od)
+                    for (dim_t os_nb = 0; os_nb < jcp.os_nb_block; ++os_nb) {
                         auto out_off = os_nb * k + od * jcp.os;
                         const dim_t os_block = nstl::min(
                                 (dim_t)jcp.os_block, jcp.os - os_nb * k);

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -809,7 +809,7 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                         = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
                 const int max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
-                for (int hw = 0; hw < jcp.os; ++hw) {
+                for (dim_t hw = 0; hw < jcp.os; ++hw) {
                     PRAGMA_OMP_SIMD()
                     for (int o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -936,7 +936,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                     for (int o = 0; o < 16; ++o)
                         d_bias[o] = 0.;
 
-                for (int os = 0; os < jcp.os; ++os) {
+                for (dim_t os = 0; os < jcp.os; ++os) {
                     PRAGMA_OMP_SIMD()
                     for (int o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -813,7 +813,7 @@ status_t jit_uni_instance_normalization_fwd_t::execute_forward(
             dim_t SP_start = 0, SP_end = 0;
             balance211(SP, nthr, ithr, SP_start, SP_end);
             const int block_size = SP_end - SP_start;
-            for (int n = 0; n < N; ++n) {
+            for (dim_t n = 0; n < N; ++n) {
                 float *local_mean = stat_reduction + n * nthr * C + ithr * C;
                 const size_t s_off
                         = (size_t)n * SP * C_padded + SP_start * C_padded;

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -294,7 +294,7 @@ protected:
                 uni_vpxor(Vmm(i), Vmm(i), Vmm(i));
 
             // unrolled loop
-            for (int i = 0; i < axis_simd_full_ / unroll; i++)
+            for (dim_t i = 0; i < axis_simd_full_ / unroll; i++)
                 for (int j = base_idx; j < base_idx + unroll; j += 2) {
                     const bool can_load_two_simdw = base_idx + unroll - j >= 2;
                     if (!can_load_two_simdw)
@@ -318,7 +318,7 @@ protected:
             }
 
             // unrolled loop remainder
-            for (int i = utils::rnd_dn(axis_simd_full_, unroll);
+            for (dim_t i = utils::rnd_dn(axis_simd_full_, unroll);
                     i < axis_simd_full_; i += 2) {
                 const bool can_load_two_simdw = axis_simd_full_ - i >= 2;
                 if (!can_load_two_simdw)
@@ -362,7 +362,7 @@ protected:
                 uni_vpxor(Vmm(i), Vmm(i), Vmm(i));
 
             // unrolled loop
-            for (int i = 0; i < axis_simd_full_ / unroll; i++)
+            for (dim_t i = 0; i < axis_simd_full_ / unroll; i++)
                 for (int j = base_idx; j < base_idx + unroll; j++) {
                     io_[src_d_.data_type()]->load(
                             src_ptr((i * unroll + j - base_idx) * simd_w_),
@@ -379,7 +379,7 @@ protected:
             }
 
             // unrolled loop remainder
-            for (int i = utils::rnd_dn(axis_simd_full_, unroll);
+            for (dim_t i = utils::rnd_dn(axis_simd_full_, unroll);
                     i < axis_simd_full_; i++) {
                 io_[src_d_.data_type()]->load(
                         src_ptr(i * simd_w_), Vmm(base_idx + 1), need_tail);
@@ -522,7 +522,7 @@ protected:
 
     void calculate_dst() {
         if (has_ne_convert_src_xf16_) {
-            for (int i = 0; i < axis_simd_full_; i += 2) {
+            for (dim_t i = 0; i < axis_simd_full_; i += 2) {
                 const bool can_load_two_simdw = axis_simd_full_ - i >= 2;
                 if (can_load_two_simdw)
                     calculate_ne_convert_xf16_dst_body(i * simd_w_);
@@ -530,7 +530,7 @@ protected:
                     calculate_dst_body(i * simd_w_);
             }
         } else {
-            for (int i = 0; i < axis_simd_full_; i++)
+            for (dim_t i = 0; i < axis_simd_full_; i++)
                 calculate_dst_body(i * simd_w_);
         }
         if (axis_simd_tail_)
@@ -893,7 +893,7 @@ protected:
             uni_vmovss(xmm_tmp, dword[reg_inv_sqrtvar]);
             uni_vbroadcastss(vmm_inv_sqrtvar, xmm_tmp);
 
-            for (int i = 0; i < axis_simd_full_; i++)
+            for (dim_t i = 0; i < axis_simd_full_; i++)
                 calculate_diff_scale_shift(i * simd_w_);
             if (axis_simd_tail_)
                 calculate_diff_scale_shift(axis_simd_full_ * simd_w_, true);
@@ -1139,7 +1139,7 @@ protected:
                 uni_vpxor(vmm_dd_scale, vmm_dd_scale, vmm_dd_scale);
                 uni_vpxor(vmm_dd_scale_x, vmm_dd_scale_x, vmm_dd_scale_x);
 
-                for (int i = 0; i < axis_simd_full_; i++)
+                for (dim_t i = 0; i < axis_simd_full_; i++)
                     compute_dd_scales(i * simd_w_);
                 if (axis_simd_tail_)
                     compute_dd_scales(axis_simd_full_ * simd_w_, true);
@@ -1149,7 +1149,7 @@ protected:
                 uni_vmulps(vmm_dd_scale_x, vmm_dd_scale_x, vmm_inv_sqrtvar);
             }
 
-            for (int i = 0; i < axis_simd_full_; i++)
+            for (dim_t i = 0; i < axis_simd_full_; i++)
                 compute_diff_src(i * simd_w_);
             if (axis_simd_tail_)
                 compute_diff_src(axis_simd_full_ * simd_w_, true);


### PR DESCRIPTION
### Description

Several loops have potential undefined behavior: a 32-bit `int` loop counter is compared against a 64-bit `dim_t` bound. When the bound exceeds `INT_MAX`, the **signed** counter overflows — which is UB, with possible consequences including non-termination, incorrect results, or a crash.

Example: src/cpu/rnn/rnn_reorders.hpp, [lines 271-275](https://github.com/uxlfoundation/oneDNN/blob/ebec7d5130121be9afd0070a6bb9435af234e214/src/cpu/rnn/rnn_reorders.hpp#L271-L275):
```cpp
                PRAGMA_OMP_SIMD()
                for (int j = 0; j < inner_dim; ++j) {
                    const float in = (float)i_[j] * scale + shift;
                    o_[j] = q10n::qz_a1b0_t<float, out_data_t>()(in);
                }
```

**The fix** in every case: widen the loop counter to match the bound's type (`dim_t`, or `ptrdiff_t` where the bound is `ptrdiff_t`).


### Reproducer

Built on jfmkl9627.jf.intel.com (GNR CPU) with g++ 11.5.0. The Release build used default cmake settings (which use OpenMP). The Debug build used some debug-specific settings, but also uses OpenMP. Problem uses `iw = 3'123'456'789` (> `INT_MAX`):
```
OMP_NUM_THREADS=32 ./tests/benchdnn/benchdnn --pool --dt=s8 mb1_ic1_iw3123456789_kw2_sw2
```


The results for both Release and Debug versions are almost the same (correctness failure):
```
$ OMP_NUM_THREADS=32 ./tests/benchdnn/benchdnn --pool --dt=s8 mb1_ic1_iw3123456789_kw2_sw2
[   0][DST][0:0:0] exp_f32:         100 exp:         100 got:          -1 diff:     101 rdiff:    1.01
...
[   9][DST][0:0:9] exp_f32:         -19 exp:         -19 got:          -1 diff:      18 rdiff:0.947368
[COMPARE_STATS][DST]: trh=0 err_max_diff:     128 err_max_rdiff:       2 all_max_diff:     128 all_max_rdiff:       2
0:FAILED (errors:1555644881 total:1561728394) (47569 ms) __REPRO: --pool --dt=s8:s8 mb1ic1iw3123456789ow1561728394kw2sw2pw0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| ref:any : 1 (100%)                                       |
============================================================
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:FAILED (errors:1555644881 total:1561728394) (47569 ms) __REPRO: --pool --dt=s8:s8 mb1ic1iw3123456789ow1561728394kw2sw2pw0
============================
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 47.57s; create_pd: 0.01s (0%); create_prim: 0.00s (0%); fill: 8.34s (18%); execute: 18.53s (39%); compute_ref: 7.37s (15%); compare: 12.31s (26%);
```

Then I commented out the line with `PRAGMA_OMP_SIMD()`. The results for Release and Debug versions are different in this case.

Debug:
```
$ OMP_NUM_THREADS=32 ./tests/benchdnn/benchdnn --pool --dt=s8 mb1_ic1_iw3123456789_kw2_sw2
Segmentation fault (core dumped)
```
The reason of the crash here is that `j` wraps to `INT_MIN` and `i_[j]`/`o_[j]` reads/writes out of bounds.

Release:
```
$ OMP_NUM_THREADS=32 ./tests/benchdnn/benchdnn --pool --dt=s8 mb1_ic1_iw3123456789_kw2_sw2
0:PASSED (17680 ms) __REPRO: --pool --dt=s8:s8 mb1ic1iw3123456789ow1561728394kw2sw2pw0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| ref:any : 1 (100%)                                       |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 17.69s; create_pd: 0.03s (0%); create_prim: 0.00s (0%); fill: 10.55s (60%); execute: 3.17s (18%); compute_ref: 1.77s (10%); compare: 1.23s (7%);
```
The test passed with Release version.

So we have 3 different test results. All runs share the same loop source; the differing outcomes come only from how each build compiles a loop that contains signed-overflow UB.



### Scope

This PR covers only the `int`-counter-vs-`dim_t`-bound loop UB described above. Companion [PR #5594](https://github.com/uxlfoundation/oneDNN/pull/5594) covers the same class in ppc64 / rv64 / gpu.

Candidates were found with a combination of `grep` over all loop-initializer forms and per-loop type verification (with help from Claude Code). Coverage may not be exhaustive. Some changes could be reverted if a given loop can be proven safe from signed overflow, but widening the counter is low-risk and consistent.

This pattern is not reported by compiler diagnostics — I verified that g++ 11.5.0 and clang 20.1.8 emit no warning even with `-Wall -Wextra -Wconversion -Wsign-conversion -Wsign-compare` (and clang's `-Wshorten-64-to-32 / -Weverything`). The comparison promotes the `int` counter to 64-bit, so there is nothing to warn about at that point; the overflow is a runtime property the compiler is allowed to assume cannot happen. Our regular Coverity runs have not surfaced it.
