### PR TITLE
GEMV IR: Support for Bias, Post-ops, Scales and Beta=1

### DIFF
--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -29,12 +29,14 @@
 #include <vector>
 
 #include "common/c_types_map.hpp"
+#include "common/memory_desc_wrapper.hpp"
 #include "common/nstl.hpp"
 #include "common/utils.hpp"
 #include "common/verbose.hpp"
 
 #include "cpu/x64/brgemm/brgemv_ir.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/ir/ir.hpp"
 #include "cpu/x64/ir/postops_injector.hpp"
@@ -378,8 +380,17 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             }
         }
 
-        if (cfg.with_injector_postops)
-            ir.inject_postops(acc, regs.advancing.y_ptr);
+        if (cfg.with_injector_postops) {
+            // Each accumulator is horizontally reduced to one scalar, so the
+            // injector sees a single active element with no mask register. Its
+            // output offset matches the store displacement below.
+            std::vector<dim_t> out_byte_off(m_block);
+            for (int r = 0; r < m_block; r++)
+                out_byte_off[r] = cfg.dt_sz_y * (dim_t)r * cfg.incy;
+
+            ir.inject_postops(acc, regs.advancing.y_ptr, out_byte_off,
+                    ir::vreg_t::none, /*elems=*/1);
+        }
 
         ir.label(skip_post_ops);
     }
@@ -469,13 +480,23 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         // callback below.
         std::unique_ptr<ir::postops_injector_t> postops_injector;
         ir::inject_postops_fn_t emit_injector;
