### PR TITLE
[backport][rls-v3.13] cpu: x64: matmul: fix extendable_k with padded src leading dimension

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1046,8 +1046,13 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
                 && (n_blk_ >= n_decomposition * 3)
                 && ((size_t)k_blk_ >= (64 / gemm_dt_sz) * 4);
 
+        // extendable_k reads A's K dimension rounded up to the tile
+        // granularity directly from memory, so it is only valid when A is
+        // contiguous along K (leading dimension equal to K). A padded LDA
+        // would make the kernel stride rows by the padded value while reading
+        // the extended K, corrupting the result.
         extendable_k_ = K % wei_k_blk != 0 && !skip_extendable_k()
-                && !use_fused_copy_a_;
+                && !use_fused_copy_a_ && get_actual_lda() == K;
 
     } else {
         if (is_postops_bound(k_blk_v)) {
@@ -1073,7 +1078,9 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
         need_prefetch_b_ = ((n_per_thread / n_blk_) >= 2) && !use_buffer_b;
         use_fused_copy_a_ = false;
 
-        extendable_k_ = K % wei_k_blk != 0 && !skip_extendable_k();
+        // extendable_k requires A to be contiguous along K.
+        extendable_k_ = K % wei_k_blk != 0 && !skip_extendable_k()
+                && get_actual_lda() == K;
     }
 
     brgemm_batch_size_ = 1;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -178,8 +178,10 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         best_blocking.need_buf_c_ = false;
         best_blocking.need_buf_a_ = false;
 
+        // extendable_k requires A to be contiguous along K (LDA == K).
         best_blocking.extendable_k_ = bgmmc.K % best_blocking.wei_k_blk != 0
-                && !best_blocking.skip_extendable_k();
+                && !best_blocking.skip_extendable_k()
+                && best_blocking.get_actual_lda() == bgmmc.K;
 
         best_blocking.is_a_nt_ = true;
         best_blocking.is_b_nt = true;


### PR DESCRIPTION
backport #5603 