### PR TITLE
avoid out-of-bounds write in deserializer_t::pop_array

### DIFF
--- a/src/common/primitive_attr_quant.cpp
+++ b/src/common/primitive_attr_quant.cpp
@@ -52,7 +52,7 @@ quant_entry_t quant_entry_t::deserialize(deserializer_t &d) {
     d.pop(e.mask_);
     d.pop(e.data_type_);
     size_t group_ndims;
-    d.pop_array(group_ndims, e.group_dims_);
+    d.pop_array(group_ndims, e.group_dims_, DNNL_MAX_NDIMS);
     e.group_ndims_ = static_cast<int>(group_ndims);
     d.pop(e.is_host_scalar_);
     d.pop(e.qmode_);

--- a/src/common/serialization.hpp
+++ b/src/common/serialization.hpp
@@ -271,8 +271,13 @@ struct deserializer_t {
                     serialization_stream_t::is_trivially_serialized<T>::value,
                     bool>
             = true>
-    void pop_array(size_t &size, T *ptr) {
+    void pop_array(size_t &size, T *ptr, size_t max_size) {
         pop(size);
+        if (size > max_size) {
+            assert(!"unexpected");
+            size = 0;
+            return;
+        }
         sstream_.get(idx_, sizeof(T) * size, reinterpret_cast<uint8_t *>(ptr));
         idx_ += sizeof(T) * size;
     }

--- a/tests/gtests/internals/test_serialization.cpp
+++ b/tests/gtests/internals/test_serialization.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "dnnl_test_common.hpp"
+#include "gtest/gtest.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "src/common/serialization.hpp"
+
+namespace dnnl {
+
+// An element count read from the stream that exceeds the destination capacity
+// must be refused instead of copied. quant_entry_t::deserialize relies on this
+// to keep group_ndims from overrunning the fixed group_dims_ array.
+TEST(test_serialization, pop_array_rejects_oversized_count) {
+    using namespace impl;
+
+    constexpr size_t capacity = 12; // DNNL_MAX_NDIMS
+    constexpr size_t bogus_count = 100;
+    constexpr int64_t sentinel = 0x5A5A5A5A5A5A5A5ALL;
+
+    serialization_stream_t s;
+    s.append(bogus_count);
+    for (size_t i = 0; i < bogus_count; i++)
+        s.append<int64_t>(static_cast<int64_t>(0x4141414141414141LL));
+
+    // Buffer larger than `capacity`; the slots past `capacity` are canaries
+    // that a copy honoring the capacity bound can never touch.
+    std::vector<int64_t> buf(capacity + 8, sentinel);
+
+    deserializer_t d(s);
+    size_t n = 0;
+    d.pop_array(n, buf.data(), capacity);
+
+    EXPECT_EQ(n, 0u);
+    for (size_t i = capacity; i < buf.size(); i++)
+        EXPECT_EQ(buf[i], sentinel) << "write past capacity at index " << i;
+}
+
+// A well-formed array whose count fits the destination round-trips unchanged.
+TEST(test_serialization, pop_array_roundtrips_valid_count) {
+    using namespace impl;
+
+    constexpr size_t capacity = 12; // DNNL_MAX_NDIMS
+    const int64_t src[3] = {5, 7, 9};
+
+    serialization_stream_t s;
+    s.append_array(3, src);
+
+    int64_t dst[capacity] = {0};
+    deserializer_t d(s);
+    size_t n = 0;
+    d.pop_array(n, dst, capacity);
+
+    ASSERT_EQ(n, 3u);
+    EXPECT_EQ(dst[0], 5);
+    EXPECT_EQ(dst[1], 7);
+    EXPECT_EQ(dst[2], 9);
+}
+
+} // namespace dnnl


### PR DESCRIPTION
# Description

ASan, deserializing a crafted quantization entry into `group_dims_`:

    ==ERROR: AddressSanitizer: stack-buffer-overflow
    WRITE of size 800
        #1 serialization_stream_t::get(...)              serialization.hpp:150
        #2 deserializer_t::pop_array<long long>(size_t&, long long*) serialization.hpp:276
      ... [192, 288) 'group_dims'  <== 96-byte buffer, 800-byte write

`quant_entry_t::deserialize` reads `group_ndims` from the byte stream and hands it to `deserializer_t::pop_array`, which copies `sizeof(dim_t) * group_ndims` into the fixed `group_dims_` (a `dims_t`, `DNNL_MAX_NDIMS` entries). Nothing bounds the count, so a serialized entry whose `group_ndims` exceeds `DNNL_MAX_NDIMS` writes past the array with stream-supplied bytes. The bound belongs in the deserializer rather than the caller, so `pop_array` now takes the destination capacity and drops counts larger than it; the quant deserializer passes `DNNL_MAX_NDIMS`. Entries whose count fits the destination round-trip unchanged.

Reproduce: build a stream of `group_ndims = 100` followed by 100 `int64` values and deserialize it into the 12-entry `group_dims_`. Before the change ASan reports the write above (704 bytes past the buffer); after it, the count is refused and the destination is left untouched. The new gtest in `tests/gtests/internals/test_serialization.cpp` covers both the oversized-count rejection and a valid round-trip.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
