### PR TITLE
xe: sdpa: fix ineffective xe_hpg guard in bwd primitive init

### DIFF
--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -426,7 +426,6 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     assert(engine->kind() == engine_kind::gpu);
     auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
     auto *dev_info = intel_engine->device_info();
-    arch_ = dev_info->gpu_arch();
     auto *d = desc();
 
     VDISPATCH_SDPA(compute::mayiuse_microkernels(intel_engine),
@@ -443,10 +442,6 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     bool quantized = false;
     bool is_integrated = intel_engine->device_info()->is_integrated();
     bool is_f32 = (desc()->qry_md()->data_type == data_type::f32);
-    use_systolic_ukernel_
-            = intel_engine->mayiuse(compute::device_ext_t::
-                              intel_subgroup_matrix_multiply_accumulate)
-            && !is_f32; // f32 -> non-systolic kernel only
 
     bool use_fma_config = !use_systolic_ukernel_;
     config = choose_bwd_config(arch_, d->head_size(), d->queries(), d->keys(),
@@ -551,8 +546,6 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             hw_info.gmdid != 0, "gmdid is 0, microkernels not supported.");
 
     ukernel_params.hwinfo = {hw_info};
-
-    sg_size_ = dev_info->min_subgroup_size();
 
     auto convert_dnnl_to_kernel_layout = [](const memory_desc_t *md) {
         return (gemm_desc_t::get_trans(*md) == dnnl_trans) ? MatrixLayout::T

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -436,7 +436,21 @@ struct micro_bwd_t : public primitive_t {
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
 
+            auto *intel_engine = utils::downcast<intel::engine_t *>(engine);
+            auto *dev_info = intel_engine->device_info();
+            arch_ = dev_info->gpu_arch();
+            sg_size_ = dev_info->min_subgroup_size();
+
             VDISPATCH_SDPA(!is_fwd(), VERBOSE_BAD_PROPKIND);
+
+            VDISPATCH_SDPA(arch_ != compute::gpu_arch_t::xe_hpg,
+                    "fused SDPA BWD not supported for xe_hpg");
+
+            bool is_f32 = (desc()->qry_md()->data_type == data_type::f32);
+            use_systolic_ukernel_
+                    = intel_engine->mayiuse(compute::device_ext_t::
+                                      intel_subgroup_matrix_multiply_accumulate)
+                    && !is_f32; // f32 -> non-systolic kernel only
 
             VDISPATCH_SDPA(utils::everyone_is(4, desc()->qry_md()->ndims,
                                    desc()->key_md()->ndims,
@@ -529,8 +543,6 @@ struct micro_bwd_t : public primitive_t {
             CHECK(init_default_ws());
             VDISPATCH_SDPA(compare_ws(hint_fwd_pd_), VERBOSE_WS_MISMATCH);
 
-            VDISPATCH_SDPA(arch() != compute::gpu_arch_t::xe_hpg,
-                    "fused SDPA BWD not supported for xe_hpg");
             CHECK(init_conf_microkernels(engine));
             CHECK(init_conf(engine));
             CHECK(init_scratchpad(engine));


### PR DESCRIPTION
## Description

The `xe_hpg` dispatch guard for fused SDPA backward was evaluated in `micro_bwd_t::pd_t::init()` **before** `arch_` was initialized. `arch_` is only assigned inside `init_conf_microkernels()`, so the guard always read the default `unknown` value and never rejected `xe_hpg`.

## Fix

Move the guard into `init_conf_microkernels()` right after `arch_` is set, so it uses the correct architecture and rejects `xe_hpg` early.
