### PR TITLE
graph: backend: dnnl: kernels: rename g_engine and g_stream

### DIFF
--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -79,17 +79,16 @@ dims group_dims(const dims &adims, dim groups) {
     return new_dims;
 }
 
-dnnl::engine make_dnnl_engine(engine_t &g_engine) {
+dnnl::engine make_dnnl_engine(engine_t &eng) {
     dnnl::engine engine;
-    engine.reset(&g_engine, true); // not own
+    engine.reset(&eng, true); // not own
     return engine;
 }
 
-dnnl::stream make_dnnl_stream(
-        const dnnl::engine &p_engine, stream_t &g_stream) {
+dnnl::stream make_dnnl_stream(const dnnl::engine &p_engine, stream_t &stream) {
     UNUSED(p_engine);
     dnnl::stream strm;
-    strm.reset(&g_stream, true); // not own
+    strm.reset(&stream, true); // not own
     return strm;
 }
 

--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -85,8 +85,7 @@ dnnl::engine make_dnnl_engine(engine_t &eng) {
     return engine;
 }
 
-dnnl::stream make_dnnl_stream(const dnnl::engine &p_engine, stream_t &stream) {
-    UNUSED(p_engine);
+dnnl::stream make_dnnl_stream(stream_t &stream) {
     dnnl::stream strm;
     strm.reset(&stream, true); // not own
     return strm;

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -60,7 +60,7 @@ dims group_dims(const dims &adims, dim groups);
 
 engine make_dnnl_engine(engine_t &eng);
 
-stream make_dnnl_stream(const engine &p_engine, stream_t &strm);
+stream make_dnnl_stream(stream_t &strm);
 
 memory::desc make_dnnl_memory_desc(const logical_tensor_t &lt);
 

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -58,9 +58,9 @@ dims get_compatible_dilates(const dims &dilates, size_t input_size = 4);
 
 dims group_dims(const dims &adims, dim groups);
 
-engine make_dnnl_engine(engine_t &g_engine);
+engine make_dnnl_engine(engine_t &eng);
 
-stream make_dnnl_stream(const engine &p_engine, stream_t &g_stream);
+stream make_dnnl_stream(const engine &p_engine, stream_t &strm);
 
 memory::desc make_dnnl_memory_desc(const logical_tensor_t &lt);
 

--- a/src/graph/backend/dnnl/dnnl_partition_impl.cpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.cpp
@@ -118,8 +118,7 @@ const backend_t *dnnl_partition_impl_t::get_assigned_backend() const {
 status_t dnnl_partition_impl_t::compile(
         compiled_partition_t *compiled_partition,
         const std::vector<logical_tensor_t> &inputs,
-        const std::vector<logical_tensor_t> &outputs,
-        engine_t *g_engine) const {
+        const std::vector<logical_tensor_t> &outputs, engine_t *eng) const {
     // compile will transform the subgraph in partition, so we make
     // a copy
     auto part = std::dynamic_pointer_cast<dnnl_partition_impl_t>(this->clone());
@@ -157,7 +156,7 @@ status_t dnnl_partition_impl_t::compile(
     // compile kernel.
     // FIXME(qun) will modify the outputs inside the compile, which
     // break the constant semantics
-    ret = kernel->compile(part.get(), g_engine, inputs, outputs);
+    ret = kernel->compile(part.get(), eng, inputs, outputs);
     if (ret != status::success) return ret;
 
     std::vector<logical_tensor_t> ordered_inputs;
@@ -170,7 +169,7 @@ status_t dnnl_partition_impl_t::compile(
 
     // wrapper kernel to dnnl_compiled_partition_impl_t
     auto pimpl = std::make_shared<dnnl_compiled_partition_impl_t>(
-            g_engine, ordered_inputs, ordered_outputs, kernel);
+            eng, ordered_inputs, ordered_outputs, kernel);
     compiled_partition->init(pimpl);
 
     return status::success;

--- a/src/graph/backend/dnnl/dnnl_partition_impl.hpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.hpp
@@ -47,35 +47,33 @@ public:
                   engine, inputs, outputs, kernel->get_inplace_pairs())
         , kernel_(kernel) {}
 
-    status_t execute(stream_t *g_stream, const std::vector<tensor_t> &inputs,
+    status_t execute(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
-        return kernel_->execute(g_stream, inputs, outputs, scratchpad_buf);
+        return kernel_->execute(strm, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t execute_sycl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_sycl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        return kernel_->execute_sycl(g_stream, inputs, outputs, scratchpad_buf,
-                sycl_deps, sycl_event);
+        return kernel_->execute_sycl(
+                strm, inputs, outputs, scratchpad_buf, sycl_deps, sycl_event);
     }
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     // It looks very similar to execute_sycl. Consider to merge them in the
     // future.
-    status_t execute_ocl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_ocl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &ocl_deps,
             cl_event *ocl_event) override {
         return kernel_->execute_ocl(
-                g_stream, inputs, outputs, scratchpad_buf, ocl_deps, ocl_event);
+                strm, inputs, outputs, scratchpad_buf, ocl_deps, ocl_event);
     }
 #endif
 
@@ -120,7 +118,7 @@ public:
     status_t compile(compiled_partition_t *compiled_partition,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs,
-            engine_t *g_engine) const override;
+            engine_t *eng) const override;
 
     status_t infer_shape(std::vector<const logical_tensor_t *> &inputs,
             std::vector<logical_tensor_t *> &outputs) const override;

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -116,7 +116,7 @@ status_t batch_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
 status_t batch_norm_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -185,7 +185,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -259,7 +259,7 @@ status_t batch_norm_fwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -393,7 +393,7 @@ void batch_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t batch_norm_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -422,7 +422,7 @@ status_t batch_norm_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -455,7 +455,7 @@ status_t batch_norm_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -53,9 +53,9 @@ void batch_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
 }
 
 status_t batch_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -113,10 +113,10 @@ status_t batch_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
     return status::success;
 }
 
-status_t batch_norm_fwd_t::execute_impl(stream_t *g_stream,
+status_t batch_norm_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -171,13 +171,13 @@ status_t batch_norm_fwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t batch_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t batch_norm_fwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -185,7 +185,7 @@ status_t batch_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -252,14 +252,14 @@ status_t batch_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t batch_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t batch_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -327,9 +327,9 @@ status_t batch_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
 //// backward part
 #if BUILD_TRAINING
 status_t batch_norm_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -390,10 +390,10 @@ void batch_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t batch_norm_bwd_t::execute_impl(stream_t *g_stream,
+status_t batch_norm_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -408,13 +408,13 @@ status_t batch_norm_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t batch_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t batch_norm_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -422,7 +422,7 @@ status_t batch_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -448,14 +448,14 @@ status_t batch_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t batch_norm_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t batch_norm_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/batch_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.hpp
@@ -63,17 +63,16 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -82,7 +81,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -114,7 +113,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -123,13 +122,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -138,7 +136,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -53,9 +53,9 @@ void binary_t::prepare_args_set(const execution_args_set_t *res,
 }
 
 status_t binary_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -100,10 +100,10 @@ status_t binary_t::compile_impl(const dnnl_partition_impl_t *part,
     return status::success;
 }
 
-status_t binary_t::execute_impl(stream_t *g_stream,
+status_t binary_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -127,13 +127,13 @@ status_t binary_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t binary_t::sycl_execute_impl(stream_t *g_stream,
+status_t binary_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -141,7 +141,7 @@ status_t binary_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -167,14 +167,14 @@ status_t binary_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t binary_t::ocl_execute_impl(stream_t *g_stream,
+status_t binary_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
 
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -103,7 +103,7 @@ status_t binary_t::compile_impl(const dnnl_partition_impl_t *part,
 status_t binary_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -141,7 +141,7 @@ status_t binary_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -174,7 +174,7 @@ status_t binary_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/binary.hpp
+++ b/src/graph/backend/dnnl/kernels/binary.hpp
@@ -74,17 +74,16 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -93,7 +92,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -107,7 +107,7 @@ template <bool quantized>
 status_t concat_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -136,7 +136,7 @@ status_t concat_t<quantized>::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -169,7 +169,7 @@ status_t concat_t<quantized>::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -34,9 +34,9 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t concat_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -104,10 +104,10 @@ void concat_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t concat_t<quantized>::execute_impl(stream_t *g_stream,
+status_t concat_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -121,14 +121,14 @@ status_t concat_t<quantized>::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t concat_t<quantized>::sycl_execute_impl(stream_t *g_stream,
+status_t concat_t<quantized>::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -136,7 +136,7 @@ status_t concat_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -162,14 +162,14 @@ status_t concat_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t concat_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t concat_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/concat.hpp
+++ b/src/graph/backend/dnnl/kernels/concat.hpp
@@ -58,7 +58,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -67,13 +67,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -82,7 +81,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/conv.cpp
+++ b/src/graph/backend/dnnl/kernels/conv.cpp
@@ -34,9 +34,9 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t conv_fwd_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -146,9 +146,9 @@ status_t conv_fwd_t<quantized>::prepare_inplace_pairs_impl() {
 
 #if BUILD_TRAINING
 status_t conv_bwd_data_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -205,9 +205,9 @@ status_t conv_bwd_data_t::compile_impl(const dnnl_partition_impl_t *part,
 }
 
 status_t conv_bwd_weights_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,

--- a/src/graph/backend/dnnl/kernels/conv.hpp
+++ b/src/graph/backend/dnnl/kernels/conv.hpp
@@ -27,7 +27,7 @@ namespace dnnl_impl {
 template <bool quantized>
 struct conv_fwd_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -43,7 +43,7 @@ using quantized_conv = conv_fwd_t</* quantized */ true>;
 #if BUILD_TRAINING
 struct conv_bwd_data_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -53,7 +53,7 @@ public:
 
 struct conv_bwd_weights_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -46,7 +46,7 @@ void conv_base_t::prepare_args_set(const execution_args_set_t *res,
 status_t conv_base_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -115,7 +115,7 @@ status_t conv_base_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -189,7 +189,7 @@ status_t conv_base_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -43,10 +43,10 @@ void conv_base_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t conv_base_t::execute_impl(stream_t *g_stream,
+status_t conv_base_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -101,13 +101,13 @@ status_t conv_base_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t conv_base_t::sycl_execute_impl(stream_t *g_stream,
+status_t conv_base_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -115,7 +115,7 @@ status_t conv_base_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -182,14 +182,14 @@ status_t conv_base_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t conv_base_t::ocl_execute_impl(stream_t *g_stream,
+status_t conv_base_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
 
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/conv_base.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.hpp
@@ -64,13 +64,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -79,7 +78,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/conv_transpose.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_transpose.cpp
@@ -33,10 +33,10 @@ namespace graph {
 namespace dnnl_impl {
 template <bool quantized>
 status_t conv_transpose_fwd_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -126,10 +126,10 @@ status_t conv_transpose_fwd_t<quantized>::prepare_inplace_pairs_impl() {
 
 #if BUILD_TRAINING
 status_t conv_transpose_bwd_data_t::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -186,10 +186,10 @@ status_t conv_transpose_bwd_data_t::compile_impl(
 }
 
 status_t conv_transpose_bwd_weights_t::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,

--- a/src/graph/backend/dnnl/kernels/conv_transpose.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_transpose.hpp
@@ -41,7 +41,7 @@ namespace dnnl_impl {
 template <bool quantized>
 struct conv_transpose_fwd_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -57,7 +57,7 @@ using quantized_convtranspose = conv_transpose_fwd_t</* quantized */ true>;
 #if BUILD_TRAINING
 struct conv_transpose_bwd_data_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -67,7 +67,7 @@ public:
 
 struct conv_transpose_bwd_weights_t : public conv_base_t {
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 

--- a/src/graph/backend/dnnl/kernels/dummy.cpp
+++ b/src/graph/backend/dnnl/kernels/dummy.cpp
@@ -68,7 +68,7 @@ status_t dummy_kernel_t::sycl_execute_impl(stream_t *strm,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     if (sycl_event) {
         // Fast path: if only one event, return it.
@@ -96,7 +96,7 @@ status_t dummy_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     if (ret_event) {
         // Fast path: if only one event, return it.

--- a/src/graph/backend/dnnl/kernels/dummy.cpp
+++ b/src/graph/backend/dnnl/kernels/dummy.cpp
@@ -26,9 +26,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t dummy_kernel_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -55,20 +55,20 @@ status_t dummy_kernel_t::compile_impl(const dnnl_partition_impl_t *part,
     return status::success;
 }
 
-status_t dummy_kernel_t::execute_impl(stream_t *g_stream,
+status_t dummy_kernel_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t dummy_kernel_t::sycl_execute_impl(stream_t *g_stream,
+status_t dummy_kernel_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     if (sycl_event) {
         // Fast path: if only one event, return it.
@@ -91,12 +91,12 @@ status_t dummy_kernel_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t dummy_kernel_t::ocl_execute_impl(stream_t *g_stream,
+status_t dummy_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     if (ret_event) {
         // Fast path: if only one event, return it.

--- a/src/graph/backend/dnnl/kernels/dummy.hpp
+++ b/src/graph/backend/dnnl/kernels/dummy.hpp
@@ -42,17 +42,16 @@ public:
 
     ~dummy_kernel_t() override = default;
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -61,7 +60,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -33,10 +33,10 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t eltwise_fwd_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -129,10 +129,10 @@ void eltwise_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t eltwise_fwd_t<quantized>::execute_impl(stream_t *g_stream,
+status_t eltwise_fwd_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -187,14 +187,14 @@ status_t eltwise_fwd_t<quantized>::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t eltwise_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
+status_t eltwise_fwd_t<quantized>::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -202,7 +202,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -270,14 +270,14 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t eltwise_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t eltwise_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -344,9 +344,9 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t eltwise_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -404,10 +404,10 @@ void eltwise_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t eltwise_bwd_t::execute_impl(stream_t *g_stream,
+status_t eltwise_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -421,13 +421,13 @@ status_t eltwise_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t eltwise_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t eltwise_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -435,7 +435,7 @@ status_t eltwise_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -460,14 +460,14 @@ status_t eltwise_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t eltwise_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t eltwise_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -132,7 +132,7 @@ template <bool quantized>
 status_t eltwise_fwd_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -202,7 +202,7 @@ status_t eltwise_fwd_t<quantized>::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -277,7 +277,7 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -407,7 +407,7 @@ void eltwise_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t eltwise_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -435,7 +435,7 @@ status_t eltwise_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -467,7 +467,7 @@ status_t eltwise_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/eltwise.hpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.hpp
@@ -68,7 +68,7 @@ public:
         return status::success;
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -77,13 +77,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -92,7 +91,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -127,7 +126,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -136,13 +135,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -151,7 +149,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
@@ -144,7 +144,7 @@ template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::execute_impl(stream_t *stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *stream);
+    dnnl::stream p_stream = make_dnnl_stream(*stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -174,7 +174,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::sycl_execute_impl(
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *stream);
+    dnnl::stream p_stream = make_dnnl_stream(*stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -208,7 +208,7 @@ status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
     auto deps = ocl_deps;
     cl_event returned_event {};
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *stream);
+    dnnl::stream p_stream = make_dnnl_stream(*stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -114,7 +114,7 @@ void genindex_t::prepare_args_set(const execution_args_set_t *res,
 status_t genindex_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -140,7 +140,7 @@ status_t genindex_t::sycl_execute_impl(stream_t *strm,
     if (p_engine_.get_kind() == engine::kind::gpu) {
         auto deps = sycl_deps;
         std::optional<::sycl::event> returned_event;
-        dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+        dnnl::stream p_stream = make_dnnl_stream(*strm);
 
         thread_local_cache_t<execution_args_set_t> res_cache;
         execution_args_set_t *res = res_cache.get_or_add(
@@ -168,7 +168,7 @@ status_t genindex_t::ocl_execute_impl(stream_t *strm,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -36,9 +36,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t genindex_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -111,10 +111,10 @@ void genindex_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t genindex_t::execute_impl(stream_t *g_stream,
+status_t genindex_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -132,7 +132,7 @@ status_t genindex_t::execute_impl(stream_t *g_stream,
     return status::success;
 }
 #ifdef DNNL_WITH_SYCL
-status_t genindex_t::sycl_execute_impl(stream_t *g_stream,
+status_t genindex_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -140,7 +140,7 @@ status_t genindex_t::sycl_execute_impl(stream_t *g_stream,
     if (p_engine_.get_kind() == engine::kind::gpu) {
         auto deps = sycl_deps;
         std::optional<::sycl::event> returned_event;
-        dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+        dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
         thread_local_cache_t<execution_args_set_t> res_cache;
         execution_args_set_t *res = res_cache.get_or_add(
@@ -158,17 +158,17 @@ status_t genindex_t::sycl_execute_impl(stream_t *g_stream,
 
         return status::success;
     }
-    return execute_impl(g_stream, inputs, outputs, scratchpad_buf);
+    return execute_impl(strm, inputs, outputs, scratchpad_buf);
 }
 #endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t genindex_t::ocl_execute_impl(stream_t *g_stream,
+status_t genindex_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/gen_index.hpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.hpp
@@ -56,15 +56,14 @@ public:
     void prepare_args_set(const execution_args_set_t *res,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs);
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -72,7 +71,7 @@ public:
             ::sycl::event *sycl_event) override;
 #endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -33,9 +33,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t group_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -121,10 +121,10 @@ void group_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t group_norm_fwd_t::execute_impl(stream_t *g_stream,
+status_t group_norm_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -179,13 +179,13 @@ status_t group_norm_fwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t group_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t group_norm_fwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -193,7 +193,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -260,14 +260,14 @@ status_t group_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t group_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t group_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -124,7 +124,7 @@ void group_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t group_norm_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -193,7 +193,7 @@ status_t group_norm_fwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -267,7 +267,7 @@ status_t group_norm_fwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/group_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.hpp
@@ -60,7 +60,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -69,13 +69,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -84,7 +83,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -202,10 +202,10 @@ void larger_partition_kernel_t::prepare_args_set(
 }
 
 status_t larger_partition_kernel_t::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -248,10 +248,10 @@ status_t larger_partition_kernel_t::compile_impl(
     return status::success;
 }
 
-status_t larger_partition_kernel_t::execute_impl(stream_t *g_stream,
+status_t larger_partition_kernel_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -306,13 +306,13 @@ status_t larger_partition_kernel_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t larger_partition_kernel_t::sycl_execute_impl(stream_t *g_stream,
+status_t larger_partition_kernel_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -320,7 +320,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -386,13 +386,13 @@ status_t larger_partition_kernel_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t larger_partition_kernel_t::ocl_execute_impl(stream_t *g_stream,
+status_t larger_partition_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &ocl_deps, cl_event *event) {
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -251,7 +251,7 @@ status_t larger_partition_kernel_t::compile_impl(
 status_t larger_partition_kernel_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -320,7 +320,7 @@ status_t larger_partition_kernel_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -392,7 +392,7 @@ status_t larger_partition_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<cl_event> &ocl_deps, cl_event *event) {
     auto deps = ocl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/large_partition.hpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.hpp
@@ -70,7 +70,7 @@ public:
     static void setup_pipeline(pass_pipeline_t &pipeline,
             memory_planner_t &mem_planner, bool enable_constant_cache);
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -84,13 +84,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -99,7 +98,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -33,9 +33,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t layer_norm_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -118,10 +118,10 @@ void layer_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t layer_norm_fwd_t::execute_impl(stream_t *g_stream,
+status_t layer_norm_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -176,13 +176,13 @@ status_t layer_norm_fwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t layer_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t layer_norm_fwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -190,7 +190,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -257,14 +257,14 @@ status_t layer_norm_fwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t layer_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t layer_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -331,9 +331,9 @@ status_t layer_norm_fwd_t::ocl_execute_impl(stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t layer_norm_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -390,10 +390,10 @@ void layer_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t layer_norm_bwd_t::execute_impl(stream_t *g_stream,
+status_t layer_norm_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -407,13 +407,13 @@ status_t layer_norm_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t layer_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t layer_norm_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -421,7 +421,7 @@ status_t layer_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -446,14 +446,14 @@ status_t layer_norm_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t layer_norm_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t layer_norm_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -121,7 +121,7 @@ void layer_norm_fwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t layer_norm_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -190,7 +190,7 @@ status_t layer_norm_fwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -264,7 +264,7 @@ status_t layer_norm_fwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -393,7 +393,7 @@ void layer_norm_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t layer_norm_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -421,7 +421,7 @@ status_t layer_norm_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -453,7 +453,7 @@ status_t layer_norm_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/layer_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.hpp
@@ -60,7 +60,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
     void prepare_args_set(const execution_args_set_t *res,
@@ -68,13 +68,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -83,7 +82,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -115,7 +114,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -124,13 +123,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -139,7 +137,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -31,9 +31,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t logsoftmax_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -91,10 +91,10 @@ void logsoftmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t logsoftmax_fwd_t::execute_impl(stream_t *g_stream,
+status_t logsoftmax_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -109,13 +109,13 @@ status_t logsoftmax_fwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t logsoftmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t logsoftmax_fwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -123,7 +123,7 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -149,14 +149,14 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t logsoftmax_fwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t logsoftmax_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -182,9 +182,9 @@ status_t logsoftmax_fwd_t::ocl_execute_impl(stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t logsoftmax_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -244,10 +244,10 @@ void logsoftmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t logsoftmax_bwd_t::execute_impl(stream_t *g_stream,
+status_t logsoftmax_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -262,13 +262,13 @@ status_t logsoftmax_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t logsoftmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t logsoftmax_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -276,7 +276,7 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -302,14 +302,14 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t logsoftmax_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t logsoftmax_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -94,7 +94,7 @@ void logsoftmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t logsoftmax_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -123,7 +123,7 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -156,7 +156,7 @@ status_t logsoftmax_fwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -247,7 +247,7 @@ void logsoftmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t logsoftmax_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -276,7 +276,7 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -309,7 +309,7 @@ status_t logsoftmax_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/log_softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.hpp
@@ -62,7 +62,7 @@ public:
         return status::success;
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -71,13 +71,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -86,7 +85,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -118,7 +117,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -127,13 +126,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -142,7 +140,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -34,9 +34,9 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t matmul_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(
             part->get_ops(), p_engine_, part->get_fpmath_mode(), true, true);
@@ -189,10 +189,10 @@ void matmul_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t matmul_t<quantized>::execute_impl(stream_t *g_stream,
+status_t matmul_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -247,14 +247,14 @@ status_t matmul_t<quantized>::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t matmul_t<quantized>::sycl_execute_impl(stream_t *g_stream,
+status_t matmul_t<quantized>::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -262,7 +262,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -330,14 +330,14 @@ status_t matmul_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t matmul_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t matmul_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -192,7 +192,7 @@ template <bool quantized>
 status_t matmul_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -262,7 +262,7 @@ status_t matmul_t<quantized>::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -337,7 +337,7 @@ status_t matmul_t<quantized>::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/matmul.hpp
+++ b/src/graph/backend/dnnl/kernels/matmul.hpp
@@ -61,7 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -70,13 +70,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -85,7 +84,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/mqa.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa.hpp
@@ -41,22 +41,22 @@ private:
     std::shared_ptr<kernel_base_t> kernel;
 
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
-        const engine_kind_t ekind = g_engine->kind();
+        const engine_kind_t ekind = eng->kind();
         const bool enable_decomp
                 = ekind == engine_kind::cpu && enable_decomp_kernel();
         status_t mqa_decomp_status = status::success;
         if (enable_decomp) {
             kernel = std::make_shared<mqa_decomp_kernel_t<quantized, dt>>();
             mqa_decomp_status
-                    = kernel->compile_impl(part, g_engine, inputs, outputs);
+                    = kernel->compile_impl(part, eng, inputs, outputs);
         }
 
         if (!enable_decomp || mqa_decomp_status != status::success) {
             kernel = std::make_shared<larger_partition_kernel_t>();
-            return kernel->compile_impl(part, g_engine, inputs, outputs);
+            return kernel->compile_impl(part, eng, inputs, outputs);
         }
         return mqa_decomp_status;
     }
@@ -76,33 +76,32 @@ public:
 #endif
     }
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
-        return kernel->execute_impl(g_stream, inputs, outputs, scratchpad_buf);
+        return kernel->execute_impl(strm, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        return kernel->sycl_execute_impl(g_stream, inputs, outputs,
-                scratchpad_buf, sycl_deps, sycl_event);
+        return kernel->sycl_execute_impl(
+                strm, inputs, outputs, scratchpad_buf, sycl_deps, sycl_event);
     }
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
             cl_event *event) override {
         return kernel->ocl_execute_impl(
-                g_stream, inputs, outputs, scratchpad_buf, deps, event);
+                strm, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -155,7 +155,7 @@ template <bool quantized, memory::data_type dt>
 status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -40,10 +40,10 @@ namespace dnnl_impl {
 
 template <bool quantized, memory::data_type dt>
 status_t mqa_decomp_kernel_t<quantized, dt>::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -152,15 +152,15 @@ void mqa_decomp_kernel_t<quantized, dt>::prepare_sub_args(
 }
 
 template <bool quantized, memory::data_type dt>
-status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
+status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream strm = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
-                    g_stream);
+                    strm);
 #endif
 
     // each thread's own local resource
@@ -250,19 +250,19 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
         }
 
         // in parallel region - these primitives should use single thread.
-        mqa_cfg_.sub_reorder0.execute(strm, res->sub_reorder0_args[tid]);
-        mqa_cfg_.sub_reorder1.execute(strm, res->sub_reorder1_args[tid]);
+        mqa_cfg_.sub_reorder0.execute(p_stream, res->sub_reorder0_args[tid]);
+        mqa_cfg_.sub_reorder1.execute(p_stream, res->sub_reorder1_args[tid]);
         dnnl_primitive_execute_without_tp_hook(
-                mqa_cfg_.sub_mm1_prim, strm, res->sub_mm1_args[tid]);
+                mqa_cfg_.sub_mm1_prim, p_stream, res->sub_mm1_args[tid]);
+
+        dnnl_primitive_execute_without_tp_hook(mqa_cfg_.sub_softmax_prim,
+                p_stream, res->sub_softmax_args[tid]);
+
+        mqa_cfg_.sub_reorder2.execute(p_stream, res->sub_reorder2_args[tid]);
 
         dnnl_primitive_execute_without_tp_hook(
-                mqa_cfg_.sub_softmax_prim, strm, res->sub_softmax_args[tid]);
-
-        mqa_cfg_.sub_reorder2.execute(strm, res->sub_reorder2_args[tid]);
-
-        dnnl_primitive_execute_without_tp_hook(
-                mqa_cfg_.sub_mm2_prim, strm, res->sub_mm2_args[tid]);
-        mqa_cfg_.sub_reorder3.execute(strm, res->sub_reorder3_args[tid]);
+                mqa_cfg_.sub_mm2_prim, p_stream, res->sub_mm2_args[tid]);
+        mqa_cfg_.sub_reorder3.execute(p_stream, res->sub_reorder3_args[tid]);
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
         auto tp = threadpool_utils::get_active_threadpool();
         threadpool_utils::activate_threadpool(tp);
@@ -279,7 +279,7 @@ status_t mqa_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
     tp_stream->after_exec_hook();
 #endif
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
@@ -65,7 +65,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -73,8 +73,7 @@ public:
             const size_t block_size,
             std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
@@ -133,13 +132,13 @@ public:
     std::function<std::shared_ptr<mqa_args_set_t>()> resource_ctor_;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        UNUSED(g_stream);
+        UNUSED(strm);
         UNUSED(inputs);
         UNUSED(outputs);
         UNUSED(sycl_deps);
@@ -149,13 +148,13 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps,
             cl_event *ret_event) override {
-        UNUSED(g_stream);
+        UNUSED(strm);
         UNUSED(inputs);
         UNUSED(outputs);
         UNUSED(cl_deps);

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -33,7 +33,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t pooling_fwd_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     // TODO(wuxun): since oneDNN pooling primitive only support u8u8 or
@@ -44,7 +44,7 @@ status_t pooling_fwd_t<quantized>::compile_impl(
     if (inputs[0].data_type != outputs[0].data_type)
         return status::unimplemented;
 
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -148,10 +148,10 @@ void pooling_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t pooling_fwd_t<quantized>::execute_impl(stream_t *g_stream,
+status_t pooling_fwd_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -206,14 +206,14 @@ status_t pooling_fwd_t<quantized>::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t pooling_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
+status_t pooling_fwd_t<quantized>::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -221,7 +221,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -289,14 +289,14 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t pooling_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t pooling_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -363,9 +363,9 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t pooling_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -435,10 +435,10 @@ void pooling_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t pooling_bwd_t::execute_impl(stream_t *g_stream,
+status_t pooling_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -454,13 +454,13 @@ status_t pooling_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t pooling_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t pooling_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -468,7 +468,7 @@ status_t pooling_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -495,14 +495,14 @@ status_t pooling_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t pooling_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t pooling_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -151,7 +151,7 @@ template <bool quantized>
 status_t pooling_fwd_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -221,7 +221,7 @@ status_t pooling_fwd_t<quantized>::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -296,7 +296,7 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -438,7 +438,7 @@ void pooling_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t pooling_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -468,7 +468,7 @@ status_t pooling_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -502,7 +502,7 @@ status_t pooling_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/pool.hpp
+++ b/src/graph/backend/dnnl/kernels/pool.hpp
@@ -61,7 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -70,13 +70,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -85,7 +84,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -120,7 +119,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -129,13 +128,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -144,7 +142,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -110,7 +110,7 @@ template <bool quantized>
 status_t prelu_fwd_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -140,7 +140,7 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -174,7 +174,7 @@ status_t prelu_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -267,7 +267,7 @@ void prelu_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t prelu_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -296,7 +296,7 @@ status_t prelu_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -329,7 +329,7 @@ status_t prelu_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -34,13 +34,13 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t prelu_fwd_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
     // output tensor should have same data type as input tensor
     if (inputs[0].data_type != outputs[0].data_type)
         return status::unimplemented;
 
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -107,10 +107,10 @@ void prelu_fwd_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t prelu_fwd_t<quantized>::execute_impl(stream_t *g_stream,
+status_t prelu_fwd_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -125,14 +125,14 @@ status_t prelu_fwd_t<quantized>::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t prelu_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
+status_t prelu_fwd_t<quantized>::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -140,7 +140,7 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -167,14 +167,14 @@ status_t prelu_fwd_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t prelu_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t prelu_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -200,9 +200,9 @@ status_t prelu_fwd_t<quantized>::ocl_execute_impl(stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t prelu_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -264,10 +264,10 @@ void prelu_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t prelu_bwd_t::execute_impl(stream_t *g_stream,
+status_t prelu_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -282,13 +282,13 @@ status_t prelu_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t prelu_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t prelu_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -296,7 +296,7 @@ status_t prelu_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -322,14 +322,14 @@ status_t prelu_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t prelu_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t prelu_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/prelu.hpp
+++ b/src/graph/backend/dnnl/kernels/prelu.hpp
@@ -59,7 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -68,13 +68,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -83,7 +82,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -117,7 +116,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -126,13 +125,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -141,7 +139,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -115,7 +115,7 @@ void quantize_dequantize_t::prepare_args_set(const execution_args_set_t *res,
 status_t quantize_dequantize_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -189,7 +189,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -263,7 +263,7 @@ status_t quantize_dequantize_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -32,9 +32,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t quantize_dequantize_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -112,10 +112,10 @@ void quantize_dequantize_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t quantize_dequantize_t::execute_impl(stream_t *g_stream,
+status_t quantize_dequantize_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -170,7 +170,7 @@ status_t quantize_dequantize_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
@@ -181,7 +181,7 @@ status_t quantize_dequantize_t::prepare_inplace_pairs_impl() {
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t quantize_dequantize_t::sycl_execute_impl(stream_t *g_stream,
+status_t quantize_dequantize_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -189,7 +189,7 @@ status_t quantize_dequantize_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -256,14 +256,14 @@ status_t quantize_dequantize_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t quantize_dequantize_t::ocl_execute_impl(stream_t *g_stream,
+status_t quantize_dequantize_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/quantize.hpp
+++ b/src/graph/backend/dnnl/kernels/quantize.hpp
@@ -59,7 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -68,15 +68,14 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
     status_t prepare_inplace_pairs_impl() override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -85,7 +84,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -110,7 +110,7 @@ template <bool quantized>
 status_t reduction_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -139,7 +139,7 @@ status_t reduction_t<quantized>::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -172,7 +172,7 @@ status_t reduction_t<quantized>::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -34,9 +34,9 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t reduction_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -107,10 +107,10 @@ void reduction_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t reduction_t<quantized>::execute_impl(stream_t *g_stream,
+status_t reduction_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -124,14 +124,14 @@ status_t reduction_t<quantized>::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t reduction_t<quantized>::sycl_execute_impl(stream_t *g_stream,
+status_t reduction_t<quantized>::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -139,7 +139,7 @@ status_t reduction_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -165,14 +165,14 @@ status_t reduction_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t reduction_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t reduction_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/reduction.hpp
+++ b/src/graph/backend/dnnl/kernels/reduction.hpp
@@ -59,7 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -68,13 +68,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -83,7 +82,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -134,7 +134,7 @@ template <bool quantized>
 status_t reorder_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -204,7 +204,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -279,7 +279,7 @@ status_t reorder_t<quantized>::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -34,9 +34,9 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t reorder_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -131,10 +131,10 @@ void reorder_t<quantized>::prepare_args_set(const execution_args_set_t *res,
 }
 
 template <bool quantized>
-status_t reorder_t<quantized>::execute_impl(stream_t *g_stream,
+status_t reorder_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -189,14 +189,14 @@ status_t reorder_t<quantized>::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t reorder_t<quantized>::sycl_execute_impl(stream_t *g_stream,
+status_t reorder_t<quantized>::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -204,7 +204,7 @@ status_t reorder_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -272,14 +272,14 @@ status_t reorder_t<quantized>::sycl_execute_impl(stream_t *g_stream,
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t reorder_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t reorder_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/reorder.hpp
+++ b/src/graph/backend/dnnl/kernels/reorder.hpp
@@ -61,7 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -70,13 +70,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -85,7 +84,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -113,7 +113,7 @@ void resampling_fwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t resampling_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -141,7 +141,7 @@ status_t resampling_fwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -173,7 +173,7 @@ status_t resampling_fwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -262,7 +262,7 @@ void resampling_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t resampling_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -290,7 +290,7 @@ status_t resampling_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -322,7 +322,7 @@ status_t resampling_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -33,9 +33,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t resampling_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -110,10 +110,10 @@ void resampling_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t resampling_fwd_t::execute_impl(stream_t *g_stream,
+status_t resampling_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -127,13 +127,13 @@ status_t resampling_fwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t resampling_fwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t resampling_fwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -141,7 +141,7 @@ status_t resampling_fwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -166,14 +166,14 @@ status_t resampling_fwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t resampling_fwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t resampling_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -198,9 +198,9 @@ status_t resampling_fwd_t::ocl_execute_impl(stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t resampling_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -259,10 +259,10 @@ void resampling_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t resampling_bwd_t::execute_impl(stream_t *g_stream,
+status_t resampling_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -276,13 +276,13 @@ status_t resampling_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t resampling_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t resampling_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -290,7 +290,7 @@ status_t resampling_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -315,14 +315,14 @@ status_t resampling_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t resampling_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t resampling_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/resampling.hpp
+++ b/src/graph/backend/dnnl/kernels/resampling.hpp
@@ -63,7 +63,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -72,13 +72,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -87,7 +86,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -119,7 +118,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -128,13 +127,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -143,7 +141,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -46,10 +46,10 @@ private:
     std::shared_ptr<kernel_base_t> kernel;
 
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
-        const engine_kind_t ekind = g_engine->kind();
+        const engine_kind_t ekind = eng->kind();
         bool enable_decomp = false;
         bool enable_ukernel = false;
 
@@ -66,17 +66,17 @@ public:
 
         if (enable_ukernel) {
             kernel = std::make_shared<sdp_primitive_kernel_t<quantized>>();
-            ret = kernel->compile_impl(part, g_engine, inputs, outputs);
+            ret = kernel->compile_impl(part, eng, inputs, outputs);
         }
 
         if (ret != status::success && enable_decomp) {
             kernel = std::make_shared<sdp_decomp_kernel_t<quantized, dt>>();
-            ret = kernel->compile_impl(part, g_engine, inputs, outputs);
+            ret = kernel->compile_impl(part, eng, inputs, outputs);
         }
 
         if (ret != status::success) {
             kernel = std::make_shared<larger_partition_kernel_t>();
-            ret = kernel->compile_impl(part, g_engine, inputs, outputs);
+            ret = kernel->compile_impl(part, eng, inputs, outputs);
         }
         if (ret == status::success)
             VDISPATCH_GRAPH_SDP(
@@ -110,33 +110,32 @@ public:
         return force > 0;
     }
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
-        return kernel->execute_impl(g_stream, inputs, outputs, scratchpad_buf);
+        return kernel->execute_impl(strm, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        return kernel->sycl_execute_impl(g_stream, inputs, outputs,
-                scratchpad_buf, sycl_deps, sycl_event);
+        return kernel->sycl_execute_impl(
+                strm, inputs, outputs, scratchpad_buf, sycl_deps, sycl_event);
     }
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
             cl_event *event) override {
         return kernel->ocl_execute_impl(
-                g_stream, inputs, outputs, scratchpad_buf, deps, event);
+                strm, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 

--- a/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
@@ -42,10 +42,10 @@ private:
     std::shared_ptr<kernel_base_t> kernel;
 
 public:
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
-        const engine_kind_t ekind = g_engine->kind();
+        const engine_kind_t ekind = eng->kind();
         bool enable_ukernel = false;
 
         if (ekind == engine_kind::gpu) {
@@ -59,12 +59,12 @@ public:
 
         if (enable_ukernel) {
             kernel = std::make_shared<sdp_bwd_primitive_kernel_t>();
-            ret = kernel->compile_impl(part, g_engine, inputs, outputs);
+            ret = kernel->compile_impl(part, eng, inputs, outputs);
         }
 
         if (ret != status::success) {
             kernel = std::make_shared<larger_partition_kernel_t>();
-            ret = kernel->compile_impl(part, g_engine, inputs, outputs);
+            ret = kernel->compile_impl(part, eng, inputs, outputs);
         }
         if (ret == status::success)
             VDISPATCH_GRAPH_SDP_BWD(
@@ -83,33 +83,32 @@ public:
         return force > 0;
     }
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override {
-        return kernel->execute_impl(g_stream, inputs, outputs, scratchpad_buf);
+        return kernel->execute_impl(strm, inputs, outputs, scratchpad_buf);
     }
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        return kernel->sycl_execute_impl(g_stream, inputs, outputs,
-                scratchpad_buf, sycl_deps, sycl_event);
+        return kernel->sycl_execute_impl(
+                strm, inputs, outputs, scratchpad_buf, sycl_deps, sycl_event);
     }
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
             cl_event *event) override {
         return kernel->ocl_execute_impl(
-                g_stream, inputs, outputs, scratchpad_buf, deps, event);
+                strm, inputs, outputs, scratchpad_buf, deps, event);
     }
 #endif
 

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -57,7 +57,7 @@ status_t sdp_bwd_primitive_kernel_t::initial_check(
 }
 
 status_t sdp_bwd_primitive_kernel_t::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
 // sdp_bwd_primitive_kernel_t only supports Intel GPU.
@@ -65,7 +65,7 @@ status_t sdp_bwd_primitive_kernel_t::compile_impl(
     return status::unimplemented;
 #endif
 
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // First, dry run on a deep copy
     subgraph_
@@ -152,10 +152,10 @@ void sdp_bwd_primitive_kernel_t::prepare_args_set(
     }
 }
 
-status_t sdp_bwd_primitive_kernel_t::execute_impl(stream_t *g_stream,
+status_t sdp_bwd_primitive_kernel_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -173,7 +173,7 @@ status_t sdp_bwd_primitive_kernel_t::execute_impl(stream_t *g_stream,
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(stream_t *g_stream,
+status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -184,7 +184,7 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(stream_t *g_stream,
 #endif
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -210,14 +210,14 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(stream_t *g_stream,
+status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
     auto deps = cl_deps;
     cl_event returned_event {};
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -155,7 +155,7 @@ void sdp_bwd_primitive_kernel_t::prepare_args_set(
 status_t sdp_bwd_primitive_kernel_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -184,7 +184,7 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(stream_t *strm,
 #endif
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -217,7 +217,7 @@ status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(stream_t *strm,
     auto deps = cl_deps;
     cl_event returned_event {};
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
@@ -56,7 +56,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -65,13 +65,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -80,7 +79,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -160,7 +160,7 @@ template <bool quantized, memory::data_type dt>
 status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -39,10 +39,10 @@ namespace graph {
 namespace dnnl_impl {
 template <bool quantized, memory::data_type dt>
 status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
     subgraph_ = std::make_shared<subgraph_t>(
@@ -157,15 +157,15 @@ void sdp_decomp_kernel_t<quantized, dt>::prepare_sub_args(
 }
 
 template <bool quantized, memory::data_type dt>
-status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
+status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream strm = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
-                    g_stream);
+                    strm);
 #endif
 
     thread_local_cache_t<sdp_args_set_t> res_cache;
@@ -373,21 +373,21 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
         }
 
         // in parallel region - these primitives should use single thread.
-        sdp_cfg_.sub_reorder0.execute(strm, res->sub_reorder0_args[tid]);
-        sdp_cfg_.sub_reorder1.execute(strm, res->sub_reorder1_args[tid]);
+        sdp_cfg_.sub_reorder0.execute(p_stream, res->sub_reorder0_args[tid]);
+        sdp_cfg_.sub_reorder1.execute(p_stream, res->sub_reorder1_args[tid]);
         dnnl_primitive_execute_without_tp_hook(
-                sdp_cfg_.sub_mm1_prim, strm, res->sub_mm1_args[tid]);
+                sdp_cfg_.sub_mm1_prim, p_stream, res->sub_mm1_args[tid]);
         if (sdp_cfg_.has_select && !sdp_cfg_.select_fusiable)
-            dnnl_primitive_execute_without_tp_hook(
-                    sdp_cfg_.sub_select_prim, strm, res->sub_select_args[tid]);
-        dnnl_primitive_execute_without_tp_hook(
-                sdp_cfg_.sub_softmax_prim, strm, res->sub_softmax_args[tid]);
+            dnnl_primitive_execute_without_tp_hook(sdp_cfg_.sub_select_prim,
+                    p_stream, res->sub_select_args[tid]);
+        dnnl_primitive_execute_without_tp_hook(sdp_cfg_.sub_softmax_prim,
+                p_stream, res->sub_softmax_args[tid]);
 
-        sdp_cfg_.sub_reorder2.execute(strm, res->sub_reorder2_args[tid]);
+        sdp_cfg_.sub_reorder2.execute(p_stream, res->sub_reorder2_args[tid]);
 
         dnnl_primitive_execute_without_tp_hook(
-                sdp_cfg_.sub_mm2_prim, strm, res->sub_mm2_args[tid]);
-        sdp_cfg_.sub_reorder3.execute(strm, res->sub_reorder3_args[tid]);
+                sdp_cfg_.sub_mm2_prim, p_stream, res->sub_mm2_args[tid]);
+        sdp_cfg_.sub_reorder3.execute(p_stream, res->sub_reorder3_args[tid]);
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
         auto tp = threadpool_utils::get_active_threadpool();
         threadpool_utils::activate_threadpool(tp);
@@ -403,7 +403,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(stream_t *g_stream,
     tp_stream->after_exec_hook();
 #endif
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -69,7 +69,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -77,8 +77,7 @@ public:
             const size_t block_size,
             std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
@@ -140,13 +139,13 @@ public:
     std::function<std::shared_ptr<sdp_args_set_t>()> resource_ctor_;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<::sycl::event> &sycl_deps,
             ::sycl::event *sycl_event) override {
-        UNUSED(g_stream);
+        UNUSED(strm);
         UNUSED(inputs);
         UNUSED(outputs);
         UNUSED(sycl_deps);
@@ -156,13 +155,13 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
             const std::vector<cl_event> &cl_deps,
             cl_event *ret_event) override {
-        UNUSED(g_stream);
+        UNUSED(strm);
         UNUSED(inputs);
         UNUSED(outputs);
         UNUSED(cl_deps);

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -42,7 +42,7 @@ namespace dnnl_impl {
 
 template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::compile_impl(
-        const dnnl_partition_impl_t *part, engine_t *g_engine,
+        const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
 // sdp_primitive_kernel_t only supports Intel GPU.
@@ -50,7 +50,7 @@ status_t sdp_primitive_kernel_t<quantized>::compile_impl(
     return status::unimplemented;
 #endif
 
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     // First, dry run on a deep copy
     subgraph_
@@ -160,10 +160,10 @@ void sdp_primitive_kernel_t<quantized>::prepare_args_set(
 }
 
 template <bool quantized>
-status_t sdp_primitive_kernel_t<quantized>::execute_impl(stream_t *g_stream,
+status_t sdp_primitive_kernel_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -182,8 +182,8 @@ status_t sdp_primitive_kernel_t<quantized>::execute_impl(stream_t *g_stream,
 
 #ifdef DNNL_WITH_SYCL
 template <bool quantized>
-status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
-        stream_t *g_stream, const std::vector<tensor_t> &inputs,
+status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(stream_t *strm,
+        const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
@@ -193,7 +193,7 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
 #endif
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -220,14 +220,14 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 template <bool quantized>
-status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(stream_t *g_stream,
+status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
     auto deps = cl_deps;
     cl_event returned_event {};
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -163,7 +163,7 @@ template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -193,7 +193,7 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(stream_t *strm,
 #endif
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -227,7 +227,7 @@ status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(stream_t *strm,
     auto deps = cl_deps;
     cl_event returned_event {};
 
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
@@ -61,7 +61,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -70,13 +70,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -85,7 +84,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -109,7 +109,7 @@ void shuffle_fwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t shuffle_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -138,7 +138,7 @@ status_t shuffle_fwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -171,7 +171,7 @@ status_t shuffle_fwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -33,9 +33,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t shuffle_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     const bool reset_layout = false;
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
@@ -106,10 +106,10 @@ void shuffle_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t shuffle_fwd_t::execute_impl(stream_t *g_stream,
+status_t shuffle_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -124,13 +124,13 @@ status_t shuffle_fwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t shuffle_fwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t shuffle_fwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -138,7 +138,7 @@ status_t shuffle_fwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
@@ -164,14 +164,14 @@ status_t shuffle_fwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t shuffle_fwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t shuffle_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(

--- a/src/graph/backend/dnnl/kernels/shuffle.hpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.hpp
@@ -58,7 +58,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -67,13 +67,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -82,7 +81,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -119,7 +119,7 @@ void softmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t softmax_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -188,7 +188,7 @@ status_t softmax_fwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -262,7 +262,7 @@ status_t softmax_fwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -394,7 +394,7 @@ void softmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
 status_t softmax_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -423,7 +423,7 @@ status_t softmax_bwd_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -456,7 +456,7 @@ status_t softmax_bwd_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -33,9 +33,9 @@ namespace graph {
 namespace dnnl_impl {
 
 status_t softmax_fwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -116,10 +116,10 @@ void softmax_fwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t softmax_fwd_t::execute_impl(stream_t *g_stream,
+status_t softmax_fwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -174,13 +174,13 @@ status_t softmax_fwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t softmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t softmax_fwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -188,7 +188,7 @@ status_t softmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -255,14 +255,14 @@ status_t softmax_fwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t softmax_fwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t softmax_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -329,9 +329,9 @@ status_t softmax_fwd_t::ocl_execute_impl(stream_t *g_stream,
 
 #if BUILD_TRAINING
 status_t softmax_bwd_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+        engine_t *eng, const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -391,10 +391,10 @@ void softmax_bwd_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t softmax_bwd_t::execute_impl(stream_t *g_stream,
+status_t softmax_bwd_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -409,13 +409,13 @@ status_t softmax_bwd_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t softmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
+status_t softmax_bwd_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -423,7 +423,7 @@ status_t softmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -449,14 +449,14 @@ status_t softmax_bwd_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t softmax_bwd_t::ocl_execute_impl(stream_t *g_stream,
+status_t softmax_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/softmax.hpp
@@ -64,7 +64,7 @@ public:
         return status::success;
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -73,13 +73,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -88,7 +87,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -120,7 +119,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -129,13 +128,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -144,7 +142,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -32,10 +32,10 @@ namespace impl {
 namespace graph {
 namespace dnnl_impl {
 
-status_t sum_t::compile_impl(const dnnl_partition_impl_t *part,
-        engine_t *g_engine, const std::vector<logical_tensor_t> &inputs,
+status_t sum_t::compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
+        const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
-    p_engine_ = make_dnnl_engine(*g_engine);
+    p_engine_ = make_dnnl_engine(*eng);
 
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
@@ -106,10 +106,10 @@ void sum_t::prepare_args_set(const execution_args_set_t *res,
     }
 }
 
-status_t sum_t::execute_impl(stream_t *g_stream,
+status_t sum_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -124,13 +124,13 @@ status_t sum_t::execute_impl(stream_t *g_stream,
         subgraph_->execs_[i]->execute(p_stream, res->get_exec_args()[i]);
     }
 
-    prolong_scratchpad_lifetime(g_stream, scratchpad);
+    prolong_scratchpad_lifetime(strm, scratchpad);
 
     return status::success;
 }
 
 #ifdef DNNL_WITH_SYCL
-status_t sum_t::sycl_execute_impl(stream_t *g_stream,
+status_t sum_t::sycl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<::sycl::event> &sycl_deps,
@@ -138,7 +138,7 @@ status_t sum_t::sycl_execute_impl(stream_t *g_stream,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -164,14 +164,14 @@ status_t sum_t::sycl_execute_impl(stream_t *g_stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-status_t sum_t::ocl_execute_impl(stream_t *g_stream,
+status_t sum_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
         const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -109,7 +109,7 @@ void sum_t::prepare_args_set(const execution_args_set_t *res,
 status_t sum_t::execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -138,7 +138,7 @@ status_t sum_t::sycl_execute_impl(stream_t *strm,
 
     auto deps = sycl_deps;
     std::optional<::sycl::event> returned_event;
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -171,7 +171,7 @@ status_t sum_t::ocl_execute_impl(stream_t *strm,
 
     auto deps = cl_deps;
     cl_event returned_event {};
-    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *strm);
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
     thread_local_cache_t<execution_args_set_t> res_cache;

--- a/src/graph/backend/dnnl/kernels/sum.hpp
+++ b/src/graph/backend/dnnl/kernels/sum.hpp
@@ -59,7 +59,7 @@ public:
         res_cache.release();
     }
 
-    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *g_engine,
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override;
 
@@ -68,13 +68,12 @@ public:
             const std::vector<tensor_t> &outputs,
             const scratchpad_t &scratchpad);
 
-    status_t execute_impl(stream_t *g_stream,
-            const std::vector<tensor_t> &inputs,
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf) override;
 
 #ifdef DNNL_WITH_SYCL
-    status_t sycl_execute_impl(stream_t *g_stream,
+    status_t sycl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
@@ -83,7 +82,7 @@ public:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    status_t ocl_execute_impl(stream_t *g_stream,
+    status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,

--- a/src/graph/backend/dnnl/scratchpad.cpp
+++ b/src/graph/backend/dnnl/scratchpad.cpp
@@ -73,12 +73,12 @@ scratchpad_t::~scratchpad_t() {
 }
 
 void prolong_scratchpad_lifetime(
-        stream_t *g_stream, const std::shared_ptr<scratchpad_t> &scratchpad) {
+        stream_t *strm, const std::shared_ptr<scratchpad_t> &scratchpad) {
     if (scratchpad->is_user_managed()) return;
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     auto *tp_stream
             = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
-                    g_stream);
+                    strm);
     tp_stream->before_exec_hook();
 
     parallel(1, [=](int, int) { UNUSED(scratchpad); });

--- a/src/graph/backend/dnnl/scratchpad.hpp
+++ b/src/graph/backend/dnnl/scratchpad.hpp
@@ -85,7 +85,7 @@ private:
 // for memory objects before they are passed into a primitive execute call.
 // No-op if the scratchpad is user-managed.
 void prolong_scratchpad_lifetime(
-        stream_t *g_stream, const std::shared_ptr<scratchpad_t> &scratchpad);
+        stream_t *strm, const std::shared_ptr<scratchpad_t> &scratchpad);
 
 class registrar_t;
 class grantor_t;

--- a/tests/gtests/graph/unit/backend/dnnl/test_op_executable.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_op_executable.cpp
@@ -60,7 +60,7 @@ TEST(test_op_executable, DummyImpl) {
     graph::engine_t *engine = get_engine();
     graph::stream_t *strm = get_stream();
     dnnl::engine p_engine = dnnl_impl::make_dnnl_engine(*engine);
-    dnnl::stream p_stream = dnnl_impl::make_dnnl_stream(p_engine, *strm);
+    dnnl::stream p_stream = dnnl_impl::make_dnnl_stream(*strm);
     auto op_exec = std::make_shared<dnnl_impl::dummy_impl_t>();
 
     // test empty input events


### PR DESCRIPTION
Continue the refactor and cleaning work in the backend.

`g_engine` and `g_stream` are also legacy names due to that we had separated "graph engine" and "graph stream" previously. Now, we can get rid of them.