### PR TITLE
[OpenCL][SYCL] Include OpenCL extension header

### DIFF
--- a/src/gpu/intel/sycl/utils.cpp
+++ b/src/gpu/intel/sycl/utils.cpp
@@ -28,6 +28,9 @@
 
 #include <sycl/ext/oneapi/backend/level_zero.hpp>
 
+// Include for cl_khr_device_uuid
+#include <CL/cl_ext.h>
+
 namespace dnnl {
 namespace impl {
 namespace gpu {


### PR DESCRIPTION
OneDNN uses `cl_khr_device_uuid`:
https://github.com/uxlfoundation/oneDNN/blob/2557390472bca15ba38df7b0091033e812028f09/src/gpu/intel/sycl/utils.cpp#L229

but that requires OpenCL extension headers.

It is passing right now because SYCL headers transitively bring in OpenCL headers, but we will soon change that.
This failure was first observed in CMPLRLLVM-76756