### PR TITLE
[CPU] Handle xf16 destination in brgemm with f32 upconversion

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -392,10 +392,12 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
             && (!one_of(dt_bias, data_type::undef, data_type::bf16,
                     data_type::f32)))
         return status::unimplemented;
+    // Matmul may upconvert f16 inputs or xf16 weights to f32
+    // while retaining the original destination and bias data types.
     if ((brg->dt_a == data_type::f32 && brg->dt_b == data_type::f32)
-            && (!one_of(dt_d, data_type::f32)
-                    || !one_of(
-                            dt_bias, data_type::undef, data_type::f32, dt_d)))
+            && (!one_of(dt_d, data_type::f32, data_type::f16, data_type::bf16)
+                    || !one_of(dt_bias, data_type::undef, data_type::f32,
+                            data_type::f16, data_type::bf16)))
         return status::unimplemented;
     if (!IMPLICATION(brg->is_bf16,
                 one_of(dt_d, data_type::f32, data_type::bf16, data_type::f16,


### PR DESCRIPTION
This is backport of #5610 
This PR fixes the [MFDNN-15355](https://jira.devtools.intel.com/browse/MFDNN-15355) - f16 matmul dispatched to references implementation on SPR.
It updates the BRGEMM implementation to support f16 where input data is upconverted to float32 (f32) but the destination and bias remain in f16.
It also adds a regression test to ensure this behavior is preserved.