### PR TITLE
xe: sdpa: Update heuristic kernel gen failure with 2d Dequan slm loads

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -530,6 +530,14 @@ static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool l
         s.ka_load = std::min(s.ka_load, s.unroll[LoopM] * 2);
     }
 
+    bool slmDequantize2DA = (problem.aOffset2D() || problem.aScale2D()) && s.slmA;
+    bool slmDequantize2DB = (problem.bOffset2D() || problem.bScale2D()) && s.slmB;
+    if (slmDequantize2DA && slmDequantize2DB) {
+        // TODO: try max of ka_load/kb_load and see if it performs better
+        int min_load = std::min(s.ka_load, s.kb_load);
+        s.ka_load = s.kb_load = min_load;
+    }
+
     s.systolic = systolic;
     if (systolic && hw >= HW::XeHPC) {
         s.extendedAtomicFMA = s.atomicFMA = true;

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -222,6 +222,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
         dim_t m_unroll = sg_size_;
         float avg_m = float(M()) / ngroups_;
         dim_t n_unroll = std::max<dim_t>(2, utils::rnd_up_pow2(dim_t(avg_m)));
+        dim_t min_n_unroll = 1;
         dim_t max_n_unroll = 0;
         dim_t max_wg_n = 4;
         dim_t min_wg_n = 1;
@@ -238,13 +239,20 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
                         ? 8
                         : 16;
                 break;
-            case compute::gpu_arch_t::xe_hpg:
+            case compute::gpu_arch_t::xe_hpg: {
+                auto product = dev_info->product();
+                bool is_xelpg = (product.family == ngen::ProductFamily::ARL
+                        || product.family == ngen::ProductFamily::MTL);
                 if (!dev_info->mayiuse_systolic()) max_wg_n = 2;
-                max_n_unroll = (problem.Ta_ext.bits() < 8)
+                max_n_unroll = (problem.Ta_ext.bits() < 8
+                                       && problem.Ta_ext.isInteger())
                         ? sg_size_ * problem.Ta_ext
                         : 16;
+                if (is_xelpg && problem.Ta_ext.bits() <= 8
+                        && problem.Ta_ext.isFP())
+                    min_n_unroll = sg_size_;
                 if (problem.Ta_ext.bits() <= 8) min_wg_n = 2;
-                break;
+            } break;
             case compute::gpu_arch_t::xe_hpc: max_n_unroll = 32; break;
             default:
                 m_unroll = sg_size_ / problem.Ta_ext;
@@ -254,7 +262,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
 
         reqs.push_back(StrategyRequirement::UnrollM == m_unroll);
         reqs.push_back(StrategyRequirement::UnrollN
-                == std::min(n_unroll, max_n_unroll));
+                == std::max(min_n_unroll, std::min(n_unroll, max_n_unroll)));
         reqs.push_back(StrategyRequirement::WGM == 2);
         reqs.push_back(StrategyRequirement::WGN
                 == utils::rnd_up_pow2(std::max(min_wg_n,


### PR DESCRIPTION
# Description

Fixes microkernel generation failures when both A and B inputs are dequantized using the slm. The current gemmstone implementation doesn't support this configuration when ka_load and kb_load are unequal. This PR updates the heuristic path so that ka_load and kb_load are the same in this situation.

Fixes: [MFDNN-15058](https://jira.devtools.intel.com/browse/MFDNN-15058) and [MFDNN-15153](https://jira.devtools.intel.com/browse/MFDNN-15153)

