### PR TITLE
xe: gemm: jit: support per-kernel override of register allocator

### DIFF
--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -210,7 +210,7 @@ status_t gen_desc_t::finalize(const char *tags) {
     if (hw_ == ngen::HW::Xe2 || hw_ == ngen::HW::Xe3) {
         // Use XeHPC register banking on Xe2/Xe3, in order
         // to successfully reuse XeHPC strategies.
-        strategy_.raHW = ngen::HW::XeHPC;
+        if (strategy_.raHW == hw_) strategy_.raHW = ngen::HW::XeHPC;
 
         // Bump up alignments to 16 bytes for block 2D if available.
         bool block_2d_a = false, block_2d_b = false;
@@ -226,7 +226,8 @@ status_t gen_desc_t::finalize(const char *tags) {
 
     if (hw_ == ngen::HW::Xe3p) {
         // Use XeHPC banking if reusing XeHPC strategies (legacy mode)
-        if (!efficient_64b_) strategy_.raHW = ngen::HW::XeHPC;
+        if (!efficient_64b_ && strategy_.raHW == hw_)
+            strategy_.raHW = ngen::HW::XeHPC;
 
         // Disable named barriers to avoid simulator errors, allow fallback to pvc strategies.
         strategy_.namedBarriers[0] = 0;

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -34,6 +34,20 @@ static void unparseAddressBase(std::ostream &s, ngen::AddressBase base);
 static void unparseCaching(HW hw, std::ostream &s, const MatrixAddressingStrategy &astrategy);
 static void unparseTiling(std::ostream &s, const MatrixAddressingStrategy &astrategy);
 
+static HW parseRAHW(const std::string &name) {
+    if (name == "xehpc")
+        return HW::XeHPC;
+
+    stub("Only raxehpc is supported for register allocation override.");
+    return HW::Unknown;
+}
+
+static const char *unparseRAHW(HW hw) {
+    if (hw == HW::XeHPC)
+        return "xehpc";
+    return nullptr;
+}
+
 bool native64Bit(HW hw)
 {
     EmulationStrategy emulate(hw);
@@ -508,6 +522,8 @@ void parseStrategy(const std::string &str, HW hw, const GEMMProblem &problem, GE
         } else if (mod.substr(0, 3) == "dot") {
             mod.erase(0,3);
             strategy.dotVL = mod.empty() ? 1 : std::stoi(mod);
+        } else if (mod.substr(0, 2) == "ra") {
+            strategy.raHW = parseRAHW(mod.substr(2));
         } else if (mod.length() >= 2) {
             if (mod.substr(0, 2) == "ms")
                 strategy.mSplitThresh = stoi(mod.substr(2));
@@ -909,6 +925,9 @@ std::string unparseStrategy(HW hw, const GEMMProblem &problem, const GEMMStrateg
 
     if (strategy.GRFs != 128)
         s << " grf" << strategy.GRFs;
+    if (strategy.raHW != hw)
+        if (auto ra = unparseRAHW(strategy.raHW))
+            s << " ra" << ra;
 
     if (strategy.coopA == CoopSplit::MN)    s << " sm";
     if (strategy.coopA == CoopSplit::FullK) s << " ska";


### PR DESCRIPTION
When forward porting kernels, we can occasionally hit issues due to changes int the raHW allocator. To simplify forward porting cases where this is largely irrelevant (such as memory bound kernels), this patch adds the ability to override the allocator on a per strategy basis. For now, this is limited to overriding with xeHPC's allocator as that is the main usage we have.