### PR TITLE
gpu: intel: sdpa: fix fwd micro kernel miscompilation with split head sizes

### DIFF
--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -487,8 +487,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #else
         const global SCALE_DATA_T *scale_ptr,
 #endif
-        int d_qk, int d_v, int k, int q,
-        const global KEY_ATTR_SCALES_DATA_T *K_scales,
+        int d_qkv, int k, int q, const global KEY_ATTR_SCALES_DATA_T *K_scales,
         const global KEY_ATTR_ZP_DATA_T *K_zp,
         const global VAL_ATTR_SCALES_DATA_T *V_scales,
         const global VAL_ATTR_ZP_DATA_T *V_zp, const int attn_mask_type
@@ -517,6 +516,11 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 ) {
 
     uint sg_ij = sub_group_broadcast(get_local_id(1), 0);
+    /* d_qk and d_v are packed into a single scalar argument to work around a
+     * GPU compiler miscompilation triggered when they are passed as two
+     * separate kernel arguments. Each head size fits in 16 bits (max 1024). */
+    const int d_qk = d_qkv & 0xFFFF;
+    const int d_v = (d_qkv >> 16) & 0xFFFF;
     uint b1 = get_group_id(2);
 
     uint b0, b0_kv;

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -1669,8 +1669,7 @@ status_t micro_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     } else {
         arg_list.append(scale);
     }
-    arg_list.append((int)D_qk);
-    arg_list.append((int)D_v);
+    arg_list.append((int)((D_qk & 0xFFFF) | ((D_v & 0xFFFF) << 16)));
     arg_list.append((int)K);
     arg_list.append((int)Q);
     arg_list.append(key_scales);


### PR DESCRIPTION
## Description

The forward micro SDPA kernel passed the QK head size (`d_qk`) and the V head size (`d_v`) as **two separate scalar `int` kernel arguments** after the asymmetric-heads change. On some GPU/driver combinations (e.g. Xe-HPG / Arc A770, Flex 170) this triggers a **compiler (IGC) miscompilation**: the kernel receives the correct argument values but generates incorrect code, producing large numerical errors in the output (and a crash on Flex 170).


### Validation

On Intel Arc A770 (Xe-HPG), `test_internals_sdpa`: all 15 previously-failing `mask2D` + device-scale forward cases that were caused by the asymmetric-heads change now pass. (The transposed-key `abdc` variants are a separate pre-existing failure on this setup and are unaffected by this change.)

 ---Edit---
CI shows BMG segfualting, locally these segfaults weren't reproduced, I tried on fmmkl10330.fm.intel.com
Segfaults on PVC disappear mentioned in MFDNN-15360
NVL-P errors change tests that give out nan with this branch. However, it seems like another heisenbug where the errors disappear in 8 out of 9 failing cases using nan tile checks in this branch hsadia/ugemm_nan_check

Fixes MFDNN-15361, MFDNN-15360