+
         if (brg_.with_eltwise || brg_.with_binary) {
-            postops_injector.reset(new ir::postops_injector_t(this,
+            // A partial right-hand-side load reads the vector tail, or one
+            // element for a scalar accumulator.
+            const int postops_tail_elems
+                    = brg_.gemv_acc_is_vector() ? brg_.gemv_tail : 1;
+
+            postops_injector.reset(new ir::postops_injector_t(*this,
                     brg_.isa_impl, brg_.attr()->post_ops_, *brg_.dst_md(),
-                    abi_param1));
-            emit_injector
-                    = [&](const std::vector<int> &acc_phys, int /*base_phys*/) {
-                postops_injector->apply(acc_phys);
+                    abi_param1, GET_OFF(post_ops_binary_rhs_arg_vec),
+                    GET_OFF(data_C_ptr_), postops_tail_elems));
+
+            emit_injector = [&](const std::vector<int> &acc_phys, int base_phys,
+                                    const std::vector<dim_t> &out_byte_off,
+                                    int mask_phys, int elems) {
+                postops_injector->apply(
+                        acc_phys, base_phys, out_byte_off, mask_phys, elems);
             };
         }
 
@@ -545,8 +566,24 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     VCONDCHECK_BRGEMV_IR(
             !brg.transA, VERBOSE_UNSUPPORTED_FEATURE, "transposed A");
 
-    VCONDCHECK_BRGEMV_IR(
-            !brg.with_binary && !brg.with_sum, VERBOSE_UNSUPPORTED_POSTOP);
+    // Post-ops go through the JIT injector. Accept only eltwise and binary, and
+    // only binary arguments the injector can handle on this ISA. Sum and other
+    // kinds fall back.
+    if (brg.attr()) {
+        const memory_desc_wrapper dst_d(brg.dst_md());
+        const std::vector<injector::post_op_type> accepted
+                = {injector::eltwise, injector::binary};
+        VCONDCHECK_BRGEMV_IR(
+                injector::post_ops_ok({brg.isa_impl, accepted,
+                        brg.attr()->post_ops_, &dst_d,
+                        /*sum_at_pos_0_only=*/false,
+                        /*sum_requires_scale_one=*/false,
+                        /*sum_requires_zp_zero=*/false,
+                        /*sum_requires_same_params=*/false,
+                        binary_injector::
+                                get_all_strategies_supported_by_injector()}),
+                VERBOSE_UNSUPPORTED_POSTOP);
+    }
     VCONDCHECK_BRGEMV_IR(!brg.with_src_scales && !brg.with_wei_scales
                     && !brg.with_dst_scales,
             VERBOSE_UNSUPPORTED_SCALES_CFG);

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -71,6 +71,12 @@ namespace {
 //   k_tail       - remaining K elements after the full blocks
 //   mblk_*_off   - byte offset to advance A/y pointers between M blocks
 //   kblk_*_off   - byte offset to advance A/x pointers between K blocks
+//   with_bias    - whether a bias is added to the output
+//   treat_y_as_row - whether the output y is a row. When true the bias is
+//                    indexed per M row, otherwise broadcast from bias[0]
+//   dt_bias      - element data type of the bias
+//   dt_sz_bias   - element size in bytes of the bias
+//   mblk_bias_off - byte offset to advance the bias pointer between M blocks
 struct brgemv_ir_conf_t {
     brgemv_ir_conf_t(const brgemm_desc_t &brg)
         : m(brg.bcast_dim)
@@ -95,7 +101,12 @@ struct brgemv_ir_conf_t {
         , mblk_a_off(dt_sz_a * m_block * lda)
         , mblk_y_off(dt_sz_y * m_block * incy)
         , kblk_a_off(dt_sz_a * k_block)
-        , kblk_x_off(dt_sz_x * k_block) {}
+        , kblk_x_off(dt_sz_x * k_block)
+        , with_bias(brg.with_bias)
+        , treat_y_as_row(brg.treat_y_as_row)
+        , dt_bias(brg.dt_bias)
+        , dt_sz_bias(brg.typesize_bias)
+        , mblk_bias_off(dt_sz_bias * m_block) {}
 
     const dim_t m, k, lda, incy;
     const int max_bs;
@@ -106,6 +117,10 @@ struct brgemv_ir_conf_t {
     const dim_t m_blocks, m_tail, k_blocks, k_tail;
     const dim_t mblk_a_off, mblk_y_off;
     const dim_t kblk_a_off, kblk_x_off;
+    const bool with_bias, treat_y_as_row;
+    const data_type_t dt_bias;
+    const int dt_sz_bias;
+    const dim_t mblk_bias_off;
 };
 
 // M-loop input register classification
@@ -128,6 +143,10 @@ struct advancing_regs_t {
     // Byte offset into A for the current M-block. Starts at 0 and advances by
     // `mblk_a_off` each iteration.
     ir::vreg_t a_off = ir::vreg_t::none;
+    // Bias base pointer. Advances by `mblk_bias_off` per M-block when
+    // `treat_y_as_row` is set, otherwise stays at the first element. `none`
+    // unless `with_bias`.
+    ir::vreg_t bias_ptr = ir::vreg_t::none;
 };
 
 // Registers that remain constant for the entire M-loop.
@@ -139,6 +158,10 @@ struct invariant_regs_t {
     // K-tail mask, shared by every masked tail load. It's only required when
     // `k_tail` is greater than 1.
     ir::vreg_t k_tail_mask = ir::vreg_t::none;
+    // Post-ops flag (params.do_post_ops). Non-zero applies the post-ops, zero
+    // stores the raw accumulator. `none` unless the kernel has a post-op to
+    // apply (currently bias).
+    ir::vreg_t do_post_ops = ir::vreg_t::none;
 };
 
 // Complete input register set for the M-loop, partitioned by whether values
@@ -178,6 +201,14 @@ m_loop_input_regs_t init_m_loop_input_regs(
         // managed automatically by the allocator.
         regs.invariant.k_tail_mask = ir.new_mask();
         ir.set_mask_imm(regs.invariant.k_tail_mask, (int)cfg.k_tail);
+    }
+
+    if (cfg.with_bias) {
+        regs.advancing.bias_ptr = ir.new_gpr();
+        ir.load_param(regs.advancing.bias_ptr, GET_OFF(ptr_bias));
+
+        regs.invariant.do_post_ops = ir.new_gpr();
+        ir.load_param(regs.invariant.do_post_ops, GET_OFF(do_post_ops));
     }
 
     return regs;
@@ -310,6 +341,27 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     for (int r = 0; r < m_block; r++)
         ir.vhreduce(acc[r], ws);
 
+    if (cfg.with_bias) {
+        const ir::label_t skip_bias = ir.new_label();
+        ir.jz(regs.invariant.do_post_ops, skip_bias);
+
+        // The broadcast bias is loop invariant, so load it once outside the
+        // loop. A row output loads a separate bias per output element.
+        const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
+        if (!cfg.treat_y_as_row)
+            ir.vload_masked(
+                    bias, regs.advancing.bias_ptr, 0, ir::vreg_t::none, 1);
+
+        for (int r = 0; r < m_block; r++) {
+            if (cfg.treat_y_as_row)
+                ir.vload_masked(bias, regs.advancing.bias_ptr,
+                        cfg.dt_sz_bias * (dim_t)r, ir::vreg_t::none, 1);
+            ir.vadd(acc[r], bias);
+        }
+
+        ir.label(skip_bias);
+    }
+
     for (int r = 0; r < m_block; r++)
         ir.vstore_masked(regs.advancing.y_ptr,
                 cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], ir::vreg_t::none, 1);
@@ -317,6 +369,9 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     // Advance to next M block
     ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);
     ir.add_imm(regs.advancing.y_ptr, cfg.mblk_y_off);
+
+    if (cfg.with_bias && cfg.treat_y_as_row)
+        ir.add_imm(regs.advancing.bias_ptr, cfg.mblk_bias_off);
 }
 
 // Builds IR for GEMV with a non-transposed A matrix.
@@ -447,8 +502,18 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     VCONDCHECK_BRGEMV_IR(
             !brg.transA, VERBOSE_UNSUPPORTED_FEATURE, "transposed A");
 
+    VCONDCHECK_BRGEMV_IR(!brg.with_eltwise && !brg.with_binary && !brg.with_sum,
+            VERBOSE_UNSUPPORTED_POSTOP);
+    VCONDCHECK_BRGEMV_IR(!brg.with_src_scales && !brg.with_wei_scales
+                    && !brg.with_dst_scales,
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VCONDCHECK_BRGEMV_IR(!brg.req_s8s8_compensation,
+            VERBOSE_UNSUPPORTED_FEATURE, "s8s8 compensation");
+    VCONDCHECK_BRGEMV_IR(utils::everyone_is(brgemm_broadcast_t::none,
+                                 brg.zp_type_a, brg.zp_type_b, brg.zp_type_c),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
     VCONDCHECK_BRGEMV_IR(
-            !brg.are_post_ops_applicable(), VERBOSE_UNSUPPORTED_POSTOP);
+            !brg.with_bias || brg.dt_bias == f32, VERBOSE_UNSUPPORTED_BIAS_CFG);
     VCONDCHECK_BRGEMV_IR(
             brg.alpha == 1.0f, VERBOSE_UNSUPPORTED_FEATURE, "alpha != 1");
     VCONDCHECK_BRGEMV_IR(brg.beta == 0.0f || brg.beta == 1.0f,

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -25,6 +25,7 @@
 // current requirements.
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "common/c_types_map.hpp"
@@ -36,6 +37,7 @@
 #include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/ir/ir.hpp"
+#include "cpu/x64/ir/postops_injector.hpp"
 #include "cpu/x64/ir/reg_alloc.hpp"
 #include "cpu/x64/jit_generator.hpp"
 
@@ -77,6 +79,8 @@ namespace {
 //   dt_bias      - element data type of the bias
 //   dt_sz_bias   - element size in bytes of the bias
 //   mblk_bias_off - byte offset to advance the bias pointer between M blocks
+//   with_injector_postops - whether attribute post-ops (eltwise/binary) are
+//                    requested
 struct brgemv_ir_conf_t {
     brgemv_ir_conf_t(const brgemm_desc_t &brg)
         : m(brg.bcast_dim)
@@ -106,7 +110,8 @@ struct brgemv_ir_conf_t {
         , treat_y_as_row(brg.treat_y_as_row)
         , dt_bias(brg.dt_bias)
         , dt_sz_bias(brg.typesize_bias)
-        , mblk_bias_off(dt_sz_bias * m_block) {}
+        , mblk_bias_off(dt_sz_bias * m_block)
+        , with_injector_postops(brg.with_eltwise || brg.with_binary) {}
 
     const dim_t m, k, lda, incy;
     const int max_bs;
@@ -121,6 +126,9 @@ struct brgemv_ir_conf_t {
     const data_type_t dt_bias;
     const int dt_sz_bias;
     const dim_t mblk_bias_off;
+    const bool with_injector_postops;
+
+    bool has_post_ops() const { return with_bias || with_injector_postops; }
 };
 
 // M-loop input register classification
@@ -160,7 +168,7 @@ struct invariant_regs_t {
     ir::vreg_t k_tail_mask = ir::vreg_t::none;
     // Post-ops flag (params.do_post_ops). Non-zero applies the post-ops, zero
     // stores the raw accumulator. `none` unless the kernel has a post-op to
-    // apply (currently bias).
+    // apply (bias or injector post-ops).
     ir::vreg_t do_post_ops = ir::vreg_t::none;
 };
 
@@ -206,7 +214,9 @@ m_loop_input_regs_t init_m_loop_input_regs(
     if (cfg.with_bias) {
         regs.advancing.bias_ptr = ir.new_gpr();
         ir.load_param(regs.advancing.bias_ptr, GET_OFF(ptr_bias));
+    }
 
+    if (cfg.has_post_ops()) {
         regs.invariant.do_post_ops = ir.new_gpr();
         ir.load_param(regs.invariant.do_post_ops, GET_OFF(do_post_ops));
     }
@@ -341,25 +351,37 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     for (int r = 0; r < m_block; r++)
         ir.vhreduce(acc[r], ws);
 
-    if (cfg.with_bias) {
-        const ir::label_t skip_bias = ir.new_label();
-        ir.jz(regs.invariant.do_post_ops, skip_bias);
+    if (cfg.has_post_ops()) {
+        // The implemented order conforms to oneDNN's defined semantics for
+        // applying scales, bias and post-ops:
+        //   src scale -> weights scale -> bias -> post-ops.
+        // Scales apply to the accumulated result before the bias add and
+        // post-ops apply after bias. The two scales can swap because both are
+        // multiplies but a scale must not move past the bias and the bias must
+        // not move past the post-ops.
+        const ir::label_t skip_post_ops = ir.new_label();
+        ir.jz(regs.invariant.do_post_ops, skip_post_ops);
 
-        // The broadcast bias is loop invariant, so load it once outside the
-        // loop. A row output loads a separate bias per output element.
-        const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
-        if (!cfg.treat_y_as_row)
-            ir.vload_masked(
-                    bias, regs.advancing.bias_ptr, 0, ir::vreg_t::none, 1);
+        if (cfg.with_bias) {
+            // The broadcast bias is loop invariant, so load it once outside the
+            // loop. A row output loads a separate bias per output element.
+            const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
+            if (!cfg.treat_y_as_row)
+                ir.vload_masked(
+                        bias, regs.advancing.bias_ptr, 0, ir::vreg_t::none, 1);
 
-        for (int r = 0; r < m_block; r++) {
-            if (cfg.treat_y_as_row)
-                ir.vload_masked(bias, regs.advancing.bias_ptr,
-                        cfg.dt_sz_bias * (dim_t)r, ir::vreg_t::none, 1);
-            ir.vadd(acc[r], bias);
+            for (int r = 0; r < m_block; r++) {
+                if (cfg.treat_y_as_row)
+                    ir.vload_masked(bias, regs.advancing.bias_ptr,
+                            cfg.dt_sz_bias * (dim_t)r, ir::vreg_t::none, 1);
+                ir.vadd(acc[r], bias);
+            }
         }
 
-        ir.label(skip_bias);
+        if (cfg.with_injector_postops)
+            ir.inject_postops(acc, regs.advancing.y_ptr);
+
+        ir.label(skip_post_ops);
     }
 
     for (int r = 0; r < m_block; r++)
@@ -440,6 +462,23 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         // Register allocation
         ir::reg_alloc_result_t alloc = allocate_registers(ir, reg_cfg.pools);
 
+        // The injector is created here, not in the emitter, because it spans
+        // the whole codegen flow (emits during `emit()`, writes its table after
+        // the postamble) and needs descriptor inputs the generic emitter lacks.
+        // The emitter drives it through the `inject_postops` operation and the
+        // callback below.
+        std::unique_ptr<ir::postops_injector_t> postops_injector;
+        ir::inject_postops_fn_t emit_injector;
+        if (brg_.with_eltwise || brg_.with_binary) {
+            postops_injector.reset(new ir::postops_injector_t(this,
+                    brg_.isa_impl, brg_.attr()->post_ops_, *brg_.dst_md(),
+                    abi_param1));
+            emit_injector
+                    = [&](const std::vector<int> &acc_phys, int /*base_phys*/) {
+                postops_injector->apply(acc_phys);
+            };
+        }
+
         preamble();
 
         // Stack frame setup
@@ -450,7 +489,7 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         // The emitter may accumulate static data (e.g. the mask table) that we
         // need to write down after the postamble.
         ir::data_section_t data;
-        ir::emit(*this, ir, alloc, reg_cfg, data);
+        ir::emit(*this, ir, alloc, reg_cfg, data, emit_injector);
 
         // Stack cleanup
         if (alloc.frame_bytes > 0) add(rsp, (uint32_t)alloc.frame_bytes);
@@ -459,6 +498,10 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
 
         // Emit any static data the emitter accumulated.
         ir::emit_data_section(*this, data);
+
+        // Emit the injector's constant table (a no-op unless the chain has
+        // eltwise).
+        if (postops_injector) postops_injector->maybe_prepare_table();
     }
 
 private:
@@ -502,8 +545,8 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     VCONDCHECK_BRGEMV_IR(
             !brg.transA, VERBOSE_UNSUPPORTED_FEATURE, "transposed A");
 
-    VCONDCHECK_BRGEMV_IR(!brg.with_eltwise && !brg.with_binary && !brg.with_sum,
-            VERBOSE_UNSUPPORTED_POSTOP);
+    VCONDCHECK_BRGEMV_IR(
+            !brg.with_binary && !brg.with_sum, VERBOSE_UNSUPPORTED_POSTOP);
     VCONDCHECK_BRGEMV_IR(!brg.with_src_scales && !brg.with_wei_scales
                     && !brg.with_dst_scales,
             VERBOSE_UNSUPPORTED_SCALES_CFG);

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -64,6 +64,7 @@ namespace {
 //   dt_a/x/y     - element data type of A, x, and y. Tags the vec vregs so the
 //                  emitter lowers each op to its dtype-specific instruction.
 //   dt_acc       - accumulation data type
+//   beta         - output scaling: 0 overwrites y, 1 accumulates into y
 //   m_blocks     - number of full M blocks
 //   m_tail       - remaining M rows after the full blocks
 //   k_blocks     - number of full K blocks
@@ -86,6 +87,7 @@ struct brgemv_ir_conf_t {
         , dt_x(brg.dt_b)
         , dt_y(brg.dt_c)
         , dt_acc(data_type::f32)
+        , beta(brg.beta)
         , m_blocks(m / m_block)
         , m_tail(m % m_block)
         , k_blocks(k / k_block)
@@ -100,6 +102,7 @@ struct brgemv_ir_conf_t {
     const int m_block, k_block;
     const int dt_sz_a, dt_sz_x, dt_sz_y;
     const data_type_t dt_a, dt_x, dt_y, dt_acc;
+    const float beta;
     const dim_t m_blocks, m_tail, k_blocks, k_tail;
     const dim_t mblk_a_off, mblk_y_off;
     const dim_t kblk_a_off, kblk_x_off;
@@ -275,7 +278,15 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     std::vector<ir::vreg_t> acc(m_block, ir::vreg_t::none);
     for (int r = 0; r < m_block; r++) {
         acc[r] = ir.new_vec(cfg.dt_acc);
-        ir.vzero(acc[r]);
+
+        // The current implementation supports only 0 and 1 for beta so for the
+        // case where beta = 1 we load `y` into the accumulator registers and
+        // then the microkernel adds the results of the multiplication to them.
+        if (cfg.beta == 0.0f)
+            ir.vzero(acc[r]);
+        else
+            ir.vload_masked(acc[r], regs.advancing.y_ptr,
+                    cfg.dt_sz_y * (dim_t)r * cfg.incy, ir::vreg_t::none, 1);
     }
 
     // Batch reduction over bs dimension
@@ -440,8 +451,8 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
             !brg.are_post_ops_applicable(), VERBOSE_UNSUPPORTED_POSTOP);
     VCONDCHECK_BRGEMV_IR(
             brg.alpha == 1.0f, VERBOSE_UNSUPPORTED_FEATURE, "alpha != 1");
-    VCONDCHECK_BRGEMV_IR(
-            brg.beta == 0.0f, VERBOSE_UNSUPPORTED_FEATURE, "beta != 0");
+    VCONDCHECK_BRGEMV_IR(brg.beta == 0.0f || brg.beta == 1.0f,
+            VERBOSE_UNSUPPORTED_FEATURE, "beta != 0 && beta != 1");
 
     VCONDCHECK_BRGEMV_IR(
             !brg.is_runtime_lda, VERBOSE_UNSUPPORTED_FEATURE, "runtime lda");

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -31,6 +31,7 @@
 #include "common/c_types_map.hpp"
 #include "common/memory_desc_wrapper.hpp"
 #include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 #include "common/verbose.hpp"
 
@@ -83,6 +84,16 @@ namespace {
 //   mblk_bias_off - byte offset to advance the bias pointer between M blocks
 //   with_injector_postops - whether attribute post-ops (eltwise/binary) are
 //                    requested
+//   with_src_scales - whether a source scale multiplies the output. Always a
+//                    single common scalar for this kernel
+//   with_wei_scales - whether a weights scale multiplies the output
+//   single_wei_scale - whether the weights scale is one scalar for the whole
+//                    output. False only for per-N scales with a row output,
+//                    where each output element has its own scale
+//   dt_src_scales / dt_wei_scales - element data type of each scale
+//   dt_sz_wei_scales - element size in bytes of the weights scale
+//   mblk_wei_scale_off - byte offset to advance the weights-scale pointer
+//                    between M blocks
 struct brgemv_ir_conf_t {
     brgemv_ir_conf_t(const brgemm_desc_t &brg)
         : m(brg.bcast_dim)
@@ -113,7 +124,16 @@ struct brgemv_ir_conf_t {
         , dt_bias(brg.dt_bias)
         , dt_sz_bias(brg.typesize_bias)
         , mblk_bias_off(dt_sz_bias * m_block)
-        , with_injector_postops(brg.with_eltwise || brg.with_binary) {}
+        , with_injector_postops(brg.with_eltwise || brg.with_binary)
+        , with_src_scales(brg.with_src_scales)
+        , with_wei_scales(brg.with_wei_scales)
+        , single_wei_scale(brg.gemv_single_wei_scale())
+        , dt_src_scales(brg.dt_src_scales)
+        , dt_wei_scales(brg.dt_wei_scales)
+        , dt_sz_wei_scales(with_wei_scales
+                          ? (int)types::data_type_size(dt_wei_scales)
+                          : 0)
+        , mblk_wei_scale_off(dt_sz_wei_scales * m_block) {}
 
     const dim_t m, k, lda, incy;
     const int max_bs;
@@ -129,8 +149,15 @@ struct brgemv_ir_conf_t {
     const int dt_sz_bias;
     const dim_t mblk_bias_off;
     const bool with_injector_postops;
+    const bool with_src_scales, with_wei_scales, single_wei_scale;
+    const data_type_t dt_src_scales, dt_wei_scales;
+    const int dt_sz_wei_scales;
+    const dim_t mblk_wei_scale_off;
 
-    bool has_post_ops() const { return with_bias || with_injector_postops; }
+    bool has_post_ops() const {
+        return with_bias || with_injector_postops || with_src_scales
+                || with_wei_scales;
+    }
 };
 
 // M-loop input register classification
@@ -157,6 +184,10 @@ struct advancing_regs_t {
     // `treat_y_as_row` is set, otherwise stays at the first element. `none`
     // unless `with_bias`.
     ir::vreg_t bias_ptr = ir::vreg_t::none;
+    // Weights-scale base pointer. Advances by `mblk_wei_scale_off` per M-block
+    // for per-N scales, otherwise stays at the first element. `none` unless
+    // `with_wei_scales`.
+    ir::vreg_t wei_scale_ptr = ir::vreg_t::none;
 };
 
 // Registers that remain constant for the entire M-loop.
@@ -170,8 +201,11 @@ struct invariant_regs_t {
     ir::vreg_t k_tail_mask = ir::vreg_t::none;
     // Post-ops flag (params.do_post_ops). Non-zero applies the post-ops, zero
     // stores the raw accumulator. `none` unless the kernel has a post-op to
-    // apply (bias or injector post-ops).
+    // apply (bias, scales, or injector post-ops).
     ir::vreg_t do_post_ops = ir::vreg_t::none;
+    // Source-scale pointer. A single common scalar, so it never advances.
+    // `none` unless `with_src_scales`.
+    ir::vreg_t src_scale_ptr = ir::vreg_t::none;
 };
 
 // Complete input register set for the M-loop, partitioned by whether values
@@ -216,6 +250,16 @@ m_loop_input_regs_t init_m_loop_input_regs(
     if (cfg.with_bias) {
         regs.advancing.bias_ptr = ir.new_gpr();
         ir.load_param(regs.advancing.bias_ptr, GET_OFF(ptr_bias));
+    }
+
+    if (cfg.with_src_scales) {
+        regs.invariant.src_scale_ptr = ir.new_gpr();
+        ir.load_param(regs.invariant.src_scale_ptr, GET_OFF(ptr_src_scales));
+    }
+
+    if (cfg.with_wei_scales) {
+        regs.advancing.wei_scale_ptr = ir.new_gpr();
+        ir.load_param(regs.advancing.wei_scale_ptr, GET_OFF(ptr_wei_scales));
     }
 
     if (cfg.has_post_ops()) {
@@ -364,6 +408,33 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         const ir::label_t skip_post_ops = ir.new_label();
         ir.jz(regs.invariant.do_post_ops, skip_post_ops);
 
+        if (cfg.with_src_scales) {
+            // Loaded once and applied to every output.
+            const ir::vreg_t sc = ir.new_vec(cfg.dt_src_scales);
+            ir.vload_masked(
+                    sc, regs.invariant.src_scale_ptr, 0, ir::vreg_t::none, 1);
+
+            for (int r = 0; r < m_block; r++)
+                ir.vmul(acc[r], sc);
+        }
+
+        if (cfg.with_wei_scales) {
+            // The single scale is loop invariant, so load it once above the
+            // loop. The per-N case loads a separate scale per output element.
+            const ir::vreg_t sc = ir.new_vec(cfg.dt_wei_scales);
+            if (cfg.single_wei_scale)
+                ir.vload_masked(sc, regs.advancing.wei_scale_ptr, 0,
+                        ir::vreg_t::none, 1);
+
+            for (int r = 0; r < m_block; r++) {
+                if (!cfg.single_wei_scale)
+                    ir.vload_masked(sc, regs.advancing.wei_scale_ptr,
+                            cfg.dt_sz_wei_scales * (dim_t)r, ir::vreg_t::none,
+                            1);
+                ir.vmul(acc[r], sc);
+            }
+        }
+
         if (cfg.with_bias) {
             // The broadcast bias is loop invariant, so load it once outside the
             // loop. A row output loads a separate bias per output element.
@@ -405,6 +476,8 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
 
     if (cfg.with_bias && cfg.treat_y_as_row)
         ir.add_imm(regs.advancing.bias_ptr, cfg.mblk_bias_off);
+    if (cfg.with_wei_scales && !cfg.single_wei_scale)
+        ir.add_imm(regs.advancing.wei_scale_ptr, cfg.mblk_wei_scale_off);
 }
 
 // Builds IR for GEMV with a non-transposed A matrix.
@@ -584,8 +657,14 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
                                 get_all_strategies_supported_by_injector()}),
                 VERBOSE_UNSUPPORTED_POSTOP);
     }
-    VCONDCHECK_BRGEMV_IR(!brg.with_src_scales && !brg.with_wei_scales
-                    && !brg.with_dst_scales,
+    VCONDCHECK_BRGEMV_IR(!brg.with_dst_scales, VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VCONDCHECK_BRGEMV_IR(!brg.is_per_k_src_scales && !brg.is_per_k_wei_scales,
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VCONDCHECK_BRGEMV_IR(
+            IMPLICATION(brg.with_src_scales, brg.dt_src_scales == f32),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VCONDCHECK_BRGEMV_IR(
+            IMPLICATION(brg.with_wei_scales, brg.dt_wei_scales == f32),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
     VCONDCHECK_BRGEMV_IR(!brg.req_s8s8_compensation,
             VERBOSE_UNSUPPORTED_FEATURE, "s8s8 compensation");

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -136,6 +136,8 @@ today. A shared runner for the fixed part is a follow-up.
   allocated IR, dispatches by ISA family, and manages the static-data section.
 * `emitter/backend_avx2.hpp`: the AVX2-family backend, the reference example of
   per-operation instruction selection.
+* `postops_injector.hpp`, `postops_injector.cpp`: the driver for the JIT post-ops
+  injector, which lowers the `inject_postops` operation.
 
 The kernel-specific builders live outside this directory. For example,
 `src/cpu/x64/brgemm/brgemv_ir.{hpp,cpp}` holds the GEMV builder and shows how

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -80,10 +80,12 @@ step. They are omitted above for clarity.
   bytes and an unresolved label. After the postamble, the bytes are written and
   the labels are bound.
 * **Post-ops injector.** The existing Xbyak post-ops injector is reused unchanged,
-  plugged in as a single `inject_postops` operation. Its variable-length argument
-  list is stored in a side table indexed from the operation's immediate field, so
-  the IR core carries only virtual-register ids. The injector saves and restores
-  its own registers and does not participate in IR allocation.
+  plugged in as a single `inject_postops` operation. Its variable-length arguments
+  live in a side table indexed from the operation's immediate field, so the
+  operation itself carries only that index. For binary post-ops the table also
+  holds each accumulator's output offset and active-element count, which the
+  injector needs to address its right-hand-side argument. The injector saves and
+  restores its own registers and does not participate in IR allocation.
 
 ### Control and Data Flow
 

--- a/src/cpu/x64/ir/emitter/backend_avx2.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx2.hpp
@@ -70,6 +70,12 @@ struct avx2_backend_t {
         else { JIT_ASSERT(!"vadd: dtype not implemented"); }
     }
 
+    void vmul(int d, int s, data_type_t dt) { // dst *= s0
+        if (dt == data_type::f32)
+            gen().vmulps(Xbyak::Ymm(d), Xbyak::Ymm(d), Xbyak::Ymm(s));
+        else { JIT_ASSERT(!"vmul: dtype not implemented"); }
+    }
+
     // dst += a * b. The multiplicand dtype `src_dt` selects the instruction.
     // f32 inputs use `vfmadd231ps`. The accumulator (dst) is always f32.
     void vdot(int d, int a, int b, data_type_t src_dt) {

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -30,7 +30,8 @@ namespace ir {
 
 template <typename backend_t>
 void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
-        const reg_config_t &rc, data_section_t &data) {
+        const reg_config_t &rc, data_section_t &data,
+        const inject_postops_fn_t &inject) {
 
     // The backend holds the generator.
     jit_generator_t &gen = be.gen();
@@ -221,6 +222,29 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 break;
             }
 
+            // Lowers to the external JIT injector via the builder-provided
+            // callback. The injector does not participate in register
+            // allocation, so it is outside the allocation model. Reloading a
+            // spilled operand into a scratch register might work but is not
+            // guaranteed, so the operands must be in their allocated registers
+            // (asserted below).
+            case op_kind_t::inject_postops: {
+                const auto &args = ir.inject_postops_args()[(int)op.imm];
+                std::vector<int> acc_phys;
+                acc_phys.reserve(args.acc.size());
+                for (vreg_t v : args.acc) {
+                    JIT_ASSERT(!spilled(v)
+                            && "inject_postops: accumulator spilled");
+                    acc_phys.push_back(phys(v));
+                }
+                JIT_ASSERT(!spilled(args.base_ptr)
+                        && "inject_postops: base pointer spilled");
+                JIT_ASSERT(
+                        inject && "inject_postops: missing injector callback");
+                inject(acc_phys, phys(args.base_ptr));
+                break;
+            }
+
             // Mask ops. Emitting the instruction is the backend's job.
             // Spilling is not supported for mask vreg for now so we assert
             // `no spills`.
@@ -307,13 +331,14 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
 }
 
 void emit(jit_generator_t &gen, const ir_t &ir, const reg_alloc_result_t &alloc,
-        const reg_config_t &reg_cfg, data_section_t &data) {
+        const reg_config_t &reg_cfg, data_section_t &data,
+        const inject_postops_fn_t &inject) {
     const cpu_isa_t isa = gen.max_cpu_isa();
     if (is_superset(isa, avx512_core)) {
         JIT_ASSERT(!"avx512 emitter is not supported");
     } else {
         avx2_backend_t be(gen, isa);
-        emit(be, ir, alloc, reg_cfg, data);
+        emit(be, ir, alloc, reg_cfg, data, inject);
     }
 }
 

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -204,6 +204,14 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
+            case op_kind_t::vadd: { // rmw: reads and writes dst
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                if (spilled(op.dst)) spill_reload(op.dst, d);
+                int s = vec_use(op.s0, vec_scratch1);
+                be.vadd(d, s, dt_of(op.dst));
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
             case op_kind_t::vhreduce: { // reads and writes dst
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
                 if (spilled(op.dst)) spill_reload(op.dst, d);

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -239,9 +239,14 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 }
                 JIT_ASSERT(!spilled(args.base_ptr)
                         && "inject_postops: base pointer spilled");
+                const bool has_mask = args.mask != vreg_t::none;
+                JIT_ASSERT(!(has_mask && spilled(args.mask))
+                        && "inject_postops: mask spilled");
                 JIT_ASSERT(
                         inject && "inject_postops: missing injector callback");
-                inject(acc_phys, phys(args.base_ptr));
+                const int mask_phys = has_mask ? phys(args.mask) : -1;
+                inject(acc_phys, phys(args.base_ptr), args.out_byte_off,
+                        mask_phys, args.elems);
                 break;
             }
 

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -213,6 +213,14 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
+            case op_kind_t::vmul: { // rmw: reads and writes dst
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                if (spilled(op.dst)) spill_reload(op.dst, d);
+                int s = vec_use(op.s0, vec_scratch1);
+                be.vmul(d, s, dt_of(op.dst));
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
             case op_kind_t::vhreduce: { // reads and writes dst
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
                 if (spilled(op.dst)) spill_reload(op.dst, d);

--- a/src/cpu/x64/ir/emitter/emitter.hpp
+++ b/src/cpu/x64/ir/emitter/emitter.hpp
@@ -73,11 +73,17 @@ struct data_section_t {
 // It is the interoperability layer between the IR and the non-IR injector. When
 // the IR has no `inject_postops` op it is unused and may be left empty.
 //
-//   acc_phys  - physical vec register indices of the accumulators, in the order
-//               passed to `ir_t::inject_postops()`
-//   base_phys - physical gpr index of the base (output) pointer
-using inject_postops_fn_t
-        = std::function<void(const std::vector<int> &acc_phys, int base_phys)>;
+//   acc_phys     - physical vec register indices of the accumulators, in the
+//                  order passed to `ir_t::inject_postops()`
+//   base_phys    - physical gpr index of the base (output) pointer
+//   out_byte_off - output byte offset of each accumulator from the base pointer,
+//                  parallel to `acc_phys`
+//   mask_phys    - physical register index of the active-element mask, or `-1`
+//                  when there is none
+//   elems        - active element count per accumulator, `-1` for a full vector
+using inject_postops_fn_t = std::function<void(const std::vector<int> &acc_phys,
+        int base_phys, const std::vector<dim_t> &out_byte_off, int mask_phys,
+        int elems)>;
 
 // Export for testing.
 void DNNL_API emit(jit_generator_t &gen, const ir_t &ir,

--- a/src/cpu/x64/ir/emitter/emitter.hpp
+++ b/src/cpu/x64/ir/emitter/emitter.hpp
@@ -21,6 +21,7 @@
 // using a `jit_generator`.
 
 #include <deque>
+#include <functional>
 #include <utility>
 #include <vector>
 
@@ -68,10 +69,20 @@ struct data_section_t {
 // This is the main entry point for the emitter. It dispatches by ISA family to
 // the matching backend.
 //
+// `inject` lowers the `inject_postops` operation to the JIT post-ops injector.
+// It is the interoperability layer between the IR and the non-IR injector. When
+// the IR has no `inject_postops` op it is unused and may be left empty.
+//
+//   acc_phys  - physical vec register indices of the accumulators, in the order
+//               passed to `ir_t::inject_postops()`
+//   base_phys - physical gpr index of the base (output) pointer
+using inject_postops_fn_t
+        = std::function<void(const std::vector<int> &acc_phys, int base_phys)>;
+
 // Export for testing.
 void DNNL_API emit(jit_generator_t &gen, const ir_t &ir,
         const reg_alloc_result_t &alloc, const reg_config_t &reg_cfg,
-        data_section_t &data);
+        data_section_t &data, const inject_postops_fn_t &inject = {});
 
 // Emit the accumulated static data after the kernel's postamble. It aligns,
 // binds each label and then write the data bytes with `db`.

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -164,6 +164,18 @@ void ir_t::prefetch(vreg_t base, dim_t disp) {
     ops_.push_back(op);
 }
 
+void ir_t::inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr) {
+    inject_postops_args_t args;
+    args.acc = acc;
+    args.base_ptr = base_ptr;
+    inject_postops_args_.push_back(args);
+
+    op_t op;
+    op.kind = op_kind_t::inject_postops;
+    op.imm = (dim_t)inject_postops_args_.size() - 1;
+    ops_.push_back(op);
+}
+
 int ir_t::loop_begin_imm(vreg_t counter, dim_t count) {
     op_t op;
     op.kind = op_kind_t::loop_begin;
@@ -279,6 +291,19 @@ void ir_t::def_use(
             d(op.dst);
             d(op.s0);
             break;
+        case op_kind_t::inject_postops: {
+            // The injector transforms the accumulators in place (read and
+            // written) and reads the base pointer. Report them so liveness is
+            // correct across the op. Operands live in the side table, not in
+            // `op_t`.
+            const auto &args = inject_postops_args_[(int)op.imm];
+            for (vreg_t v : args.acc) {
+                u(v);
+                d(v);
+            }
+            u(args.base_ptr);
+            break;
+        }
         case op_kind_t::set_mask_imm: d(op.dst); break;
         case op_kind_t::vload_masked:
             u(op.mem.base);

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -114,6 +114,14 @@ void ir_t::vadd(vreg_t dst, vreg_t src) {
     ops_.push_back(op);
 }
 
+void ir_t::vmul(vreg_t dst, vreg_t src) {
+    op_t op;
+    op.kind = op_kind_t::vmul;
+    op.dst = dst;
+    op.s0 = src;
+    ops_.push_back(op);
+}
+
 void ir_t::vhreduce(vreg_t dst, vreg_t workspace) {
     op_t op;
     op.kind = op_kind_t::vhreduce;
@@ -285,6 +293,7 @@ void ir_t::def_use(
             d(op.dst);
             break;
         case op_kind_t::vadd: // read-modify-write
+        case op_kind_t::vmul: // read-modify-write
             u(op.dst);
             u(op.s0);
             d(op.dst);

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -106,6 +106,14 @@ void ir_t::vdot(vreg_t dst, vreg_t a, vreg_t b) {
     ops_.push_back(op);
 }
 
+void ir_t::vadd(vreg_t dst, vreg_t src) {
+    op_t op;
+    op.kind = op_kind_t::vadd;
+    op.dst = dst;
+    op.s0 = src;
+    ops_.push_back(op);
+}
+
 void ir_t::vhreduce(vreg_t dst, vreg_t workspace) {
     op_t op;
     op.kind = op_kind_t::vhreduce;
@@ -258,6 +266,11 @@ void ir_t::def_use(
             u(op.dst);
             u(op.s0);
             u(op.s1);
+            d(op.dst);
+            break;
+        case op_kind_t::vadd: // read-modify-write
+            u(op.dst);
+            u(op.s0);
             d(op.dst);
             break;
         case op_kind_t::vhreduce: // dst and workspace are both read and written

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -164,10 +164,14 @@ void ir_t::prefetch(vreg_t base, dim_t disp) {
     ops_.push_back(op);
 }
 
-void ir_t::inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr) {
+void ir_t::inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr,
+        const std::vector<dim_t> &out_byte_off, vreg_t mask, int elems) {
     inject_postops_args_t args;
     args.acc = acc;
     args.base_ptr = base_ptr;
+    args.out_byte_off = out_byte_off;
+    args.mask = mask;
+    args.elems = elems;
     inject_postops_args_.push_back(args);
 
     op_t op;
@@ -293,15 +297,15 @@ void ir_t::def_use(
             break;
         case op_kind_t::inject_postops: {
             // The injector transforms the accumulators in place (read and
-            // written) and reads the base pointer. Report them so liveness is
-            // correct across the op. Operands live in the side table, not in
-            // `op_t`.
+            // written) and reads the base pointer and the tail mask. Report them
+            // so liveness is correct across the op.
             const auto &args = inject_postops_args_[(int)op.imm];
             for (vreg_t v : args.acc) {
                 u(v);
                 d(v);
             }
             u(args.base_ptr);
+            u(args.mask);
             break;
         }
         case op_kind_t::set_mask_imm: d(op.dst); break;

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -112,8 +112,7 @@ enum class op_kind_t {
     //
     // Apply post-ops via an injector to a set of accumulators. The injector is
     // not IR-based, so lowering to it needs interoperability code (see the
-    // emitter's `inject_postops_fn_t`). `imm` indexes `inject_postops_args()`,
-    // which holds the variadic operand `acc` (an `op_t` has a fixed field set).
+    // emitter's `inject_postops_fn_t`). Operands are in `inject_postops_args_t`.
     inject_postops,
 
     // Mask operations
@@ -211,12 +210,29 @@ struct vreg_info_t {
 // `acc` list. Each `inject_postops` op stores only its index into that table in
 // `imm`.
 //
-//   acc      - accumulators transformed in place by the post-ops
-//   base_ptr - gpr holding the output base pointer, used by binary post-ops to
-//              address their right-hand-side argument
+//   acc          - accumulators transformed in place by the post-ops
+//   base_ptr     - gpr holding the output base pointer, used by binary post-ops
+//                  to address their right-hand-side argument
+//   out_byte_off - output byte offset of each accumulator from `base_ptr`,
+//                  parallel to `acc`. Locates each accumulator in the
+//                  destination tensor so binary post-ops address the matching
+//                  right-hand-side slice
+//   mask, elems  - active-element descriptor of the accumulators, the same
+//                  `mask` and `elems` that `vload_masked` / `vstore_masked`
+//                  take. `elems` is the active element count and `mask` holds
+//                  that pattern, or `vreg_t::none` for a single element or a
+//                  full vector. `elems == -1` marks a full vector, every element
+//                  valid. A binary post-op reads `elems` right-hand-side
+//                  elements per accumulator, keeping the read in bounds
+//
+// `base_ptr`, `out_byte_off`, `mask`, and `elems` are unused by an eltwise-only
+// chain.
 struct inject_postops_args_t {
     std::vector<vreg_t> acc;
     vreg_t base_ptr = vreg_t::none;
+    std::vector<dim_t> out_byte_off;
+    vreg_t mask = vreg_t::none;
+    int elems = -1;
 };
 
 // An `ir_t` is the operation list plus, for each virtual register, its info
@@ -297,10 +313,11 @@ struct DNNL_API ir_t {
     void set_mask_imm(vreg_t mask, int n_elems);
 
     // post-ops
-    // Apply post-ops to `acc` in place. `base_ptr` is the output base pointer
-    // for binary post-ops. Stored in `inject_postops_args()`, indexed by the
-    // operation's `imm`.
-    void inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr);
+    // Apply post-ops to `acc` in place. `base_ptr`, `out_byte_off`, `mask`, and
+    // `elems` describe where each accumulator lands in the output and how many
+    // elements are active (see `inject_postops_args_t`).
+    void inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr,
+            const std::vector<dim_t> &out_byte_off, vreg_t mask, int elems);
 
     // control flow
     // Pass the returned op index to `loop_end` to close the loop.
@@ -329,7 +346,7 @@ private:
     std::vector<vreg_info_t> vreg_info_;
     // All operations, in order
     std::vector<op_t> ops_;
-    // Arguments of each `inject_postops` operation, indexed by the op's `imm`.
+    // Arguments of each `inject_postops` operation.
     std::vector<inject_postops_args_t> inject_postops_args_;
 
     // Label counter.

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -104,6 +104,8 @@ enum class op_kind_t {
     vdot,
     // dst += s0 (vector add)
     vadd,
+    // dst *= s0 (vector multiply)
+    vmul,
     // horizontal reduction of dst; result in element 0. s0 is scratch
     // (overwritten).
     vhreduce,
@@ -292,6 +294,7 @@ struct DNNL_API ir_t {
     void vload(vreg_t dst, vreg_t base, dim_t disp);
     void vdot(vreg_t dst, vreg_t a, vreg_t b);
     void vadd(vreg_t dst, vreg_t src);
+    void vmul(vreg_t dst, vreg_t src);
     // `workspace` is scratch. It is overwritten by this call, so pass a vreg
     // whose value is not needed afterwards.
     void vhreduce(vreg_t dst, vreg_t workspace);

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -102,6 +102,8 @@ enum class op_kind_t {
     vload,
     // dst += sum_{i=0}^{N-1} (s0[i] * s1[i]), where N is the dot length
     vdot,
+    // dst += s0 (vector add)
+    vadd,
     // horizontal reduction of dst; result in element 0. s0 is scratch
     // (overwritten).
     vhreduce,
@@ -248,6 +250,7 @@ struct DNNL_API ir_t {
     void vzero(vreg_t dst);
     void vload(vreg_t dst, vreg_t base, dim_t disp);
     void vdot(vreg_t dst, vreg_t a, vreg_t b);
+    void vadd(vreg_t dst, vreg_t src);
     // `workspace` is scratch. It is overwritten by this call, so pass a vreg
     // whose value is not needed afterwards.
     void vhreduce(vreg_t dst, vreg_t workspace);

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -108,6 +108,14 @@ enum class op_kind_t {
     // (overwritten).
     vhreduce,
 
+    // Post-ops
+    //
+    // Apply post-ops via an injector to a set of accumulators. The injector is
+    // not IR-based, so lowering to it needs interoperability code (see the
+    // emitter's `inject_postops_fn_t`). `imm` indexes `inject_postops_args()`,
+    // which holds the variadic operand `acc` (an `op_t` has a fixed field set).
+    inject_postops,
+
     // Mask operations
     //
     // set_mask_imm creates a mask for `imm` active elements.
@@ -174,6 +182,7 @@ struct mem_t {
 //         * loop_begin     -> loop trip count
 //         * set_mask_imm   -> active element count
 //         * vload_masked / vstore_masked -> active element count
+//         * inject_postops -> index into inject_postops_args()
 // mem   - memory address used only by load/store operations.
 // match - for loop_end, index of matching loop_begin operation.
 // label_id - target label id for label/jmp/jz. When unused it's `none`.
@@ -197,6 +206,19 @@ struct vreg_info_t {
     data_type_t dt = data_type::undef;
 };
 
+// Arguments of an `inject_postops` operation. They live in a side table in
+// `ir_t` because an `op_t` has a fixed field set and cannot hold the variadic
+// `acc` list. Each `inject_postops` op stores only its index into that table in
+// `imm`.
+//
+//   acc      - accumulators transformed in place by the post-ops
+//   base_ptr - gpr holding the output base pointer, used by binary post-ops to
+//              address their right-hand-side argument
+struct inject_postops_args_t {
+    std::vector<vreg_t> acc;
+    vreg_t base_ptr = vreg_t::none;
+};
+
 // An `ir_t` is the operation list plus, for each virtual register, its info
 // (kind and for a vec its element data type) so the allocator knows which
 // physical registers it can use and the emitter knows which dtype-specific
@@ -217,6 +239,9 @@ struct vreg_info_t {
 struct DNNL_API ir_t {
     const std::vector<vreg_info_t> &vreg_info() const { return vreg_info_; }
     const std::vector<op_t> &ops() const { return ops_; }
+    const std::vector<inject_postops_args_t> &inject_postops_args() const {
+        return inject_postops_args_;
+    }
     int n_labels() const { return n_labels_; }
 
     // Convenience wrappers around `new_vreg` for the specific kinds.
@@ -271,6 +296,12 @@ struct DNNL_API ir_t {
     // mask
     void set_mask_imm(vreg_t mask, int n_elems);
 
+    // post-ops
+    // Apply post-ops to `acc` in place. `base_ptr` is the output base pointer
+    // for binary post-ops. Stored in `inject_postops_args()`, indexed by the
+    // operation's `imm`.
+    void inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr);
+
     // control flow
     // Pass the returned op index to `loop_end` to close the loop.
     int loop_begin_imm(vreg_t counter, dim_t count);
@@ -298,6 +329,8 @@ private:
     std::vector<vreg_info_t> vreg_info_;
     // All operations, in order
     std::vector<op_t> ops_;
+    // Arguments of each `inject_postops` operation, indexed by the op's `imm`.
+    std::vector<inject_postops_args_t> inject_postops_args_;
 
     // Label counter.
     int n_labels_ = 0;

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -34,11 +34,11 @@ namespace {
 
 // Create an injector for the target ISA and return it type-erased.
 template <typename Vmm>
-std::shared_ptr<void> create_injector(jit_generator_t *host, cpu_isa_t isa,
+std::shared_ptr<void> create_injector(jit_generator_t &gen, cpu_isa_t isa,
         const post_ops_t &post_ops,
         const binary_injector::static_params_t &bsp) {
     return std::shared_ptr<injector_base_t<Vmm>>(
-            injector_base_t<Vmm>::create(host, isa, post_ops, bsp));
+            injector_base_t<Vmm>::create(&gen, isa, post_ops, bsp));
 }
 
 template <typename Vmm>
@@ -48,10 +48,11 @@ injector_base_t<Vmm> *cast2tgt(void *injector) {
 
 } // namespace
 
-postops_injector_t::postops_injector_t(jit_generator_t *host, cpu_isa_t isa,
+postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
         const post_ops_t &post_ops, const memory_desc_t &dst_md,
-        const Xbyak::Reg64 &param_reg)
-    : is_zmm_(is_superset(isa, avx512_core)) {
+        const Xbyak::Reg64 &param_reg, size_t rhs_arg_offset,
+        size_t dst_orig_off, int tail_elems)
+    : is_zmm_(is_superset(isa, avx512_core)), tail_elems_(tail_elems) {
     const memory_desc_wrapper dst_d(dst_md);
 
     // The injector preserves the state of the gpr and vec registers it borrows.
@@ -59,18 +60,18 @@ postops_injector_t::postops_injector_t(jit_generator_t *host, cpu_isa_t isa,
     static constexpr bool preserve_vmm = true;
     static constexpr bool use_exact_tail_scalar_bcast = false;
 
-    // Right-hand-side argument config for binary post-ops. Eltwise does not use
-    // it.
-    // TODO: pass the rhs-arg offset and tail size in when binary support lands.
-    const std::size_t rhs_dt_helper_vmm_idx = 0;
-    const std::size_t rhs_arg_offset = 0;
-    const std::size_t dst_orig_offset = 0;
-    const std::size_t tail_size = 0;
+    const size_t rhs_dt_helper_vmm_idx = 0;
 
+    // Right-hand-side argument config for binary post-ops. Eltwise does not use
+    // it. `rhs_arg_offset` locates the argument pointer array in the parameter
+    // struct. `dst_orig_off` locates the destination origin, used to turn an
+    // accumulator address into its destination position. `tail_elems` is the
+    // element count a partial load reads on avx2. The avx512 opmask path is not
+    // enabled yet.
     const binary_injector::rhs_arg_static_params_t rhs_sp {
-            rhs_dt_helper_vmm_idx, host->r14, host->r15, host->r13,
-            preserve_gpr, preserve_vmm, rhs_arg_offset, dst_orig_offset, dst_d,
-            tail_size, use_exact_tail_scalar_bcast};
+            rhs_dt_helper_vmm_idx, gen.r14, gen.r15, gen.r13, preserve_gpr,
+            preserve_vmm, rhs_arg_offset, dst_orig_off, dst_d,
+            (size_t)tail_elems, use_exact_tail_scalar_bcast};
 
     const binary_injector::static_params_t bsp {param_reg,
             binary_injector::get_all_strategies_supported_by_injector(),
@@ -80,19 +81,59 @@ postops_injector_t::postops_injector_t(jit_generator_t *host, cpu_isa_t isa,
                         : create_injector<Xbyak::Ymm>(gen, isa, post_ops, bsp);
     assert(injector_ && "ir post-ops injector creation failed");
 
-    const auto eltwise_ind = post_ops.find(primitive_kind::eltwise);
-    with_eltwise_ = eltwise_ind != -1;
+    with_eltwise_ = post_ops.find(primitive_kind::eltwise) != -1;
+    // Prelu is injected through the binary injector and needs the same
+    // right-hand-side arguments, so treat it like a binary post-op.
+    with_binary_ = post_ops.find(primitive_kind::binary) != -1
+            || post_ops.find(primitive_kind::prelu) != -1;
 }
 
-void postops_injector_t::apply(const std::vector<int> &acc_phys) {
+void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
+        const std::vector<dim_t> &out_byte_off, int mask_phys, int elems) {
     injector_utils::vmm_index_set_t vmm_idxs;
     for (int idx : acc_phys)
         vmm_idxs.insert((size_t)idx);
 
+    if (!with_binary_) {
+        // Eltwise-only chains have no right-hand-side arguments to address.
+        if (is_zmm_)
+            cast2tgt<Xbyak::Zmm>(injector_.get())
+                    ->compute_vector_range(vmm_idxs);
+        else
+            cast2tgt<Xbyak::Ymm>(injector_.get())
+                    ->compute_vector_range(vmm_idxs);
+        return;
+    }
+
+    // `mask_phys` is a K register (avx512 opmask). The avx512 emitter is not
+    // enabled yet, so it is currently unused.
+    MAYBE_UNUSED(mask_phys);
+
+    // `elems == -1` is a full vector. A positive count is a partial load of
+    // `elems` right-hand-side elements and must match `tail_elems_`.
+    JIT_ASSERT((elems == -1 || elems > 0)
+            && "inject_postops: elems must be -1 or a positive count");
+    const bool is_tail = elems > 0;
+    JIT_ASSERT((!is_tail || elems == tail_elems_)
+            && "inject_postops: tail count does not match the injector");
+
+    // Map each accumulator to its destination address so the injector locates
+    // the matching right-hand-side slice.
+    binary_injector::rhs_arg_dynamic_params_t rhs_args;
+    const Xbyak::Reg64 out_reg(base_phys);
+    for (size_t i = 0; i < acc_phys.size(); i++) {
+        rhs_args.vmm_idx_to_out_reg.emplace(acc_phys[i], out_reg);
+        rhs_args.vmm_idx_to_out_elem_off_val.emplace(
+                acc_phys[i], (size_t)out_byte_off[i]);
+        if (is_tail) rhs_args.vmm_tail_idx_.emplace(acc_phys[i]);
+    }
+
     if (is_zmm_)
-        cast2tgt<Xbyak::Zmm>(injector_.get())->compute_vector_range(vmm_idxs);
+        cast2tgt<Xbyak::Zmm>(injector_.get())
+                ->compute_vector_range(vmm_idxs, rhs_args);
     else
-        cast2tgt<Xbyak::Ymm>(injector_.get())->compute_vector_range(vmm_idxs);
+        cast2tgt<Xbyak::Ymm>(injector_.get())
+                ->compute_vector_range(vmm_idxs, rhs_args);
 }
 
 void postops_injector_t::maybe_prepare_table() {

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cassert>
+
+#include "common/memory_desc_wrapper.hpp"
+
+#include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/x64/ir/postops_injector.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+template <typename Vmm>
+using injector_base_t = injector::jit_uni_postops_injector_base_t<Vmm>;
+
+namespace {
+
+// Create an injector for the target ISA and return it type-erased.
+template <typename Vmm>
+std::shared_ptr<void> create_injector(jit_generator_t *host, cpu_isa_t isa,
+        const post_ops_t &post_ops,
+        const binary_injector::static_params_t &bsp) {
+    return std::shared_ptr<injector_base_t<Vmm>>(
+            injector_base_t<Vmm>::create(host, isa, post_ops, bsp));
+}
+
+template <typename Vmm>
+injector_base_t<Vmm> *cast2tgt(void *injector) {
+    return static_cast<injector_base_t<Vmm> *>(injector);
+}
+
+} // namespace
+
+postops_injector_t::postops_injector_t(jit_generator_t *host, cpu_isa_t isa,
+        const post_ops_t &post_ops, const memory_desc_t &dst_md,
+        const Xbyak::Reg64 &param_reg)
+    : is_zmm_(is_superset(isa, avx512_core)) {
+    const memory_desc_wrapper dst_d(dst_md);
+
+    // The injector preserves the state of the gpr and vec registers it borrows.
+    static constexpr bool preserve_gpr = true;
+    static constexpr bool preserve_vmm = true;
+    static constexpr bool use_exact_tail_scalar_bcast = false;
+
+    // Right-hand-side argument config for binary post-ops. Eltwise does not use
+    // it.
+    // TODO: pass the rhs-arg offset and tail size in when binary support lands.
+    const std::size_t rhs_dt_helper_vmm_idx = 0;
+    const std::size_t rhs_arg_offset = 0;
+    const std::size_t dst_orig_offset = 0;
+    const std::size_t tail_size = 0;
+
+    const binary_injector::rhs_arg_static_params_t rhs_sp {
+            rhs_dt_helper_vmm_idx, host->r14, host->r15, host->r13,
+            preserve_gpr, preserve_vmm, rhs_arg_offset, dst_orig_offset, dst_d,
+            tail_size, use_exact_tail_scalar_bcast};
+
+    const binary_injector::static_params_t bsp {param_reg,
+            binary_injector::get_all_strategies_supported_by_injector(),
+            rhs_sp};
+
+    injector_ = is_zmm_ ? create_injector<Xbyak::Zmm>(gen, isa, post_ops, bsp)
+                        : create_injector<Xbyak::Ymm>(gen, isa, post_ops, bsp);
+    assert(injector_ && "ir post-ops injector creation failed");
+
+    const auto eltwise_ind = post_ops.find(primitive_kind::eltwise);
+    with_eltwise_ = eltwise_ind != -1;
+}
+
+void postops_injector_t::apply(const std::vector<int> &acc_phys) {
+    injector_utils::vmm_index_set_t vmm_idxs;
+    for (int idx : acc_phys)
+        vmm_idxs.insert((size_t)idx);
+
+    if (is_zmm_)
+        cast2tgt<Xbyak::Zmm>(injector_.get())->compute_vector_range(vmm_idxs);
+    else
+        cast2tgt<Xbyak::Ymm>(injector_.get())->compute_vector_range(vmm_idxs);
+}
+
+void postops_injector_t::maybe_prepare_table() {
+    // The constant table is only needed for eltwise.
+    if (!with_eltwise_) return;
+
+    const bool generate = true;
+    if (is_zmm_)
+        cast2tgt<Xbyak::Zmm>(injector_.get())->prepare_table(generate);
+    else
+        cast2tgt<Xbyak::Ymm>(injector_.get())->prepare_table(generate);
+}
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -21,7 +21,7 @@
 // operation (see `emitter.hpp` and `inject_postops_fn_t`).
 //
 // The IR operation and the emitter callback that drives this
-// `postops_injector_t` are builder-independent. An IR-based kernel wires it up
+// `postops_injector_t` are builder-independent. An IR-based kernel sets it up
 // in `generate()`:
 //   1. Create this object from the post-ops chain and the destination
 //      descriptor.
@@ -52,22 +52,34 @@ namespace x64 {
 namespace ir {
 
 struct postops_injector_t {
-    // gen       - generator the injected post-op code is emitted into
-    // isa       - kernel ISA
-    // post_ops  - attribute post-ops chain to apply
-    // dst_md    - destination memory descriptor (used by binary post-ops)
-    // param_reg - gpr holding the kernel-parameter-struct pointer (used by
-    //             binary post-ops to reach their right-hand-side arguments)
+    // gen            - generator the injected post-op code is emitted into
+    // isa            - kernel ISA
+    // post_ops       - attribute post-ops chain to apply
+    // dst_md         - destination memory descriptor (used by binary post-ops)
+    // param_reg      - gpr holding the kernel-parameter-struct pointer (used by
+    //                  binary post-ops to reach their right-hand-side arguments)
+    // rhs_arg_offset - byte offset in the parameter struct of the binary
+    //                  right-hand-side argument pointer array
+    // dst_orig_off   - byte offset in the parameter struct of the destination
+    //                  origin pointer, used to turn an accumulator address into
+    //                  its position in the destination tensor
+    // tail_elems     - right-hand-side elements a partial (tail) load reads
     postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
             const post_ops_t &post_ops, const memory_desc_t &dst_md,
-            const Xbyak::Reg64 &param_reg);
+            const Xbyak::Reg64 &param_reg, size_t rhs_arg_offset,
+            size_t dst_orig_off, int tail_elems);
 
     postops_injector_t(const postops_injector_t &) = delete;
     postops_injector_t &operator=(const postops_injector_t &) = delete;
 
     // Apply the post-ops to the accumulators in `acc_phys` (physical vec
-    // register indices).
-    void apply(const std::vector<int> &acc_phys);
+    // register indices). For binary post-ops, `base_phys` and `out_byte_off`
+    // give each accumulator's output address. `elems` is the active element
+    // count, `-1` for a full vector, and limits how many right-hand-side
+    // elements are read. `mask_phys` is the tail opmask (a K register), used
+    // only by the avx512 emitter, which is not enabled yet.
+    void apply(const std::vector<int> &acc_phys, int base_phys,
+            const std::vector<dim_t> &out_byte_off, int mask_phys, int elems);
 
     // Emit the post-ops constant table. Call once, after the postamble. Only
     // eltwise post-ops have a table, so this is a no-op without one.
@@ -80,6 +92,10 @@ private:
     bool is_zmm_ = false;
     // Whether the chain has an eltwise post-op (the only kind with a table).
     bool with_eltwise_ = false;
+    // Whether the chain has a binary post-op (the only kind needing rhs args).
+    bool with_binary_ = false;
+    // Number of right-hand-side elements a tail load reads.
+    int tail_elems_ = 0;
 };
 
 } // namespace ir

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -51,6 +51,7 @@ namespace cpu {
 namespace x64 {
 namespace ir {
 
+// Interfaces marked with DNNL_API are exported for testing purposes only.
 struct postops_injector_t {
     // gen            - generator the injected post-op code is emitted into
     // isa            - kernel ISA
@@ -64,7 +65,7 @@ struct postops_injector_t {
     //                  origin pointer, used to turn an accumulator address into
     //                  its position in the destination tensor
     // tail_elems     - right-hand-side elements a partial (tail) load reads
-    postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
+    DNNL_API postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
             const post_ops_t &post_ops, const memory_desc_t &dst_md,
             const Xbyak::Reg64 &param_reg, size_t rhs_arg_offset,
             size_t dst_orig_off, int tail_elems);
@@ -78,12 +79,12 @@ struct postops_injector_t {
     // count, `-1` for a full vector, and limits how many right-hand-side
     // elements are read. `mask_phys` is the tail opmask (a K register), used
     // only by the avx512 emitter, which is not enabled yet.
-    void apply(const std::vector<int> &acc_phys, int base_phys,
+    void DNNL_API apply(const std::vector<int> &acc_phys, int base_phys,
             const std::vector<dim_t> &out_byte_off, int mask_phys, int elems);
 
     // Emit the post-ops constant table. Call once, after the postamble. Only
     // eltwise post-ops have a table, so this is a no-op without one.
-    void maybe_prepare_table();
+    void DNNL_API maybe_prepare_table();
 
 private:
     // Type-erased `jit_uni_postops_injector_base_t<Vmm>`. Cast to the target

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_IR_POSTOPS_INJECTOR_HPP
+#define CPU_X64_IR_POSTOPS_INJECTOR_HPP
+
+// Driver for the JIT-based post-ops injector. It lowers the `inject_postops` IR
+// operation (see `emitter.hpp` and `inject_postops_fn_t`).
+//
+// The IR operation and the emitter callback that drives this
+// `postops_injector_t` are builder-independent. An IR-based kernel wires it up
+// in `generate()`:
+//   1. Create this object from the post-ops chain and the destination
+//      descriptor.
+//   2. Wrap it in a callback passed to the emitter that calls `apply()`.
+//   3. Call `maybe_prepare_table()` once after the postamble.
+//
+// ISA handling:
+// - The only ISA-specific detail is the vector width (Ymm or Zmm), chosen from
+//   the `isa`. The width-specific injector is stored type-erased, so IR-based
+//   kernels do not need to be templated.
+//
+// Register handling:
+// - The injector saves and restores every register it uses, so its registers
+//   need not be reserved in the IR allocator. The save/restore cost is paid
+//   once per call.
+
+#include <memory>
+#include <vector>
+
+#include "common/c_types_map.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+struct postops_injector_t {
+    // gen       - generator the injected post-op code is emitted into
+    // isa       - kernel ISA
+    // post_ops  - attribute post-ops chain to apply
+    // dst_md    - destination memory descriptor (used by binary post-ops)
+    // param_reg - gpr holding the kernel-parameter-struct pointer (used by
+    //             binary post-ops to reach their right-hand-side arguments)
+    postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
+            const post_ops_t &post_ops, const memory_desc_t &dst_md,
+            const Xbyak::Reg64 &param_reg);
+
+    postops_injector_t(const postops_injector_t &) = delete;
+    postops_injector_t &operator=(const postops_injector_t &) = delete;
+
+    // Apply the post-ops to the accumulators in `acc_phys` (physical vec
+    // register indices).
+    void apply(const std::vector<int> &acc_phys);
+
+    // Emit the post-ops constant table. Call once, after the postamble. Only
+    // eltwise post-ops have a table, so this is a no-op without one.
+    void maybe_prepare_table();
+
+private:
+    // Type-erased `jit_uni_postops_injector_base_t<Vmm>`. Cast to the target
+    // type when used, based on `is_zmm_`.
+    std::shared_ptr<void> injector_;
+    bool is_zmm_ = false;
+    // Whether the chain has an eltwise post-op (the only kind with a table).
+    bool with_eltwise_ = false;
+};
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -16,14 +16,18 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #include "gtest/gtest.h"
+
+#include "oneapi/dnnl/dnnl.hpp"
 
 #include "common/c_types_map.hpp"
 
 #include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/ir/ir.hpp"
+#include "cpu/x64/ir/postops_injector.hpp"
 #include "cpu/x64/ir/reg_alloc.hpp"
 #include "cpu/x64/ir/reg_config.hpp"
 #include "cpu/x64/jit_generator.hpp"
@@ -205,6 +209,23 @@ public:
         fn(args);
     }
 
+    // Optional post-ops injector setup. When `post_ops` is set, generate()
+    // creates the JIT post-ops injector and drives the `inject_postops` op
+    // through it, the same way a real IR kernel does.
+    //   rhs_arg_offset  - byte offset in the argument struct of the binary
+    //                     right-hand-side pointer array
+    //   dst_orig_offset - byte offset in the argument struct of the
+    //                     destination origin pointer
+    //   tail_elems      - right-hand-side elements a partial (tail) load reads
+    struct postops_cfg_t {
+        const impl::post_ops_t *post_ops = nullptr;
+        const impl::memory_desc_t *dst_md = nullptr;
+        size_t rhs_arg_offset = 0;
+        size_t dst_orig_offset = 0;
+        int tail_elems = 0;
+    };
+    void set_postops(const postops_cfg_t &cfg) { postops_cfg_ = cfg; }
+
     // Allocation outcome. Becomes valid after `run_ir_pipeline()`.
     //
     // True if the generated kernel has any spills.
@@ -240,19 +261,42 @@ protected:
         spilled_ = alloc.any_spill;
         stack_size_ = alloc.frame_bytes;
 
+        // Create the post-ops injector and the callback the emitter uses to
+        // lower the `inject_postops` op, the same as a real IR kernel's
+        // generate(). The injector saves and restores every register it borrows,
+        // so it takes no part in the IR register allocation.
+        std::unique_ptr<postops_injector_t> injector;
+        inject_postops_fn_t emit_injector;
+        if (postops_cfg_.post_ops) {
+            injector.reset(new postops_injector_t(*this, avx2,
+                    *postops_cfg_.post_ops, *postops_cfg_.dst_md, abi_param1,
+                    postops_cfg_.rhs_arg_offset, postops_cfg_.dst_orig_offset,
+                    postops_cfg_.tail_elems));
+            emit_injector = [&](const std::vector<int> &acc_phys, int base_phys,
+                                    const std::vector<dim_t> &out_byte_off,
+                                    int mask_phys, int elems) {
+                injector->apply(
+                        acc_phys, base_phys, out_byte_off, mask_phys, elems);
+            };
+        }
+
         preamble();
 
         const int frame = (int)utils::rnd_up(alloc.frame_bytes, 16);
         if (frame > 0) sub(rsp, frame);
 
         data_section_t data;
-        emit(*this, ir_, alloc, reg_cfg, data);
+        emit(*this, ir_, alloc, reg_cfg, data, emit_injector);
 
         if (frame > 0) add(rsp, frame);
 
         postamble();
 
         emit_data_section(*this, data);
+
+        // The injector's constant table follows the postamble. A no-op unless
+        // the chain has an eltwise post-op.
+        if (injector) injector->maybe_prepare_table();
     }
 
 private:
@@ -260,6 +304,7 @@ private:
     int vec_regs_limit_ = 0;
     bool spilled_ = false;
     size_t stack_size_ = 0;
+    postops_cfg_t postops_cfg_ {};
 };
 
 // IR builder tests
@@ -459,6 +504,62 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
         // Each value is either spilled or has a physical register assigned.
         EXPECT_TRUE(as.spilled || as.phys >= 0);
     }
+}
+
+// Validates the inject_postops builder and its liveness. The operation stores
+// its variable-length operands in a side table and keeps only the table index,
+// so the test checks that the side table holds exactly what the builder was
+// given. def_use must report each accumulator as read and written in place, and
+// the base pointer and mask as read, or liveness across the injected post-ops
+// would be wrong.
+TEST(IRBuilderTests, InjectPostopsRecordsArgsAndDefUse) {
+    ir_t ir;
+
+    const vreg_t base = ir.new_gpr();
+    ir.load_param(base, 0);
+
+    const vreg_t mask = ir.new_mask();
+    ir.set_mask_imm(mask, simd_w - 1);
+
+    constexpr int n = 3;
+    std::vector<vreg_t> acc(n, vreg_t::none);
+    for (int r = 0; r < n; r++) {
+        acc[r] = ir.new_vec(data_type::f32);
+        ir.vzero(acc[r]);
+    }
+
+    std::vector<dim_t> out_byte_off(n);
+    for (int r = 0; r < n; r++)
+        out_byte_off[r] = r * (dim_t)sizeof(float);
+
+    ir.inject_postops(acc, base, out_byte_off, mask, /*elems=*/simd_w - 1);
+
+    const int idx = find_op(ir, op_kind_t::inject_postops);
+    ASSERT_NE(idx, -1);
+
+    // The operation carries only an index into the side table, which holds the
+    // full argument set.
+    ASSERT_EQ(ir.inject_postops_args().size(), 1u);
+    const auto &args = ir.inject_postops_args()[(int)ir.ops()[idx].imm];
+    EXPECT_EQ(args.acc, acc);
+    EXPECT_EQ(args.base_ptr, base);
+    EXPECT_EQ(args.out_byte_off, out_byte_off);
+    EXPECT_EQ(args.mask, mask);
+    EXPECT_EQ(args.elems, simd_w - 1);
+
+    // def_use reports every accumulator as read and written, and the base
+    // pointer and mask as read.
+    std::vector<int> defs, uses;
+    ir.def_use(ir.ops()[idx], defs, uses);
+
+    for (int r = 0; r < n; r++) {
+        EXPECT_NE(std::find(defs.begin(), defs.end(), (int)acc[r]), defs.end())
+                << "acc " << r << " not written";
+        EXPECT_NE(std::find(uses.begin(), uses.end(), (int)acc[r]), uses.end())
+                << "acc " << r << " not read";
+    }
+    EXPECT_NE(std::find(uses.begin(), uses.end(), (int)base), uses.end());
+    EXPECT_NE(std::find(uses.begin(), uses.end(), (int)mask), uses.end());
 }
 
 // Allocator tests
@@ -894,6 +995,114 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     kernel.run(&args_b);
     for (int i = 0; i < simd_w; i++)
         EXPECT_FLOAT_EQ(c_data[i], b_data[i]) << "lane " << i;
+}
+
+// Arguments for the binary post-op kernel. `binary_rhs` points to the array of
+// right-hand-side base pointers the injector indexes, and `dst_orig` is the
+// destination origin it subtracts to locate each accumulator's output element.
+struct binary_args_t {
+    const float *a;
+    const float *b;
+    float *c;
+    const void **binary_rhs;
+    const void *dst_orig;
+};
+
+// Validates the binary post-op path end to end. It computes n independent dot
+// products, adds a per-element right-hand-side through the JIT post-ops
+// injector, and checks each result against a reference. This exercises the
+// inject_postops op, the postops_injector_t driver, and the injector's
+// destination-relative right-hand-side addressing with a one-element
+// (scalar accumulator) tail load.
+TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
+    SKIP_IF_NO_AVX2();
+
+    constexpr int n = 4;
+
+    // Destination and right-hand-side share the same n x 1 shape, which selects
+    // the injector's no-broadcast (per-element) strategy. The descriptors and
+    // post-ops are built with the public API, then handed to the injector as the
+    // internal types it takes.
+    using dt = dnnl::memory::data_type;
+    using tag = dnnl::memory::format_tag;
+    const dnnl::memory::desc dst_desc({n, 1}, dt::f32, tag::ab);
+    const dnnl::memory::desc rhs_desc({n, 1}, dt::f32, tag::ab);
+
+    dnnl::post_ops po;
+    po.append_binary(dnnl::algorithm::binary_add, rhs_desc);
+
+    const impl::memory_desc_t &dst_md = *dst_desc.get();
+    const impl::post_ops_t &post_ops = *po.get();
+
+    // Build the dot-product IR that feeds the injector: one accumulator per
+    // output element, each reduced to a scalar.
+    ir_t ir;
+
+    const vreg_t a_ptr = ir.new_gpr();
+    ir.load_param(a_ptr, offsetof(binary_args_t, a));
+
+    const vreg_t b_ptr = ir.new_gpr();
+    ir.load_param(b_ptr, offsetof(binary_args_t, b));
+
+    const vreg_t c_ptr = ir.new_gpr();
+    ir.load_param(c_ptr, offsetof(binary_args_t, c));
+
+    const vreg_t b = ir.new_vec(data_type::f32);
+    ir.vload(b, b_ptr, 0);
+
+    std::vector<vreg_t> acc(n, vreg_t::none);
+    for (int r = 0; r < n; r++) {
+        acc[r] = ir.new_vec(data_type::f32);
+        ir.vzero(acc[r]);
+
+        const vreg_t a = ir.new_vec(data_type::f32);
+        ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
+        ir.vdot(acc[r], a, b);
+    }
+
+    const vreg_t ws = ir.new_vec(data_type::f32);
+    for (int r = 0; r < n; r++)
+        ir.vhreduce(acc[r], ws);
+
+    // Each accumulator is a single scalar. Its output offset locates it in the
+    // destination so the injector reads the matching right-hand-side element.
+    std::vector<dim_t> out_byte_off(n);
+    for (int r = 0; r < n; r++)
+        out_byte_off[r] = r * (dim_t)sizeof(float);
+    ir.inject_postops(acc, c_ptr, out_byte_off, vreg_t::none, /*elems=*/1);
+
+    for (int r = 0; r < n; r++)
+        ir.vstore_masked(
+                c_ptr, r * (dim_t)sizeof(float), acc[r], vreg_t::none, 1);
+
+    ir_kernel_t kernel(ir);
+    ir_kernel_t::postops_cfg_t cfg;
+    cfg.post_ops = &post_ops;
+    cfg.dst_md = &dst_md;
+    cfg.rhs_arg_offset = offsetof(binary_args_t, binary_rhs);
+    cfg.dst_orig_offset = offsetof(binary_args_t, dst_orig);
+    cfg.tail_elems = 1;
+    kernel.set_postops(cfg);
+
+    ASSERT_TRUE(kernel.run_ir_pipeline());
+
+    std::vector<float> a(n * simd_w), b_data(simd_w), rhs(n), c(n, 0.f);
+    for (int i = 0; i < n * simd_w; i++)
+        a[i] = (float)(i % 5) - 2.f;
+    for (int i = 0; i < simd_w; i++)
+        b_data[i] = (float)(i - 3);
+    for (int r = 0; r < n; r++)
+        rhs[r] = (float)(10 * (r + 1));
+
+    const void *rhs_ptrs[1] = {rhs.data()};
+    binary_args_t args {a.data(), b_data.data(), c.data(), rhs_ptrs, c.data()};
+    kernel.run(&args);
+
+    for (int r = 0; r < n; r++) {
+        const float expected
+                = ref_dot(&a[r * simd_w], b_data.data(), simd_w) + rhs[r];
+        EXPECT_FLOAT_EQ(c[r], expected) << "row " << r;
+    }
 }
 
 } // namespace dnnl


### PR DESCRIPTION
This PR extends the IR infrastructure to support the following features in the GEMV kernel:

* **cpu: x64: add support for beta=1 in brgemv ir**: enables the `beta=1` case in `brgemv_ir` (no changes to the shared IR infrastructure).
* **cpu: x64: brgemv: add support for bias**: adds support for `vadd` to the shared IR infrastructure and uses it in `brgemv_ir` to support bias.
* **cpu: x64: ir, brgemm: add support for injector, eltwise only**: adds the `inject_postops` operation and an interoperability layer to the shared IR infrastructure, and enables it for eltwise post-ops in `brgemv_ir`.
* **cpu: x64: ir, brgemm: add binary post-op support to brgemv ir**: extends the `inject_postops` operation and interoperability layer to support binary post-ops.
* **gtests: internals: add tests for using injector in IR**: adds a couple of tests for the `inject_postops` operation.
* **cpu: x64: brgemm: support src and wei scales in gemv IR kernel**: adds `vmul` to the shared IR infrastructure and uses it to enable `src` and `wei` scales in `brgemv_ir`.

The IR kernel is structurally identical to the non-IR one but much leaner:  over 128 different combinations (different tails, post ops, bias, scale, row or col output) mean: IR ~280 vs non-IR ~351 instructions (~20% fewer).

The IR kernel doesn't have redundant code branches, doesn't allocate stack and never spills as it's not needed (the non-IR one does spill up to 21 stores), doesn't use redundant instructions for data flow control (loops), etc.

So performance of both kernels is therefore identical too.