### PR TITLE
cpu: rv64: add f16 and backward batch normalization

### DIFF
--- a/src/cpu/cpu_batch_normalization_list.cpp
+++ b/src/cpu/cpu_batch_normalization_list.cpp
@@ -32,7 +32,7 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/jit_uni_batch_normalization_s8.hpp"
 using namespace dnnl::impl::cpu::aarch64;
 #elif DNNL_RV64
-#include "cpu/rv64/rvv_batch_normalization.hpp"
+#include "cpu/rv64/jit_uni_batch_normalization.hpp"
 using namespace dnnl::impl::cpu::rv64;
 #endif
 
@@ -57,7 +57,8 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_tbb_batch_normalization_fwd_t<sse41>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_fwd_t<sve>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_fwd_t<asimd>)
-            CPU_INSTANCE_RV64(rvv_batch_normalization_fwd_t)
+            CPU_INSTANCE_RV64(jit_uni_batch_normalization_fwd_t<v>)
+            CPU_INSTANCE_RV64(jit_uni_batch_normalization_fwd_t<zvfh>)
             CPU_INSTANCE(ncsp_batch_normalization_fwd_t<f32>)
             CPU_INSTANCE(ncsp_batch_normalization_fwd_t<bf16>)
             CPU_INSTANCE(ncsp_batch_normalization_fwd_t<f16>)
@@ -84,7 +85,8 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_tbb_batch_normalization_bwd_t<sse41>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_bwd_t<sve>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_bwd_t<asimd>)
-            CPU_INSTANCE_RV64(rvv_batch_normalization_bwd_t)
+            CPU_INSTANCE_RV64(jit_uni_batch_normalization_bwd_t<v>)
+            CPU_INSTANCE_RV64(jit_uni_batch_normalization_bwd_t<zvfh>)
             CPU_INSTANCE(ncsp_batch_normalization_bwd_t<f32>)
             CPU_INSTANCE(ncsp_batch_normalization_bwd_t<bf16>)
             CPU_INSTANCE(ncsp_batch_normalization_bwd_t<f16>)

--- a/src/cpu/cpu_batch_normalization_list.cpp
+++ b/src/cpu/cpu_batch_normalization_list.cpp
@@ -84,6 +84,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_tbb_batch_normalization_bwd_t<sse41>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_bwd_t<sve>)
             CPU_INSTANCE_AARCH64(jit_uni_batch_normalization_bwd_t<asimd>)
+            CPU_INSTANCE_RV64(rvv_batch_normalization_bwd_t)
             CPU_INSTANCE(ncsp_batch_normalization_bwd_t<f32>)
             CPU_INSTANCE(ncsp_batch_normalization_bwd_t<bf16>)
             CPU_INSTANCE(ncsp_batch_normalization_bwd_t<f16>)

