### PR TITLE
fix ub in loops (ppc64, rv64, gpu)

### DIFF
--- a/src/cpu/ppc64/gemm/gemm_driver.cpp
+++ b/src/cpu/ppc64/gemm/gemm_driver.cpp
@@ -1,4 +1,20 @@
 /*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*******************************************************************************
 * Copyright 2022 IBM Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,7 +99,7 @@ static void sum_matrices(dim_t m, dim_t n, mat_t *__restrict dst, dim_t ld_dst,
 
     for (dim_t j = 0; j < n; j++) {
         PRAGMA_OMP_SIMD()
-        for (int i = 0; i < m; i++)
+        for (dim_t i = 0; i < m; i++)
             dst[i + j * ld_dst] += src[i + j * ld_src];
     }
 }
@@ -541,9 +557,9 @@ static dnnl_status_t gemm_kernel_driver(int ithr, dim_t m, dim_t n, dim_t k,
                     // Currently calculating the b_col sum here only to check unit test ase passed or not
                     if (arg->ao != 0) {
                         if (arg->transb == 1) {
-                            for (int i = 0; i < sizeN; i++) {
+                            for (dim_t i = 0; i < sizeN; i++) {
                                 int sum = 0;
-                                for (int j = 0; j < sizeK; j++) {
+                                for (dim_t j = 0; j < sizeK; j++) {
                                     if (arg->b_is_signed) {
                                         sum += b_block[j * ldb + i] + 128;
                                     } else {
@@ -553,9 +569,9 @@ static dnnl_status_t gemm_kernel_driver(int ithr, dim_t m, dim_t n, dim_t k,
                                 b_col_sum[i] = sum;
                             }
                         } else {
-                            for (int i = 0; i < sizeN; i++) {
+                            for (dim_t i = 0; i < sizeN; i++) {
                                 int sum = 0;
-                                for (int j = 0; j < sizeK; j++) {
+                                for (dim_t j = 0; j < sizeK; j++) {
                                     if (arg->b_is_signed) {
                                         sum += b_block[i * ldb + j] + 128;
                                     } else {
@@ -758,9 +774,9 @@ static dnnl_status_t kernel_driver_parallel_acopiedbcopy(int ithr, dim_t m,
             }
             if (arg->ao != 0) {
                 if (arg->transb == 1) {
-                    for (int i = 0; i < sizeN; i++) {
+                    for (dim_t i = 0; i < sizeN; i++) {
                         int sum = 0;
-                        for (int j = 0; j < k; j++) {
+                        for (dim_t j = 0; j < k; j++) {
                             if (arg->b_is_signed) {
                                 sum += b_block[j * ldb + i] + 128;
                             } else {
@@ -770,9 +786,9 @@ static dnnl_status_t kernel_driver_parallel_acopiedbcopy(int ithr, dim_t m,
                         b_col_sum[i] = sum;
                     }
                 } else {
-                    for (int i = 0; i < sizeN; i++) {
+                    for (dim_t i = 0; i < sizeN; i++) {
                         int sum = 0;
-                        for (int j = 0; j < k; j++) {
+                        for (dim_t j = 0; j < k; j++) {
                             if (arg->b_is_signed) {
                                 sum += b_block[i * ldb + j] + 128;
                             } else {

--- a/src/cpu/ppc64/ppc64_gemm_s8x8s32.cpp
+++ b/src/cpu/ppc64/ppc64_gemm_s8x8s32.cpp
@@ -1,4 +1,20 @@
 /*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*******************************************************************************
 * Copyright 2022 IBM Corporation
 *   
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -129,35 +145,35 @@ dnnl_status_t cblas_gemm_s8x8s32_ppc64(int ATflag, int BTflag,
                 free(comparray);
                 return dnnl_out_of_memory;
             }
-            for (int i = 0; i < m; ++i)
+            for (dim_t i = 0; i < m; ++i)
                 comparray[i] = 0;
             if (ATflag) {
-                for (int i = 0; i < m; ++i) {
+                for (dim_t i = 0; i < m; ++i) {
                     int ca = 0;
                     const int8_t *at = &A[lda * i];
-                    for (int j = 0; j < k; ++j) {
+                    for (dim_t j = 0; j < k; ++j) {
                         ca += (int)*at++;
                     }
                     comparray[i] = ca;
                 }
             } else {
-                for (int j = 0; j < k; ++j) {
+                for (dim_t j = 0; j < k; ++j) {
                     int *ca = comparray;
                     const int8_t *at = &A[lda * j];
-                    for (int i = 0; i < m; ++i) {
+                    for (dim_t i = 0; i < m; ++i) {
                         *ca++ += (int)*at++;
                     }
                 }
             }
-            for (int i = 0; i < m; ++i) {
+            for (dim_t i = 0; i < m; ++i) {
                 comparray[i] = cpu::q10n::out_round<int32_t>(
                         cpu::q10n::saturate<int32_t>(
                                 ((double)comparray[i]) * alpha * -128.0));
             }
-            for (int j = 0; j < n; ++j) {
+            for (dim_t j = 0; j < n; ++j) {
                 int *ca = comparray;
                 int *ct = &C[ldc * j];
-                for (int i = 0; i < m; ++i) {
+                for (dim_t i = 0; i < m; ++i) {
                     *ct++ += *ca++;
                 }
             }
@@ -167,16 +183,16 @@ dnnl_status_t cblas_gemm_s8x8s32_ppc64(int ATflag, int BTflag,
         free(BPraw);
     }
     if (*offsetc == 'F' || *offsetc == 'f')
-        for (int i = 0; i < n; ++i)
-            for (int j = 0; j < m; ++j)
+        for (dim_t i = 0; i < n; ++i)
+            for (dim_t j = 0; j < m; ++j)
                 C[ldc * i + j] += co[0];
     if (*offsetc == 'R' || *offsetc == 'r')
-        for (int i = 0; i < n; ++i)
-            for (int j = 0; j < m; ++j)
+        for (dim_t i = 0; i < n; ++i)
+            for (dim_t j = 0; j < m; ++j)
                 C[ldc * i + j] += co[i];
     if (*offsetc == 'C' || *offsetc == 'c')
-        for (int i = 0; i < n; ++i)
-            for (int j = 0; j < m; ++j)
+        for (dim_t i = 0; i < n; ++i)
+            for (dim_t j = 0; j < m; ++j)
                 C[ldc * i + j] += co[j];
 
     return dnnl_success;

--- a/src/cpu/rv64/reorder/jit_uni_reorder.cpp
+++ b/src/cpu/rv64/reorder/jit_uni_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2025 Intel Corporation
+* Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
 * Copyright 2022-2025 Arm Ltd. and affiliates
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
@@ -634,7 +634,7 @@ status_t jit_uni_reorder_t::execute(const exec_ctx_t &ctx) const {
                     = scratchpad.template get<float>(memory_tracking::names::
                                       key_reorder_precomputed_dst_scales)
                     + ithr * dst_scales_scratch_size_ithr;
-            for (int i = 0; i < dst_scales_scratch_size_ithr; i++) {
+            for (dim_t i = 0; i < dst_scales_scratch_size_ithr; i++) {
                 dst_scales_inv_ptr[i] = 1.f / dst_scales_ptr[i];
             }
         }

--- a/src/cpu/rv64/rvv_gemm_convolution.cpp
+++ b/src/cpu/rv64/rvv_gemm_convolution.cpp
@@ -159,7 +159,7 @@ status_t riscv_gemm_convolution_fwd_t::execute_forward_thr_nspc(
             }
         }
 
-        for (int od = 0; od < jcp.od; od++) {
+        for (dim_t od = 0; od < jcp.od; od++) {
             data_t *__restrict dst = dst_base + n * dst_mb_stride
                     + g * dst_g_stride
                     + ((od * jcp.oh + oh) * jcp.ow + ow) * dst_os_stride;
@@ -399,7 +399,7 @@ status_t riscv_gemm_convolution_fwd_t::execute_forward_ncsp(
                             args.dst_md = pd()->dst_md();
                             args.l_offset = d_ - dst;
 
-                            for (int oS = 0; oS < m; ++oS) {
+                            for (dim_t oS = 0; oS < m; ++oS) {
                                 d_[oS] += b;
                                 post_ops_->execute(d_[oS], args);
                                 args.l_offset++;
@@ -441,7 +441,7 @@ status_t riscv_gemm_convolution_fwd_t::execute_forward_ncsp(
 
         if (jcp.loop_order == gemm_loop_rlb)
             for (curr.ic = 0; curr.ic < jcp.ic; curr.ic += step.ic)
-                for (int spatial = start.sp; spatial < end.sp;
+                for (dim_t spatial = start.sp; spatial < end.sp;
                         spatial += step.sp) {
                     nd_iterator_init(spatial, curr.n, jcp.mb, curr.g,
                             jcp.ngroups, curr.od, jcp.od, curr.sp, jcp.os);
@@ -456,7 +456,8 @@ status_t riscv_gemm_convolution_fwd_t::execute_forward_ncsp(
                     }
                 }
         else if (jcp.loop_order == gemm_loop_lrb)
-            for (int spatial = start.sp; spatial < end.sp; spatial += step.sp) {
+            for (dim_t spatial = start.sp; spatial < end.sp;
+                    spatial += step.sp) {
                 nd_iterator_init(spatial, curr.n, jcp.mb, curr.g, jcp.ngroups,
                         curr.od, jcp.od, curr.sp, jcp.os);
                 for (curr.ic = 0; curr.ic < jcp.ic; curr.ic += step.ic)

--- a/src/cpu/rv64/rvv_gemm_convolution_utils.cpp
+++ b/src/cpu/rv64/rvv_gemm_convolution_utils.cpp
@@ -2248,12 +2248,12 @@ void bwd_weights_reduction_par_nspc(int ithr, int nthr, size_t g_start,
             const float *__restrict ws_ptr = ws_base + w * jcp.oc;
             if (tidx == 0) {
                 PRAGMA_OMP_SIMD()
-                for (auto oc = 0; oc < jcp.oc; ++oc) {
+                for (dim_t oc = 0; oc < jcp.oc; ++oc) {
                     dwei_ptr[oc] = ws_ptr[oc];
                 }
             } else {
                 PRAGMA_OMP_SIMD()
-                for (auto oc = 0; oc < jcp.oc; ++oc) {
+                for (dim_t oc = 0; oc < jcp.oc; ++oc) {
                     dwei_ptr[oc] += ws_ptr[oc];
                 }
             }

--- a/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
+++ b/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
@@ -47,7 +47,7 @@ struct layer_normalization_fwd_kernel_vec_t {
                   DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)) {}
 
     void operator()(::sycl::nd_item<1> item) const {
-        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+        for (dim_t idx = item.get_global_id(0); idx < conf_.wk_size;
                 idx += item.get_global_range(0)) {
             if (idx < conf_.N) { compute_alg_n(idx); }
         }
@@ -146,7 +146,7 @@ struct layer_normalization_fwd_kernel_vec1_t {
                   DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)) {}
 
     void operator()(::sycl::nd_item<1> item) const {
-        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+        for (dim_t idx = item.get_global_id(0); idx < conf_.wk_size;
                 idx += item.get_global_range(0)) {
             if (idx < conf_.N) { compute_alg_n(idx); }
         }

--- a/src/gpu/generic/sycl/softmax_kernels.hpp
+++ b/src/gpu/generic/sycl/softmax_kernels.hpp
@@ -119,7 +119,7 @@ struct softmax_fwd_kernel_vec_t {
             }
         };
 
-        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+        for (dim_t idx = item.get_global_id(0); idx < conf_.wk_size;
                 idx += item.get_global_range(0)) {
             dim_t in = (idx / (1)) % conf_.inner_size;
             dim_t ou = (idx / (conf_.inner_size)) % conf_.outer_size;
@@ -195,7 +195,7 @@ struct softmax_bwd_kernel_vec_t {
             }
         };
 
-        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+        for (dim_t idx = item.get_global_id(0); idx < conf_.wk_size;
                 idx += item.get_global_range(0)) {
             dim_t in = (idx / 1) % conf_.inner_size;
             dim_t ou = (idx / conf_.inner_size) % conf_.outer_size;

--- a/src/gpu/intel/conv/jit/plan_utils.hpp
+++ b/src/gpu/intel/conv/jit/plan_utils.hpp
@@ -33,7 +33,7 @@ namespace jit {
 using namespace intel::jit;
 
 struct base_plan_t {
-    base_plan_t(const dsl::hw_t hw = dsl::hw_t()) : hw(hw) {}
+    base_plan_t(const dsl::hw_t &hw = dsl::hw_t()) : hw(hw) {}
 
     int grf_size() const {
         gpu_assert(hw.ngen_hw() != ngen::HW::Unknown);

--- a/src/gpu/intel/conv/jit/v2/plan.cpp
+++ b/src/gpu/intel/conv/jit/v2/plan.cpp
@@ -604,7 +604,7 @@ private:
         int bias_off_elems = 0;
         auto &a_mapper = dim_mapper_manager_.mapper(tensor_kind_t::a);
         auto &b_mapper = dim_mapper_manager_.mapper(tensor_kind_t::b);
-        for (int i = 0; i < outer_size; i++) {
+        for (dim_t i = 0; i < outer_size; i++) {
             auto sub_coord = coord_info_.iter_coord();
             if (!outer_dim.is_undef()) {
                 sub_coord[outer_dim] += sub_tile[outer_dim] * i;

--- a/src/gpu/intel/conv/jit/zp_plan.cpp
+++ b/src/gpu/intel/conv/jit/zp_plan.cpp
@@ -341,7 +341,7 @@ public:
             auto off = offset_bytes<int>(b_layout_, start);
             auto mask = (small_ic) ? kw_var < simd_bcast(kw - start.get(kw_idx))
                                    : expr_t();
-            for (int i = 0; i < tile.elems(); i += sdepth_size)
+            for (int64_t i = 0; i < tile.elems(); i += sdepth_size)
                 stmt = stmt.append(store_t::make(dpas_buf, off + i, wei_load,
                         store_t::default_stride, mask, true));
         }
@@ -462,7 +462,7 @@ public:
                 dpas_buf, 0, -load_t::make(dsl::type_t::s8(), src_buf, 0)));
         stmt = stmt.append(int8_bcast4(dpas_buf));
         auto fill = simd_bcast(load_t::make(dsl::type_t::u32(), dpas_buf, 0));
-        for (int i = 0; i < size_bytes(src_layout_); i += simd_ * 4)
+        for (dim_t i = 0; i < size_bytes(src_layout_); i += simd_ * 4)
             stmt = stmt.append(store_t::make(dpas_buf, i, fill));
         return stmt;
     }
@@ -498,7 +498,8 @@ public:
         for (auto &start : comp_layout_.iter(get_simd_tile())) {
             if (!in_subtile(start, subtile_idx)) continue;
             auto comp = comp_buf[get_comp_off(start)];
-            for (int ck = 0; ck < wei_layout_.elems(ck_idx_); ck += ck_blk) {
+            for (int64_t ck = 0; ck < wei_layout_.elems(ck_idx_);
+                    ck += ck_blk) {
                 auto zp = zp_buf[get_zp_off(start, ck)];
                 auto wei = wei_buf[get_wei_off(start, ck)];
                 stmt = stmt.append(create_tile_stmt(zp, wei, comp, buf_mgr));
@@ -1254,7 +1255,7 @@ public:
         std::vector<int> mask_off;
         for (auto &start : c_layout_.iter(sd.get_simd_tile())) {
             if (!sd.in_subtile(start, subtile_idx)) continue;
-            for (int kw = 0; kw < kw_dim; kw++) {
+            for (dim_t kw = 0; kw < kw_dim; kw++) {
                 comp_off.emplace_back(get_comp_off(start, kw, sd));
                 mask_off.emplace_back(
                         (mask_buf.is_empty()) ? -1 : get_mask_off(start, kw));
@@ -1330,7 +1331,7 @@ public:
         } else {
             for (auto &start : c_layout_.iter(sd.get_simd_tile())) {
                 if (!sd.in_subtile(start, subtile_idx)) continue;
-                for (int kw = 0; kw < kw_dim; kw++) {
+                for (dim_t kw = 0; kw < kw_dim; kw++) {
                     auto comp = comp_buf[get_comp_off(start, kw, sd)];
                     auto mask = mask_buf.is_empty()
                             ? expr_t()

--- a/src/gpu/intel/conv/jit/zp_plan.cpp
+++ b/src/gpu/intel/conv/jit/zp_plan.cpp
@@ -639,14 +639,14 @@ private:
         return ret;
     }
 
-    int get_wei_off(const icoord_t &_start, int ck) const {
+    int get_wei_off(const icoord_t &_start, dim_t ck) const {
         auto start = _start;
         start[ck_idx_] = ck;
         int off = offset_bytes<int>(wei_layout_, start);
         return off % wei_reg_buf_size();
     }
 
-    int get_zp_off(const icoord_t &_start, int ck) const {
+    int get_zp_off(const icoord_t &_start, dim_t ck) const {
         icoord_t start(2);
         if (_start.has(g_idx_)) start[0] = _start[g_idx_];
         start[1] = is_zp_common() ? 0 : ck;
@@ -1381,7 +1381,7 @@ private:
         return utils::rnd_up(ret, grf_size());
     }
 
-    int get_comp_off(const icoord_t &_start, int kw,
+    int get_comp_off(const icoord_t &_start, dim_t kw,
             const split_dispatcher_t &sd) const {
         auto start = sd.c_to_comp(_start);
         start[comp_kw_idx_] = kw;
@@ -1389,7 +1389,7 @@ private:
         return off % comp_reg_buf_size(sd);
     }
 
-    int get_mask_off(const icoord_t &_start, int kw) const {
+    int get_mask_off(const icoord_t &_start, dim_t kw) const {
         // c:    ngcdhw or ngc[osp]
         // mask: ngcdhw[kd][kh][kw] or ngc[osp][kd][kh][kw]
         auto start = _start;
@@ -1399,7 +1399,8 @@ private:
         return off;
     }
 
-    int get_c_off(const icoord_t &start, int kw) const {
+    int get_c_off(const icoord_t &start, dim_t kw) const {
+        UNUSED(kw);
         int off = offset_bytes<int>(c_layout_, start);
         return off;
     }

--- a/src/gpu/intel/jit/ir/tensor.cpp
+++ b/src/gpu/intel/jit/ir/tensor.cpp
@@ -32,7 +32,7 @@ tile_coord_t split(const layout_t &layout, const grid_info_t &grid_info,
     tile_coord_t min_tile_coord = tile_coord_t::invalid();
     std::vector<dim_t> cur_dims(grid_info.ndims(), 1);
 
-    for (int iter = 0; iter < grid_info.elems(); iter++) {
+    for (dim_t iter = 0; iter < grid_info.elems(); iter++) {
         for (dim_idx_t i = 0; i < grid_info.ndims(); i++) {
             if (++cur_dims[i] <= grid_info.dim(i)) break;
             cur_dims[i] = 1;

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -479,7 +479,7 @@ public:
         if (elems() % nmasks != 0) return expr_t();
 
         std::vector<expr_t> vec(nmasks);
-        for (int i = 0; i < elems(); i++) {
+        for (dim_t i = 0; i < elems(); i++) {
             auto &channel_mask = vec[i % nmasks];
             auto &cur_mask = id2masks_[masks_[i]];
             if (channel_mask.is_empty()) {

--- a/src/gpu/intel/pool/jit/ir_builder.cpp
+++ b/src/gpu/intel/pool/jit/ir_builder.cpp
@@ -456,7 +456,7 @@ stmt_t builder_t::try_build(builder_t &pb, const kernel_info_t &ki,
         stmt = stmt_t();
 
         const auto a_fv = gen_fill_values(simd, is_neg, acc_type);
-        for (int i = 0; i < acc_size; i += simd * 4)
+        for (dim_t i = 0; i < acc_size; i += simd * 4)
             stmt = stmt.append(store_t::make(acc_buf, i,
                     (acc_size - i < simd * 4) ? a_fv.first : a_fv.second));
         fill_stmt = gen_zero_out(simd, is_neg, read_buf, src_tile, read_layout);
@@ -493,7 +493,7 @@ stmt_t builder_t::try_build(builder_t &pb, const kernel_info_t &ki,
                 filter = cast_t::make(dsl::type_t::f32(), dhw);
             }
             filter = shuffle_t::make_broadcast(filter, simd);
-            for (int i = 0; i < acc_size; i += simd * acc_sc_size) {
+            for (dim_t i = 0; i < acc_size; i += simd * acc_sc_size) {
                 auto acc = cast_t::make(dsl::type_t::f32(simd),
                         load_t::make(acc_type, acc_buf, i));
                 stmt = stmt.append(store_t::make(acc_buf, i, acc / filter));


### PR DESCRIPTION
### Description

Same class of undefined behavior as [PR #5593](https://github.com/uxlfoundation/oneDNN/pull/5593): loops where a 32-bit `int` counter is compared against a 64-bit `dim_t` bound, which overflows (UB) when the bound exceeds `INT_MAX`. See #5593 for the detailed problem description, reproducer, and analysis.

This PR covers the cases in **ppc64, rv64, and gpu** (kept separate from the cpu/x64 changes in #5593). The fix is the same: widen the loop counter to match the bound's type (`dim_t`, or `ptrdiff_t` where the bound is `ptrdiff_t`).

It also includes two small clang-tidy fixes in `gpu/intel` that the CI surfaced once these files were touched (a value→const-reference parameter and a `dim_t`→`int` narrowing in zp_plan offset helpers).
