### PR TITLE
oneDNN v3.12.3 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.12.2")
+set(PROJECT_VERSION "3.12.3")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.12.2:
* Fixed potential memory corruption in Graph API for logical tensors with number of dimensions exceeding 12 (1470adbd35a0bea094763c474dfd0f0c675a752d)
* Enabled matmul and inner product primitives compatibility with SYCL Graph native recording mode on Intel GPUs (817bf1f170c37a1ff8caffa48795a792927eaeed, a16c22ff6a3257ebd21ba4dc888fdb47e320ec53, ad55577cb4411f8bee805f84fc4365b911f6b0ea)
* Fixed performance regression in SDPA subgraph with head size 64 on Intel GPUs based on Xe2 architecture (486c7f760e5279e6dc30538393ae20a047e0a143, ee77a161a28b91f68f4bd6541902c1232a45a949)