--- a/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_batch_normalization_kernel.cpp
@@ -25,11 +25,29 @@ using namespace Xbyak_riscv;
 
 namespace {
 
-template <bool per_elem_params, bool with_relu>
-void dispatch_jit_batch_normalization_f32(
+template <data_type_t data_type, bool per_elem_params, bool with_relu>
+void dispatch_jit_batch_normalization_fwd(
         const jit_rvv_batch_normalization_fwd_kernel_t::call_params_t *p) {
     static const jit_rvv_batch_normalization_fwd_kernel_t kernel(
-            per_elem_params, with_relu);
+            data_type, per_elem_params, with_relu);
+    kernel(p);
+}
+
+template <data_type_t data_type, bool per_elem_params>
+void dispatch_jit_batch_normalization_bwd_reduce(
+        const jit_rvv_batch_normalization_bwd_reduce_kernel_t::call_params_t
+                *p) {
+    static const jit_rvv_batch_normalization_bwd_reduce_kernel_t kernel(
+            data_type, per_elem_params);
+    kernel(p);
+}
+
+template <data_type_t data_type, bool per_elem_params>
+void dispatch_jit_batch_normalization_bwd_apply(
+        const jit_rvv_batch_normalization_bwd_apply_kernel_t::call_params_t
+                *p) {
+    static const jit_rvv_batch_normalization_bwd_apply_kernel_t kernel(
+            data_type, per_elem_params);
     kernel(p);
 }
 
@@ -37,33 +55,57 @@ void dispatch_jit_batch_normalization_f32(
 
 jit_rvv_batch_normalization_fwd_kernel_t::
         jit_rvv_batch_normalization_fwd_kernel_t(
-                bool per_elem_params, bool with_relu)
+                data_type_t data_type, bool per_elem_params, bool with_relu)
     : jit_generator_t("jit_rvv_batch_normalization_fwd_kernel")
+    , data_type_(data_type)
     , per_elem_params_(per_elem_params)
     , with_relu_(with_relu) {
     create_kernel();
 }
 
-void jit_rvv_batch_normalization_apply_f32(const float *src, float *dst,
-        dim_t len, const float *mean, const float *scale_mul,
-        const float *scale_add, bool per_elem_params, bool with_relu) {
+void jit_rvv_batch_normalization_apply(const void *src, void *dst, dim_t len,
+        const float *mean, const float *scale_mul, const float *scale_add,
+        data_type_t dt, bool per_elem_params, bool with_relu) {
     const jit_rvv_batch_normalization_fwd_kernel_t::call_params_t p {
             src, dst, len, mean, scale_mul, scale_add};
-    if (per_elem_params) {
-        if (with_relu)
-            dispatch_jit_batch_normalization_f32<true, true>(&p);
-        else
-            dispatch_jit_batch_normalization_f32<true, false>(&p);
+    if (dt == data_type::f16) {
+        if (per_elem_params) {
+            if (with_relu)
+                dispatch_jit_batch_normalization_fwd<data_type::f16, true,
+                        true>(&p);
+            else
+                dispatch_jit_batch_normalization_fwd<data_type::f16, true,
+                        false>(&p);
+        } else {
+            if (with_relu)
+                dispatch_jit_batch_normalization_fwd<data_type::f16, false,
+                        true>(&p);
+            else
+                dispatch_jit_batch_normalization_fwd<data_type::f16, false,
+                        false>(&p);
+        }
     } else {
-        if (with_relu)
-            dispatch_jit_batch_normalization_f32<false, true>(&p);
-        else
-            dispatch_jit_batch_normalization_f32<false, false>(&p);
+        if (per_elem_params) {
+            if (with_relu)
+                dispatch_jit_batch_normalization_fwd<data_type::f32, true,
+                        true>(&p);
+            else
+                dispatch_jit_batch_normalization_fwd<data_type::f32, true,
+                        false>(&p);
+        } else {
+            if (with_relu)
+                dispatch_jit_batch_normalization_fwd<data_type::f32, false,
+                        true>(&p);
+            else
+                dispatch_jit_batch_normalization_fwd<data_type::f32, false,
+                        false>(&p);
+        }
     }
 }
 
 void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const bool is_f16 = data_type_ == data_type::f16;
     const Reg reg_param = a0;
     const Reg reg_src = a1;
     const Reg reg_dst = a2;
@@ -80,10 +122,11 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
     const FReg f_zero = fa3;
 
     const VReg v_mask(0);
-    const VReg v_src(4);
-    const VReg v_mean(8);
+    const VReg v_src16(4);
+    const VReg v_src(8);
+    const VReg v_mean(10);
     const VReg v_sm(12);
-    const VReg v_sv(16);
+    const VReg v_sv(14);
 
     ld(reg_src, reg_param, 0);
     ld(reg_dst, reg_param, 8);
@@ -102,8 +145,17 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
     Label loop, done;
     L(loop);
     beqz(reg_len, done);
-    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
-    vle32_v(v_src, reg_src);
+    if (is_f16) {
+        vsetvli(
+                reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vle16_v(v_src16, reg_src);
+        vfwcvt_f_f_v(v_src, v_src16);
+        vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+    } else {
+        vsetvli(
+                reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
+        vle32_v(v_src, reg_src);
+    }
     if (per_elem_params_) {
         vle32_v(v_mean, reg_mean);
         vle32_v(v_sm, reg_sm);
@@ -120,15 +172,314 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
         vmflt_vf(v_mask, v_src, f_zero);
         vfmerge_vfm(v_src, v_src, f_zero);
     }
-    vse32_v(v_src, reg_dst);
+    if (is_f16) {
+        vsetvli(reg_vl, reg_vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vfncvt_f_f_w(v_src16, v_src);
+        vse16_v(v_src16, reg_dst);
+    } else {
+        vse32_v(v_src, reg_dst);
+    }
 
-    slli(reg_bytes, reg_vl, 2);
+    slli(reg_bytes, reg_vl, is_f16 ? 1 : 2);
     add(reg_src, reg_src, reg_bytes);
     add(reg_dst, reg_dst, reg_bytes);
     if (per_elem_params_) {
+        slli(reg_bytes, reg_vl, 2);
         add(reg_mean, reg_mean, reg_bytes);
         add(reg_sm, reg_sm, reg_bytes);
         add(reg_sv, reg_sv, reg_bytes);
+    }
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(done);
+    ret();
+#else
+    ret();
+#endif
+}
+
+jit_rvv_batch_normalization_bwd_reduce_kernel_t::
+        jit_rvv_batch_normalization_bwd_reduce_kernel_t(
+                data_type_t data_type, bool per_elem_params)
+    : jit_generator_t("jit_rvv_batch_normalization_bwd_reduce_kernel")
+    , data_type_(data_type)
+    , per_elem_params_(per_elem_params) {
+    create_kernel();
+}
+
+void jit_rvv_batch_normalization_bwd_reduce(const void *src,
+        const void *diff_dst, dim_t len, const float *mean, float *diff_scale,
+        float *diff_shift, data_type_t dt, bool per_elem_params) {
+    const jit_rvv_batch_normalization_bwd_reduce_kernel_t::call_params_t p {
+            src, diff_dst, len, mean, diff_scale, diff_shift};
+    if (dt == data_type::f16) {
+        if (per_elem_params)
+            dispatch_jit_batch_normalization_bwd_reduce<data_type::f16, true>(
+                    &p);
+        else
+            dispatch_jit_batch_normalization_bwd_reduce<data_type::f16, false>(
+                    &p);
+    } else {
+        if (per_elem_params)
+            dispatch_jit_batch_normalization_bwd_reduce<data_type::f32, true>(
+                    &p);
+        else
+            dispatch_jit_batch_normalization_bwd_reduce<data_type::f32, false>(
+                    &p);
+    }
+}
+
+void jit_rvv_batch_normalization_bwd_reduce_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const bool is_f16 = data_type_ == data_type::f16;
+    const LMUL compute_lmul = is_f16 ? LMUL::m2 : LMUL::m1;
+
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_diff_dst = a2;
+    const Reg reg_len = a3;
+    const Reg reg_mean = a4;
+    const Reg reg_diff_scale = a5;
+    const Reg reg_diff_shift = a6;
+    const Reg reg_vl = t0;
+    const Reg reg_data_bytes = t1;
+    const Reg reg_param_bytes = t2;
+
+    const FReg f_mean = fa0;
+    const FReg f_diff_scale = fa1;
+    const FReg f_diff_shift = fa2;
+    const FReg f_reduce = fa3;
+
+    const VReg v_src16(2);
+    const VReg v_diff_dst16(4);
+    const VReg v_src(8);
+    const VReg v_diff_dst(10);
+    const VReg v_mean(12);
+    const VReg v_diff_scale(14);
+    const VReg v_diff_shift(16);
+    const VReg v_work(18);
+    const VReg v_zero(20);
+    const VReg v_reduce(21);
+
+    ld(reg_src, reg_param, 0);
+    ld(reg_diff_dst, reg_param, 8);
+    ld(reg_len, reg_param, 16);
+    ld(reg_mean, reg_param, 24);
+    ld(reg_diff_scale, reg_param, 32);
+    ld(reg_diff_shift, reg_param, 40);
+
+    if (!per_elem_params_) {
+        flw(f_mean, reg_mean, 0);
+        flw(f_diff_scale, reg_diff_scale, 0);
+        flw(f_diff_shift, reg_diff_shift, 0);
+        vsetvli(reg_param_bytes, x0, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
+        vmv_v_x(v_zero, x0);
+    }
+
+    Label loop, done;
+    L(loop);
+    beqz(reg_len, done);
+    if (is_f16) {
+        vsetvli(
+                reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vle16_v(v_src16, reg_src);
+        vle16_v(v_diff_dst16, reg_diff_dst);
+        vfwcvt_f_f_v(v_src, v_src16);
+        vfwcvt_f_f_v(v_diff_dst, v_diff_dst16);
+        vsetvli(
+                reg_vl, reg_vl, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+    } else {
+        vsetvli(
+                reg_vl, reg_len, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+        vle32_v(v_src, reg_src);
+        vle32_v(v_diff_dst, reg_diff_dst);
+    }
+
+    if (per_elem_params_) {
+        vle32_v(v_mean, reg_mean);
+        vle32_v(v_diff_scale, reg_diff_scale);
+        vle32_v(v_diff_shift, reg_diff_shift);
+        vfsub_vv(v_work, v_src, v_mean);
+        vfmul_vv(v_work, v_work, v_diff_dst);
+        vfadd_vv(v_diff_scale, v_diff_scale, v_work);
+        vfadd_vv(v_diff_shift, v_diff_shift, v_diff_dst);
+        vse32_v(v_diff_scale, reg_diff_scale);
+        vse32_v(v_diff_shift, reg_diff_shift);
+    } else {
+        vfsub_vf(v_work, v_src, f_mean);
+        vfmul_vv(v_work, v_work, v_diff_dst);
+
+        vfredusum_vs(v_reduce, v_work, v_zero);
+        vfmv_f_s(f_reduce, v_reduce);
+        fadd_s(f_diff_scale, f_diff_scale, f_reduce);
+        vfredusum_vs(v_reduce, v_diff_dst, v_zero);
+        vfmv_f_s(f_reduce, v_reduce);
+        fadd_s(f_diff_shift, f_diff_shift, f_reduce);
+    }
+
+    slli(reg_data_bytes, reg_vl, is_f16 ? 1 : 2);
+    add(reg_src, reg_src, reg_data_bytes);
+    add(reg_diff_dst, reg_diff_dst, reg_data_bytes);
+    if (per_elem_params_) {
+        slli(reg_param_bytes, reg_vl, 2);
+        add(reg_mean, reg_mean, reg_param_bytes);
+        add(reg_diff_scale, reg_diff_scale, reg_param_bytes);
+        add(reg_diff_shift, reg_diff_shift, reg_param_bytes);
+    }
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(done);
+    if (!per_elem_params_) {
+        fsw(f_diff_scale, reg_diff_scale, 0);
+        fsw(f_diff_shift, reg_diff_shift, 0);
+    }
+    ret();
+#else
+    ret();
+#endif
+}
+
+jit_rvv_batch_normalization_bwd_apply_kernel_t::
+        jit_rvv_batch_normalization_bwd_apply_kernel_t(
+                data_type_t data_type, bool per_elem_params)
+    : jit_generator_t("jit_rvv_batch_normalization_bwd_apply_kernel")
+    , data_type_(data_type)
+    , per_elem_params_(per_elem_params) {
+    create_kernel();
+}
+
+void jit_rvv_batch_normalization_bwd_apply(const void *src,
+        const void *diff_dst, void *diff_src, dim_t len, const float *mean,
+        const float *scale_mul, const float *diff_scale_mul,
+        const float *diff_shift_add, data_type_t dt,
+        bool per_elem_params) {
+    const jit_rvv_batch_normalization_bwd_apply_kernel_t::call_params_t p {src,
+            diff_dst, diff_src, len, mean, scale_mul, diff_scale_mul,
+            diff_shift_add};
+    if (dt == data_type::f16) {
+        if (per_elem_params)
+            dispatch_jit_batch_normalization_bwd_apply<data_type::f16, true>(
+                    &p);
+        else
+            dispatch_jit_batch_normalization_bwd_apply<data_type::f16, false>(
+                    &p);
+    } else {
+        if (per_elem_params)
+            dispatch_jit_batch_normalization_bwd_apply<data_type::f32, true>(
+                    &p);
+        else
+            dispatch_jit_batch_normalization_bwd_apply<data_type::f32, false>(
+                    &p);
+    }
+}
+
+void jit_rvv_batch_normalization_bwd_apply_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const bool is_f16 = data_type_ == data_type::f16;
+    const LMUL compute_lmul = is_f16 ? LMUL::m2 : LMUL::m1;
+
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_diff_dst = a2;
+    const Reg reg_diff_src = a3;
+    const Reg reg_len = a4;
+    const Reg reg_mean = a5;
+    const Reg reg_scale_mul = a6;
+    const Reg reg_diff_scale_mul = a7;
+    const Reg reg_diff_shift_add = t0;
+    const Reg reg_vl = t1;
+    const Reg reg_data_bytes = t2;
+    const Reg reg_param_bytes = t3;
+
+    const FReg f_mean = fa0;
+    const FReg f_scale_mul = fa1;
+    const FReg f_diff_scale_mul = fa2;
+    const FReg f_diff_shift_add = fa3;
+
+    const VReg v_src16(2);
+    const VReg v_diff_dst16(4);
+    const VReg v_diff_src16(6);
+    const VReg v_src(8);
+    const VReg v_diff_dst(10);
+    const VReg v_mean(12);
+    const VReg v_scale_mul(14);
+    const VReg v_diff_scale_mul(16);
+    const VReg v_diff_shift_add(18);
+    const VReg v_work(20);
+
+    ld(reg_src, reg_param, 0);
+    ld(reg_diff_dst, reg_param, 8);
+    ld(reg_diff_src, reg_param, 16);
+    ld(reg_len, reg_param, 24);
+    ld(reg_mean, reg_param, 32);
+    ld(reg_scale_mul, reg_param, 40);
+    ld(reg_diff_scale_mul, reg_param, 48);
+    ld(reg_diff_shift_add, reg_param, 56);
+
+    if (!per_elem_params_) {
+        flw(f_mean, reg_mean, 0);
+        flw(f_scale_mul, reg_scale_mul, 0);
+        flw(f_diff_scale_mul, reg_diff_scale_mul, 0);
+        flw(f_diff_shift_add, reg_diff_shift_add, 0);
+    }
+
+    Label loop, done;
+    L(loop);
+    beqz(reg_len, done);
+    if (is_f16) {
+        vsetvli(
+                reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vle16_v(v_src16, reg_src);
+        vle16_v(v_diff_dst16, reg_diff_dst);
+        vfwcvt_f_f_v(v_src, v_src16);
+        vfwcvt_f_f_v(v_diff_dst, v_diff_dst16);
+        vsetvli(
+                reg_vl, reg_vl, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+    } else {
+        vsetvli(
+                reg_vl, reg_len, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+        vle32_v(v_src, reg_src);
+        vle32_v(v_diff_dst, reg_diff_dst);
+    }
+
+    if (per_elem_params_) {
+        vle32_v(v_mean, reg_mean);
+        vle32_v(v_scale_mul, reg_scale_mul);
+        vle32_v(v_diff_scale_mul, reg_diff_scale_mul);
+        vle32_v(v_diff_shift_add, reg_diff_shift_add);
+        vfsub_vv(v_work, v_src, v_mean);
+        vfmul_vv(v_work, v_work, v_diff_scale_mul);
+        vfadd_vv(v_work, v_work, v_diff_shift_add);
+        vfsub_vv(v_diff_dst, v_diff_dst, v_work);
+        vfmul_vv(v_diff_dst, v_diff_dst, v_scale_mul);
+    } else {
+        vfsub_vf(v_work, v_src, f_mean);
+        vfmul_vf(v_work, v_work, f_diff_scale_mul);
+        vfadd_vf(v_work, v_work, f_diff_shift_add);
+        vfsub_vv(v_diff_dst, v_diff_dst, v_work);
+        vfmul_vf(v_diff_dst, v_diff_dst, f_scale_mul);
+    }
+
+    if (is_f16) {
+        vsetvli(reg_vl, reg_vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vfncvt_f_f_w(v_diff_src16, v_diff_dst);
+        vse16_v(v_diff_src16, reg_diff_src);
+    } else {
+        vse32_v(v_diff_dst, reg_diff_src);
+    }
+
+    slli(reg_data_bytes, reg_vl, is_f16 ? 1 : 2);
+    add(reg_src, reg_src, reg_data_bytes);
+    add(reg_diff_dst, reg_diff_dst, reg_data_bytes);
+    add(reg_diff_src, reg_diff_src, reg_data_bytes);
+    if (per_elem_params_) {
+        slli(reg_param_bytes, reg_vl, 2);
+        add(reg_mean, reg_mean, reg_param_bytes);
+        add(reg_scale_mul, reg_scale_mul, reg_param_bytes);
+        add(reg_diff_scale_mul, reg_diff_scale_mul, reg_param_bytes);
+        add(reg_diff_shift_add, reg_diff_shift_add, reg_param_bytes);
     }
     sub(reg_len, reg_len, reg_vl);
     j_(loop);

--- a/src/cpu/rv64/jit_rvv_batch_normalization_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_batch_normalization_kernel.hpp
@@ -27,8 +27,8 @@ namespace rv64 {
 
 struct jit_rvv_batch_normalization_fwd_kernel_t : public jit_generator_t {
     struct call_params_t {
-        const float *src;
-        float *dst;
+        const void *src;
+        void *dst;
         dim_t len;
         const float *mean;
         const float *scale_mul;
@@ -38,7 +38,7 @@ struct jit_rvv_batch_normalization_fwd_kernel_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_batch_normalization_fwd_kernel_t)
 
     jit_rvv_batch_normalization_fwd_kernel_t(
-            bool per_elem_params, bool with_relu);
+            data_type_t data_type, bool per_elem_params, bool with_relu);
 
     void operator()(const call_params_t *p) const {
         jit_generator_t::operator()(p);
@@ -48,13 +48,84 @@ protected:
     void generate() override;
 
 private:
+    data_type_t data_type_;
     bool per_elem_params_;
     bool with_relu_;
 };
 
-void jit_rvv_batch_normalization_apply_f32(const float *src, float *dst,
-        dim_t len, const float *mean, const float *scale_mul,
-        const float *scale_add, bool per_elem_params, bool with_relu);
+struct jit_rvv_batch_normalization_bwd_reduce_kernel_t
+    : public jit_generator_t {
+    struct call_params_t {
+        const void *src;
+        const void *diff_dst;
+        dim_t len;
+        const float *mean;
+        float *diff_scale;
+        float *diff_shift;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(
+            jit_rvv_batch_normalization_bwd_reduce_kernel_t)
+
+    jit_rvv_batch_normalization_bwd_reduce_kernel_t(
+            data_type_t data_type, bool per_elem_params);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    data_type_t data_type_;
+    bool per_elem_params_;
+};
+
+struct jit_rvv_batch_normalization_bwd_apply_kernel_t
+    : public jit_generator_t {
+    struct call_params_t {
+        const void *src;
+        const void *diff_dst;
+        void *diff_src;
+        dim_t len;
+        const float *mean;
+        const float *scale_mul;
+        const float *diff_scale_mul;
+        const float *diff_shift_add;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(
+            jit_rvv_batch_normalization_bwd_apply_kernel_t)
+
+    jit_rvv_batch_normalization_bwd_apply_kernel_t(
+            data_type_t data_type, bool per_elem_params);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    data_type_t data_type_;
+    bool per_elem_params_;
+};
+
+void jit_rvv_batch_normalization_apply(const void *src, void *dst, dim_t len,
+        const float *mean, const float *scale_mul, const float *scale_add,
+        data_type_t data_type, bool per_elem_params, bool with_relu);
+
+void jit_rvv_batch_normalization_bwd_reduce(const void *src,
+        const void *diff_dst, dim_t len, const float *mean, float *diff_scale,
+        float *diff_shift, data_type_t data_type, bool per_elem_params);
+
+void jit_rvv_batch_normalization_bwd_apply(const void *src,
+        const void *diff_dst, void *diff_src, dim_t len, const float *mean,
+        const float *scale_mul, const float *diff_scale_mul,
+        const float *diff_shift_add, data_type_t data_type,
+        bool per_elem_params);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/rv64/jit_uni_batch_normalization.cpp
@@ -1,5 +1,6 @@
 /******************************************************************************
 * Copyright 2025 ZTE Corporation
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,8 +23,8 @@
 #include "common/dnnl_thread.hpp"
 #include "common/type_helpers.hpp"
 
-#include "cpu/rv64/jit_rvv_batch_normalization_kernel.hpp"
-#include "cpu/rv64/rvv_batch_normalization.hpp"
+#include "cpu/rv64/jit_uni_batch_normalization.hpp"
+#include "cpu/rv64/jit_uni_batch_normalization_kernel.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -32,17 +33,17 @@ namespace rv64 {
 
 namespace {
 
-static inline void bn_fwd_kernel(const void *s_base, void *d_base,
-        size_t len, const float *mean, const float *sm, const float *sv,
+static inline void bn_fwd_kernel(const void *s_base, void *d_base, size_t len,
+        const float *mean, const float *sm, const float *sv,
         data_type_t data_type, bool per_elem_params, bool with_relu) {
-    jit_rvv_batch_normalization_apply(s_base, d_base,
-            static_cast<dim_t>(len), mean, sm, sv, data_type, per_elem_params,
-            with_relu);
+    jit_uni_batch_normalization_apply(s_base, d_base, static_cast<dim_t>(len),
+            mean, sm, sv, data_type, per_elem_params, with_relu);
 }
 
 } // namespace
 
-status_t rvv_batch_normalization_fwd_t::execute_forward(
+template <cpu_isa_t isa>
+status_t jit_uni_batch_normalization_fwd_t<isa>::execute_forward(
         const exec_ctx_t &ctx) const {
     const memory_desc_wrapper data_d(pd()->src_md());
     const auto dtsrc = pd()->src_md()->data_type;
@@ -94,8 +95,7 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
             size_t base_off = off(n, c, d, h, 0);
 
             const void *s_ptr = reinterpret_cast<const void *>(
-                    reinterpret_cast<const char *>(src)
-                    + base_off * data_size);
+                    reinterpret_cast<const char *>(src) + base_off * data_size);
             void *d_ptr = reinterpret_cast<void *>(
                     reinterpret_cast<char *>(dst) + base_off * data_size);
             const float mean_b[1] = {vmean};
@@ -122,8 +122,7 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
         parallel_nd(N, D, H, W, [&](dim_t n, dim_t d, dim_t h, dim_t w) {
             const size_t base_off = off(n, 0, d, h, w);
             const void *s_ptr = reinterpret_cast<const void *>(
-                    reinterpret_cast<const char *>(src)
-                    + base_off * data_size);
+                    reinterpret_cast<const char *>(src) + base_off * data_size);
             void *d_ptr = reinterpret_cast<void *>(
                     reinterpret_cast<char *>(dst) + base_off * data_size);
             bn_fwd_kernel(s_ptr, d_ptr, static_cast<size_t>(C), mean, sm_arr,
@@ -134,7 +133,8 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
     return status::success;
 }
 
-status_t rvv_batch_normalization_bwd_t::execute_backward(
+template <cpu_isa_t isa>
+status_t jit_uni_batch_normalization_bwd_t<isa>::execute_backward(
         const exec_ctx_t &ctx) const {
     const memory_desc_wrapper data_d(pd()->src_md());
     const data_type_t data_type = pd()->src_md()->data_type;
@@ -154,15 +154,12 @@ status_t rvv_batch_normalization_bwd_t::execute_backward(
     const void *diff_dst = CTX_IN_MEM(const void *, DNNL_ARG_DIFF_DST);
     void *diff_src = CTX_OUT_MEM(void *, DNNL_ARG_DIFF_SRC);
     const float *mean = CTX_IN_MEM(const float *, DNNL_ARG_MEAN);
-    const float *variance
-            = CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE);
+    const float *variance = CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE);
     const float *scale = pd()->use_scale()
             ? CTX_IN_MEM(const float *, DNNL_ARG_SCALE)
             : nullptr;
-    float *diff_scale_out
-            = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_SCALE);
-    float *diff_shift_out
-            = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_SHIFT);
+    float *diff_scale_out = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_SCALE);
+    float *diff_shift_out = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_SHIFT);
 
     auto &grantor = ctx.get_scratchpad_grantor();
     float *tmp = grantor.template get<float>(
@@ -201,7 +198,7 @@ status_t rvv_batch_normalization_bwd_t::execute_backward(
                 for (dim_t d = 0; d < D; ++d) {
                     for (dim_t h = 0; h < H; ++h) {
                         const size_t base_off = off(n, c, d, h, 0);
-                        jit_rvv_batch_normalization_bwd_reduce(
+                        jit_uni_batch_normalization_bwd_reduce(
                                 data_ptr(src, base_off),
                                 data_ptr(diff_dst, base_off), W, mean + c,
                                 diff_scale + c, diff_shift + c, data_type,
@@ -234,10 +231,9 @@ status_t rvv_batch_normalization_bwd_t::execute_backward(
                 const dim_t d = q % D;
                 const dim_t n = q / D;
                 const size_t base_off = off(n, 0, d, h, w);
-                jit_rvv_batch_normalization_bwd_reduce(
-                        data_ptr(src, base_off),
-                        data_ptr(diff_dst, base_off), C, mean,
-                        local_diff_scale, local_diff_shift, data_type,
+                jit_uni_batch_normalization_bwd_reduce(data_ptr(src, base_off),
+                        data_ptr(diff_dst, base_off), C, mean, local_diff_scale,
+                        local_diff_shift, data_type,
                         /*per_elem_params=*/true);
             }
         });
@@ -267,32 +263,33 @@ status_t rvv_batch_normalization_bwd_t::execute_backward(
     });
 
     if (!channels_dense) {
-        parallel_nd(C, N, D, H,
-                [&](dim_t c, dim_t n, dim_t d, dim_t h) {
-                    const size_t base_off = off(n, c, d, h, 0);
-                    jit_rvv_batch_normalization_bwd_apply(
-                            data_ptr(src, base_off),
-                            data_ptr(diff_dst, base_off),
-                            mutable_data_ptr(diff_src, base_off), W, mean + c,
-                            scale_mul + c, diff_scale_mul + c,
-                            diff_shift_add + c, data_type,
-                            /*per_elem_params=*/false);
-                });
+        parallel_nd(C, N, D, H, [&](dim_t c, dim_t n, dim_t d, dim_t h) {
+            const size_t base_off = off(n, c, d, h, 0);
+            jit_uni_batch_normalization_bwd_apply(data_ptr(src, base_off),
+                    data_ptr(diff_dst, base_off),
+                    mutable_data_ptr(diff_src, base_off), W, mean + c,
+                    scale_mul + c, diff_scale_mul + c, diff_shift_add + c,
+                    data_type,
+                    /*per_elem_params=*/false);
+        });
     } else {
-        parallel_nd(N, D, H, W,
-                [&](dim_t n, dim_t d, dim_t h, dim_t w) {
-                    const size_t base_off = off(n, 0, d, h, w);
-                    jit_rvv_batch_normalization_bwd_apply(
-                            data_ptr(src, base_off),
-                            data_ptr(diff_dst, base_off),
-                            mutable_data_ptr(diff_src, base_off), C, mean,
-                            scale_mul, diff_scale_mul, diff_shift_add, data_type,
-                            /*per_elem_params=*/true);
-                });
+        parallel_nd(N, D, H, W, [&](dim_t n, dim_t d, dim_t h, dim_t w) {
+            const size_t base_off = off(n, 0, d, h, w);
+            jit_uni_batch_normalization_bwd_apply(data_ptr(src, base_off),
+                    data_ptr(diff_dst, base_off),
+                    mutable_data_ptr(diff_src, base_off), C, mean, scale_mul,
+                    diff_scale_mul, diff_shift_add, data_type,
+                    /*per_elem_params=*/true);
+        });
     }
 
     return status::success;
 }
+
+template struct jit_uni_batch_normalization_fwd_t<v>;
+template struct jit_uni_batch_normalization_fwd_t<zvfh>;
+template struct jit_uni_batch_normalization_bwd_t<v>;
+template struct jit_uni_batch_normalization_bwd_t<zvfh>;
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_uni_batch_normalization.hpp
+++ b/src/cpu/rv64/jit_uni_batch_normalization.hpp
@@ -1,5 +1,6 @@
 /******************************************************************************
 * Copyright 2025 ZTE Corporation
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,8 +15,8 @@
 * limitations under the License.
 ******************************************************************************/
 
-#ifndef CPU_RV64_RVV_BATCH_NORMALIZATION_HPP
-#define CPU_RV64_RVV_BATCH_NORMALIZATION_HPP
+#ifndef CPU_RV64_JIT_UNI_BATCH_NORMALIZATION_HPP
+#define CPU_RV64_JIT_UNI_BATCH_NORMALIZATION_HPP
 
 #include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
@@ -30,14 +31,14 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
-struct rvv_batch_normalization_fwd_t : public primitive_t {
+template <cpu_isa_t isa>
+struct jit_uni_batch_normalization_fwd_t : public primitive_t {
     struct pd_t : public cpu_batch_normalization_fwd_pd_t {
         using cpu_batch_normalization_fwd_pd_t::
                 cpu_batch_normalization_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T(
-                JIT_IMPL_NAME_HELPER("jit:", isa_, ""),
-                rvv_batch_normalization_fwd_t);
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa, ""),
+                jit_uni_batch_normalization_fwd_t);
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
@@ -46,21 +47,17 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
 
             // Vector kernels are JIT-emitted; the rv64gc baseline build means a
             // non-V CPU must defer to the next (reference) implementation.
-            VDISPATCH_BNORM(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_BNORM(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_BNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
 
             const data_type_t dtsrc = src_md()->data_type;
             const data_type_t dtdst = dst_md()->data_type;
-            isa_ = dtsrc == f16 ? zvfh : v;
-            const bool types_ok = utils::one_of(dtsrc, f32, f16)
-                    && dtdst == dtsrc
+            const data_type_t expected_dt = isa == zvfh ? f16 : f32;
+            const bool types_ok = dtsrc == expected_dt && dtdst == dtsrc
                     && platform::has_data_type_support(dtsrc)
                     && IMPLICATION(is_training(),
                             platform::has_training_support(dtsrc));
             VDISPATCH_BNORM(types_ok, VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_BNORM(
-                    IMPLICATION(dtsrc == f16, mayiuse(zvfh)),
-                    VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_BNORM(check_scale_shift_data_type(),
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "unsupported scale or shift data type");
@@ -116,8 +113,7 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
                     && dst_d.is_dense(/*with_padding=*/false);
             bool same_layouts = src_d.similar_to(dst_d, /*with_strides=*/true,
                     /*with_pads=*/false);
-            const bool vector_dim_dense
-                    = src_d.blocking_desc().strides[1] == 1
+            const bool vector_dim_dense = src_d.blocking_desc().strides[1] == 1
                     || src_d.blocking_desc().strides[ndims() - 1] == 1;
             return ndims_ok && plain_dense && same_layouts && vector_dim_dense;
         }
@@ -132,11 +128,10 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
             scratchpad.template book<float>(key_bnorm_tmp_mean, C());
             scratchpad.template book<float>(key_bnorm_tmp_var, C());
         }
-        cpu_isa_t isa_ = v;
         bool fused_relu_in_kernel_ = false;
     };
 
-    rvv_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+    jit_uni_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -147,41 +142,37 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 };
 
-struct rvv_batch_normalization_bwd_t : public primitive_t {
+template <cpu_isa_t isa>
+struct jit_uni_batch_normalization_bwd_t : public primitive_t {
     struct pd_t : public cpu_batch_normalization_bwd_pd_t {
         using cpu_batch_normalization_bwd_pd_t::
                 cpu_batch_normalization_bwd_pd_t;
 
-        DECLARE_COMMON_PD_T(
-                JIT_IMPL_NAME_HELPER("jit:", isa_, ""),
-                rvv_batch_normalization_bwd_t);
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", isa, ""),
+                jit_uni_batch_normalization_bwd_t);
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
             using namespace data_type;
 
-            VDISPATCH_BNORM(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_BNORM(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_BNORM(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
 
             const data_type_t dt = src_md()->data_type;
-            isa_ = dt == f16 ? zvfh : v;
-            VDISPATCH_BNORM(utils::one_of(dt, f32, f16)
-                            && utils::everyone_is(dt,
-                                    diff_dst_md()->data_type,
+            const data_type_t expected_dt = isa == zvfh ? f16 : f32;
+            VDISPATCH_BNORM(dt == expected_dt
+                            && utils::everyone_is(dt, diff_dst_md()->data_type,
                                     diff_src_md()->data_type)
                             && platform::has_data_type_support(dt)
                             && platform::has_training_support(dt),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_BNORM(IMPLICATION(dt == f16, mayiuse(zvfh)),
-                    VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_BNORM(check_scale_shift_data_type(),
                     VERBOSE_UNSUPPORTED_FEATURE,
                     "unsupported scale or shift data type");
             VDISPATCH_BNORM(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_BNORM(!fuse_norm_add_relu(),
-                    VERBOSE_UNSUPPORTED_FEATURE,
+            VDISPATCH_BNORM(!fuse_norm_add_relu(), VERBOSE_UNSUPPORTED_FEATURE,
                     "fuse_norm_add_relu not supported");
             VDISPATCH_BNORM(!fuse_norm_relu(), VERBOSE_UNSUPPORTED_FEATURE,
                     "fused ReLU backward not supported");
@@ -206,14 +197,12 @@ struct rvv_batch_normalization_bwd_t : public primitive_t {
                 const memory_desc_wrapper &diff_dst_d,
                 const memory_desc_wrapper &diff_src_d) const {
             const bool ndims_ok = utils::one_of(ndims(), 3, 4, 5);
-            const bool plain_dense
-                    = src_d.blocking_desc().inner_nblks == 0
+            const bool plain_dense = src_d.blocking_desc().inner_nblks == 0
                     && diff_dst_d.blocking_desc().inner_nblks == 0
                     && diff_src_d.blocking_desc().inner_nblks == 0
                     && src_d.is_dense(false) && diff_dst_d.is_dense(false)
                     && diff_src_d.is_dense(false);
-            const bool vector_dim_dense
-                    = src_d.blocking_desc().strides[1] == 1
+            const bool vector_dim_dense = src_d.blocking_desc().strides[1] == 1
                     || src_d.blocking_desc().strides[ndims() - 1] == 1;
             return ndims_ok && plain_dense
                     && src_d.similar_to(
@@ -231,11 +220,10 @@ struct rvv_batch_normalization_bwd_t : public primitive_t {
             scratchpad.template book<float>(key_bnorm_tmp_diff_ss, 5 * C());
         }
 
-        cpu_isa_t isa_ = v;
         int nthr_ = 1;
     };
 
-    rvv_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
+    jit_uni_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);
@@ -251,4 +239,4 @@ private:
 } // namespace impl
 } // namespace dnnl
 
-#endif // CPU_RV64_RVV_BATCH_NORMALIZATION_HPP
+#endif // CPU_RV64_JIT_UNI_BATCH_NORMALIZATION_HPP

--- a/src/cpu/rv64/jit_uni_batch_normalization_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_batch_normalization_kernel.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "cpu/rv64/jit_rvv_batch_normalization_kernel.hpp"
+#include "cpu/rv64/jit_uni_batch_normalization_kernel.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -27,46 +27,46 @@ namespace {
 
 template <data_type_t data_type, bool per_elem_params, bool with_relu>
 void dispatch_jit_batch_normalization_fwd(
-        const jit_rvv_batch_normalization_fwd_kernel_t::call_params_t *p) {
-    static const jit_rvv_batch_normalization_fwd_kernel_t kernel(
+        const jit_uni_batch_normalization_fwd_kernel_t::call_params_t *p) {
+    static const jit_uni_batch_normalization_fwd_kernel_t kernel(
             data_type, per_elem_params, with_relu);
     kernel(p);
 }
 
 template <data_type_t data_type, bool per_elem_params>
 void dispatch_jit_batch_normalization_bwd_reduce(
-        const jit_rvv_batch_normalization_bwd_reduce_kernel_t::call_params_t
+        const jit_uni_batch_normalization_bwd_reduce_kernel_t::call_params_t
                 *p) {
-    static const jit_rvv_batch_normalization_bwd_reduce_kernel_t kernel(
+    static const jit_uni_batch_normalization_bwd_reduce_kernel_t kernel(
             data_type, per_elem_params);
     kernel(p);
 }
 
 template <data_type_t data_type, bool per_elem_params>
 void dispatch_jit_batch_normalization_bwd_apply(
-        const jit_rvv_batch_normalization_bwd_apply_kernel_t::call_params_t
+        const jit_uni_batch_normalization_bwd_apply_kernel_t::call_params_t
                 *p) {
-    static const jit_rvv_batch_normalization_bwd_apply_kernel_t kernel(
+    static const jit_uni_batch_normalization_bwd_apply_kernel_t kernel(
             data_type, per_elem_params);
     kernel(p);
 }
 
 } // namespace
 
-jit_rvv_batch_normalization_fwd_kernel_t::
-        jit_rvv_batch_normalization_fwd_kernel_t(
+jit_uni_batch_normalization_fwd_kernel_t::
+        jit_uni_batch_normalization_fwd_kernel_t(
                 data_type_t data_type, bool per_elem_params, bool with_relu)
-    : jit_generator_t("jit_rvv_batch_normalization_fwd_kernel")
+    : jit_generator_t("jit_uni_batch_normalization_fwd_kernel")
     , data_type_(data_type)
     , per_elem_params_(per_elem_params)
     , with_relu_(with_relu) {
     create_kernel();
 }
 
-void jit_rvv_batch_normalization_apply(const void *src, void *dst, dim_t len,
+void jit_uni_batch_normalization_apply(const void *src, void *dst, dim_t len,
         const float *mean, const float *scale_mul, const float *scale_add,
         data_type_t dt, bool per_elem_params, bool with_relu) {
-    const jit_rvv_batch_normalization_fwd_kernel_t::call_params_t p {
+    const jit_uni_batch_normalization_fwd_kernel_t::call_params_t p {
             src, dst, len, mean, scale_mul, scale_add};
     if (dt == data_type::f16) {
         if (per_elem_params) {
@@ -103,7 +103,7 @@ void jit_rvv_batch_normalization_apply(const void *src, void *dst, dim_t len,
     }
 }
 
-void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
+void jit_uni_batch_normalization_fwd_kernel_t::generate() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const bool is_f16 = data_type_ == data_type::f16;
     const Reg reg_param = a0;
@@ -146,14 +146,12 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
     L(loop);
     beqz(reg_len, done);
     if (is_f16) {
-        vsetvli(
-                reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vle16_v(v_src16, reg_src);
         vfwcvt_f_f_v(v_src, v_src16);
         vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
     } else {
-        vsetvli(
-                reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
         vle32_v(v_src, reg_src);
     }
     if (per_elem_params_) {
@@ -199,19 +197,19 @@ void jit_rvv_batch_normalization_fwd_kernel_t::generate() {
 #endif
 }
 
-jit_rvv_batch_normalization_bwd_reduce_kernel_t::
-        jit_rvv_batch_normalization_bwd_reduce_kernel_t(
+jit_uni_batch_normalization_bwd_reduce_kernel_t::
+        jit_uni_batch_normalization_bwd_reduce_kernel_t(
                 data_type_t data_type, bool per_elem_params)
-    : jit_generator_t("jit_rvv_batch_normalization_bwd_reduce_kernel")
+    : jit_generator_t("jit_uni_batch_normalization_bwd_reduce_kernel")
     , data_type_(data_type)
     , per_elem_params_(per_elem_params) {
     create_kernel();
 }
 
-void jit_rvv_batch_normalization_bwd_reduce(const void *src,
+void jit_uni_batch_normalization_bwd_reduce(const void *src,
         const void *diff_dst, dim_t len, const float *mean, float *diff_scale,
         float *diff_shift, data_type_t dt, bool per_elem_params) {
-    const jit_rvv_batch_normalization_bwd_reduce_kernel_t::call_params_t p {
+    const jit_uni_batch_normalization_bwd_reduce_kernel_t::call_params_t p {
             src, diff_dst, len, mean, diff_scale, diff_shift};
     if (dt == data_type::f16) {
         if (per_elem_params)
@@ -230,7 +228,7 @@ void jit_rvv_batch_normalization_bwd_reduce(const void *src,
     }
 }
 
-void jit_rvv_batch_normalization_bwd_reduce_kernel_t::generate() {
+void jit_uni_batch_normalization_bwd_reduce_kernel_t::generate() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const bool is_f16 = data_type_ == data_type::f16;
     const LMUL compute_lmul = is_f16 ? LMUL::m2 : LMUL::m1;
@@ -281,17 +279,14 @@ void jit_rvv_batch_normalization_bwd_reduce_kernel_t::generate() {
     L(loop);
     beqz(reg_len, done);
     if (is_f16) {
-        vsetvli(
-                reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vle16_v(v_src16, reg_src);
         vle16_v(v_diff_dst16, reg_diff_dst);
         vfwcvt_f_f_v(v_src, v_src16);
         vfwcvt_f_f_v(v_diff_dst, v_diff_dst16);
-        vsetvli(
-                reg_vl, reg_vl, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_vl, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
     } else {
-        vsetvli(
-                reg_vl, reg_len, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_len, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
         vle32_v(v_src, reg_src);
         vle32_v(v_diff_dst, reg_diff_dst);
     }
@@ -341,21 +336,20 @@ void jit_rvv_batch_normalization_bwd_reduce_kernel_t::generate() {
 #endif
 }
 
-jit_rvv_batch_normalization_bwd_apply_kernel_t::
-        jit_rvv_batch_normalization_bwd_apply_kernel_t(
+jit_uni_batch_normalization_bwd_apply_kernel_t::
+        jit_uni_batch_normalization_bwd_apply_kernel_t(
                 data_type_t data_type, bool per_elem_params)
-    : jit_generator_t("jit_rvv_batch_normalization_bwd_apply_kernel")
+    : jit_generator_t("jit_uni_batch_normalization_bwd_apply_kernel")
     , data_type_(data_type)
     , per_elem_params_(per_elem_params) {
     create_kernel();
 }
 
-void jit_rvv_batch_normalization_bwd_apply(const void *src,
+void jit_uni_batch_normalization_bwd_apply(const void *src,
         const void *diff_dst, void *diff_src, dim_t len, const float *mean,
         const float *scale_mul, const float *diff_scale_mul,
-        const float *diff_shift_add, data_type_t dt,
-        bool per_elem_params) {
-    const jit_rvv_batch_normalization_bwd_apply_kernel_t::call_params_t p {src,
+        const float *diff_shift_add, data_type_t dt, bool per_elem_params) {
+    const jit_uni_batch_normalization_bwd_apply_kernel_t::call_params_t p {src,
             diff_dst, diff_src, len, mean, scale_mul, diff_scale_mul,
             diff_shift_add};
     if (dt == data_type::f16) {
@@ -375,7 +369,7 @@ void jit_rvv_batch_normalization_bwd_apply(const void *src,
     }
 }
 
-void jit_rvv_batch_normalization_bwd_apply_kernel_t::generate() {
+void jit_uni_batch_normalization_bwd_apply_kernel_t::generate() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const bool is_f16 = data_type_ == data_type::f16;
     const LMUL compute_lmul = is_f16 ? LMUL::m2 : LMUL::m1;
@@ -429,17 +423,14 @@ void jit_rvv_batch_normalization_bwd_apply_kernel_t::generate() {
     L(loop);
     beqz(reg_len, done);
     if (is_f16) {
-        vsetvli(
-                reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vle16_v(v_src16, reg_src);
         vle16_v(v_diff_dst16, reg_diff_dst);
         vfwcvt_f_f_v(v_src, v_src16);
         vfwcvt_f_f_v(v_diff_dst, v_diff_dst16);
-        vsetvli(
-                reg_vl, reg_vl, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_vl, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
     } else {
-        vsetvli(
-                reg_vl, reg_len, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
+        vsetvli(reg_vl, reg_len, SEW::e32, compute_lmul, VTA::ta, VMA::ma);
         vle32_v(v_src, reg_src);
         vle32_v(v_diff_dst, reg_diff_dst);
     }

--- a/src/cpu/rv64/jit_uni_batch_normalization_kernel.hpp
+++ b/src/cpu/rv64/jit_uni_batch_normalization_kernel.hpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef CPU_RV64_JIT_RVV_BATCH_NORMALIZATION_KERNEL_HPP
-#define CPU_RV64_JIT_RVV_BATCH_NORMALIZATION_KERNEL_HPP
+#ifndef CPU_RV64_JIT_UNI_BATCH_NORMALIZATION_KERNEL_HPP
+#define CPU_RV64_JIT_UNI_BATCH_NORMALIZATION_KERNEL_HPP
 
 #include "common/c_types_map.hpp"
 #include "cpu/rv64/jit_generator.hpp"
@@ -25,7 +25,7 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
-struct jit_rvv_batch_normalization_fwd_kernel_t : public jit_generator_t {
+struct jit_uni_batch_normalization_fwd_kernel_t : public jit_generator_t {
     struct call_params_t {
         const void *src;
         void *dst;
@@ -35,9 +35,9 @@ struct jit_rvv_batch_normalization_fwd_kernel_t : public jit_generator_t {
         const float *scale_add;
     };
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_batch_normalization_fwd_kernel_t)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_batch_normalization_fwd_kernel_t)
 
-    jit_rvv_batch_normalization_fwd_kernel_t(
+    jit_uni_batch_normalization_fwd_kernel_t(
             data_type_t data_type, bool per_elem_params, bool with_relu);
 
     void operator()(const call_params_t *p) const {
@@ -53,7 +53,7 @@ private:
     bool with_relu_;
 };
 
-struct jit_rvv_batch_normalization_bwd_reduce_kernel_t
+struct jit_uni_batch_normalization_bwd_reduce_kernel_t
     : public jit_generator_t {
     struct call_params_t {
         const void *src;
@@ -65,9 +65,9 @@ struct jit_rvv_batch_normalization_bwd_reduce_kernel_t
     };
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(
-            jit_rvv_batch_normalization_bwd_reduce_kernel_t)
+            jit_uni_batch_normalization_bwd_reduce_kernel_t)
 
-    jit_rvv_batch_normalization_bwd_reduce_kernel_t(
+    jit_uni_batch_normalization_bwd_reduce_kernel_t(
             data_type_t data_type, bool per_elem_params);
 
     void operator()(const call_params_t *p) const {
@@ -82,8 +82,7 @@ private:
     bool per_elem_params_;
 };
 
-struct jit_rvv_batch_normalization_bwd_apply_kernel_t
-    : public jit_generator_t {
+struct jit_uni_batch_normalization_bwd_apply_kernel_t : public jit_generator_t {
     struct call_params_t {
         const void *src;
         const void *diff_dst;
@@ -96,9 +95,9 @@ struct jit_rvv_batch_normalization_bwd_apply_kernel_t
     };
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(
-            jit_rvv_batch_normalization_bwd_apply_kernel_t)
+            jit_uni_batch_normalization_bwd_apply_kernel_t)
 
-    jit_rvv_batch_normalization_bwd_apply_kernel_t(
+    jit_uni_batch_normalization_bwd_apply_kernel_t(
             data_type_t data_type, bool per_elem_params);
 
     void operator()(const call_params_t *p) const {
@@ -113,15 +112,15 @@ private:
     bool per_elem_params_;
 };
 
-void jit_rvv_batch_normalization_apply(const void *src, void *dst, dim_t len,
+void jit_uni_batch_normalization_apply(const void *src, void *dst, dim_t len,
         const float *mean, const float *scale_mul, const float *scale_add,
         data_type_t data_type, bool per_elem_params, bool with_relu);
 
-void jit_rvv_batch_normalization_bwd_reduce(const void *src,
+void jit_uni_batch_normalization_bwd_reduce(const void *src,
         const void *diff_dst, dim_t len, const float *mean, float *diff_scale,
         float *diff_shift, data_type_t data_type, bool per_elem_params);
 
-void jit_rvv_batch_normalization_bwd_apply(const void *src,
+void jit_uni_batch_normalization_bwd_apply(const void *src,
         const void *diff_dst, void *diff_src, dim_t len, const float *mean,
         const float *scale_mul, const float *diff_scale_mul,
         const float *diff_shift_add, data_type_t data_type,
@@ -132,4 +131,4 @@ void jit_rvv_batch_normalization_bwd_apply(const void *src,
 } // namespace impl
 } // namespace dnnl
 
-#endif // CPU_RV64_JIT_RVV_BATCH_NORMALIZATION_KERNEL_HPP
+#endif // CPU_RV64_JIT_UNI_BATCH_NORMALIZATION_KERNEL_HPP

--- a/src/cpu/rv64/rvv_batch_normalization.cpp
+++ b/src/cpu/rv64/rvv_batch_normalization.cpp
@@ -32,12 +32,12 @@ namespace rv64 {
 
 namespace {
 
-static inline void bn_fwd_kernel_f32(const void *s_base, void *d_base,
+static inline void bn_fwd_kernel(const void *s_base, void *d_base,
         size_t len, const float *mean, const float *sm, const float *sv,
-        bool per_elem_params, bool with_relu) {
-    jit_rvv_batch_normalization_apply_f32(static_cast<const float *>(s_base),
-            static_cast<float *>(d_base), static_cast<dim_t>(len), mean, sm, sv,
-            per_elem_params, with_relu);
+        data_type_t data_type, bool per_elem_params, bool with_relu) {
+    jit_rvv_batch_normalization_apply(s_base, d_base,
+            static_cast<dim_t>(len), mean, sm, sv, data_type, per_elem_params,
+            with_relu);
 }
 
 } // namespace
@@ -55,6 +55,7 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
     const dim_t W = pd()->W();
 
     const float eps = pd()->desc()->batch_norm_epsilon;
+    const size_t data_size = types::data_type_size(dtsrc);
 
     void *dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
     const void *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
@@ -92,28 +93,16 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
             const float sv = vshift;
             size_t base_off = off(n, c, d, h, 0);
 
-            switch (dtsrc) {
-                case data_type::f32: {
-                    const size_t data_size
-                            = types::data_type_size(data_type::f32);
-                    const void *s_ptr = reinterpret_cast<const void *>(
-                            reinterpret_cast<const char *>(src)
-                            + base_off * data_size);
-                    void *d_ptr = reinterpret_cast<void *>(
-                            reinterpret_cast<char *>(dst)
-                            + base_off * data_size);
-                    const float mean_b[1] = {vmean};
-                    const float sm_b[1] = {sm};
-                    const float sv_b[1] = {sv};
-                    bn_fwd_kernel_f32(s_ptr, d_ptr, static_cast<size_t>(W),
-                            mean_b, sm_b, sv_b, /*per_elem_params=*/false,
-                            with_relu);
-                    break;
-                }
-                default:
-                    assert(!"Unsupported data type for RVV batch "
-                            "normalization");
-            }
+            const void *s_ptr = reinterpret_cast<const void *>(
+                    reinterpret_cast<const char *>(src)
+                    + base_off * data_size);
+            void *d_ptr = reinterpret_cast<void *>(
+                    reinterpret_cast<char *>(dst) + base_off * data_size);
+            const float mean_b[1] = {vmean};
+            const float sm_b[1] = {sm};
+            const float sv_b[1] = {sv};
+            bn_fwd_kernel(s_ptr, d_ptr, static_cast<size_t>(W), mean_b, sm_b,
+                    sv_b, dtsrc, /*per_elem_params=*/false, with_relu);
         });
     } else {
         // axb data tag: vectorize across channels
@@ -131,28 +120,175 @@ status_t rvv_batch_normalization_fwd_t::execute_forward(
         }
 
         parallel_nd(N, D, H, W, [&](dim_t n, dim_t d, dim_t h, dim_t w) {
-            switch (dtsrc) {
-                case data_type::f32: {
-                    const size_t data_size
-                            = types::data_type_size(data_type::f32);
-                    size_t base_off = off(n, 0, d, h, w);
-                    const void *s_ptr = reinterpret_cast<const void *>(
-                            reinterpret_cast<const char *>(src)
-                            + base_off * data_size);
-                    void *d_ptr = reinterpret_cast<void *>(
-                            reinterpret_cast<char *>(dst)
-                            + base_off * data_size);
+            const size_t base_off = off(n, 0, d, h, w);
+            const void *s_ptr = reinterpret_cast<const void *>(
+                    reinterpret_cast<const char *>(src)
+                    + base_off * data_size);
+            void *d_ptr = reinterpret_cast<void *>(
+                    reinterpret_cast<char *>(dst) + base_off * data_size);
+            bn_fwd_kernel(s_ptr, d_ptr, static_cast<size_t>(C), mean, sm_arr,
+                    sv_arr, dtsrc, /*per_elem_params=*/true, with_relu);
+        });
+    }
 
-                    bn_fwd_kernel_f32(s_ptr, d_ptr, static_cast<size_t>(C),
-                            mean, sm_arr, sv_arr,
-                            /*per_elem_params=*/true, with_relu);
-                    break;
+    return status::success;
+}
+
+status_t rvv_batch_normalization_bwd_t::execute_backward(
+        const exec_ctx_t &ctx) const {
+    const memory_desc_wrapper data_d(pd()->src_md());
+    const data_type_t data_type = pd()->src_md()->data_type;
+    const size_t data_size = types::data_type_size(data_type);
+    const int ndims = data_d.ndims();
+
+    const dim_t N = pd()->MB();
+    const dim_t C = pd()->C();
+    const dim_t D = pd()->D();
+    const dim_t H = pd()->H();
+    const dim_t W = pd()->W();
+    const dim_t M = N * D * H * W;
+    const float eps = pd()->desc()->batch_norm_epsilon;
+    const bool calculate_diff_stats = !pd()->use_global_stats();
+
+    const void *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    const void *diff_dst = CTX_IN_MEM(const void *, DNNL_ARG_DIFF_DST);
+    void *diff_src = CTX_OUT_MEM(void *, DNNL_ARG_DIFF_SRC);
+    const float *mean = CTX_IN_MEM(const float *, DNNL_ARG_MEAN);
+    const float *variance
+            = CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE);
+    const float *scale = pd()->use_scale()
+            ? CTX_IN_MEM(const float *, DNNL_ARG_SCALE)
+            : nullptr;
+    float *diff_scale_out
+            = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_SCALE);
+    float *diff_shift_out
+            = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_SHIFT);
+
+    auto &grantor = ctx.get_scratchpad_grantor();
+    float *tmp = grantor.template get<float>(
+            memory_tracking::names::key_bnorm_tmp_diff_ss);
+    float *reduction = grantor.template get<float>(
+            memory_tracking::names::key_bnorm_reduction);
+    float *diff_scale = diff_scale_out ? diff_scale_out : tmp;
+    float *diff_shift = diff_shift_out ? diff_shift_out : tmp + C;
+    float *scale_mul = tmp + 2 * C;
+    float *diff_scale_mul = tmp + 3 * C;
+    float *diff_shift_add = tmp + 4 * C;
+
+    auto off = [&](dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) -> size_t {
+        switch (ndims) {
+            case 3: return data_d.off(n, c, w);
+            case 4: return data_d.off(n, c, h, w);
+            case 5: return data_d.off(n, c, d, h, w);
+            default: assert(!"unsupported ndims"); return dim_t(0);
+        }
+    };
+    auto data_ptr = [&](const void *base, size_t elem_off) {
+        return reinterpret_cast<const void *>(
+                reinterpret_cast<const char *>(base) + elem_off * data_size);
+    };
+    auto mutable_data_ptr = [&](void *base, size_t elem_off) {
+        return reinterpret_cast<void *>(
+                reinterpret_cast<char *>(base) + elem_off * data_size);
+    };
+
+    const bool channels_dense = data_d.blocking_desc().strides[1] == 1;
+    if (!channels_dense) {
+        parallel_nd(C, [&](dim_t c) {
+            diff_scale[c] = 0.0f;
+            diff_shift[c] = 0.0f;
+            for (dim_t n = 0; n < N; ++n) {
+                for (dim_t d = 0; d < D; ++d) {
+                    for (dim_t h = 0; h < H; ++h) {
+                        const size_t base_off = off(n, c, d, h, 0);
+                        jit_rvv_batch_normalization_bwd_reduce(
+                                data_ptr(src, base_off),
+                                data_ptr(diff_dst, base_off), W, mean + c,
+                                diff_scale + c, diff_shift + c, data_type,
+                                /*per_elem_params=*/false);
+                    }
                 }
-                default:
-                    assert(!"Unsupported data type for RVV batch "
-                            "normalization");
             }
         });
+    } else {
+        const dim_t rows = N * D * H * W;
+        const int nthr = pd()->nthr();
+        for (dim_t i = 0; i < 2 * C * nthr; ++i)
+            reduction[i] = 0.0f;
+        parallel(nthr, [&](int ithr, int nthr) {
+            float *local_diff_scale = reduction + 2 * C * ithr;
+            float *local_diff_shift = local_diff_scale + C;
+            for (dim_t c = 0; c < C; ++c) {
+                local_diff_scale[c] = 0.0f;
+                local_diff_shift[c] = 0.0f;
+            }
+
+            dim_t start = 0, end = 0;
+            balance211(rows, nthr, ithr, start, end);
+            for (dim_t row = start; row < end; ++row) {
+                dim_t q = row;
+                const dim_t w = q % W;
+                q /= W;
+                const dim_t h = q % H;
+                q /= H;
+                const dim_t d = q % D;
+                const dim_t n = q / D;
+                const size_t base_off = off(n, 0, d, h, w);
+                jit_rvv_batch_normalization_bwd_reduce(
+                        data_ptr(src, base_off),
+                        data_ptr(diff_dst, base_off), C, mean,
+                        local_diff_scale, local_diff_shift, data_type,
+                        /*per_elem_params=*/true);
+            }
+        });
+
+        parallel_nd(C, [&](dim_t c) {
+            float dg = 0.0f;
+            float db = 0.0f;
+            for (int ithr = 0; ithr < pd()->nthr(); ++ithr) {
+                dg += reduction[2 * C * ithr + c];
+                db += reduction[2 * C * ithr + C + c];
+            }
+            diff_scale[c] = dg;
+            diff_shift[c] = db;
+        });
+    }
+
+    parallel_nd(C, [&](dim_t c) {
+        const float inv_std = 1.0f / sqrtf(variance[c] + eps);
+        diff_scale[c] *= inv_std;
+        scale_mul[c] = (scale ? scale[c] : 1.0f) * inv_std;
+        diff_scale_mul[c] = calculate_diff_stats
+                ? diff_scale[c] * inv_std / static_cast<float>(M)
+                : 0.0f;
+        diff_shift_add[c] = calculate_diff_stats
+                ? diff_shift[c] / static_cast<float>(M)
+                : 0.0f;
+    });
+
+    if (!channels_dense) {
+        parallel_nd(C, N, D, H,
+                [&](dim_t c, dim_t n, dim_t d, dim_t h) {
+                    const size_t base_off = off(n, c, d, h, 0);
+                    jit_rvv_batch_normalization_bwd_apply(
+                            data_ptr(src, base_off),
+                            data_ptr(diff_dst, base_off),
+                            mutable_data_ptr(diff_src, base_off), W, mean + c,
+                            scale_mul + c, diff_scale_mul + c,
+                            diff_shift_add + c, data_type,
+                            /*per_elem_params=*/false);
+                });
+    } else {
+        parallel_nd(N, D, H, W,
+                [&](dim_t n, dim_t d, dim_t h, dim_t w) {
+                    const size_t base_off = off(n, 0, d, h, w);
+                    jit_rvv_batch_normalization_bwd_apply(
+                            data_ptr(src, base_off),
+                            data_ptr(diff_dst, base_off),
+                            mutable_data_ptr(diff_src, base_off), C, mean,
+                            scale_mul, diff_scale_mul, diff_shift_add, data_type,
+                            /*per_elem_params=*/true);
+                });
     }
 
     return status::success;

--- a/src/cpu/rv64/rvv_batch_normalization.hpp
+++ b/src/cpu/rv64/rvv_batch_normalization.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_RV64_RVV_BATCH_NORMALIZATION_HPP
 #define CPU_RV64_RVV_BATCH_NORMALIZATION_HPP
 
+#include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
 
@@ -34,7 +35,9 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
         using cpu_batch_normalization_fwd_pd_t::
                 cpu_batch_normalization_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T_("jit:rvv", rvv_batch_normalization_fwd_t);
+        DECLARE_COMMON_PD_T(
+                JIT_IMPL_NAME_HELPER("jit:", isa_, ""),
+                rvv_batch_normalization_fwd_t);
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
@@ -48,11 +51,19 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
 
             const data_type_t dtsrc = src_md()->data_type;
             const data_type_t dtdst = dst_md()->data_type;
-            bool types_ok = (dtsrc == f32 && dtdst == f32)
+            isa_ = dtsrc == f16 ? zvfh : v;
+            const bool types_ok = utils::one_of(dtsrc, f32, f16)
+                    && dtdst == dtsrc
                     && platform::has_data_type_support(dtsrc)
                     && IMPLICATION(is_training(),
                             platform::has_training_support(dtsrc));
             VDISPATCH_BNORM(types_ok, VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_BNORM(
+                    IMPLICATION(dtsrc == f16, mayiuse(zvfh)),
+                    VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_BNORM(check_scale_shift_data_type(),
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "unsupported scale or shift data type");
 
             VDISPATCH_BNORM(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
 
@@ -105,7 +116,10 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
                     && dst_d.is_dense(/*with_padding=*/false);
             bool same_layouts = src_d.similar_to(dst_d, /*with_strides=*/true,
                     /*with_pads=*/false);
-            return ndims_ok && plain_dense && same_layouts;
+            const bool vector_dim_dense
+                    = src_d.blocking_desc().strides[1] == 1
+                    || src_d.blocking_desc().strides[ndims() - 1] == 1;
+            return ndims_ok && plain_dense && same_layouts && vector_dim_dense;
         }
 
         bool fused_relu_in_kernel() const { return fused_relu_in_kernel_; }
@@ -118,6 +132,7 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
             scratchpad.template book<float>(key_bnorm_tmp_mean, C());
             scratchpad.template book<float>(key_bnorm_tmp_var, C());
         }
+        cpu_isa_t isa_ = v;
         bool fused_relu_in_kernel_ = false;
     };
 
@@ -129,6 +144,105 @@ struct rvv_batch_normalization_fwd_t : public primitive_t {
 
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+struct rvv_batch_normalization_bwd_t : public primitive_t {
+    struct pd_t : public cpu_batch_normalization_bwd_pd_t {
+        using cpu_batch_normalization_bwd_pd_t::
+                cpu_batch_normalization_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                JIT_IMPL_NAME_HELPER("jit:", isa_, ""),
+                rvv_batch_normalization_bwd_t);
+
+        status_t init(engine_t *engine) {
+            UNUSED(engine);
+            using namespace data_type;
+
+            VDISPATCH_BNORM(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
+            VDISPATCH_BNORM(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+
+            const data_type_t dt = src_md()->data_type;
+            isa_ = dt == f16 ? zvfh : v;
+            VDISPATCH_BNORM(utils::one_of(dt, f32, f16)
+                            && utils::everyone_is(dt,
+                                    diff_dst_md()->data_type,
+                                    diff_src_md()->data_type)
+                            && platform::has_data_type_support(dt)
+                            && platform::has_training_support(dt),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_BNORM(IMPLICATION(dt == f16, mayiuse(zvfh)),
+                    VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_BNORM(check_scale_shift_data_type(),
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "unsupported scale or shift data type");
+            VDISPATCH_BNORM(
+                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+            VDISPATCH_BNORM(!fuse_norm_add_relu(),
+                    VERBOSE_UNSUPPORTED_FEATURE,
+                    "fuse_norm_add_relu not supported");
+            VDISPATCH_BNORM(!fuse_norm_relu(), VERBOSE_UNSUPPORTED_FEATURE,
+                    "fused ReLU backward not supported");
+
+            VDISPATCH_BNORM(
+                    set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
+            const memory_desc_wrapper src_d(src_md());
+            const memory_desc_wrapper diff_dst_d(diff_dst_md());
+            const memory_desc_wrapper diff_src_d(diff_src_md());
+            VDISPATCH_BNORM(check_layouts(src_d, diff_dst_d, diff_src_d),
+                    VERBOSE_UNSUPPORTED_TAG);
+
+            nthr_ = dnnl_get_max_threads();
+            init_scratchpad();
+            return status::success;
+        }
+
+        int nthr() const { return nthr_; }
+
+    private:
+        bool check_layouts(const memory_desc_wrapper &src_d,
+                const memory_desc_wrapper &diff_dst_d,
+                const memory_desc_wrapper &diff_src_d) const {
+            const bool ndims_ok = utils::one_of(ndims(), 3, 4, 5);
+            const bool plain_dense
+                    = src_d.blocking_desc().inner_nblks == 0
+                    && diff_dst_d.blocking_desc().inner_nblks == 0
+                    && diff_src_d.blocking_desc().inner_nblks == 0
+                    && src_d.is_dense(false) && diff_dst_d.is_dense(false)
+                    && diff_src_d.is_dense(false);
+            const bool vector_dim_dense
+                    = src_d.blocking_desc().strides[1] == 1
+                    || src_d.blocking_desc().strides[ndims() - 1] == 1;
+            return ndims_ok && plain_dense
+                    && src_d.similar_to(
+                            diff_dst_d, /*with_strides=*/true, false)
+                    && src_d.similar_to(
+                            diff_src_d, /*with_strides=*/true, false)
+                    && vector_dim_dense;
+        }
+
+        void init_scratchpad() {
+            using namespace memory_tracking::names;
+            auto scratchpad = scratchpad_registry().registrar();
+            scratchpad.template book<float>(
+                    key_bnorm_reduction, 2 * C() * nthr_);
+            scratchpad.template book<float>(key_bnorm_tmp_diff_ss, 5 * C());
+        }
+
+        cpu_isa_t isa_ = v;
+        int nthr_ = 1;
+    };
+
+    rvv_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_backward(ctx);
+    }
+
+private:
+    status_t execute_backward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 };
 


### PR DESCRIPTION
# Description

This PR extends the RV64 JIT batch normalization implementation with f16 support and backward propagation.

The main changes are:

- Add f16 batch normalization forward support using Zvfh.
- Add f32 and f16 backward implementations.
- Add RVV JIT kernels for backward statistics reduction, diff-src calculation, and diff-scale/diff-shift calculation.
- Widen f16 input to f32 for computation and narrow the result to f16 at the store boundary.
- Support plain dense 3D, 4D, and 5D layouts where either the channel or the innermost dimension is contiguous.
- Use per-thread scratchpad buffers for channels-last backward reduction.
- Refactor the RV64 implementation to follow the common ISA-templated organization:
  - `jit_uni_batch_normalization_fwd_t`
  - `jit_uni_batch_normalization_fwd_t`
  - `jit_uni_batch_normalization_bwd_t`
  - `jit_uni_batch_normalization_bwd_t`
- Rename the RV64 primitive and kernel files to the `jit_uni_batch_normalization` convention.
- Preserve fallback to the following implementations for unsupported data types, layouts, attributes, and fused operations.

The `v` instances handle f32, while the `zvfh` instances handle f16. Both data types share the same primitive and kernel structure.

# Performance

## Test setup

- Platform: Muse Pi Pro
- CPU: Spacemit X60, 8 RISC-V cores
- Runtime threads: 8
- CPU affinity: cores 0-7
- Baseline: `build-artifact-weekly.zip`, produced by the last Weekly RISC-V CI
- Metric: minimum execution time reported by benchdnn
- Repetitions: 10 fixed executions per problem

The official batch normalization smoke batch was used:

```text
tests/benchdnn/inputs/bnorm/test_bnorm_smoke
```

The batch contains the following two official 2D CI shapes:


```ic256ih28n"bnorm_ci_2d:1"
mb4ic200ih17iw16n"bnorm_ci_2d:2"
ic256ih28n"bnorm_ci_2d:1"
mb4ic200ih17iw16n"bnorm_ci_2d:2"
```

For f16, it covers forward training, forward inference, backward data, backward data/weights, global statistics, scale/shift, and fused ReLU in a channels-last plain layout.


The command used for both builds was:


```BashOMP_NUM_THREADS=8 taskset -c 0-7 ./benchdnn \
    --bnorm \
    --mode=P \
    --fix-times-per-prb=10 \
    --perf-template=csv \
    --batch=tests/benchdnn/inputs/bnorm/test_bnorm_smoke
BashOMP_NUM_THREADS=8 taskset -c 0-7 ./benchdnn \
    --bnorm \
    --mode=P \
    --fix-times-per-prb=10 \
    --perf-template=csv \
    --batch=tests/benchdnn/inputs/bnorm/test_bnorm_smoke
```

Speedup is calculated as:


```
baseline minimum time / PR minimum time
```

Only cases that selected an RV64 JIT implementation in the PR build are included below.


## Performance summary

| Direction | Data type | Cases | Baseline implementation | PR implementation | Geometric mean speedup | Range |
|---|---:|---:|---|---|---:|---:|
| FWD_D | f32 | 2 | `jit:rvv` | `jit:rvv` | 0.98x | 0.978x-0.985x |
| FWD_I | f32 | 4 | `jit:rvv` | `jit:rvv` | 0.98x | 0.965x-1.012x |
| FWD_D | f16 | 2 | `nspc_bnorm:any` | `jit:rvv_zvfh` | 56.37x | 42.19x-75.31x |
| FWD_I | f16 | 6 | `nspc_bnorm:any` | `jit:rvv_zvfh` | 53.61x | 39.53x-76.37x |
| BWD_D | f32 | 4 | `nspc_bnorm:any` | `jit:rvv` | 8.66x | 4.81x-15.43x |
| BWD_DW | f32 | 4 | `nspc_bnorm:any` | `jit:rvv` | 9.06x | 5.10x-16.65x |
| BWD_D | f16 | 4 | `nspc_bnorm:any` | `jit:rvv_zvfh` | 26.84x | 18.26x-40.45x |
| BWD_DW | f16 | 4 | `nspc_bnorm:any` | `jit:rvv_zvfh` | 28.42x | 18.35x-37.62x |

## f32 forward JIT

| Shape | Direction | Flags/post-op | Weekly, ms | PR, ms | Speedup |
|---|---|---|---:|---:|---:|
| `ic256ih28` | FWD_D | `G` | 0.5291 | 0.5371 | 0.985x |
| `mb4ic200ih17iw16` | FWD_D | `G` | 0.1665 | 0.1702 | 0.978x |
| `ic256ih28` | FWD_I | `G` | 0.5366 | 0.5300 | 1.012x |
| `ic256ih28` | FWD_I | `G`, ReLU | 0.5376 | 0.5405 | 0.995x |
| `mb4ic200ih17iw16` | FWD_I | `G` | 0.1672 | 0.1733 | 0.965x |
| `mb4ic200ih17iw16` | FWD_I | `G`, ReLU | 0.1692 | 0.1748 | 0.968x |

## backward JIT

| Shape | Direction | Data type | Flags | Baseline implementation | Baseline, ms | PR implementation | PR, ms | Speedup |
|---|---|---:|---|---|---:|---|---:|---:|
| `ic256ih28` | BWD_D | f32 | none | `nspc_bnorm:any` | 20.9668 | `jit:rvv` | 1.3591 | 15.43x |
| `ic256ih28` | BWD_D | f32 | `G` | `nspc_bnorm:any` | 14.7007 | `jit:rvv` | 1.3589 | 10.82x |
| `mb4ic200ih17iw16` | BWD_D | f32 | none | `nspc_bnorm:any` | 5.4077 | `jit:rvv` | 0.7725 | 7.00x |
| `mb4ic200ih17iw16` | BWD_D | f32 | `G` | `nspc_bnorm:any` | 3.7539 | `jit:rvv` | 0.7808 | 4.81x |
| `ic256ih28` | BWD_DW | f32 | none | `nspc_bnorm:any` | 22.5989 | `jit:rvv` | 1.3577 | 16.65x |
| `ic256ih28` | BWD_DW | f32 | `G` | `nspc_bnorm:any` | 15.1565 | `jit:rvv` | 1.3494 | 11.23x |
| `mb4ic200ih17iw16` | BWD_DW | f32 | none | `nspc_bnorm:any` | 5.4878 | `jit:rvv` | 0.7771 | 7.06x |
| `mb4ic200ih17iw16` | BWD_DW | f32 | `G` | `nspc_bnorm:any` | 3.8462 | `jit:rvv` | 0.7537 | 5.10x |
| `ic256ih28` | BWD_D | f16 | none | `nspc_bnorm:any` | 29.6270 | `jit:rvv_zvfh` | 0.7324 | 40.45x |
| `ic256ih28` | BWD_D | f16 | `G` | `nspc_bnorm:any` | 20.0493 | `jit:rvv_zvfh` | 0.7329 | 27.36x |
| `mb4ic200ih17iw16` | BWD_D | f16 | none | `nspc_bnorm:any` | 7.4309 | `jit:rvv_zvfh` | 0.2896 | 25.66x |
| `mb4ic200ih17iw16` | BWD_D | f16 | `G` | `nspc_bnorm:any` | 5.3145 | `jit:rvv_zvfh` | 0.2910 | 18.26x |
| `ic256ih28` | BWD_DW | f16 | none | `nspc_bnorm:any` | 28.4973 | `jit:rvv_zvfh` | 0.7576 | 37.62x |
| `ic256ih28` | BWD_DW | f16 | `G` | `nspc_bnorm:any` | 20.3862 | `jit:rvv_zvfh` | 0.7180 | 28.39x |
| `mb4ic200ih17iw16` | BWD_DW | f16 | none | `nspc_bnorm:any` | 9.8106 | `jit:rvv_zvfh` | 0.2947 | 33.29x |
| `mb4ic200ih17iw16` | BWD_DW | f16 | `G` | `nspc_bnorm:any` | 5.3672 | `jit:rvv_zvfh` | 0.2925 | 18.35x |

## f16 forward JIT

| Shape | Direction | Flags/post-op | Baseline implementation | Baseline, ms | PR implementation | PR, ms | Speedup |
|---|---|---|---|---:|---|---:|---:|
| `ic256ih28` | FWD_D | `G` | `nspc_bnorm:any` | 14.9116 | `jit:rvv_zvfh` | 0.1980 | 75.31x |
| `mb4ic200ih17iw16` | FWD_D | `G` | `nspc_bnorm:any` | 3.9656 | `jit:rvv_zvfh` | 0.0940 | 42.19x |
| `ic256ih28` | FWD_I | `G` | `nspc_bnorm:any` | 14.3506 | `jit:rvv_zvfh` | 0.2046 | 70.14x |
| `mb4ic200ih17iw16` | FWD_I | `G` | `nspc_bnorm:any` | 3.9451 | `jit:rvv_zvfh` | 0.0889 | 44.39x |
| `ic256ih28` | FWD_I | `G`, ReLU | `nspc_bnorm:any` | 14.9397 | `jit:rvv_zvfh` | 0.2539 | 58.84x |
| `mb4ic200ih17iw16` | FWD_I | `G`, ReLU | `nspc_bnorm:any` | 4.0147 | `jit:rvv_zvfh` | 0.1016 | 39.53x |