### PR TITLE
cpu: aarch64: binary: remove faulty skip logic for asimd

### DIFF
--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -88,7 +88,6 @@ static bool data_type_supported(const data_type_t dtype) {
 
 static bool data_format_supported(
         const memory_desc_wrapper &mdw, const cpu_isa_t isa) {
-    if (!is_superset(isa, sve)) return false;
     if (mdw.is_plain()) return true;
     if (!mdw.is_blocking_desc()) return false;
     const auto blk_size = mdw.blocking_desc().inner_blks[0];


### PR DESCRIPTION

# Description
This guard was included as part of 50ec5d30 (PR #5101) but is unneeded and leads to regressions on platforms without SVE support.

```
# Before
$ qemu-aarch64-static -cpu neoverse-n1 -- ./build/tests/benchdnn/benchdnn --binary --global-impl='jit' --batch=test_binary_all
...
tests:22913 passed:0 skipped:22913 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 5.52s; create_pd: 0.68s (12%); create_prim: 0.00s (0%); fill: 0.00s (0%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);

# After
$ qemu-aarch64-static -cpu neoverse-n1 -- ./build/tests/benchdnn/benchdnn --binary --global-impl='jit' --batch=test_binary_all
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:uni : 3373 (100%)                                    |
============================================================
tests:22913 passed:3270 skipped:19540 mistrusted:103 unimplemented:0 invalid_arguments:0 failed:0 listed:0
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?