### PR TITLE
[GPU] gemm: fix overriding dt by GEMM_KERNEL string

### DIFF
--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -137,9 +137,22 @@ status_t gen_desc_t::finalize(const char *tags) {
         gpu_assert(val == "gemm");
         ss >> val;
         const char *pstr = val.c_str();
+        // The external (buffer) data types are fixed by the actual problem /
+        // memory allocation and must NOT be overridden by the kernel string.
+        // A catalog precision like "OHS" encodes the *compute* precision of C
+        // as 'S' (f32 accumulate); parsePrecisions on a single letter sets
+        // both the compute and external type, which would reinterpret the
+        // f16 output buffer as f32 and write out of bounds => CL_OUT_OF_RESOURCES.
+        // Preserve the external types and only override the internal/compute ones.
+        const Type Ta_ext_orig = problem_.Ta_ext;
+        const Type Tb_ext_orig = problem_.Tb_ext;
+        const Type Tc_ext_orig = problem_.Tc_ext;
         pstr = parsePrecisions(pstr, problem_.Ta_ext, problem_.Ta);
         pstr = parsePrecisions(pstr, problem_.Tb_ext, problem_.Tb);
         pstr = parsePrecisions(pstr, problem_.Tc, problem_.Tc_ext);
+        problem_.Ta_ext = Ta_ext_orig;
+        problem_.Tb_ext = Tb_ext_orig;
+        problem_.Tc_ext = Tc_ext_orig;
         ss >> val;
         pstr = val.c_str();
         pstr = parseLayout(pstr, problem_.A);

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -128,31 +128,20 @@ status_t gen_desc_t::finalize(const char *tags) {
     std::string ovr_strategy;
     ovr_strategy = gpu_utils::dev_getenv("GEMM_KERNEL", ovr_strategy);
     if (!ovr_strategy.empty()) {
-        // Warning: will override problem data types (including up/down
-        // conversions) - this will cause inaccuracies if precisions/layouts
-        // are chosen that are incompatible with the given problem
         std::stringstream ss(ovr_strategy);
         std::string val;
         ss >> val;
         gpu_assert(val == "gemm");
         ss >> val;
         const char *pstr = val.c_str();
-        // The external (buffer) data types are fixed by the actual problem /
-        // memory allocation and must NOT be overridden by the kernel string.
-        // A catalog precision like "OHS" encodes the *compute* precision of C
-        // as 'S' (f32 accumulate); parsePrecisions on a single letter sets
-        // both the compute and external type, which would reinterpret the
-        // f16 output buffer as f32 and write out of bounds => CL_OUT_OF_RESOURCES.
-        // Preserve the external types and only override the internal/compute ones.
-        const Type Ta_ext_orig = problem_.Ta_ext;
-        const Type Tb_ext_orig = problem_.Tb_ext;
-        const Type Tc_ext_orig = problem_.Tc_ext;
-        pstr = parsePrecisions(pstr, problem_.Ta_ext, problem_.Ta);
-        pstr = parsePrecisions(pstr, problem_.Tb_ext, problem_.Tb);
-        pstr = parsePrecisions(pstr, problem_.Tc, problem_.Tc_ext);
-        problem_.Ta_ext = Ta_ext_orig;
-        problem_.Tb_ext = Tb_ext_orig;
-        problem_.Tc_ext = Tc_ext_orig;
+        // Cannot modify external data types
+        Type ext_dt;
+        pstr = parsePrecisions(pstr, ext_dt, problem_.Ta);
+        gpu_assert(ext_dt == problem_.Ta_ext) << "Invalid external A data type";
+        pstr = parsePrecisions(pstr, ext_dt, problem_.Tb);
+        gpu_assert(ext_dt == problem_.Tb_ext) << "Invalid external B data type";
+        pstr = parsePrecisions(pstr, problem_.Tc, ext_dt);
+        gpu_assert(ext_dt == problem_.Tc_ext) << "Invalid external C data type";
         ss >> val;
         pstr = val.c_str();
         pstr = parseLayout(pstr, problem_.A);


### PR DESCRIPTION
PR improves (alignes with regular way) logic of data types override with GEMM_KERNEL env usage.
It preserves the external (buffer) types across the parsePrecisions() calls in the override what allow to avoid CL_OUT_OF_RESOURCES. Useful for performance tuning validation / kernels selection.
For example, OH**S** in GEMM_KERNEL env string applied to f16:s8:**f16** problem might cause out of bound writes.
The strings with correct brackets, e.g. OH[SH], are unaffected.
