### PR TITLE
[GPU] Update CRI thread counting

### DIFF
--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -288,6 +288,11 @@ int max_threads_per_eu(const ngen::Product &product) {
 int device_info_t::threads_per_eu(
         const ngen::Product &product, int grf_per_thread) {
     gpu_assert(grf_per_thread > 0) << "Invalid GRF per thread";
+
+    // CRI has an exception: 256 GRF/thread is restricted to 4 threads/EU due to lack of accumulators
+    if (product.family == ngen::ProductFamily::CRI && grf_per_thread == 256)
+        return 4;
+
     int hw_max = max_threads_per_eu(product);
     return std::min(hw_max, grf_per_eu(product) / grf_per_thread);
 }

--- a/src/gpu/intel/gemm/jit/dsl/hw.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/hw.cpp
@@ -110,6 +110,9 @@ int max_threads_per_eu(const ngen::Product product) {
 } // namespace
 
 int hw_t::threads_per_eu(int regs) const {
+    // CRI has an exception: 256 GRF/thread is restricted to 4 threads/EU due to lack of accumulators
+    if (product().family == ngen::ProductFamily::CRI && regs == 256) return 4;
+
     int max_threads = max_threads_per_eu(product());
     return std::min(max_threads, grf_per_eu(product()) / regs);
 }

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -550,6 +550,7 @@ gen_nocopy_desc_t::select_kernel(const compute::device_info_t &dev_info,
     eval_params_.sizes = base.sizes;
     eval_params_.alpha = alpha;
     eval_params_.beta = beta;
+    eval_params_.product = product_;
     eval_params_.postOps = !problem.postOps.empty();
     eval_params_.cConvert = (problem.Tc != problem.Tc_ext);
     eval_params_.euCount = dev_info.eu_count();
@@ -723,6 +724,7 @@ status_t gen_xe_systolic_kernel_desc_t::select_kernel(
     eval_params.sizes = match_params.sizes;
     eval_params.alpha = alpha;
     eval_params.beta = beta;
+    eval_params.product = product_;
     eval_params.euCount = dev_info.eu_count();
     eval_params.postOps = !problem_.postOps.empty();
     eval_params.cConvert = (acc_type != c_type);

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -237,6 +237,7 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
     evalParams.sizes = matchParams.sizes;
     evalParams.alpha = 1;
     evalParams.beta = 0;
+    evalParams.product = product;
     evalParams.euCount = hwInfo.euCount;
 
     /* Generate interface */

--- a/src/gpu/intel/gemm/jit/generator/pieces/hw_utils.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/hw_utils.hpp
@@ -115,8 +115,9 @@ static inline size_t maxSLMPerWG(ngen::Product p, int grfCount)
     return slmMax;
 }
 
-static inline int GRFPerEU(ngen::HW hw)
+static inline int GRFPerEU(const ngen::Product &product)
 {
+    ngen::HW hw = ngen::getCore(product.family);
     switch (hw) {
         case ngen::HW::XeLP:  return 896; // Equivalent for 128 GRF/thread, 7 threads/EU.
         case ngen::HW::XeHP:
@@ -124,17 +125,22 @@ static inline int GRFPerEU(ngen::HW hw)
         case ngen::HW::XeHPC:
         case ngen::HW::Xe2:
         case ngen::HW::Xe3:
-        case ngen::HW::Xe3p:  return 1024;
+        case ngen::HW::Xe3p:
+            return product.family == ngen::ProductFamily::CRI ? 2048 : 1024;
         default:              return 0;
     }
 }
 
-static inline int threadsPerEU(ngen::HW hw, const CommonStrategy &strategy)
+static inline int threadsPerEU(const ngen::Product &product, const CommonStrategy &strategy)
 {
-    if (hw <= ngen::HW::XeLP)
+    // CRI has an exception: 256 GRF/thread is restricted to 4 threads/EU due to lack of accumulators
+    if (product.family == ngen::ProductFamily::CRI && strategy.GRFs == 256)
+        return 4;
+
+    if (product.family <= ngen::ProductFamily::GenericXeLP)
         return 7;
 
-    return GRFPerEU(hw) / strategy.GRFs;
+    return GRFPerEU(product) / strategy.GRFs;
 }
 
 static inline int eusPerSubslice(ngen::HW hw)

--- a/src/gpu/intel/gemm/jit/generator/pieces/kernel_queries.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/kernel_queries.cpp
@@ -57,7 +57,7 @@ size_t gemmPerKSLMSize(HW hw, const GEMMProblem &problem, const GEMMStrategy &st
         // Calculate max SLM usage that doesn't reduce thread count.
         int mnThreads = strategy.wg[LoopM] * strategy.wg[LoopN];
         if (mnThreads <= 0) stub();
-        int concurrentK = std::max(1, threadsPerEU(hw, strategy) * eusPerSubslice(hw) / mnThreads);
+        int concurrentK = std::max(1, threadsPerEU(problem.product, strategy) * eusPerSubslice(hw) / mnThreads);
         slmSize = rounddown_pow2(maxSLMPerWG(problem.product, strategy.GRFs) / concurrentK);
         if (!problem.sumA && !problem.sumB) {
             auto singleTile = strategy.wg[LoopM] * strategy.wg[LoopN]

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -211,6 +211,11 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     checkBeta1 |= C.atomic && !problem.beta1();
 
     GRFs = std::min(GRFs, GRF::maxRegs(hw));
+    // CRI has unique GRF mode behaviour - automatically update to optimal options
+    if (problem.product.family == ngen::ProductFamily::CRI) {
+        if (GRFs == 128) GRFs = 192;
+        if (GRFs == 256) GRFs = 512;
+    }
 
     // Fixed systolic kernel handling.
     if (fixedSystolic) {

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -470,7 +470,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     if (wg[loopOrder[1]] <= 0) wg[loopOrder[1]] = defaultWGY;
     if (wg[LoopK] <= 0) {
         if (kParallelLocal)
-            wg[LoopK] = (threadsPerEU(hw, *this) * eusPerSubslice(hw)) / (wg[LoopM] * wg[LoopN]);
+            wg[LoopK] = (threadsPerEU(problem.product, *this) * eusPerSubslice(hw)) / (wg[LoopM] * wg[LoopN]);
         else
             wg[LoopK] = 1;
     }

--- a/src/gpu/intel/gemm/jit/include/gemmstone/kernel_evaluator.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/kernel_evaluator.hpp
@@ -32,6 +32,7 @@ struct EvaluateParams {
     SizeParams sizes;
     double alpha, beta;
     int euCount;
+    ngen::Product product;
     int tileCount = 1;
     bool effective = false;
     bool cConvert = false;

--- a/src/gpu/intel/gemm/jit/selector/kernel_evaluator.cpp
+++ b/src/gpu/intel/gemm/jit/selector/kernel_evaluator.cpp
@@ -19,6 +19,7 @@
 #include "gemmstone/type.hpp"
 #include "gemmstone/problem.hpp"
 #include "internal/utils.hpp"
+#include "ngen_core.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -26,18 +27,34 @@
 
 GEMMSTONE_NAMESPACE_START
 
-static inline int grfPerEU(char hw)
+static inline int grfPerEU(ngen::Product product)
 {
+    ngen::HW hw = ngen::getCore(product.family);
     switch (hw) {
-        case kcatalog::HWTagGen12LP: return 896;
-        case kcatalog::HWTagXeHPG:
-        case kcatalog::HWTagXeHPC:
-        case kcatalog::HWTagXe2:
-        case kcatalog::HWTagXe3:
-        case kcatalog::HWTagXe3p:   return 1024;
+        case ngen::HW::Gen12LP: return 896;
+        case ngen::HW::XeHPG:
+        case ngen::HW::XeHPC:
+        case ngen::HW::Xe2:
+        case ngen::HW::Xe3:
+        case ngen::HW::Xe3p:
+            return product.family == ngen::ProductFamily::CRI ? 2048 : 1024;
+        default: return 1024;
     }
     return 1024;
 }
+
+static inline int threadsPerEU(const ngen::Product &product, int grf_per_thread)
+{
+    // CRI has an exception: 256 GRF/thread is restricted to 4 threads/EU due to lack of accumulators
+    if (product.family == ngen::ProductFamily::CRI && grf_per_thread == 256)
+        return 4;
+
+    if (product.family <= ngen::ProductFamily::GenericXeLP)
+        return 7;
+
+    return grfPerEU(product) / grf_per_thread;
+}
+
 
 template <typename T1, typename T2>
 static inline T1 divUp(T1 x, T2 y)
@@ -549,7 +566,7 @@ DerivedEvaluateParams getDerivedParams(const kcatalog::Entry &e, const EvaluateP
     dp.threadCount *= threadsPerWG;
     dp.threadCount *= (dp.wgCountK * p.sizes.batch);
 
-    dp.threadsPerEU = grfPerEU(e.selector.hw) / e.driverInfo.grfCount;
+    dp.threadsPerEU = threadsPerEU(p.product, e.driverInfo.grfCount);
 
     int ssCount;
     switch (e.selector.hw) {


### PR DESCRIPTION
Round 3 (I think) of updating CRI thread counting. This one might address [MFDNN-15240](https://jira.devtools.intel.com/browse/MFDNN-15240).

On CRI, 256 GRF/thread configurations would get spawned with 8 threads/EU according to existing logic. But due to a special case on CRI only, due to increased GRF/EU for this platform in combination with Variable Registers per Thread (VRT) allowing grf512 configurations, grf256 kernels will only get 4 threads/EU. This means we spawn 2x too many threads when using persistent threading, which could lead to performance issues. This fixes the thread counting to account for this.

Simultaneously, grf256 strategies are strictly inferior on CRI to grf512 strategies (and likewise for grf128 which are inferior to grf192). They have the same number of threads/EU, but just use a portion of the GRF space available. The final commit automatically upgrades the GRF mode selection to the optimal setting. This is important when selecting CRI kernels from those tuned for pre-Xe3 platforms.