### PR TITLE
fp8: saturate the output value after dynamic scaling instead of overflowing

### DIFF
--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -114,12 +114,11 @@ value). In particular, some hardware platforms have no direct
 conversion instructions from `f32` data type to low-precision data types
 such as `f8` or `f4`, and will perform conversion through an
 intermediate data type (for example `f16` or `bf16`), which may result in
-[double
-rounding](https://en.wikipedia.org/wiki/Rounding#Double_rounding).
+[double rounding](https://en.wikipedia.org/wiki/Rounding#Double_rounding).
 
-Conversions to integral datatypes saturate upon overflow, whereas
-conversions to floating-point datatypes don't. To force saturation behavior for
-floating-point datatypes use @ref dev_guide_attributes_post_ops_eltwise with clip algorithm.
+Conversions to integral datatypes saturate upon overflow. Conversions of
+floating-point datatypes compliant to MXFP schemes saturate upon overflow,
+whereas conversions to any other floating-point datatypes don't.
 
 
 ### Rounding mode and denormal handling

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -384,6 +384,17 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                             data_type::f32, temp_dst, temp_dst_off);
                     d *= dst_group_scale;
 
+                    // A dynamically-computed scale is rounded down to the
+                    // nearest representable power-of-two (e8m0). When the
+                    // resulting (pre-inverted) scale is less than one, its
+                    // inverse applied here is greater than one and may push
+                    // the value beyond the representable range of the
+                    // destination data type. Saturate to the max/min
+                    // representable value instead of overflowing to NaN.
+                    const float dst_max
+                            = types::max_value<float>(dst_d.data_type());
+                    d = nstl::min(nstl::max(d, -dst_max), dst_max);
+
                     if (dst_rnd_mode == rounding_mode::stochastic)
                         d = math::stochastic_round_fwd(d, dst_off,
                                 dropout_seed_val, dst_d.data_type());

--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -143,6 +143,7 @@ bool has_data_type_support(data_type_t data_type) {
 #endif
         case data_type::f8_e5m2:
         case data_type::f8_e4m3:
+        case data_type::e8m0:
 #if DNNL_X64
             return x64::mayiuse(x64::avx512_core_fp16);
 #else

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -2656,10 +2656,23 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
 
             const auto i_off = input_d.off_l(idx);
             const auto o_off = output_d.off_l(idx);
-            float d = src_scale * (input[i_off] - src_zp_val);
-            if (beta) d += beta * output[o_off];
-            d = d / dst_scale + dst_zp;
-            output[o_off] = _qz_a1b0<data_type::f32, type_o>()(d);
+            if (type_i == data_type::e8m0) {
+                // Reorder from e8m0 to f32 is used for benchdnn correctness
+                // validation purpose only. Keep a separate branch where it has
+                // no support for any feature as this is the reorder of e8m0
+                // dynamic dst scales to f32 for comparison.
+                // A dedicated path is required to preserve a minimal e8m0 value
+                // which gets converted by any compiler to 0 if any
+                // floating-point operation (such as add or mul) or comparison
+                // operation is around the value.
+                auto s = io::load_float_value(type_i, input, i_off);
+                io::store_float_value(type_o, s, output, o_off);
+            } else {
+                float d = src_scale * (input[i_off] - src_zp_val);
+                if (beta) d += beta * output[o_off];
+                d = d / dst_scale + dst_zp;
+                output[o_off] = _qz_a1b0<data_type::f32, type_o>()(d);
+            }
         });
         return status::success;
     }

--- a/src/gpu/intel/dynamic_scale.cl
+++ b/src/gpu/intel/dynamic_scale.cl
@@ -97,7 +97,9 @@ __kernel void dynamic_scale_dst(__global float *restrict src,
         off = DST_OFF(m, n_iter, 0, 0, 0);
 #endif
 #endif
-        dst[off] = TO_DST(src[off] / scale_val);
+        // Saturate to the max/low data type value instead of overflowing.
+        dst[off] = TO_DST(
+                max(min(src[off] / scale_val, DST_DATA_FMAX), DST_DATA_FLOW));
     }
 
     long scale_off = 0;

