### PR TITLE
refactor: pd_t::init(...) to pass 'const engine_t *' and to all its dependants

### DIFF
--- a/src/common/concat.cpp
+++ b/src/common/concat.cpp
@@ -43,8 +43,9 @@ namespace dnnl {
 namespace impl {
 
 status_t concat_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
-        engine_t *engine, const memory_desc_t *dst_md, int n, int concat_dim,
-        const memory_desc_t *const *src_mds, const primitive_attr_t *attr) {
+        const engine_t *engine, const memory_desc_t *dst_md, int n,
+        int concat_dim, const memory_desc_t *const *src_mds,
+        const primitive_attr_t *attr) {
     VCHECK_CONCAT(!any_null(src_mds) && n > 0, VERBOSE_NULL_ARG);
 
     if (attr == nullptr)
@@ -149,8 +150,9 @@ status_t concat_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
 }
 
 status_t concat_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
-        engine_t *engine, const memory_desc_t *dst_md, int n, int concat_dim,
-        const memory_desc_t *src_mds, const primitive_attr_t *attr) {
+        const engine_t *engine, const memory_desc_t *dst_md, int n,
+        int concat_dim, const memory_desc_t *src_mds,
+        const primitive_attr_t *attr) {
     std::vector<const memory_desc_t *> src_mds_ptrs(n);
     for (int i = 0; i < n; i++)
         src_mds_ptrs[i] = &src_mds[i];

--- a/src/common/concat.hpp
+++ b/src/common/concat.hpp
@@ -26,8 +26,9 @@ namespace impl {
 
 struct primitive_desc_t;
 status_t concat_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
-        engine_t *engine, const memory_desc_t *dst_md, int n, int concat_dim,
-        const memory_desc_t *src_mds, const primitive_attr_t *attr = nullptr);
+        const engine_t *engine, const memory_desc_t *dst_md, int n,
+        int concat_dim, const memory_desc_t *src_mds,
+        const primitive_attr_t *attr = nullptr);
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/concat_pd.hpp
+++ b/src/common/concat_pd.hpp
@@ -274,7 +274,7 @@ private:
 
 #define DECLARE_CONCAT_PD_t(impl_name, ...) \
     static status_t create(concat_pd_t **concat_pd, \
-            dnnl::impl::engine_t *engine, const primitive_attr_t *attr, \
+            const dnnl::impl::engine_t *engine, const primitive_attr_t *attr, \
             const memory_desc_t *dst_md, int n, int concat_dim, \
             const memory_desc_t *const *src_mds) { \
         using namespace status; \

--- a/src/common/impl_list_item.hpp
+++ b/src/common/impl_list_item.hpp
@@ -137,7 +137,7 @@ struct impl_list_item_t {
 
 private:
     status_t operator()(primitive_desc_t **pd, const op_desc_t *adesc,
-            const primitive_attr_t *attr, engine_t *engine,
+            const primitive_attr_t *attr, const engine_t *engine,
             const primitive_desc_t *hint_fwd, int pd_iterator_offset,
             int skip_idx) const {
         assert(create_pd_func_);
@@ -150,7 +150,7 @@ private:
         return status;
     }
 
-    status_t operator()(concat_pd_t **concat_pd, engine_t *engine,
+    status_t operator()(concat_pd_t **concat_pd, const engine_t *engine,
             const primitive_attr_t *attr, const memory_desc_t *dst_md, int n,
             int concat_dim, const memory_desc_t *const *src_mds) const {
         assert(create_concat_pd_func_);
@@ -159,7 +159,7 @@ private:
                 concat_pd, engine, attr, dst_md, n, concat_dim, src_mds);
     }
 
-    status_t operator()(sum_pd_t **sum_pd, engine_t *engine,
+    status_t operator()(sum_pd_t **sum_pd, const engine_t *engine,
             const primitive_attr_t *attr, const memory_desc_t *dst_md, int n,
             const float *scales, const memory_desc_t *const *src_mds) const {
         assert(create_sum_pd_func_);
@@ -168,9 +168,9 @@ private:
                 sum_pd, engine, attr, dst_md, n, scales, src_mds);
     }
 
-    status_t operator()(reorder_pd_t **reorder_pd, engine_t *engine,
-            const primitive_attr_t *attr, engine_t *src_engine,
-            const memory_desc_t *src_md, engine_t *dst_engine,
+    status_t operator()(reorder_pd_t **reorder_pd, const engine_t *engine,
+            const primitive_attr_t *attr, const engine_t *src_engine,
+            const memory_desc_t *src_md, const engine_t *dst_engine,
             const memory_desc_t *dst_md) const {
         if (!create_reorder_pd_func_) return status::runtime_error;
         return create_reorder_pd_func_(reorder_pd, engine, attr, src_engine,
@@ -178,20 +178,20 @@ private:
     }
 
     using create_pd_func_t = status_t (*)(primitive_desc_t **,
-            const op_desc_t *, const primitive_attr_t *, engine_t *,
+            const op_desc_t *, const primitive_attr_t *, const engine_t *,
             const primitive_desc_t *);
 
-    using create_concat_pd_func_t = status_t (*)(concat_pd_t **, engine_t *,
-            const primitive_attr_t *, const memory_desc_t *, int, int,
-            const memory_desc_t *const *);
+    using create_concat_pd_func_t = status_t (*)(concat_pd_t **,
+            const engine_t *, const primitive_attr_t *, const memory_desc_t *,
+            int, int, const memory_desc_t *const *);
 
-    using create_sum_pd_func_t = status_t (*)(sum_pd_t **, engine_t *,
+    using create_sum_pd_func_t = status_t (*)(sum_pd_t **, const engine_t *,
             const primitive_attr_t *, const memory_desc_t *, int, const float *,
             const memory_desc_t *const *);
 
-    using create_reorder_pd_func_t = status_t (*)(reorder_pd_t **, engine_t *,
-            const primitive_attr_t *, engine_t *, const memory_desc_t *,
-            engine_t *, const memory_desc_t *);
+    using create_reorder_pd_func_t = status_t (*)(reorder_pd_t **,
+            const engine_t *, const primitive_attr_t *, const engine_t *,
+            const memory_desc_t *, const engine_t *, const memory_desc_t *);
 
     create_pd_func_t create_pd_func_ = nullptr;
     create_concat_pd_func_t create_concat_pd_func_ = nullptr;
@@ -202,17 +202,17 @@ private:
     // descriptors.
     friend struct primitive_desc_iterator_t;
     friend status_t concat_primitive_desc_create(
-            std::shared_ptr<primitive_desc_t> &, engine_t *,
+            std::shared_ptr<primitive_desc_t> &, const engine_t *,
             const memory_desc_t *, int, int, const memory_desc_t *const *,
             const primitive_attr_t *);
     friend status_t sum_primitive_desc_create(
             std::shared_ptr<primitive_desc_t> &, const memory_desc_t *, int,
             const float *, const memory_desc_t *const *,
-            const primitive_attr_t *, engine_t *);
+            const primitive_attr_t *, const engine_t *);
     friend status_t reorder_primitive_desc_create(
-            std::shared_ptr<primitive_desc_t> &, engine_t *,
-            const memory_desc_t *, engine_t *, const memory_desc_t *,
-            engine_t *, const primitive_attr_t *);
+            std::shared_ptr<primitive_desc_t> &, const engine_t *,
+            const memory_desc_t *, const engine_t *, const memory_desc_t *,
+            const engine_t *, const primitive_attr_t *);
 };
 
 } // namespace impl

--- a/src/common/impl_list_item.hpp
+++ b/src/common/impl_list_item.hpp
@@ -205,9 +205,10 @@ private:
             std::shared_ptr<primitive_desc_t> &, engine_t *,
             const memory_desc_t *, int, int, const memory_desc_t *const *,
             const primitive_attr_t *);
-    friend status_t sum_primitive_desc_create(primitive_desc_iface_t **,
-            const memory_desc_t *, int, const float *,
-            const memory_desc_t *const *, const primitive_attr_t *, engine_t *);
+    friend status_t sum_primitive_desc_create(
+            std::shared_ptr<primitive_desc_t> &, const memory_desc_t *, int,
+            const float *, const memory_desc_t *const *,
+            const primitive_attr_t *, engine_t *);
     friend status_t reorder_primitive_desc_create(
             std::shared_ptr<primitive_desc_t> &, engine_t *,
             const memory_desc_t *, engine_t *, const memory_desc_t *,

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -753,7 +753,7 @@ status_t matmul_desc_init(matmul_desc_t *matmul_desc,
 }
 
 status_t create_matmul_pd(std::shared_ptr<primitive_desc_t> &matmul_pd,
-        engine_t *engine, const memory_desc_t *src_md,
+        const engine_t *engine, const memory_desc_t *src_md,
         const memory_desc_t *wei_md, const memory_desc_t *bias_md,
         const memory_desc_t *dst_md, const primitive_attr_t *attr,
         const memory_desc_t *reduce_md, matmul_reduce_kind_t reduce_kind,

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -206,13 +206,14 @@ struct matmul_pd_t : public primitive_desc_t {
 
     int dst_qmask_M() const { return src_qmask_M(); }
 
-    virtual bool attr_scales_ok(const std::vector<int> &supported_args
+    virtual status_t attr_scales_ok(engine_t *engine,
+            const std::vector<int> &supported_args
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
             const std::vector<int> &supported_qmodes
             = {quantization_mode::static_sazp},
             const std::map<int, std::vector<int>> &extra_masks = {}) const {
         const auto &scales = attr()->scales_;
-        if (scales.has_default_values()) return true;
+        if (scales.has_default_values()) return status::success;
 
         const auto extra_mask_ok = [&](int arg, int mask) {
             const auto it = extra_masks.find(arg);
@@ -223,7 +224,8 @@ struct matmul_pd_t : public primitive_desc_t {
             return false;
         };
 
-        bool ok = scales.has_default_values(supported_args);
+        VDISPATCH_MATMUL(scales.has_default_values(supported_args),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
         for (int arg : supported_args) {
             if (scales.has_default_values(arg)) { continue; }
 
@@ -233,7 +235,8 @@ struct matmul_pd_t : public primitive_desc_t {
                 is_qmode_supported = is_qmode_supported
                         || (scales.get(arg).get_quantization_mode() == qmode);
             }
-            ok = ok && is_qmode_supported;
+            VDISPATCH_MATMUL(
+                    is_qmode_supported, VERBOSE_UNSUPPORTED_SCALES_CFG);
 
             const auto &mask = scales.get_mask(arg);
             if (arg == DNNL_ARG_WEIGHTS) {
@@ -242,7 +245,10 @@ struct matmul_pd_t : public primitive_desc_t {
                 const bool wei_k_group_ok = IMPLICATION(g0 > 1, K() % g0 == 0);
                 const bool wei_n_group_ok = IMPLICATION(g1 > 1, N() % g1 == 0);
 
-                ok = ok && wei_k_group_ok && wei_n_group_ok;
+                VDISPATCH_MATMUL(
+                        wei_k_group_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                VDISPATCH_MATMUL(
+                        wei_n_group_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
 
                 // Mask over K dim is allowed for fp types or weights decompression only.
                 if (types::is_integral_dt(weights_md(0)->data_type)) {
@@ -253,46 +259,53 @@ struct matmul_pd_t : public primitive_desc_t {
                             && IMPLICATION(
                                     !types::is_integral_dt(src_md()->data_type),
                                     attr()->fpmath_.apply_to_int_);
-                    ok = ok
-                            && IMPLICATION(
-                                    (mask & wei_qmask_K()), is_decompression);
+                    VDISPATCH_MATMUL(IMPLICATION((mask & wei_qmask_K()),
+                                             is_decompression),
+                            VERBOSE_UNSUPPORTED_SCALES_CFG);
                 }
             } else if (arg == DNNL_ARG_SRC) {
                 // Masks supported across all implementations. Implementation
                 // specific masks can be passed through `extra_masks`.
-                ok = ok
-                        && (utils::one_of(mask, 0, src_qmask_K(),
-                                    src_qmask_M() + src_qmask_K(),
-                                    full_tensor_mask())
-                                || extra_mask_ok(arg, mask));
-                ok = ok
-                        && IMPLICATION((mask & src_qmask_K()),
-                                !scales.get(arg).has_default_groups());
-                ok = ok
-                        && IMPLICATION(!scales.get(arg).has_default_groups(),
-                                scales.get_group(arg, 0)
-                                        && K() % scales.get_group(arg, 1) == 0);
-                ok = ok
-                        && IMPLICATION(mask == src_qmask_M(),
-                                scales.get(arg).has_default_groups());
+                VDISPATCH_MATMUL((utils::one_of(mask, 0, src_qmask_K(),
+                                          src_qmask_M() + src_qmask_K(),
+                                          full_tensor_mask())
+                                         || extra_mask_ok(arg, mask)),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+                VDISPATCH_MATMUL(IMPLICATION((mask & src_qmask_K()),
+                                         !scales.get(arg).has_default_groups()),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+                VDISPATCH_MATMUL(
+                        IMPLICATION(!scales.get(arg).has_default_groups(),
+                                scales.get_group(arg, 0) == 1),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+                VDISPATCH_MATMUL(
+                        IMPLICATION(!scales.get(arg).has_default_groups(),
+                                K() % scales.get_group(arg, 1) == 0),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+                VDISPATCH_MATMUL(IMPLICATION(mask == src_qmask_M(),
+                                         scales.get(arg).has_default_groups()),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
             } else if (arg == DNNL_ARG_DST) {
                 // Masks supported across all implementations. Implementation
                 // specific masks can be passed through `extra_masks`.
-                ok = ok
-                        && (utils::one_of(mask, 0, dst_qmask_N(),
-                                    dst_qmask_M() + dst_qmask_N(),
-                                    full_tensor_mask())
-                                || extra_mask_ok(arg, mask));
-                ok = ok
-                        && IMPLICATION(!scales.get(arg).has_default_groups(),
-                                (M() % scales.get_group(arg, -2)) == 0
-                                        && (N() % scales.get_group(arg, -1))
-                                                == 0);
+                VDISPATCH_MATMUL((utils::one_of(mask, 0, dst_qmask_N(),
+                                          dst_qmask_M() + dst_qmask_N(),
+                                          full_tensor_mask())
+                                         || extra_mask_ok(arg, mask)),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+                VDISPATCH_MATMUL(
+                        IMPLICATION(!scales.get(arg).has_default_groups(),
+                                (M() % scales.get_group(arg, -2)) == 0),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
+                VDISPATCH_MATMUL(
+                        IMPLICATION(!scales.get(arg).has_default_groups(),
+                                (N() % scales.get_group(arg, -1)) == 0),
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
             } else {
                 assert(!"Unsupported arg");
             }
         }
-        return ok;
+        return status::success;
     }
 
 protected:

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -52,7 +52,7 @@ status_t matmul_desc_init(matmul_desc_t *matmul_desc,
         const memory_desc_t *bias_desc, const memory_desc_t *dst_desc);
 
 status_t create_matmul_pd(std::shared_ptr<primitive_desc_t> &matmul_pd,
-        engine_t *engine, const memory_desc_t *src_md,
+        const engine_t *engine, const memory_desc_t *src_md,
         const memory_desc_t *wei_md, const memory_desc_t *bias_md,
         const memory_desc_t *dst_md, const primitive_attr_t *attr,
         const memory_desc_t *reduce_md = nullptr,
@@ -206,7 +206,7 @@ struct matmul_pd_t : public primitive_desc_t {
 
     int dst_qmask_M() const { return src_qmask_M(); }
 
-    virtual status_t attr_scales_ok(engine_t *engine,
+    virtual status_t attr_scales_ok(const engine_t *engine,
             const std::vector<int> &supported_args
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
             const std::vector<int> &supported_qmodes
@@ -308,7 +308,7 @@ struct matmul_pd_t : public primitive_desc_t {
         return status::success;
     }
 
-    virtual status_t attr_zero_points_ok(engine_t *engine,
+    virtual status_t attr_zero_points_ok(const engine_t *engine,
             const std::vector<int> &supported_args
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
             const std::vector<int> &supported_qmodes

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -266,10 +266,10 @@ struct matmul_pd_t : public primitive_desc_t {
             } else if (arg == DNNL_ARG_SRC) {
                 // Masks supported across all implementations. Implementation
                 // specific masks can be passed through `extra_masks`.
-                VDISPATCH_MATMUL((utils::one_of(mask, 0, src_qmask_K(),
-                                          src_qmask_M() + src_qmask_K(),
-                                          full_tensor_mask())
-                                         || extra_mask_ok(arg, mask)),
+                VDISPATCH_MATMUL(utils::one_of(mask, 0, src_qmask_K(),
+                                         src_qmask_M() + src_qmask_K(),
+                                         full_tensor_mask())
+                                || extra_mask_ok(arg, mask),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
                 VDISPATCH_MATMUL(IMPLICATION((mask & src_qmask_K()),
                                          !scales.get(arg).has_default_groups()),
@@ -288,10 +288,10 @@ struct matmul_pd_t : public primitive_desc_t {
             } else if (arg == DNNL_ARG_DST) {
                 // Masks supported across all implementations. Implementation
                 // specific masks can be passed through `extra_masks`.
-                VDISPATCH_MATMUL((utils::one_of(mask, 0, dst_qmask_N(),
-                                          dst_qmask_M() + dst_qmask_N(),
-                                          full_tensor_mask())
-                                         || extra_mask_ok(arg, mask)),
+                VDISPATCH_MATMUL(utils::one_of(mask, 0, dst_qmask_N(),
+                                         dst_qmask_M() + dst_qmask_N(),
+                                         full_tensor_mask())
+                                || extra_mask_ok(arg, mask),
                         VERBOSE_UNSUPPORTED_SCALES_CFG);
                 VDISPATCH_MATMUL(
                         IMPLICATION(!scales.get(arg).has_default_groups(),
@@ -305,6 +305,94 @@ struct matmul_pd_t : public primitive_desc_t {
                 assert(!"Unsupported arg");
             }
         }
+        return status::success;
+    }
+
+    virtual status_t attr_zero_points_ok(engine_t *engine,
+            const std::vector<int> &supported_args
+            = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+            const std::vector<int> &supported_qmodes
+            = {quantization_mode::static_sazp},
+            const std::map<int, std::vector<int>> &extra_masks = {}) const {
+        const auto &zp = attr()->zero_points_;
+        if (zp.has_default_values()) return status::success;
+
+        const auto extra_mask_ok = [&](int arg, int mask) {
+            const auto it = extra_masks.find(arg);
+            if (it != extra_masks.end()) {
+                for (const auto &extra_mask : it->second)
+                    if (mask == extra_mask) return true;
+            }
+            return false;
+        };
+
+        const auto broadcast_mask = [](const memory_desc_t &md) {
+            int mask = 0;
+            for (int d = 0; d < md.ndims; ++d)
+                if (md.dims[d] == 1) mask |= (1 << d);
+            return mask;
+        };
+
+        VDISPATCH_MATMUL(zp.has_default_values(supported_args),
+                VERBOSE_UNSUPPORTED_ZP_CFG);
+        for (int arg : supported_args) {
+            if (zp.has_default_values(arg)) { continue; }
+
+            // Fold-left to check if quantization mode is supported
+            bool is_qmode_supported = false;
+            for (auto &qmode : supported_qmodes) {
+                is_qmode_supported = is_qmode_supported
+                        || (zp.get(arg).get_quantization_mode() == qmode);
+            }
+            VDISPATCH_MATMUL(is_qmode_supported, VERBOSE_UNSUPPORTED_ZP_CFG);
+
+            if (arg == DNNL_ARG_WEIGHTS) {
+                if (!zp.get(arg).has_default_groups()) {
+                    const auto gK = zp.get_group(arg, -2);
+                    VDISPATCH_MATMUL(IMPLICATION(gK > 1, K() % gK == 0),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
+
+                    const auto gN = zp.get_group(arg, -1);
+                    VDISPATCH_MATMUL(IMPLICATION(gN > 1, N() % gN == 0),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
+
+                    // Only one non-unit group is supported.
+                    VDISPATCH_MATMUL(utils::one_of(1, gK, gN),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
+                }
+            } else if (arg == DNNL_ARG_SRC) {
+                const int bcast_mask = broadcast_mask(*src_md());
+                const auto &mask = zp.get_mask(arg) & ~bcast_mask;
+
+                VDISPATCH_MATMUL(
+                        utils::one_of(mask, 0, src_qmask_K() & ~bcast_mask,
+                                (src_qmask_M() + src_qmask_K()) & ~bcast_mask)
+                                || extra_mask_ok(arg, mask),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+
+                if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
+                    const auto gM = zp.get_group(DNNL_ARG_SRC, -2);
+                    VDISPATCH_MATMUL(gM == 1, VERBOSE_UNSUPPORTED_ZP_CFG);
+
+                    const auto gK = zp.get_group(DNNL_ARG_SRC, -1);
+                    VDISPATCH_MATMUL(IMPLICATION(gK > 1, K() % gK == 0),
+                            VERBOSE_UNSUPPORTED_ZP_CFG);
+                }
+            } else if (arg == DNNL_ARG_DST) {
+                const int bcast_mask = broadcast_mask(*dst_md());
+                const auto &mask = zp.get_mask(arg) & ~bcast_mask;
+
+                VDISPATCH_MATMUL(
+                        utils::one_of(mask, 0, dst_qmask_N() & ~bcast_mask)
+                                || extra_mask_ok(arg, mask),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+                VDISPATCH_MATMUL(zp.get(arg).has_default_groups(),
+                        VERBOSE_UNSUPPORTED_ZP_CFG);
+            } else {
+                assert(!"Unsupported arg");
+            }
+        }
+
         return status::success;
     }
 

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -83,7 +83,7 @@ struct primitive_desc_t {
     // Note: The `do_init` workaround is utilized during ITT task setup for
     //     primitive operations, since the `info_` string is used as metadata
     //     for ITT tasks and can significantly slow down execution times.
-    const char *info(engine_t *engine, bool do_init = true) const {
+    const char *info(const engine_t *engine, bool do_init = true) const {
         if (!info_.is_initialized() && do_init) info_.init(engine, this);
         return info_.c_str();
     }
@@ -97,7 +97,7 @@ struct primitive_desc_t {
     //     not available in verbose translation unit.
     // Note: requires all internals to be defined for ONEDNN_VERBOSE=OFF, but
     //     doesn't require any special handling since `get_verbose` is `false`.
-    std::string info_with_runtime_dims(engine_t *engine,
+    std::string info_with_runtime_dims(const engine_t *engine,
             const memory_desc_t *src_md, const memory_desc_t *wei_md,
             const memory_desc_t *bia_md, const memory_desc_t *dst_md) const {
         std::string info_str = info(engine);
@@ -561,7 +561,7 @@ protected:
 
     template <typename pd_t>
     static status_t create(primitive_desc_t **pd, const op_desc_t *adesc,
-            const primitive_attr_t *attr, engine_t *engine,
+            const primitive_attr_t *attr, const engine_t *engine,
             const primitive_desc_t *hint_fwd) {
         using namespace dnnl::impl::status;
         if (adesc->primitive_kind != pd_t::base_pkind) return invalid_arguments;
@@ -611,7 +611,8 @@ inline bool is_ref_impl(const primitive_desc_t *pd) {
     template <typename pd_t> \
     friend status_t primitive_desc_t::create(primitive_desc_t **pd, \
             const op_desc_t *adesc, const primitive_attr_t *attr, \
-            dnnl::impl::engine_t *engine, const primitive_desc_t *hint_fwd);
+            const dnnl::impl::engine_t *engine, \
+            const primitive_desc_t *hint_fwd);
 
 #define DECLARE_COMMON_PD_T_USE_GLOBAL_SCRATCHPAD(impl_name, impl_type) \
     DECLARE_COMMON_PD_t(impl_name, impl_type, true)

--- a/src/common/primitive_desc_iface.cpp
+++ b/src/common/primitive_desc_iface.cpp
@@ -58,10 +58,10 @@ status_t primitive_desc_create(primitive_desc_iface_t **primitive_desc_iface,
 } // namespace dnnl
 
 dnnl_primitive_desc::dnnl_primitive_desc(
-        const std::shared_ptr<primitive_desc_t> &pd, engine_t *engine)
+        const std::shared_ptr<primitive_desc_t> &pd, const engine_t *engine)
     : pd_(pd), engine_(engine) {}
 
-dnnl_primitive_desc::dnnl_primitive_desc(engine_t *engine,
+dnnl_primitive_desc::dnnl_primitive_desc(const engine_t *engine,
         const op_desc_t *op_desc, const primitive_attr_t *attr,
         const primitive_desc_t *hint_fwd_pd) {
 
@@ -118,7 +118,10 @@ const std::shared_ptr<primitive_desc_t> &dnnl_primitive_desc::impl() const {
 }
 
 dnnl::impl::engine_t *dnnl_primitive_desc::engine() const {
-    return engine_;
+    // This method is passed to primitive_create which is not yet converted to
+    // `const engine_t *`. This `const_cast` will be automatically removed once
+    // it changes.
+    return const_cast<dnnl::impl::engine_t *>(engine_);
 }
 const dnnl::impl::primitive_attr_t *dnnl_primitive_desc::attr() const {
     return impl()->attr();

--- a/src/common/primitive_desc_iface.hpp
+++ b/src/common/primitive_desc_iface.hpp
@@ -43,9 +43,9 @@ status_t primitive_desc_create(primitive_desc_iface_t **primitive_desc_iface,
 // 2. engine_t - a dnnl engine
 struct dnnl_primitive_desc {
     dnnl_primitive_desc(const std::shared_ptr<dnnl::impl::primitive_desc_t> &pd,
-            dnnl::impl::engine_t *engine);
+            const dnnl::impl::engine_t *engine);
 
-    dnnl_primitive_desc(dnnl::impl::engine_t *engine,
+    dnnl_primitive_desc(const dnnl::impl::engine_t *engine,
             const dnnl::impl::op_desc_t *op_desc,
             const dnnl::impl::primitive_attr_t *attr,
             const dnnl::impl::primitive_desc_t *hint_fwd_pd);
@@ -82,7 +82,7 @@ protected:
     // Until it's done we need to have primitive descriptor (`pd_`) and
     // engine (engine_) here.
     std::shared_ptr<dnnl::impl::primitive_desc_t> pd_;
-    dnnl::impl::engine_t *engine_;
+    const dnnl::impl::engine_t *engine_;
 };
 
 #endif

--- a/src/common/primitive_desc_iterator.hpp
+++ b/src/common/primitive_desc_iterator.hpp
@@ -33,7 +33,7 @@ namespace impl {
 struct primitive_desc_t;
 
 struct primitive_desc_iterator_t {
-    primitive_desc_iterator_t(engine_t *engine, const op_desc_t *op_desc,
+    primitive_desc_iterator_t(const engine_t *engine, const op_desc_t *op_desc,
             const primitive_attr_t *attr, const primitive_desc_t *hint_fwd_pd,
             int skip_idx = -1)
         : idx_(-1)
@@ -50,7 +50,7 @@ struct primitive_desc_iterator_t {
             ++last_idx_;
     }
 
-    engine_t *engine() const { return engine_; }
+    const engine_t *engine() const { return engine_; }
 
     bool operator==(const primitive_desc_iterator_t &rhs) const {
         return idx_ == rhs.idx_ && engine_ == rhs.engine_;
@@ -102,7 +102,7 @@ struct primitive_desc_iterator_t {
 
 protected:
     int idx_;
-    engine_t *engine_;
+    const engine_t *engine_;
     std::shared_ptr<primitive_desc_t> pd_;
     std::unique_ptr<op_desc_t> op_desc_;
     const primitive_attr_t attr_;
@@ -113,7 +113,7 @@ protected:
     int offset_;
 
 private:
-    primitive_desc_iterator_t(engine_t *engine, int last_idx)
+    primitive_desc_iterator_t(const engine_t *engine, int last_idx)
         : idx_(last_idx)
         , engine_(engine)
         , hint_fwd_pd_(nullptr)

--- a/src/common/reorder.cpp
+++ b/src/common/reorder.cpp
@@ -43,7 +43,8 @@ namespace impl {
             status::unimplemented, msg, ##__VA_ARGS__);
 
 namespace {
-engine_t *get_reorder_engine(engine_t *src_engine, engine_t *dst_engine) {
+const engine_t *get_reorder_engine(
+        const engine_t *src_engine, const engine_t *dst_engine) {
     auto s_ek = src_engine->kind();
     auto d_ek = dst_engine->kind();
     auto s_rk = src_engine->runtime_kind();
@@ -64,9 +65,9 @@ engine_t *get_reorder_engine(engine_t *src_engine, engine_t *dst_engine) {
 } // namespace
 
 status_t reorder_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
-        engine_t *engine, const memory_desc_t *src_md, engine_t *src_engine,
-        const memory_desc_t *dst_md, engine_t *dst_engine,
-        const primitive_attr_t *attr) {
+        const engine_t *engine, const memory_desc_t *src_md,
+        const engine_t *src_engine, const memory_desc_t *dst_md,
+        const engine_t *dst_engine, const primitive_attr_t *attr) {
     pd.reset();
 
     auto s_ek = src_engine->kind();
@@ -169,7 +170,7 @@ status_t reorder_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
 }
 
 status_t reorder_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
-        engine_t *engine, const memory_desc_t *src_md,
+        const engine_t *engine, const memory_desc_t *src_md,
         const memory_desc_t *dst_md, const primitive_attr_t *attr) {
     return reorder_primitive_desc_create(
             pd, engine, src_md, engine, dst_md, engine, attr);

--- a/src/common/reorder.hpp
+++ b/src/common/reorder.hpp
@@ -26,13 +26,13 @@ namespace impl {
 
 struct primitive_desc_t;
 status_t reorder_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
-        engine_t *engine, const memory_desc_t *src_md,
+        const engine_t *engine, const memory_desc_t *src_md,
         const memory_desc_t *dst_md, const primitive_attr_t *attr = nullptr);
 
 status_t reorder_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
-        engine_t *engine, const memory_desc_t *src_md, engine_t *src_engine,
-        const memory_desc_t *dst_md, engine_t *dst_engine,
-        const primitive_attr_t *attr = nullptr);
+        const engine_t *engine, const memory_desc_t *src_md,
+        const engine_t *src_engine, const memory_desc_t *dst_md,
+        const engine_t *dst_engine, const primitive_attr_t *attr = nullptr);
 } // namespace impl
 } // namespace dnnl
 

--- a/src/common/reorder_pd.hpp
+++ b/src/common/reorder_pd.hpp
@@ -47,7 +47,7 @@ namespace impl {
 
 struct reorder_primitive_desc_iface_t : public dnnl_primitive_desc {
     reorder_primitive_desc_iface_t(const std::shared_ptr<primitive_desc_t> &pd,
-            engine_t *engine, engine_t *src_engine, engine_t *dst_engine)
+            const engine_t *engine, engine_t *src_engine, engine_t *dst_engine)
         : dnnl_primitive_desc(pd, engine)
         , src_engine_(src_engine)
         , dst_engine_(dst_engine)

--- a/src/common/sum.cpp
+++ b/src/common/sum.cpp
@@ -47,7 +47,7 @@ namespace impl {
 status_t sum_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
         const memory_desc_t *dst_md, int n, const float *scales,
         const memory_desc_t *const *src_mds, const primitive_attr_t *attr,
-        engine_t *engine) {
+        const engine_t *engine) {
 
     VCHECK_SUM(!any_null(src_mds, scales) && n > 0, VERBOSE_NULL_ARG);
 

--- a/src/common/sum.cpp
+++ b/src/common/sum.cpp
@@ -44,13 +44,12 @@ using namespace dnnl::impl::status;
 namespace dnnl {
 namespace impl {
 
-status_t sum_primitive_desc_create(primitive_desc_iface_t **sum_pd_iface,
+status_t sum_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
         const memory_desc_t *dst_md, int n, const float *scales,
         const memory_desc_t *const *src_mds, const primitive_attr_t *attr,
         engine_t *engine) {
 
-    VCHECK_SUM(!any_null(sum_pd_iface, src_mds, scales) && n > 0,
-            VERBOSE_NULL_ARG);
+    VCHECK_SUM(!any_null(src_mds, scales) && n > 0, VERBOSE_NULL_ARG);
 
     if (attr == nullptr) attr = &default_attr();
     VCHECK_SUM_UNIMPL(attr->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
@@ -99,20 +98,15 @@ status_t sum_primitive_desc_create(primitive_desc_iface_t **sum_pd_iface,
     auto desc = sum_desc_t(primitive_kind::sum, dst_md, n, scales, src_mds);
     primitive_hashing::key_t key(
             engine, reinterpret_cast<op_desc_t *>(&desc), attr, 0, {}, -1);
-    auto pd = primitive_cache().get_pd(key);
+    pd = primitive_cache().get_pd(key);
 
-    if (pd) {
-        return safe_ptr_assign(
-                *sum_pd_iface, new primitive_desc_iface_t(pd, engine));
-    }
+    if (pd) return success;
 
     for (auto s = engine->get_sum_implementation_list(); *s; ++s) {
         sum_pd_t *sum_pd = nullptr;
         if ((*s)(&sum_pd, engine, attr, dst_md, n, scales, src_mds)
                 == success) {
             pd.reset(sum_pd);
-            CHECK(safe_ptr_assign(
-                    *sum_pd_iface, new primitive_desc_iface_t(pd, engine)));
             return status::success;
         }
     }
@@ -126,6 +120,11 @@ status_t dnnl_sum_primitive_desc_create(primitive_desc_iface_t **sum_pd_iface,
         engine_t *engine, const memory_desc_t *dst_md, int n,
         const float *scales, const memory_desc_t *const *src_mds,
         const primitive_attr_t *attr) {
-    return sum_primitive_desc_create(
-            sum_pd_iface, dst_md, n, scales, src_mds, attr, engine);
+    if (any_null(sum_pd_iface)) return invalid_arguments;
+
+    std::shared_ptr<primitive_desc_t> pd;
+    CHECK(sum_primitive_desc_create(
+            pd, dst_md, n, scales, src_mds, attr, engine));
+    return safe_ptr_assign(
+            *sum_pd_iface, new primitive_desc_iface_t(pd, engine));
 }

--- a/src/common/sum.hpp
+++ b/src/common/sum.hpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef COMMON_SUM_HPP
+#define COMMON_SUM_HPP
+
+#include <memory>
+
+#include "c_types_map.hpp"
+
+namespace dnnl {
+namespace impl {
+
+struct primitive_desc_t;
+status_t sum_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
+        const memory_desc_t *dst_md, int n, const float *scales,
+        const memory_desc_t *const *src_mds, const primitive_attr_t *attr,
+        engine_t *engine);
+
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/common/sum.hpp
+++ b/src/common/sum.hpp
@@ -28,7 +28,7 @@ struct primitive_desc_t;
 status_t sum_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
         const memory_desc_t *dst_md, int n, const float *scales,
         const memory_desc_t *const *src_mds, const primitive_attr_t *attr,
-        engine_t *engine);
+        const engine_t *engine);
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/sum_pd.hpp
+++ b/src/common/sum_pd.hpp
@@ -145,7 +145,7 @@ protected:
         dst_acc_md_.data_type = dnnl_f32;
     }
     /* inits dst_md_ in simple cases. The call may fail. */
-    status_t init(engine_t *engine) {
+    status_t init(const engine_t *engine) {
         for (int i = 0; i < n_; ++i) {
             const memory_desc_wrapper src_d(&src_mds_[i]);
             if (!src_d.is_blocking_desc() || src_d.is_additional_buffer())
@@ -199,9 +199,10 @@ private:
 // NOLINTEND(google-default-arguments)
 
 #define DECLARE_SUM_PD_t(impl_name, ...) \
-    static status_t create(sum_pd_t **sum_pd, dnnl::impl::engine_t *engine, \
-            const primitive_attr_t *attr, const memory_desc_t *dst_md, int n, \
-            const float *scales, const memory_desc_t *const *src_mds) { \
+    static status_t create(sum_pd_t **sum_pd, \
+            const dnnl::impl::engine_t *engine, const primitive_attr_t *attr, \
+            const memory_desc_t *dst_md, int n, const float *scales, \
+            const memory_desc_t *const *src_mds) { \
         using namespace status; \
         auto _pd = make_unique_pd<pd_t>(attr, dst_md, n, scales, src_mds); \
         if (_pd == nullptr) return out_of_memory; \

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1834,7 +1834,7 @@ std::string rt_dims2fmt_str(primitive_kind_t prim_kind,
     return s;
 }
 
-void pd_info_t::init(engine_t *engine, const primitive_desc_t *pd) {
+void pd_info_t::init(const engine_t *engine, const primitive_desc_t *pd) {
     // Handles VERBOSE_DISABLE since `is_initialized_` is set to `true`.
     if (is_initialized_) return;
 

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -347,7 +347,7 @@ struct pd_info_t {
     const char *c_str() const { return str_.c_str(); }
     bool is_initialized() const { return is_initialized_; }
 
-    void init(engine_t *engine, const primitive_desc_t *pd);
+    void init(const engine_t *engine, const primitive_desc_t *pd);
 
 private:
     std::string str_;

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -83,7 +84,7 @@ using conv_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);
 
 template <typename op_t, typename post_ops_t>
 status_t init_scratchpad(op_t &conv, memory_tracking::registrar_t &scratchpad,
-        const std::map<int, conv_key_t> &conv_keys, engine_t *engine,
+        const std::map<int, conv_key_t> &conv_keys, const engine_t *engine,
         post_ops_t &post_ops, dnnl::impl::post_ops_t &attr_post_ops,
         arm_compute::ActivationLayerInfo &act_info, bool &use_dst_acc_for_sum,
         const dnnl::impl::memory_desc_t &dst_md) {

--- a/src/cpu/aarch64/acl_deconvolution.hpp
+++ b/src/cpu/aarch64/acl_deconvolution.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022-2024, 2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -88,7 +89,7 @@ struct acl_deconvolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "acl", acl_deconvolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
 

--- a/src/cpu/aarch64/acl_depthwise_convolution.cpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023-2024 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,7 +40,7 @@ status_t acl_depthwise_convolution_fwd_t::execute_forward(
             ctx, acl_obj_.get(), pd(), depthwise_conv_keys);
 }
 
-status_t acl_depthwise_convolution_fwd_t::pd_t::init(engine_t *engine) {
+status_t acl_depthwise_convolution_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
 
     const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)

--- a/src/cpu/aarch64/acl_depthwise_convolution.hpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023-2024, 2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +37,7 @@ struct acl_depthwise_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T("depthwise_convolution:acl",
                 acl_depthwise_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         acl_conv_conf_t acp_ = utils::zero<decltype(acp_)>();
         post_ops_fallback_t post_ops;

--- a/src/cpu/aarch64/acl_eltwise.cpp
+++ b/src/cpu/aarch64/acl_eltwise.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2022, 2024 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,7 +67,7 @@ status_t acl_eltwise_fwd_t::execute_forward(
     return status::success;
 }
 
-status_t acl_eltwise_fwd_t::pd_t::init(engine_t *engine) {
+status_t acl_eltwise_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace utils;
     using namespace data_type;
     const memory_desc_wrapper src_d(src_md());

--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2024, 2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +44,7 @@ struct acl_eltwise_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("acl", acl_eltwise_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         acl_eltwise_conf_t aep;
 

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,7 +52,7 @@ const std::map<int, conv_key_t> gemm_conv_keys
 template <data_type_t src_t, data_type_t wei_t, data_type_t dst_t,
         data_type_t bia_t>
 status_t acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::pd_t::init(
-        engine_t *engine) {
+        const engine_t *engine) {
     using namespace data_type;
     using smask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +42,7 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "gemm:acl", acl_gemm_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         acl_conv_conf_t acp_ = utils::zero<decltype(acp_)>();
         post_ops_fallback_t post_ops;

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2022, 2024, 2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -86,7 +87,8 @@ status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init_conf() {
     return status::success;
 }
 
-status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init(engine_t *engine) {
+status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init(
+        const engine_t *engine) {
     using namespace data_type;
     using smask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2024, 2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T("indirect_gemm:acl",
                 acl_indirect_gemm_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         acl_conv_conf_t acp_ = utils::zero<decltype(acp_)>();
         post_ops_fallback_t post_ops;

--- a/src/cpu/aarch64/acl_inner_product.cpp
+++ b/src/cpu/aarch64/acl_inner_product.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2022, 2024-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -91,7 +92,7 @@ status_t acl_inner_product_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status::success;
 }
 
-status_t acl_inner_product_fwd_t::pd_t::init(engine_t *engine) {
+status_t acl_inner_product_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using smask_t = primitive_attr_t::skip_mask_t;
     const format_kind_t weights_format_kind_received = weights_md_.format_kind;
@@ -126,7 +127,7 @@ status_t acl_inner_product_fwd_t::pd_t::init(engine_t *engine) {
 }
 
 status_t acl_inner_product_fwd_t::pd_t::init_conf_ip(
-        engine_t *engine, format_kind_t weights_format_kind_received) {
+        const engine_t *engine, format_kind_t weights_format_kind_received) {
 
     const int ndims = src_md()->ndims;
 

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,14 +49,14 @@ struct acl_inner_product_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("acl", acl_inner_product_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         acl_ip_conf_t aip_ = utils::zero<decltype(aip_)>();
 
         post_ops_fallback_t post_ops;
 
-        status_t init_conf_ip(
-                engine_t *engine, format_kind_t weights_format_kind_received);
+        status_t init_conf_ip(const engine_t *engine,
+                format_kind_t weights_format_kind_received);
     }; // pd_t
 
     // constructor

--- a/src/cpu/aarch64/acl_pooling.cpp
+++ b/src/cpu/aarch64/acl_pooling.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022-2023, 2025 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +23,7 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-status_t acl_pooling_fwd_t::pd_t::init(engine_t *engine) {
+status_t acl_pooling_fwd_t::pd_t::init(const engine_t *engine) {
 
     // Compute Library supports forward propagation only
     bool ok = set_default_params() == status::success && is_fwd()

--- a/src/cpu/aarch64/acl_pooling.hpp
+++ b/src/cpu/aarch64/acl_pooling.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022-2023, 2025 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +44,7 @@ struct acl_pooling_fwd_t : public primitive_t {
         using cpu_pooling_fwd_pd_t::cpu_pooling_fwd_pd_t;
         DECLARE_COMMON_PD_T("acl", acl_pooling_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool use_acl_avg_pool_heuristic(int problem_size, int thread_count,
                 bool is_nhwc, bool use_square_acl_kernel);

--- a/src/cpu/aarch64/acl_softmax.cpp
+++ b/src/cpu/aarch64/acl_softmax.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2024 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,7 +26,7 @@ const acl_softmax_fwd_t::pd_t *acl_softmax_fwd_t::pd() const {
     return static_cast<const pd_t *>(primitive_t::pd().get());
 }
 
-status_t acl_softmax_fwd_t::pd_t::init(engine_t *engine) {
+status_t acl_softmax_fwd_t::pd_t::init(const engine_t *engine) {
 
     bool ok = is_fwd()
             && set_default_formats() == status::success

--- a/src/cpu/aarch64/acl_softmax.hpp
+++ b/src/cpu/aarch64/acl_softmax.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2024 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +44,7 @@ struct acl_softmax_fwd_t : public primitive_t {
         using cpu_softmax_fwd_pd_t::cpu_softmax_fwd_pd_t;
 
         DECLARE_COMMON_PD_T("acl", acl_softmax_fwd_t);
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         acl_softmax_conf_t asp_;
     }; // pd_t

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -72,7 +73,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
                     && attr()->has_default_values(

--- a/src/cpu/aarch64/eltwise_lut.hpp
+++ b/src/cpu/aarch64/eltwise_lut.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +42,7 @@ struct eltwise_lut_fwd_t : public primitive_t {
         using cpu_eltwise_fwd_pd_t::cpu_eltwise_fwd_pd_t;
         DECLARE_COMMON_PD_T("lut", eltwise_lut_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace ::dnnl::impl;
             using namespace ::dnnl::impl::utils;
 

--- a/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
@@ -91,7 +91,7 @@ bool post_ops_ok(jit_brdgmm_conv_conf_t &jcp, const primitive_attr_t &attr,
 }
 
 template <cpu_isa_t isa>
-status_t brdgmm_dw_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brdgmm_dw_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using skip_mask_t = primitive_attr_t::skip_mask_t;
     const auto &cd = *desc();
     const auto src_type = cd.src_desc.data_type;

--- a/src/cpu/aarch64/jit_brdgmm_dw_conv.hpp
+++ b/src/cpu/aarch64/jit_brdgmm_dw_conv.hpp
@@ -40,7 +40,7 @@ struct brdgmm_dw_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brdgmm_dw:", jcp_.isa, ""),
                 brdgmm_dw_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         jit_brdgmm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
         std::vector<brgemm_desc_t> bcps_;
         std::vector<brgemm_batch_element_t> batches_;

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -44,7 +44,7 @@ using namespace data_type;
     ((ndims == 5) ? (v5) : (ndims == 4) ? (v4) : (ndims == 3) ? (v3) : 0)
 
 template <cpu_isa_t isa>
-status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
 

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
@@ -49,7 +49,7 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgconv_1x1:", isa, ""),
                 brgemm_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t> brgs_;
         bool with_sum = false;

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -294,7 +294,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
     brgemm_descriptors_

--- a/src/cpu/aarch64/jit_brgemm_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.hpp
@@ -49,7 +49,7 @@ struct brgemm_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgconv:", jcp_.isa, ""),
                 brgemm_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         int brgs_sz_;
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t>

--- a/src/cpu/aarch64/jit_brgemm_conv_bwd.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_bwd.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2025 FUJITSU LIMITED
 * Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -100,7 +101,7 @@ status_t fwd_conv_desc_create(
 } // namespace
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_bwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_convolution_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
 

--- a/src/cpu/aarch64/jit_brgemm_conv_bwd.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_bwd.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025 FUJITSU LIMITED
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,7 +39,7 @@ struct brgemm_convolution_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), brgemm_convolution_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> fwd_pd_;
 

--- a/src/cpu/aarch64/jit_brgemm_deconv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_deconv.cpp
@@ -91,7 +91,7 @@ status_t check_embedded_impl_init(primitive_desc_iterator_t &it) {
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
     using namespace format_tag;

--- a/src/cpu/aarch64/jit_brgemm_deconv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_deconv.hpp
@@ -46,7 +46,7 @@ struct brgemm_deconvolution_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), brgemm_deconvolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool post_ops_ok() const {
             return attr()->post_ops_.find(primitive_kind::convolution) == -1;

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
@@ -53,7 +53,7 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", isa_, ""),
                 jit_sve_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
 #if defined(DNNL_AARCH64_USE_ACL)
             if (attr()->fpmath_.mode_ == fpmath_mode::bf16) {
@@ -219,7 +219,7 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t depthwise_po_init(engine_t *engine) {
+        status_t depthwise_po_init(const engine_t *engine) {
 
             using namespace memory_tracking;
             auto &jcp_1x1 = jcp_;
@@ -410,7 +410,7 @@ struct jit_sve_1x1_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", isa_, ""),
                 jit_sve_1x1_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && desc()->prop_kind == prop_kind::backward_data
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(diff_src_type, wei_type,
@@ -558,7 +558,7 @@ struct jit_sve_1x1_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", isa_, ""),
                 jit_sve_1x1_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && desc()->prop_kind == prop_kind::backward_weights
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(data_type::f32, data_type::f32,

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
@@ -277,7 +277,7 @@ struct jit_sve_512_core_x8s8s32x_deconvolution_fwd_t : public primitive_t {
                 JIT_IMPL_NAME_HELPER("jit_deconvolution:", sve_512, ""),
                 jit_sve_512_core_x8s8s32x_deconvolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
             const bool ok = mayiuse(sve_512) && is_fwd()

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
@@ -42,7 +42,7 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_int8:", sve_512, ""),
                 jit_sve_512_x8s8s32x_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using smask_t = primitive_attr_t::skip_mask_t;
             bool ok = true && is_fwd()
                     && set_default_alg_kind(alg_kind::convolution_direct)

--- a/src/cpu/aarch64/jit_sve_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_convolution.hpp
@@ -45,7 +45,7 @@ struct jit_sve_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa, ""),
                 jit_sve_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
 #if defined(DNNL_AARCH64_USE_ACL)
             if (attr()->fpmath_.mode_ == fpmath_mode::bf16) {
                 // prefer ACL to jit for fpmath_mode::bf16 if available
@@ -126,7 +126,7 @@ struct jit_sve_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa, ""),
                 jit_sve_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && desc()->prop_kind == prop_kind::backward_data
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(diff_src_type, wei_type,
@@ -195,7 +195,7 @@ struct jit_sve_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa, ""),
                 jit_sve_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && desc()->prop_kind == prop_kind::backward_weights
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(src_type, diff_weights_type,

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -2204,7 +2204,8 @@ using namespace utils;
 /* fwd */
 
 template <cpu_isa_t isa>
-status_t jit_uni_batch_normalization_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_batch_normalization_fwd_t<isa>::pd_t::init(
+        const engine_t *engine) {
     VDISPATCH_BNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_BNORM(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
     VDISPATCH_BNORM(!has_zero_dim_memory(), "zero dims are not supported");
@@ -2327,7 +2328,8 @@ jit_uni_batch_normalization_fwd_t<isa>::~jit_uni_batch_normalization_fwd_t() {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_batch_normalization_bwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_batch_normalization_bwd_t<isa>::pd_t::init(
+        const engine_t *engine) {
     VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_BNORM(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
     VDISPATCH_BNORM(!has_zero_dim_memory(), "zero dims are not supported");

--- a/src/cpu/aarch64/jit_uni_batch_normalization.hpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.hpp
@@ -44,7 +44,7 @@ struct jit_uni_batch_normalization_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("bnorm_jit:", isa, ""),
                 jit_uni_batch_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         int nthr_; // To not exceed the limit in execute used for set up.
     };
 
@@ -70,7 +70,7 @@ struct jit_uni_batch_normalization_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("bnorm_jit:", isa, ""),
                 jit_uni_batch_normalization_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         int nthr_; // To not exceed the limit in execute used for set up.
     };
 

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
@@ -411,7 +411,7 @@ using namespace utils;
 
 template <cpu_isa_t isa>
 status_t jit_uni_batch_normalization_s8_fwd_t<isa>::pd_t::init(
-        engine_t *engine) {
+        const engine_t *engine) {
     auto desired_fmt_tag = (ndims() == 4) ? nhwc : ndhwc;
 
     bool ok = true && mayiuse(isa) && is_fwd() && !has_zero_dim_memory()

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.hpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.hpp
@@ -48,7 +48,7 @@ struct jit_uni_batch_normalization_s8_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("bnorm_s8_jit:", isa, ""),
                 jit_uni_batch_normalization_s8_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     using data_t = int8_t;

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -103,7 +103,7 @@ static int get_exec_num_of_threads(const memory_desc_wrapper &dst_d) {
     return dst_d.nelems() <= max_nthr * min_work_per_thread ? 1 : max_nthr;
 }
 
-status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
     using sm = primitive_attr_t::skip_mask_t;
 
     conf_.dst_type = dst_md()->data_type;

--- a/src/cpu/aarch64/jit_uni_binary.hpp
+++ b/src/cpu/aarch64/jit_uni_binary.hpp
@@ -41,7 +41,7 @@ struct jit_uni_binary_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_binary_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         jit_binary_conf_t get_conf() const { return conf_; }
 

--- a/src/cpu/aarch64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_convolution.hpp
@@ -46,7 +46,7 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
                 jit_uni_dw_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && is_fwd()
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(src_type, src_type, data_type::undef,
@@ -119,7 +119,7 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
                 jit_uni_dw_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && desc()->prop_kind == prop_kind::backward_data
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(diff_src_type, diff_dst_type,
@@ -207,7 +207,7 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
                 jit_uni_dw_convolution_bwd_weights);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && desc()->prop_kind == prop_kind::backward_weights
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(src_type, diff_weights_type,

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -499,7 +499,7 @@ inline void jit_uni_kernel_t<cpu_isa_t::sve>::pack_fp16(TReg &v0, TReg &v1) {
 } // namespace
 
 template <cpu_isa_t isa>
-status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace alg_kind;
 
     const memory_desc_wrapper src_d(src_md());
@@ -581,7 +581,7 @@ status_t jit_uni_eltwise_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace alg_kind;
 
     const memory_desc_wrapper data_d(data_md());

--- a/src/cpu/aarch64/jit_uni_eltwise.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.hpp
@@ -45,7 +45,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_eltwise_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_fwd_t(const pd_t *apd);
@@ -68,7 +68,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_eltwise_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_bwd_t(const pd_t *apd);

--- a/src/cpu/aarch64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.cpp
@@ -347,7 +347,8 @@ void jit_uni_subkernel_int_t<sve_512>::store_8bit(const bool vectorize,
 } /* namespace */
 
 template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_eltwise_int_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_int_fwd_t<isa, d_type>::pd_t::init(
+        const engine_t *engine) {
     bool ok = is_fwd() && mayiuse(isa)
             && utils::everyone_is(
                     d_type, src_md()->data_type, dst_md()->data_type)

--- a/src/cpu/aarch64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.hpp
@@ -45,7 +45,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_int8:", isa, ""),
                 jit_uni_eltwise_int_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_int_fwd_t(const pd_t *apd);

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
@@ -44,7 +44,7 @@ struct jit_uni_i8i8_pooling_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_int:", isa, ""),
                 jit_uni_i8i8_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = true && mayiuse(isa) && utils::one_of(ndims(), 3, 4, 5)
                     && set_default_params() == status::success
                     && desc()->prop_kind == prop_kind::forward_inference

--- a/src/cpu/aarch64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_layer_normalization.cpp
@@ -458,7 +458,8 @@ private:
 } // namespace
 
 template <cpu_isa_t isa>
-status_t jit_uni_layer_normalization_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_layer_normalization_fwd_t<isa>::pd_t::init(
+        const engine_t *engine) {
     using skip_mask_t = primitive_attr_t::skip_mask_t;
     const memory_desc_wrapper src_d(src_md());
 

--- a/src/cpu/aarch64/jit_uni_layer_normalization.hpp
+++ b/src/cpu/aarch64/jit_uni_layer_normalization.hpp
@@ -65,7 +65,7 @@ public:
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_lnorm:", isa, ""),
                 jit_uni_layer_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool use_tmp_stats() const { return reorder_pd_ || stats_are_tmp(); }
 

--- a/src/cpu/aarch64/jit_uni_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_pooling.hpp
@@ -48,7 +48,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
                 jit_uni_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
 
             const bool ok = mayiuse(isa) && is_superset(isa, sve) && is_fwd()
@@ -119,7 +119,7 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
                 jit_uni_pooling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
 
             const bool ok = mayiuse(isa) && is_superset(isa, sve)

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -47,7 +47,7 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_softmax_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             auto is_dense = [&]() {
                 const memory_desc_wrapper src_d(src_md());
                 const auto &bd = src_d.blocking_desc();
@@ -134,7 +134,7 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_softmax_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             auto is_dense = [&]() {
                 const memory_desc_wrapper dst_d(dst_md());
                 const auto &bd = dst_d.blocking_desc();

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2024-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,7 +41,7 @@ const std::vector<lowp_matmul_key_t> lowp_matmul_keys = {
         memory_tracking::names::key_gemm_mm_signed_output,
 };
 } // namespace
-status_t acl_lowp_matmul_t::pd_t::init(engine_t *engine) {
+status_t acl_lowp_matmul_t::pd_t::init(const engine_t *engine) {
     VDISPATCH_MATMUL(set_default_formats(), "failed to set default formats");
     using smask_t = primitive_attr_t::skip_mask_t;
     VDISPATCH_MATMUL(attr()->has_default_values(smask_t::scales

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2024-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,7 +56,7 @@ struct acl_lowp_matmul_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "lowp_gemm:acl", acl_lowp_matmul_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
                 const arm_compute::experimental::MemoryRequirements

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -59,7 +60,7 @@ status_t acl_lowp_matmul_sq_t::init(engine_t *engine) {
     return status::success;
 }
 
-status_t acl_lowp_matmul_sq_t::pd_t::init(engine_t *engine) {
+status_t acl_lowp_matmul_sq_t::pd_t::init(const engine_t *engine) {
 
     VDISPATCH_MATMUL(set_default_formats(), "failed to set default formats");
     using smask_t = primitive_attr_t::skip_mask_t;
@@ -211,7 +212,7 @@ status_t acl_lowp_matmul_sq_t::pd_t::init(engine_t *engine) {
 // Keys are anonymous with local linkage. So deduce the type automagically.
 using matmul_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);
 
-status_t acl_lowp_matmul_sq_t::pd_t::init_scratchpad(engine_t *engine,
+status_t acl_lowp_matmul_sq_t::pd_t::init_scratchpad(const engine_t *engine,
         memory_tracking::registrar_t &scratchpad, post_ops_fallback_t &post_ops,
         dnnl::impl::post_ops_t &attr_post_ops,
         arm_compute::ActivationLayerInfo &act_info,

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.hpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,9 +52,9 @@ struct acl_lowp_matmul_sq_t : public primitive_t {
         DECLARE_COMMON_PD_T("lowp_gemm_sq:acl", acl_lowp_matmul_sq_t,
                 USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
-        status_t init_scratchpad(engine_t *engine,
+        status_t init_scratchpad(const engine_t *engine,
                 memory_tracking::registrar_t &scratchpad,
                 post_ops_fallback_t &post_ops,
                 dnnl::impl::post_ops_t &attr_post_ops,

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,7 +65,7 @@ status_t acl_matmul_t::init(engine_t *engine) {
     return status::success;
 }
 
-status_t acl_matmul_t::pd_t::init(engine_t *engine) {
+status_t acl_matmul_t::pd_t::init(const engine_t *engine) {
     using smask_t = primitive_attr_t::skip_mask_t;
     const bool is_fp32_ok
             = utils::everyone_is(data_type::f32, src_md()->data_type,

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,7 +36,7 @@ struct acl_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("gemm:acl", acl_matmul_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         acl_matmul_conf_t amp_ = utils::zero<decltype(amp_)>();
         post_ops_fallback_t post_ops;

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -111,20 +111,22 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         return IMPLICATION(with_bias(), is_bia_dt_correct && is_bias_1xN());
     };
 
-    auto check_attr_scales = [&]() -> bool {
+    auto check_attr_scales = [&]() -> status_t {
         const std::vector<int> supported_args
                 = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
-        bool ok = attr_scales_ok(supported_args);
+        CHECK(attr_scales_ok(engine, supported_args));
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad
-            if (is_runtime_value(N())) ok = false;
+            VDISPATCH_MATMUL(
+                    !is_runtime_value(N()), VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
 
-        if (!attr()->post_ops_.sum_with_default_dt()) return false;
+        VDISPATCH_MATMUL(attr()->post_ops_.sum_with_default_dt(),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-        return ok;
+        return status::success;
     };
 
     auto check_attr_zero_points = [&]() -> bool {
@@ -165,7 +167,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_MATMUL(attr()->post_ops_.check_sum_consistency(dst_dt, is_int8),
             VERBOSE_UNSUPPORTED_DT);
-    VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(check_attr_scales());
     VDISPATCH_MATMUL(check_attr_zero_points(), VERBOSE_UNSUPPORTED_ZP_CFG);
     VDISPATCH_MATMUL(check_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
 

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -88,7 +88,7 @@ int brgemm_matmul_t<isa>::pd_t::get_brg_kernel_idx(bool is_bs_tail,
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
     const auto src_dt = src_md_.data_type;
     const auto wei_dt = weights_md_.data_type;
     const auto dst_dt = dst_md_.data_type;

--- a/src/cpu/aarch64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.hpp
@@ -51,7 +51,7 @@ struct brgemm_matmul_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("brg:", isa, ""), brgemm_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         int get_brg_kernel_idx(bool is_bs_tail, bool do_initialization,
                 int m_ker_idx, bool is_N_tail, bool is_K_tail) const;
         const brgemm_desc_t &get_brg_desc(int idx) const {

--- a/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
@@ -26,8 +26,8 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-status_t brgemm_matmul_copy_reorder_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t brgemm_matmul_copy_reorder_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
     using namespace status;
     using namespace format_tag;
 
@@ -135,9 +135,9 @@ status_t brgemm_matmul_copy_reorder_t::pd_t::init(
 }
 
 status_t brgemm_matmul_copy_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     using namespace status;
 
     auto _pd = std::unique_ptr<pd_t>(new pd_t(

--- a/src/cpu/aarch64/matmul/brgemm_matmul_reorders.hpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_reorders.hpp
@@ -36,14 +36,14 @@ struct brgemm_matmul_copy_reorder_t : public primitive_t {
 
         // required to re-use brgemm matmul copy_b jit kernels
         matmul::brgemm_matmul_conf_t matmul_conf_for_reorder_;
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         void init_scratchpad() {}
         friend dnnl::impl::impl_list_item_t;

--- a/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
@@ -276,7 +276,7 @@ struct jit_bf16_matmul_kernel_t : public jit_generator_t {
     int k_residual_blk;
 };
 
-status_t jit_bf16_matmul_t::pd_t::init(engine_t *engine) {
+status_t jit_bf16_matmul_t::pd_t::init(const engine_t *engine) {
     const memory_desc_wrapper src_d(src_md_);
     const memory_desc_wrapper weights_d(weights_md_);
     const memory_desc_wrapper dst_d(dst_md_);

--- a/src/cpu/aarch64/matmul/jit_bf16_matmul.hpp
+++ b/src/cpu/aarch64/matmul/jit_bf16_matmul.hpp
@@ -52,7 +52,7 @@ struct jit_bf16_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:bf16", jit_bf16_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool formats_ok() const {
 

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -865,7 +865,7 @@ private:
 };
 
 template <cpu_isa_t isa>
-status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_int8_matmul_t<isa>::pd_t::init(const engine_t *engine) {
 
     const auto src_type = src_md(0)->data_type;
     const auto wei_type = weights_md(0)->data_type;

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -893,7 +893,7 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
     int dims = src_d.ndims();
 
-    auto check_attr_scales = [&]() -> bool {
+    auto check_attr_scales = [&]() -> status_t {
         const std::vector<int> supported_args
                 = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
         const auto &scales = attr()->scales_;
@@ -906,24 +906,29 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
         auto src_scl_msk = src_scales.get_mask();
         const bool is_src_per_m = src_scl_msk == src_qmask_M();
 
-        bool ok = attr_scales_ok(supported_args,
+        CHECK(attr_scales_ok(engine, supported_args,
                 {quantization_mode::static_sazp},
-                {{DNNL_ARG_SRC, {src_qmask_M()}}});
-        ok = ok && IMPLICATION(is_src_per_m, src_scales.has_default_groups());
+                {{DNNL_ARG_SRC, {src_qmask_M()}}}));
+        VDISPATCH_MATMUL(
+                IMPLICATION(is_src_per_m, src_scales.has_default_groups()),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-        if (is_src_scl && !scales.has_default_data_type(DNNL_ARG_SRC))
-            return false;
+        VDISPATCH_MATMUL(IMPLICATION(is_src_scl,
+                                 scales.has_default_data_type(DNNL_ARG_SRC)),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-        if ((src_scl_msk > 0 && !is_src_per_m)
-                || (wei_scl_msk > 0 && wei_scl_msk != 1 << (dims - 1))
-                || dst_scl_msk > 0)
-            return false;
+        VDISPATCH_MATMUL(
+                !((src_scl_msk > 0 && !is_src_per_m)
+                        || (wei_scl_msk > 0 && wei_scl_msk != 1 << (dims - 1))
+                        || dst_scl_msk > 0),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
 
         if (is_src_scl && is_wei_scl && wei_scl_msk > 0) {
             // This case requires scratchpad.
-            if (is_runtime_value(N())) ok = false;
+            VDISPATCH_MATMUL(
+                    !is_runtime_value(N()), VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
-        return ok;
+        return status::success;
     };
 
     auto check_bias = [&]() -> bool {
@@ -992,7 +997,7 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
     VDISPATCH_MATMUL(check_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
 
-    VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(check_attr_scales());
 
     const bool problem_dt_correct = (is_s8 || is_u8 || is_u8_s8)
             && utils::one_of(dst_type, f32, s32, f16, bf16, s8, u8)

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.hpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2025 FUJITSU LIMITED
 * Copyright 2025-2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +44,7 @@ struct jit_int8_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:int8", jit_int8_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         int get_idx(bool is_zp_cal, bool is_m_tail, bool is_k_tail,
                 bool is_n_tail, const brg_int8_t &brg) const;

--- a/src/cpu/aarch64/post_ops_fallback.cpp
+++ b/src/cpu/aarch64/post_ops_fallback.cpp
@@ -29,7 +29,7 @@ namespace aarch64 {
     VCONDCHECK(primitive, create, dispatch, post_ops_fallback, (cond), \
             status::unimplemented, __VA_ARGS__)
 
-status_t post_ops_fallback_t::init(engine_t *engine, post_ops_t &post_ops,
+status_t post_ops_fallback_t::init(const engine_t *engine, post_ops_t &post_ops,
         const memory_desc_t &dst_md, int post_op_start_index) {
 
     post_op_start_index_ = post_op_start_index;
@@ -160,7 +160,7 @@ status_t post_ops_fallback_t::execute_binary(const exec_ctx_t &ctx,
     return post_op->execute(binary_ctx);
 }
 
-status_t post_ops_fallback_t::create_binary_primitive(engine_t *engine,
+status_t post_ops_fallback_t::create_binary_primitive(const engine_t *engine,
         const binary_desc_t &binary_desc,
         std::shared_ptr<primitive_t> &primitive) const {
     auto empty_attr = dnnl_primitive_attr();
@@ -176,10 +176,11 @@ status_t post_ops_fallback_t::create_binary_primitive(engine_t *engine,
     }
     if (!binary_pd) return status::unimplemented;
 
-    return binary_pd->create_primitive(primitive, engine);
+    return binary_pd->create_primitive(
+            primitive, const_cast<engine_t *>(engine));
 }
 
-status_t post_ops_fallback_t::create_eltwise_primitive(engine_t *engine,
+status_t post_ops_fallback_t::create_eltwise_primitive(const engine_t *engine,
         const eltwise_desc_t &eltwise_desc,
         std::shared_ptr<primitive_t> &primitive) const {
     auto empty_attr = dnnl_primitive_attr();
@@ -195,7 +196,8 @@ status_t post_ops_fallback_t::create_eltwise_primitive(engine_t *engine,
     }
     if (!eltwise_pd) return status::unimplemented;
 
-    return eltwise_pd->create_primitive(primitive, engine);
+    return eltwise_pd->create_primitive(
+            primitive, const_cast<engine_t *>(engine));
 }
 
 status_t post_ops_fallback_t::execute_eltwise(const exec_ctx_t &ctx,

--- a/src/cpu/aarch64/post_ops_fallback.hpp
+++ b/src/cpu/aarch64/post_ops_fallback.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022-2024, 2026 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +34,7 @@ struct post_ops_fallback_t {
 
     // init the post_ops_fallback_t. Note that this function modifies the passed in
     // post ops by setting the preferred memory formats
-    status_t init(engine_t *engine, post_ops_t &post_ops,
+    status_t init(const engine_t *engine, post_ops_t &post_ops,
             const memory_desc_t &dst_md, int post_op_start_index = 0);
 
     bool has_sum() const { return sum_index >= 0; }
@@ -44,11 +45,11 @@ struct post_ops_fallback_t {
             const exec_ctx_t &ctx, void *src, void *dst = nullptr) const;
 
 private:
-    status_t create_binary_primitive(engine_t *engine,
+    status_t create_binary_primitive(const engine_t *engine,
             const binary_desc_t &binary_desc,
             std::shared_ptr<primitive_t> &primitive) const;
 
-    status_t create_eltwise_primitive(engine_t *engine,
+    status_t create_eltwise_primitive(const engine_t *engine,
             const eltwise_desc_t &eltwise_desc,
             std::shared_ptr<primitive_t> &primitive) const;
 

--- a/src/cpu/aarch64/prelu/jit_uni_prelu_forward.cpp
+++ b/src/cpu/aarch64/prelu/jit_uni_prelu_forward.cpp
@@ -496,7 +496,7 @@ jit_prelu_forward_kernel_t *jit_prelu_forward_kernel_t::create(cpu_isa_t isa,
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_prelu_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_prelu_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     UNUSED(engine);
 
     const memory_desc_wrapper src_d {src_md(0)};

--- a/src/cpu/aarch64/prelu/jit_uni_prelu_forward.hpp
+++ b/src/cpu/aarch64/prelu/jit_uni_prelu_forward.hpp
@@ -52,7 +52,7 @@ struct jit_uni_prelu_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_prelu_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         // Broadcast kind selected during primitive descriptor initialization.
         // execute() and the JIT kernel both use this to choose pointer movement.

--- a/src/cpu/aarch64/reorder/acl_reorder.cpp
+++ b/src/cpu/aarch64/reorder/acl_reorder.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023, 2025 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -63,9 +64,9 @@ status_t acl_reorder_resource_t::configure(const acl_reorder_conf_t &app) {
 }
 
 status_t acl_reorder_fwd_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     using namespace acl_utils;
     using namespace dnnl::impl;
 

--- a/src/cpu/aarch64/reorder/acl_reorder.hpp
+++ b/src/cpu/aarch64/reorder/acl_reorder.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023-2025 Arm Ltd. and affiliates
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -62,10 +63,10 @@ struct acl_reorder_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("acl", acl_reorder_fwd_t);
 
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         friend dnnl::impl::impl_list_item_t;
         acl_reorder_conf_t app_;

--- a/src/cpu/aarch64/reorder/jit_blk_reorder.cpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder.cpp
@@ -49,9 +49,9 @@ namespace cpu {
 namespace aarch64 {
 
 status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     if (!impl::is_dense_format_kind({src_md, dst_md}))
         return status::unimplemented;
     auto prb = tr::prb_t();

--- a/src/cpu/aarch64/reorder/jit_blk_reorder.hpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder.hpp
@@ -40,10 +40,10 @@ struct jit_blk_reorder_t : public primitive_t {
         tr::prb_t prb_;
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         // Swap last two nodes, put block 4, 8, 16 nodes to first
         static void prb_tile_normalize(tr::prb_t &p);

--- a/src/cpu/aarch64/reorder/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder.cpp
@@ -49,8 +49,8 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-status_t jit_uni_reorder_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t jit_uni_reorder_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
     CHECK(cpu_reorder_pd_t::init(engine, src_engine, dst_engine));
 
     CHECK(init_scratchpad());
@@ -94,9 +94,9 @@ status_t jit_uni_reorder_t::pd_t::init_scratchpad() {
 }
 
 status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     if (!impl::is_dense_format_kind({src_md, dst_md}))
         return status::unimplemented;
     auto prb = tr::prb_t();

--- a/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder.hpp
@@ -44,15 +44,15 @@ struct jit_uni_reorder_t : public primitive_t {
         bool with_groups_ = false;
         dim_t D_mask_ = 0;
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
     private:
         status_t init_scratchpad();
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         friend dnnl::impl::impl_list_item_t;
     };

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
@@ -34,7 +34,7 @@ namespace cpu {
 namespace aarch64 {
 
 template <cpu_isa_t isa>
-status_t jit_uni_shuffle_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_shuffle_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace format_tag;
     using namespace data_type;
     using namespace types;

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
@@ -43,7 +43,7 @@ struct jit_uni_shuffle_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", conf_.isa, ""), jit_uni_shuffle_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         jit_shuffle_conf_t get_conf() const { return conf_; }
 

--- a/src/cpu/gemm_convolution.hpp
+++ b/src/cpu/gemm_convolution.hpp
@@ -39,7 +39,7 @@ struct gemm_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 GEMM_IMPL_STR, gemm_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(
@@ -145,7 +145,7 @@ struct gemm_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_convolution_bwd_data_t,
                 USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace dnnl::impl::data_type;
 
             VDISPATCH_CONV(
@@ -202,7 +202,7 @@ struct gemm_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_convolution_bwd_weights_t,
                 USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace dnnl::impl::data_type;
 
             VDISPATCH_CONV(

--- a/src/cpu/gemm_inner_product.hpp
+++ b/src/cpu/gemm_inner_product.hpp
@@ -42,7 +42,7 @@ struct gemm_inner_product_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_inner_product_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
 
             VDISPATCH_INNER_PRODUCT(
@@ -144,7 +144,7 @@ struct gemm_inner_product_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_inner_product_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             VDISPATCH_INNER_PRODUCT(
                     DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
                     VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
@@ -188,7 +188,7 @@ struct gemm_inner_product_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_inner_product_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             VDISPATCH_INNER_PRODUCT(
                     DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
                     VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);

--- a/src/cpu/gemm_x8s8s32x_convolution.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.hpp
@@ -46,7 +46,7 @@ struct gemm_x8s8s32x_convolution_fwd_t : public primitive_t {
                         : IGEMM_S8S8S32_IMPL_STR,
                 gemm_x8s8s32x_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
             const auto dst_type = dst_md(0)->data_type;
@@ -138,7 +138,7 @@ struct gemm_x8s8s32x_convolution_bwd_data_t : public primitive_t {
                         : IGEMM_S8S8S32_IMPL_STR,
                 gemm_x8s8s32x_convolution_bwd_data_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(

--- a/src/cpu/gemm_x8s8s32x_inner_product.hpp
+++ b/src/cpu/gemm_x8s8s32x_inner_product.hpp
@@ -49,7 +49,7 @@ struct gemm_x8s8s32x_inner_product_fwd_t : public primitive_t {
                         : IGEMM_S8S8S32_IMPL_STR,
                 gemm_x8s8s32x_inner_product_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_INNER_PRODUCT(

--- a/src/cpu/matmul/cpu_matmul_pd.hpp
+++ b/src/cpu/matmul/cpu_matmul_pd.hpp
@@ -30,7 +30,7 @@ namespace matmul {
 struct cpu_matmul_pd_t : public matmul_pd_t {
     using matmul_pd_t::matmul_pd_t;
     // NOLINTBEGIN(google-default-arguments)
-    status_t attr_scales_ok(engine_t *engine,
+    status_t attr_scales_ok(const engine_t *engine,
             const std::vector<int> &supported_args
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
             const std::vector<int> &supported_qmodes

--- a/src/cpu/matmul/cpu_matmul_pd.hpp
+++ b/src/cpu/matmul/cpu_matmul_pd.hpp
@@ -30,14 +30,15 @@ namespace matmul {
 struct cpu_matmul_pd_t : public matmul_pd_t {
     using matmul_pd_t::matmul_pd_t;
     // NOLINTBEGIN(google-default-arguments)
-    bool attr_scales_ok(const std::vector<int> &supported_args
+    status_t attr_scales_ok(engine_t *engine,
+            const std::vector<int> &supported_args
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
             const std::vector<int> &supported_qmodes
             = {quantization_mode::static_sazp},
             const std::map<int, std::vector<int>> &extra_masks
             = {}) const override {
-        bool ok = matmul_pd_t::attr_scales_ok(
-                supported_args, supported_qmodes, extra_masks);
+        CHECK(matmul_pd_t::attr_scales_ok(
+                engine, supported_args, supported_qmodes, extra_masks));
         const auto &scales = attr()->scales_;
         for (int arg : supported_args) {
             if (scales.has_default_values(arg)) { continue; }
@@ -46,11 +47,11 @@ struct cpu_matmul_pd_t : public matmul_pd_t {
 
             // Any group is allowed to be greater than 1 but only one at a
             // time, not both.
-            ok = ok
-                    && IMPLICATION(!scales.get(arg).has_default_groups(),
-                            utils::one_of(1, g0, g1));
+            VDISPATCH_MATMUL(IMPLICATION(!scales.get(arg).has_default_groups(),
+                                     utils::one_of(1, g0, g1)),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
-        return ok;
+        return status::success;
     }
     // NOLINTEND(google-default-arguments)
 };

--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -105,15 +105,16 @@ static bool should_gemm_execute_sum_po(const gemm_based::params_t &params,
 template <impl::data_type_t dst_type>
 status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
         engine_t *engine) {
-    auto check_attr_scales = [&]() -> bool {
-        bool ok = attr_scales_ok();
+    auto check_attr_scales = [&]() -> status_t {
+        CHECK(attr_scales_ok(engine));
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
-            if (is_runtime_value(N())) ok = false;
+            VDISPATCH_MATMUL(
+                    !is_runtime_value(N()), VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
-        return ok;
+        return status::success;
     };
 
     auto check_attr_post_ops = [&]() -> bool {
@@ -142,7 +143,7 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
     };
 
     // check basic attributes
-    VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(check_attr_scales());
 
     // set state
     CHECK(params_.pp_attr_.copy_from(*attr()));

--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -44,7 +44,7 @@ namespace matmul {
 using namespace data_type;
 
 template <impl::data_type_t dst_type>
-status_t gemm_bf16_matmul_t<dst_type>::pd_t::init(engine_t *engine) {
+status_t gemm_bf16_matmul_t<dst_type>::pd_t::init(const engine_t *engine) {
     auto check_bias = [&]() -> bool {
         return !with_bias()
                 || (utils::one_of(weights_md(1)->data_type, f32, bf16)
@@ -104,7 +104,7 @@ static bool should_gemm_execute_sum_po(const gemm_based::params_t &params,
 
 template <impl::data_type_t dst_type>
 status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
-        engine_t *engine) {
+        const engine_t *engine) {
     auto check_attr_scales = [&]() -> status_t {
         CHECK(attr_scales_ok(engine));
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)

--- a/src/cpu/matmul/gemm_bf16_matmul.hpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.hpp
@@ -41,13 +41,13 @@ struct gemm_bf16_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("gemm:jit:bf16", gemm_bf16_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         const gemm_based::params_t &params() const { return params_; }
 
         int nthr_; // To not exceed the limit in execute used for set up.
 
     private:
-        status_t check_and_configure_attributes(engine_t *engine);
+        status_t check_and_configure_attributes(const engine_t *engine);
         gemm_based::params_t params_;
     };
 

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -48,15 +48,16 @@ status_t gemm_f32_matmul_t::pd_t::init(engine_t *engine) {
                 || (weights_md(1)->data_type == f32 && is_bias_1xN());
     };
 
-    auto check_attr_scales = [&]() -> bool {
-        bool ok = attr_scales_ok();
+    auto check_attr_scales = [&]() -> status_t {
+        CHECK(attr_scales_ok(engine));
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
-            if (is_runtime_value(N())) ok = false;
+            VDISPATCH_MATMUL(
+                    !is_runtime_value(N()), VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
-        return ok;
+        return status::success;
     };
 
     auto check_attr_post_ops = [&]() -> bool {
@@ -103,7 +104,7 @@ status_t gemm_f32_matmul_t::pd_t::init(engine_t *engine) {
     VDISPATCH_MATMUL(attr()->post_ops_.check_sum_consistency(dst_type,
                              /* is_int8 */ false),
             VERBOSE_UNSUPPORTED_POSTOP);
-    VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(check_attr_scales());
     VDISPATCH_MATMUL(check_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
     VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
     // Should be followed by `set_default_formats`.

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -42,7 +42,7 @@ namespace matmul {
 
 using namespace data_type;
 
-status_t gemm_f32_matmul_t::pd_t::init(engine_t *engine) {
+status_t gemm_f32_matmul_t::pd_t::init(const engine_t *engine) {
     auto check_bias = [&]() -> bool {
         return !with_bias()
                 || (weights_md(1)->data_type == f32 && is_bias_1xN());

--- a/src/cpu/matmul/gemm_f32_matmul.hpp
+++ b/src/cpu/matmul/gemm_f32_matmul.hpp
@@ -39,7 +39,7 @@ struct gemm_f32_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("gemm:jit:f32", gemm_f32_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         const gemm_based::params_t &params() const { return params_; }
 
         int nthr_; // To not exceed the limit in execute used for set up.

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -59,15 +59,16 @@ status_t gemm_x8s8s32x_matmul_t::pd_t::init(engine_t *engine) {
     using namespace utils;
     using namespace data_type;
 
-    auto check_attr_scales = [&]() -> bool {
-        bool ok = attr_scales_ok();
+    auto check_attr_scales = [&]() -> status_t {
+        CHECK(attr_scales_ok(engine));
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
-            if (is_runtime_value(N())) ok = false;
+            VDISPATCH_MATMUL(
+                    !is_runtime_value(N()), VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
-        return ok;
+        return status::success;
     };
 
     auto check_attr_zero_points = [&]() -> bool {
@@ -126,7 +127,7 @@ status_t gemm_x8s8s32x_matmul_t::pd_t::init(engine_t *engine) {
                     /* is_int8 */ true),
             VERBOSE_UNSUPPORTED_POSTOP);
     VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
-    VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(check_attr_scales());
     VDISPATCH_MATMUL(check_attr_zero_points(), VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_MATMUL(
             attr()->has_default_values(primitive_attr_t::skip_mask_t::scales

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -55,7 +55,7 @@ bool need_post_processing(const pd_t *pd, float runtime_dst_zero_point = 0.f) {
 }
 } // namespace
 
-status_t gemm_x8s8s32x_matmul_t::pd_t::init(engine_t *engine) {
+status_t gemm_x8s8s32x_matmul_t::pd_t::init(const engine_t *engine) {
     using namespace utils;
     using namespace data_type;
 

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.hpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.hpp
@@ -41,7 +41,7 @@ struct gemm_x8s8s32x_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("gemm:jit", gemm_x8s8s32x_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         const gemm_based::params_t &params() const { return params_; }
 
         int nthr_; // To not exceed the limit in execute used for set up.

--- a/src/cpu/matmul/ref_grouped_gemm.hpp
+++ b/src/cpu/matmul/ref_grouped_gemm.hpp
@@ -50,7 +50,7 @@ struct ref_grouped_t : public primitive_t {
 
         bool is_2dby2d() const { return is_2dby2d_; }
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             memory_desc_wrapper src_d(src_md());
             memory_desc_wrapper wei_d(weights_md(0));
 
@@ -64,7 +64,7 @@ struct ref_grouped_t : public primitive_t {
     private:
         bool is_2dby2d_ = false;
 
-        status_t init_2dby3d(engine_t *engine) {
+        status_t init_2dby3d(const engine_t *engine) {
             using namespace data_type;
             const auto src_type = src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;
@@ -245,7 +245,7 @@ struct ref_grouped_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_2dby2d(engine_t *engine) {
+        status_t init_2dby2d(const engine_t *engine) {
             using namespace data_type;
             const auto src_type = src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;

--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -104,12 +104,11 @@ struct ref_matmul_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_MATMUL(ref_post_ops_t::post_ops_ok(attr()->post_ops_),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_MATMUL(attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS,
-                                                    DNNL_ARG_DST},
-                                     {quantization_mode::static_sazp,
-                                             quantization_mode::dynamic_mx,
-                                             quantization_mode::dynamic_fp}),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok(engine,
+                    {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+                    {quantization_mode::static_sazp,
+                            quantization_mode::dynamic_mx,
+                            quantization_mode::dynamic_fp}));
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_MATMUL(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_MATMUL(

--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -109,8 +109,9 @@ struct ref_matmul_t : public primitive_t {
                     {quantization_mode::static_sazp,
                             quantization_mode::dynamic_mx,
                             quantization_mode::dynamic_fp}));
+            CHECK(attr_zero_points_ok(engine, {DNNL_ARG_WEIGHTS},
+                    {quantization_mode::static_sazp}));
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_MATMUL(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_MATMUL(
                     attr_.set_default_formats(dst_md(0)) == status::success,
                     VERBOSE_UNSUPPORTED_POSTOP);
@@ -126,30 +127,6 @@ struct ref_matmul_t : public primitive_t {
 
     private:
         void init_scratchpad();
-
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-            if (!zp.has_default_values(DNNL_ARG_SRC)) { return false; }
-            /* weights decompression requires zero points support */
-            if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
-                if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
-                    const auto gK = zp.get_group(DNNL_ARG_WEIGHTS, 0);
-                    bool ok = IMPLICATION(gK > 1, K() % gK == 0);
-                    if (!ok) return false;
-
-                    const auto gN = zp.get_group(DNNL_ARG_WEIGHTS, 1);
-                    ok = IMPLICATION(gN > 1, N() % gN == 0);
-                    if (!ok) return false;
-
-                    // Only one non-unit group is supported.
-                    ok = utils::one_of(1, gK, gN);
-                    if (!ok) return false;
-                }
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) { return false; }
-
-            return true;
-        }
 
         status_t dropout_ok() const {
             if (attr_.dropout_.has_default_values()) return status::success;

--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -41,7 +41,7 @@ struct ref_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_matmul_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto src_type = src_md(0)->data_type;

--- a/src/cpu/matmul/ref_matmul_int8.hpp
+++ b/src/cpu/matmul/ref_matmul_int8.hpp
@@ -41,7 +41,7 @@ struct ref_matmul_int8_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref_int8:any", ref_matmul_int8_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto src_type = src_md(0)->data_type;

--- a/src/cpu/matmul/ref_matmul_int8.hpp
+++ b/src/cpu/matmul/ref_matmul_int8.hpp
@@ -76,11 +76,10 @@ struct ref_matmul_int8_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_MATMUL(ref_post_ops_t::post_ops_ok(attr()->post_ops_),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_MATMUL(attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS,
-                                                    DNNL_ARG_DST},
-                                     {quantization_mode::static_sazp},
-                                     {{DNNL_ARG_SRC, {src_qmask_M()}}}),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok(engine,
+                    {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+                    {quantization_mode::static_sazp},
+                    {{DNNL_ARG_SRC, {src_qmask_M()}}}));
             CHECK(attr_zero_points_ok(engine));
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_MATMUL(

--- a/src/cpu/matmul/ref_matmul_int8.hpp
+++ b/src/cpu/matmul/ref_matmul_int8.hpp
@@ -80,62 +80,14 @@ struct ref_matmul_int8_t : public primitive_t {
                     {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
                     {quantization_mode::static_sazp},
                     {{DNNL_ARG_SRC, {src_qmask_M()}}}));
-            CHECK(attr_zero_points_ok(engine));
+            CHECK(attr_zero_points_ok(engine,
+                    {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+                    {quantization_mode::static_sazp}));
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_MATMUL(
                     attr_.set_default_formats(dst_md(0)) == status::success,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
-            return status::success;
-        }
-
-    private:
-        status_t attr_zero_points_ok(engine_t *engine) const {
-            const auto &zp = attr()->zero_points_;
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                VDISPATCH_MATMUL(utils::one_of(mask_src, 0, src_qmask_K(),
-                                         src_qmask_M() + src_qmask_K(),
-                                         full_tensor_mask()),
-                        VERBOSE_UNSUPPORTED_ZP_CFG);
-                VDISPATCH_MATMUL(IMPLICATION(mask_src == full_tensor_mask(),
-                                         ndims() <= 3),
-                        VERBOSE_UNSUPPORTED_ZP_CFG);
-                VDISPATCH_MATMUL(IMPLICATION(mask_src == full_tensor_mask()
-                                                 && ndims() == 3,
-                                         src_md()->dims[0] == 1),
-                        VERBOSE_UNSUPPORTED_ZP_CFG);
-
-                if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
-                    const auto gM = zp.get_group(DNNL_ARG_SRC, 0);
-                    VDISPATCH_MATMUL(gM == 1, VERBOSE_UNSUPPORTED_ZP_CFG);
-
-                    const auto gK = zp.get_group(DNNL_ARG_SRC, 1);
-                    VDISPATCH_MATMUL(IMPLICATION(gK > 1, K() % gK == 0),
-                            VERBOSE_UNSUPPORTED_ZP_CFG);
-                }
-            }
-            /* weights decompression requires zero points support */
-            if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
-                if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
-                    const auto gK = zp.get_group(DNNL_ARG_WEIGHTS, 0);
-                    VDISPATCH_MATMUL(IMPLICATION(gK > 1, K() % gK == 0),
-                            VERBOSE_UNSUPPORTED_ZP_CFG);
-
-                    const auto gN = zp.get_group(DNNL_ARG_WEIGHTS, 1);
-                    VDISPATCH_MATMUL(IMPLICATION(gN > 1, N() % gN == 0),
-                            VERBOSE_UNSUPPORTED_ZP_CFG);
-
-                    // Only one non-unit group is supported.
-                    VDISPATCH_MATMUL(utils::one_of(1, gK, gN),
-                            VERBOSE_UNSUPPORTED_ZP_CFG);
-                }
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                VDISPATCH_MATMUL(utils::one_of(mask_dst, 0, wei_qmask_N()),
-                        VERBOSE_UNSUPPORTED_ZP_CFG);
-            }
             return status::success;
         }
     };

--- a/src/cpu/matmul/ref_sparse_matmul.hpp
+++ b/src/cpu/matmul/ref_sparse_matmul.hpp
@@ -35,7 +35,7 @@ struct ref_sparse_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_sparse_matmul_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto src_type = src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -41,7 +41,7 @@ struct nchw_pooling_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple_nchw:any", nchw_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             const format_tag_t desired_fmt_tag = utils::pick(ndims() - 3,
                     format_tag::ncw, format_tag::nchw, format_tag::ncdhw);
 
@@ -134,7 +134,7 @@ struct nchw_pooling_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple_nchw:any", nchw_pooling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             const format_tag_t desired_fmt_tag = utils::pick(ndims() - 3,
                     format_tag::ncw, format_tag::nchw, format_tag::ncdhw);
 

--- a/src/cpu/ncsp_batch_normalization.hpp
+++ b/src/cpu/ncsp_batch_normalization.hpp
@@ -42,7 +42,7 @@ struct ncsp_batch_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ncsp_bnorm:any", ncsp_batch_normalization_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
 
@@ -136,7 +136,7 @@ struct ncsp_batch_normalization_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ncsp_bnorm:any", ncsp_batch_normalization_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
 

--- a/src/cpu/ncsp_group_normalization.hpp
+++ b/src/cpu/ncsp_group_normalization.hpp
@@ -40,7 +40,7 @@ struct ncsp_group_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ncsp_gnorm:any", ncsp_group_normalization_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
             using skip_mask_t = primitive_attr_t::skip_mask_t;

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -47,7 +47,7 @@ struct nhwc_pooling_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple_nhwc:any", nhwc_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             const format_tag_t desired_fmt_tag = utils::pick(ndims() - 3,
                     format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
@@ -156,7 +156,7 @@ struct nhwc_pooling_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple_nhwc:any", nhwc_pooling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             const format_tag_t desired_fmt_tag = utils::pick(ndims() - 3,
                     format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 

--- a/src/cpu/nspc_batch_normalization.hpp
+++ b/src/cpu/nspc_batch_normalization.hpp
@@ -41,7 +41,7 @@ struct nspc_batch_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("nspc_bnorm:any", nspc_batch_normalization_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
 
@@ -133,7 +133,7 @@ struct nspc_batch_normalization_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("nspc_bnorm:any", nspc_batch_normalization_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
 

--- a/src/cpu/ppc64/ppc64_gemm_reorder.cpp
+++ b/src/cpu/ppc64/ppc64_gemm_reorder.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 IBM Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,8 +38,8 @@ typedef __vector signed short vec_short_t;
 typedef __vector signed int vec_int_t;
 typedef __vector float vec_float_t;
 
-status_t ppc64_matrixA_reorder_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t ppc64_matrixA_reorder_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
     using namespace status;
 
     using namespace format_tag;
@@ -71,9 +72,9 @@ status_t ppc64_matrixA_reorder_t::pd_t::init(
 }
 
 status_t ppc64_matrixA_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     auto _pd = make_unique_pd<pd_t>(
             attr, src_engine->kind(), src_md, dst_engine->kind(), dst_md);
 

--- a/src/cpu/ppc64/ppc64_gemm_reorder.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_reorder.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 IBM Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,13 +52,13 @@ struct ppc64_matrixA_reorder_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ppc64_matrixA_reorder_t", ppc64_matrixA_reorder_t);
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
     private:
         static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
+                const primitive_attr_t *attr, const engine_t *src_engine,
+                const memory_desc_t *src_md, const engine_t *dst_engine,
                 const memory_desc_t *dst_md);
 
         void init_scratchpad() {}

--- a/src/cpu/ref_batch_normalization.hpp
+++ b/src/cpu/ref_batch_normalization.hpp
@@ -40,7 +40,7 @@ struct ref_batch_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_batch_normalization_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_BNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_BNORM(utils::everyone_is(d_type, src_md()->data_type,
@@ -97,7 +97,7 @@ struct ref_batch_normalization_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_batch_normalization_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/ref_binary.hpp
+++ b/src/cpu/ref_binary.hpp
@@ -39,7 +39,7 @@ struct ref_binary_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_binary_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 

--- a/src/cpu/ref_concat.hpp
+++ b/src/cpu/ref_concat.hpp
@@ -35,7 +35,7 @@ struct ref_concat_t : public primitive_t {
 
         DECLARE_CONCAT_PD_T("ref:any", ref_concat_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
             VDISPATCH_CONCAT(attr()->has_default_values(sm::scales),
                     VERBOSE_UNSUPPORTED_ATTR);

--- a/src/cpu/ref_convolution.hpp
+++ b/src/cpu/ref_convolution.hpp
@@ -37,7 +37,7 @@ struct ref_convolution_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto src_type = src_md(0)->data_type;
@@ -124,7 +124,7 @@ struct ref_convolution_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto diff_src_type = diff_src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;
@@ -183,7 +183,7 @@ struct ref_convolution_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto src_type = src_md(0)->data_type;
             const auto diff_wei_type = diff_weights_md(0)->data_type;

--- a/src/cpu/ref_convolution_int8.hpp
+++ b/src/cpu/ref_convolution_int8.hpp
@@ -37,7 +37,7 @@ struct ref_convolution_int8_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_convolution_int8_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto src_type = src_md(0)->data_type;
@@ -118,7 +118,7 @@ struct ref_convolution_int8_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_convolution_int8_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto diff_src_type = diff_src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;

--- a/src/cpu/ref_deconvolution.hpp
+++ b/src/cpu/ref_deconvolution.hpp
@@ -104,7 +104,7 @@ struct ref_deconvolution_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), ref_deconvolution_fwd_t);
 
-        status_t init_convolution(engine_t *engine) {
+        status_t init_convolution(const engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
 
@@ -158,7 +158,7 @@ struct ref_deconvolution_fwd_t : public primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
@@ -336,7 +336,7 @@ struct ref_deconvolution_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), ref_deconvolution_bwd_data_t);
 
-        status_t init_convolution(engine_t *engine) {
+        status_t init_convolution(const engine_t *engine) {
             using namespace types;
 
             convolution_desc_t cd;
@@ -357,7 +357,7 @@ struct ref_deconvolution_bwd_data_t : public primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             auto dsrc_type = desc()->diff_src_desc.data_type;
             auto wei_type = desc()->weights_desc.data_type;
@@ -445,7 +445,7 @@ struct ref_deconvolution_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), ref_deconvolution_bwd_weights_t);
 
-        status_t init_convolution(engine_t *engine) {
+        status_t init_convolution(const engine_t *engine) {
             using namespace types;
             using namespace format_tag;
 
@@ -476,7 +476,7 @@ struct ref_deconvolution_bwd_weights_t : public primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
             auto src_type = invariant_src_md()->data_type;

--- a/src/cpu/ref_eltwise.hpp
+++ b/src/cpu/ref_eltwise.hpp
@@ -39,7 +39,7 @@ struct ref_eltwise_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_eltwise_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
@@ -136,7 +136,7 @@ struct ref_eltwise_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_eltwise_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             using namespace data_type;
 

--- a/src/cpu/ref_fused_convolution.hpp
+++ b/src/cpu/ref_fused_convolution.hpp
@@ -78,7 +78,7 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), ref_fused_convolution_fwd_t);
 
-        virtual status_t init(engine_t *engine) {
+        virtual status_t init(const engine_t *engine) {
             using namespace primitive_kind;
 
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -183,7 +183,7 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
         const unsigned int max_fusions_ = 1;
 
         status_t append_op(std::shared_ptr<primitive_desc_t> &op_pd,
-                size_t &sp_begin, size_t &sp_end, engine_t *engine) {
+                size_t &sp_begin, size_t &sp_end, const engine_t *engine) {
             auto from_md = op_pds_.back()->dst_md();
             auto to_md = op_pd->src_md();
 
@@ -215,7 +215,7 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_ops(engine_t *engine) {
+        status_t init_ops(const engine_t *engine) {
             using namespace data_type;
             primitive_attr_t root_attr(*attr());
             if (!root_attr.is_initialized()) return status::out_of_memory;

--- a/src/cpu/ref_group_normalization.hpp
+++ b/src/cpu/ref_group_normalization.hpp
@@ -35,7 +35,7 @@ struct ref_group_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_group_normalization_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
 
@@ -96,7 +96,7 @@ struct ref_group_normalization_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_group_normalization_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_GNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/ref_inner_product.hpp
+++ b/src/cpu/ref_inner_product.hpp
@@ -38,7 +38,7 @@ struct ref_inner_product_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_inner_product_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto src_type = src_md(0)->data_type;
@@ -114,7 +114,7 @@ struct ref_inner_product_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_inner_product_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto diff_src_type = diff_src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;
@@ -166,7 +166,7 @@ struct ref_inner_product_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_inner_product_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto src_type = src_md(0)->data_type;
             const auto diff_wei_type = diff_weights_md(0)->data_type;

--- a/src/cpu/ref_inner_product_int8.hpp
+++ b/src/cpu/ref_inner_product_int8.hpp
@@ -37,7 +37,7 @@ struct ref_inner_product_int8_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_inner_product_int8_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto src_type = src_md(0)->data_type;

--- a/src/cpu/ref_layer_normalization.hpp
+++ b/src/cpu/ref_layer_normalization.hpp
@@ -41,7 +41,7 @@ struct ref_layer_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_layer_normalization_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
 
@@ -111,7 +111,7 @@ struct ref_layer_normalization_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_layer_normalization_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_LNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_LNORM(utils::one_of(src_md()->data_type, f32, bf16, f16),

--- a/src/cpu/ref_lrn.hpp
+++ b/src/cpu/ref_lrn.hpp
@@ -39,7 +39,7 @@ struct ref_lrn_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_lrn_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
 
@@ -96,7 +96,7 @@ struct ref_lrn_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_lrn_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
 

--- a/src/cpu/ref_pooling.hpp
+++ b/src/cpu/ref_pooling.hpp
@@ -39,7 +39,7 @@ struct ref_pooling_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
 
             VDISPATCH_POOLING(
@@ -93,7 +93,7 @@ struct ref_pooling_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_pooling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto diff_src_type = diff_src_md(0)->data_type;
             const auto diff_dst_type = diff_dst_md(0)->data_type;

--- a/src/cpu/ref_prelu.hpp
+++ b/src/cpu/ref_prelu.hpp
@@ -50,7 +50,7 @@ struct ref_prelu_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_prelu_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_PRELU(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_PRELU(src_md(0)->data_type == dst_md(0)->data_type,
@@ -89,7 +89,7 @@ struct ref_prelu_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_prelu_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_PRELU(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_PRELU(diff_src_md(0)->data_type == src_md(0)->data_type,

--- a/src/cpu/ref_reduction.hpp
+++ b/src/cpu/ref_reduction.hpp
@@ -34,7 +34,7 @@ struct ref_reduction_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_reduction_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
             const auto src_type = src_md(0)->data_type;

--- a/src/cpu/ref_resampling.hpp
+++ b/src/cpu/ref_resampling.hpp
@@ -39,7 +39,7 @@ struct ref_resampling_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_resampling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -95,7 +95,7 @@ struct ref_resampling_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_resampling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_RESAMPLING(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_RESAMPLING(

--- a/src/cpu/ref_shuffle.hpp
+++ b/src/cpu/ref_shuffle.hpp
@@ -39,7 +39,7 @@ struct ref_shuffle_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_shuffle_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
 
             const memory_desc_wrapper src_d(

--- a/src/cpu/ref_softmax.hpp
+++ b/src/cpu/ref_softmax.hpp
@@ -40,7 +40,7 @@ struct ref_softmax_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_softmax_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
 
@@ -192,7 +192,7 @@ struct ref_softmax_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ref:any", ref_softmax_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             bool ok = !is_fwd()
                     && utils::one_of(dst_md()->data_type, f32, bf16, f16)

--- a/src/cpu/ref_sum.hpp
+++ b/src/cpu/ref_sum.hpp
@@ -37,7 +37,7 @@ struct ref_sum_t : public primitive_t {
 
         DECLARE_SUM_PD_T("ref:any", ref_sum_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             bool ok = cpu_sum_pd_t::init(engine) == status::success;
             VDISPATCH_SUM(ok, VERBOSE_BAD_ENGINE_KIND);
 

--- a/src/cpu/reorder/cpu_reorder_pd.hpp
+++ b/src/cpu/reorder/cpu_reorder_pd.hpp
@@ -31,8 +31,8 @@ namespace cpu {
 struct cpu_reorder_pd_t : public reorder_pd_t {
     using reorder_pd_t::reorder_pd_t;
 
-    status_t init(
-            engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+    status_t init(const engine_t *engine, const engine_t *src_engine,
+            const engine_t *dst_engine) {
         const auto &post_ops = attr()->post_ops_;
         bool args_ok = IMPLICATION(post_ops.len() != 0,
                 post_ops.len() == 1

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -2679,10 +2679,10 @@ struct simple_reorder_t : public primitive_t {
         DECLARE_COMMON_PD_T("simple:any", simple_reorder_t);
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md) {
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md) {
             // Since `type_i` and `type_o` are templated arguments, no need
             // to put them under verbose_dispatch logic.
             bool ok = src_md->data_type == type_i

--- a/src/cpu/reorder/simple_sparse_reorder.hpp
+++ b/src/cpu/reorder/simple_sparse_reorder.hpp
@@ -203,10 +203,10 @@ struct simple_sparse_reorder_t : public primitive_t {
         std::shared_ptr<primitive_desc_t> reorder_pd_;
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md) {
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md) {
 
             const bool ok = src_md->data_type == type_i
                     && dst_md->data_type == type_o;
@@ -225,8 +225,8 @@ struct simple_sparse_reorder_t : public primitive_t {
             return safe_ptr_assign(*reorder_pd, _pd.release());
         }
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine) {
             // Convert sparse packed desc to blocking desc.
             auto converted_dst_md = cvt_sparse_packed2blocked(*this->dst_md());
             CHECK(reorder_primitive_desc_create(

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -54,7 +54,7 @@ using namespace rnn_utils;
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
 status_t dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
-        acc_type>::pd_t::init_ref(engine_t *engine) {
+        acc_type>::pd_t::init_ref(const engine_t *engine) {
 
     using namespace prop_kind;
     using namespace utils;
@@ -297,7 +297,7 @@ template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
 status_t
 ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
-        engine_t *engine) {
+        const engine_t *engine) {
     using namespace prop_kind;
     using namespace utils;
     using namespace format_tag;
@@ -541,7 +541,7 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
 status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init(
-        engine_t *engine) {
+        const engine_t *engine) {
     status_t st = init_brgemm(engine);
     if (st != status::success) {
         rnn_.is_brgemm = false;

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -152,9 +152,9 @@ struct ref_rnn_common_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(impl_name(), impl_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init_ref(engine_t *engine);
-        status_t init_brgemm(engine_t *engine);
-        status_t init(engine_t *engine);
+        status_t init_ref(const engine_t *engine);
+        status_t init_brgemm(const engine_t *engine);
+        status_t init(const engine_t *engine);
 
         rnn_utils::rnn_conf_t rnn_;
         std::shared_ptr<primitive_desc_t> matmul_layer_1_pd_;

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -193,10 +193,10 @@ struct rnn_data_reorder_t : public primitive_t {
         DECLARE_COMMON_PD_T("rnn_data_reorder", rnn_data_reorder_t);
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md) {
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md) {
             using namespace format_tag;
             using namespace status;
             const memory_desc_wrapper id(src_md), od(dst_md);
@@ -320,8 +320,8 @@ struct rnn_weights_reorder_s8_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("rnn_weights_reorder_s8", rnn_weights_reorder_s8_t);
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine) {
             status_t status
                     = cpu_reorder_pd_t::init(engine, src_engine, dst_engine);
             if (status != status::success) return status;
@@ -339,10 +339,10 @@ struct rnn_weights_reorder_s8_t : public primitive_t {
         gemm_pack_f gemm_pack;
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md) {
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md) {
             using namespace format_tag;
             using namespace rnn_packed_format;
             using namespace status;
@@ -541,8 +541,8 @@ struct rnn_weights_reorder_t : public primitive_t {
 
         format_tag_t itag_;
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine) {
             status_t status
                     = cpu_reorder_pd_t::init(engine, src_engine, dst_engine);
             if (status != status::success) return status;
@@ -553,10 +553,10 @@ struct rnn_weights_reorder_t : public primitive_t {
         }
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md) {
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md) {
             using namespace format_tag;
             using namespace rnn_packed_format;
             using namespace status;
@@ -733,8 +733,8 @@ struct rnn_brgemm_weights_reorder_s8_t : public primitive_t {
         int nthr_; // To not exceed the limit in execute used for set up.
         size_t thr_scratch_comp_sz_ = 0;
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine) {
             status_t status
                     = cpu_reorder_pd_t::init(engine, src_engine, dst_engine);
             if (status != status::success) return status;
@@ -746,10 +746,10 @@ struct rnn_brgemm_weights_reorder_s8_t : public primitive_t {
         }
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md) {
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md) {
             using namespace status;
             using namespace format_tag;
             using namespace memory_extra_flags;

--- a/src/cpu/rv64/jit_rvv_1x1_convolution.hpp
+++ b/src/cpu/rv64/jit_rvv_1x1_convolution.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025 ZTE Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +42,7 @@ struct jit_rvv_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", isa_, ""),
                 jit_rvv_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             using namespace format_tag;
 

--- a/src/cpu/rv64/jit_uni_batch_normalization.hpp
+++ b/src/cpu/rv64/jit_uni_batch_normalization.hpp
@@ -1,6 +1,7 @@
 /******************************************************************************
 * Copyright 2025 ZTE Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,7 +41,7 @@ struct jit_uni_batch_normalization_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa, ""),
                 jit_uni_batch_normalization_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
 
             using namespace data_type;
@@ -151,7 +152,7 @@ struct jit_uni_batch_normalization_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa, ""),
                 jit_uni_batch_normalization_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
             using namespace data_type;
 

--- a/src/cpu/rv64/jit_uni_binary.hpp
+++ b/src/cpu/rv64/jit_uni_binary.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2025 ZTE Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,7 +65,7 @@ struct jit_uni_binary_t : public primitive_t {
         using cpu_binary_pd_t::cpu_binary_pd_t;
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_binary_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;

--- a/src/cpu/rv64/jit_uni_dwconv.hpp
+++ b/src/cpu/rv64/jit_uni_dwconv.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 SpacemiT Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@ struct jit_uni_dwconv_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit_dw:uni", jit_uni_dwconv_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
 

--- a/src/cpu/rv64/jit_uni_eltwise.cpp
+++ b/src/cpu/rv64/jit_uni_eltwise.cpp
@@ -280,7 +280,7 @@ private:
 } // namespace
 
 template <cpu_isa_t isa>
-status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     const memory_desc_wrapper src_d(src_md());
     const data_type_t d_type = src_md()->data_type;
 
@@ -369,7 +369,7 @@ status_t jit_uni_eltwise_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     // For *_use_dst_for_bwd algs the kernel reads DNNL_ARG_DST and the
     // derivative is expressed in the forward output; otherwise it reads
     // DNNL_ARG_SRC. data_md() selects the matching tensor.

--- a/src/cpu/rv64/jit_uni_eltwise.hpp
+++ b/src/cpu/rv64/jit_uni_eltwise.hpp
@@ -2,6 +2,7 @@
 * Copyright 2017 Intel Corporation
 * Copyright 2025 ZTE Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_eltwise_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_fwd_t(const pd_t *apd);
@@ -73,7 +74,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_eltwise_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_bwd_t(const pd_t *apd);

--- a/src/cpu/rv64/jit_uni_group_normalization.cpp
+++ b/src/cpu/rv64/jit_uni_group_normalization.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -505,7 +506,7 @@ jit_uni_group_normalization_fwd_t::kernel_norm_base_t::create(const pd_t *pd) {
 
 // =============================== pd::init ===============================
 
-status_t jit_uni_group_normalization_fwd_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_group_normalization_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace format_tag;
     using skip_mask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/cpu/rv64/jit_uni_group_normalization.hpp
+++ b/src/cpu/rv64/jit_uni_group_normalization.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,7 +56,7 @@ struct jit_uni_group_normalization_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa_, ""),
                 jit_uni_group_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool is_ncsp_ = true; // tag_kind: channel-first vs channel-last
         cpu_isa_t isa_ = v; // kernel isa; selects the impl-name suffix

--- a/src/cpu/rv64/jit_uni_pooling.hpp
+++ b/src/cpu/rv64/jit_uni_pooling.hpp
@@ -49,7 +49,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
                 jit_uni_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             using namespace data_type;
             using namespace prop_kind;
@@ -173,7 +173,7 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
                 jit_uni_pooling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             using namespace data_type;
 

--- a/src/cpu/rv64/jit_uni_prelu.hpp
+++ b/src/cpu/rv64/jit_uni_prelu.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 openKylin community
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -63,7 +64,7 @@ struct jit_uni_prelu_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:rvv", jit_uni_prelu_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
             using namespace dnnl::impl::data_type;
 

--- a/src/cpu/rv64/jit_uni_reduction.hpp
+++ b/src/cpu/rv64/jit_uni_reduction.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 SpacemiT Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@ struct jit_uni_reduction_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_reduction_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
 

--- a/src/cpu/rv64/reorder/jit_blk_reorder.cpp
+++ b/src/cpu/rv64/reorder/jit_blk_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2025 Intel Corporation
+* Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
 * Copyright 2022-2025 Arm Ltd. and affiliates
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
@@ -462,9 +462,9 @@ void jit_single_blk_kernel_t::emit_transpose_kernel() {
 /* ----------------------------- primitive ----------------------------- */
 
 status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     VDISPATCH_REORDER_IC(impl::is_dense_format_kind({src_md, dst_md}),
             VERBOSE_UNSUPPORTED_SPARSE_CFG);
     auto prb = tr::prb_t();

--- a/src/cpu/rv64/reorder/jit_blk_reorder.hpp
+++ b/src/cpu/rv64/reorder/jit_blk_reorder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2025 Intel Corporation
+* Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
 * Copyright 2022-2025 Arm Ltd. and affiliates
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
@@ -81,10 +81,10 @@ struct jit_blk_reorder_t : public primitive_t {
         tr::prb_t prb_;
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         // Put the 4/8/16/32 block node first.
         static void prb_tile_normalize(tr::prb_t &p);

--- a/src/cpu/rv64/reorder/jit_uni_reorder.cpp
+++ b/src/cpu/rv64/reorder/jit_uni_reorder.cpp
@@ -162,8 +162,8 @@ bool is_heavy_tail_byte_plain_blocked_16c_reorder(
 
 } // namespace
 
-status_t jit_uni_reorder_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t jit_uni_reorder_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
     CHECK(cpu_reorder_pd_t::init(engine, src_engine, dst_engine));
 
     CHECK(init_scratchpad());
@@ -207,9 +207,9 @@ status_t jit_uni_reorder_t::pd_t::init_scratchpad() {
 }
 
 status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     VDISPATCH_REORDER_IC(impl::is_dense_format_kind({src_md, dst_md}),
             VERBOSE_UNSUPPORTED_SPARSE_CFG);
 

--- a/src/cpu/rv64/reorder/jit_uni_reorder.hpp
+++ b/src/cpu/rv64/reorder/jit_uni_reorder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2025 Intel Corporation
+* Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
 * Copyright 2022-2025 Arm Ltd. and affiliates
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
@@ -48,15 +48,15 @@ struct jit_uni_reorder_t : public primitive_t {
         bool with_groups_ = false;
         dim_t D_mask_ = 0;
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
     private:
         status_t init_scratchpad();
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         friend dnnl::impl::impl_list_item_t;
     };

--- a/src/cpu/rv64/rvv_brgemm_conv.cpp
+++ b/src/cpu/rv64/rvv_brgemm_conv.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 ZTE Corporation
+* Copyright 2026 Intel Corporation
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +34,7 @@ using namespace dnnl::impl::status;
 using namespace dnnl::impl::utils;
 using namespace data_type;
 
-status_t rvv_brgemm_convolution_fwd_t::pd_t::init(engine_t *engine) {
+status_t rvv_brgemm_convolution_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
 
     // Drive the impl name by input dtype (set before any rejection below).

--- a/src/cpu/rv64/rvv_brgemm_conv.hpp
+++ b/src/cpu/rv64/rvv_brgemm_conv.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 ZTE Corporation
+* Copyright 2026 Intel Corporation
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +44,7 @@ struct rvv_brgemm_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgemm:", isa_, ""),
                 rvv_brgemm_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         // ISA that drives the impl name: v (f32), zvfh (f16), or zvfbfwma
         // (bf16). Set in init() before any dtype/ISA rejection.

--- a/src/cpu/rv64/rvv_brgemm_inner_product.cpp
+++ b/src/cpu/rv64/rvv_brgemm_inner_product.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 ZTE Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,7 +36,7 @@ using namespace dnnl::impl::utils;
 using namespace data_type;
 using namespace format_tag;
 
-status_t rvv_brgemm_inner_product_fwd_t::pd_t::init(engine_t *engine) {
+status_t rvv_brgemm_inner_product_fwd_t::pd_t::init(const engine_t *engine) {
     VDISPATCH_INNER_PRODUCT(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
 
     VDISPATCH_INNER_PRODUCT(is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/rv64/rvv_brgemm_inner_product.hpp
+++ b/src/cpu/rv64/rvv_brgemm_inner_product.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 ZTE Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +42,7 @@ struct rvv_brgemm_inner_product_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgemm:", isa_, ""),
                 rvv_brgemm_inner_product_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         // ISA that drives the impl name: v (f32), zvfh (f16), or zvfbfwma
         // (bf16). Set in init() before any dtype/ISA rejection.

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 ZTE Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -189,7 +190,7 @@ private:
     int input_typesize_;
 };
 
-status_t rvv_brgemm_matmul_t::pd_t::init(engine_t *engine) {
+status_t rvv_brgemm_matmul_t::pd_t::init(const engine_t *engine) {
     using smask_t = primitive_attr_t::skip_mask_t;
 
     VDISPATCH_MATMUL(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);

--- a/src/cpu/rv64/rvv_brgemm_matmul.hpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 ZTE Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,7 +47,7 @@ struct rvv_brgemm_matmul_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("brgemm:", isa_, ""), rvv_brgemm_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<brgemm_kernel_t> brg_kernel_;
         std::shared_ptr<jit_pack_a_tile_t> pack_kernel_;

--- a/src/cpu/rv64/rvv_gemm_convolution.hpp
+++ b/src/cpu/rv64/rvv_gemm_convolution.hpp
@@ -45,7 +45,7 @@ struct riscv_gemm_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T("gemm:rvv", riscv_gemm_convolution_fwd_t,
                 USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             // The GEMM path is JIT-emitted (rvv_gemm_f32); on the rv64gc

--- a/src/cpu/rv64/rvv_gemm_inner_product.hpp
+++ b/src/cpu/rv64/rvv_gemm_inner_product.hpp
@@ -1,5 +1,6 @@
 /******************************************************************************
  * Copyright 2025 ZTE Corporation
+ * Copyright 2026 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +41,7 @@ struct rvv_gemm_inner_product_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("gemm:rvv", rvv_gemm_inner_product_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;

--- a/src/cpu/rv64/rvv_inner_product.hpp
+++ b/src/cpu/rv64/rvv_inner_product.hpp
@@ -1,5 +1,6 @@
 /******************************************************************************
  * Copyright 2025 ZTE Corporation
+ * Copyright 2026 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +41,7 @@ struct rvv_inner_product_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:rvv", rvv_inner_product_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
 
             // V is not part of the RV64 baseline and the JIT kernel emits vector

--- a/src/cpu/rv64/rvv_layer_normalization.hpp
+++ b/src/cpu/rv64/rvv_layer_normalization.hpp
@@ -44,7 +44,7 @@ struct rvv_layer_normalization_fwd_t : public primitive_t {
         // verbose impl name (jit_lnorm:rvv vs jit_lnorm:rvv_zvfh).
         cpu_isa_t isa_ = v;
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper src_d(src_md());

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -41,7 +41,7 @@ struct rvv_matmul_t : public primitive_t {
         // converts it inside the JIT kernel before adding to the s32 acc.
         static constexpr data_type_t bias_d_type = data_type::f32;
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
             using smask_t = primitive_attr_t::skip_mask_t;
             using namespace data_type;

--- a/src/cpu/rv64/rvv_softmax.hpp
+++ b/src/cpu/rv64/rvv_softmax.hpp
@@ -1,5 +1,6 @@
 /******************************************************************************
 * Copyright 2025 ZTE Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@ struct rvv_softmax_fwd_t : public primitive_t {
         // f32 uses isa v, f16 uses Zvfh (vfwcvt/vfncvt); drives the impl name.
         cpu_isa_t isa_ = v;
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             UNUSED(engine);
 
             VDISPATCH_SOFTMAX(set_default_formats() == status::success,

--- a/src/cpu/rv64/rvv_winograd_convolution.hpp
+++ b/src/cpu/rv64/rvv_winograd_convolution.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2026 ZTE Corporation
+* Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -145,7 +146,7 @@ struct rvv_wino_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "wino:rvv", rvv_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);

--- a/src/cpu/simple_concat.hpp
+++ b/src/cpu/simple_concat.hpp
@@ -37,7 +37,7 @@ struct simple_concat_t : public primitive_t {
 
         DECLARE_CONCAT_PD_T("simple:any", simple_concat_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             const memory_desc_wrapper dst_d(dst_md());
             VDISPATCH_CONCAT(platform::has_data_type_support(data_type),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/cpu/simple_layer_normalization.cpp
+++ b/src/cpu/simple_layer_normalization.cpp
@@ -35,7 +35,7 @@ namespace cpu {
 using namespace memory_tracking::names;
 using namespace data_type;
 
-status_t simple_layer_normalization_fwd_t::pd_t::init(engine_t *engine) {
+status_t simple_layer_normalization_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using skip_mask_t = primitive_attr_t::skip_mask_t;
     const memory_desc_wrapper src_d(src_md());
@@ -250,7 +250,7 @@ status_t simple_layer_normalization_fwd_t::execute_forward(
     return status::success;
 }
 
-status_t simple_layer_normalization_bwd_t::pd_t::init(engine_t *engine) {
+status_t simple_layer_normalization_bwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     const memory_desc_wrapper src_d(src_md());
 

--- a/src/cpu/simple_layer_normalization.hpp
+++ b/src/cpu/simple_layer_normalization.hpp
@@ -42,7 +42,7 @@ struct simple_layer_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple:any", simple_layer_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool use_tmp_stats() const { return reorder_pd_ || stats_are_tmp(); }
 
@@ -165,7 +165,7 @@ struct simple_layer_normalization_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple:any", simple_layer_normalization_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool use_tmp_stats() const { return reorder_pd_.get(); }
 

--- a/src/cpu/simple_resampling.hpp
+++ b/src/cpu/simple_resampling.hpp
@@ -82,7 +82,7 @@ struct simple_resampling_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple:any", simple_resampling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
@@ -149,7 +149,7 @@ struct simple_resampling_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("simple:any", simple_resampling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
             VDISPATCH_RESAMPLING(!is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/simple_sum.hpp
+++ b/src/cpu/simple_sum.hpp
@@ -42,7 +42,7 @@ struct simple_sum_t : public primitive_t {
 
         DECLARE_SUM_PD_T("simple:any", simple_sum_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             const int n = n_inputs();
 
             VDISPATCH_SUM(platform::has_data_type_support(src_data_type),

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -42,7 +42,7 @@ struct gemm_bf16_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_bf16_convolution_fwd_t,
                 USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace dnnl::impl::data_type;
 
             VDISPATCH_CONV(
@@ -246,7 +246,7 @@ struct gemm_bf16_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_bf16_convolution_bwd_data_t,
                 USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace dnnl::impl::data_type;
 
             VDISPATCH_CONV(
@@ -309,7 +309,7 @@ struct gemm_bf16_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_bf16_convolution_bwd_weights_t,
                 USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace dnnl::impl::data_type;
 
             VDISPATCH_CONV(

--- a/src/cpu/x64/gemm_bf16_inner_product.hpp
+++ b/src/cpu/x64/gemm_bf16_inner_product.hpp
@@ -46,7 +46,7 @@ struct gemm_bf16_inner_product_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_bf16_inner_product_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             using namespace data_type;
 
@@ -159,7 +159,7 @@ struct gemm_bf16_inner_product_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(GEMM_IMPL_STR, gemm_bf16_inner_product_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_INNER_PRODUCT(
                     DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
@@ -233,7 +233,7 @@ struct gemm_bf16_inner_product_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 GEMM_IMPL_STR, gemm_bf16_inner_product_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             using namespace data_type;
             VDISPATCH_INNER_PRODUCT(

--- a/src/cpu/x64/ip_convolution.cpp
+++ b/src/cpu/x64/ip_convolution.cpp
@@ -140,7 +140,7 @@ status_t set_and_or_check_formats(const convolution_desc_t &desc,
 
 } // anonymous namespace
 
-status_t ip_convolution_fwd_t::pd_t::init(engine_t *engine) {
+status_t ip_convolution_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace format_tag;
     using smask_t = primitive_attr_t::skip_mask_t;
 
@@ -197,7 +197,7 @@ status_t ip_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
     return ip_p_->execute(conv_ctx);
 }
 
-status_t ip_convolution_bwd_data_t::pd_t::init(engine_t *engine) {
+status_t ip_convolution_bwd_data_t::pd_t::init(const engine_t *engine) {
     using namespace format_tag;
 
     VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_data,
@@ -253,7 +253,7 @@ status_t ip_convolution_bwd_data_t::execute(const exec_ctx_t &ctx) const {
     return ip_p_->execute(conv_ctx);
 }
 
-status_t ip_convolution_bwd_weights_t::pd_t::init(engine_t *engine) {
+status_t ip_convolution_bwd_weights_t::pd_t::init(const engine_t *engine) {
     using namespace format_tag;
 
     VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_weights,

--- a/src/cpu/x64/ip_convolution.hpp
+++ b/src/cpu/x64/ip_convolution.hpp
@@ -43,7 +43,7 @@ struct ip_convolution_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), ip_convolution_fwd_t);
 
-        status_t init_ip(engine_t *engine) {
+        status_t init_ip(const engine_t *engine) {
             inner_product_desc_t ipd;
             CHECK(ip_desc_create(&ipd));
             primitive_desc_iterator_t it(
@@ -69,7 +69,7 @@ struct ip_convolution_fwd_t : public primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> ip_pd_;
 
@@ -117,7 +117,7 @@ struct ip_convolution_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), ip_convolution_bwd_data_t);
 
-        status_t init_ip(engine_t *engine) {
+        status_t init_ip(const engine_t *engine) {
             inner_product_desc_t ipd;
             CHECK(ip_desc_create(&ipd));
             primitive_desc_iterator_t it(
@@ -142,7 +142,7 @@ struct ip_convolution_bwd_data_t : public primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> ip_pd_;
 
@@ -189,7 +189,7 @@ struct ip_convolution_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), ip_convolution_bwd_weights_t);
 
-        status_t init_ip(engine_t *engine) {
+        status_t init_ip(const engine_t *engine) {
             inner_product_desc_t ipd;
             CHECK(ip_desc_create(&ipd));
             primitive_desc_iterator_t it(
@@ -214,7 +214,7 @@ struct ip_convolution_bwd_weights_t : public primitive_t {
             }
             return status::unimplemented;
         }
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> ip_pd_;
 

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -51,7 +51,7 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", jcp_.isa, ""),
                 jit_avx2_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(expect_data_types(f32, f32, f32, f32, f32),
@@ -184,7 +184,7 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t depthwise_po_init(engine_t *engine) {
+        status_t depthwise_po_init(const engine_t *engine) {
 
             using namespace memory_tracking;
             auto &jcp_1x1 = jcp_;
@@ -373,7 +373,7 @@ struct jit_avx2_1x1_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", avx2, ""),
                 jit_avx2_1x1_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_data,
@@ -475,7 +475,7 @@ struct jit_avx2_1x1_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", avx2, ""),
                 jit_avx2_1x1_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_weights,

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -40,7 +40,7 @@ struct jit_avx2_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jcp_.isa, ""),
                 jit_avx2_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -137,7 +137,7 @@ struct jit_avx2_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", avx2, ""),
                 jit_avx2_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_data,
@@ -225,7 +225,7 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", avx2, ""),
                 jit_avx2_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_weights,

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -52,7 +52,7 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", avx512_core, ""),
                 jit_avx512_common_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(expect_data_types(src_type, wei_type, dst_type,
@@ -174,7 +174,7 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t depthwise_po_init(engine_t *engine) {
+        status_t depthwise_po_init(const engine_t *engine) {
 
             using namespace memory_tracking;
             auto &jcp_1x1 = jcp_;
@@ -369,7 +369,7 @@ struct jit_avx512_common_1x1_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", avx512_core, ""),
                 jit_avx512_common_1x1_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_data,
                     VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(
@@ -479,7 +479,7 @@ struct jit_avx512_common_1x1_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", avx512_core, ""),
                 jit_avx512_common_1x1_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_weights,
                     VERBOSE_BAD_PROPKIND);

--- a/src/cpu/x64/jit_avx512_common_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.hpp
@@ -44,7 +44,7 @@ struct jit_avx512_common_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", avx512_core, ""),
                 jit_avx512_common_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(expect_data_types(src_type, wei_type, dst_type,
                                    dst_type, data_type::undef),
@@ -120,7 +120,7 @@ struct jit_avx512_common_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", avx512_core, ""),
                 jit_avx512_common_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_data,
                     VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(
@@ -193,7 +193,7 @@ struct jit_avx512_common_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", avx512_core, ""),
                 jit_avx512_common_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_weights,
                     VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
@@ -38,7 +38,7 @@ struct jit_avx512_core_amx_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", jcp_.isa, ""),
                 jit_avx512_core_amx_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             bool is_bf16_convolution

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -44,7 +44,7 @@ struct jit_avx512_core_amx_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jcp_.isa, ""),
                 jit_avx512_core_amx_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             bool is_bf16_convolution
@@ -132,7 +132,7 @@ struct jit_avx512_core_amx_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jcp_.isa, ""),
                 jit_avx512_core_amx_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             const data_type_t wdt = weights_md_.data_type;
             bool is_xf16_convolution
                     = utils::one_of(wdt, data_type::bf16, data_type::f16)
@@ -200,7 +200,7 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jcp_.isa, ""),
                 jit_avx512_core_amx_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(is_bwd_w(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(

--- a/src/cpu/x64/jit_avx512_core_amx_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_deconvolution.hpp
@@ -41,7 +41,7 @@ struct jit_avx512_core_amx_deconvolution_fwd_t : public primitive_t {
                 JIT_IMPL_NAME_HELPER("jit_deconvolution:", jcp_.isa, ""),
                 jit_avx512_core_amx_deconvolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             bool is_bf16_deconvolution = true

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -51,7 +51,7 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_bf16_1x1:", jcp_.isa, ""),
                 jit_avx512_core_bf16_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             // Disabling verbose dispatch messages for unsupported isa for
             // better readability.
@@ -205,7 +205,7 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t depthwise_po_init(engine_t *engine) {
+        status_t depthwise_po_init(const engine_t *engine) {
             using namespace memory_tracking;
             auto &jcp_1x1 = jcp_;
             jit_conv_conf_t *jcp_dw = nullptr;
@@ -377,7 +377,7 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_bf16_1x1:", jcp_.isa, ""),
                 jit_avx512_core_bf16_1x1_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             // disabling verbose dispatch messages for unsupported isa for better readability
             if (!mayiuse(avx512_core)) return status::unimplemented;
@@ -489,7 +489,7 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_bf16_1x1:", jcp_.isa, ""),
                 jit_avx512_core_bf16_1x1_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::cpu);

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
@@ -42,7 +42,7 @@ struct jit_avx512_core_bf16_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_bf16:", jcp_.isa, ""),
                 jit_avx512_core_bf16_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             // disabling verbose dispatch messages for unsupported isa for better readability
             if (!mayiuse(avx512_core)) return status::unimplemented;
@@ -126,7 +126,7 @@ struct jit_avx512_core_bf16_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_bf16:", jcp_.isa, ""),
                 jit_avx512_core_bf16_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             // disabling verbose dispatch messages for unsupported isa for better readability
@@ -193,7 +193,7 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_bf16:", jcp_.isa, ""),
                 jit_avx512_core_bf16_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             // disabling verbose dispatch messages for unsupported isa for better readability
             if (!mayiuse(avx512_core)) return status::unimplemented;

--- a/src/cpu/x64/jit_avx512_core_resampling.cpp
+++ b/src/cpu/x64/jit_avx512_core_resampling.cpp
@@ -817,7 +817,7 @@ data_type_t jit_avx512_core_resampling_kernel_base_t::dst_data_type() const {
         return pd_->diff_src_md()->data_type;
 }
 
-status_t jit_avx512_core_resampling_bwd_t::pd_t::init(engine_t *engine) {
+status_t jit_avx512_core_resampling_bwd_t::pd_t::init(const engine_t *engine) {
     using namespace format_tag;
     using namespace data_type;
     // disabling verbose dispatch messages for unsupported isa for

--- a/src/cpu/x64/jit_avx512_core_resampling.hpp
+++ b/src/cpu/x64/jit_avx512_core_resampling.hpp
@@ -51,7 +51,7 @@ struct jit_avx512_core_resampling_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", avx512_core, ""),
                 jit_avx512_core_resampling_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_avx512_core_resampling_bwd_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -50,7 +50,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                         ((jcp_.has_vnni) ? avx512_core_vnni : avx512_core), ""),
                 jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -185,7 +185,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t depthwise_po_init(engine_t *engine) {
+        status_t depthwise_po_init(const engine_t *engine) {
             using namespace memory_tracking;
             auto &jcp_1x1 = jcp_;
             primitive_attr_t attr_1x1(*attr());

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_deconvolution.hpp
@@ -47,7 +47,7 @@ struct jit_avx512_core_x8s8s32x_1x1_deconvolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(name_.c_str(),
                 jit_avx512_core_x8s8s32x_1x1_deconvolution_fwd_t);
 
-        status_t init_convolution(engine_t *engine) {
+        status_t init_convolution(const engine_t *engine) {
             convolution_desc_t cd;
 
             auto dd = desc();
@@ -72,7 +72,7 @@ struct jit_avx512_core_x8s8s32x_1x1_deconvolution_fwd_t : public primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
             VDISPATCH_DECONVOLUTION(is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
@@ -38,7 +38,7 @@ struct jit_avx512_core_x8s8s32x_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_int8:", jcp_.isa, ""),
                 jit_avx512_core_x8s8s32x_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -257,7 +257,7 @@ struct jit_avx512_core_x8s8s32x_deconvolution_fwd_t : public primitive_t {
                         ((jcp_.has_vnni) ? avx512_core_vnni : avx512_core), ""),
                 jit_avx512_core_x8s8s32x_deconvolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
             VDISPATCH_DECONVOLUTION(is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -107,7 +107,7 @@ cpu_isa_t get_supported_isa(bool is_f32, bool is_int8, bool is_bf16,
     return isa_undef;
 }
 
-status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
+status_t brdgmm_dw_convolution_fwd_t::pd_t::init(const engine_t *engine) {
 
     using skip_mask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/cpu/x64/jit_brdgmm_dw_conv.hpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.hpp
@@ -37,7 +37,7 @@ struct brdgmm_dw_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brdgmm_dw:", jcp_.isa, ""),
                 brdgmm_dw_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         jit_brdgmm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
         std::vector<brgemm_desc_t> bcps_;
         std::vector<brgemm_batch_element_t> batches_;

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -42,7 +42,7 @@ using namespace data_type;
     ((ndims == 5) ? (v5) : (ndims == 4) ? (v4) : (ndims == 3) ? (v3) : 0)
 
 template <cpu_isa_t isa>
-status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
 

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -50,7 +50,7 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgconv_1x1:", isa, ""),
                 brgemm_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         struct brgemm_init_params_t {
             brgemm_init_params_t(int k_accum_idx, int m, int n, int k,

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -340,7 +340,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
     brgemm_descriptors_

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -57,7 +57,7 @@ struct brgemm_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brg_conv_fwd:", isa, ""),
                 brgemm_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         int brgs_sz_ {};
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t>

--- a/src/cpu/x64/jit_brgemm_conv_bwd.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd.cpp
@@ -101,7 +101,7 @@ status_t fwd_conv_desc_create(
 } // namespace
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_bwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_convolution_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd.hpp
@@ -41,7 +41,7 @@ struct brgemm_convolution_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), brgemm_convolution_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> fwd_pd_;
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -67,7 +67,8 @@ static bool impl_supports_datatype(data_type_t data_type) {
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(
+        const engine_t *engine) {
     using namespace data_type;
 
     const auto diff_src_type = diff_src_md(0)->data_type;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
@@ -48,7 +48,7 @@ struct brgemm_convolution_bwd_strided_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgconv_strided:", isa, ""),
                 brgemm_convolution_bwd_strided_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         int brgs_sz_ {};
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t> brgs_;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -39,7 +39,7 @@ using namespace data_type;
     (pd()->with_groups() ? (d).blk_off((g), __VA_ARGS__) \
                          : (d).blk_off(__VA_ARGS__))
 
-status_t brgemm_convolution_bwd_weights_t::pd_t::init(engine_t *engine) {
+status_t brgemm_convolution_bwd_weights_t::pd_t::init(const engine_t *engine) {
     const auto src_type = src_md(0)->data_type;
     const auto diff_wei_type = diff_weights_md(0)->data_type;
     const auto diff_bia_type = diff_weights_md(1)->data_type;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
@@ -53,7 +53,7 @@ struct brgemm_convolution_bwd_weights_t : public primitive_t {
                 JIT_IMPL_NAME_HELPER("brgconv_bwd_w:", jcp_.isa, ""),
                 brgemm_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
         jit_conv_conf_t jit_jcp_;

--- a/src/cpu/x64/jit_brgemm_deconv.cpp
+++ b/src/cpu/x64/jit_brgemm_deconv.cpp
@@ -151,7 +151,7 @@ status_t check_embedded_impl_init(primitive_desc_iterator_t &it) {
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
     using namespace format_tag;

--- a/src/cpu/x64/jit_brgemm_deconv.hpp
+++ b/src/cpu/x64/jit_brgemm_deconv.hpp
@@ -48,7 +48,7 @@ struct brgemm_deconvolution_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), brgemm_deconvolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool post_ops_ok() const {
             return attr()->post_ops_.find(primitive_kind::convolution) == -1;

--- a/src/cpu/x64/jit_sse41_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.hpp
@@ -48,7 +48,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", sse41, ""),
                 jit_sse41_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(expect_data_types(f32, f32, f32, f32, f32),
@@ -155,7 +155,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t depthwise_po_init(engine_t *engine) {
+        status_t depthwise_po_init(const engine_t *engine) {
 
             using namespace memory_tracking;
             auto &jcp_1x1 = jcp_;

--- a/src/cpu/x64/jit_sse41_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_convolution.hpp
@@ -39,7 +39,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", sse41, ""),
                 jit_sse41_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(expect_data_types(f32, f32, f32, f32, f32),

--- a/src/cpu/x64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.cpp
@@ -2333,7 +2333,8 @@ using namespace utils;
 /* fwd */
 
 template <cpu_isa_t isa>
-status_t jit_uni_batch_normalization_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_batch_normalization_fwd_t<isa>::pd_t::init(
+        const engine_t *engine) {
     VDISPATCH_BNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
 
     // disabling verbose dispatch checks for unsupported isa for better readability
@@ -2473,7 +2474,8 @@ jit_uni_batch_normalization_fwd_t<isa>::~jit_uni_batch_normalization_fwd_t() {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_batch_normalization_bwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_batch_normalization_bwd_t<isa>::pd_t::init(
+        const engine_t *engine) {
     VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
 
     // disabling verbose dispatch checks for unsupported isa for better readability

--- a/src/cpu/x64/jit_uni_batch_normalization.hpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.hpp
@@ -58,7 +58,7 @@ struct jit_uni_batch_normalization_fwd_t : public primitive_t {
                         ""),
                 jit_uni_batch_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         int nthr_; // To not exceed the limit in execute used for set up.
     };
 
@@ -94,7 +94,7 @@ struct jit_uni_batch_normalization_bwd_t : public primitive_t {
                         ""),
                 jit_uni_batch_normalization_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         int nthr_; // To not exceed the limit in execute used for set up.
     };
 

--- a/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
@@ -697,7 +697,7 @@ using namespace utils;
 
 template <cpu_isa_t isa>
 status_t jit_uni_batch_normalization_s8_fwd_t<isa>::pd_t::init(
-        engine_t *engine) {
+        const engine_t *engine) {
     auto desired_fmt_tag = (ndims() == 4) ? nhwc : ndhwc;
 
     // disabling verbose dispatch checks for unsupported isa for better readability

--- a/src/cpu/x64/jit_uni_batch_normalization_s8.hpp
+++ b/src/cpu/x64/jit_uni_batch_normalization_s8.hpp
@@ -46,7 +46,7 @@ struct jit_uni_batch_normalization_s8_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("bnorm_s8_jit:", isa, ""),
                 jit_uni_batch_normalization_s8_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     using data_t = int8_t;

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -111,7 +111,7 @@ static bool data_format_supported(
             || (is_superset(isa, sse41) && blk_size == 4);
 }
 
-status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
     using sm = primitive_attr_t::skip_mask_t;
 
     conf_.dst_type = dst_md()->data_type;

--- a/src/cpu/x64/jit_uni_binary.hpp
+++ b/src/cpu/x64/jit_uni_binary.hpp
@@ -38,7 +38,7 @@ struct jit_uni_binary_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_binary_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         jit_binary_conf_t get_conf() const { return conf_; }
 

--- a/src/cpu/x64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.hpp
@@ -47,7 +47,7 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
                 jit_uni_dw_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_CONV(expect_data_types(src_type, src_type,
@@ -123,7 +123,7 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
                 jit_uni_dw_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_data,
                     VERBOSE_BAD_PROPKIND);
@@ -198,7 +198,7 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
                 jit_uni_dw_convolution_bwd_weights);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             VDISPATCH_CONV(desc()->prop_kind == prop_kind::backward_weights,
                     VERBOSE_BAD_PROPKIND);

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -278,7 +278,7 @@ private:
 } // namespace
 
 template <cpu_isa_t isa>
-status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace alg_kind;
     using namespace data_type;
 
@@ -368,7 +368,7 @@ status_t jit_uni_eltwise_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace alg_kind;
     using namespace data_type;
 

--- a/src/cpu/x64/jit_uni_eltwise.hpp
+++ b/src/cpu/x64/jit_uni_eltwise.hpp
@@ -43,7 +43,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_eltwise_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_fwd_t(const pd_t *apd);
@@ -67,7 +67,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_eltwise_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_bwd_t(const pd_t *apd);

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -444,7 +444,7 @@ void jit_uni_subkernel_int_t<avx512_core>::store_8bit(const bool vectorize,
 } /* namespace */
 
 template <cpu_isa_t isa>
-status_t jit_uni_eltwise_int_fwd_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_eltwise_int_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     // disabling verbose dispatch messages for unsupported isa for better readability
     if (!mayiuse(isa)) return status::unimplemented;

--- a/src/cpu/x64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.hpp
@@ -40,7 +40,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_int8:", isa, ""),
                 jit_uni_eltwise_int_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_uni_eltwise_int_fwd_t(const pd_t *apd);

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -787,7 +787,7 @@ jit_uni_group_normalization_fwd_t::kernel_stat_base_t::create(
     }
 }
 
-status_t jit_uni_group_normalization_fwd_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_group_normalization_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace format_tag;
     using skip_mask_t = primitive_attr_t::skip_mask_t;

--- a/src/cpu/x64/jit_uni_group_normalization.hpp
+++ b/src/cpu/x64/jit_uni_group_normalization.hpp
@@ -37,7 +37,7 @@ struct jit_uni_group_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit_group:uni", jit_uni_group_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         int nthr_; // To not exceed the limit in execute used for set up.
     };

--- a/src/cpu/x64/jit_uni_i8i8_pooling.hpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.hpp
@@ -42,7 +42,7 @@ struct jit_uni_i8i8_pooling_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_int:", isa, ""),
                 jit_uni_i8i8_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace format_tag;
             // disabling verbose dispatch messages for unsupported isa for better readability
             if (!mayiuse(isa)) return status::unimplemented;

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -659,7 +659,8 @@ jit_uni_instance_normalization_fwd_t::kernel_stat_base_t::create(
     }
 }
 
-status_t jit_uni_instance_normalization_fwd_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_instance_normalization_fwd_t::pd_t::init(
+        const engine_t *engine) {
     using namespace data_type;
     using namespace format_tag;
     using skip_mask_t = primitive_attr_t::skip_mask_t;

--- a/src/cpu/x64/jit_uni_instance_normalization.hpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.hpp
@@ -38,7 +38,7 @@ struct jit_uni_instance_normalization_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "jit_instance:uni", jit_uni_instance_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         int nthr_; // To not exceed the limit in execute used for set up.
     };

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -1214,7 +1214,7 @@ diff_data_kernel_t *diff_data_kernel_t::create(
         return nullptr;
     }
 }
-status_t jit_uni_layer_normalization_fwd_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_layer_normalization_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using skip_mask_t = primitive_attr_t::skip_mask_t;
     const memory_desc_wrapper src_d(src_md());

--- a/src/cpu/x64/jit_uni_layer_normalization.hpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.hpp
@@ -93,7 +93,7 @@ struct jit_uni_layer_normalization_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_layer_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         bool use_tmp_stats() const { return reorder_pd_ || stats_are_tmp(); }
 
@@ -217,7 +217,7 @@ struct jit_uni_layer_normalization_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_layer_normalization_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const memory_desc_wrapper src_d(src_md());
 

--- a/src/cpu/x64/jit_uni_ncsp_convolution.cpp
+++ b/src/cpu/x64/jit_uni_ncsp_convolution.cpp
@@ -126,7 +126,7 @@ bool reduction_helper_t::is_gemm() {
 }
 
 status_t jit_uni_ncsp_convolution_fwd_t::pd_t::init_convolution(
-        engine_t *engine) {
+        const engine_t *engine) {
     format_tag_t nspc_tag = get_axb_tag(ndims());
     nspc_src_md_ = *src_md();
     nspc_dst_md_ = *dst_md();
@@ -171,7 +171,8 @@ status_t jit_uni_ncsp_convolution_fwd_t::pd_t::init_convolution(
     return status::success;
 }
 
-status_t jit_uni_ncsp_convolution_fwd_t::pd_t::init_matmul(engine_t *engine) {
+status_t jit_uni_ncsp_convolution_fwd_t::pd_t::init_matmul(
+        const engine_t *engine) {
     CHECK(reduction_helper_.reshape_activations(
             &matmul_dst_md_, dst_md(0), true));
 
@@ -211,7 +212,7 @@ status_t jit_uni_ncsp_convolution_fwd_t::pd_t::init_matmul(engine_t *engine) {
     return status::success;
 }
 
-status_t jit_uni_ncsp_convolution_fwd_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_ncsp_convolution_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
 
@@ -389,7 +390,8 @@ status_t jit_uni_ncsp_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
     return status::runtime_error;
 }
 
-status_t jit_uni_ncsp_convolution_bwd_weights_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_ncsp_convolution_bwd_weights_t::pd_t::init(
+        const engine_t *engine) {
     VDISPATCH_CONV(attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_CONV(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
     VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
@@ -419,7 +421,7 @@ status_t jit_uni_ncsp_convolution_bwd_weights_t::pd_t::init(engine_t *engine) {
 }
 
 status_t jit_uni_ncsp_convolution_bwd_weights_t::pd_t::init_convolution(
-        engine_t *engine) {
+        const engine_t *engine) {
     format_tag_t nspc_tag = get_axb_tag(ndims());
     nspc_src_md_ = *src_md();
     nspc_diff_dst_md_ = *diff_dst_md();
@@ -548,7 +550,8 @@ status_t jit_uni_ncsp_convolution_bwd_weights_t::execute(
     return execute_convolution(ctx);
 }
 
-status_t jit_uni_ncsp_convolution_bwd_data_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_ncsp_convolution_bwd_data_t::pd_t::init(
+        const engine_t *engine) {
     VDISPATCH_CONV(attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_CONV(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
     VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
@@ -587,7 +590,7 @@ status_t jit_uni_ncsp_convolution_bwd_data_t::pd_t::init(engine_t *engine) {
 }
 
 status_t jit_uni_ncsp_convolution_bwd_data_t::pd_t::init_convolution(
-        engine_t *engine) {
+        const engine_t *engine) {
     format_tag_t nspc_tag = get_axb_tag(ndims());
     nspc_diff_src_md_ = *diff_src_md();
     nspc_diff_dst_md_ = *diff_dst_md();
@@ -622,7 +625,7 @@ status_t jit_uni_ncsp_convolution_bwd_data_t::pd_t::init_convolution(
 }
 
 status_t jit_uni_ncsp_convolution_bwd_data_t::pd_t::init_matmul(
-        engine_t *engine) {
+        const engine_t *engine) {
     CHECK(reduction_helper_.reshape_activations(
             &matmul_wei_md_, diff_dst_md(0), true));
     // initialize diff weights to plain format.

--- a/src/cpu/x64/jit_uni_ncsp_convolution.hpp
+++ b/src/cpu/x64/jit_uni_ncsp_convolution.hpp
@@ -57,7 +57,7 @@ struct jit_uni_ncsp_convolution_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), jit_uni_ncsp_convolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> matmul_pd_;
         std::shared_ptr<primitive_desc_t> nspc_conv_pd_;
@@ -72,8 +72,8 @@ struct jit_uni_ncsp_convolution_fwd_t : public primitive_t {
         memory_desc_t nspc_dst_md_;
 
     private:
-        status_t init_convolution(engine_t *engine);
-        status_t init_matmul(engine_t *engine);
+        status_t init_convolution(const engine_t *engine);
+        status_t init_matmul(const engine_t *engine);
         reduction_helper_t reduction_helper_;
         bool is_matmul_ = false;
         std::string name_ = "jit_uni_ncsp:";
@@ -117,7 +117,7 @@ struct jit_uni_ncsp_convolution_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 name_.c_str(), jit_uni_ncsp_convolution_bwd_weights_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> nspc_conv_pd_;
         std::shared_ptr<primitive_desc_t> src_reorder_pd_;
@@ -126,7 +126,7 @@ struct jit_uni_ncsp_convolution_bwd_weights_t : public primitive_t {
         memory_desc_t nspc_diff_dst_md_;
 
     private:
-        status_t init_convolution(engine_t *engine);
+        status_t init_convolution(const engine_t *engine);
         std::string name_;
         void init_scratchpad();
         void init_name() {
@@ -161,7 +161,7 @@ struct jit_uni_ncsp_convolution_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), jit_uni_ncsp_convolution_bwd_data_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> matmul_diff_src_pd_;
         std::shared_ptr<primitive_desc_t> nspc_conv_pd_;
@@ -174,8 +174,8 @@ struct jit_uni_ncsp_convolution_bwd_data_t : public primitive_t {
         memory_desc_t matmul_dst_md_;
 
     private:
-        status_t init_convolution(engine_t *engine);
-        status_t init_matmul(engine_t *engine);
+        status_t init_convolution(const engine_t *engine);
+        status_t init_matmul(const engine_t *engine);
         reduction_helper_t reduction_helper_;
         bool is_matmul_ = false;
         std::string name_;

--- a/src/cpu/x64/jit_uni_pooling.hpp
+++ b/src/cpu/x64/jit_uni_pooling.hpp
@@ -48,7 +48,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
                 jit_uni_pooling_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
 
             VDISPATCH_POOLING(is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -124,7 +124,7 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
                 jit_uni_pooling_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace utils;
 
             VDISPATCH_POOLING(set_default_params() == status::success,

--- a/src/cpu/x64/jit_uni_reduction.cpp
+++ b/src/cpu/x64/jit_uni_reduction.cpp
@@ -49,7 +49,7 @@ static bool impl_supports_datatype(data_type_t data_type) {
     }
 }
 
-status_t jit_uni_reduction_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_reduction_t::pd_t::init(const engine_t *engine) {
     using namespace alg_kind;
     using namespace data_type;
     using namespace format_tag;

--- a/src/cpu/x64/jit_uni_reduction.hpp
+++ b/src/cpu/x64/jit_uni_reduction.hpp
@@ -38,7 +38,7 @@ struct jit_uni_reduction_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", conf_.isa, ""),
                 jit_uni_reduction_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         const jit_reduction_conf_t &get_conf() const { return conf_; }
 

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -2317,8 +2317,8 @@ static void prb_thread_kernel_balance(
     }
 }
 
-status_t jit_uni_reorder_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t jit_uni_reorder_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
     CHECK(cpu_reorder_pd_t::init(engine, src_engine, dst_engine));
 
     CHECK(init_scratchpad());
@@ -2362,9 +2362,9 @@ status_t jit_uni_reorder_t::pd_t::init_scratchpad() {
 }
 
 status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     VDISPATCH_REORDER_IC(impl::is_dense_format_kind({src_md, dst_md}),
             VERBOSE_UNSUPPORTED_SPARSE_CFG);
     auto prb = tr::prb_t();
@@ -2817,9 +2817,9 @@ status_t jit_uni_reorder_t::execute(const exec_ctx_t &ctx) const {
 }
 
 status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     VDISPATCH_REORDER_IC(impl::is_dense_format_kind({src_md, dst_md}),
             VERBOSE_UNSUPPORTED_SPARSE_CFG);
     auto prb = tr::prb_t();

--- a/src/cpu/x64/jit_uni_reorder.hpp
+++ b/src/cpu/x64/jit_uni_reorder.hpp
@@ -223,15 +223,15 @@ struct jit_uni_reorder_t : public primitive_t {
         bool with_groups_ = false;
         dim_t D_mask_ = 0;
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
     private:
         status_t init_scratchpad();
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         friend dnnl::impl::impl_list_item_t;
     };
@@ -279,10 +279,10 @@ struct jit_blk_reorder_t : public primitive_t {
         tr::prb_t prb_;
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         // Swap last two nodes, put block 4, 8, 16 nodes to first
         static void prb_tile_normalize(tr::prb_t &p);

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
@@ -243,9 +243,9 @@ private:
 };
 
 status_t jit_uni_reorder_direct_copy_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     auto _pd = make_unique_pd<pd_t>(
             attr, src_engine->kind(), src_md, dst_engine->kind(), dst_md);
     if (_pd == nullptr) return status::out_of_memory;
@@ -255,8 +255,8 @@ status_t jit_uni_reorder_direct_copy_t::pd_t::create(reorder_pd_t **reorder_pd,
     return safe_ptr_assign(*reorder_pd, _pd.release());
 }
 
-status_t jit_uni_reorder_direct_copy_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t jit_uni_reorder_direct_copy_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
     using namespace data_type;
 
     VDISPATCH_REORDER(is_dense_format_kind({src_md(), dst_md()}),

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
@@ -36,16 +36,16 @@ struct jit_uni_reorder_direct_copy_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "jit_direct_copy:uni", jit_uni_reorder_direct_copy_t);
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
         cpu_isa_t isa_;
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         friend dnnl::impl::impl_list_item_t;
     };

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -61,7 +61,7 @@ static bool impl_supports_datatype(data_type_t data_type) {
     }
 }
 
-status_t jit_uni_resampling_fwd_t::pd_t::init(engine_t *engine) {
+status_t jit_uni_resampling_fwd_t::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using sm = primitive_attr_t::skip_mask_t;
 

--- a/src/cpu/x64/jit_uni_resampling.hpp
+++ b/src/cpu/x64/jit_uni_resampling.hpp
@@ -39,7 +39,7 @@ struct jit_uni_resampling_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", conf_.isa, ""),
                 jit_uni_resampling_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         const jit_resampling_conf_t &get_conf() const { return conf_; }
 

--- a/src/cpu/x64/jit_uni_softmax.hpp
+++ b/src/cpu/x64/jit_uni_softmax.hpp
@@ -81,7 +81,7 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(impl_name(), jit_uni_softmax_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
 
@@ -289,7 +289,7 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(impl_name(), jit_uni_softmax_bwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
 
             // try multiple vlen

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -2456,7 +2456,7 @@ using namespace utils;
 /* fwd */
 template <cpu_isa_t isa>
 status_t jit_uni_tbb_batch_normalization_fwd_t<isa>::pd_t::init(
-        engine_t *engine) {
+        const engine_t *engine) {
     VDISPATCH_BNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
 
     // disabling verbose dispatch checks for unsupported isa for better readability
@@ -2592,7 +2592,7 @@ template struct jit_uni_tbb_batch_normalization_fwd_t<avx512_core>;
 /* bwd */
 template <cpu_isa_t isa>
 status_t jit_uni_tbb_batch_normalization_bwd_t<isa>::pd_t::init(
-        engine_t *engine) {
+        const engine_t *engine) {
     VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
 
     // disabling verbose dispatch checks for unsupported isa for better readability

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.hpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.hpp
@@ -56,7 +56,7 @@ struct jit_uni_tbb_batch_normalization_fwd_t : public primitive_t {
                         ""),
                 jit_uni_tbb_batch_normalization_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         jit_memory_tag_kind_t tag_kind_;
     };
@@ -93,7 +93,7 @@ struct jit_uni_tbb_batch_normalization_bwd_t : public primitive_t {
                         ""),
                 jit_uni_tbb_batch_normalization_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         jit_memory_tag_kind_t tag_kind_;
     };

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -51,7 +51,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                         isa == avx2 && jcp_.has_vnni ? avx2_vnni : isa, ""),
                 jit_uni_x8s8s32x_1x1_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 
@@ -235,7 +235,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             return weights_md_ == want_wei_md;
         }
 
-        status_t depthwise_po_init(engine_t *engine) {
+        status_t depthwise_po_init(const engine_t *engine) {
             using namespace memory_tracking;
             auto &jcp_1x1 = jcp_;
             primitive_attr_t attr_1x1(*attr());

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_deconvolution.hpp
@@ -48,7 +48,7 @@ struct jit_uni_x8s8s32x_1x1_deconvolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 name_.c_str(), jit_uni_x8s8s32x_1x1_deconvolution_fwd_t);
 
-        status_t init_convolution(engine_t *engine) {
+        status_t init_convolution(const engine_t *engine) {
             convolution_desc_t cd;
 
             auto dd = desc();
@@ -73,7 +73,7 @@ struct jit_uni_x8s8s32x_1x1_deconvolution_fwd_t : public primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
             VDISPATCH_DECONVOLUTION(is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
@@ -42,7 +42,7 @@ struct jit_uni_x8s8s32x_convolution_fwd_t : public primitive_t {
                         isa == avx2 && jcp_.has_vnni ? avx2_vnni : isa, ""),
                 jit_uni_x8s8s32x_convolution_fwd_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
             VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -1463,7 +1463,7 @@ jit_uni_x8s8s32x_deconvolution_fwd_t<
 
 template <cpu_isa_t isa>
 status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::pd_t::init(
-        engine_t *engine) {
+        const engine_t *engine) {
     using namespace data_type;
     using skip_mask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -196,7 +196,7 @@ struct jit_uni_x8s8s32x_deconvolution_fwd_t : public primitive_t {
                         isa == avx2 && jcp_.has_vnni ? avx2_vnni : isa, ""),
                 jit_uni_x8s8s32x_deconvolution_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         jit_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
     };
 

--- a/src/cpu/x64/jit_uni_xf16_sum.hpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.hpp
@@ -255,7 +255,7 @@ struct jit_xf16_sum_t : public primitive_t {
         DECLARE_SUM_PD_T(JIT_IMPL_NAME_HELPER("jit_xf16_", jsp_.isa, ""),
                 jit_xf16_sum_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
 
             unsigned int max_num_arrs;
             // disabling verbose dispatch messages for unsupported isa for

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn.cpp
@@ -34,7 +34,8 @@ using namespace dnnl::impl::utils;
 using namespace data_type;
 
 template <data_type_t d_type>
-status_t jit_avx512_common_lrn_fwd_t<d_type>::pd_t::init(engine_t *engine) {
+status_t jit_avx512_common_lrn_fwd_t<d_type>::pd_t::init(
+        const engine_t *engine) {
     using namespace prop_kind;
     using namespace alg_kind;
 
@@ -97,7 +98,8 @@ template struct jit_avx512_common_lrn_fwd_t<bf16>;
 template struct jit_avx512_common_lrn_fwd_t<f16>;
 
 template <data_type_t d_type>
-status_t jit_avx512_common_lrn_bwd_t<d_type>::pd_t::init(engine_t *engine) {
+status_t jit_avx512_common_lrn_bwd_t<d_type>::pd_t::init(
+        const engine_t *engine) {
     using namespace alg_kind;
 
     const memory_desc_wrapper src_d(src_md());

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn.hpp
@@ -48,7 +48,7 @@ struct jit_avx512_common_lrn_fwd_t : public primitive_t {
                         ""),
                 jit_avx512_common_lrn_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_avx512_common_lrn_fwd_t(const pd_t *apd);
@@ -88,7 +88,7 @@ struct jit_avx512_common_lrn_bwd_t : public primitive_t {
                         ""),
                 jit_avx512_common_lrn_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     jit_avx512_common_lrn_bwd_t(const pd_t *apd);

--- a/src/cpu/x64/lrn/jit_uni_lrn.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn.cpp
@@ -167,7 +167,7 @@ status_t jit_uni_lrn_fwd_t<isa, d_type>::execute_forward(
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_lrn_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
+status_t jit_uni_lrn_fwd_t<isa, d_type>::pd_t::init(const engine_t *engine) {
     using namespace prop_kind;
     using namespace alg_kind;
 
@@ -349,7 +349,7 @@ status_t jit_uni_lrn_bwd_t<isa, d_type>::execute_backward(
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_lrn_bwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
+status_t jit_uni_lrn_bwd_t<isa, d_type>::pd_t::init(const engine_t *engine) {
     using namespace prop_kind;
     using namespace alg_kind;
 

--- a/src/cpu/x64/lrn/jit_uni_lrn.hpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn.hpp
@@ -40,7 +40,7 @@ struct jit_uni_lrn_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_lrn_fwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         format_tag_t dat_tag_;
     };
@@ -75,7 +75,7 @@ struct jit_uni_lrn_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", isa, ""), jit_uni_lrn_bwd_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         format_tag_t dat_tag_;
     };

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -210,38 +210,46 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         return ok;
     };
 
-    auto check_attr_scales = [&]() -> bool {
+    auto check_attr_scales = [&]() -> status_t {
         const std::vector<int> supported_args
                 = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
-        bool ok = attr_scales_ok(supported_args);
+        CHECK(attr_scales_ok(engine, supported_args));
         const auto &asc = attr()->scales_;
         if (!asc.has_default_values(DNNL_ARG_SRC)
                 && !asc.has_default_values(DNNL_ARG_WEIGHTS)
                 && asc.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad
-            if (is_runtime_value(N())) ok = false;
+            VDISPATCH_MATMUL(
+                    !is_runtime_value(N()), VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
         // Impl suppports f32 scales only for non-weight decompression
         if (!(is_bf16_with_int_wei || is_f16_with_int_wei || is_f32_with_int_wei
                     || with_int8_grouped_quantization)) {
-            ok = ok && one_of(asc.get_data_type(DNNL_ARG_SRC), undef, f32);
-            ok = ok && one_of(asc.get_data_type(DNNL_ARG_WEIGHTS), undef, f32);
-            ok = ok && one_of(asc.get_data_type(DNNL_ARG_DST), undef, f32);
+            VDISPATCH_MATMUL(
+                    one_of(asc.get_data_type(DNNL_ARG_SRC), undef, f32),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_MATMUL(
+                    one_of(asc.get_data_type(DNNL_ARG_WEIGHTS), undef, f32),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_MATMUL(
+                    one_of(asc.get_data_type(DNNL_ARG_DST), undef, f32),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
         // Implementation has limited support w.r.t. scales groups.
         if (!asc.has_default_values(DNNL_ARG_WEIGHTS)) {
             if (!asc.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
                 // Only grouping over K is supported.
-                ok = ok && asc.get_group(DNNL_ARG_WEIGHTS, 1) == 1;
+                VDISPATCH_MATMUL(asc.get_group(DNNL_ARG_WEIGHTS, 1) == 1,
+                        VERBOSE_UNSUPPORTED_SCALES_CFG);
                 // masks 3 per-(k,n) and 7 per-(b,k,n) are supported
                 const int mask = asc.get_mask(DNNL_ARG_WEIGHTS);
                 const int kn_mask = wei_qmask_N() + wei_qmask_K();
                 const int batch_mask = full_tensor_mask() & ~kn_mask;
                 const bool mask_ok = (mask & ~(kn_mask | batch_mask)) == 0;
-                ok = ok && mask_ok;
+                VDISPATCH_MATMUL(mask_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
             }
         }
-        return ok;
+        return status::success;
     };
 
     auto check_attr_zero_points
@@ -320,7 +328,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                     po, dst_d),
             VERBOSE_UNSUPPORTED_POSTOP);
 
-    VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(check_attr_scales());
     VDISPATCH_MATMUL(
             check_attr_zero_points(is_bf16_with_int_wei || is_f16_with_int_wei
                             || is_f32_with_int_wei

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -135,7 +135,7 @@ int brgemm_matmul_t<isa>::pd_t::get_brg_kernel_idx(bool is_bs_tail,
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
+status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
     const auto src_dt = src_md_.data_type;
     const auto wei_dt = weights_md_.data_type;
     const auto dst_dt = dst_md_.data_type;

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -59,7 +59,7 @@ struct brgemm_matmul_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("brg_matmul:", isa, ""), brgemm_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         int get_brg_kernel_idx(bool is_bs_tail, bool do_initialization,
                 int m_ker_idx, int n_ker_idx, bool is_K_tail,
                 bool is_prefetching) const;

--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -265,8 +265,8 @@ status_t init_conf(matmul::brgemm_matmul_conf_t &conf,
     return status::success;
 }
 
-status_t brgemm_matmul_copy_reorder_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t brgemm_matmul_copy_reorder_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
     using namespace status;
 
     CHECK(cpu_reorder_pd_t::init(engine, src_engine, dst_engine));
@@ -354,9 +354,9 @@ status_t brgemm_matmul_copy_reorder_t::pd_t::init(
 }
 
 status_t brgemm_matmul_copy_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     using namespace status;
 
     VDISPATCH_REORDER_IC(impl::is_dense_format_kind({src_md, dst_md}),

--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.hpp
@@ -34,14 +34,14 @@ struct brgemm_matmul_copy_reorder_t : public primitive_t {
 
         // required to re-use brgemm matmul copy_b jit kernels
         matmul::brgemm_matmul_conf_t matmul_conf_for_reorder_;
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         void init_scratchpad() {}
         friend dnnl::impl::impl_list_item_t;

--- a/src/cpu/x64/matmul/jit_uni_sparse_matmul.hpp
+++ b/src/cpu/x64/matmul/jit_uni_sparse_matmul.hpp
@@ -41,7 +41,7 @@ struct jit_uni_sparse_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_sparse_matmul_t);
 
-        status_t init(engine_t *engine) {
+        status_t init(const engine_t *engine) {
             using namespace data_type;
             const auto src_type = src_md(0)->data_type;
             const auto wei_type = weights_md(0)->data_type;

--- a/src/cpu/x64/matmul_inner_product.cpp
+++ b/src/cpu/x64/matmul_inner_product.cpp
@@ -31,7 +31,7 @@ bool is_desired_mm_impl(const std::shared_ptr<primitive_desc_t> &matmul_pd) {
 }
 
 status_t create_matmul_pd(std::shared_ptr<primitive_desc_t> &matmul_pd,
-        engine_t *engine, const memory_desc_t *src_md,
+        const engine_t *engine, const memory_desc_t *src_md,
         const memory_desc_t *wei_md, const memory_desc_t *dst_md,
         const memory_desc_t *bia_md, const memory_desc_t *reduce_md,
         const primitive_attr_t *attr) {
@@ -160,7 +160,7 @@ int matmul_inner_product_fwd_t::pd_t::get_k_blk(format_tag_t tag) const {
 // mechanism to map inner product weights layouts to the matmul ones and
 // vice versa.
 status_t matmul_inner_product_fwd_t::pd_t::init_matmul_params(
-        engine_t *engine) {
+        const engine_t *engine) {
     using namespace format_tag;
 
     // clang-format off
@@ -317,7 +317,7 @@ status_t matmul_inner_product_fwd_t::pd_t::init_matmul_params(
 }
 
 status_t matmul_inner_product_bwd_data_t::pd_t::init_matmul_params(
-        engine_t *engine) {
+        const engine_t *engine) {
     memory_desc_t mm_src_md {};
     memory_desc_t mm_wei_md {};
     memory_desc_t mm_dst_md {};
@@ -335,7 +335,7 @@ status_t matmul_inner_product_bwd_data_t::pd_t::init_matmul_params(
 }
 
 status_t matmul_inner_product_bwd_weights_t::pd_t::init_matmul_params(
-        engine_t *engine) {
+        const engine_t *engine) {
     memory_desc_t mm_src_md {};
     memory_desc_t mm_wei_md {};
     memory_desc_t mm_dst_md {};

--- a/src/cpu/x64/matmul_inner_product.hpp
+++ b/src/cpu/x64/matmul_inner_product.hpp
@@ -33,9 +33,10 @@ namespace cpu {
 namespace x64 {
 
 status_t create_matmul_pd(std::shared_ptr<primitive_desc_t> &matmul_pd,
-        engine_t *engine, const memory_desc_t *a_md, const memory_desc_t *b_md,
-        const memory_desc_t *c_md, const memory_desc_t *ip_bia_md,
-        const memory_desc_t *reduce_md, const primitive_attr_t *attr);
+        const engine_t *engine, const memory_desc_t *a_md,
+        const memory_desc_t *b_md, const memory_desc_t *c_md,
+        const memory_desc_t *ip_bia_md, const memory_desc_t *reduce_md,
+        const primitive_attr_t *attr);
 
 status_t init_matmul_md(memory_desc_t &mm_md, const memory_desc_t &ip_md,
         format_tag_t tag, bool swap_dims = false);
@@ -51,7 +52,7 @@ struct matmul_inner_product_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T((matmul_pd_ ? matmul_pd_->name() : "matmul"),
                 matmul_inner_product_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
 
@@ -90,7 +91,7 @@ struct matmul_inner_product_fwd_t : public primitive_t {
 
     private:
         int get_k_blk(format_tag_t tag) const;
-        status_t init_matmul_params(engine_t *engine);
+        status_t init_matmul_params(const engine_t *engine);
 
         void init_scratchpad() {
             auto scratchpad = scratchpad_registry().registrar();
@@ -124,7 +125,7 @@ struct matmul_inner_product_bwd_data_t : public primitive_t {
                     diff_src_md()->data_type, diff_dst_md()->data_type);
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
 
@@ -165,7 +166,7 @@ struct matmul_inner_product_bwd_data_t : public primitive_t {
         std::shared_ptr<primitive_desc_t> matmul_pd_;
 
     private:
-        status_t init_matmul_params(engine_t *engine);
+        status_t init_matmul_params(const engine_t *engine);
         status_t set_formats() {
             return set_training_formats(&diff_src_md_, &weights_md_, nullptr,
                     &diff_dst_md_, get_prop_kind());
@@ -198,7 +199,7 @@ struct matmul_inner_product_bwd_weights_t : public primitive_t {
         DECLARE_COMMON_PD_T((matmul_pd_ ? matmul_pd_->name() : "matmul"),
                 matmul_inner_product_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
 
@@ -241,7 +242,7 @@ struct matmul_inner_product_bwd_weights_t : public primitive_t {
         std::shared_ptr<primitive_desc_t> matmul_pd_;
 
     private:
-        status_t init_matmul_params(engine_t *engine);
+        status_t init_matmul_params(const engine_t *engine);
         status_t set_formats() {
             return set_training_formats(&src_md_, &diff_weights_md_,
                     &diff_bias_md_, &diff_dst_md_, get_prop_kind());

--- a/src/cpu/x64/prelu/jit_prelu_backward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_backward.cpp
@@ -33,7 +33,7 @@ namespace x64 {
 static constexpr dim_t alignment = platform::get_cache_line_size()
         / sizeof(float); // align to cache line size to avoid false sharing
 
-status_t jit_prelu_bwd_t::pd_t::init(engine_t *engine) {
+status_t jit_prelu_bwd_t::pd_t::init(const engine_t *engine) {
     const memory_desc_wrapper src_d {src_md(0)};
     const memory_desc_wrapper weights_d {weights_md(0)};
     const memory_desc_wrapper src_diff_d {diff_src_md(0)};

--- a/src/cpu/x64/prelu/jit_prelu_backward.hpp
+++ b/src/cpu/x64/prelu/jit_prelu_backward.hpp
@@ -39,7 +39,7 @@ public:
     public:
         using cpu_prelu_bwd_pd_t::cpu_prelu_bwd_pd_t;
         DECLARE_COMMON_PD_T("jit_uni", jit_prelu_bwd_t);
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
         int nthr_; // To not exceed the limit in execute used for set up.
 
     private:

--- a/src/cpu/x64/prelu/jit_prelu_forward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_forward.cpp
@@ -30,7 +30,7 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-status_t jit_prelu_fwd_t::pd_t::init(engine_t *engine) {
+status_t jit_prelu_fwd_t::pd_t::init(const engine_t *engine) {
     const memory_desc_wrapper src_d {src_md(0)};
     const memory_desc_wrapper weights_d {weights_md(0)};
     const memory_desc_wrapper dst_d {dst_md(0)};

--- a/src/cpu/x64/prelu/jit_prelu_forward.hpp
+++ b/src/cpu/x64/prelu/jit_prelu_forward.hpp
@@ -36,7 +36,7 @@ public:
     public:
         using cpu_prelu_fwd_pd_t::cpu_prelu_fwd_pd_t;
         DECLARE_COMMON_PD_T("jit_uni", jit_prelu_fwd_t);
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
     private:
         bool bcast_supported(const memory_desc_wrapper &src_d,

--- a/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
@@ -43,7 +43,7 @@ static bool impl_supports_datatype(cpu_isa_t isa, data_type_t data_type) {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_shuffle_t<isa>::pd_t::init(engine_t *engine) {
+status_t jit_uni_shuffle_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace format_tag;
     using namespace data_type;
 

--- a/src/cpu/x64/shuffle/jit_uni_shuffle.hpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle.hpp
@@ -41,7 +41,7 @@ struct jit_uni_shuffle_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 JIT_IMPL_NAME_HELPER("jit:", conf_.isa, ""), jit_uni_shuffle_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
 
         const jit_shuffle_conf_t &get_conf() const { return conf_; }
 

--- a/src/gpu/amd/miopen_batch_normalization.hpp
+++ b/src/gpu/amd/miopen_batch_normalization.hpp
@@ -69,7 +69,7 @@ struct miopen_batch_normalization_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_batch_normalization_fwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
             using namespace types;
 
@@ -143,7 +143,7 @@ struct miopen_batch_normalization_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_batch_normalization_bwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
             using namespace types;
 

--- a/src/gpu/amd/miopen_binary.hpp
+++ b/src/gpu/amd/miopen_binary.hpp
@@ -39,7 +39,7 @@ struct miopen_binary_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_binary_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
 
             bool ok = (set_default_params() == status::success)

--- a/src/gpu/amd/miopen_convolution.hpp
+++ b/src/gpu/amd/miopen_convolution.hpp
@@ -46,7 +46,7 @@ struct miopen_convolution_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_convolution_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             using sm_t = primitive_attr_t::skip_mask_t;
@@ -105,7 +105,8 @@ struct miopen_convolution_fwd_t : public gpu::primitive_t {
             }
 
             impl_.reset(new miopen_convolution_impl_fwd_t());
-            return impl_->init(engine, this, use_temp_dst);
+            return impl_->init(
+                    const_cast<impl::engine_t *>(engine), this, use_temp_dst);
         }
 
         // MIOpen requires src, weights and dst tensors to have the same format.
@@ -278,7 +279,7 @@ struct miopen_convolution_bwd_data_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_convolution_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             bool ok = desc()->prop_kind == prop_kind::backward_data;
@@ -316,7 +317,7 @@ struct miopen_convolution_bwd_data_t : public gpu::primitive_t {
             if (!check_format()) return status::unimplemented;
 
             impl_.reset(new miopen_convolution_impl_bwd_data_t());
-            return impl_->init(engine, this);
+            return impl_->init(const_cast<impl::engine_t *>(engine), this);
         }
 
         //MIOpen supports uniform tags Only
@@ -391,7 +392,7 @@ struct miopen_convolution_bwd_weights_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_convolution_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             bool ok = desc()->prop_kind == prop_kind::backward_weights;
@@ -430,7 +431,7 @@ struct miopen_convolution_bwd_weights_t : public gpu::primitive_t {
 
             if (!check_format()) return status::unimplemented;
 
-            return impl_->init(engine, this);
+            return impl_->init(const_cast<impl::engine_t *>(engine), this);
         }
 
         //MIOpen supports uniform tags Only

--- a/src/gpu/amd/miopen_deconvolution.hpp
+++ b/src/gpu/amd/miopen_deconvolution.hpp
@@ -122,7 +122,7 @@ struct miopen_deconvolution_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_deconvolution_fwd_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
 
@@ -156,7 +156,7 @@ struct miopen_deconvolution_fwd_t : public gpu::primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
             bool ok = true && is_fwd();
             ok = ok
@@ -251,7 +251,7 @@ struct miopen_deconvolution_bwd_data_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_deconvolution_bwd_data_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             convolution_desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr = *attr();
@@ -264,7 +264,7 @@ struct miopen_deconvolution_bwd_data_t : public gpu::primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
 
             bool ok = true && desc()->prop_kind == prop_kind::backward_data
                     && (utils::everyone_is(data_type::f32,
@@ -349,7 +349,7 @@ struct miopen_deconvolution_bwd_weights_t : public gpu::primitive_t {
         DECLARE_COMMON_PD_T(
                 "hip:miopen:any", miopen_deconvolution_bwd_weights_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             convolution_desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr = *attr();
@@ -363,7 +363,7 @@ struct miopen_deconvolution_bwd_weights_t : public gpu::primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
             bool ok = true && desc()->prop_kind == prop_kind::backward_weights
                     && (utils::everyone_is(data_type::f32,

--- a/src/gpu/amd/miopen_eltwise.hpp
+++ b/src/gpu/amd/miopen_eltwise.hpp
@@ -36,7 +36,7 @@ struct miopen_eltwise_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_eltwise_fwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace alg_kind;
             bool ok = is_fwd()
                     // Supported algorithms
@@ -77,7 +77,7 @@ struct miopen_eltwise_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_eltwise_bwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace alg_kind;
             bool ok = !is_fwd()
                     // Supported algorithms

--- a/src/gpu/amd/miopen_gemm_inner_product.hpp
+++ b/src/gpu/amd/miopen_gemm_inner_product.hpp
@@ -167,7 +167,7 @@ struct miopen_gemm_inner_product_fwd_t : public miopen_inner_product_fwd_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:gemm", miopen_gemm_inner_product_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace data_type;
@@ -221,7 +221,8 @@ struct miopen_gemm_inner_product_fwd_t : public miopen_inner_product_fwd_t {
             inner_product_impl_.reset(
                     new miopen_gemm_inner_product_fwd_impl_t());
 
-            return inner_product_impl_->init(engine, this, with_eltwise,
+            return inner_product_impl_->init(
+                    const_cast<impl::engine_t *>(engine), this, with_eltwise,
                     with_eltwise, with_sum, need_reorder);
         }
 
@@ -247,7 +248,7 @@ struct miopen_gemm_inner_product_bwd_data_t
         DECLARE_COMMON_PD_T(
                 "hip:miopen:gemm", miopen_gemm_inner_product_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
@@ -279,7 +280,8 @@ struct miopen_gemm_inner_product_bwd_data_t
                     new miopen_gemm_inner_product_bwd_data_impl_t());
 
             return inner_product_impl_->init(
-                    engine, this, false, false, false, need_reorder);
+                    const_cast<impl::engine_t *>(engine), this, false, false,
+                    false, need_reorder);
         }
 
         status_t set_default_params() {
@@ -305,7 +307,7 @@ struct miopen_gemm_inner_product_bwd_weights_t
         DECLARE_COMMON_PD_T(
                 "hip:miopen:gemm", miopen_gemm_inner_product_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
@@ -338,7 +340,8 @@ struct miopen_gemm_inner_product_bwd_weights_t
             inner_product_impl_.reset(
                     new miopen_gemm_inner_product_bwd_weights_impl_t());
             return inner_product_impl_->init(
-                    engine, this, false, false, false, need_reorder);
+                    const_cast<impl::engine_t *>(engine), this, false, false,
+                    false, need_reorder);
         }
 
         status_t set_default_params() {

--- a/src/gpu/amd/miopen_lrn.hpp
+++ b/src/gpu/amd/miopen_lrn.hpp
@@ -40,7 +40,7 @@ struct miopen_lrn_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_lrn_fwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
             bool ok = is_fwd()
                     // MIOpen LRN implementation within channel supports only 2D spatial.
@@ -102,7 +102,7 @@ struct miopen_lrn_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_lrn_bwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
             bool ok = !is_fwd()
                     // MIOpen LRN implementation within channel supports only 2D spatial.

--- a/src/gpu/amd/miopen_matmul.hpp
+++ b/src/gpu/amd/miopen_matmul.hpp
@@ -40,7 +40,7 @@ struct miopen_matmul_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_matmul_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/gpu/amd/miopen_pooling.hpp
+++ b/src/gpu/amd/miopen_pooling.hpp
@@ -58,7 +58,7 @@ struct miopen_pooling_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_pooling_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace alg_kind;
@@ -123,7 +123,7 @@ struct miopen_pooling_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_pooling_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace alg_kind;
             using namespace format_tag;

--- a/src/gpu/amd/miopen_reduction.hpp
+++ b/src/gpu/amd/miopen_reduction.hpp
@@ -40,7 +40,7 @@ struct miopen_reduction_t : public gpu::primitive_t {
         using reduction_pd_t::reduction_pd_t;
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_reduction_t);
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const bool ok = (set_default_params() == status::success)
@@ -71,7 +71,8 @@ struct miopen_reduction_t : public gpu::primitive_t {
             auto status = reduction_impl_->init(this);
 
             if (status == status::success)
-                reduction_impl_->create_and_set_workspace(this, engine);
+                reduction_impl_->create_and_set_workspace(
+                        this, const_cast<impl::engine_t *>(engine));
             return status;
         }
 

--- a/src/gpu/amd/miopen_reorder.hpp
+++ b/src/gpu/amd/miopen_reorder.hpp
@@ -95,8 +95,9 @@ struct miopen_reorder_t : public gpu::primitive_t {
                     || has_zero_dims(dst_md()->dims, dst_md()->ndims);
         }
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::scales
                     | primitive_attr_t::skip_mask_t::post_ops;
             const bool ok = true && (engine == dst_engine)
@@ -115,9 +116,9 @@ struct miopen_reorder_t : public gpu::primitive_t {
 
     private:
         static status_t create(reorder_pd_t **reorder_pd,
-                impl::engine_t *engine, const primitive_attr_t *attr,
-                impl::engine_t *src_engine, const memory_desc_t *src_md,
-                impl::engine_t *dst_engine, const memory_desc_t *dst_md) {
+                const impl::engine_t *engine, const primitive_attr_t *attr,
+                const impl::engine_t *src_engine, const memory_desc_t *src_md,
+                const impl::engine_t *dst_engine, const memory_desc_t *dst_md) {
             auto _pd = make_unique_pd<pd_t>(attr, src_engine->kind(), src_md,
                     dst_engine->kind(), dst_md);
             if (_pd == nullptr) return status::out_of_memory;

--- a/src/gpu/amd/miopen_softmax.hpp
+++ b/src/gpu/amd/miopen_softmax.hpp
@@ -41,7 +41,7 @@ struct miopen_softmax_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_softmax_fwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             const memory_desc_wrapper src_d(src_md());
             const memory_desc_wrapper dst_d(dst_md());
             bool ok = is_fwd()
@@ -86,7 +86,7 @@ struct miopen_softmax_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("hip:miopen:any", miopen_softmax_bwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             const memory_desc_wrapper diff_src_d(diff_src_md());
             const memory_desc_wrapper diff_dst_d(diff_dst_md());
             const memory_desc_wrapper dst_d(dst_md());

--- a/src/gpu/generic/convolution_deconvolution.hpp
+++ b/src/gpu/generic/convolution_deconvolution.hpp
@@ -90,7 +90,7 @@ struct convolution_deconvolution_fwd_t : public gpu::primitive_t {
         using gpu_deconvolution_fwd_pd_t::gpu_deconvolution_fwd_pd_t;
 
         DECLARE_COMMON_PD_T(name_.c_str(), convolution_deconvolution_fwd_t);
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             convolution_desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr(*attr());
@@ -103,7 +103,7 @@ struct convolution_deconvolution_fwd_t : public gpu::primitive_t {
             return (conv_pd_) ? status::success : status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -254,7 +254,7 @@ struct convolution_deconvolution_bwd_data_t : public gpu::primitive_t {
         DECLARE_COMMON_PD_T(
                 name_.c_str(), convolution_deconvolution_bwd_data_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             convolution_desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr(*attr());
@@ -266,7 +266,7 @@ struct convolution_deconvolution_bwd_data_t : public gpu::primitive_t {
             return (conv_pd_) ? status::success : status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             VDISPATCH_DECONVOLUTION(
                     desc()->prop_kind == prop_kind::backward_data,
                     VERBOSE_BAD_PROPKIND);

--- a/src/gpu/generic/cross_engine_reorder.cpp
+++ b/src/gpu/generic/cross_engine_reorder.cpp
@@ -27,10 +27,11 @@ namespace impl {
 namespace gpu {
 namespace generic {
 
-void cross_engine_reorder_t::pd_t::init_scratchpad(impl::engine_t *gpu_engine) {
+void cross_engine_reorder_t::pd_t::init_scratchpad(
+        const impl::engine_t *gpu_engine) {
     if (do_reorder_) {
         using namespace memory_tracking::names;
-        auto gpu_align = utils::downcast<gpu::engine_t *>(gpu_engine)
+        auto gpu_align = utils::downcast<const gpu::engine_t *>(gpu_engine)
                                  ->get_buffer_alignment();
         auto scratchpad = scratchpad_registry().registrar();
         auto needs_dst = desc()->src_engine_kind == reorder_engine_kind_;
@@ -41,8 +42,8 @@ void cross_engine_reorder_t::pd_t::init_scratchpad(impl::engine_t *gpu_engine) {
     }
 }
 
-status_t cross_engine_reorder_t::pd_t::init(impl::engine_t *engine,
-        impl::engine_t *src_engine, impl::engine_t *dst_engine) {
+status_t cross_engine_reorder_t::pd_t::init(const impl::engine_t *engine,
+        const impl::engine_t *src_engine, const impl::engine_t *dst_engine) {
     VDISPATCH_REORDER(src_engine != dst_engine, VERBOSE_BAD_ENGINE_KIND);
     VDISPATCH_REORDER(utils::one_of(engine_kind::gpu, src_engine->kind(),
                               dst_engine->kind()),
@@ -66,7 +67,7 @@ status_t cross_engine_reorder_t::pd_t::init(impl::engine_t *engine,
             || sum_quant.with_scale() || sum_quant.with_zp();
     do_reorder_ = with_sum_ab || src_mdw != dst_mdw;
 
-    impl::engine_t *reorder_engine
+    const impl::engine_t *reorder_engine
             = src_engine->kind() == engine_kind::gpu ? src_engine : dst_engine;
 
     primitive_attr_t r_attr(*attr());

--- a/src/gpu/generic/cross_engine_reorder.hpp
+++ b/src/gpu/generic/cross_engine_reorder.hpp
@@ -45,15 +45,16 @@ struct cross_engine_reorder_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:cross_engine::any", cross_engine_reorder_t);
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine);
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine);
 
         std::shared_ptr<primitive_desc_t> reorder_pd_;
         engine_kind_t reorder_engine_kind_ = engine_kind::gpu;
         bool do_reorder_ = true;
 
     private:
-        void init_scratchpad(impl::engine_t *engine);
+        void init_scratchpad(const impl::engine_t *engine);
         DECLARE_GPU_REORDER_CREATE();
     };
 

--- a/src/gpu/generic/direct_copy.hpp
+++ b/src/gpu/generic/direct_copy.hpp
@@ -33,8 +33,9 @@ struct direct_copy_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("gpu:direct_copy", direct_copy_t);
 
-        status_t init(impl::engine_t *engine, impl::engine_t * /*src_engine*/,
-                impl::engine_t * /*dst_engine*/) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t * /*src_engine*/,
+                const impl::engine_t * /*dst_engine*/) {
             VDISPATCH_REORDER(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_REORDER(

--- a/src/gpu/generic/ref_concat.hpp
+++ b/src/gpu/generic/ref_concat.hpp
@@ -37,7 +37,7 @@ struct ref_concat_t : public gpu::primitive_t {
 
         DECLARE_CONCAT_PD_T("ref:any", ref_concat_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
 
             VDISPATCH_CONCAT(attr()->has_default_values(sm::scales),
@@ -91,8 +91,9 @@ struct ref_concat_t : public gpu::primitive_t {
         memory_desc_t tent_dst_md_;
 
     private:
-        void init_scratchpad(impl::engine_t *engine) {
-            auto *gpu_engine = utils::downcast<gpu::engine_t *>(engine);
+        void init_scratchpad(const impl::engine_t *engine) {
+            const auto *gpu_engine
+                    = utils::downcast<const gpu::engine_t *>(engine);
             auto scratchpad = scratchpad_registry().registrar();
 
             if (use_tent_dst()) {

--- a/src/gpu/generic/ref_sum.hpp
+++ b/src/gpu/generic/ref_sum.hpp
@@ -44,7 +44,7 @@ struct ref_sum_t : public gpu::primitive_t {
 
         DECLARE_SUM_PD_T("ref:any", ref_sum_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             VDISPATCH_SUM_SC(
                     gpu_sum_pd_t::init(engine), VERBOSE_BAD_ENGINE_KIND);
 
@@ -85,10 +85,11 @@ struct ref_sum_t : public gpu::primitive_t {
         memory_desc_t scale_md_;
 
     private:
-        void init_scratchpad(impl::engine_t *engine) {
+        void init_scratchpad(const impl::engine_t *engine) {
             using namespace memory_tracking::names;
             auto scratchpad = scratchpad_registry().registrar();
-            auto *gpu_engine = utils::downcast<gpu::engine_t *>(engine);
+            const auto *gpu_engine
+                    = utils::downcast<const gpu::engine_t *>(engine);
             if (need_output_reorder()) {
                 const memory_desc_wrapper dst_acc_d(dst_acc_md());
                 scratchpad.book(key_sum_reduction, dst_acc_d.size(), 1,

--- a/src/gpu/generic/ref_sum_many_inputs.cpp
+++ b/src/gpu/generic/ref_sum_many_inputs.cpp
@@ -14,28 +14,19 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "gpu/generic/sycl/ref_sum_many_inputs.hpp"
-#include "common/primitive_desc_iface.hpp"
+#include "gpu/generic/ref_sum_many_inputs.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace gpu {
 namespace generic {
-namespace sycl {
-
-status_t ref_sum_many_inputs_t::pd_t::init_conf() {
-    conf_ = sycl_sum_conf_t();
-    conf_.n = n_inputs();
-
-    return status::success;
-}
 
 status_t ref_sum_many_inputs_t::init(engine_t *engine) {
     const size_t n = pd()->base_pds_.size();
     base_prims_.resize(n);
     for (size_t i = 0; i < n; ++i) {
-        CHECK(pd()->base_pds_[i]->impl()->create_primitive(
-                base_prims_[i], engine, cache_blob()));
+        CHECK(create_nested_primitive(
+                base_prims_[i], pd()->base_pds_[i], engine));
     }
 
     return status::success;
@@ -45,13 +36,13 @@ status_t ref_sum_many_inputs_t::execute(const exec_ctx_t &ctx) const {
     memory_arg_t dst_mem_arg = {ctx.args().at(DNNL_ARG_DST).mem(), false};
     memory_arg_t dst_read_mem_arg = {ctx.args().at(DNNL_ARG_DST).mem(), true};
 
-    int n_remaining = pd()->conf_.n;
+    int n_remaining = pd()->n_inputs();
     int in_arg_offset = 0;
     int i = 0;
 
     while (n_remaining > 0) {
         bool pass_in_dst = i > 0;
-        int max_n_child_inputs = DNNL_REF_SUM_MAX_NUM_TENSORS - pass_in_dst;
+        int max_n_child_inputs = pd_t::max_num_tensors - pass_in_dst;
         int args_handled = std::min(n_remaining, max_n_child_inputs);
         exec_args_t r_args;
         r_args[DNNL_ARG_DST] = dst_mem_arg;
@@ -73,7 +64,6 @@ status_t ref_sum_many_inputs_t::execute(const exec_ctx_t &ctx) const {
     return status::success;
 }
 
-} // namespace sycl
 } // namespace generic
 } // namespace gpu
 } // namespace impl

--- a/src/gpu/generic/ref_sum_many_inputs.hpp
+++ b/src/gpu/generic/ref_sum_many_inputs.hpp
@@ -14,30 +14,29 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef GPU_GENERIC_SYCL_REF_SUM_MANY_INPUTS_HPP
-#define GPU_GENERIC_SYCL_REF_SUM_MANY_INPUTS_HPP
+#ifndef GPU_GENERIC_REF_SUM_MANY_INPUTS_HPP
+#define GPU_GENERIC_REF_SUM_MANY_INPUTS_HPP
 
 #include "common/primitive.hpp"
-#include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
-#include "gpu/generic/sycl/sycl_io_helper.hpp"
-#include "gpu/generic/sycl/sycl_post_ops.hpp"
-#include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "common/sum.hpp"
+
+#include "gpu/gpu_primitive.hpp"
 #include "gpu/gpu_sum_pd.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace gpu {
 namespace generic {
-namespace sycl {
 
-struct ref_sum_many_inputs_t : public gpu::generic::sycl::primitive_t {
-    using gpu::generic::sycl::primitive_t::primitive_t;
+struct ref_sum_many_inputs_t : public gpu::primitive_t {
+    using gpu::primitive_t::primitive_t;
 
     struct pd_t : public gpu_sum_pd_t {
         using gpu_sum_pd_t::gpu_sum_pd_t;
 
         DECLARE_SUM_PD_t("sycl:many_inputs:any", ref_sum_many_inputs_t);
+
+        static constexpr int max_num_tensors = 8;
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
@@ -49,22 +48,19 @@ struct ref_sum_many_inputs_t : public gpu::generic::sycl::primitive_t {
             VDISPATCH_SUM(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             // prevent inf recursion
-            VDISPATCH_SUM(n > DNNL_REF_SUM_MAX_NUM_TENSORS, VERBOSE_BAD_PARAM,
-                    "n_inputs");
+            VDISPATCH_SUM(n > max_num_tensors, VERBOSE_BAD_PARAM, "n_inputs");
 
             // the first kernel handles up to 8 inputs and remaining ones up to 7
-            const int n_kernels = n == 1
-                    ? 1
-                    : utils::div_up(n - 1, DNNL_REF_SUM_MAX_NUM_TENSORS - 1);
+            const int n_kernels
+                    = n == 1 ? 1 : utils::div_up(n - 1, max_num_tensors - 1);
             base_pds_.resize(n_kernels);
             int in_arg_offset = 0;
             int n_remaining = n;
             for (auto i = 0; i < n_kernels; ++i) {
                 bool pass_in_dst = i > 0;
-                int max_n_child_inputs
-                        = DNNL_REF_SUM_MAX_NUM_TENSORS - pass_in_dst;
+                int max_n_child_inputs = max_num_tensors - pass_in_dst;
                 int n_child_inputs = std::min(n_remaining, max_n_child_inputs);
-                const memory_desc_t *src[DNNL_REF_SUM_MAX_NUM_TENSORS];
+                const memory_desc_t *src[max_num_tensors];
                 if (pass_in_dst) { src[0] = dst_md(); }
                 for (int j = 0; j < n_child_inputs; j++) {
                     src[j + pass_in_dst] = src_md(j + in_arg_offset);
@@ -73,16 +69,15 @@ struct ref_sum_many_inputs_t : public gpu::generic::sycl::primitive_t {
                 n_remaining -= n_child_inputs;
 
                 primitive_attr_t r_attr;
-                CHECK(dnnl_sum_primitive_desc_create(&base_pds_[i], engine,
-                        dst_md(), n_child_inputs + pass_in_dst, scales(), src,
-                        &r_attr));
+                CHECK(sum_primitive_desc_create(base_pds_[i], dst_md(),
+                        n_child_inputs + pass_in_dst, scales(), src, &r_attr,
+                        engine));
             }
 
-            return init_conf();
+            return status::success;
         }
 
-        sycl_sum_conf_t conf_;
-        std::vector<primitive_desc_iface_t *> base_pds_;
+        std::vector<std::shared_ptr<primitive_desc_t>> base_pds_;
 
     private:
         status_t init_conf();
@@ -96,7 +91,6 @@ private:
     std::vector<std::shared_ptr<impl::primitive_t>> base_prims_;
 };
 
-} // namespace sycl
 } // namespace generic
 } // namespace gpu
 } // namespace impl

--- a/src/gpu/generic/ref_sum_many_inputs.hpp
+++ b/src/gpu/generic/ref_sum_many_inputs.hpp
@@ -38,7 +38,7 @@ struct ref_sum_many_inputs_t : public gpu::primitive_t {
 
         static constexpr int max_num_tensors = 8;
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper dst_d(dst_md());

--- a/src/gpu/generic/shuffle_by_reorder.hpp
+++ b/src/gpu/generic/shuffle_by_reorder.hpp
@@ -39,7 +39,7 @@ struct shuffle_by_reorder_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("reorder-based:any", shuffle_by_reorder_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             const auto &md_src = is_fwd() ? src_md() : diff_src_md();
             const auto &md_dst = is_fwd() ? dst_md() : diff_dst_md();
             const memory_desc_wrapper src_d(md_src);

--- a/src/gpu/generic/sycl/ref_batch_normalization.hpp
+++ b/src/gpu/generic/sycl/ref_batch_normalization.hpp
@@ -42,7 +42,7 @@ struct ref_batch_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
                 gpu_batch_normalization_fwd_pd_t;
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_batch_normalization_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper data_d(src_md(0));
@@ -106,7 +106,7 @@ struct ref_batch_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_batch_normalization_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper data_d(src_md(0));

--- a/src/gpu/generic/sycl/ref_binary.hpp
+++ b/src/gpu/generic/sycl/ref_binary.hpp
@@ -40,7 +40,7 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_binary_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -82,7 +82,7 @@ struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_convolution_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -162,7 +162,7 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_convolution_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -243,7 +243,7 @@ struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_convolution_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper data_d(src_md());

--- a/src/gpu/generic/sycl/ref_deconvolution.hpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.hpp
@@ -42,7 +42,7 @@ struct ref_deconvolution_bwd_weights_t
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_deconvolution_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper data_d(src_md());

--- a/src/gpu/generic/sycl/ref_eltwise.hpp
+++ b/src/gpu/generic/sycl/ref_eltwise.hpp
@@ -38,7 +38,7 @@ struct ref_sycl_eltwise_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_eltwise_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
 
             const memory_desc_wrapper src_d(src_md());
@@ -103,7 +103,7 @@ struct ref_sycl_eltwise_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_eltwise_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper diff_src_d(diff_src_md());

--- a/src/gpu/generic/sycl/ref_group_normalization.cpp
+++ b/src/gpu/generic/sycl/ref_group_normalization.cpp
@@ -18,7 +18,8 @@
 #include "gpu/generic/sycl/ref_group_normalization.hpp"
 
 namespace dnnl::impl::gpu::generic::sycl {
-status_t ref_group_normalization_fwd_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_group_normalization_fwd_t::pd_t::init(
+        const impl::engine_t *engine) {
     using namespace data_type;
     VDISPATCH_GNORM(set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
     VDISPATCH_GNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -113,7 +114,8 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
     return status::success;
 }
 
-status_t ref_group_normalization_bwd_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_group_normalization_bwd_t::pd_t::init(
+        const impl::engine_t *engine) {
     using namespace data_type;
     // TODO: remove me
     VDISPATCH_GNORM(

--- a/src/gpu/generic/sycl/ref_group_normalization.hpp
+++ b/src/gpu/generic/sycl/ref_group_normalization.hpp
@@ -35,7 +35,7 @@ struct ref_group_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
         using group_normalization_fwd_pd_t::group_normalization_fwd_pd_t;
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_group_normalization_fwd_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         ::sycl::nd_range<2> launch_range;
         sycl_group_norm_conf_t conf_;
@@ -59,7 +59,7 @@ struct ref_group_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
         using group_normalization_bwd_pd_t ::group_normalization_bwd_pd_t;
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_group_normalization_bwd_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         ::sycl::nd_range<1> launch_range;
         sycl_gnorm_bwd_conf_t conf_;

--- a/src/gpu/generic/sycl/ref_inner_product.cpp
+++ b/src/gpu/generic/sycl/ref_inner_product.cpp
@@ -23,7 +23,7 @@ namespace detail {
 
 // TODO: this seems like a function generic enough to go a common utils file.
 status_t get_primitive_descriptor(op_desc_t *op_desc,
-        const primitive_attr_t *attributes, impl::engine_t *engine,
+        const primitive_attr_t *attributes, const impl::engine_t *engine,
         std::shared_ptr<primitive_desc_t> &pd) {
 
     primitive_desc_iterator_t it(engine, op_desc, attributes, nullptr);
@@ -40,7 +40,7 @@ status_t get_primitive_descriptor(op_desc_t *op_desc,
     return status::out_of_memory;
 }
 
-status_t init_matmul_pd(impl::engine_t *engine,
+status_t init_matmul_pd(const impl::engine_t *engine,
         const primitive_attr_t *attributes, const memory_desc_t *src_desc,
         const memory_desc_t *weights_desc, const memory_desc_t *bias_desc,
         const memory_desc_t *dst_desc,
@@ -55,8 +55,8 @@ status_t init_matmul_pd(impl::engine_t *engine,
     return status::success;
 }
 
-status_t init_reorder_pd(impl::engine_t *engine, const memory_desc_t *src_md,
-        const memory_desc_t *dst_md,
+status_t init_reorder_pd(const impl::engine_t *engine,
+        const memory_desc_t *src_md, const memory_desc_t *dst_md,
         std::shared_ptr<primitive_desc_t> &reorder_pd) {
     // This will always be a gpu-gpu copy in our case.
     CHECK(reorder_primitive_desc_create(reorder_pd, engine, src_md, dst_md));
@@ -146,7 +146,7 @@ bool ref_inner_product_bwd_weights_t::pd_t::check_bwd_weights_dtypes(
 }
 
 status_t ref_inner_product_bwd_weights_t::pd_t::init_reduction_pd(
-        impl::engine_t *engine, const memory_desc_t *src_desc,
+        const impl::engine_t *engine, const memory_desc_t *src_desc,
         const memory_desc_t *dest_desc) {
     reduction_desc_t reduction_descriptor;
     //diff_bias is 1D, diff_dst will be 2D, reshape diff_bias to 1xOC
@@ -162,7 +162,7 @@ status_t ref_inner_product_bwd_weights_t::pd_t::init_reduction_pd(
     return status::success;
 }
 
-status_t ref_inner_product_fwd_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_inner_product_fwd_t::pd_t::init(const impl::engine_t *engine) {
 
     const bool ok = (set_default_params() == status::success);
     VDISPATCH_INNER_PRODUCT(ok, VERBOSE_UNSUPPORTED_TAG);
@@ -318,7 +318,8 @@ status_t ref_inner_product_fwd_t::pd_t::init(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t ref_inner_product_bwd_data_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_inner_product_bwd_data_t::pd_t::init(
+        const impl::engine_t *engine) {
 
     bool ok = (set_default_params() == status::success)
             && attr()->has_default_values();
@@ -445,7 +446,8 @@ status_t ref_inner_product_bwd_data_t::pd_t::init(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t ref_inner_product_bwd_weights_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_inner_product_bwd_weights_t::pd_t::init(
+        const impl::engine_t *engine) {
 
     bool ok = (set_default_params() == status::success);
     VDISPATCH_INNER_PRODUCT(ok, VERBOSE_UNSUPPORTED_TAG);

--- a/src/gpu/generic/sycl/ref_inner_product.hpp
+++ b/src/gpu/generic/sycl/ref_inner_product.hpp
@@ -34,18 +34,18 @@
 namespace dnnl::impl::gpu::generic::sycl {
 
 namespace detail {
-status_t init_matmul_pd(impl::engine_t *engine,
+status_t init_matmul_pd(const impl::engine_t *engine,
         const primitive_attr_t *attributes, const memory_desc_t *src_desc,
         const memory_desc_t *weights_desc, const memory_desc_t *bias_desc,
         const memory_desc_t *dst_desc,
         std::shared_ptr<primitive_desc_t> &matmul_pd);
 
-status_t init_reorder_pd(impl::engine_t *engine, const memory_desc_t *src_md,
-        const memory_desc_t *dst_md,
+status_t init_reorder_pd(const impl::engine_t *engine,
+        const memory_desc_t *src_md, const memory_desc_t *dst_md,
         std::shared_ptr<primitive_desc_t> &reorder_pd);
 
 status_t get_primitive_descriptor(op_desc_t *op_desc,
-        const primitive_attr_t *attributes, impl::engine_t *engine,
+        const primitive_attr_t *attributes, const impl::engine_t *engine,
         std::shared_ptr<primitive_desc_t> &pd);
 
 std::vector<int> get_dim_order(int ndims, const dims_t strides);
@@ -65,7 +65,7 @@ struct ref_inner_product_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_inner_product_fwd_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> matmul_pd;
         std::shared_ptr<primitive_desc_t> src_reorder_pd;
@@ -99,7 +99,7 @@ struct ref_inner_product_bwd_data_t : public gpu::generic::sycl::primitive_t {
         using gpu_inner_product_bwd_data_pd_t::gpu_inner_product_bwd_data_pd_t;
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_inner_product_bwd_data_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> matmul_pd;
         std::shared_ptr<primitive_desc_t> dst_reorder_pd;
@@ -134,7 +134,7 @@ struct ref_inner_product_bwd_weights_t
                 gpu_inner_product_bwd_weights_pd_t;
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_inner_product_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<primitive_desc_t> matmul_pd;
         std::shared_ptr<primitive_desc_t> reduction_pd;
@@ -150,7 +150,7 @@ struct ref_inner_product_bwd_weights_t
                 const data_type_t &dst_dt, const data_type_t &weight_dt,
                 const data_type_t &bias_dt) const;
 
-        status_t init_reduction_pd(impl::engine_t *engine,
+        status_t init_reduction_pd(const impl::engine_t *engine,
                 const memory_desc_t *src_desc, const memory_desc_t *dest_desc);
     };
 

--- a/src/gpu/generic/sycl/ref_layer_normalizations.hpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.hpp
@@ -42,7 +42,7 @@ struct ref_layer_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_layer_normalization_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -115,7 +115,7 @@ struct ref_layer_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_layer_normalization_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper data_d(src_md(0));

--- a/src/gpu/generic/sycl/ref_lrn.hpp
+++ b/src/gpu/generic/sycl/ref_lrn.hpp
@@ -36,7 +36,7 @@ struct ref_sycl_lrn_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_lrn_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
 
@@ -90,7 +90,7 @@ struct ref_sycl_lrn_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_lrn_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
 

--- a/src/gpu/generic/sycl/ref_matmul.hpp
+++ b/src/gpu/generic/sycl/ref_matmul.hpp
@@ -60,9 +60,7 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
                     attr()->has_default_values(sm::post_ops | sm::dropout
                             | sm::scales_data_type | sm::zero_points_data_type),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_MATMUL(IMPLICATION(!attr()->scales_.has_default_values(),
-                                     scales_ok()),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(scales_ok(engine));
             VDISPATCH_MATMUL(sycl_post_ops_t::post_ops_ok(attr()),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_MATMUL(md_dims_in_range(src_md()),
@@ -120,20 +118,22 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
             return status::success;
         }
 
-        bool scales_ok() const {
+        status_t scales_ok(impl::engine_t *engine) const {
             const std::vector<int> supported_args
                     = {DNNL_ARG_SRC_0, DNNL_ARG_WEIGHTS_0, DNNL_ARG_DST};
 
             const auto &scales = attr()->scales_;
-            bool dt_ok = true;
             for (auto arg : supported_args) {
                 if (!scales.get(arg).has_default_values()) {
-                    dt_ok = dt_ok
-                            && is_supported_type(scales.get_data_type(arg))
-                            && !scales.get(arg).is_host_scalar();
+                    VDISPATCH_MATMUL(
+                            is_supported_type(scales.get_data_type(arg)),
+                            VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    VDISPATCH_MATMUL(!scales.get(arg).is_host_scalar(),
+                            VERBOSE_UNSUPPORTED_SCALES_CFG);
                 }
             }
-            return dt_ok && attr_scales_ok(supported_args);
+            CHECK(attr_scales_ok(engine, supported_args));
+            return status::success;
         }
 
         static bool check_data_types(const memory_desc_wrapper &src,

--- a/src/gpu/generic/sycl/ref_matmul.hpp
+++ b/src/gpu/generic/sycl/ref_matmul.hpp
@@ -40,7 +40,7 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_matmul_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -118,7 +118,7 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
             return status::success;
         }
 
-        status_t scales_ok(impl::engine_t *engine) const {
+        status_t scales_ok(const impl::engine_t *engine) const {
             const std::vector<int> supported_args
                     = {DNNL_ARG_SRC_0, DNNL_ARG_WEIGHTS_0, DNNL_ARG_DST};
 

--- a/src/gpu/generic/sycl/ref_pooling.hpp
+++ b/src/gpu/generic/sycl/ref_pooling.hpp
@@ -42,7 +42,7 @@ struct ref_pooling_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_pooling_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace alg_kind;
@@ -106,7 +106,7 @@ struct ref_pooling_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_pooling_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper diff_dst_d(diff_dst_md(0));

--- a/src/gpu/generic/sycl/ref_prelu.cpp
+++ b/src/gpu/generic/sycl/ref_prelu.cpp
@@ -72,7 +72,7 @@ status_t ref_prelu_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     });
 }
 
-status_t ref_prelu_bwd_t::pd_t::init_reduction(impl::engine_t *engine) {
+status_t ref_prelu_bwd_t::pd_t::init_reduction(const impl::engine_t *engine) {
     if (reduce_diff_weights_) {
         reduction_desc_t rdesc;
         scratch_md_ = memory_desc_t(*src_md(0));

--- a/src/gpu/generic/sycl/ref_prelu.hpp
+++ b/src/gpu/generic/sycl/ref_prelu.hpp
@@ -44,7 +44,7 @@ struct ref_prelu_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_prelu_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper data_d(src_md(0));
@@ -101,7 +101,7 @@ struct ref_prelu_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_prelu_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             const memory_desc_wrapper data_d(src_md(0));
             const memory_desc_wrapper weights_d(weights_md(0));
@@ -138,7 +138,7 @@ struct ref_prelu_bwd_t : public gpu::generic::sycl::primitive_t {
         }
 
         status_t init_conf();
-        status_t init_reduction(impl::engine_t *engine);
+        status_t init_reduction(const impl::engine_t *engine);
         void init_scratchpad();
 
         static bool check_data_types(const memory_desc_wrapper &src,

--- a/src/gpu/generic/sycl/ref_reduction.cpp
+++ b/src/gpu/generic/sycl/ref_reduction.cpp
@@ -85,7 +85,7 @@ status_t ref_reduction_t::pd_t::init_out_scratchpad() {
     return status::success;
 }
 
-status_t ref_reduction_t::pd_t::init_reorder(impl::engine_t *engine) {
+status_t ref_reduction_t::pd_t::init_reorder(const impl::engine_t *engine) {
     reorder_src_md_ = *dst_md();
     reorder_src_md_.data_type = data_type::f32;
     CHECK(reorder_primitive_desc_create(
@@ -149,7 +149,7 @@ std::vector<int> ref_reduction_t::pd_t::get_first_two_out_sizes(
     return result;
 }
 
-status_t ref_reduction_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_reduction_t::pd_t::init_conf(const impl::engine_t *engine) {
     auto *sycl_engine = utils::downcast<const impl::xpu::sycl::engine_impl_t *>(
             engine->impl());
     const ::sycl::device &sycl_device = sycl_engine->device();

--- a/src/gpu/generic/sycl/ref_reduction.hpp
+++ b/src/gpu/generic/sycl/ref_reduction.hpp
@@ -51,7 +51,7 @@ struct ref_reduction_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_reduction_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
 
             memory_desc_wrapper src_wrap(src_md());
@@ -110,8 +110,8 @@ struct ref_reduction_t : public gpu::generic::sycl::primitive_t {
                 const std::vector<int> &axes, int reduce_size);
         status_t init_scratchpad();
         status_t init_out_scratchpad();
-        status_t init_reorder(impl::engine_t *engine);
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_reorder(const impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
     };
 
     status_t init(impl::engine_t *engine) override;

--- a/src/gpu/generic/sycl/ref_reorder.hpp
+++ b/src/gpu/generic/sycl/ref_reorder.hpp
@@ -39,8 +39,9 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_reorder_t);
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 

--- a/src/gpu/generic/sycl/ref_resampling.hpp
+++ b/src/gpu/generic/sycl/ref_resampling.hpp
@@ -40,7 +40,7 @@ struct ref_resampling_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_resampling_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace alg_kind;
             using sm = primitive_attr_t::skip_mask_t;
@@ -91,7 +91,7 @@ struct ref_resampling_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_resampling_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const memory_desc_wrapper diff_dst_d(diff_dst_md(0));

--- a/src/gpu/generic/sycl/ref_shuffle.hpp
+++ b/src/gpu/generic/sycl/ref_shuffle.hpp
@@ -40,7 +40,7 @@ struct ref_shuffle_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_shuffle_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
             auto src_data_md = invariant_src_md();

--- a/src/gpu/generic/sycl/ref_softmax.hpp
+++ b/src/gpu/generic/sycl/ref_softmax.hpp
@@ -36,7 +36,7 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_softmax_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
 
             VDISPATCH_SOFTMAX(is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -102,7 +102,7 @@ struct ref_sycl_softmax_bwd_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_sycl_softmax_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             VDISPATCH_SOFTMAX(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_SOFTMAX(

--- a/src/gpu/generic/sycl/ref_sum.hpp
+++ b/src/gpu/generic/sycl/ref_sum.hpp
@@ -39,7 +39,7 @@ struct ref_sum_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_SUM_PD_T("sycl:ref:any", ref_sum_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
 
             const memory_desc_wrapper dst_d(dst_md());

--- a/src/gpu/generic/sycl/rnn/ref_rnn.cpp
+++ b/src/gpu/generic/sycl/rnn/ref_rnn.cpp
@@ -141,7 +141,7 @@ status_t ref_rnn_bwd_t::pd_t::set_default_params() {
 // The inputs of create_matmul_pd describe a matmul in column major.
 // Below, we have to transpose the a and b descriptor to describe
 // the matmul as a row major problem.
-status_t create_matmul_pd(impl::engine_t *engine,
+status_t create_matmul_pd(const impl::engine_t *engine,
         std::shared_ptr<primitive_desc_t> &matmul_pd, dim_t m, dim_t n, dim_t k,
         std::pair<dim_t, dim_t> a_strides, std::pair<dim_t, dim_t> b_strides,
         std::pair<dim_t, dim_t> c_strides, data_type_t a_dt, data_type_t b_dt,
@@ -168,7 +168,7 @@ status_t create_matmul_pd(impl::engine_t *engine,
             matmul_pd, engine, &a_md, &b_md, nullptr, &c_md, &attr);
 }
 
-status_t ref_rnn_fwd_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_rnn_fwd_t::pd_t::init(const impl::engine_t *engine) {
     using namespace prop_kind;
     using namespace utils;
     using namespace rnn_utils;
@@ -342,7 +342,7 @@ status_t ref_rnn_fwd_t::pd_t::init(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t ref_rnn_bwd_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_rnn_bwd_t::pd_t::init(const impl::engine_t *engine) {
     using namespace prop_kind;
     using namespace utils;
     using namespace rnn_utils;

--- a/src/gpu/generic/sycl/rnn/ref_rnn.hpp
+++ b/src/gpu/generic/sycl/rnn/ref_rnn.hpp
@@ -178,7 +178,7 @@ struct ref_rnn_fwd_t : ref_rnn_common_base_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_rnn_fwd_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         status_t set_default_params();
 
@@ -265,7 +265,7 @@ struct ref_rnn_bwd_t : ref_rnn_common_base_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", ref_rnn_bwd_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         status_t set_default_params();
 

--- a/src/gpu/generic/sycl/simple_reduction.hpp
+++ b/src/gpu/generic/sycl/simple_reduction.hpp
@@ -41,7 +41,7 @@ struct simple_reduction_t : public gpu::generic::sycl::primitive_t {
 
         DECLARE_COMMON_PD_T("sycl:ref:any", simple_reduction_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
 
             memory_desc_wrapper src_wrap(src_md());

--- a/src/gpu/gpu_reorder_pd.cpp
+++ b/src/gpu/gpu_reorder_pd.cpp
@@ -24,7 +24,7 @@ namespace impl {
 namespace gpu {
 
 status_t gpu_reorder_pd_t::maybe_create_zp_precompute_conv_pd(
-        impl::engine_t *dst_engine) {
+        const impl::engine_t *dst_engine) {
     memory_desc_wrapper dst_mdw(dst_md());
     auto &extra = dst_mdw.extra();
     auto needs_conv = memory_extra_flags::compensation_gpu_conv_asymmetric_src;
@@ -44,7 +44,7 @@ status_t gpu_reorder_pd_t::maybe_create_zp_precompute_conv_pd(
             prop));
 
     using namespace memory_tracking::names;
-    auto gpu_align = utils::downcast<gpu::engine_t *>(dst_engine)
+    auto gpu_align = utils::downcast<const gpu::engine_t *>(dst_engine)
                              ->get_buffer_alignment();
     auto scratchpad = scratchpad_registry().registrar();
     const auto &registry = zp_precomp_conv_pd_->scratchpad_registry();

--- a/src/gpu/gpu_reorder_pd.hpp
+++ b/src/gpu/gpu_reorder_pd.hpp
@@ -75,7 +75,8 @@ protected:
                 && check_md_extra_flags_compensation_gpu(dst_md()->extra.flags);
     }
 
-    status_t maybe_create_zp_precompute_conv_pd(impl::engine_t *dst_engine);
+    status_t maybe_create_zp_precompute_conv_pd(
+            const impl::engine_t *dst_engine);
 
 public:
     status_t maybe_create_zp_precompute_conv(
@@ -96,9 +97,11 @@ private:
 
 #define DECLARE_GPU_REORDER_CREATE() \
     static status_t create(reorder_pd_t **reorder_pd, \
-            dnnl::impl::engine_t *engine, const primitive_attr_t *attr, \
-            dnnl::impl::engine_t *src_engine, const memory_desc_t *src_md, \
-            dnnl::impl::engine_t *dst_engine, const memory_desc_t *dst_md) { \
+            const dnnl::impl::engine_t *engine, const primitive_attr_t *attr, \
+            const dnnl::impl::engine_t *src_engine, \
+            const memory_desc_t *src_md, \
+            const dnnl::impl::engine_t *dst_engine, \
+            const memory_desc_t *dst_md) { \
         auto _pd = make_unique_pd<pd_t>( \
                 attr, src_engine->kind(), src_md, dst_engine->kind(), dst_md); \
         if (_pd == nullptr) return status::out_of_memory; \

--- a/src/gpu/gpu_sum_list.cpp
+++ b/src/gpu/gpu_sum_list.cpp
@@ -20,6 +20,7 @@
 #include "gpu/gpu_sum_pd.hpp"
 
 #include "gpu/generic/ref_sum.hpp"
+#include "gpu/generic/ref_sum_many_inputs.hpp"
 
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
 #include "gpu/intel/sum/many_inputs.hpp"
@@ -34,7 +35,6 @@
 
 #ifdef GENERIC_SYCL_KERNELS_ENABLED
 #include "gpu/generic/sycl/ref_sum.hpp"
-#include "gpu/generic/sycl/ref_sum_many_inputs.hpp"
 #endif
 
 namespace dnnl {
@@ -51,7 +51,7 @@ constexpr impl_list_item_t impl_list[] = REG_SUM_P({
         GPU_SUM_INSTANCE_INTEL(intel::sum::simple_t<data_type::f32>)
         GPU_SUM_INSTANCE_NVIDIA(nvidia::cudnn_ref_sum_t)
         GPU_SUM_INSTANCE_GENERIC_SYCL(generic::sycl::ref_sum_t)
-        GPU_SUM_INSTANCE_GENERIC_SYCL(generic::sycl::ref_sum_many_inputs_t)
+        GPU_SUM_INSTANCE_GENERIC(generic::ref_sum_many_inputs_t)
         GPU_SUM_INSTANCE_GENERIC(generic::ref_sum_t)
         nullptr,
 });

--- a/src/gpu/gpu_zero_points_conv.cpp
+++ b/src/gpu/gpu_zero_points_conv.cpp
@@ -26,7 +26,7 @@ namespace impl {
 namespace gpu {
 
 status_t create_zp_precompute_conv_pd(std::shared_ptr<primitive_desc_t> &retn,
-        dnnl::impl::engine_t *eng, const primitive_attr_t &attr,
+        const dnnl::impl::engine_t *eng, const primitive_attr_t &attr,
         const memory_desc_t *wei, const dim_t *idhw, const dim_t *odhw,
         const dim_t *pdhw, const dim_t *ddhw, data_type_t out_type,
         prop_kind_t prop, bool has_offset0) {

--- a/src/gpu/gpu_zero_points_conv.hpp
+++ b/src/gpu/gpu_zero_points_conv.hpp
@@ -24,7 +24,7 @@ namespace impl {
 namespace gpu {
 
 status_t create_zp_precompute_conv_pd(std::shared_ptr<primitive_desc_t> &retn,
-        dnnl::impl::engine_t *eng, const primitive_attr_t &attr,
+        const dnnl::impl::engine_t *eng, const primitive_attr_t &attr,
         const memory_desc_t *wei, const dim_t *idhw, const dim_t *odhw,
         const dim_t *pdhw, const dim_t *ddhw, data_type_t out_type,
         prop_kind_t prop, bool has_offset0 = true);

--- a/src/gpu/intel/binary/multi_po_reorder.hpp
+++ b/src/gpu/intel/binary/multi_po_reorder.hpp
@@ -37,7 +37,7 @@ struct multi_po_reorder_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("reorder+postops", multi_po_reorder_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             if (!attr()->scales_.has_default_values(DNNL_ARG_SRC_0)
                     || !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values()
                     || attr()->post_ops_.len() >= 1) {

--- a/src/gpu/intel/binary/simple.cpp
+++ b/src/gpu/intel/binary/simple.cpp
@@ -24,7 +24,7 @@ namespace gpu {
 namespace intel {
 namespace binary {
 
-status_t simple_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t simple_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper src0_d(src_md(0));
     const memory_desc_wrapper src1_d(src_md(1));
     const memory_desc_wrapper src2_d(src_md(2));
@@ -99,7 +99,7 @@ status_t simple_t::pd_t::init_conf(impl::engine_t *engine) {
         }
     }
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(dst_d.md_);
     if (conf.is_tensor_op && conf.is_dense && conf.is_same_md
             && !conf.with_binary_post_op) {

--- a/src/gpu/intel/binary/simple.hpp
+++ b/src/gpu/intel/binary/simple.hpp
@@ -34,7 +34,7 @@ struct simple_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:simple:any", simple_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -90,7 +90,7 @@ struct simple_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         bool with_scales(int position) const {

--- a/src/gpu/intel/binary/xe.cpp
+++ b/src/gpu/intel/binary/xe.cpp
@@ -59,7 +59,7 @@ bool check_broadcast(
     return true;
 }
 
-status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
     const memory_desc_wrapper src0_d(src_md(0));
     const memory_desc_wrapper src1_d(src_md(1));
@@ -112,7 +112,7 @@ status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
         }
     }
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(dst_d.md_);
 
     format_tag_t dst_tag = dst_d.matches_one_of_tag(nc, ncw, nchw, ncdhw);

--- a/src/gpu/intel/binary/xe.hpp
+++ b/src/gpu/intel/binary/xe.hpp
@@ -34,12 +34,13 @@ struct xe_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe", xe_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace format_tag;
             using sm = primitive_attr_t::skip_mask_t;
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = sm::post_ops | sm::scales;
             VDISPATCH_BINARY_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
@@ -107,7 +108,7 @@ struct xe_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 

--- a/src/gpu/intel/bnorm/lookup_table.cpp
+++ b/src/gpu/intel/bnorm/lookup_table.cpp
@@ -41,9 +41,9 @@ void maybe_override_bn_conf_params_env(params_t &conf) {
 // Gets bnorm parameters from a lookup table
 // BN_TUNING env var must be unset or zero;
 void maybe_override_bn_conf_params_table(
-        params_t &conf, impl::engine_t *engine) {
+        params_t &conf, const impl::engine_t *engine) {
     assert(!conf.bn_tuning);
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto gpu_arch = intel_engine->device_info()->gpu_arch();
     static lookup_table_t table(conf.use_stats_one_pass);
     auto *s_params = table.find(conf, gpu_arch);
@@ -53,7 +53,8 @@ void maybe_override_bn_conf_params_table(
     }
 }
 
-void maybe_override_bn_conf_params(params_t &conf, impl::engine_t *engine) {
+void maybe_override_bn_conf_params(
+        params_t &conf, const impl::engine_t *engine) {
     // Environment var BN_TUNING turns ON/OFF tuning mode
     conf.bn_tuning = getenv_int("BN_TUNING", 0);
 

--- a/src/gpu/intel/bnorm/lookup_table.hpp
+++ b/src/gpu/intel/bnorm/lookup_table.hpp
@@ -176,8 +176,9 @@ public:
 
 void maybe_override_bn_conf_params_env(params_t &conf);
 void maybe_override_bn_conf_params_table(
-        params_t &conf, impl::engine_t *engine);
-void maybe_override_bn_conf_params(params_t &conf, impl::engine_t *engine);
+        params_t &conf, const impl::engine_t *engine);
+void maybe_override_bn_conf_params(
+        params_t &conf, const impl::engine_t *engine);
 
 inline std::string getenv_str(const char *s, const std::string &def) {
     char buf[1024];

--- a/src/gpu/intel/bnorm/model.cpp
+++ b/src/gpu/intel/bnorm/model.cpp
@@ -83,8 +83,8 @@ dim_t get_nhwc_calc_stat_ic(dim_t ic, int ic_block, int sg_size) {
     return div_up(ic, ic_block) * sg_size;
 }
 
-void init_hw_params(hw_params_t &hw_params, impl::engine_t *engine) {
-    auto *intel_engine = downcast<intel::engine_t *>(engine);
+void init_hw_params(hw_params_t &hw_params, const impl::engine_t *engine) {
+    auto *intel_engine = downcast<const intel::engine_t *>(engine);
     auto &device_info = *intel_engine->device_info();
     hw_params.gpu_arch = device_info.gpu_arch();
     hw_params.eu_count = device_info.eu_count();
@@ -731,7 +731,7 @@ void dump_params(std::vector<model_params_t> &params) {
 
 status_t get_estimated_hw_utilization(model_params_t &p, nhwc_params_t &conf,
         hw_params_t &hw_params, kernel_desc_t &desc) {
-    auto *intel_engine = downcast<intel::engine_t *>(hw_params.engine);
+    auto *intel_engine = downcast<const intel::engine_t *>(hw_params.engine);
     compute::dispatch_t dry_run_dispatch // to get auto-generated lws
             = intel_engine->create_dispatch();
 

--- a/src/gpu/intel/bnorm/model.hpp
+++ b/src/gpu/intel/bnorm/model.hpp
@@ -36,7 +36,7 @@ constexpr float max_appr_ss_util = 8;
 constexpr float max_appr_thr_util = 1;
 
 struct hw_params_t {
-    impl::engine_t *engine;
+    const impl::engine_t *engine;
     compute::gpu_arch_t gpu_arch;
     int eu_count;
     int threads_per_eu;
@@ -72,7 +72,7 @@ struct model_params_t {
     int vect_size;
     std::vector<kernel_desc_t> kernel_descs;
 };
-void init_hw_params(hw_params_t &hw_params, impl::engine_t *engine);
+void init_hw_params(hw_params_t &hw_params, const impl::engine_t *engine);
 float get_used_ss_thr_utilization(hw_params_t &hw_params, int sg_size,
         const compute::range_t &gws, const compute::range_t &lws);
 std::string to_string(const kernel_kind_t &kernel);

--- a/src/gpu/intel/bnorm/nhwc.cpp
+++ b/src/gpu/intel/bnorm/nhwc.cpp
@@ -48,8 +48,8 @@ static size_t get_slm_buff_size(
 }
 // Local group size adjustment for calc_stat kernel
 static void adjust_lws_calc_kernel(int ic_block, nhwc_params_t &conf,
-        compute::dispatch_t &dispatch, impl::engine_t *engine) {
-    auto *intel_engine = downcast<intel::engine_t *>(engine);
+        compute::dispatch_t &dispatch, const impl::engine_t *engine) {
+    const auto *intel_engine = downcast<const intel::engine_t *>(engine);
     auto eu_count = intel_engine->device_info()->eu_count();
     auto max_lws = intel_engine->device_info()->max_wg_size();
     auto eus_per_ss = intel_engine->device_info()->max_eus_per_wg();
@@ -109,7 +109,7 @@ static int get_reduce_sub_group_count(
 }
 
 status_t nhwc_kernel_dispatching(kernel_kind_t kernel, nhwc_params_t &conf,
-        impl::engine_t *engine, compute::dispatch_t &dispatch) {
+        const impl::engine_t *engine, compute::dispatch_t &dispatch) {
 
     conf.stat_sp_nblocks
             = rnd_up(conf.sp, conf.stat_sp_block()) / conf.stat_sp_block();
@@ -192,7 +192,7 @@ static status_t init_conf_common(nhwc_params_t &conf, offsets_t &off,
         compute::dispatch_t &dispatch_calc_stat,
         compute::dispatch_t &dispatch_reduce_stat,
         compute::dispatch_t &dispatch, compute::dispatch_t &dispatch_reduce_aux,
-        const pd_t *pd, impl::engine_t *engine) {
+        const pd_t *pd, const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
     const memory_desc_wrapper data_mdw(
             pd->is_fwd() ? pd->src_md() : pd->diff_src_md());
@@ -205,7 +205,7 @@ static status_t init_conf_common(nhwc_params_t &conf, offsets_t &off,
     // TODO: create flags() accessor that returns the correct type
     conf.flags = (normalization_flags_t)pd->desc()->flags;
 
-    auto *intel_engine = downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = downcast<const intel::engine_t *>(engine);
     auto gpu_arch = intel_engine->device_info()->gpu_arch();
 
     // nhwc-optimized implemntation does not support ic tail processing yet
@@ -368,7 +368,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t nhwc_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t nhwc_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, dispatch_calc_stat, dispatch_reduce_stat,
             dispatch, dispatch_reduce_aux, this, engine);
 }
@@ -570,7 +570,7 @@ status_t nhwc_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t nhwc_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t nhwc_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, dispatch_calc_stat, dispatch_reduce_stat,
             dispatch, dispatch_reduce_aux, this, engine);
 }

--- a/src/gpu/intel/bnorm/nhwc.hpp
+++ b/src/gpu/intel/bnorm/nhwc.hpp
@@ -51,7 +51,7 @@ struct nhwc_params_t : public lookup_table::params_t {
 };
 
 status_t nhwc_kernel_dispatching(kernel_kind_t kernel, nhwc_params_t &conf,
-        impl::engine_t *engine, compute::dispatch_t &dispatch);
+        const impl::engine_t *engine, compute::dispatch_t &dispatch);
 
 struct nhwc_fwd_t : public primitive_t {
     using primitive_t::primitive_t;
@@ -63,9 +63,10 @@ struct nhwc_fwd_t : public primitive_t {
         const char *impl_name() const {
             return conf.use_stats_one_pass ? "ocl:nhwc:onepass" : "ocl:nhwc";
         }
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
 
@@ -112,7 +113,7 @@ struct nhwc_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 
@@ -212,8 +213,9 @@ struct nhwc_bwd_t : public primitive_t {
 
         const char *impl_name() const { return "ocl:nhwc"; }
 
-        status_t init(impl::engine_t *engine) {
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        status_t init(const impl::engine_t *engine) {
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             using namespace data_type;
 
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -254,7 +256,7 @@ struct nhwc_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 

--- a/src/gpu/intel/bnorm/nhwc_reusable.cpp
+++ b/src/gpu/intel/bnorm/nhwc_reusable.cpp
@@ -93,7 +93,7 @@ static status_t init_conf_common(nhwc_params_t &bn_conf,
         compute::dispatch_t &dispatch_calc_stat,
         compute::dispatch_t &dispatch_reduce_stat,
         compute::dispatch_t &dispatch, compute::dispatch_t &dispatch_reduce_aux,
-        const pd_t *pd, impl::engine_t *engine) {
+        const pd_t *pd, const impl::engine_t *engine) {
 
     // This implementation is temporarly unavailable by default
     // TODO: remove the guard after performance tuning
@@ -115,7 +115,7 @@ static status_t init_conf_common(nhwc_params_t &bn_conf,
     // TODO: create flags() accessor that returns the correct type
     bn_conf.flags = (normalization_flags_t)pd->desc()->flags;
 
-    auto *intel_engine = downcast<intel::engine_t *>(engine);
+    auto *intel_engine = downcast<const intel::engine_t *>(engine);
     auto gpu_arch = intel_engine->device_info()->gpu_arch();
 
     // nhwc-optimized implemntation does not support ic tail processing yet
@@ -233,7 +233,7 @@ static void init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("MAX_IC_BLOCK", cmpl_conf.max_ic_block);
 }
 
-status_t nhwc_reusable_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t nhwc_reusable_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(bn_conf, cmpl_conf, rt_conf, dispatch_calc_stat,
             dispatch_reduce_stat, dispatch, dispatch_reduce_aux, this, engine);
 }
@@ -528,7 +528,7 @@ status_t nhwc_reusable_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
             arg_list);
 }
 
-status_t nhwc_reusable_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t nhwc_reusable_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(bn_conf, cmpl_conf, rt_conf, dispatch_calc_stat,
             dispatch_reduce_stat, dispatch, dispatch_reduce_aux, this, engine);
 }

--- a/src/gpu/intel/bnorm/nhwc_reusable.hpp
+++ b/src/gpu/intel/bnorm/nhwc_reusable.hpp
@@ -110,9 +110,10 @@ struct nhwc_reusable_fwd_t : public primitive_t {
                                               : "ocl:nhwc_reusable";
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
 
@@ -159,7 +160,7 @@ struct nhwc_reusable_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
 
         nhwc_reusable_compile_params_t cmpl_conf;
@@ -196,9 +197,10 @@ struct nhwc_reusable_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:nhwc_reusable", nhwc_reusable_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_BNORM(
@@ -238,7 +240,7 @@ struct nhwc_reusable_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
 
         nhwc_reusable_compile_params_t cmpl_conf;

--- a/src/gpu/intel/bnorm/ref.cpp
+++ b/src/gpu/intel/bnorm/ref.cpp
@@ -29,9 +29,9 @@ namespace bnorm {
 
 static void init_calculate_stats_conf(conf_t &conf,
         compute::dispatch_t &dispatch_calc_stat,
-        compute::dispatch_t &dispatch_reduce_stat, impl::engine_t *engine,
+        compute::dispatch_t &dispatch_reduce_stat, const impl::engine_t *engine,
         const memory_desc_wrapper &data_mdw) {
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     const int ndims = conf.ndims;
     dispatch_calc_stat = intel_engine->create_dispatch(data_mdw.md_);
     dim_t calc_dims[5];
@@ -74,7 +74,7 @@ static void init_calculate_stats_conf(conf_t &conf,
 
 static void init_conf_common(conf_t &conf, compute::dispatch_t &dispatch,
         offsets_t &off, const pd_t *pd, const memory_desc_wrapper &data_mdw,
-        impl::engine_t *engine) {
+        const impl::engine_t *engine) {
     const desc_t &bd = *pd->desc();
     const int ndims = data_mdw.ndims();
 
@@ -105,7 +105,7 @@ static void init_conf_common(conf_t &conf, compute::dispatch_t &dispatch,
 
     set_offsets(data_mdw, off.src_off);
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     dispatch = intel_engine->create_dispatch(data_mdw.md_);
     dispatch.define_dim("MB", 0, conf.mb);
@@ -154,7 +154,7 @@ static void init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     def_dispatch(kernel_ctx, dispatch);
 }
 
-void ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+void ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper data_mdw(src_md());
     init_conf_common(conf, dispatch, off, this, data_mdw, engine);
 
@@ -283,7 +283,7 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return parallel_for(ctx, nd_range, kernel_, arg_list);
 }
 
-void ref_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+void ref_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
     const memory_desc_wrapper data_mdw(diff_src_md());
     init_conf_common(conf, dispatch, off, this, data_mdw, engine);

--- a/src/gpu/intel/bnorm/ref.hpp
+++ b/src/gpu/intel/bnorm/ref.hpp
@@ -34,9 +34,10 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
 
@@ -82,7 +83,7 @@ struct ref_fwd_t : public primitive_t {
             return status::success;
         }
 
-        void init_conf(impl::engine_t *engine);
+        void init_conf(const impl::engine_t *engine);
         void init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 
@@ -142,9 +143,10 @@ struct ref_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_BNORM(utils::one_of(src_md()->data_type, f32, bf16, f16),
@@ -180,7 +182,7 @@ struct ref_bwd_t : public primitive_t {
             return status::success;
         }
 
-        void init_conf(impl::engine_t *engine);
+        void init_conf(const impl::engine_t *engine);
         void init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 

--- a/src/gpu/intel/bnorm/reusable.cpp
+++ b/src/gpu/intel/bnorm/reusable.cpp
@@ -54,10 +54,10 @@ static std::vector<dim_idx_t> get_dims(size_t ndims) {
 }
 
 static status_t init_calculate_stats_conf(reusable_params_t &conf,
-        reusable_runtime_params_t &rt_conf, impl::engine_t *engine,
+        reusable_runtime_params_t &rt_conf, const impl::engine_t *engine,
         const memory_desc_wrapper &data_mdw,
         const gpu_primitive_attr_t *gpu_attr) {
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     const size_t ndims = static_cast<size_t>(data_mdw.ndims());
     dim_t calc_dims[MAX_DIMS];
     auto &dims = data_mdw.dims();
@@ -155,7 +155,7 @@ static status_t init_calculate_stats_conf(reusable_params_t &conf,
 
 static status_t init_conf_common(reusable_params_t &conf,
         reusable_runtime_params_t &rt_conf, const pd_t *pd,
-        const memory_desc_wrapper &data_mdw, impl::engine_t *engine,
+        const memory_desc_wrapper &data_mdw, const impl::engine_t *engine,
         const gpu_primitive_attr_t *&gpu_attr) {
     const desc_t &bd = *pd->desc();
 
@@ -176,7 +176,7 @@ static status_t init_conf_common(reusable_params_t &conf,
 
     conf.with_leaky_relu = conf.with_relu && rt_conf.relu_negative_slope != 0.f;
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     size_t ndims = static_cast<size_t>(data_mdw.ndims());
     std::vector<dim_idx_t> dims = get_dims(ndims);
@@ -228,7 +228,7 @@ static void init_kernel_ctx_common(
     conf.reduce_stat_params.def_kernel_macros(kernel_ctx, "REDUCE");
 }
 
-status_t reusable_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t reusable_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper data_mdw(src_md());
     const auto *gpu_attr
             = utils::downcast<gpu_primitive_attr_t *>(attr()->gpu_attr_.get());
@@ -378,7 +378,7 @@ status_t reusable_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return parallel_for(ctx, nd_range, kernel_, arg_list);
 }
 
-status_t reusable_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t reusable_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
     const memory_desc_wrapper data_mdw(diff_src_md());
     const auto *gpu_attr

--- a/src/gpu/intel/bnorm/reusable.hpp
+++ b/src/gpu/intel/bnorm/reusable.hpp
@@ -104,9 +104,10 @@ struct reusable_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:reusable", reusable_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
 
@@ -151,7 +152,7 @@ struct reusable_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
 
         reusable_params_t conf;
@@ -203,9 +204,10 @@ struct reusable_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:reusable", reusable_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_BNORM(utils::one_of(src_md()->data_type, f32, bf16, f16),
@@ -240,7 +242,7 @@ struct reusable_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
 
         reusable_params_t conf;

--- a/src/gpu/intel/bnorm/simple.cpp
+++ b/src/gpu/intel/bnorm/simple.cpp
@@ -110,7 +110,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t simple_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t simple_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     CHECK(init_conf_common(conf, off, this));
 
     // This implementation optimizes the stat calculation - skip it if we're not calculating stats
@@ -119,7 +119,7 @@ status_t simple_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
     const memory_desc_wrapper data_mdw(src_md());
     const dim_idx_t ndims = into<dim_idx_t>(data_mdw.ndims());
 
-    intel::engine_t *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     dispatch_calc_stat = intel_engine->create_dispatch(data_mdw.md_);
     dim_t calc_dims[5];
@@ -282,10 +282,10 @@ status_t simple_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return parallel_for(ctx, nd_range, kernel_, arg_list);
 }
 
-status_t simple_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t simple_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
     CHECK(init_conf_common(conf, off, this));
-    intel::engine_t *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     const memory_desc_wrapper data_mdw(diff_src_md());
 
     const bool has_padding = !data_mdw.is_dense();

--- a/src/gpu/intel/bnorm/simple.hpp
+++ b/src/gpu/intel/bnorm/simple.hpp
@@ -34,9 +34,10 @@ struct simple_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:simple", simple_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
 
@@ -81,7 +82,7 @@ struct simple_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 
@@ -128,9 +129,10 @@ struct simple_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:simple", simple_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_BNORM(utils::one_of(src_md()->data_type, f32, bf16, f16),
@@ -165,7 +167,7 @@ struct simple_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 

--- a/src/gpu/intel/bnorm/xe.cpp
+++ b/src/gpu/intel/bnorm/xe.cpp
@@ -31,11 +31,11 @@ using namespace lookup_table;
 using namespace dnnl::impl::utils;
 using namespace dnnl::impl::gpu::intel::gpu_utils;
 
-static bool use_fused_atomics_reduction(
-        lookup_table::params_t &conf, const pd_t *pd, impl::engine_t *engine) {
+static bool use_fused_atomics_reduction(lookup_table::params_t &conf,
+        const pd_t *pd, const impl::engine_t *engine) {
     // Currently the fused atomics reduction is targeting to PVC only.
     // Heuristics experimentally selected, based on PVC perf data
-    auto *intel_engine = downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = downcast<const intel::engine_t *>(engine);
     auto gpu_arch = intel_engine->device_info()->gpu_arch();
     const size_t sp = conf.mb * conf.id * conf.ih * conf.iw;
     return !pd->attr()->deterministic_
@@ -58,9 +58,9 @@ static size_t get_slm_buff_size(
 
 // Local group size adjustment.
 static void adjust_lws_calc_kernel(lookup_table::params_t &conf,
-        compute::dispatch_t &dispatch, impl::engine_t *engine,
+        compute::dispatch_t &dispatch, const impl::engine_t *engine,
         int grf_per_thread) {
-    auto *intel_engine = downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = downcast<const intel::engine_t *>(engine);
     auto eu_count = intel_engine->device_info()->eu_count();
     auto max_lws = intel_engine->device_info()->max_wg_size(grf_per_thread);
     auto eus_per_ss = intel_engine->device_info()->max_eus_per_wg();
@@ -137,7 +137,7 @@ static status_t init_conf_common(lookup_table::params_t &conf, offsets_t &off,
         compute::dispatch_t &dispatch_calc_stat,
         compute::dispatch_t &dispatch_reduce_stat,
         compute::dispatch_t &dispatch, compute::dispatch_t &dispatch_reduce_aux,
-        const pd_t *pd, impl::engine_t *engine) {
+        const pd_t *pd, const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
     const memory_desc_wrapper data_mdw(
             pd->is_fwd() ? pd->src_md() : pd->diff_src_md());
@@ -147,7 +147,7 @@ static status_t init_conf_common(lookup_table::params_t &conf, offsets_t &off,
     init_conf_basic(conf, pd);
     set_offsets(data_mdw, off.src_off);
 
-    auto *intel_engine = downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = downcast<const intel::engine_t *>(engine);
     auto gpu_arch = intel_engine->device_info()->gpu_arch();
 
     conf.mb_block = 1;
@@ -393,7 +393,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t xe_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, dispatch_calc_stat, dispatch_reduce_stat,
             dispatch, dispatch_reduce_aux, this, engine);
 }
@@ -596,7 +596,7 @@ status_t xe_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t xe_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, dispatch_calc_stat, dispatch_reduce_stat,
             dispatch, dispatch_reduce_aux, this, engine);
 }

--- a/src/gpu/intel/bnorm/xe.hpp
+++ b/src/gpu/intel/bnorm/xe.hpp
@@ -38,9 +38,10 @@ struct xe_fwd_t : public primitive_t {
         const char *impl_name() const {
             return conf.use_stats_one_pass ? "ocl:xe:onepass" : "ocl:xe";
         }
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
 
@@ -89,7 +90,7 @@ struct xe_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 
@@ -189,8 +190,9 @@ struct xe_bwd_t : public primitive_t {
 
         const char *impl_name() const { return "ocl:xe"; }
 
-        status_t init(impl::engine_t *engine) {
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        status_t init(const impl::engine_t *engine) {
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             using namespace data_type;
 
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -231,7 +233,7 @@ struct xe_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 

--- a/src/gpu/intel/concat/multi.hpp
+++ b/src/gpu/intel/concat/multi.hpp
@@ -47,7 +47,7 @@ struct multi_t : public primitive_t {
             return batch_failure;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             VDISPATCH_CONCAT(max_batch_size() != batch_failure,
                     VERBOSE_SKIP_PRIMITIVE_IMPL);
             VDISPATCH_CONCAT(

--- a/src/gpu/intel/concat/simple.cpp
+++ b/src/gpu/intel/concat/simple.cpp
@@ -29,14 +29,14 @@ namespace intel {
 namespace concat {
 
 static status_t normalize(simple_params_t &conf,
-        simple_runtime_params_t &rt_conf, impl::engine_t *engine,
+        simple_runtime_params_t &rt_conf, const impl::engine_t *engine,
         const concat_pd_t *pd, const normalization_t &normalize) {
 
     const memory_desc_wrapper ref_dst_mdw = *pd->dst_md();
 
     const auto axis = pd->concat_dim();
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *device_info = intel_engine->device_info();
     dim_t max_write_size = normalize.max_write_size();
     dim_t max_read_size = normalize.max_read_size();
@@ -165,7 +165,7 @@ static status_t normalize(simple_params_t &conf,
 }
 
 static status_t try_normalize_internal_padding(simple_params_t &conf,
-        simple_runtime_params_t &rt_conf, impl::engine_t *engine,
+        simple_runtime_params_t &rt_conf, const impl::engine_t *engine,
         const concat_pd_t *pd, const normalization_t &normalize) {
 
     using namespace utils;
@@ -173,7 +173,7 @@ static status_t try_normalize_internal_padding(simple_params_t &conf,
 
     const auto concat_dim = pd->concat_dim();
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *device_info = intel_engine->device_info();
 
     const int max_sg_size = device_info->max_subgroup_size();
@@ -327,8 +327,9 @@ static status_t try_normalize_internal_padding(simple_params_t &conf,
     return status::success;
 }
 
-static status_t init_conf_common(impl::engine_t *engine, const concat_pd_t *pd,
-        simple_params_t &conf, simple_runtime_params_t &rt_conf) {
+static status_t init_conf_common(const impl::engine_t *engine,
+        const concat_pd_t *pd, simple_params_t &conf,
+        simple_runtime_params_t &rt_conf) {
     using namespace utils;
     const memory_desc_t &ref_dst_md = *pd->dst_md();
 
@@ -373,7 +374,7 @@ compute::kernel_ctx_t simple_params_t::get_kernel_ctx() const {
     return kernel_ctx;
 }
 
-status_t simple_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t simple_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(engine, this, conf, rt_conf);
 }
 

--- a/src/gpu/intel/concat/simple.hpp
+++ b/src/gpu/intel/concat/simple.hpp
@@ -88,7 +88,7 @@ struct simple_t : public primitive_t {
 
         DECLARE_CONCAT_PD_T("ocl:simple:reusable", simple_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             VDISPATCH_CONCAT(n_inputs() <= 64, VERBOSE_BAD_PARAM, "n_inputs");
             VDISPATCH_CONCAT(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
@@ -99,7 +99,7 @@ struct simple_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         simple_params_t conf;
         simple_runtime_params_t rt_conf;

--- a/src/gpu/intel/concat/xe.cpp
+++ b/src/gpu/intel/concat/xe.cpp
@@ -107,7 +107,7 @@ int xe_t::pd_t::calculate_sub_group_size(
     return 1;
 }
 
-status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_t::pd_t::init_conf(const impl::engine_t *engine) {
     const concat_pd_t *pd = this;
 
     const memory_desc_wrapper dst_mdw(pd->dst_md());
@@ -118,7 +118,7 @@ status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
     conf.dst_offset0 = dst_mdw.offset0();
     conf.src_type = memory_desc_wrapper(pd->src_md(0)).data_type();
     conf.ndims = dst_mdw.ndims();
-    const auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(dst_mdw.md_);
     conf.n = pd->n_inputs();
     conf.concat_axis = pd->concat_dim();

--- a/src/gpu/intel/concat/xe.hpp
+++ b/src/gpu/intel/concat/xe.hpp
@@ -39,7 +39,7 @@ struct xe_t : public primitive_t {
 
         DECLARE_CONCAT_PD_T("xe:any", xe_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
 
             using sm = primitive_attr_t::skip_mask_t;
 
@@ -53,7 +53,7 @@ struct xe_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/conv/deconvolution.hpp
+++ b/src/gpu/intel/conv/deconvolution.hpp
@@ -91,7 +91,7 @@ struct conv_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(name_.c_str(), conv_bwd_weights_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             conv::desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr(*attr());
@@ -103,7 +103,7 @@ struct conv_bwd_weights_t : public primitive_t {
             return (conv_pd_) ? status::success : status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
             VDISPATCH_DECONVOLUTION(
                     desc()->prop_kind == prop_kind::backward_weights,

--- a/src/gpu/intel/conv/jit.cpp
+++ b/src/gpu/intel/conv/jit.cpp
@@ -60,10 +60,10 @@ public:
     static const int max_kernels = 16;
 
     template <typename T>
-    static status_t init_pd(T *pd, impl::engine_t *engine) {
+    static status_t init_pd(T *pd, const impl::engine_t *engine) {
         try {
             using intel::engine_t;
-            auto *intel_engine = utils::downcast<engine_t *>(engine);
+            auto *intel_engine = utils::downcast<const engine_t *>(engine);
 
             VDISPATCH_CONV_IC(intel_engine->mayiuse_ngen_kernels(),
                     VERBOSE_BAD_ENGINE_KIND);
@@ -525,7 +525,7 @@ private:
     }
 
     static status_t report_runtime_error(const convolution_pd_t *pd,
-            impl::engine_t *engine, const char *msg = "internal error") {
+            const impl::engine_t *engine, const char *msg = "internal error") {
         VERROR(primitive, gpu, "%s,%s", pd->info(engine), msg);
         return status::runtime_error;
     }
@@ -535,7 +535,7 @@ private:
     std::shared_ptr<impl::primitive_t> zp_prim_;
 };
 
-status_t gen_fwd_t::pd_t::init(impl::engine_t *engine) {
+status_t gen_fwd_t::pd_t::init(const impl::engine_t *engine) {
     VDISPATCH_CONV_IC(is_fwd(), VERBOSE_BAD_PROPKIND);
     CHECK(gen_t::init_pd(this, engine));
     return status::success;
@@ -550,13 +550,13 @@ status_t gen_fwd_t::execute(const exec_ctx_t &ctx) const {
     return impl_->execute(this, ctx);
 }
 
-status_t gen_bwd_data_t::pd_t::init(impl::engine_t *engine) {
+status_t gen_bwd_data_t::pd_t::init(const impl::engine_t *engine) {
     VDISPATCH_CONV_IC(is_bwd_d(), VERBOSE_BAD_PROPKIND);
     CHECK(gen_t::init_pd(this, engine));
     return status::success;
 }
 
-status_t gen_bwd_weights_t::pd_t::init(impl::engine_t *engine) {
+status_t gen_bwd_weights_t::pd_t::init(const impl::engine_t *engine) {
     VDISPATCH_CONV_IC(is_bwd_w(), VERBOSE_BAD_PROPKIND);
     CHECK(gen_t::init_pd(this, engine));
     return status::success;

--- a/src/gpu/intel/conv/jit.hpp
+++ b/src/gpu/intel/conv/jit.hpp
@@ -43,7 +43,7 @@ public:
 
         DECLARE_COMMON_PD_T("jit:ir", gen_fwd_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<pd_data_t> data;
     };
@@ -70,7 +70,7 @@ public:
 
         DECLARE_COMMON_PD_T("jit:ir", gen_bwd_data_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<pd_data_t> data;
     };
@@ -97,7 +97,7 @@ public:
 
         DECLARE_COMMON_PD_T("jit:ir", gen_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<pd_data_t> data;
     };

--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -123,7 +123,7 @@ bool is_small_oc(const problem_t &prb) {
 }
 
 status_t problem_t::init(
-        impl::engine_t *engine, const convolution_pd_t *conv_pd) {
+        const impl::engine_t *engine, const convolution_pd_t *conv_pd) {
     using namespace compute;
 
     VDISPATCH_CHECK(conv_pd, engine, !conv_pd->has_zero_dim_memory(),
@@ -706,7 +706,7 @@ void prepare_zp_precompute(const problem_t &prb, dim_t *idhw, dim_t *odhw,
 }
 
 status_t init_tensor_layouts(
-        config_t &cfg, convolution_pd_t *pd, impl::engine_t *engine) {
+        config_t &cfg, convolution_pd_t *pd, const impl::engine_t *engine) {
     const auto &prb = cfg.prb();
     // Compute layout tags and user layout tags. If a compute layout is
     // different from a user layout then an extra pre/post reorder will be
@@ -879,8 +879,8 @@ bool hw_ok(const dsl::hw_t &hw) {
     return true;
 }
 
-bool data_types_ok(
-        const problem_t &prb, const dsl::hw_t &hw, impl::engine_t *engine) {
+bool data_types_ok(const problem_t &prb, const dsl::hw_t &hw,
+        const impl::engine_t *engine) {
     auto src = prb.src_data_type;
     auto wei = prb.wei_data_type;
     auto dst = prb.dst_data_type;
@@ -892,7 +892,7 @@ bool data_types_ok(
     if (!prb.is_f64_accumulator()
             && utils::one_of(data_type::f64, src, wei, dst, bia))
         return false;
-    auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *device_info = intel_engine->device_info();
     if (prb.is_f64_accumulator() && !device_info->has_native(data_type::f64))
         return false;
@@ -1041,7 +1041,7 @@ bool should_use_mad(const problem_t &prb) {
 }
 
 status_t init_fma_kind(
-        config_t &cfg, convolution_pd_t *pd, impl::engine_t *engine) {
+        config_t &cfg, convolution_pd_t *pd, const impl::engine_t *engine) {
     if (cfg.fma_kind_param().is_overridden()) return status::success;
     const auto &prb = cfg.prb();
     auto fma_kind = get_supported_fma_kind(cfg.hw(), to_ir(prb.a_data_type),
@@ -1136,7 +1136,8 @@ void init_bwd_d_optimize(config_t &cfg) {
 }
 
 status_t init_pd_time_cfg(const problem_t &prb, config_t &cfg,
-        impl::engine_t *engine, convolution_pd_t *pd, primitive_attr_t *attr) {
+        const impl::engine_t *engine, convolution_pd_t *pd,
+        primitive_attr_t *attr) {
     dsl::hw_t hw(make_ir_hw(engine));
 
     VDISPATCH_CHECK(pd, engine, hw_ok(hw), VERBOSE_UNSUPPORTED_ISA);

--- a/src/gpu/intel/conv/jit/config.hpp
+++ b/src/gpu/intel/conv/jit/config.hpp
@@ -682,7 +682,7 @@ private:
 };
 
 status_t init_pd_time_cfg(const problem_t &prb, config_t &cfg,
-        impl::engine_t *engine, pd_t *pd, primitive_attr_t *attr);
+        const impl::engine_t *engine, pd_t *pd, primitive_attr_t *attr);
 status_t init_cfg(config_t &cfg, const primitive_t *prim);
 void init_regs(config_t &cfg);
 int slm_bufs_hint(const problem_t &prb, dim_t m_tg, dim_t n_tg,

--- a/src/gpu/intel/conv/jit/problem.hpp
+++ b/src/gpu/intel/conv/jit/problem.hpp
@@ -104,7 +104,7 @@ class problem_t {
 public:
     problem_t() = default;
 
-    status_t init(impl::engine_t *engine, const pd_t *conv_pd);
+    status_t init(const impl::engine_t *engine, const pd_t *conv_pd);
 
     bool is_stride1() const { return sd == 1 && sh == 1 && sw == 1; }
 

--- a/src/gpu/intel/conv/jit_v2.cpp
+++ b/src/gpu/intel/conv/jit_v2.cpp
@@ -128,11 +128,12 @@ public:
     }
 
     template <typename T>
-    static status_t init_pd(T *pd, impl::engine_t *engine, prop_kind_t prop) {
+    static status_t init_pd(
+            T *pd, const impl::engine_t *engine, prop_kind_t prop) {
         if (!is_supported(pd, prop)) return status::unimplemented;
 
         using intel::engine_t;
-        auto *intel_engine = utils::downcast<engine_t *>(engine);
+        auto *intel_engine = utils::downcast<const engine_t *>(engine);
         if (!intel_engine->mayiuse_ngen_kernels()) return status::unimplemented;
         if (!pd->set_default_alg_kind(alg_kind::convolution_direct))
             return status::unimplemented;
@@ -197,7 +198,7 @@ private:
     primitive_exec_plan_t exec_plan_;
 };
 
-status_t gen_fwd_t::pd_t::init(impl::engine_t *engine) {
+status_t gen_fwd_t::pd_t::init(const impl::engine_t *engine) {
     return gen_t::init_pd(this, engine, prop_kind::forward);
 }
 
@@ -210,7 +211,7 @@ status_t gen_fwd_t::execute(const exec_ctx_t &ctx) const {
     return impl_->execute(this, ctx);
 }
 
-status_t gen_bwd_data_t::pd_t::init(impl::engine_t *engine) {
+status_t gen_bwd_data_t::pd_t::init(const impl::engine_t *engine) {
     return gen_t::init_pd(this, engine, prop_kind::backward_data);
 }
 
@@ -223,7 +224,7 @@ status_t gen_bwd_data_t::execute(const exec_ctx_t &ctx) const {
     return impl_->execute(this, ctx);
 }
 
-status_t gen_bwd_weights_t::pd_t::init(impl::engine_t *engine) {
+status_t gen_bwd_weights_t::pd_t::init(const impl::engine_t *engine) {
     return gen_t::init_pd(this, engine, prop_kind::backward_weights);
 }
 

--- a/src/gpu/intel/conv/jit_v2.hpp
+++ b/src/gpu/intel/conv/jit_v2.hpp
@@ -47,7 +47,7 @@ public:
         using fwd_pd_t::fwd_pd_t;
 
         DECLARE_COMMON_PD_T("jit:ir_v2", gen_fwd_t);
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<primitive_init_plan_t> init_plan;
     };
@@ -72,7 +72,7 @@ public:
         using bwd_data_pd_t::bwd_data_pd_t;
 
         DECLARE_COMMON_PD_T("jit:ir_v2", gen_bwd_data_t);
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<primitive_init_plan_t> init_plan;
     };
@@ -97,7 +97,7 @@ public:
         using bwd_weights_pd_t::bwd_weights_pd_t;
 
         DECLARE_COMMON_PD_T("jit:ir_v2", gen_bwd_weights_t);
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         std::shared_ptr<primitive_init_plan_t> init_plan;
     };

--- a/src/gpu/intel/conv/ref.cpp
+++ b/src/gpu/intel/conv/ref.cpp
@@ -24,7 +24,7 @@ namespace intel {
 namespace conv {
 
 static status_t init_conf_common(
-        conf_t &conf, const pd_t *pd, impl::engine_t *engine) {
+        conf_t &conf, const pd_t *pd, const impl::engine_t *engine) {
     const desc_t &cd = *pd->desc();
     const memory_desc_t &src_md = *pd->invariant_src_md();
     const memory_desc_t &weights_md = *pd->invariant_wei_md();
@@ -36,7 +36,7 @@ static status_t init_conf_common(
     conf.require_stateless_addressing = pd->has_large_buffers();
 
     int oc_idx = (int)conf.with_groups;
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     switch (cd.prop_kind) {
         case prop_kind::forward_training:
         case prop_kind::forward_inference: {
@@ -168,7 +168,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     CHECK(init_conf_common(conf, this, engine));
     return status::success;
 }
@@ -251,7 +251,7 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
             ctx, repack_nd_range, kernels_[1], repack_arg_list, 4);
 }
 
-status_t ref_bwd_data_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_data_t::pd_t::init_conf(const impl::engine_t *engine) {
     CHECK(init_conf_common(conf, this, engine));
     return status::success;
 }
@@ -332,7 +332,7 @@ status_t ref_bwd_data_t::execute_backward_data(const exec_ctx_t &ctx) const {
             ctx, repack_nd_range, kernels_[1], repack_arg_list, 4);
 }
 
-status_t ref_bwd_weights_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_weights_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 

--- a/src/gpu/intel/conv/ref.hpp
+++ b/src/gpu/intel/conv/ref.hpp
@@ -36,11 +36,11 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const bool is_int8 = utils::one_of(src_md_.data_type, s8, u8);
             const bool is_fp8
@@ -118,7 +118,7 @@ struct ref_fwd_t : public primitive_t {
             return init_conf(engine);
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         bool subbyte_pack_ = false;
 
@@ -170,7 +170,7 @@ struct ref_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
             auto attr_skip_mask = sm::post_ops | sm::scales;
@@ -179,7 +179,7 @@ struct ref_bwd_data_t : public primitive_t {
             }
             using namespace data_type;
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
                     VERBOSE_BAD_ALGORITHM);
@@ -232,7 +232,7 @@ struct ref_bwd_data_t : public primitive_t {
             return init_conf(engine);
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         bool subbyte_pack_ = false;
 
@@ -284,10 +284,10 @@ struct ref_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
                     VERBOSE_BAD_ALGORITHM);
@@ -348,7 +348,7 @@ struct ref_bwd_weights_t : public primitive_t {
             return init_conf(engine);
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         bool subbyte_pack_ = false;
 

--- a/src/gpu/intel/conv/xe_wino.cpp
+++ b/src/gpu/intel/conv/xe_wino.cpp
@@ -111,7 +111,7 @@ static void fwd_compute_block_sizes(
     conf.wino_oc = utils::rnd_up(conf.oc, conf.wino_oc_block);
 }
 
-status_t xe_wino_fwd_t::pd_t::init_conf(intel::engine_t *engine) {
+status_t xe_wino_fwd_t::pd_t::init_conf(const intel::engine_t *engine) {
     const desc_t &cd = *desc();
     const memory_desc_wrapper src_mdw(src_md());
     const memory_desc_wrapper weights_mdw(weights_md());

--- a/src/gpu/intel/conv/xe_wino.hpp
+++ b/src/gpu/intel/conv/xe_wino.hpp
@@ -38,11 +38,12 @@ struct xe_wino_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe:wino", xe_wino_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto src_data_t = this->desc()->src_desc.data_type;
             auto dst_data_t = this->desc()->dst_desc.data_type;
@@ -97,7 +98,7 @@ struct xe_wino_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(intel::engine_t *engine);
+        status_t init_conf(const intel::engine_t *engine);
         void init_scratchpad();
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 

--- a/src/gpu/intel/eltwise/ref.cpp
+++ b/src/gpu/intel/eltwise/ref.cpp
@@ -23,7 +23,7 @@ namespace intel {
 namespace eltwise {
 
 static status_t init_conf_common(
-        conf_t &conf, const pd_t *pd, impl::engine_t *engine) {
+        conf_t &conf, const pd_t *pd, const impl::engine_t *engine) {
     alg_kind_t alg = pd->desc()->alg_kind;
     const bool is_forward = pd->is_fwd();
     const auto &src_md = pd->use_dst() ? pd->dst_md() : pd->src_md();
@@ -50,7 +50,7 @@ static status_t init_conf_common(
     conf.with_zero_padding = src_d.nelems(false) != src_d.nelems(true);
 
     int max_ndims = 6;
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(
             is_forward ? src_d.md_ : diff_data_d.md_);
     for (int i = 0; i < max_ndims; ++i) {
@@ -101,7 +101,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 
@@ -177,7 +177,7 @@ status_t ref_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
     return large_parallel_for(ctx, nd_range, kernel_, arg_list, 4);
 }
 
-status_t ref_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 

--- a/src/gpu/intel/eltwise/ref.hpp
+++ b/src/gpu/intel/eltwise/ref.hpp
@@ -54,8 +54,9 @@ struct ref_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init(impl::engine_t *engine) {
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        status_t init(const impl::engine_t *engine) {
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = (primitive_attr_t::skip_mask_t::post_ops
                     | primitive_attr_t::skip_mask_t::dropout);
@@ -92,7 +93,7 @@ struct ref_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -127,11 +128,12 @@ struct ref_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace utils;
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             using namespace alg_kind;
             VDISPATCH_ELTWISE(!is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -167,7 +169,7 @@ struct ref_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/eltwise/xe.cpp
+++ b/src/gpu/intel/eltwise/xe.cpp
@@ -25,10 +25,10 @@ namespace gpu {
 namespace intel {
 namespace eltwise {
 
-status_t xe_jit_params_t::init(impl::engine_t *engine,
+status_t xe_jit_params_t::init(const impl::engine_t *engine,
         const memory_desc_wrapper data_d, alg_kind_t alg_kind_) {
     *this = {};
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     arch = intel_engine->device_info()->gpu_arch();
     data_type = data_d.data_type();
@@ -80,7 +80,7 @@ compute::kernel_ctx_t xe_jit_params_t::get_kernel_ctx() const {
     return kernel_ctx;
 }
 
-status_t xe_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper data_d(use_dst() ? dst_md() : src_md());
     status_t status = conf.init(engine, data_d, this->desc()->alg_kind);
     conf.require_stateless_addressing = has_large_buffers();
@@ -121,7 +121,7 @@ status_t xe_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t xe_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
 
     const memory_desc_wrapper data_d(data_md());

--- a/src/gpu/intel/eltwise/xe.hpp
+++ b/src/gpu/intel/eltwise/xe.hpp
@@ -40,8 +40,8 @@ struct xe_jit_params_t : public trivially_serializable_t<xe_jit_params_t> {
         return names;
     }
 
-    status_t init(impl::engine_t *engine, const memory_desc_wrapper data_d,
-            alg_kind_t alg_kind);
+    status_t init(const impl::engine_t *engine,
+            const memory_desc_wrapper data_d, alg_kind_t alg_kind);
     compute::kernel_ctx_t get_kernel_ctx() const;
 
     compute::gpu_arch_t arch;
@@ -62,8 +62,9 @@ struct xe_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe:any", xe_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        status_t init(const impl::engine_t *engine) {
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             using namespace alg_kind;
             VDISPATCH_ELTWISE(is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -90,7 +91,7 @@ struct xe_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         xe_jit_params_t conf;
     };
@@ -116,11 +117,12 @@ struct xe_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe:any", xe_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace utils;
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             using namespace alg_kind;
             VDISPATCH_ELTWISE(!is_fwd(), VERBOSE_BAD_PROPKIND);
@@ -153,7 +155,7 @@ struct xe_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         xe_jit_params_t conf;
     };

--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -104,14 +104,14 @@ bool with_quantize_common(const quant_entries_t &q, int arg) {
     return !q.has_default_values(arg) && (q.get_mask(arg) == 0);
 }
 
-int sg_size(impl::engine_t *engine) {
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+int sg_size(const impl::engine_t *engine) {
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     return intel_engine->device_info()->min_subgroup_size();
 }
 
 } // anonymous namespace
 
-status_t micro_horz_t::pd_t::init(impl::engine_t *engine) {
+status_t micro_horz_t::pd_t::init(const impl::engine_t *engine) {
     //VDISPATCH_GATED_MLP(gpu_utils::dev_getenv("gmlp_horz_ukern", false),
     //        VERBOSE_SKIP_PRIMITIVE_IMPL);
     memory_desc_t inter_md;
@@ -156,9 +156,9 @@ gemmstone::Type get_ab_type(gemmstone::Type src, gemmstone::Type wei) {
 }
 
 status_t micro_horz_t::pd_t::init_microkernels(
-        impl::engine_t *engine, const memory_desc_t *inter_md) {
+        const impl::engine_t *engine, const memory_desc_t *inter_md) {
     assert(engine->kind() == engine_kind::gpu);
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *dev_info = intel_engine->device_info();
 
     VCONDCHECK(primitive, create, check, gated_mlp,

--- a/src/gpu/intel/gated_mlp/micro_horz.hpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.hpp
@@ -40,7 +40,7 @@ struct micro_horz_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:micro_horz:any", micro_horz_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         status_t get_gate_dst_md(memory_desc_t &retn) const {
             data_type_t dt = arg_md(DNNL_ARG_WEIGHTS_DOWN)->data_type;
@@ -98,7 +98,7 @@ struct micro_horz_t : public primitive_t {
         }
 
         status_t init_microkernels(
-                impl::engine_t *engine, const memory_desc_t *inter_md);
+                const impl::engine_t *engine, const memory_desc_t *inter_md);
 
         gemmstone::microkernel::Package gemm_gate_up_pkg_;
     };

--- a/src/gpu/intel/gated_mlp/ref.hpp
+++ b/src/gpu/intel/gated_mlp/ref.hpp
@@ -41,7 +41,7 @@ struct ref_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             memory_desc_t gate_dst_md, up_dst_md;
             CHECK(get_gate_dst_md(gate_dst_md));
             CHECK(get_up_dst_md(up_dst_md));
@@ -165,7 +165,7 @@ struct ref_t : public primitive_t {
         }
 
         status_t create_matmul(std::shared_ptr<primitive_desc_t> &retn,
-                impl::engine_t *e, const primitive_attr_t &attr,
+                const impl::engine_t *e, const primitive_attr_t &attr,
                 const memory_desc_t *src_desc, const memory_desc_t *wei_desc,
                 const memory_desc_t *dst_desc) const {
             return impl::create_matmul_pd(

--- a/src/gpu/intel/gemm/conv.hpp
+++ b/src/gpu/intel/gemm/conv.hpp
@@ -36,7 +36,7 @@ struct conv_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("conv:ir", conv_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             // This is currently only used for experimentation purposes
             bool enabled = gpu_utils::dev_getenv("enable_conv_gemm", false);
             VDISPATCH_GEMM(

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -84,7 +84,7 @@ struct gen_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:gemm:any", gen_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             using namespace primitive_kind;
@@ -93,7 +93,8 @@ struct gen_t : public primitive_t {
             using arch_t = compute::gpu_arch_t;
 
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             CHECK(set_default_formats(false));
 
@@ -357,8 +358,9 @@ struct gen_t : public primitive_t {
                 if (valid) {
                     auto try_create = [&]() {
                         std::vector<compute::kernel_t> kernel_(1);
-                        auto *intel_engine
-                                = utils::downcast<intel::engine_t *>(engine);
+                        const auto *intel_engine
+                                = utils::downcast<const intel::engine_t *>(
+                                        engine);
                         auto key = std::make_shared<
                                 trivial_key_container_t<dnnl::impl::gpu::intel::
                                                 gemm::jit::gen_nocopy_desc_t>>(

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -820,7 +820,7 @@ status_t pd_t::init_GEMMProblem(
         problem.autoTypeConversions(has_systolic);
 
     if (problem.needsAGroupSums()) {
-        if (!problem.hasGroupSumsA) return status::unimplemented;
+        VDISPATCH_GEMM(problem.hasGroupSumsA, VERBOSE_UNSUPPORTED_ZP_CFG);
         data_type_t gs_dt = a_quant.gs_type == data_type::undef
                 ? data_type::s32
                 : a_quant.gs_type;
@@ -830,7 +830,7 @@ status_t pd_t::init_GEMMProblem(
         if (problem.aqGroupK == 0) problem.aqGroupK = problem.bqGroupK;
     }
     if (problem.needsBGroupSums()) {
-        if (!problem.hasGroupSumsB) return status::unimplemented;
+        VDISPATCH_GEMM(problem.hasGroupSumsB, VERBOSE_UNSUPPORTED_ZP_CFG);
         data_type_t gs_dt = b_quant.gs_type == data_type::undef
                 ? data_type::s32
                 : b_quant.gs_type;

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -66,7 +66,7 @@ int quant_entry_ndims(
 }
 } // anonymous namespace
 
-status_t pd_t::init_post_ops(impl::engine_t *engine) {
+status_t pd_t::init_post_ops(const impl::engine_t *engine) {
     using namespace primitive_kind;
     using namespace alg_kind;
     using namespace data_type;
@@ -248,7 +248,7 @@ bool pd_t::quant_enabled() const {
     return wei_decomp() || dy_quant_enabled();
 }
 
-status_t pd_t::init_attrs(impl::engine_t *engine) {
+status_t pd_t::init_attrs(const impl::engine_t *engine) {
     wei_decomp_ = wei_decomp();
     dy_quant_enabled_ = dy_quant_enabled();
     quant_enabled_ = quant_enabled();
@@ -358,7 +358,7 @@ status_t pd_t::init_attrs(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t pd_t::zp_ok(impl::engine_t *engine) {
+status_t pd_t::zp_ok(const impl::engine_t *engine) {
     using namespace data_type;
     auto &attr_zps = attr()->zero_points_;
     if (attr_zps.has_default_values()) return status::success;
@@ -448,7 +448,7 @@ status_t pd_t::zp_ok(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t pd_t::gs_ok(impl::engine_t *engine) {
+status_t pd_t::gs_ok(const impl::engine_t *engine) {
     auto &attr_gs = attr()->precomputed_reductions_;
     if (attr_gs.has_default_values()) return status::success;
 
@@ -468,7 +468,7 @@ status_t pd_t::gs_ok(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t pd_t::scales_ok(impl::engine_t *engine) {
+status_t pd_t::scales_ok(const impl::engine_t *engine) {
     const auto &scales = attr()->scales_;
     if (scales.has_default_values()) return status::success;
     int ndims = desc()->a_desc.ndims;

--- a/src/gpu/intel/gemm/jit/pd.hpp
+++ b/src/gpu/intel/gemm/jit/pd.hpp
@@ -57,7 +57,7 @@ struct pd_t : public gemm::pd_t {
     using gemm::pd_t::pd_t;
 
     // Assumes desc() was already initialized with default formats
-    status_t init(impl::engine_t *engine, compute::gpu_arch_t arch) {
+    status_t init(const impl::engine_t *engine, compute::gpu_arch_t arch) {
 
         arch_ = arch;
         with_sround_ = attr()->rounding_mode_.get(DNNL_ARG_DST)
@@ -96,11 +96,11 @@ struct pd_t : public gemm::pd_t {
                 binary_div, binary_min, binary_max);
     }
 
-    status_t init_post_ops(impl::engine_t *engine);
-    status_t init_attrs(impl::engine_t *engine);
-    status_t scales_ok(impl::engine_t *engine);
-    status_t zp_ok(impl::engine_t *engine);
-    status_t gs_ok(impl::engine_t *engine);
+    status_t init_post_ops(const impl::engine_t *engine);
+    status_t init_attrs(const impl::engine_t *engine);
+    status_t scales_ok(const impl::engine_t *engine);
+    status_t zp_ok(const impl::engine_t *engine);
+    status_t gs_ok(const impl::engine_t *engine);
 
     dim_t ld_binary(int idx) const;
     dim_t stride_binary(int idx, int stride = 0) const;

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -32,7 +32,7 @@ namespace gemm {
 
 using namespace gemmstone;
 
-status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
+status_t xe_hp_systolic_t::pd_t::init(const impl::engine_t *engine) {
     using namespace prop_kind;
     using namespace data_type;
     using namespace primitive_kind;
@@ -40,7 +40,7 @@ status_t xe_hp_systolic_t::pd_t::init(impl::engine_t *engine) {
     using arch_t = compute::gpu_arch_t;
 
     assert(engine->kind() == engine_kind::gpu);
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     VDISPATCH_GEMM(intel_engine->mayiuse_ngen_kernels(),
             VERBOSE_UNSUPPORTED_DEVICE_FEATURE, "ngen kernels");

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
@@ -37,7 +37,7 @@ struct xe_hp_systolic_t : public gemm::primitive_t {
 
         DECLARE_COMMON_PD_T("jit:xe_hp:gemm:any", xe_hp_systolic_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
         void init_scratchpad();
 
         bool use_nocopy();

--- a/src/gpu/intel/gemm/ref.hpp
+++ b/src/gpu/intel/gemm/ref.hpp
@@ -96,7 +96,7 @@ struct ref_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/gpu/intel/gemm/utils.hpp
+++ b/src/gpu/intel/gemm/utils.hpp
@@ -118,7 +118,7 @@ static inline status_t create_gemm_desc(gemm_desc_t *_gemm_desc,
 }
 
 static inline status_t create_gemm_pd(
-        std::shared_ptr<primitive_desc_t> &gemm_pd_, engine_t *engine,
+        std::shared_ptr<primitive_desc_t> &gemm_pd_, const engine_t *engine,
         const memory_desc_t *a_md, const memory_desc_t *b_md,
         const memory_desc_t *c_md, const memory_desc_t *bias_md,
         data_type_t acc_dt, const primitive_attr_t *attr, bool skip_ref = false,

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -23,7 +23,7 @@ namespace gpu {
 namespace intel {
 namespace gemm {
 
-status_t with_post_ops_t::pd_t::init(impl::engine_t *engine) {
+status_t with_post_ops_t::pd_t::init(const impl::engine_t *engine) {
     using namespace data_type;
 
     const auto &d = desc();
@@ -116,7 +116,7 @@ status_t with_post_ops_t::pd_t::init(impl::engine_t *engine) {
     if (!it_with_po.is_initialized()) return status::invalid_arguments;
     pd_ = *(++it_with_po);
     // exit if gemm kernel support post ops
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto arch = intel_engine->device_info()->gpu_arch();
     bool is_xe_hp = arch >= compute::gpu_arch_t::xe_hp;
     auto skip_impl = is_xe_hp ? "ocl" : "ref";

--- a/src/gpu/intel/gemm/with_post_ops.hpp
+++ b/src/gpu/intel/gemm/with_post_ops.hpp
@@ -34,7 +34,7 @@ struct with_post_ops_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:with_po:any", with_post_ops_t);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         void init_scratchpad();
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;

--- a/src/gpu/intel/gnorm/ref.cpp
+++ b/src/gpu/intel/gnorm/ref.cpp
@@ -66,7 +66,7 @@ static status_t init_kernel_ctx_common(
     return status::success;
 }
 
-status_t ref_fwd_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init(const impl::engine_t *engine) {
     using namespace data_type;
 
     using skip_mask_t = primitive_attr_t::skip_mask_t;
@@ -92,7 +92,7 @@ status_t ref_fwd_t::pd_t::init(impl::engine_t *engine) {
     CHECK(attr_.set_default_formats(
             dst_md(0))); // can't use attr() due to it is const
 
-    const auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     dispatch = intel_engine->create_dispatch(src_md());
 
     dispatch.define_dim("BATCH", MB());
@@ -160,7 +160,7 @@ status_t ref_fwd_t::execute(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t ref_bwd_t::pd_t::init(impl::engine_t *engine) {
+status_t ref_bwd_t::pd_t::init(const impl::engine_t *engine) {
     using namespace data_type;
 
     // TODO: remove me
@@ -183,7 +183,7 @@ status_t ref_bwd_t::pd_t::init(impl::engine_t *engine) {
 
     VDISPATCH_GNORM(set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
 
-    const auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     dispatch = intel_engine->create_dispatch(diff_src_md());
     // put parallelization dimension
     dispatch.define_dim("CHANNEL", C());

--- a/src/gpu/intel/gnorm/ref.hpp
+++ b/src/gpu/intel/gnorm/ref.hpp
@@ -36,9 +36,9 @@ struct ref_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
         // check data types compatibility and initialize `dispatch`
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         // define kernel compile time environment
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
@@ -76,7 +76,7 @@ struct ref_bwd_t : public primitive_t {
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
         // check data types compatibility and initialize `dispatch`
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         // define kernel compile time environment
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;

--- a/src/gpu/intel/ip/conv.cpp
+++ b/src/gpu/intel/ip/conv.cpp
@@ -34,7 +34,7 @@ static int adjust_dims(dims_t &dims, const memory_desc_t *dst, int ndims) {
     return max_dims;
 }
 
-status_t conv_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t conv_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     const desc_t &ipd = *desc();
 
     const auto *src_md = invariant_src_md();

--- a/src/gpu/intel/ip/conv.hpp
+++ b/src/gpu/intel/ip/conv.hpp
@@ -35,12 +35,13 @@ struct conv_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:conv", conv_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::scales
                     | primitive_attr_t::skip_mask_t::post_ops;
@@ -86,7 +87,7 @@ struct conv_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/ip/matmul.hpp
+++ b/src/gpu/intel/ip/matmul.hpp
@@ -45,7 +45,7 @@ struct matmul_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 (matmul_pd_ ? matmul_pd_->name() : "ocl:matmul"), matmul_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             assert(engine->kind() == engine_kind::gpu);
@@ -157,7 +157,7 @@ struct matmul_bwd_data_t : public primitive_t {
                     diff_src_md()->data_type, diff_dst_md()->data_type);
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
@@ -242,7 +242,7 @@ struct matmul_bwd_weights_t : public primitive_t {
                     src_md()->data_type, diff_dst_md()->data_type);
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
 

--- a/src/gpu/intel/ip/ref.cpp
+++ b/src/gpu/intel/ip/ref.cpp
@@ -24,8 +24,8 @@ namespace gpu {
 namespace intel {
 namespace ip {
 
-static status_t init_conf_common(
-        conf_t &conf, offsets_t &off, const pd_t *pd, impl::engine_t *engine) {
+static status_t init_conf_common(conf_t &conf, offsets_t &off, const pd_t *pd,
+        const impl::engine_t *engine) {
     const desc_t &ipd = *pd->desc();
     const memory_desc_wrapper src_d(pd->invariant_src_md());
     const memory_desc_wrapper wei_d(pd->invariant_wei_md());
@@ -73,7 +73,7 @@ static status_t init_conf_common(
     conf.is_backward_data = ipd.prop_kind == prop_kind::backward_data;
     conf.is_backward_weights = ipd.prop_kind == prop_kind::backward_weights;
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     if (conf.is_forward) {
         conf.with_bias = ipd.bias_desc.format_kind != format_kind::undef;
         conf.bia_dt = conf.with_bias ? ipd.bias_desc.data_type : data_type::f32;
@@ -162,7 +162,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine);
 }
 
@@ -212,7 +212,7 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t ref_bwd_data_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_data_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine);
 }
 
@@ -247,7 +247,7 @@ status_t ref_bwd_data_t::execute_backward_data(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t ref_bwd_weights_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_weights_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine);
 }
 

--- a/src/gpu/intel/ip/ref.hpp
+++ b/src/gpu/intel/ip/ref.hpp
@@ -34,12 +34,13 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::scales
                     | primitive_attr_t::skip_mask_t::post_ops;
@@ -97,7 +98,7 @@ struct ref_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -133,7 +134,7 @@ struct ref_bwd_data_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             assert(engine->kind() == engine_kind::gpu);
@@ -162,7 +163,7 @@ struct ref_bwd_data_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -198,7 +199,7 @@ struct ref_bwd_weights_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             assert(engine->kind() == engine_kind::gpu);
@@ -227,7 +228,7 @@ struct ref_bwd_weights_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/jit/generator.hpp
+++ b/src/gpu/intel/jit/generator.hpp
@@ -149,7 +149,7 @@ public:
 };
 
 inline ngen::HW to_ngen_hw(const impl::engine_t *engine) {
-    auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     return intel_engine->device_info()->ngen_hw();
 }
 

--- a/src/gpu/intel/kernel_cache.cpp
+++ b/src/gpu/intel/kernel_cache.cpp
@@ -24,11 +24,11 @@ namespace intel {
 using namespace compute;
 
 status_t get_or_create(const kernel_cache::key_t &key,
-        gpu_kernel_value_t &jit_generator, impl::engine_t *engine,
+        gpu_kernel_value_t &jit_generator, const impl::engine_t *engine,
         cache_state_t &kernel_cache_hit) {
     struct create_context_t {
         const gpu_kernel_key_impl_t &params;
-        impl::engine_t *engine;
+        const impl::engine_t *engine;
         cache_state_t cache_status;
     };
 
@@ -51,7 +51,7 @@ status_t get_or_create(const kernel_cache::key_t &key,
 
 template <typename value_type>
 status_t get_cached_kernels(std::shared_ptr<gpu_kernel_key_impl_t> &&key_impl,
-        impl::engine_t *engine, std::vector<kernel_t> &kernels,
+        const impl::engine_t *engine, std::vector<kernel_t> &kernels,
         const std::vector<const char *> &kernel_names,
         cache_state_t &kernel_cache_hit) {
     kernel_cache::key_t key {std::move(key_impl)};
@@ -86,12 +86,12 @@ status_t get_cached_kernels(std::shared_ptr<gpu_kernel_key_impl_t> &&key_impl,
 
 template status_t get_cached_kernels<kernel_t>(
         std::shared_ptr<gpu_kernel_key_impl_t> &&key_impl,
-        impl::engine_t *engine, std::vector<kernel_t> &kernels,
+        const impl::engine_t *engine, std::vector<kernel_t> &kernels,
         const std::vector<const char *> &kernel_names,
         cache_state_t &kernel_cache_hit);
 template status_t get_cached_kernels<kernel_bundle_t>(
         std::shared_ptr<gpu_kernel_key_impl_t> &&key_impl,
-        impl::engine_t *engine, std::vector<kernel_t> &kernels,
+        const impl::engine_t *engine, std::vector<kernel_t> &kernels,
         const std::vector<const char *> &kernel_names,
         cache_state_t &kernel_cache_hit);
 

--- a/src/gpu/intel/kernel_cache.hpp
+++ b/src/gpu/intel/kernel_cache.hpp
@@ -141,7 +141,7 @@ private:
 // GPU specific abstract interface for kernel_cache::key_impl_t
 struct gpu_kernel_key_impl_t : public kernel_cache::key_impl_t {
     virtual status_t create_generator(
-            impl::engine_t *engine, gpu_kernel_value_t &generator) const
+            const impl::engine_t *engine, gpu_kernel_value_t &generator) const
             = 0;
 };
 
@@ -164,13 +164,14 @@ struct gpu_kernel_key_container_t final : public gpu_kernel_key_impl_t {
     gpu_kernel_key_container_t(Args &&...args)
         : key(std::forward<Args>(args)...) {}
 
-    status_t create_generator(impl::engine_t *engine,
+    status_t create_generator(const impl::engine_t *engine,
             gpu_kernel_value_t &generator) const override {
 
         auto g = std::make_shared<gpu_kernel_value_container_t<value_type>>(
                 value_type());
 
-        auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        const auto *intel_engine
+                = utils::downcast<const intel::engine_t *>(engine);
         auto status = key.create_generator(*intel_engine, g->value);
         generator = std::static_pointer_cast<kernel_cache::value_impl_t>(g);
         return status;
@@ -194,19 +195,19 @@ using trivial_key_container_t = gpu_kernel_key_container_t<trivial_key_t<K>>;
 // location
 template <typename value_type>
 status_t get_cached_kernels(std::shared_ptr<gpu_kernel_key_impl_t> &&key_impl,
-        impl::engine_t *engine, std::vector<compute::kernel_t> &kernels,
+        const impl::engine_t *engine, std::vector<compute::kernel_t> &kernels,
         const std::vector<const char *> &kernel_names,
         cache_state_t &kernel_cache_hit);
 
 extern template status_t get_cached_kernels<compute::kernel_t>(
         std::shared_ptr<gpu_kernel_key_impl_t> &&key_impl,
-        impl::engine_t *engine, std::vector<compute::kernel_t> &kernels,
+        const impl::engine_t *engine, std::vector<compute::kernel_t> &kernels,
         const std::vector<const char *> &kernel_names,
         cache_state_t &kernel_cache_hit);
 
 extern template status_t get_cached_kernels<compute::kernel_bundle_t>(
         std::shared_ptr<gpu_kernel_key_impl_t> &&key_impl,
-        impl::engine_t *engine, std::vector<compute::kernel_t> &kernels,
+        const impl::engine_t *engine, std::vector<compute::kernel_t> &kernels,
         const std::vector<const char *> &kernel_names,
         cache_state_t &kernel_cache_hit);
 

--- a/src/gpu/intel/lnorm/ref.cpp
+++ b/src/gpu/intel/lnorm/ref.cpp
@@ -25,7 +25,7 @@ namespace intel {
 namespace lnorm {
 
 static status_t init_conf_common(
-        conf_t &conf, const pd_t *pd, impl::engine_t *engine) {
+        conf_t &conf, const pd_t *pd, const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
 
     memory_desc_wrapper src_mdw(
@@ -58,7 +58,7 @@ static status_t init_conf_common(
         conf.weights_data_type = weights_mdw.data_type();
     }
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch_scaleshift = intel_engine->create_dispatch();
     conf.dispatch = intel_engine->create_dispatch(
             pd->is_fwd() ? dst_mdw.md_ : src_mdw.md_);
@@ -113,7 +113,7 @@ static status_t init_kernel_ctx_common(
     return status::success;
 }
 
-status_t ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 
@@ -159,7 +159,7 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t ref_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 

--- a/src/gpu/intel/lnorm/ref.hpp
+++ b/src/gpu/intel/lnorm/ref.hpp
@@ -36,11 +36,11 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto src_dt = src_md()->data_type;
             auto dst_dt = dst_md()->data_type;
@@ -73,7 +73,7 @@ struct ref_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -116,11 +116,11 @@ struct ref_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto src_dt = src_md()->data_type;
             auto diff_dst_dt = diff_dst_md()->data_type;
@@ -151,7 +151,7 @@ struct ref_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/lnorm/reusable.cpp
+++ b/src/gpu/intel/lnorm/reusable.cpp
@@ -142,7 +142,7 @@ void init_scratchpad_common(
     }
 }
 
-status_t reusable_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t reusable_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     size_t ndims = static_cast<size_t>(src_md()->ndims);
     std::vector<dim_idx_t> dims = get_dims(ndims);
     std::vector<dim_idx_t> stat_dims = get_dims(ndims, true);
@@ -162,7 +162,7 @@ status_t reusable_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
     const auto *gpu_attr
             = utils::downcast<gpu_primitive_attr_t *>(attr()->gpu_attr_.get());
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto lws_strategy = compute::default_lws_strategy_t(intel_engine, gpu_attr);
 
     return status::success;
@@ -275,7 +275,7 @@ status_t reusable_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
 /********** BWD implementation ***********/
 
-status_t reusable_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t reusable_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     size_t ndims = static_cast<size_t>(diff_dst_md()->ndims);
     std::vector<dim_idx_t> dims = get_dims(ndims);
     std::vector<dim_idx_t> stat_dims = get_dims(ndims, true);

--- a/src/gpu/intel/lnorm/reusable.hpp
+++ b/src/gpu/intel/lnorm/reusable.hpp
@@ -84,9 +84,10 @@ struct reusable_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:reusable:ref", reusable_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             data_type_t src_dt = src_md()->data_type;
             data_type_t dst_dt = dst_md()->data_type;
@@ -116,7 +117,7 @@ struct reusable_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
 
         reusable_params_t conf;
@@ -158,9 +159,10 @@ struct reusable_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:reusable:ref", reusable_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             data_type_t src_dt = diff_src_md()->data_type;
             data_type_t dst_dt = diff_dst_md()->data_type;
@@ -188,7 +190,7 @@ struct reusable_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         reusable_params_t conf;
         reusable_runtime_params_t rt_conf;

--- a/src/gpu/intel/lnorm/reusable_vectorized.cpp
+++ b/src/gpu/intel/lnorm/reusable_vectorized.cpp
@@ -177,7 +177,8 @@ static status_t init_conf_common(const pd_t *pd,
     return status::success;
 }
 
-status_t reusable_vectorized_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t reusable_vectorized_fwd_t::pd_t::init_conf(
+        const impl::engine_t *engine) {
     size_t ndims = static_cast<size_t>(src_md()->ndims);
     vector<dim_idx_t> dims = get_dims(ndims);
     vector<dim_idx_t> stat_dims = get_dims(ndims, true);

--- a/src/gpu/intel/lnorm/reusable_vectorized.hpp
+++ b/src/gpu/intel/lnorm/reusable_vectorized.hpp
@@ -97,9 +97,10 @@ struct reusable_vectorized_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T(
                 "ocl:reusable:vectorized", reusable_vectorized_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             data_type_t src_dt = src_md()->data_type;
             data_type_t dst_dt = dst_md()->data_type;
@@ -131,7 +132,7 @@ struct reusable_vectorized_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         reusable_vectorized_params_t conf;
         reusable_vectorized_runtime_params_t rt_conf;

--- a/src/gpu/intel/lnorm/simple.cpp
+++ b/src/gpu/intel/lnorm/simple.cpp
@@ -25,7 +25,7 @@ namespace intel {
 namespace lnorm {
 
 static status_t init_conf_common(
-        conf_t &conf, const pd_t *pd, impl::engine_t *engine) {
+        conf_t &conf, const pd_t *pd, const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
 
     memory_desc_wrapper src_mdw(
@@ -73,7 +73,7 @@ static status_t init_conf_common(
         c_is_last_physical = src_mdw.blocking_desc().strides[ndims - 1] == 1;
     }
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch_scaleshift = intel_engine->create_dispatch();
     conf.dispatch_scaleshift_finalize = intel_engine->create_dispatch();
     conf.dispatch = intel_engine->create_dispatch(
@@ -270,7 +270,7 @@ static status_t init_kernel_ctx_common(
     return status::success;
 }
 
-status_t simple_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t simple_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 
@@ -316,7 +316,7 @@ status_t simple_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t simple_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t simple_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 

--- a/src/gpu/intel/lnorm/simple.hpp
+++ b/src/gpu/intel/lnorm/simple.hpp
@@ -36,11 +36,11 @@ struct simple_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("lnorm_simple:any", simple_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto src_dt = src_md()->data_type;
             auto dst_dt = dst_md()->data_type;
@@ -72,7 +72,7 @@ struct simple_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -115,11 +115,11 @@ struct simple_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("lnorm_simple:any", simple_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto src_dt = src_md()->data_type;
             auto diff_dst_dt = diff_dst_md()->data_type;
@@ -151,7 +151,7 @@ struct simple_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 

--- a/src/gpu/intel/lnorm/vectorized.cpp
+++ b/src/gpu/intel/lnorm/vectorized.cpp
@@ -28,15 +28,15 @@ namespace lnorm {
 using namespace compute;
 using namespace dnnl::impl::format_tag;
 
-bool mayiuse_sg(const int sg_size, impl::engine_t *engine) {
-    auto *intel_engine = utils::downcast<engine_t *>(engine);
+bool mayiuse_sg(const int sg_size, const impl::engine_t *engine) {
+    auto *intel_engine = utils::downcast<const engine_t *>(engine);
     return intel_engine->mayiuse_sub_group(sg_size)
             && intel_engine->mayiuse_block_reads_writes_with_sub_group(sg_size);
 }
 
 bool is_fused_kernel_applicable(conf_t &conf, const pd_t *pd,
-        impl::engine_t *engine, int grf_per_thread) {
-    auto *intel_engine = utils::downcast<engine_t *>(engine);
+        const impl::engine_t *engine, int grf_per_thread) {
+    auto *intel_engine = utils::downcast<const engine_t *>(engine);
 
     auto gpu_arch = intel_engine->device_info()->gpu_arch();
     memory_desc_wrapper src_mdw(pd->src_md());
@@ -174,9 +174,9 @@ bool is_fused_kernel_applicable(conf_t &conf, const pd_t *pd,
 }
 
 static status_t init_conf_common(
-        conf_t &conf, const pd_t *pd, impl::engine_t *engine) {
+        conf_t &conf, const pd_t *pd, const impl::engine_t *engine) {
 
-    auto *intel_engine = utils::downcast<engine_t *>(engine);
+    auto *intel_engine = utils::downcast<const engine_t *>(engine);
     auto &device_info = *intel_engine->device_info();
     auto gpu_arch = device_info.gpu_arch();
 
@@ -526,7 +526,7 @@ static status_t init_kernel_ctx_common(
     return status::success;
 }
 
-status_t vectorized_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t vectorized_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 
@@ -571,7 +571,7 @@ status_t vectorized_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t vectorized_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t vectorized_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 

--- a/src/gpu/intel/lnorm/vectorized.hpp
+++ b/src/gpu/intel/lnorm/vectorized.hpp
@@ -36,10 +36,11 @@ struct vectorized_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:vectorized", vectorized_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             auto src_data_t = src_md()->data_type;
             auto dst_data_t = dst_md()->data_type;
 
@@ -71,7 +72,7 @@ struct vectorized_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -113,9 +114,10 @@ struct vectorized_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:vectorized", vectorized_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto src_dt = src_md()->data_type;
             auto diff_dst_dt = diff_dst_md()->data_type;
@@ -148,7 +150,7 @@ struct vectorized_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 

--- a/src/gpu/intel/lrn/ref.hpp
+++ b/src/gpu/intel/lrn/ref.hpp
@@ -35,10 +35,11 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_LRN(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_LRN(utils::one_of(src_md()->data_type, f32, f16, bf16),
@@ -164,10 +165,11 @@ struct ref_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             VDISPATCH_LRN(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_LRN(utils::one_of(src_md()->data_type, f32, bf16, f16),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -41,7 +41,7 @@ struct gemm_t : public primitive_t {
 
         DECLARE_COMMON_PD_T(gemm_pd_ ? gemm_pd_->name() : "gemm_t", gemm_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             primitive_attr_t gemm_attr;

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -38,14 +38,15 @@ namespace gpu {
 namespace intel {
 namespace matmul {
 
-status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
+status_t grouped_micro_gemm_t::pd_t::init_microkernels(
+        const impl::engine_t *engine) {
     using namespace jit;
     using namespace gemmstone;
     using namespace gemmstone::microkernel;
     using gemm::jit::convert_dnnl_to_kernel_type;
 
     assert(engine->kind() == engine_kind::gpu);
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *dev_info = intel_engine->device_info();
     bool use_systolic_ukernel = dev_info->mayiuse_systolic();
 
@@ -303,7 +304,7 @@ void calc_group_sizes(std::array<int, N> &dims, const quant_entry_t &entry,
     });
 }
 
-status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
+status_t grouped_micro_gemm_t::pd_t::init(const impl::engine_t *engine) {
     using namespace data_type;
 
     memory_desc_wrapper src_d(src_md());
@@ -392,7 +393,7 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
     }
 
     assert(engine->kind() == engine_kind::gpu);
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *dev_info = intel_engine->device_info();
     VDISPATCH_MATMUL(compute::mayiuse_microkernels(intel_engine),
             VERBOSE_UNSUPPORTED_DEVICE_FEATURE, "microkernels");

--- a/src/gpu/intel/matmul/grouped_micro_gemm.hpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.hpp
@@ -66,8 +66,8 @@ struct grouped_micro_gemm_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("grouped_gemm:micro", grouped_micro_gemm_t);
 
-        status_t init(impl::engine_t *engine);
-        status_t init_microkernels(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
+        status_t init_microkernels(const impl::engine_t *engine);
         bool is_gemv_ = false;
         bool with_post_op_ = false;
         po_kind_t po_chain_[3]

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -73,7 +73,9 @@ struct ref_t : public primitive_t {
                             quantization_mode::dynamic_mx,
                             quantization_mode::dynamic_fp},
                     {{DNNL_ARG_SRC, {src_qmask_M()}}}));
-            VDISPATCH_MATMUL(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok(engine,
+                    {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+                    {quantization_mode::static_sazp}));
             VDISPATCH_MATMUL(
                     precomputed_reductions_ok(), VERBOSE_UNSUPPORTED_PR_CFG);
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
@@ -160,58 +162,6 @@ struct ref_t : public primitive_t {
         attr_info_t attr_info_ = {};
 
     private:
-        int broadcast_mask(const memory_desc_t *md) const {
-            int mask = 0;
-            for (int d = 0; d < md->ndims; ++d)
-                if (md->dims[d] == 1) mask |= (1 << d);
-            return mask;
-        }
-
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int bcast_mask = broadcast_mask(src_md());
-                int mask_src = zp.get_mask(DNNL_ARG_SRC) & ~bcast_mask;
-                bool ok = utils::one_of(mask_src, 0,
-                        src_qmask_K() & ~bcast_mask,
-                        (src_qmask_M() + src_qmask_K()) & ~bcast_mask);
-                if (!ok) return false;
-
-                if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
-                    const auto gM = zp.get_group(DNNL_ARG_SRC, 0);
-                    ok = gM == 1;
-                    if (!ok) return false;
-
-                    const auto gK = zp.get_group(DNNL_ARG_SRC, 1);
-                    ok = IMPLICATION(gK > 1, K() % gK == 0);
-                    if (!ok) return false;
-                }
-            }
-            /* weights decompression requires zero points support */
-            if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
-                if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
-                    const auto gK = zp.get_group(DNNL_ARG_WEIGHTS, 0);
-                    bool ok = IMPLICATION(gK > 1, K() % gK == 0);
-                    if (!ok) return false;
-
-                    const auto gN = zp.get_group(DNNL_ARG_WEIGHTS, 1);
-                    ok = IMPLICATION(gN > 1, N() % gN == 0);
-                    if (!ok) return false;
-
-                    // Only one non-unit group is supported.
-                    ok = utils::one_of(1, gK, gN);
-                    if (!ok) return false;
-                }
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int bcast_mask = broadcast_mask(dst_md());
-                int mask_dst = zp.get_mask(DNNL_ARG_DST) & ~bcast_mask;
-                bool ok = utils::one_of(
-                        mask_dst, 0, dst_qmask_N() & ~bcast_mask);
-                if (!ok) return false;
-            }
-            return true;
-        }
         status_t dropout_ok() const {
             if (attr_.dropout_.has_default_values()) return status::success;
 

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -42,7 +42,7 @@ struct ref_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 
@@ -50,7 +50,8 @@ struct ref_t : public primitive_t {
             dst_dt_ = dst_md()->data_type;
             wei_dt_ = weights_md(0)->data_type;
             bia_dt_ = with_bias() ? weights_md(1)->data_type : data_type::f32;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto dev_info_ = intel_engine->device_info();
 

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -67,13 +67,12 @@ struct ref_t : public primitive_t {
                             | smask_t::fpmath_mode | smask_t::rounding_mode
                             | smask_t::precomputed_reductions),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_MATMUL(attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS,
-                                                    DNNL_ARG_DST},
-                                     {quantization_mode::static_sazp,
-                                             quantization_mode::dynamic_mx,
-                                             quantization_mode::dynamic_fp},
-                                     {{DNNL_ARG_SRC, {src_qmask_M()}}}),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok(engine,
+                    {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+                    {quantization_mode::static_sazp,
+                            quantization_mode::dynamic_mx,
+                            quantization_mode::dynamic_fp},
+                    {{DNNL_ARG_SRC, {src_qmask_M()}}}));
             VDISPATCH_MATMUL(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_MATMUL(
                     precomputed_reductions_ok(), VERBOSE_UNSUPPORTED_PR_CFG);

--- a/src/gpu/intel/matmul/ref_grouped_gemm.hpp
+++ b/src/gpu/intel/matmul/ref_grouped_gemm.hpp
@@ -52,7 +52,7 @@ struct ref_grouped_t : public primitive_t {
 
         bool is_2dby2d() const { return is_2dby2d_; }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             memory_desc_wrapper src_d(src_md());
             memory_desc_wrapper wei_d(weights_md(0));
 
@@ -80,7 +80,7 @@ struct ref_grouped_t : public primitive_t {
     private:
         bool is_2dby2d_ = false;
 
-        status_t init_2dby3d(impl::engine_t *engine) {
+        status_t init_2dby3d(const impl::engine_t *engine) {
             using namespace data_type;
 
             memory_desc_wrapper wei_d(weights_md(0));
@@ -234,7 +234,7 @@ struct ref_grouped_t : public primitive_t {
         //   per-group  [G, 1]       -> [G, 1, 1]
         //   per-token  [total_M, 1] -> [1, total_M, 1]
         //   per-token  [total_M, N] -> [1, total_M, N]
-        status_t setup_post_ops(impl::engine_t *engine) {
+        status_t setup_post_ops(const impl::engine_t *engine) {
             auto &attr_po = attr_.post_ops_;
             generic_po_ = attr_po;
 
@@ -269,7 +269,7 @@ struct ref_grouped_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_2dby2d(impl::engine_t *engine) {
+        status_t init_2dby2d(const impl::engine_t *engine) {
             using namespace data_type;
 
             memory_desc_wrapper dst_d(dst_md());

--- a/src/gpu/intel/matmul/sparse_ref.hpp
+++ b/src/gpu/intel/matmul/sparse_ref.hpp
@@ -39,7 +39,7 @@ struct ref_sparse_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_sparse_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             src_dt_ = src_md()->data_type;

--- a/src/gpu/intel/pool/jit.cpp
+++ b/src/gpu/intel/pool/jit.cpp
@@ -32,11 +32,11 @@ namespace pool {
 
 using namespace jit;
 
-status_t gen_fwd_t::pd_t::init(impl::engine_t *engine) {
+status_t gen_fwd_t::pd_t::init(const impl::engine_t *engine) {
     using namespace data_type;
     using namespace prop_kind;
     using namespace alg_kind;
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto arch = intel_engine->device_info()->gpu_arch();
     auto src_data_t = src_md()->data_type;
     auto dst_data_t = dst_md()->data_type;

--- a/src/gpu/intel/pool/jit.hpp
+++ b/src/gpu/intel/pool/jit.hpp
@@ -37,7 +37,7 @@ public:
 
         DECLARE_COMMON_PD_T("jit:ir", gen_fwd_t);
 
-        status_t init(impl::engine_t *);
+        status_t init(const impl::engine_t *);
 
         std::shared_ptr<conf_t> conf;
         std::shared_ptr<jit::dsl::kernel::options_t> options;

--- a/src/gpu/intel/pool/ref.cpp
+++ b/src/gpu/intel/pool/ref.cpp
@@ -23,7 +23,7 @@ namespace intel {
 namespace pool {
 
 static status_t init_conf_common(conf_t &conf, offsets_t &off, const pd_t *pd,
-        impl::engine_t *engine, const bool is_bwd) {
+        const impl::engine_t *engine, const bool is_bwd) {
     using namespace dnnl::impl::format_tag;
 
     const memory_desc_wrapper src_mdw(pd->invariant_src_md());
@@ -36,7 +36,7 @@ static status_t init_conf_common(conf_t &conf, offsets_t &off, const pd_t *pd,
     set_offsets(src_mdw, off.src_off);
     set_offsets(dst_mdw, off.dst_off);
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(
             conf.is_backward ? src_mdw.md_ : dst_mdw.md_);
     conf.dispatch.define_dim("MB", 0, conf.mb_padded);
@@ -109,7 +109,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine, false);
 }
 
@@ -136,7 +136,7 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return parallel_for(ctx, nd_range, kernel_, arg_list);
 }
 
-status_t ref_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine, true);
 }
 

--- a/src/gpu/intel/pool/ref.hpp
+++ b/src/gpu/intel/pool/ref.hpp
@@ -35,7 +35,7 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace alg_kind;
@@ -46,7 +46,7 @@ struct ref_fwd_t : public primitive_t {
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
 
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_POOLING_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_POOLING(utils::one_of(desc()->prop_kind, forward_training,
@@ -114,7 +114,7 @@ struct ref_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -149,12 +149,12 @@ struct ref_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace alg_kind;
 
             const auto *intel_engine
-                    = utils::downcast<intel::engine_t *>(engine);
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_POOLING_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_POOLING(utils::one_of(desc()->prop_kind, backward_data),
@@ -197,7 +197,7 @@ struct ref_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/pool/xe.cpp
+++ b/src/gpu/intel/pool/xe.cpp
@@ -22,8 +22,8 @@ namespace gpu {
 namespace intel {
 namespace pool {
 
-static status_t init_conf_common(
-        conf_t &conf, offsets_t &off, const pd_t *pd, impl::engine_t *engine) {
+static status_t init_conf_common(conf_t &conf, offsets_t &off, const pd_t *pd,
+        const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
     using namespace dnnl::impl::alg_kind;
 
@@ -125,7 +125,7 @@ static status_t init_conf_common(
                     "ocl ref_kernel is faster");
         }
     }
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(
             conf.is_backward ? src_mdw.md_ : dst_mdw.md_);
 
@@ -245,7 +245,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t xe_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine);
 }
 
@@ -281,7 +281,7 @@ status_t xe_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t xe_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine);
 }
 

--- a/src/gpu/intel/pool/xe.hpp
+++ b/src/gpu/intel/pool/xe.hpp
@@ -36,11 +36,12 @@ struct xe_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe", xe_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace alg_kind;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             auto src_data_t = src_md()->data_type;
             auto dst_data_t = dst_md()->data_type;
             auto acc_data_t = desc()->accum_data_type;
@@ -97,7 +98,7 @@ struct xe_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -132,10 +133,11 @@ struct xe_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe:any", xe_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace alg_kind;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             VDISPATCH_POOLING_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_POOLING(utils::one_of(desc()->prop_kind, backward_data),
@@ -189,7 +191,7 @@ struct xe_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/pool/xe_global.cpp
+++ b/src/gpu/intel/pool/xe_global.cpp
@@ -22,8 +22,9 @@ namespace gpu {
 namespace intel {
 namespace pool {
 
-dim_t calculate_spatial_chunk(const conf_t &conf, impl::engine_t *engine) {
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+dim_t calculate_spatial_chunk(
+        const conf_t &conf, const impl::engine_t *engine) {
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     const int hw_threads = intel_engine->device_info()->hw_threads();
     const bool is_xe_hp_plus = intel_engine->is_xe_hp()
             || intel_engine->is_xe_hpg() || intel_engine->is_xe_hpc();
@@ -44,8 +45,8 @@ dim_t calculate_spatial_chunk(const conf_t &conf, impl::engine_t *engine) {
     return chunk_size;
 }
 
-static status_t init_conf_common(
-        conf_t &conf, offsets_t &off, const pd_t *pd, impl::engine_t *engine) {
+static status_t init_conf_common(conf_t &conf, offsets_t &off, const pd_t *pd,
+        const impl::engine_t *engine) {
     using namespace dnnl::impl::format_tag;
 
     set_default_conf(conf, *pd->desc(), *pd->invariant_src_md(),
@@ -84,7 +85,7 @@ static status_t init_conf_common(
     set_offsets(src_mdw, off.src_off);
     set_offsets(dst_mdw, off.dst_off);
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     conf.is_plain = src_mdw.is_plain();
     conf.global_spatial_chunk = calculate_spatial_chunk(conf, engine);
@@ -160,7 +161,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t xe_global_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_global_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine);
 }
 
@@ -213,7 +214,7 @@ status_t xe_global_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     }
 }
 
-status_t xe_global_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t xe_global_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, off, this, engine);
 }
 

--- a/src/gpu/intel/pool/xe_global.hpp
+++ b/src/gpu/intel/pool/xe_global.hpp
@@ -36,7 +36,7 @@ struct xe_global_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe_global:any", xe_global_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace alg_kind;
@@ -72,12 +72,12 @@ struct xe_global_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         void init_scratchpad();
 
-        status_t init_reduction(impl::engine_t *engine) {
+        status_t init_reduction(const impl::engine_t *engine) {
             using namespace alg_kind;
 
             reduction_desc_t rdesc;
@@ -145,10 +145,11 @@ struct xe_global_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe_global:any", xe_global_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace alg_kind;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto diff_dst_dt = diff_dst_md()->data_type;
             auto diff_src_dt = diff_src_md()->data_type;
@@ -197,7 +198,7 @@ struct xe_global_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/prelu/ref.cpp
+++ b/src/gpu/intel/prelu/ref.cpp
@@ -25,7 +25,7 @@ namespace intel {
 namespace prelu {
 
 static status_t init_conf_common(
-        conf_t &conf, const pd_t *pd, impl::engine_t *engine) {
+        conf_t &conf, const pd_t *pd, const impl::engine_t *engine) {
 
     conf.is_forward = pd->is_fwd();
 
@@ -59,7 +59,7 @@ static status_t init_conf_common(
 
     const auto &ndims = dst_mdw.ndims();
 
-    const auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(src_mdw.md_);
 
     for (int i = 0; i < MAX_NDIMS; ++i) {
@@ -100,7 +100,7 @@ static status_t init_kernel_ctx_common(
     return status::success;
 }
 
-status_t ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 
@@ -127,7 +127,7 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return status;
 }
 
-status_t ref_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     return init_conf_common(conf, this, engine);
 }
 

--- a/src/gpu/intel/prelu/ref.hpp
+++ b/src/gpu/intel/prelu/ref.hpp
@@ -37,7 +37,7 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
 
             VDISPATCH_PRELU(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_PRELU(src_md()->data_type == dst_md()->data_type,
@@ -55,7 +55,7 @@ struct ref_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;
@@ -91,7 +91,7 @@ struct ref_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
 
             VDISPATCH_PRELU(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_PRELU(
@@ -117,11 +117,11 @@ struct ref_bwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();
 
-        status_t init_reduction(impl::engine_t *engine) {
+        status_t init_reduction(const impl::engine_t *engine) {
             reduction_desc_t rdesc;
             memory_desc_t red_diff_mem_desc(*src_md(0));
             red_diff_mem_desc.data_type = dnnl_f32;

--- a/src/gpu/intel/reduction/atomic.cpp
+++ b/src/gpu/intel/reduction/atomic.cpp
@@ -307,7 +307,7 @@ void atomic_t::pd_t::init_scratchpad() {
     }
 }
 
-status_t atomic_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t atomic_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper src_mdw(src_md());
     const memory_desc_wrapper dst_mdw(dst_md());
     const int ndims = src_mdw.ndims();
@@ -364,7 +364,7 @@ status_t atomic_t::pd_t::init_conf(impl::engine_t *engine) {
     }
 
     const intel::engine_t *intel_engine
-            = utils::downcast<intel::engine_t *>(engine);
+            = utils::downcast<const intel::engine_t *>(engine);
     auto *gpu_attr
             = utils::downcast<gpu_primitive_attr_t *>(attr()->gpu_attr_.get());
 
@@ -429,7 +429,7 @@ status_t atomic_t::pd_t::init_conf(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t atomic_t::pd_t::init_finalization_pd(impl::engine_t *engine) {
+status_t atomic_t::pd_t::init_finalization_pd(const impl::engine_t *engine) {
     eltwise_desc_t eltwise_desc;
     memory_desc_t eltwise_mem_desc(*dst_md());
     // XXX: Just for mean currently

--- a/src/gpu/intel/reduction/atomic.hpp
+++ b/src/gpu/intel/reduction/atomic.hpp
@@ -85,7 +85,7 @@ struct atomic_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:atomic", atomic_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto attr_skip_mask = smask_t::gpu_attr;
             VDISPATCH_REDUCTION_SC(
@@ -105,8 +105,8 @@ struct atomic_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
-        status_t init_finalization_pd(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
+        status_t init_finalization_pd(const impl::engine_t *engine);
         void init_scratchpad();
 
         dim_t div = 0;

--- a/src/gpu/intel/reduction/combined.cpp
+++ b/src/gpu/intel/reduction/combined.cpp
@@ -238,7 +238,7 @@ status_t split_into_phases(const subproblem_t &subprb,
     return status::success;
 }
 
-status_t combined_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t combined_t::pd_t::init_conf(const impl::engine_t *engine) {
     // To start, check for compatibility
     const memory_desc_wrapper src_mdw(src_md());
     const memory_desc_wrapper dst_mdw(dst_md());
@@ -291,7 +291,7 @@ status_t combined_t::pd_t::init_conf(impl::engine_t *engine) {
             VERBOSE_BAD_ALGORITHM);
 
     const intel::engine_t *intel_engine
-            = utils::downcast<intel::engine_t *>(engine);
+            = utils::downcast<const intel::engine_t *>(engine);
 
     auto *gpu_attr
             = utils::downcast<gpu_primitive_attr_t *>(attr()->gpu_attr_.get());

--- a/src/gpu/intel/reduction/combined.hpp
+++ b/src/gpu/intel/reduction/combined.hpp
@@ -49,7 +49,7 @@ struct combined_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:combined", combined_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto attr_skip_mask = smask_t::post_ops | smask_t::gpu_attr;
             VDISPATCH_REDUCTION_SC(
@@ -69,7 +69,7 @@ struct combined_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx,
                 const phase_conf_t &phase) const;
         void init_scratchpad();

--- a/src/gpu/intel/reduction/jit.cpp
+++ b/src/gpu/intel/reduction/jit.cpp
@@ -34,7 +34,7 @@ namespace reduction {
 
 using namespace gpu_utils;
 
-status_t gen_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t gen_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper src_mdw(src_md());
     const memory_desc_wrapper dst_mdw(dst_md());
     const int ndims = src_mdw.ndims();
@@ -64,7 +64,7 @@ status_t gen_t::pd_t::init_conf(impl::engine_t *engine) {
     dim_t inner_nelems = reduction_stride;
     int dt_size = into<int>(sizeof(float));
 
-    auto &intel_engine = *utils::downcast<intel::engine_t *>(engine);
+    auto &intel_engine = *utils::downcast<const intel::engine_t *>(engine);
     const compute::device_info_t &device_info = *intel_engine.device_info();
     int reg_size = device_info.grf_size();
     int elems_per_reg = reg_size / dt_size;

--- a/src/gpu/intel/reduction/jit.hpp
+++ b/src/gpu/intel/reduction/jit.hpp
@@ -44,7 +44,7 @@ struct gen_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("jit:xe", gen_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             // Require the corresponding environment variable - skip this impl
             // unless requested (do not report this skip to verbose)
             bool enabled = gpu_utils::dev_getenv("enable_jit_reduction", false);
@@ -75,7 +75,7 @@ struct gen_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         dim_t reduction_size = 0;
         dim_t reduction_stride = 0;
         int nregs = 1;

--- a/src/gpu/intel/reduction/ref.cpp
+++ b/src/gpu/intel/reduction/ref.cpp
@@ -25,7 +25,7 @@ namespace gpu {
 namespace intel {
 namespace reduction {
 
-status_t ref_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_t::pd_t::init_conf(const impl::engine_t *engine) {
     const pd_t *pd = this;
 
     const memory_desc_wrapper src_mdw(pd->src_md());
@@ -34,7 +34,7 @@ status_t ref_t::pd_t::init_conf(impl::engine_t *engine) {
     const int ndims = src_mdw.ndims();
     const auto src_dims = src_mdw.md_->dims;
     const auto dst_dims = dst_mdw.md_->dims;
-    const auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     conf.alg = pd->desc()->alg_kind;
     conf.src_md_info = memory_desc_info_t::create(src_mdw);

--- a/src/gpu/intel/reduction/ref.hpp
+++ b/src/gpu/intel/reduction/ref.hpp
@@ -36,7 +36,7 @@ struct ref_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using sm = primitive_attr_t::skip_mask_t;
             const auto attr_skip_mask = sm::post_ops | sm::gpu_attr;
 
@@ -55,7 +55,7 @@ struct ref_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/reduction/reusable_ref.cpp
+++ b/src/gpu/intel/reduction/reusable_ref.cpp
@@ -101,7 +101,7 @@ void reusable_ref_t::pd_t::init_scratchpad() {
     }
 }
 
-status_t reusable_ref_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t reusable_ref_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper src_mdw(src_md());
     const memory_desc_wrapper dst_mdw(dst_md());
     const int ndims = src_mdw.ndims();
@@ -160,7 +160,7 @@ status_t reusable_ref_t::pd_t::init_conf(impl::engine_t *engine) {
     }
 
     const intel::engine_t *intel_engine
-            = utils::downcast<intel::engine_t *>(engine);
+            = utils::downcast<const intel::engine_t *>(engine);
     auto *gpu_attr
             = utils::downcast<gpu_primitive_attr_t *>(attr()->gpu_attr_.get());
 

--- a/src/gpu/intel/reduction/reusable_ref.hpp
+++ b/src/gpu/intel/reduction/reusable_ref.hpp
@@ -78,7 +78,7 @@ struct reusable_ref_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:reusable:ref", reusable_ref_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using smask_t = primitive_attr_t::skip_mask_t;
             const auto attr_skip_mask = smask_t::gpu_attr;
             VDISPATCH_REDUCTION_SC(
@@ -96,7 +96,7 @@ struct reusable_ref_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
 
         dim_t div = 0;

--- a/src/gpu/intel/reorder/custom.cpp
+++ b/src/gpu/intel/reorder/custom.cpp
@@ -512,7 +512,7 @@ void custom_t::pd_t::alt_gen() {
     conf.dispatch.generate_override(gws, lws);
 }
 
-status_t custom_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t custom_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace format_tag;
 
     const memory_desc_wrapper src_mdw(src_md());
@@ -539,7 +539,7 @@ status_t custom_t::pd_t::init_conf(impl::engine_t *engine) {
     dim_idx_t last = conf.ndims - 1;
     size_t last_dim = padded_dims[last];
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     conf.implementation = select_kernel(
             conf, src_mdw, dst_mdw, intel_engine->device_info());

--- a/src/gpu/intel/reorder/custom.hpp
+++ b/src/gpu/intel/reorder/custom.hpp
@@ -39,8 +39,9 @@ struct custom_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:custom:any", custom_t);
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
 
             VDISPATCH_REORDER(
                     src_engine == dst_engine, VERBOSE_BAD_ENGINE_KIND);
@@ -54,7 +55,7 @@ struct custom_t : public primitive_t {
                                               .has_runtime_dims_or_strides()),
                     VERBOSE_RUNTIMEDIM_UNSUPPORTED);
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(
+            const auto *intel_engine = utils::downcast<const intel::engine_t *>(
                     dst_engine->kind() == engine_kind::gpu ? dst_engine
                                                            : src_engine);
             using namespace data_type;
@@ -93,7 +94,7 @@ struct custom_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void alt_gen();
         void alt_defines(compute::kernel_ctx_t &kernel_ctx) const;
         void init_scratchpad();

--- a/src/gpu/intel/reorder/generic.cpp
+++ b/src/gpu/intel/reorder/generic.cpp
@@ -767,7 +767,7 @@ bool fill_conf_vld(const memory_desc_wrapper &src,
     return true;
 }
 
-status_t generic_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t generic_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace format_tag;
 
     size_t memlimit_bytes;
@@ -813,7 +813,7 @@ status_t generic_t::pd_t::init_conf(impl::engine_t *engine) {
 
     conf.sub_group_size = 1;
     if (conf.nelems == 0) { return status::success; }
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     // Theoretically, bursts should be at least big enough to span whole
     // cache line and bigger bursts should give better perf as long as

--- a/src/gpu/intel/reorder/generic.hpp
+++ b/src/gpu/intel/reorder/generic.hpp
@@ -37,8 +37,9 @@ struct generic_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:generic:any", generic_t);
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
 
             VDISPATCH_REORDER(
                     src_engine == dst_engine, VERBOSE_BAD_ENGINE_KIND);
@@ -52,7 +53,7 @@ struct generic_t : public primitive_t {
                                               .has_runtime_dims_or_strides()),
                     VERBOSE_RUNTIMEDIM_UNSUPPORTED);
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(
+            const auto *intel_engine = utils::downcast<const intel::engine_t *>(
                     dst_engine->kind() == engine_kind::gpu ? dst_engine
                                                            : src_engine);
 
@@ -91,7 +92,7 @@ struct generic_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 

--- a/src/gpu/intel/reorder/jit.cpp
+++ b/src/gpu/intel/reorder/jit.cpp
@@ -34,11 +34,11 @@ namespace reorder {
 
 using namespace jit;
 
-status_t gen_t::pd_t::init(impl::engine_t *engine, impl::engine_t *src_engine,
-        impl::engine_t *dst_engine) {
+status_t gen_t::pd_t::init(const impl::engine_t *engine,
+        const impl::engine_t *src_engine, const impl::engine_t *dst_engine) {
     const auto src_dt = src_md()->data_type;
     const auto dst_dt = dst_md()->data_type;
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *device_info = intel_engine->device_info();
     using namespace data_type;
 

--- a/src/gpu/intel/reorder/jit.hpp
+++ b/src/gpu/intel/reorder/jit.hpp
@@ -38,7 +38,8 @@ public:
 
         DECLARE_COMMON_PD_T("jit:ir", gen_t);
 
-        status_t init(impl::engine_t *, impl::engine_t *, impl::engine_t *);
+        status_t init(const impl::engine_t *, const impl::engine_t *,
+                const impl::engine_t *);
         status_t init_kernel_info();
 
         std::shared_ptr<jit::config_t> cfg;

--- a/src/gpu/intel/reorder/ref.cpp
+++ b/src/gpu/intel/reorder/ref.cpp
@@ -25,7 +25,7 @@ namespace reorder {
 
 using namespace dnnl::impl::memory_tracking::names;
 
-status_t ref_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace format_tag;
     using namespace data_type;
 
@@ -47,7 +47,7 @@ status_t ref_t::pd_t::init_conf(impl::engine_t *engine) {
     conf.ndims = src_mdw.ndims();
     conf.nelems = utils::array_product(padded_dims, conf.ndims);
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *device_info = intel_engine->device_info();
     int sub_group_size = 1;
     if (device_info->mayiuse_sub_group(16)) sub_group_size = 16;

--- a/src/gpu/intel/reorder/ref.hpp
+++ b/src/gpu/intel/reorder/ref.hpp
@@ -37,8 +37,9 @@ struct ref_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
             using namespace data_type;
             using smask_t = dnnl_primitive_attr::skip_mask_t;
             using compute::device_ext_t;
@@ -82,7 +83,7 @@ struct ref_t : public primitive_t {
                             f4_e2m1, f4_e3m0, s32, s8, u8, s4, u4, f64),
                     VERBOSE_UNSUPPORTED_DT);
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(
+            const auto *intel_engine = utils::downcast<const intel::engine_t *>(
                     dst_engine->kind() == engine_kind::gpu ? dst_engine
                                                            : src_engine);
 
@@ -114,7 +115,7 @@ struct ref_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         void init_scratchpad();
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 

--- a/src/gpu/intel/resampling/ref.cpp
+++ b/src/gpu/intel/resampling/ref.cpp
@@ -59,9 +59,9 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
 
 // ---------- ref_fwd_t ------------ //
 
-status_t ref_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(dst_md());
 
     conf.dispatch.define_dim("MB", 0, dst_md()->padded_dims[0]);
@@ -135,9 +135,9 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
 // -------- ref_bwd_t ---------- //
 
-status_t ref_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(diff_src_md());
 
     conf.dispatch.define_dim("MB", 0, diff_src_md()->padded_dims[0]);

--- a/src/gpu/intel/resampling/ref.hpp
+++ b/src/gpu/intel/resampling/ref.hpp
@@ -33,7 +33,7 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
             using sm = primitive_attr_t::skip_mask_t;
@@ -55,7 +55,7 @@ struct ref_fwd_t : public primitive_t {
         conf_t conf;
 
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
     };
 
     status_t init(impl::engine_t *engine) override {
@@ -89,7 +89,7 @@ struct ref_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
 
@@ -103,7 +103,7 @@ struct ref_bwd_t : public primitive_t {
         }
         conf_t conf;
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
     };
 

--- a/src/gpu/intel/resampling/vectorized.cpp
+++ b/src/gpu/intel/resampling/vectorized.cpp
@@ -103,7 +103,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     return status::success;
 }
 
-status_t vectorized_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t vectorized_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace data_type;
     assert(engine->kind() == engine_kind::gpu);
     VDISPATCH_RESAMPLING_IC(!is_fwd(), VERBOSE_BAD_PROPKIND);

--- a/src/gpu/intel/resampling/vectorized.hpp
+++ b/src/gpu/intel/resampling/vectorized.hpp
@@ -33,7 +33,7 @@ struct vectorized_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:vectorized", vectorized_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
 
@@ -47,7 +47,7 @@ struct vectorized_bwd_t : public primitive_t {
         }
         conf_t conf;
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
     };
 

--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -575,12 +575,12 @@ status_t simple_common_t<prop_kind::backward>::pd_t::set_default_params() {
 }
 
 template <prop_kind_t aprop>
-status_t simple_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
+status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
     using namespace prop_kind;
     using namespace format_tag;
 
     assert(engine->kind() == engine_kind::gpu);
-    auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     const compute::device_info_t &device_info = *(intel_engine->device_info());
     max_eus_per_wg = device_info.max_eus_per_wg();

--- a/src/gpu/intel/rnn/grid.hpp
+++ b/src/gpu/intel/rnn/grid.hpp
@@ -76,7 +76,7 @@ struct simple_common_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:simple:any", class_name);
 
-        status_t init(impl::engine_t *engine);
+        status_t init(const impl::engine_t *engine);
 
         status_t set_default_params();
 

--- a/src/gpu/intel/rnn/reorders.cpp
+++ b/src/gpu/intel/rnn/reorders.cpp
@@ -22,7 +22,7 @@ namespace gpu {
 namespace intel {
 namespace rnn {
 
-status_t weights_reorder_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t weights_reorder_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper src_mdw(src_md());
     const memory_desc_wrapper dst_mdw(dst_md());
 
@@ -37,7 +37,7 @@ status_t weights_reorder_t::pd_t::init_conf(impl::engine_t *engine) {
     conf.sub_group_size = 1;
 
     // only for LDIGO
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
 
     conf.dispatch = intel_engine->create_dispatch(dst_mdw.md_);
     conf.dispatch.define_dim("D0", 0, dims[0]);

--- a/src/gpu/intel/rnn/reorders.hpp
+++ b/src/gpu/intel/rnn/reorders.hpp
@@ -39,8 +39,9 @@ struct weights_reorder_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("cross_engine::rnn", weights_reorder_t);
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
             VDISPATCH_REORDER(dst_md()->extra.flags
                             & memory_extra_flags::rnn_u8s8_compensation,
                     VERBOSE_BAD_FLAGS);
@@ -51,7 +52,8 @@ struct weights_reorder_t : public primitive_t {
             VDISPATCH_REORDER(dst_engine->kind() == engine_kind::gpu,
                     VERBOSE_BAD_ENGINE_KIND);
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(dst_engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(dst_engine);
 
             VDISPATCH_REORDER(intel_engine->mayiuse(
                                       compute::device_ext_t::intel_subgroups),
@@ -72,7 +74,7 @@ struct weights_reorder_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         reorder_conf_t conf;

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -143,12 +143,13 @@ status_t update_config_from_devenv_values(bwd_config_t *config) {
     return status::success;
 }
 
-status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
+status_t micro_fwd_t::pd_t::init_conf_microkernels(
+        const impl::engine_t *engine) {
     using namespace jit;
     using gemm::jit::convert_dnnl_to_kernel_type;
 
     assert(engine->kind() == engine_kind::gpu);
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *dev_info = intel_engine->device_info();
 
     auto *d = desc();
@@ -419,12 +420,13 @@ status_t micro_fwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
+status_t micro_bwd_t::pd_t::init_conf_microkernels(
+        const impl::engine_t *engine) {
     using namespace jit;
     using gemm::jit::convert_dnnl_to_kernel_type;
 
     assert(engine->kind() == engine_kind::gpu);
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     auto *dev_info = intel_engine->device_info();
     auto *d = desc();
 
@@ -845,7 +847,7 @@ static void init_conf_common(conf_t &conf, pd_type *pd) {
     conf.use_systolic_ukernel = pd->use_systolic_ukernel();
 }
 
-status_t micro_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t micro_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     using namespace micro;
     init_conf_common(conf, this);
     conf.d_max_kq = d_max_kq();
@@ -965,7 +967,7 @@ status_t micro_fwd_t::pd_t::init_conf(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t micro_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t micro_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     init_conf_common(conf, this);
     conf.d_max = d_max();
 
@@ -1017,10 +1019,10 @@ status_t micro_bwd_t::pd_t::init_conf(impl::engine_t *engine) {
     return status::success;
 }
 
-status_t micro_bwd_t::pd_t::init_scratchpad(impl::engine_t *engine) {
+status_t micro_bwd_t::pd_t::init_scratchpad(const impl::engine_t *engine) {
     auto scratchpad = scratchpad_registry().registrar();
-    auto gpu_align
-            = utils::downcast<gpu::engine_t *>(engine)->get_buffer_alignment();
+    auto gpu_align = utils::downcast<const gpu::engine_t *>(engine)
+                             ->get_buffer_alignment();
     size_t wspace_size = memory_desc_wrapper(desc()->diff_qry_md()).nelems();
     // f32 can directly atomic add to output
     // others need intermediate scratchpad before conversion

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -163,11 +163,12 @@ struct micro_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:micro:reusable", micro_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             auto *dev_info = intel_engine->device_info();
             arch_ = dev_info->gpu_arch();
             sg_size_ = dev_info->min_subgroup_size();
@@ -395,8 +396,8 @@ struct micro_fwd_t : public primitive_t {
         bool use_systolic_ukernel_ = true;
         compute::gpu_arch_t arch_ = compute::gpu_arch_t::unknown;
 
-        status_t init_conf_microkernels(impl::engine_t *engine);
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf_microkernels(const impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         status_t set_default_format(memory_desc_t &md, bool allow_transpose) {
             using namespace format_tag;
@@ -433,10 +434,11 @@ struct micro_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:micro:reusable", micro_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             auto *dev_info = intel_engine->device_info();
             arch_ = dev_info->gpu_arch();
             sg_size_ = dev_info->min_subgroup_size();
@@ -581,9 +583,9 @@ struct micro_bwd_t : public primitive_t {
         bool use_systolic_ukernel_ = true;
         compute::gpu_arch_t arch_ = compute::gpu_arch_t::unknown;
 
-        status_t init_scratchpad(impl::engine_t *engine);
-        status_t init_conf_microkernels(impl::engine_t *engine);
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_scratchpad(const impl::engine_t *engine);
+        status_t init_conf_microkernels(const impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
 
         status_t set_default_format(memory_desc_t &md, bool allow_transpose) {
             using namespace format_tag;

--- a/src/gpu/intel/sdpa/ref.hpp
+++ b/src/gpu/intel/sdpa/ref.hpp
@@ -34,7 +34,7 @@ struct ref_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/gpu/intel/shuffle/ref.cpp
+++ b/src/gpu/intel/shuffle/ref.cpp
@@ -24,7 +24,7 @@ namespace shuffle {
 
 using namespace format_tag;
 
-status_t ref_t::pd_t::init_conf(impl::engine_t *engine) {
+status_t ref_t::pd_t::init_conf(const impl::engine_t *engine) {
     const memory_desc_wrapper input_mdw(is_fwd() ? src_md() : diff_dst_md());
     conf.data_type = input_mdw.data_type();
     const memory_desc_wrapper output_mdw(is_fwd() ? dst_md() : diff_src_md());
@@ -41,7 +41,7 @@ status_t ref_t::pd_t::init_conf(impl::engine_t *engine) {
 
     set_offsets(input_mdw, off.src_off);
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     conf.dispatch = intel_engine->create_dispatch(input_mdw.md_);
     for (int i = 0; i < MAX_NDIMS; ++i) {
         auto dim_str = utils::format("D%d", i);

--- a/src/gpu/intel/shuffle/ref.hpp
+++ b/src/gpu/intel/shuffle/ref.hpp
@@ -35,9 +35,10 @@ struct ref_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:ref:any", ref_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace format_tag;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const auto &md_src = is_fwd() ? src_md() : diff_src_md();
             const auto &md_dst = is_fwd() ? dst_md() : diff_dst_md();
@@ -62,7 +63,7 @@ struct ref_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_conf(impl::engine_t *engine);
+        status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         conf_t conf;

--- a/src/gpu/intel/softmax/reusable.cpp
+++ b/src/gpu/intel/softmax/reusable.cpp
@@ -83,7 +83,7 @@ static std::vector<dim_idx_t> get_dims(size_t ndims) {
 }
 
 status_t reusable_fwd_t::pd_t::init_dispatch_subgroup_per_reduction(
-        gpu::engine_t *engine) {
+        const gpu::engine_t *engine) {
     compute::range_t gws {(size_t)conf.subgroup_size};
     compute::range_t lws {(size_t)conf.subgroup_size};
     for (int i = 0; i < ndims(); i++) {
@@ -97,7 +97,7 @@ status_t reusable_fwd_t::pd_t::init_dispatch_subgroup_per_reduction(
 }
 
 status_t reusable_fwd_t::pd_t::init_dispatch_default_reusable(
-        gpu::engine_t *engine) {
+        const gpu::engine_t *engine) {
     using dims_vec_t = std::vector<dim_idx_t>;
 
     dims_vec_t src_dim_ids(memory_desc_wrapper(src_md()).ndims());
@@ -109,7 +109,7 @@ status_t reusable_fwd_t::pd_t::init_dispatch_default_reusable(
     compute::named_buffer_t src_buf("SRC", *src_md(), src_dim_ids);
     compute::named_buffer_t dst_buf("DST", src_buf);
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     compute::reusable_dispatch_config_t dispatch_config(
             intel_engine, std::move(dispatch_dim_ids));
     CHECK(dispatch_config.register_buffer(src_buf));
@@ -128,7 +128,7 @@ status_t reusable_fwd_t::pd_t::init_dispatch_default_reusable(
 }
 
 status_t reusable_fwd_t::pd_t::init_dispatch_workgroup_per_reduction(
-        gpu::engine_t *engine, const size_t num_workers_per_workgroup) {
+        const gpu::engine_t *engine, const size_t num_workers_per_workgroup) {
 
     const memory_desc_wrapper src_mdw(src_md());
     std::vector<dim_idx_t> dims_ids = get_dims(src_mdw.ndims());
@@ -182,7 +182,7 @@ status_t reusable_fwd_t::pd_t::init_dispatch_workgroup_per_reduction(
     std::vector<dim_idx_t> dispatch_dims = std::move(dims_ids);
     dispatch_dims[softmax_axis] = dims::workers;
 
-    auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+    const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
     compute::reusable_dispatch_config_t dispatch_config(
             intel_engine, std::move(dispatch_dims));
     CHECK(dispatch_config.register_buffer(src_buf));

--- a/src/gpu/intel/softmax/reusable.hpp
+++ b/src/gpu/intel/softmax/reusable.hpp
@@ -92,9 +92,10 @@ struct reusable_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:reusable", reusable_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using arch_t = compute::gpu_arch_t;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             const arch_t arch = intel_engine->device_info()->gpu_arch();
 
             const memory_desc_wrapper src_mdw(src_md());
@@ -270,10 +271,12 @@ struct reusable_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init_dispatch_default_reusable(gpu::engine_t *engine);
+        status_t init_dispatch_default_reusable(const gpu::engine_t *engine);
         status_t init_dispatch_workgroup_per_reduction(
-                gpu::engine_t *engine, const size_t num_workers_per_workgroup);
-        status_t init_dispatch_subgroup_per_reduction(gpu::engine_t *engine);
+                const gpu::engine_t *engine,
+                const size_t num_workers_per_workgroup);
+        status_t init_dispatch_subgroup_per_reduction(
+                const gpu::engine_t *engine);
 
         reusable_params_t conf;
         reusable_runtime_params_t rt_conf;

--- a/src/gpu/intel/softmax/simple.hpp
+++ b/src/gpu/intel/softmax/simple.hpp
@@ -58,8 +58,9 @@ struct simple_fwd_t : public primitive_t {
             return status::success;
         }
 
-        status_t init(impl::engine_t *engine) {
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        status_t init(const impl::engine_t *engine) {
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const memory_desc_wrapper src_d(src_md());
             const memory_desc_wrapper dst_d(dst_md());
@@ -234,8 +235,9 @@ struct simple_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:simple:any", simple_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        status_t init(const impl::engine_t *engine) {
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const memory_desc_wrapper diff_dst_d(diff_dst_md());
             const memory_desc_wrapper diff_src_d(diff_src_md());

--- a/src/gpu/intel/softmax/xe.hpp
+++ b/src/gpu/intel/softmax/xe.hpp
@@ -38,9 +38,10 @@ struct xe_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe", xe_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace dnnl::impl::format_tag;
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             auto arch = intel_engine->device_info()->gpu_arch();
             const memory_desc_wrapper src_d(src_md());
@@ -249,10 +250,11 @@ struct xe_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("ocl:xe", xe_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace dnnl::impl::format_tag;
 
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
 
             const memory_desc_wrapper diff_src_d(diff_src_md());
             const memory_desc_wrapper diff_dst_d(diff_dst_md());

--- a/src/gpu/intel/sum/many_inputs.hpp
+++ b/src/gpu/intel/sum/many_inputs.hpp
@@ -37,7 +37,7 @@ struct many_inputs_t : public primitive_t {
 
         DECLARE_SUM_PD_T("ocl:many_inputs", many_inputs_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             const int n = n_inputs();
 
             VDISPATCH_SUM_SC(sum::pd_t::init(engine), VERBOSE_BAD_ENGINE_KIND);

--- a/src/gpu/intel/sum/multi_po_reorder.hpp
+++ b/src/gpu/intel/sum/multi_po_reorder.hpp
@@ -39,7 +39,7 @@ struct multi_po_reorder_t : public primitive_t {
 
         DECLARE_SUM_PD_T("reorder+post_ops", multi_po_reorder_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             VDISPATCH_SUM_SC(sum::pd_t::init(engine), VERBOSE_BAD_ENGINE_KIND);
 
             if (has_zero_dim_memory()) return status::success;

--- a/src/gpu/intel/sum/simple.hpp
+++ b/src/gpu/intel/sum/simple.hpp
@@ -36,7 +36,7 @@ struct simple_t : public primitive_t {
 
         DECLARE_SUM_PD_T("ocl:simple:any", simple_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             const int n = n_inputs();
 
             VDISPATCH_SUM_SC(sum::pd_t::init(engine), VERBOSE_BAD_ENGINE_KIND);

--- a/src/gpu/intel/sum/xe.hpp
+++ b/src/gpu/intel/sum/xe.hpp
@@ -38,7 +38,7 @@ struct xe_t : public primitive_t {
 
         DECLARE_SUM_PD_T("ocl:xe:any", xe_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             const int n = n_inputs();
 
             VDISPATCH_SUM(n <= max_num_arrs, "too many inputs for primitive");

--- a/src/gpu/intel/zeropad/simple.hpp
+++ b/src/gpu/intel/zeropad/simple.hpp
@@ -37,8 +37,9 @@ struct simple_t : public primitive_t {
         using zeropad::pd_t::pd_t;
 
         DECLARE_COMMON_PD_T("ocl:simple:any", simple_t);
-        status_t init(impl::engine_t *engine) {
-            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+        status_t init(const impl::engine_t *engine) {
+            const auto *intel_engine
+                    = utils::downcast<const intel::engine_t *>(engine);
             VDISPATCH_ZERO_PAD(intel_engine->mayiuse_sub_group(16),
                     VERBOSE_UNSUPPORTED_DEVICE_FEATURE, "subgroup(16)");
             return status::success;

--- a/src/gpu/nvidia/cudnn_batch_normalization.hpp
+++ b/src/gpu/nvidia/cudnn_batch_normalization.hpp
@@ -67,7 +67,7 @@ struct cudnn_batch_normalization_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_batch_normalization_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace types;
 
@@ -137,7 +137,7 @@ struct cudnn_batch_normalization_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_batch_normalization_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace types;
 

--- a/src/gpu/nvidia/cudnn_binary.hpp
+++ b/src/gpu/nvidia/cudnn_binary.hpp
@@ -40,7 +40,7 @@ struct cudnn_binary_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_binary_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             bool ok = (set_default_params() == status::success)
@@ -88,14 +88,14 @@ struct cudnn_binary_t : public gpu::primitive_t {
             return true;
         }
 
-        bool check_data_types(impl::engine_t *engine) const {
+        bool check_data_types(const impl::engine_t *engine) const {
             using namespace data_type;
             bool inputs_same = src_md(0)->data_type == src_md(1)->data_type;
             dnnl_data_type_t input_type = src_md(0)->data_type;
             dnnl_data_type_t output_type = dst_md()->data_type;
 
-            auto sycl_dev
-                    = utils::downcast<nvidia::engine_t *>(engine)->device();
+            auto sycl_dev = utils::downcast<const nvidia::engine_t *>(engine)
+                                    ->device();
 
             if (!IMPLICATION(utils::one_of(bf16, input_type, output_type),
                         has_bf16_support(sycl_dev)))

--- a/src/gpu/nvidia/cudnn_conv_inner_product.hpp
+++ b/src/gpu/nvidia/cudnn_conv_inner_product.hpp
@@ -60,7 +60,7 @@ struct cudnn_conv_inner_product_fwd_t : public cudnn_inner_product_fwd_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:conv", cudnn_conv_inner_product_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using sm_t = primitive_attr_t::skip_mask_t;
@@ -90,7 +90,8 @@ struct cudnn_conv_inner_product_fwd_t : public cudnn_inner_product_fwd_t {
             inner_product_impl_.reset(
                     new cudnn_conv_inner_product_fwd_impl_t());
 
-            auto st = inner_product_impl_->init(engine, this, with_relu(),
+            auto st = inner_product_impl_->init(
+                    const_cast<impl::engine_t *>(engine), this, with_relu(),
                     with_eltwise(), with_sum(), use_fused_path_for_blocking,
                     false);
             return st;
@@ -170,7 +171,7 @@ struct cudnn_conv_inner_product_fwd_t : public cudnn_inner_product_fwd_t {
                     && memory_desc_matches_nchw_vect_c(weights_md(0));
         }
 
-        bool data_types_ok(impl::engine_t *engine) const {
+        bool data_types_ok(const impl::engine_t *engine) const {
             using namespace data_type;
             dnnl_data_type_t src_type = src_md()->data_type;
             dnnl_data_type_t weights_type = weights_md(0)->data_type;
@@ -178,7 +179,8 @@ struct cudnn_conv_inner_product_fwd_t : public cudnn_inner_product_fwd_t {
             dnnl_data_type_t dst_type = dst_md()->data_type;
             dnnl_data_type_t acc_type = desc()->accum_data_type;
 
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             if (!IMPLICATION(utils::one_of(bf16, src_type, weights_type,
                                      bias_type, dst_type, acc_type),
@@ -232,7 +234,7 @@ struct cudnn_conv_inner_product_bwd_data_t
         DECLARE_COMMON_PD_T(
                 "cuda:cudnn:conv", cudnn_conv_inner_product_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
 
@@ -251,7 +253,8 @@ struct cudnn_conv_inner_product_bwd_data_t
                     new cudnn_conv_inner_product_bwd_data_impl_t());
 
             return inner_product_impl_->init(
-                    engine, this, false, false, false, false, false);
+                    const_cast<impl::engine_t *>(engine), this, false, false,
+                    false, false, false);
         }
 
         status_t set_default_params() {
@@ -289,8 +292,9 @@ struct cudnn_conv_inner_product_bwd_data_t
                     == 0;
         }
 
-        bool data_types_ok(impl::engine_t *engine) const {
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+        bool data_types_ok(const impl::engine_t *engine) const {
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             auto diff_src_dt = diff_src_md()->data_type;
             auto weights_dt = weights_md(0)->data_type;
@@ -322,7 +326,7 @@ struct cudnn_conv_inner_product_bwd_weights_t
         DECLARE_COMMON_PD_T(
                 "cuda:cudnn:conv", cudnn_conv_inner_product_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             bool ok = true && (set_default_params() == status::success);
@@ -342,7 +346,8 @@ struct cudnn_conv_inner_product_bwd_weights_t
                     new cudnn_conv_inner_product_bwd_weights_impl_t());
 
             return inner_product_impl_->init(
-                    engine, this, false, false, false, false, false);
+                    const_cast<impl::engine_t *>(engine), this, false, false,
+                    false, false, false);
         }
 
         status_t set_default_params() {
@@ -383,8 +388,9 @@ struct cudnn_conv_inner_product_bwd_weights_t
                     == 0;
         }
 
-        bool data_types_ok(impl::engine_t *engine) const {
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+        bool data_types_ok(const impl::engine_t *engine) const {
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             if (!IMPLICATION(utils::one_of(data_type::bf16,
                                      diff_weights_md(1)->data_type,

--- a/src/gpu/nvidia/cudnn_convolution.hpp
+++ b/src/gpu/nvidia/cudnn_convolution.hpp
@@ -46,13 +46,14 @@ struct cudnn_convolution_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_convolution_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             using sm_t = primitive_attr_t::skip_mask_t;
             const auto attr_skip_mask
                     = sm_t::scales | sm_t::post_ops | sm_t::fpmath_mode;
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             bool ok = utils::one_of(desc()->prop_kind,
                     prop_kind::forward_training, prop_kind::forward_inference);
@@ -111,7 +112,8 @@ struct cudnn_convolution_fwd_t : public gpu::primitive_t {
             }
 
             impl_.reset(new cudnn_convolution_impl_fwd_t());
-            return impl_->init(engine, this, use_temp_dst, use_scales_dst);
+            return impl_->init(const_cast<impl::engine_t *>(engine), this,
+                    use_temp_dst, use_scales_dst);
         }
         bool with_scratchpad() const { return impl_->with_scratchpad(); }
         std::shared_ptr<cudnn_convolution_impl_base_t> impl_;
@@ -240,7 +242,7 @@ struct cudnn_convolution_bwd_data_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_convolution_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             bool ok = desc()->prop_kind == prop_kind::backward_data;
@@ -280,7 +282,7 @@ struct cudnn_convolution_bwd_data_t : public gpu::primitive_t {
             if (check_for_zero_dims()) return status::success;
 
             impl_.reset(new cudnn_convolution_impl_bwd_data_t());
-            return impl_->init(engine, this);
+            return impl_->init(const_cast<impl::engine_t *>(engine), this);
         }
 
         std::shared_ptr<cudnn_convolution_impl_base_t> impl_;
@@ -319,7 +321,7 @@ struct cudnn_convolution_bwd_weights_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_convolution_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             bool ok = desc()->prop_kind == prop_kind::backward_weights;
             auto *sycl_engine_impl
@@ -361,7 +363,7 @@ struct cudnn_convolution_bwd_weights_t : public gpu::primitive_t {
             impl_.reset(new cudnn_convolution_impl_bwd_weights_t());
             if (check_for_zero_dims()) { return impl_->init_zero_dims(this); };
 
-            return impl_->init(engine, this);
+            return impl_->init(const_cast<impl::engine_t *>(engine), this);
         }
 
         std::shared_ptr<cudnn_convolution_impl_base_t> impl_;

--- a/src/gpu/nvidia/cudnn_deconvolution.hpp
+++ b/src/gpu/nvidia/cudnn_deconvolution.hpp
@@ -123,12 +123,12 @@ struct cudnn_deconvolution_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_deconvolution_fwd_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             using namespace format_tag;
             using namespace data_type;
 
-            auto sycl_dev
-                    = utils::downcast<nvidia::engine_t *>(engine)->device();
+            auto sycl_dev = utils::downcast<const nvidia::engine_t *>(engine)
+                                    ->device();
             convolution_desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr = *attr();
@@ -163,7 +163,7 @@ struct cudnn_deconvolution_fwd_t : public gpu::primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             auto *sycl_engine_impl
                     = utils::downcast<const xpu::sycl::engine_impl_t *>(
                             engine->impl());
@@ -270,7 +270,7 @@ struct cudnn_deconvolution_bwd_data_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_deconvolution_bwd_data_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             convolution_desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr = *attr();
@@ -283,7 +283,7 @@ struct cudnn_deconvolution_bwd_data_t : public gpu::primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             auto *sycl_engine_impl
                     = utils::downcast<const xpu::sycl::engine_impl_t *>(
                             engine->impl());
@@ -378,7 +378,7 @@ struct cudnn_deconvolution_bwd_weights_t : public gpu::primitive_t {
         DECLARE_COMMON_PD_T(
                 "cuda:cudnn:any", cudnn_deconvolution_bwd_weights_t);
 
-        status_t init_convolution(impl::engine_t *engine) {
+        status_t init_convolution(const impl::engine_t *engine) {
             convolution_desc_t cd;
             CHECK(conv_descr_create(desc(), &cd));
             primitive_attr_t conv_attr = *attr();
@@ -392,7 +392,7 @@ struct cudnn_deconvolution_bwd_weights_t : public gpu::primitive_t {
             return status::unimplemented;
         }
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             auto *sycl_engine_impl
                     = utils::downcast<const xpu::sycl::engine_impl_t *>(
                             engine->impl());

--- a/src/gpu/nvidia/cudnn_eltwise.hpp
+++ b/src/gpu/nvidia/cudnn_eltwise.hpp
@@ -36,11 +36,11 @@ struct cudnn_eltwise_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_eltwise_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace alg_kind;
 
-            auto sycl_dev
-                    = utils::downcast<nvidia::engine_t *>(engine)->device();
+            auto sycl_dev = utils::downcast<const nvidia::engine_t *>(engine)
+                                    ->device();
 
             bool ok = is_fwd()
                     // Supported algorithms
@@ -82,7 +82,7 @@ struct cudnn_eltwise_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_eltwise_bwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace alg_kind;
             bool ok = !is_fwd()
                     // Supported algorithms

--- a/src/gpu/nvidia/cudnn_gemm_inner_product.hpp
+++ b/src/gpu/nvidia/cudnn_gemm_inner_product.hpp
@@ -167,7 +167,7 @@ struct cudnn_gemm_inner_product_fwd_t : public cudnn_inner_product_fwd_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:gemm", cudnn_gemm_inner_product_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace data_type;
@@ -210,7 +210,8 @@ struct cudnn_gemm_inner_product_fwd_t : public cudnn_inner_product_fwd_t {
             dnnl_data_type_t dst_type = dst_md()->data_type;
             dnnl_data_type_t acc_type = desc()->accum_data_type;
 
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             ok = ok && memory_format_ok(src_md())
                     && memory_format_ok(weights_md(0))
@@ -228,7 +229,8 @@ struct cudnn_gemm_inner_product_fwd_t : public cudnn_inner_product_fwd_t {
 
             inner_product_impl_.reset(
                     new cudnn_gemm_inner_product_fwd_impl_t());
-            return inner_product_impl_->init(engine, this, with_eltwise,
+            return inner_product_impl_->init(
+                    const_cast<impl::engine_t *>(engine), this, with_eltwise,
                     with_eltwise, with_sum, need_reorder, use_f32_sum);
         }
 
@@ -254,7 +256,7 @@ struct cudnn_gemm_inner_product_bwd_data_t
         DECLARE_COMMON_PD_T(
                 "cuda:cudnn:gemm", cudnn_gemm_inner_product_bwd_data_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
@@ -268,7 +270,8 @@ struct cudnn_gemm_inner_product_bwd_data_t
                     ? false
                     : reorder_check(diff_src_md(), weights_md(), diff_dst_md());
 
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             auto diff_src_dt = diff_src_md()->data_type;
             auto weights_dt = weights_md(0)->data_type;
@@ -293,7 +296,8 @@ struct cudnn_gemm_inner_product_bwd_data_t
                     new cudnn_gemm_inner_product_bwd_data_impl_t());
 
             return inner_product_impl_->init(
-                    engine, this, false, false, false, need_reorder, false);
+                    const_cast<impl::engine_t *>(engine), this, false, false,
+                    false, need_reorder, false);
         }
 
         status_t set_default_params() {
@@ -318,7 +322,7 @@ struct cudnn_gemm_inner_product_bwd_weights_t
         DECLARE_COMMON_PD_T(
                 "cuda:cudnn:gemm", cudnn_gemm_inner_product_bwd_weights_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace data_type;
             assert(engine->kind() == engine_kind::gpu);
@@ -332,7 +336,8 @@ struct cudnn_gemm_inner_product_bwd_weights_t
                     ? false
                     : reorder_check(src_md(), diff_weights_md(), diff_dst_md());
 
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             ok = ok && expect_data_types(f32, f32, f32, f32, f32)
                     && attr()->has_default_values()
@@ -349,7 +354,8 @@ struct cudnn_gemm_inner_product_bwd_weights_t
             inner_product_impl_.reset(
                     new cudnn_gemm_inner_product_bwd_weights_impl_t());
             return inner_product_impl_->init(
-                    engine, this, false, false, false, need_reorder, false);
+                    const_cast<impl::engine_t *>(engine), this, false, false,
+                    false, need_reorder, false);
         }
 
         status_t set_default_params() {

--- a/src/gpu/nvidia/cudnn_lrn.hpp
+++ b/src/gpu/nvidia/cudnn_lrn.hpp
@@ -40,7 +40,7 @@ struct cudnn_lrn_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_lrn_fwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
             using namespace format_tag;
 
@@ -91,7 +91,7 @@ struct cudnn_lrn_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_lrn_bwd_t);
 
-        status_t init(impl::engine_t *) {
+        status_t init(const impl::engine_t *) {
             using namespace data_type;
 
             bool ok = !is_fwd()

--- a/src/gpu/nvidia/cudnn_matmul.hpp
+++ b/src/gpu/nvidia/cudnn_matmul.hpp
@@ -41,7 +41,7 @@ struct cudnn_matmul_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_matmul_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 

--- a/src/gpu/nvidia/cudnn_matmul_lt.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_lt.hpp
@@ -42,7 +42,7 @@ struct cudnn_matmul_lt_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cublaslt:any", cudnn_matmul_lt_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
 
@@ -170,8 +170,9 @@ struct cudnn_matmul_lt_t : public gpu::primitive_t {
             }
 
             params_ = std::make_shared<cublas_lt_params>();
-            CHECK(params_->init(engine, src_md(), weights_md(), dst_md(),
-                    weights_md(1), attr(), batched(), with_bias()));
+            CHECK(params_->init(const_cast<impl::engine_t *>(engine), src_md(),
+                    weights_md(), dst_md(), weights_md(1), attr(), batched(),
+                    with_bias()));
 
             if (!params_->has_runtime_params()) {
                 auto scratchpad = scratchpad_registry().registrar();
@@ -211,7 +212,7 @@ struct cudnn_matmul_lt_t : public gpu::primitive_t {
             return ok;
         }
 
-        status_t create_scale_binary_pd(impl::engine_t *engine, int ARG) {
+        status_t create_scale_binary_pd(const impl::engine_t *engine, int ARG) {
             if (ARG != DNNL_ARG_DST) return status::unimplemented;
 
             auto md = arg_md(ARG);
@@ -240,7 +241,7 @@ struct cudnn_matmul_lt_t : public gpu::primitive_t {
                     arg_md(ARG), scale_md, alg_kind::binary_div);
         }
 
-        status_t init_scale_binary_pd(impl::engine_t *engine, int ARG,
+        status_t init_scale_binary_pd(const impl::engine_t *engine, int ARG,
                 std::shared_ptr<primitive_desc_t> &scale_binary_pd,
                 const memory_desc_t *in_out, memory_desc_t &in2,
                 alg_kind_t mul_or_div) {

--- a/src/gpu/nvidia/cudnn_pooling.hpp
+++ b/src/gpu/nvidia/cudnn_pooling.hpp
@@ -54,7 +54,7 @@ struct cudnn_pooling_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_pooling_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
             using namespace prop_kind;
             using namespace alg_kind;
@@ -62,7 +62,8 @@ struct cudnn_pooling_fwd_t : public gpu::primitive_t {
 
             assert(engine->kind() == engine_kind::gpu);
             auto src_dt = src_md()->data_type;
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             bool ok = true && is_fwd()
                     && utils::one_of(desc()->prop_kind, forward_training,
@@ -124,12 +125,13 @@ struct cudnn_pooling_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_pooling_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace prop_kind;
             using namespace alg_kind;
             using namespace format_tag;
             assert(engine->kind() == engine_kind::gpu);
-            auto *sycl_engine = utils::downcast<nvidia::engine_t *>(engine);
+            const auto *sycl_engine
+                    = utils::downcast<const nvidia::engine_t *>(engine);
 
             bool ok = true && !is_fwd()
                     && set_default_params() == status::success

--- a/src/gpu/nvidia/cudnn_reduction.hpp
+++ b/src/gpu/nvidia/cudnn_reduction.hpp
@@ -40,7 +40,7 @@ struct cudnn_reduction_t : public gpu::primitive_t {
         using reduction_pd_t::reduction_pd_t;
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_reduction_t);
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             using namespace data_type;
 
             const bool ok = (set_default_params() == status::success)
@@ -71,7 +71,8 @@ struct cudnn_reduction_t : public gpu::primitive_t {
             auto status = reduction_impl_->init(this);
 
             if (status == status::success)
-                reduction_impl_->create_and_set_workspace(this, engine);
+                reduction_impl_->create_and_set_workspace(
+                        this, const_cast<impl::engine_t *>(engine));
             return status;
         }
 

--- a/src/gpu/nvidia/cudnn_reorder.hpp
+++ b/src/gpu/nvidia/cudnn_reorder.hpp
@@ -39,9 +39,9 @@ struct cudnn_reorder_t : public gpu::primitive_t {
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_reorder_t);
 
         // Function to verify data and memory format
-        bool valid_data_n_mem_format(impl::engine_t *engine) const {
-            auto sycl_dev
-                    = utils::downcast<nvidia::engine_t *>(engine)->device();
+        bool valid_data_n_mem_format(const impl::engine_t *engine) const {
+            auto sycl_dev = utils::downcast<const nvidia::engine_t *>(engine)
+                                    ->device();
 
             bool ok = utils::one_of(src_md()->data_type, data_type::s8,
                               data_type::bf16, data_type::f16, data_type::f32)
@@ -102,8 +102,9 @@ struct cudnn_reorder_t : public gpu::primitive_t {
             return p.len() == 0 || (p.len() == 1 && p.entry_[0].is_sum(false));
         }
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::scales
                     | primitive_attr_t::skip_mask_t::post_ops;
             bool ok = engine == dst_engine

--- a/src/gpu/nvidia/cudnn_reorder_lt.hpp
+++ b/src/gpu/nvidia/cudnn_reorder_lt.hpp
@@ -41,7 +41,7 @@ struct cudnn_reorder_lt_t : public gpu::primitive_t {
         DECLARE_COMMON_PD_T("cuda:cublaslt:any", cudnn_reorder_lt_t);
 
         // Function to verify data and memory format
-        bool valid_data_n_mem_format(impl::engine_t *engine) {
+        bool valid_data_n_mem_format(const impl::engine_t *engine) {
             auto src_dt_ = src_md()->data_type;
             auto dst_dt_ = dst_md()->data_type;
             bool ok = utils::one_of(
@@ -136,8 +136,9 @@ struct cudnn_reorder_lt_t : public gpu::primitive_t {
             return p.len() == 0 || (p.len() == 1 && p.entry_[0].is_sum(false));
         }
 
-        status_t init(impl::engine_t *engine, impl::engine_t *src_engine,
-                impl::engine_t *dst_engine) {
+        status_t init(const impl::engine_t *engine,
+                const impl::engine_t *src_engine,
+                const impl::engine_t *dst_engine) {
             const auto attr_skip_mask = primitive_attr_t::skip_mask_t::scales
                     | primitive_attr_t::skip_mask_t::post_ops;
             bool ok = engine == dst_engine && src_engine == dst_engine

--- a/src/gpu/nvidia/cudnn_softmax.hpp
+++ b/src/gpu/nvidia/cudnn_softmax.hpp
@@ -39,12 +39,12 @@ struct cudnn_softmax_fwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_softmax_fwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             const memory_desc_wrapper src_d(src_md());
             const memory_desc_wrapper dst_d(dst_md());
 
-            auto sycl_dev
-                    = utils::downcast<nvidia::engine_t *>(engine)->device();
+            auto sycl_dev = utils::downcast<const nvidia::engine_t *>(engine)
+                                    ->device();
 
             bool ok = is_fwd()
                     && utils::one_of(src_d.data_type(), data_type::f32,
@@ -96,13 +96,13 @@ struct cudnn_softmax_bwd_t : public gpu::primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_softmax_bwd_t);
 
-        status_t init(impl::engine_t *engine) {
+        status_t init(const impl::engine_t *engine) {
             const memory_desc_wrapper diff_src_d(diff_src_md());
             const memory_desc_wrapper diff_dst_d(diff_dst_md());
             const memory_desc_wrapper dst_d(dst_md());
 
-            auto sycl_dev
-                    = utils::downcast<nvidia::engine_t *>(engine)->device();
+            auto sycl_dev = utils::downcast<const nvidia::engine_t *>(engine)
+                                    ->device();
 
             bool ok = !is_fwd()
                     && utils::one_of(dst_d.data_type(), data_type::f32,


### PR DESCRIPTION
It was noticed that none of underlying calls in `pd_t::init()` modify `engine` state. Likely, the historical context didn't let it make `const` in the beginning, but now it's fine to do so. This PR covers only primitive descriptor part, primitive part remain to use non-const version.

This PR has a single commit from #5514 which was partially a trigger for this refactor.

Matmul quant functions received verbose boost and were properly consolidated under a single call.