### PR TITLE
[GPU] Fixup GEMM tail handling

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -1880,14 +1880,18 @@ void CopyPlan::planEmulatedBF8ToBF(CopyInstruction &i)
     // shl          y:uw    x:ub    8               /* already done */
     // asr          y:w     y:w     3
     // and          y:uw    y:uw    0x8FFF
+    // cmp (ge)f0   null:bf (abs)y:bf 0x0FA0:bf     /* NaN check */
     // mul          y:bf    y:bf    0x7780:bf
+    // (f0) or      y:uw    y:uw    0x7FFF          /* Preserve NaNs */
 
-    auto ie = splitMultiple<3>(i);
+    auto ie = splitMultiple<5>(i);
 
     auto y = i.dst, yUW = y, yW = y;
     yUW.type = DataType::uw;
     yW.type = DataType::w;
     y.type = DataType::bf;
+
+    auto f = newFlag(i.simd);
 
     ie[0]->op = Opcode::asr;
     ie[0]->src0 = ie[0]->dst = yW;
@@ -1897,9 +1901,23 @@ void CopyPlan::planEmulatedBF8ToBF(CopyInstruction &i)
     ie[1]->src0 = ie[1]->dst = yUW;
     ie[1]->src1 = 0x8FFF;
 
-    ie[2]->op = Opcode::mul;
-    ie[2]->src0 = ie[2]->dst = y;
-    ie[2]->src1 = bfImmediate(0x7780, false);
+    ie[2]->op = Opcode::cmp;
+    ie[2]->src0 = abs(y);
+    ie[2]->src1 = bfImmediate(0x0FA0, false);
+    ie[2]->dst = CopyOperand();
+    ie[2]->dst.stride = y.stride;
+    ie[2]->dst.type = DataType::bf;
+    ie[2]->cmod = ConditionModifier::ge;
+    ie[2]->flag = f;
+
+    ie[3]->op = Opcode::mul;
+    ie[3]->src0 = ie[3]->dst = y;
+    ie[3]->src1 = bfImmediate(0x7780, false);
+
+    ie[4]->op = Opcode::or_;
+    ie[4]->src0 = ie[4]->dst = yUW;
+    ie[4]->src1 = 0x7FFF;
+    ie[4]->flag = f;
 }
 
 // Emulation sequence for hf8->hf conversion.

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -1880,9 +1880,9 @@ void CopyPlan::planEmulatedBF8ToBF(CopyInstruction &i)
     // shl          y:uw    x:ub    8               /* already done */
     // asr          y:w     y:w     3
     // and          y:uw    y:uw    0x8FFF
-    // cmp (ge)f0   null:bf (abs)y:bf 0x0FA0:bf     /* NaN check */
+    // cmp (ge)f0   null:bf (abs)y:bf 0x0F80:bf     /* Inf/NaN check */
     // mul          y:bf    y:bf    0x7780:bf
-    // (f0) or      y:uw    y:uw    0x7FFF          /* Preserve NaNs */
+    // (f0) or      y:uw    y:uw    0x7F80          /* Preserve Inf/NaNs */
 
     auto ie = splitMultiple<5>(i);
 
@@ -1903,7 +1903,7 @@ void CopyPlan::planEmulatedBF8ToBF(CopyInstruction &i)
 
     ie[2]->op = Opcode::cmp;
     ie[2]->src0 = abs(y);
-    ie[2]->src1 = bfImmediate(0x0FA0, false);
+    ie[2]->src1 = bfImmediate(0x0F80, false);
     ie[2]->dst = CopyOperand();
     ie[2]->dst.stride = y.stride;
     ie[2]->dst.type = DataType::bf;
@@ -1916,7 +1916,7 @@ void CopyPlan::planEmulatedBF8ToBF(CopyInstruction &i)
 
     ie[4]->op = Opcode::or_;
     ie[4]->src0 = ie[4]->dst = yUW;
-    ie[4]->src1 = 0x7FFF;
+    ie[4]->src1 = 0x7F80;
     ie[4]->flag = f;
 }
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/k_loop_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/k_loop_setup.cxx
@@ -154,10 +154,18 @@ bool Generator<hw>::kLoopSetup(const GEMMProblem &problem, const GEMMStrategy &s
     auto &A_descRem = state.A_descRem, &B_descRem = state.B_descRem;
     A_descRem = B_descRem = false;
 
+    // Descriptor remainder rounds count up to crosspack, will overread
+    // when src is wider than weights, unless the buffer is padded.
+    auto kDescRemOverreadHazard = [](Type narrow, Type wide,
+            const MatrixAddressingStrategy &narrowAstrategy) {
+        return narrow.size() < wide.size() && !narrowAstrategy.padded;
+    };
+
     if (strategy.kDescRem) {
         if (ka_loadRem == 1) {
             int frag = checkDescriptorRemainder(hw, Ta_load, unrollM, strategy.ka_load, true, false, problem.A, strategy.A);
             if (frag > 1) {
+                if (kDescRemOverreadHazard(Ta_ext, Tb_ext, strategy.A)) stub();
                 ka_loadRem = frag;
                 A_lateKRem = A_descRem = true;
             }
@@ -165,6 +173,7 @@ bool Generator<hw>::kLoopSetup(const GEMMProblem &problem, const GEMMStrategy &s
         if (kb_loadRem == 1 && !A_descRem) {
             int frag = checkDescriptorRemainder(hw, Tb_load, strategy.kb_load, unrollN, false, false, problem.B, strategy.B);
             if (frag > 1) {
+                if (kDescRemOverreadHazard(Tb_ext, Ta_ext, strategy.B)) stub();
                 kb_loadRem = frag;
                 B_lateKRem = B_descRem = true;
             }


### PR DESCRIPTION
# Description

Fixup handling tails for weights decompression GEMM cases:

- reenable NaN detection in fp8->bf emulated conversion routine, was hiding issues
- disable `kDescRem` remainder handling parameter in cases where it causes overreading garbage data that may not be masked out by multiplying by 0. 

Fixes # [MFDNN-14869](https://jira.devtools.intel.com/browse/MFDNN-14869)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
 