--- a/src/gpu/intel/jit/eltwise_injector.cpp
+++ b/src/gpu/intel/jit/eltwise_injector.cpp
@@ -334,8 +334,8 @@ void eltwise_injector_f32_t<ngen_generator_t>::mx_scale_compute_fwd(int simd,
     // Inverse max float within e8m0 range for f8_e2m5, f8_e4m3, f4_e2m1.
     float zero_e8m0 = 5.877472e-39f, inv_fmax_bf8 = 0.000030517578125f,
           inv_fmax_hf8 = 0.00390625f, inv_fmax_f4_e2m1 = 0.25f;
-    auto fmax = (dst_dt == ngen::DataType::bf8) ? Immediate::f(inv_fmax_bf8)
-            : (dst_dt == ngen::DataType::hf8)   ? Immediate::f(inv_fmax_hf8)
+    auto inv_fmax = (dst_dt == ngen::DataType::bf8) ? Immediate::f(inv_fmax_bf8)
+            : (dst_dt == ngen::DataType::hf8)       ? Immediate::f(inv_fmax_hf8)
                                               : Immediate::f(inv_fmax_f4_e2m1);
 
     // Handle Inf/NaNs during max selection.
@@ -360,7 +360,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::mx_scale_compute_fwd(int simd,
     h->and_(1, max.ud(0), max.ud(0), Immediate::ud(0x7F800000));
 
     // Compute scale within e8m0 range.
-    h->mul(1, max.f(0), max.f(0), fmax);
+    h->mul(1, max.f(0), max.f(0), inv_fmax);
     h->and_(1, max.ud(0), max.ud(0), Immediate::ud(0x7F800000));
     h->sel(1 | ge, max.f(0)(1), max.f(0), Immediate::f(zero_e8m0));
 

--- a/src/gpu/intel/jit/eltwise_injector.cpp
+++ b/src/gpu/intel/jit/eltwise_injector.cpp
@@ -313,6 +313,11 @@ void eltwise_injector_f32_t<ngen_generator_t>::round_compute_fwd(
     h->rnde(simd, r, r);
 }
 
+// Note: since interface can only take a single `GRF`, but block of `32` for MX
+// scaling requires two GRFs, `off` argument is responsible to get a second
+// part of 32-element block.
+// When computing the scale, both `r` and `GRF(off)` (a.k.a. `r_alt`) must be
+// updated or used.
 template <typename ngen_generator_t>
 void eltwise_injector_f32_t<ngen_generator_t>::mx_scale_compute_fwd(int simd,
         const ngen::GRF &r, int off, const ngen::Subregister &seed, int nreg,
@@ -370,6 +375,20 @@ void eltwise_injector_f32_t<ngen_generator_t>::mx_scale_compute_fwd(int simd,
     // Apply scale to dst.
     h->mul(16, r, r, max.f(1)(0));
     h->mul(16, r_alt.f(0)(1), r_alt.f(0)(1), max.f(1)(0));
+
+    // Saturate dst value to fmax and flow instead of overflowing..
+    float fmax_bf8 = 57344.f, fmax_hf8 = 448.f, fmax_f4_e2m1 = 6.f;
+    float flow_bf8 = -57344.f, flow_hf8 = -448.f, flow_f4_e2m1 = -6.f;
+    auto fmax = (dst_dt == ngen::DataType::bf8) ? Immediate::f(fmax_bf8)
+            : (dst_dt == ngen::DataType::hf8)   ? Immediate::f(fmax_hf8)
+                                                : Immediate::f(fmax_f4_e2m1);
+    auto flow = (dst_dt == ngen::DataType::bf8) ? Immediate::f(flow_bf8)
+            : (dst_dt == ngen::DataType::hf8)   ? Immediate::f(flow_hf8)
+                                                : Immediate::f(flow_f4_e2m1);
+    h->sel(16 | ge, r, r, flow);
+    h->sel(16 | le, r, r, fmax);
+    h->sel(16 | ge, r_alt.f(0)(1), r_alt.f(0)(1), flow);
+    h->sel(16 | le, r_alt.f(0)(1), r_alt.f(0)(1), fmax);
 
     // Store scale value.
     h->shr(1, max.ud(0), max.ud(0), 23);

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -334,6 +334,20 @@ static void compute_ref_matmul_chunk(const chunk_params_t &p, int64_t M,
         }
         float dst = p.dst_m->get_f32_elem(dst_off);
         float dst_val = dst_scale * dst + dst_zp;
+        if (p.has_dst_dynamic) {
+            // When the computed dst_scale is < 1.f, its inverse is > 1.f and
+            // may push the value beyond the representable range of the dst dt,
+            // including NaN or inf.
+            // Saturate to the max/min representable value preserving sign
+            // instead of overflowing according to spec.
+            if (std::isnan(dst_val) || std::isinf(dst_val)) {
+                float dst_val_sign = std::signbit(dst_val) ? -1 : 1;
+                dst_val = max_dt(p.dst_dt) * dst_val_sign;
+            } else {
+                dst_val = MAX2(
+                        MIN2(dst_val, max_dt(p.dst_dt)), lowest_dt(p.dst_dt));
+            }
+        }
         maybe_round(attr, DNNL_ARG_DST, dst_val, dst_off, p.dst_dt);
         p.dst_m->set_f32_elem(dst_off, dst_val);
     }

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -268,7 +268,8 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
                     [&](dnnl_data_type_t dt) { return got_mem.dt() == dt; });
     const bool has_exp_eltwise
             = attr.post_ops.find(attr_t::post_ops_t::kind_t::EXP) >= 0;
-    const bool has_dst_scale = !attr.scales.get(DNNL_ARG_DST).is_def();
+    const auto &dst_scale = attr.scales.get(DNNL_ARG_DST);
+    const bool has_dst_scale = !dst_scale.is_def();
 
     // Idea is to pad nelems to mimic uniform load between available threads.
     // It allows to make a clear assumption when the last element is processed
@@ -350,11 +351,21 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
 
             // Discard tiny values very close to each other. It's impossible to
             // compare them reliably and fit into any criterion.
-            ok = fabsf(args.exp) <= 1e-5f && args.diff < epsilon_dt(dnnl_f32);
+            //
+            // Note: the only exception from this condition is `e8m0` dt since
+            // its minimal value passes this criterion though in the way it's
+            // written. The minimal value must be check for exactness and if it
+            // wasn't, it should be reported. Skipping `e8m0` in this condition
+            // allows to catch the error properly.
+            ok = fabsf(args.exp) <= 1e-5f && args.diff < epsilon_dt(dnnl_f32)
+                    && args.dt != dnnl_e8m0;
             if (ok) break;
 
             // Standard check for relative diff is under set threshold.
-            ok = (fabsf(args.exp) > 1e-5f ? args.rel_diff : args.diff) <= trh_;
+            //
+            // Note: and same limitations for `e8m0`.
+            ok = (fabsf(args.exp) > 1e-5f ? args.rel_diff : args.diff) <= trh_
+                    && args.dt != dnnl_e8m0;
             if (ok) break;
 
             // When NaNs or infinity are allowed for the driver, check
@@ -402,13 +413,14 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
                     && args.rel_diff <= std::max(epsilon_dt(dt), 5e-6f);
             if (ok) break;
 
-            // Attr dst scale is used as a divisor to quantize data to dt.
+            // f32 dst scale is used as a divisor to quantize data to dt.
             // Implementation might decide to pre-compute inverse value and
             // multiply on it in kernel. This difference might result in a
             // slight error comparing to a division operation.
             const float experimental_dst_scale_trh
                     = std::max(epsilon_dt(dt), 1e-5f);
-            ok = has_dst_scale && args.rel_diff <= experimental_dst_scale_trh;
+            ok = has_dst_scale && dst_scale.dt == dnnl_f32
+                    && args.rel_diff <= experimental_dst_scale_trh;
             if (ok) break;
 
             // Binary MAX, MIN and comparison operations post-ops may return

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -259,13 +259,16 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
     const auto dt = got_mem.dt();
     const bool has_eltwise
             = attr.post_ops.eltwise_index() != -1 || has_eltwise_post_op_;
-    const std::vector<dnnl_data_type_t> dt_with_nan {
-            dnnl_f16, dnnl_e8m0, dnnl_f8_e5m2, dnnl_f8_e4m3};
+    // Output fp8 data types expected to have dynamic dst scaling. When such
+    // scaling is enabled, it saturates, doesn't overflow, thus, NaNs are not
+    // expected in the output. No dynamic scaling - NaN may happen.
+    const bool non_scaled_fp8_output
+            = (dt == dnnl_f8_e5m2 || dt == dnnl_f8_e4m3)
+            && !attr.scales.get(DNNL_ARG_DST).is_dynamic();
     const bool output_has_nans = op_output_has_nans_
             || eltwise::eltwise_alg_returns_nan_or_inf(attr)
             || has_binary_po_algs(attr, {attr_t::post_ops_t::kind_t::DIV})
-            || std::any_of(dt_with_nan.begin(), dt_with_nan.end(),
-                    [&](dnnl_data_type_t dt) { return got_mem.dt() == dt; });
+            || dt == dnnl_f16 || non_scaled_fp8_output;
     const bool has_exp_eltwise
             = attr.post_ops.find(attr_t::post_ops_t::kind_t::EXP) >= 0;
     const auto &dst_scale = attr.scales.get(DNNL_ARG_DST);

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -144,6 +144,9 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
 
+    // Dynamic scales must not be filled.
+    if (e.is_dynamic()) return OK;
+
     if (mem_dt) { assert(mem_dt.nelems() == mem_fp.nelems()); }
 
     if (e.has_single_element()) {

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -154,6 +154,7 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
         mem_fp.set_f32_elem(0, e.scale);
         // TODO: replace reorder with `fill` that takes any pattern unlike
         // memset.
+        if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
     } else {
         // 1/16, 1/8 and 1/4 to properly work with grouped scaling.
         // Full density as zero scales are prohibited.
@@ -161,8 +162,6 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
         fill_cfg_t fill_cfg(scales_set, /* density = */ 1.f, "scales");
         SAFE(fill_random_real(mem_dt, mem_fp, res, fill_cfg), WARN);
     }
-
-    if (mem_dt) SAFE(mem_dt.reorder(mem_fp, res), WARN);
 
     return OK;
 }


### PR DESCRIPTION
[MFDNN-15157](https://jira.devtools.intel.com/browse/MFDNN-15157)

The GPU part was done in collaboration with @kealan-barbieri, thank you!

The PR includes changes to all implementations that are involved in producing scales and fp8 outputs and also tightening nuts in benchdnn to verify better scales outputs and not let it slip due to other conditions.