### PR TITLE
doc, gpu, tests: extend quantization recipes supported by grouped matmul ref impl

### DIFF
--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -518,8 +518,8 @@ The following are supported:
     | u8, s8, s4, u4             | f32, bf16, f16            |
 - Zero points attribute for source and weights tensors:
   - The masks must match the scales mask
-  - Source zero points data types include `u8`, `s8`
-  - Weights zero points data types include `u8`, `s8`, `u4`, `s4`
+  - Source zero points data types include `u8`, `s8`, `s32`
+  - Weights zero points data types include `u8`, `s8`, `u4`, `s4`, `s32`
 - Post-ops: eltwise and binary multiplication post-ops are supported. Binary post-op
   tensors accept both dense and grouped memory descriptors.
   Common patterns include `eltwise_swish` (SiLU) or

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -352,6 +352,13 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
     VDISPATCH_MATMUL(
             utils::one_of(dst_dt, f32, f16, bf16), VERBOSE_UNSUPPORTED_DT_CFG);
 
+    // WOQ (fp src + int wei) requires weight scales and fpmath apply_to_int
+    VDISPATCH_MATMUL(
+            IMPLICATION(!types::is_integral_dt(src_dt)
+                            && types::is_integral_dt(wei_dt),
+                    wei_quant_.with_scale() && attr()->fpmath_.apply_to_int_),
+            VERBOSE_UNSUPPORTED_DT_CFG);
+
     const bool src_subbyte = utils::one_of(src_dt, s4, u4);
     const bool wei_subbyte = utils::one_of(wei_dt, s4, u4);
     VDISPATCH_MATMUL(IMPLICATION(src_subbyte, (K() % 2) == 0), VERBOSE_BAD_DIM,

--- a/src/gpu/intel/matmul/ref_grouped_gemm.cl
+++ b/src/gpu/intel/matmul/ref_grouped_gemm.cl
@@ -19,7 +19,7 @@
 
 // Grouped GEMM OCL reference kernel
 //
-// Per group g: C[g] = A[g] * B[g] (+ bias / scales for the 2Dx3D pattern)
+// Per group g: C[g] = A[g] * B[g] (+ bias / scales / zero-points for 2Dx3D)
 //
 // 2D grouped src (variable M) x 3D dense wei -> 2D grouped dst (variable M)
 // partner_offsets buffer is dst_offsets
@@ -36,10 +36,11 @@
 // get_global_id(2): output column (n)
 //
 // Supported:
-//  Data types: f32, f16, bf16
-//  Row-wise (per-token) src scales; column-wise weight scales
-//  Bias (shape [group_count, N])
-//  Post-ops (2Dx3D only): eltwise (swish), grouped/dense/nvfp4 binary scale
+//  f32/f16/bf16
+// For 2Dx3D only:
+//  u8/s8 src, u8/s8/s4/u4/f8/f4 wei (incl. WOQ)
+//  row/col-wise or K-grouped scales & zero-points
+//  bias [group_count, N] and post-ops
 __kernel void ref_grouped_gemm_matmul(__global const SRC_DATA_T *src,
         __global const int *src_offsets, __global const WEI_DATA_T *wei,
         __global const int *partner_offsets, __global DST_DATA_T *dst,
@@ -48,18 +49,31 @@ __kernel void ref_grouped_gemm_matmul(__global const SRC_DATA_T *src,
         const long src_stride_k, const long wei_stride_k,
         const long wei_stride_n, const long dst_stride_m,
         const long dst_stride_n, const long src_group_stride,
-        const long wei_group_stride, const long dst_group_stride
+        const long wei_group_stride, const long dst_group_stride,
+        const long n_k_groups
 #if WITH_BIAS
         ,
         __global const BIA_DATA_T *bias // Bias [group_count, N]
 #endif
 #if WITH_SRC_SCALES
         ,
-        __global const float *src_scales
+        __global const SRC_SCALES_DATA_T *src_scales,
+        const long src_scale_ngroups_k
 #endif
 #if WITH_WEI_SCALES
         ,
-        __global const float *wei_scales
+        __global const WEI_SCALES_DATA_T *wei_scales,
+        const long wei_scale_ngroups_k
+#endif
+#if WITH_SRC_ZPOINTS
+        ,
+        __global const SRC_ZP_DATA_T *src_zero_points,
+        const long src_zp_ngroups_k
+#endif
+#if WITH_WEI_ZPOINTS
+        ,
+        __global const WEI_ZP_DATA_T *wei_zero_points,
+        const long wei_zp_ngroups_k
 #endif
                 POST_OP_ARGS) {
     const off_t group_id = get_global_id(0);
@@ -106,21 +120,61 @@ __kernel void ref_grouped_gemm_matmul(__global const SRC_DATA_T *src,
     const long wei_base = wei_group_start * wei_group_stride;
     const long dst_base = dst_group_start * dst_group_stride;
 
-    ACC_DATA_T acc = (ACC_DATA_T)0;
-    for (int k = 0; k < K_g; k++) {
-        const long src_idx = src_base + m * src_stride_m + k * src_stride_k;
-        const long wei_idx = wei_base + k * wei_stride_k + n * wei_stride_n;
-        acc += SRC_TO_REF(src[src_idx]) * WEI_TO_REF(wei[wei_idx]);
-    }
+    // src attribute row (global token) = group start + local row
+    const long src_attr_row = src_group_start + m;
+    const long k_group_size = K_g / n_k_groups;
 
+    FLT_ACC_DATA_T acc = 0;
+    for (long i_group = 0; i_group < n_k_groups; i_group++) {
+        ACC_DATA_T acc_g = (ACC_DATA_T)0;
+        for (long k = 0; k < k_group_size; k++) {
+            const long k_abs = k + i_group * k_group_size;
+            const long src_idx
+                    = src_base + m * src_stride_m + k_abs * src_stride_k;
+            const long wei_idx
+                    = wei_base + k_abs * wei_stride_k + n * wei_stride_n;
+            int src_zp = 0;
+#if WITH_SRC_ZPOINTS
+            src_zp = SRC_ZP_TO_REF(src_zero_points,
+                    src_attr_row * src_zp_ngroups_k
+                            + i_group * src_zp_ngroups_k / n_k_groups);
+#endif
+            int wei_zp = 0;
+#if WITH_WEI_ZPOINTS
+            wei_zp = WEI_ZP_TO_REF(wei_zero_points,
+                    group_id * wei_zp_ngroups_k * N
+                            + (i_group * wei_zp_ngroups_k / n_k_groups) * N
+                            + n);
+#endif
+#if SRC_DT_F4_E2M1 || SRC_DT_F4_E3M0
+            ACC_DATA_T s
+                    = TO_ACC(SRC_TO_REF(GET_HALF_BYTE(src, src_idx)) - src_zp);
+#else
+            ACC_DATA_T s = TO_ACC(SRC_TO_REF(src[src_idx]) - src_zp);
+#endif
+#if WEI_DT_S4 || WEI_DT_U4 || WEI_DT_F4_E2M1 || WEI_DT_F4_E3M0
+            ACC_DATA_T w
+                    = TO_ACC(WEI_TO_REF(GET_HALF_BYTE(wei, wei_idx)) - wei_zp);
+#else
+            ACC_DATA_T w = TO_ACC(WEI_TO_REF(wei[wei_idx]) - wei_zp);
+#endif
+            acc_g += s * w;
+        }
+        FLT_ACC_DATA_T src_scale = 1.f;
+        FLT_ACC_DATA_T wei_scale = 1.f;
 #if WITH_SRC_SCALES
-    // Row-wise (per global token) src scale; global token = src_group_start + m.
-    acc *= (ACC_DATA_T)src_scales[src_group_start + m];
+        src_scale = SRC_SCALES_TO_REF(
+                src_scales[src_attr_row * src_scale_ngroups_k
+                        + i_group * src_scale_ngroups_k / n_k_groups]);
 #endif
 #if WITH_WEI_SCALES
-    // Column-wise weight scale, shape [group_count, N].
-    acc *= (ACC_DATA_T)wei_scales[group_id * N + n];
+        wei_scale = WEI_SCALES_TO_REF(wei_scales[group_id * wei_scale_ngroups_k
+                        * N
+                + (i_group * wei_scale_ngroups_k / n_k_groups) * N + n]);
 #endif
+        acc += ACC_TO_REF(acc_g) * src_scale * wei_scale;
+    }
+
 #if WITH_BIAS
     acc += BIA_TO_REF(bias[group_id * N + n]);
 #endif

--- a/src/gpu/intel/matmul/ref_grouped_gemm.cpp
+++ b/src/gpu/intel/matmul/ref_grouped_gemm.cpp
@@ -18,6 +18,8 @@
 
 #if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 
+#include <algorithm>
+
 #include "common/c_types_map.hpp"
 #include "gpu/intel/compute/utils.hpp"
 
@@ -91,8 +93,32 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
     const bool with_bias = pd()->with_bias();
     const auto &attr_scales = pd()->attr()->scales_;
     const bool with_src_scales = !attr_scales.has_default_values(DNNL_ARG_SRC);
+    const auto src_scale_group_k = attr_scales.get_group(DNNL_ARG_SRC, -1);
+    const dim_t src_scale_ngroups_k
+            = src_scale_group_k > 1 ? K_fixed / src_scale_group_k : 1;
+
     const bool with_wei_scales
             = !attr_scales.has_default_values(DNNL_ARG_WEIGHTS);
+    const auto wei_scale_group_k = attr_scales.get_group(DNNL_ARG_WEIGHTS, -2);
+    const dim_t wei_scale_ngroups_k
+            = wei_scale_group_k > 1 ? K_fixed / wei_scale_group_k : 1;
+
+    const auto &attr_zps = pd()->attr()->zero_points_;
+    const bool with_src_zp = !attr_zps.has_default_values(DNNL_ARG_SRC);
+    const auto src_zp_group_k = attr_zps.get_group(DNNL_ARG_SRC, -1);
+    const dim_t src_zp_ngroups_k
+            = src_zp_group_k > 1 ? K_fixed / src_zp_group_k : 1;
+
+    const bool with_wei_zp = !attr_zps.has_default_values(DNNL_ARG_WEIGHTS);
+    const auto wei_zp_group_k = attr_zps.get_group(DNNL_ARG_WEIGHTS, -2);
+    const dim_t wei_zp_ngroups_k
+            = wei_zp_group_k > 1 ? K_fixed / wei_zp_group_k : 1;
+
+    // Finest K-group granularity across src/wei scales and ZPs
+    const dim_t n_k_groups = is_2dby2d
+            ? 1
+            : std::max({src_scale_ngroups_k, wei_scale_ngroups_k,
+                      src_zp_ngroups_k, wei_zp_ngroups_k});
 
     compute::kernel_arg_list_t arg_list;
     int arg_idx = 0;
@@ -120,13 +146,28 @@ status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
     arg_list.set(arg_idx++, src_group_stride);
     arg_list.set(arg_idx++, wei_group_stride);
     arg_list.set(arg_idx++, dst_group_stride);
+    arg_list.set(arg_idx++, n_k_groups);
     if (with_bias) arg_list.set(arg_idx++, CTX_IN_STORAGE(DNNL_ARG_BIAS));
-    if (with_src_scales)
+    if (with_src_scales) {
         arg_list.set(
                 arg_idx++, CTX_IN_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC));
-    if (with_wei_scales)
+        arg_list.set(arg_idx++, src_scale_ngroups_k);
+    }
+    if (with_wei_scales) {
         arg_list.set(arg_idx++,
                 CTX_IN_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS));
+        arg_list.set(arg_idx++, wei_scale_ngroups_k);
+    }
+    if (with_src_zp) {
+        arg_list.set(arg_idx++,
+                CTX_IN_STORAGE(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC));
+        arg_list.set(arg_idx++, src_zp_ngroups_k);
+    }
+    if (with_wei_zp) {
+        arg_list.set(arg_idx++,
+                CTX_IN_STORAGE(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS));
+        arg_list.set(arg_idx++, wei_zp_ngroups_k);
+    }
 
     // Post-ops apply to the 2Dx3D pattern only (grouped dst)
     arg_idx = append_post_ops_to_arg_list(

--- a/src/gpu/intel/matmul/ref_grouped_gemm.hpp
+++ b/src/gpu/intel/matmul/ref_grouped_gemm.hpp
@@ -92,47 +92,138 @@ struct ref_grouped_t : public primitive_t {
             VDISPATCH_MATMUL(wei_d.is_blocking_desc() && wei_d.ndims() == 3,
                     VERBOSE_UNSUPPORTED_SPARSE_CFG);
 
-            // GPU ref currently only supports matching data types
-            const auto src_dt = src_md()->data_type;
-            VDISPATCH_MATMUL(src_dt == weights_md(0)->data_type
-                            && src_dt == dst_md()->data_type
-                            && utils::one_of(src_dt, f32, bf16, f16),
+            // Supported data types: fp and int for src/wei
+            const auto src_type = src_md(0)->data_type;
+            const auto wei_type = weights_md(0)->data_type;
+            const auto dst_type = dst_md(0)->data_type;
+            const bool is_fp_src = utils::one_of(
+                    src_type, f32, bf16, f16, f8_e5m2, f8_e4m3, f4_e2m1);
+            const bool is_fp_wei = utils::one_of(
+                    wei_type, f32, bf16, f16, f8_e5m2, f8_e4m3, f4_e2m1);
+            const bool is_int_src = utils::one_of(src_type, u8, s8);
+            const bool is_int_wei = utils::one_of(wei_type, u8, s8, s4, u4);
+
+            // Supported: fp src + int wei (WOQ), int src + int wei, fp src + fp wei
+            VDISPATCH_MATMUL(is_fp_src || is_int_src, VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_MATMUL(is_fp_wei || is_int_wei, VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_MATMUL(utils::one_of(dst_type, f32, bf16, f16),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_MATMUL(IMPLICATION(is_int_src, is_int_wei),
+                    VERBOSE_UNSUPPORTED_DT_CFG);
+            // WOQ requires weight scales and fpmath with apply_to_int
+            VDISPATCH_MATMUL(IMPLICATION(is_fp_src && is_int_wei,
+                                     !attr()->scales_.has_default_values(
+                                             DNNL_ARG_WEIGHTS)),
+                    VERBOSE_UNSUPPORTED_DT_CFG);
+            VDISPATCH_MATMUL(IMPLICATION(is_fp_src && is_int_wei,
+                                     attr()->fpmath_.apply_to_int_),
                     VERBOSE_UNSUPPORTED_DT_CFG);
 
             // Check for supported quantization schemes
             const auto &attr_scales = attr()->scales_;
             if (!attr_scales.has_default_values(DNNL_ARG_SRC)) {
                 const int src_mask = attr_scales.get_mask(DNNL_ARG_SRC);
-                const int rowwise_mask = src_qmask_M();
-                // Only row-wise f32 scales supported for src
-                VDISPATCH_MATMUL(src_mask == rowwise_mask,
+                // Allow row-wise or blocked (K-grouping) scales for src
+                VDISPATCH_MATMUL(src_mask == src_qmask_M()
+                                || src_mask == (src_qmask_M() | src_qmask_K()),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
-                VDISPATCH_MATMUL(attr_scales.get_data_type(DNNL_ARG_SRC) == f32,
-                        VERBOSE_UNSUPPORTED_SCALES_CFG);
-                // No groups for src scales
                 VDISPATCH_MATMUL(
-                        attr_scales.get(DNNL_ARG_SRC).has_default_groups(),
+                        utils::one_of(attr_scales.get_data_type(DNNL_ARG_SRC),
+                                f32, bf16, f16, e8m0, f8_e4m3, f8_e5m2),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
+                if (!attr_scales.get(DNNL_ARG_SRC).has_default_groups()) {
+                    const auto gM = attr_scales.get_group(DNNL_ARG_SRC, -2);
+                    VDISPATCH_MATMUL(gM == 1, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    const auto gK = attr_scales.get_group(DNNL_ARG_SRC, -1);
+                    VDISPATCH_MATMUL(gK > 1, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    VDISPATCH_MATMUL(
+                            K() % gK == 0, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                }
             }
             if (!attr_scales.has_default_values(DNNL_ARG_WEIGHTS)) {
                 const int wei_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
-                const int colwise_mask = wei_qmask_N();
-                // Only column-wise f32 scales supported for weights
-                VDISPATCH_MATMUL(wei_mask == colwise_mask,
+                // Allow column-wise or blocked (K-grouping) scales for weights
+                VDISPATCH_MATMUL(wei_mask == wei_qmask_N()
+                                || wei_mask == (wei_qmask_K() | wei_qmask_N()),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
                 VDISPATCH_MATMUL(
-                        attr_scales.get_data_type(DNNL_ARG_WEIGHTS) == f32,
+                        utils::one_of(
+                                attr_scales.get_data_type(DNNL_ARG_WEIGHTS),
+                                f32, bf16, f16, e8m0, f8_e4m3, f8_e5m2),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
-                // No groups for weight scales
-                VDISPATCH_MATMUL(
-                        attr_scales.get(DNNL_ARG_WEIGHTS).has_default_groups(),
-                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+                if (!attr_scales.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
+                    const auto gK = attr_scales.get_group(DNNL_ARG_WEIGHTS, -2);
+                    VDISPATCH_MATMUL(gK > 1, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    VDISPATCH_MATMUL(
+                            K() % gK == 0, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    const auto gN = attr_scales.get_group(DNNL_ARG_WEIGHTS, -1);
+                    VDISPATCH_MATMUL(gN == 1, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                }
             }
             VDISPATCH_MATMUL(attr_scales.has_default_values(DNNL_ARG_DST),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
-            // Zero-points are not supported
-            VDISPATCH_MATMUL(attr()->zero_points_.has_default_values(),
+
+            // Zero-points: src (int src), wei (int wei); row/col-wise or K-grouped
+            const auto &attr_zps = attr()->zero_points_;
+            VDISPATCH_MATMUL(attr_zps.has_default_values(DNNL_ARG_DST),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
+            if (!attr_zps.has_default_values(DNNL_ARG_SRC)) {
+                VDISPATCH_MATMUL(is_int_src, VERBOSE_UNSUPPORTED_ZP_CFG);
+                VDISPATCH_MATMUL(
+                        utils::one_of(attr_zps.get_data_type(DNNL_ARG_SRC), u8,
+                                s8, s32),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                const int zp_mask = attr_zps.get_mask(DNNL_ARG_SRC);
+                VDISPATCH_MATMUL(zp_mask == src_qmask_M()
+                                || zp_mask == (src_qmask_M() | src_qmask_K()),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                if (!attr_zps.get(DNNL_ARG_SRC).has_default_groups()) {
+                    const auto gM = attr_zps.get_group(DNNL_ARG_SRC, -2);
+                    VDISPATCH_MATMUL(gM == 1, VERBOSE_UNSUPPORTED_ZP_CFG);
+                    const auto gK = attr_zps.get_group(DNNL_ARG_SRC, -1);
+                    VDISPATCH_MATMUL(gK > 1, VERBOSE_UNSUPPORTED_ZP_CFG);
+                    VDISPATCH_MATMUL(K() % gK == 0, VERBOSE_UNSUPPORTED_ZP_CFG);
+                }
+            }
+            if (!attr_zps.has_default_values(DNNL_ARG_WEIGHTS)) {
+                VDISPATCH_MATMUL(is_int_wei, VERBOSE_UNSUPPORTED_ZP_CFG);
+                VDISPATCH_MATMUL(
+                        utils::one_of(attr_zps.get_data_type(DNNL_ARG_WEIGHTS),
+                                u8, s8, u4, s4, s32),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                const int zp_mask = attr_zps.get_mask(DNNL_ARG_WEIGHTS);
+                VDISPATCH_MATMUL(zp_mask == wei_qmask_N()
+                                || zp_mask == (wei_qmask_K() | wei_qmask_N()),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                if (!attr_zps.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
+                    const auto gK = attr_zps.get_group(DNNL_ARG_WEIGHTS, -2);
+                    VDISPATCH_MATMUL(gK > 1, VERBOSE_UNSUPPORTED_ZP_CFG);
+                    VDISPATCH_MATMUL(K() % gK == 0, VERBOSE_UNSUPPORTED_ZP_CFG);
+                    const auto gN = attr_zps.get_group(DNNL_ARG_WEIGHTS, -1);
+                    VDISPATCH_MATMUL(gN == 1, VERBOSE_UNSUPPORTED_ZP_CFG);
+                }
+            }
+            // For K grouping, src/wei scale group sizes must be multiples
+            if (!attr_scales.has_default_values(DNNL_ARG_SRC)
+                    && !attr_scales.get(DNNL_ARG_SRC).has_default_groups()
+                    && !attr_scales.has_default_values(DNNL_ARG_WEIGHTS)
+                    && !attr_scales.get(DNNL_ARG_WEIGHTS)
+                                .has_default_groups()) {
+                const auto src_gK = attr_scales.get_group(DNNL_ARG_SRC, -1);
+                const auto wei_gK = attr_scales.get_group(DNNL_ARG_WEIGHTS, -2);
+                VDISPATCH_MATMUL(src_gK % wei_gK == 0 || wei_gK % src_gK == 0,
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+            }
+            // Weight scales and ZPs K-groups must match
+            if (!attr_scales.has_default_values(DNNL_ARG_WEIGHTS)
+                    && !attr_zps.has_default_values(DNNL_ARG_WEIGHTS)) {
+                const auto scale_gK
+                        = attr_scales.get_group(DNNL_ARG_WEIGHTS, -2);
+                const auto zp_gK = attr_zps.get_group(DNNL_ARG_WEIGHTS, -2);
+                VDISPATCH_MATMUL(scale_gK == zp_gK, VERBOSE_INCONSISTENT_DIM,
+                        "wei_scale_group_k", (int)scale_gK, "wei_zp_group_k",
+                        (int)zp_gK);
+            }
 
             if (attr_.post_ops_.len() > 0) CHECK(setup_post_ops(engine));
 
@@ -214,6 +305,14 @@ struct ref_grouped_t : public primitive_t {
         def_data_type(kernel_ctx, pd()->weights_md(0)->data_type, "WEI");
         def_data_type(kernel_ctx, pd()->dst_md()->data_type, "DST");
         def_data_type(kernel_ctx, pd()->desc()->accum_data_type, "ACC");
+
+        // Zero-point data types (def_attr_info covers scale data types only)
+        def_data_type(kernel_ctx,
+                pd()->attr()->zero_points_.get_data_type(DNNL_ARG_SRC),
+                "SRC_ZP");
+        def_data_type(kernel_ctx,
+                pd()->attr()->zero_points_.get_data_type(DNNL_ARG_WEIGHTS),
+                "WEI_ZP");
 
         auto attr_info = attr_info_t::create(pd()->attr());
         CHECK(def_attr_info(kernel_ctx, attr_info, pd()->generic_po_,

--- a/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
@@ -59,24 +59,24 @@
 --attr-scales=src:1+wei:7:bf16:128x1,src:1+wei:7:bf16:32x1
 32x512:4x512x256
 
-# Combine row-wise src scales and zp u8/s8
+# Combine row-wise src scales and zp u8/s8/s32
 --reset
 --dt=s8:s4:f32,s8:s4:bf16,u8:s4:bf16
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8
 --bia-dt=undef,bf16 --bia_mask=2
 --attr-scales=src:1+wei:7:f32:128x1
---attr-zero-points=,src:1:u8,src:1:s8
+--attr-zero-points=,src:1:u8,src:1:s8,src:1:s32
 32x512:4x512x256
 
-# Combine blocked src scales and zp u8/s8
+# Combine blocked src scales and zp u8/s8/s32
 --reset
 --dt=s8:s4:bf16,u8:s4:bf16
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8
 --bia-dt=undef,bf16 --bia_mask=2
 --attr-scales=src:3:f32:1x128
---attr-zero-points=,src:3:u8:1x128,src:3:s8:1x128
+--attr-zero-points=,src:3:u8:1x128,src:3:s8:1x128,src:3:s32:1x128
 32x512:4x512x256
 
 # int src + int wei with column-wise scales and ZPs
@@ -85,7 +85,7 @@
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8
 --attr-scales=wei:5:f32
---attr-zero-points=wei:5:s8
+--attr-zero-points=wei:5:s8,wei:5:s32
 32x64:4x64x32
 
 # int src + int wei with blocked scales and ZPs
@@ -94,7 +94,7 @@
 --wtag=abc
 --grouped=0:4:8+8+8+8
 --attr-scales=wei:7:bf16:128x1
---attr-zero-points=wei:7:s8:128x1
+--attr-zero-points=wei:7:s8:128x1,wei:7:s32:128x1
 32x512:4x512x256
 
 # WOQ: f16 activation + s4/u4 weights with blocked scales and ZPs


### PR DESCRIPTION
Addressed next gaps (as mentioned in [MFDNN-15340](https://jira.devtools.intel.com/browse/MFDNN-15340)):
- All impls supports s32 zps, but it was never documented or tested
- GPU opt was missing check for `apply_to_int_` being set for WOQ
- GPU ref didn't support all the quantization recipes that are documented and supported by CPU ref/GPU opt

Note: full Nightly scope with only ref impl didn't show any issues.