### PR TITLE
cpu: rv64: add dst support for s8 gemm kernel

### DIFF
--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
@@ -17,6 +17,7 @@
 #include "cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp"
 
 #include <array>
+#include <cstdlib>
 #include <memory>
 #include <mutex>
 
@@ -27,15 +28,16 @@ namespace rv64 {
 namespace gemm_utils {
 
 using namespace Xbyak_riscv;
+using namespace dnnl::impl::utils;
 
 jit_rvv_gemm_s8_kernel_t::jit_rvv_gemm_s8_kernel_t(dim_t n_cols, bool isTransA,
-        bool isTransB, bool b_signed, bool dst_is_f32, bool has_bias)
+        bool isTransB, bool b_signed, data_type_t dst_dt, bool has_bias)
     : jit_generator_t("rv64_gemm_kernel_s8_jit")
     , n_cols_(n_cols)
     , isTransA_(isTransA)
     , isTransB_(isTransB)
     , b_signed_(b_signed)
-    , dst_is_f32_(dst_is_f32)
+    , dst_dt_(dst_dt)
     , has_bias_(has_bias) {
     create_kernel();
 }
@@ -50,7 +52,7 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
     const Reg reg_lda_bytes = t0; // A is s8: 1 byte per element
     const Reg reg_ldb_bytes = t1; // B is s8/u8: 1 byte per element
-    const Reg reg_ldc_bytes = t2; // C is s32/f32: 4 bytes per element
+    const Reg reg_ldc_bytes = t2; // C element size in bytes
     const Reg reg_K = t3;
     const Reg reg_alpha_bits = t4;
     const Reg reg_bias_ptr = t4; // reuse after alpha bits moved to freg
@@ -103,9 +105,14 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
     if (has_bias_) { ld(reg_bias_ptr, reg_param, 72); }
 
-    // A is s8 (1 byte), B is s8/u8 (1 byte): element stride == byte stride.
-    // C is s32/f32 (4 bytes): ldc * 4 = byte stride.
-    slli(reg_ldc_bytes, reg_ldc_bytes, 2);
+    // Scale ldc from element-count to byte stride.
+    if (one_of(dst_dt_, data_type::s8, data_type::u8)) {
+        // 1-byte element: element units == byte units, no shift needed.
+    } else if (one_of(dst_dt_, data_type::f16, data_type::bf16)) {
+        slli(reg_ldc_bytes, reg_ldc_bytes, 1);
+    } else {
+        slli(reg_ldc_bytes, reg_ldc_bytes, 2);
+    }
 
     // Save callee-saved registers (s2..s5 hold reg_b[2..5] when n_cols >= 3).
     const bool need_callee_save = (n_cols_ >= 3);
@@ -222,7 +229,7 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     // C-update: switch back to e32 LMUL=m4 (VL=m) for the epilogue.
     vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
 
-    // Computes the address of C's col_idx column into reg_tmp3.
+    // Computes the address of C's col_idx column into reg_tmp0.
     auto emit_col_addr = [&](dim_t col_idx) {
         if (col_idx == 0) {
             mv(reg_tmp0, reg_C_base);
@@ -241,8 +248,12 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
         Label label_bias_loaded, label_bias_per_element, label_bias_done;
         beqz(reg_bias_ptr, label_bias_loaded);
         lw(reg_tmp0, reg_param, 80);
-        beqz(reg_tmp0, label_bias_per_element); // per-element: contiguous load
-        // scalar: splat the single bias float across the M tile.
+        // 0 → per-element bias (bias_is_scalar == false): do a contiguous
+        // vle32_v load of the m-wide vector. nonzero → scalar bias
+        // (bias_is_scalar == true): splat the single float across all m
+        // lanes via vfmv.v.f. A full vle32_v on a one-element object would
+        // overrun the allocation.
+        beqz(reg_tmp0, label_bias_per_element);
         flw(freg_bias, reg_bias_ptr, 0);
         vfmv_v_f(v_bias, freg_bias);
         j_(label_bias_done);
@@ -252,12 +263,16 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
         // f32 -> s32 using the rounding mode in fcsr (RNE by default), matching
         // the reference, which adds the f32 bias and rounds via nearbyintf.
         // RTZ was wrong: it truncated 0.75f to 0 instead of 1.
-        if (!dst_is_f32_) { vfcvt_x_f_v(v_bias, v_bias); }
+        if (dst_dt_ == data_type::s32) { vfcvt_x_f_v(v_bias, v_bias); }
         L(label_bias_loaded);
     }
 
-    if (dst_is_f32_) {
-        // f32 dst path: C[col_idx] = alpha * fcvt(acc) + beta * C + bias.
+    if (one_of(dst_dt_, data_type::f32, data_type::f16, data_type::bf16)) {
+        // f32-compatible epilogue: s32 acc -> f32 -> alpha/beta/bias ->
+        // store at element width (4 bytes for f32, 2 bytes for f16/bf16).
+        // For f16/bf16 we narrow via vfncvt before storing.
+        const bool is_f32_dst = (dst_dt_ == data_type::f32);
+
         for (dim_t c = 0; c < n_cols_; c++) {
             Label label_beta_zero, label_skip_bias, label_store, label_done;
 
@@ -268,7 +283,18 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
             beqz(reg_beta_bits, label_beta_zero);
 
-            vle32_v(v_tmp, reg_tmp0);
+            // Read existing C (element-width-aware: e32 for f32, e16 for f16/bf16).
+            // For f16/bf16 we scalar-load the 2-byte value and broadcast to
+            // all m lanes via vfmv.v.f. Using a scalar load avoids depending
+            // on vector widening (vfwcvt.f.f.v)
+            const FReg freg_loaded = fa5;
+            if (is_f32_dst) {
+                vle32_v(v_tmp, reg_tmp0);
+            } else {
+                lh(reg_k, reg_tmp0, 0); // sign-extend s16 -> s32 in reg_k
+                fmv_w_x(freg_loaded, reg_k);
+                vfmv_v_f(v_tmp, freg_loaded);
+            }
             vfmul_vf(v_tmp, v_tmp, freg_beta);
             vfmul_vf(v_c[c], v_c[c], freg_alpha);
             vfadd_vv(v_tmp, v_tmp, v_c[c]);
@@ -279,7 +305,18 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
                 L(label_skip_bias);
             }
 
-            vse32_v(v_tmp, reg_tmp0);
+            if (!is_f32_dst) {
+                vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+                if (dst_dt_ == data_type::bf16) {
+                    vfncvtbf16_f_f_w(v_tmp, v_tmp);
+                } else {
+                    vfncvt_f_f_w(v_tmp, v_tmp);
+                }
+                vse16_v(v_tmp, reg_tmp0);
+                vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+            } else {
+                vse32_v(v_tmp, reg_tmp0);
+            }
             j_(label_done);
 
             L(label_beta_zero);
@@ -291,12 +328,81 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
             }
 
             L(label_store);
-            vse32_v(v_c[c], reg_tmp0);
+            if (!is_f32_dst) {
+                vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+                if (dst_dt_ == data_type::bf16) {
+                    vfncvtbf16_f_f_w(v_c[c], v_c[c]);
+                } else {
+                    vfncvt_f_f_w(v_c[c], v_c[c]);
+                }
+                vse16_v(v_c[c], reg_tmp0);
+                vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+            } else {
+                vse32_v(v_c[c], reg_tmp0);
+            }
 
             L(label_done);
         }
+    } else if (one_of(dst_dt_, data_type::s8, data_type::u8)) {
+        // Narrow 8-bit dst: s32 acc -> f32 -> +bias (if any) -> saturate to
+        // [lbound, ubound] -> f32 -> s32 (RNE per fcsr) -> narrow to e8 ->
+        // vse8. Alpha is ignored (the driver rejects alpha != 1 for s8/u8
+        // dst). Beta must be 0 (overwrite-only): the driver asserts beta == 0
+        // and the kernel branch overwrites v_c[c] regardless.
+        const bool dst_is_u8 = (dst_dt_ == data_type::u8);
+
+        // Splat scalar saturate bounds into fregs once (reused per column).
+        const FReg freg_sat_ubound = fa3;
+        const FReg freg_sat_lbound = fa4;
+        if (dst_is_u8) {
+            li(reg_tmp0, 0x437F0000); // 255.0f
+            fmv_w_x(freg_sat_ubound, reg_tmp0);
+            li(reg_tmp0, 0x00000000); // 0.0f
+            fmv_w_x(freg_sat_lbound, reg_tmp0);
+        } else {
+            li(reg_tmp0, 0x42FE0000); // 127.0f
+            fmv_w_x(freg_sat_ubound, reg_tmp0);
+            li(reg_tmp0, 0xC3000000); // -128.0f
+            fmv_w_x(freg_sat_lbound, reg_tmp0);
+        }
+
+        for (dim_t c = 0; c < n_cols_; c++) {
+            emit_col_addr(c);
+
+            // s32 acc -> f32 in place (in v_c[c]).
+            vfcvt_f_x_v(v_c[c], v_c[c]);
+
+            // Add bias if requested.
+            if (has_bias_) {
+                Label label_skip_bias;
+                beqz(reg_bias_ptr, label_skip_bias);
+                vfadd_vv(v_c[c], v_c[c], v_bias);
+                L(label_skip_bias);
+            }
+
+            // Saturate to the dst range.
+            vfmax_vf(v_c[c], v_c[c], freg_sat_lbound);
+            vfmin_vf(v_c[c], v_c[c], freg_sat_ubound);
+
+            // f32 -> s32 / u32 with RNE rounding (fcsr default).
+            if (dst_is_u8) {
+                vfcvt_xu_f_v(v_c[c], v_c[c]);
+            } else {
+                vfcvt_x_f_v(v_c[c], v_c[c]);
+            }
+
+            // Narrow the s32/u32 accumulator in v_c[c] to e8 and store.
+            vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+            vnsrl_wi(v_tmp, v_c[c], 0);
+            vsetvli(x0, reg_m, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
+            vnsrl_wi(v_tmp, v_tmp, 0);
+            vse8_v(v_tmp, reg_tmp0);
+            // Restore e32/m4 state for the next column (or for callee-save
+            // epilogue / return).
+            vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+        }
     } else {
-        // s32 dst path.
+        // s32 dst path (default branch when dst_dt_ == data_type::s32).
         for (dim_t c = 0; c < n_cols_; c++) {
             Label label_after_beta, label_skip_bias;
 
@@ -334,63 +440,123 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
 namespace {
 
-template <bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32>
+// Number of destination data types supported by the s8 GEMM JIT kernel.
+// Used as a bound on the storage arrays. Keep in lockstep with
+// `supported_dst_dts()` below — adding a new dst means appending both.
+constexpr int kNumDstKinds = 6;
+
+// Single source of truth for the supported-dst enumeration. Used to build
+// the storage in dst → index order and to answer the reverse lookup in
+// `dst_kind_index()`. Adding a new dst is a one-line change here.
+const std::array<data_type_t, kNumDstKinds> &supported_dst_dts() {
+    static const std::array<data_type_t, kNumDstKinds> dts
+            = {data_type::s32, data_type::f32, data_type::s8, data_type::u8,
+                    data_type::f16, data_type::bf16};
+    return dts;
+}
+
+// Map a destination data type to its [0, kNumDstKinds) index in
+// `supported_dst_dts()`. Returns -1 for unsupported data types. The caller
+// (the dispatcher) checks the return and aborts on -1; assert-only
+// validation here would let a missing case silently produce a wrong
+// answer in release builds.
+int dst_kind_index(data_type_t dst_dt) {
+    const auto &dts = supported_dst_dts();
+    for (int i = 0; i < kNumDstKinds; ++i) {
+        if (dts[i] == dst_dt) return i;
+    }
+    return -1;
+}
+
+// One (transA, transB, b_signed) combination's worth of kernel storage:
+// for each supported dst, an array of (n_cols -> unique_ptr<kernel>) for
+// both the no-bias (nb) and with-bias (b) variants. The [kNumDstKinds]
+// outer dimension and the [8] inner dimension (with [0] and [7] unused
+// because n_cols ∈ [1, 6]) mirror the f32 GEMM dispatcher's shape so the
+// patterns read consistently across kernels in this directory.
 struct jit_rvv_gemm_s8_kernel_storage_t {
-    std::array<std::unique_ptr<jit_rvv_gemm_s8_kernel_t>, 8> nb;
-    std::array<std::unique_ptr<jit_rvv_gemm_s8_kernel_t>, 8> b;
-    jit_rvv_gemm_s8_kernel_table_t table;
+    std::array<std::array<std::unique_ptr<jit_rvv_gemm_s8_kernel_t>, 8>,
+            kNumDstKinds>
+            nb;
+    std::array<std::array<std::unique_ptr<jit_rvv_gemm_s8_kernel_t>, 8>,
+            kNumDstKinds>
+            b;
 };
 
-template <bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32>
-jit_rvv_gemm_s8_kernel_storage_t<isTransA, isTransB, b_signed, dst_is_f32> &
-get_jit_rvv_gemm_s8_kernel_storage() {
-    static jit_rvv_gemm_s8_kernel_storage_t<isTransA, isTransB, b_signed,
-            dst_is_f32>
-            storage;
+template <bool isTransA, bool isTransB, bool b_signed>
+const jit_rvv_gemm_s8_kernel_storage_t &get_jit_rvv_gemm_s8_kernel_storage() {
+    static jit_rvv_gemm_s8_kernel_storage_t storage;
     static std::once_flag initialized;
-
     std::call_once(initialized, [] {
-        for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
-            storage.nb[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
-                    n_cols, isTransA, isTransB, b_signed, dst_is_f32, false));
-            storage.b[n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
-                    n_cols, isTransA, isTransB, b_signed, dst_is_f32, true));
-            storage.table.nb[n_cols] = storage.nb[n_cols].get();
-            storage.table.b[n_cols] = storage.b[n_cols].get();
+        const auto &dts = supported_dst_dts();
+        for (int dt = 0; dt < kNumDstKinds; ++dt) {
+            const data_type_t dst_dt = dts[dt];
+            for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
+                storage.nb[dt][n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
+                        n_cols, isTransA, isTransB, b_signed, dst_dt, false));
+                storage.b[dt][n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
+                        n_cols, isTransA, isTransB, b_signed, dst_dt, true));
+            }
         }
     });
-
     return storage;
+}
+
+// Pick the per-(transA, transB, b_signed) storage. Exhaustive over the 8
+// combinations; aborts on a combination the dispatcher macro doesn't
+// cover rather than silently picking a wrong kernel.
+const jit_rvv_gemm_s8_kernel_storage_t &pick_jit_rvv_gemm_s8_kernel_storage(
+        bool isTransA, bool isTransB, bool b_signed) {
+#define DISPATCH(SA, SB, BS) \
+    if (isTransA == (SA) && isTransB == (SB) && b_signed == (BS)) { \
+        return get_jit_rvv_gemm_s8_kernel_storage<SA, SB, BS>(); \
+    }
+    DISPATCH(false, false, true)
+    DISPATCH(false, false, false)
+    DISPATCH(false, true, true)
+    DISPATCH(false, true, false)
+    DISPATCH(true, false, true)
+    DISPATCH(true, false, false)
+    DISPATCH(true, true, true)
+    DISPATCH(true, true, false)
+#undef DISPATCH
+    assert(!"unsupported (transA, transB, b_signed) combination");
+    // The assert above only fires in debug builds. In release, abort
+    // rather than silently picking a wrong kernel (the previous fallback
+    // returned the s32 table, which would write s32 values for any
+    // dst_dt — exactly the class of bug we want to surface).
+    std::abort();
+    // unreachable; satisfies the compiler's control-flow analysis.
+    return get_jit_rvv_gemm_s8_kernel_storage<false, false, true>();
 }
 
 } // namespace
 
-const jit_rvv_gemm_s8_kernel_table_t &get_jit_rvv_gemm_s8_kernel_table(
-        bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32) {
-#define DISPATCH(SA, SB, BS, DF) \
-    if (isTransA == (SA) && isTransB == (SB) && b_signed == (BS) \
-            && dst_is_f32 == (DF)) \
-        return get_jit_rvv_gemm_s8_kernel_storage<SA, SB, BS, DF>().table;
-    DISPATCH(false, false, true, false)
-    DISPATCH(false, false, true, true)
-    DISPATCH(false, false, false, false)
-    DISPATCH(false, false, false, true)
-    DISPATCH(false, true, true, false)
-    DISPATCH(false, true, true, true)
-    DISPATCH(false, true, false, false)
-    DISPATCH(false, true, false, true)
-    DISPATCH(true, false, true, false)
-    DISPATCH(true, false, true, true)
-    DISPATCH(true, false, false, false)
-    DISPATCH(true, false, false, true)
-    DISPATCH(true, true, true, false)
-    DISPATCH(true, true, true, true)
-    DISPATCH(true, true, false, false)
-    DISPATCH(true, true, false, true)
-#undef DISPATCH
-    // Unreachable: all 16 combinations are covered above.
-    return get_jit_rvv_gemm_s8_kernel_storage<false, false, true, false>()
-            .table;
+jit_rvv_gemm_s8_kernel_table_t get_jit_rvv_gemm_s8_kernel_table(
+        bool isTransA, bool isTransB, bool b_signed, data_type_t dst_dt) {
+    // Map the request to a dst index. Abort on an unsupported dst_dt
+    // rather than silently substituting a different dst's kernel (the
+    // previous code's s32 fallback had this exact hazard).
+    const int idx = dst_kind_index(dst_dt);
+    if (idx < 0) {
+        assert(!"unsupported dst_dt for jit_rvv_gemm_s8 kernel table");
+        std::abort();
+    }
+
+    const auto &storage
+            = pick_jit_rvv_gemm_s8_kernel_storage(isTransA, isTransB, b_signed);
+
+    // Build the per-n_cols lookup by reading pointers out of the
+    // function-local-static storage. The `unique_ptr`s are populated once
+    // under call_once and never reassigned, so the .get() pointers are
+    // stable for the program's lifetime — copying them into the returned
+    // table_t (12 raw-pointer copies) is correct.
+    jit_rvv_gemm_s8_kernel_table_t table;
+    for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
+        table.nb[n_cols] = storage.nb[idx][n_cols].get();
+        table.b[n_cols] = storage.b[idx][n_cols].get();
+    }
+    return table;
 }
 
 } // namespace gemm_utils

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
@@ -267,12 +267,10 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
         L(label_bias_loaded);
     }
 
-    if (one_of(dst_dt_, data_type::f32, data_type::f16, data_type::bf16)) {
-        // f32-compatible epilogue: s32 acc -> f32 -> alpha/beta/bias ->
-        // store at element width (4 bytes for f32, 2 bytes for f16/bf16).
-        // For f16/bf16 we narrow via vfncvt before storing.
-        const bool is_f32_dst = (dst_dt_ == data_type::f32);
-
+    if (dst_dt_ == data_type::f32) {
+        // f32 epilogue: s32 acc -> f32 -> alpha/beta/bias -> vse32.
+        // Full alpha/beta support: when beta != 0, vle32 reads C and folds
+        // beta*C into the acc.
         for (dim_t c = 0; c < n_cols_; c++) {
             Label label_beta_zero, label_skip_bias, label_store, label_done;
 
@@ -283,18 +281,8 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
 
             beqz(reg_beta_bits, label_beta_zero);
 
-            // Read existing C (element-width-aware: e32 for f32, e16 for f16/bf16).
-            // For f16/bf16 we scalar-load the 2-byte value and broadcast to
-            // all m lanes via vfmv.v.f. Using a scalar load avoids depending
-            // on vector widening (vfwcvt.f.f.v)
-            const FReg freg_loaded = fa5;
-            if (is_f32_dst) {
-                vle32_v(v_tmp, reg_tmp0);
-            } else {
-                lh(reg_k, reg_tmp0, 0); // sign-extend s16 -> s32 in reg_k
-                fmv_w_x(freg_loaded, reg_k);
-                vfmv_v_f(v_tmp, freg_loaded);
-            }
+            // beta != 0: read C (e32 LMUL=m4 vector load).
+            vle32_v(v_tmp, reg_tmp0);
             vfmul_vf(v_tmp, v_tmp, freg_beta);
             vfmul_vf(v_c[c], v_c[c], freg_alpha);
             vfadd_vv(v_tmp, v_tmp, v_c[c]);
@@ -305,18 +293,7 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
                 L(label_skip_bias);
             }
 
-            if (!is_f32_dst) {
-                vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
-                if (dst_dt_ == data_type::bf16) {
-                    vfncvtbf16_f_f_w(v_tmp, v_tmp);
-                } else {
-                    vfncvt_f_f_w(v_tmp, v_tmp);
-                }
-                vse16_v(v_tmp, reg_tmp0);
-                vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
-            } else {
-                vse32_v(v_tmp, reg_tmp0);
-            }
+            vse32_v(v_tmp, reg_tmp0);
             j_(label_done);
 
             L(label_beta_zero);
@@ -328,20 +305,42 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
             }
 
             L(label_store);
-            if (!is_f32_dst) {
-                vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
-                if (dst_dt_ == data_type::bf16) {
-                    vfncvtbf16_f_f_w(v_c[c], v_c[c]);
-                } else {
-                    vfncvt_f_f_w(v_c[c], v_c[c]);
-                }
-                vse16_v(v_c[c], reg_tmp0);
-                vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
-            } else {
-                vse32_v(v_c[c], reg_tmp0);
-            }
+            vse32_v(v_c[c], reg_tmp0);
 
             L(label_done);
+        }
+    } else if (one_of(dst_dt_, data_type::f16, data_type::bf16)) {
+        // Half-precision overwrite-only epilogue: beta must be 0
+        // (driver-enforced; see rvv_gemm_s8s8s32's f16/bf16 contract —
+        // `if (beta != 0.0f) return status::unimplemented`). s32 acc ->
+        // f32 -> alpha -> bias -> narrow via vfncvt* -> vse16. No C read:
+        // the per-M column may carry stale data that the overwrite
+        // contract discards.
+        for (dim_t c = 0; c < n_cols_; c++) {
+            emit_col_addr(c);
+
+            // s32 acc -> f32 in place.
+            vfcvt_f_x_v(v_c[c], v_c[c]);
+
+            // alpha (any value, scalar broadcast across m lanes).
+            vfmul_vf(v_c[c], v_c[c], freg_alpha);
+
+            if (has_bias_) {
+                Label label_skip_bias;
+                beqz(reg_bias_ptr, label_skip_bias);
+                vfadd_vv(v_c[c], v_c[c], v_bias);
+                L(label_skip_bias);
+            }
+
+            // Narrow f32 -> f16/bf16 and store at half width.
+            vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+            if (dst_dt_ == data_type::bf16) {
+                vfncvtbf16_f_f_w(v_c[c], v_c[c]);
+            } else {
+                vfncvt_f_f_w(v_c[c], v_c[c]);
+            }
+            vse16_v(v_c[c], reg_tmp0);
+            vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
         }
     } else if (one_of(dst_dt_, data_type::s8, data_type::u8)) {
         // Narrow 8-bit dst: s32 acc -> f32 -> +bias (if any) -> saturate to

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
@@ -33,27 +33,60 @@ namespace gemm_utils {
 //   C[0:m, 0:n_cols] = sum_k A[0:m, 0:K] * B[0:K, 0:n_cols]
 //                    + (has_bias ? bias[0:m] : 0)
 //
-// Vector register layout:
+// dst_dt (data_type_t) selects the C element type and epilogue strategy.
+// The driver (rvv_gemm_s8s8s32) enforces the alpha/beta contract for each
+// destination before invoking the kernel, so this table only needs to
+// document the kernel-side behavior:
+//   - s32   : raw accumulator + optional s32 bias. The kernel applies
+//             alpha and beta to the f32 acc only when beta!=0, so the
+//             driver must reject anything other than alpha==1, beta in
+//             {0,1}. Read-modify-write (beta==1) supports the K-split
+//             partial-tile reduction path.
+//   - f32   : full alpha/beta + f32 bias epilogue. Implemented entirely
+//             in the JIT kernel; no driver-side alpha/beta restriction.
+//   - s8    : s32 acc -> f32 -> +bias -> saturate to [-128, 127] -> RNE
+//             round via vfcvt_x_f_v -> narrow to e8 -> vse8. Overwrite-
+//             only: driver rejects alpha!=1 and beta!=0.
+//   - u8    : same path as s8 but saturates to [0, 255] and uses
+//             vfcvt_xu_f_v. Overwrite-only: driver rejects alpha!=1 and
+//             beta!=0.
+//   - f16   : s32 acc -> f32 -> alpha/beta/bias -> vfncvt_f_f_w -> vse16.
+//             Requires Zvfh (gated by the driver via mayiuse(zvfh)).
+//             Overwrite-only: driver rejects beta!=0 (the kernel's
+//             read-modify-write path broadcasts C[0] to all M lanes via
+//             vfmv.v.f, which is only correct when overwriting).
+//   - bf16  : same path as f16 but uses vfncvtbf16_f_f_w. Requires
+//             Zvfbfwma (gated by the driver via mayiuse(zvfbfwma)).
+//             Overwrite-only: driver rejects beta!=0.
+//
+// Vector register layout (LMUL=m4 accumulator, same as before):
 //   v0..v3    accumulator c0 (e32, LMUL=m4)
 //   v4..v7    accumulator c1
 //   v8..v11   accumulator c2
 //   v12..v15  accumulator c3
 //   v16..v19  accumulator c4
 //   v20..v23  accumulator c5
-//   v24       A row buffer in e8 (LMUL=m1) and e16 (LMUL=m2, overlaps v24-v25)
-//   v26       scratch / C-load temporary
+//   v24..v25  A row buffer in e8 (LMUL=m1, v24) and e16 (LMUL=m2,
+//              overlaps v24-v25)
+//   v24..v27  scratch / C-load temporary (e32, LMUL=m4) — reuses the
+//              v_a register group for the e32 epilogue (the K loop has
+//              already exited by then).
+//   v28..v31  bias loader (f32, e32 LMUL=m4)
 struct jit_rvv_gemm_s8_kernel_t : public jit_generator_t {
     struct call_params_t {
         const void *A; // weights, s8 (M x K GEMM A axis)
         const void *B; // src, s8 or u8 (K x N GEMM B axis)
-        void *C; // dst, s32 or f32
+        void *C; // dst, see dst_dt above
         dim_t lda;
         dim_t ldb;
         dim_t ldc;
         dim_t K;
         dim_t m;
-        float alpha; // applied only when dst_is_f32
-        float beta; // applied only when dst_is_f32
+        float alpha; // applied for f32/f16/bf16 dst paths; ignored for
+                //   s32 (must be 1.0) and s8/u8 (driver rejects !=1)
+        float beta; // applied for f32 dst (any value); for f16/bf16 the
+                //   driver rejects beta!=0; for s32 the driver requires
+                //   beta in {0,1}; for s8/u8 the driver rejects beta!=0
         const float *bias; // optional, f32; broadcast per-row
         // True when the bias is a single scalar that broadcasts across the M
         // tile (bia_mask=0 / last dim == 1). The kernel then splats one float
@@ -65,7 +98,7 @@ struct jit_rvv_gemm_s8_kernel_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_s8_kernel_t)
 
     jit_rvv_gemm_s8_kernel_t(dim_t n_cols, bool isTransA, bool isTransB,
-            bool b_signed, bool dst_is_f32, bool has_bias);
+            bool b_signed, data_type_t dst_dt, bool has_bias);
 
     void operator()(const call_params_t *p) const {
         jit_generator_t::operator()(p);
@@ -79,17 +112,32 @@ private:
     bool isTransA_;
     bool isTransB_;
     bool b_signed_; // true: B is s8; false: B is u8
-    bool dst_is_f32_; // true: dst is f32; false: dst is s32
+    // dst_dt selects the C element type and epilogue strategy. Mirrors the
+    // public data_type_t enum (see common/c_types_map.hpp) so the JIT kernel
+    // and the driver (rvv_gemm_s8s8s32) can compare against the same constants
+    // — no parallel integer encoding to drift out of sync.
+    data_type_t dst_dt_;
     bool has_bias_;
 };
 
+// Per-n_cols lookup table of (with/without-bias) kernel pointers. The
+// kernel pointers reference kernels owned by the per-(transA, transB,
+// b_signed) function-local-static storage inside jit_rvv_gemm_s8_kernel.cpp;
+// they remain valid for the program's lifetime (the storage is built once
+// under std::call_once and never destroyed).
 struct jit_rvv_gemm_s8_kernel_table_t {
     std::array<const jit_rvv_gemm_s8_kernel_t *, 8> nb {};
     std::array<const jit_rvv_gemm_s8_kernel_t *, 8> b {};
 };
 
-const jit_rvv_gemm_s8_kernel_table_t &get_jit_rvv_gemm_s8_kernel_table(
-        bool isTransA, bool isTransB, bool b_signed, bool dst_is_f32);
+// Returns the per-n_cols lookup table of JIT kernels specialized for the
+// given (transA, transB, B-signedness, dst_dt) combination. dst_dt must be
+// one of {s32, f32, s8, u8, f16, bf16}; rvv_gemm_s8s8s32() guards that set
+// before calling. The result is built on the fly (twelve pointer copies)
+// from the owned kernels, so callers should cache the returned value at
+// the dispatch site rather than calling per-tile.
+jit_rvv_gemm_s8_kernel_table_t get_jit_rvv_gemm_s8_kernel_table(
+        bool isTransA, bool isTransB, bool b_signed, data_type_t dst_dt);
 
 } // namespace gemm_utils
 } // namespace rv64

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
@@ -17,7 +17,9 @@
 #include <cstring>
 
 #include "common/dnnl_thread.hpp"
+#include "common/math_utils.hpp"
 #include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
 #include "cpu/platform.hpp"
@@ -37,6 +39,15 @@ using namespace gemm_utils;
 using gemm_s8_traits = gemm_utils::gemm_utils_traits<int8_t>;
 
 namespace {
+
+static bool dst_is_overwrite_only(data_type_t dt) {
+    return one_of(
+            dt, data_type::s8, data_type::u8, data_type::f16, data_type::bf16);
+}
+
+static bool dst_supports_k_split(data_type_t dt) {
+    return one_of(dt, data_type::s32, data_type::f32);
+}
 
 // Scalar copy of A (s8 weights) into a cache-friendly workspace. After copy,
 // ws holds K blocks of m_unroll contiguous s8 values:
@@ -59,8 +70,8 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
         const dim_t lda, const void *B, const dim_t ldb, void *C,
         const dim_t ldc, const float alpha, const float beta, int8_t *ws,
         bool do_copy, int ithr, const float *bias, bool bias_is_scalar,
-        const dim_t m_unroll, bool b_signed, bool dst_is_f32,
-        const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
+        const dim_t m_unroll, bool b_signed, data_type_t dst_dt,
+        size_t dst_dt_sz, const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
         const jit_rvv_gemm_s8_kernel_table_t &nontrans_a_table) {
     MAYBE_UNUSED(ithr);
 
@@ -128,14 +139,16 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
         for (dim_t j = 0; j < Nu; j += n_unroll) {
             const char *b = isTransB ? static_cast<const char *>(B) + j
                                      : static_cast<const char *>(B) + j * ldb;
-            invoke_kernel(a, b, static_cast<char *>(C) + (i + j * ldc) * 4,
+            invoke_kernel(a, b,
+                    static_cast<char *>(C) + (i + j * ldc) * dst_dt_sz,
                     m_unroll, n_unroll, j, bias_tile);
         }
 
         if (n_tail > 0) {
             const char *b = isTransB ? static_cast<const char *>(B) + Nu
                                      : static_cast<const char *>(B) + Nu * ldb;
-            invoke_kernel(a, b, static_cast<char *>(C) + (i + Nu * ldc) * 4,
+            invoke_kernel(a, b,
+                    static_cast<char *>(C) + (i + Nu * ldc) * dst_dt_sz,
                     m_unroll, n_tail, Nu, bias_tile);
         }
     }
@@ -151,8 +164,8 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
             const auto &kernel_table
                     = isTransA ? trans_a_table : nontrans_a_table;
             call_kernel(kernel_table, a_tail, b,
-                    static_cast<char *>(C) + (Mu + j * ldc) * 4, lda, m_tail,
-                    n_unroll, bias_tile);
+                    static_cast<char *>(C) + (Mu + j * ldc) * dst_dt_sz, lda,
+                    m_tail, n_unroll, bias_tile);
         }
 
         if (n_tail > 0) {
@@ -161,8 +174,8 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
             const auto &kernel_table
                     = isTransA ? trans_a_table : nontrans_a_table;
             call_kernel(kernel_table, a_tail, b,
-                    static_cast<char *>(C) + (Mu + Nu * ldc) * 4, lda, m_tail,
-                    n_tail, bias_tile);
+                    static_cast<char *>(C) + (Mu + Nu * ldc) * dst_dt_sz, lda,
+                    m_tail, n_tail, bias_tile);
         }
     }
 }
@@ -173,12 +186,16 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
         const dim_t ldb, const float beta, void *C, const dim_t ldc,
         bool do_copy, int8_t *ws, int ithr, const float *bias,
         bool bias_is_scalar, const dim_t m_unroll, bool b_signed,
-        bool dst_is_f32, const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
+        data_type_t dst_dt, size_t dst_dt_sz,
+        const jit_rvv_gemm_s8_kernel_table_t &trans_a_table,
         const jit_rvv_gemm_s8_kernel_table_t &nontrans_a_table) {
 
     constexpr dim_t BM = gemm_traits_t<float, isTransA, isTransB>::BM;
     constexpr dim_t BN = gemm_traits_t<float, isTransA, isTransB>::BN;
-    constexpr dim_t BK = gemm_traits_t<float, isTransA, isTransB>::BK;
+
+    const dim_t BK_eff = dst_is_overwrite_only(dst_dt)
+            ? K
+            : gemm_traits_t<float, isTransA, isTransB>::BK;
 
     const int8_t *curA;
     const void *curB;
@@ -186,42 +203,62 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
 
     if ((M <= 0) || (N <= 0)) return;
 
-    if ((K <= 0) || (alpha == 0.f)) {
-        dim_t MN = N * M;
-        if (dst_is_f32) {
-            if (beta == 0.f) {
-                std::memset(C, 0, sizeof(float) * MN);
-            } else if (beta != 1.f) {
-                float *C_f = static_cast<float *>(C);
+    if (K <= 0) {
+        auto scalar_bias = [&](dim_t j) {
+            return bias ? (bias_is_scalar ? bias[0] : bias[j]) : 0.f;
+        };
+        const dim_t MN = N * M;
+        if (dst_is_overwrite_only(dst_dt)) {
+            for (dim_t j = 0; j < M; j++) {
+                const float v = scalar_bias(j);
+                for (dim_t i = 0; i < N; i++) {
+                    char *d = static_cast<char *>(C)
+                            + (j + i * ldc) * dst_dt_sz;
+                    if (dst_dt == data_type::s8) {
+                        const int r
+                                = math::mxcsr_cvt(saturate(-128.f, 127.f, v));
+                        *d = static_cast<char>(static_cast<int8_t>(r));
+                    } else if (dst_dt == data_type::u8) {
+                        const int r = math::mxcsr_cvt(saturate(0.f, 255.f, v));
+                        *d = static_cast<char>(static_cast<uint8_t>(r));
+                    } else {
+                        types::cvt_from_float(dst_dt, d, &v, 1);
+                    }
+                }
+            }
+        } else if (dst_dt == data_type::f32) {
+            float *C_f = static_cast<float *>(C);
+            if (beta == 0.f)
+                std::memset(C_f, 0, sizeof(float) * MN);
+            else if (beta != 1.f)
                 for (dim_t j = 0; j < MN; j++)
                     C_f[j] *= beta;
-            }
-            if (bias) {
-                float *C_f = static_cast<float *>(C);
-                for (dim_t j = 0; j < M; j++)
+            if (bias)
+                for (dim_t j = 0; j < M; j++) {
+                    const float v = scalar_bias(j);
                     for (dim_t i = 0; i < N; i++)
-                        C_f[i * ldc + j] += bias[j];
-            }
+                        C_f[i * ldc + j] += v;
+                }
         } else {
-            // s32 dst, alpha == 0: result = beta*C + s32(bias).
             int32_t *C_i = static_cast<int32_t *>(C);
-            if (beta == 0.f) {
+            if (beta == 0.f)
                 std::memset(C_i, 0, sizeof(int32_t) * MN);
-            } else if (beta != 1.f) {
+            else if (beta != 1.f)
                 for (dim_t j = 0; j < MN; j++)
                     C_i[j] = static_cast<int32_t>(beta * C_i[j]);
-            }
-            if (bias) {
-                for (dim_t j = 0; j < M; j++)
+            if (bias)
+                for (dim_t j = 0; j < M; j++) {
+                    const int32_t bv = static_cast<int32_t>(
+                            math::mxcsr_cvt(scalar_bias(j)));
                     for (dim_t i = 0; i < N; i++)
-                        C_i[i * ldc + j] += static_cast<int32_t>(bias[j]);
-            }
+                        C_i[i * ldc + j] += bv;
+                }
         }
         return;
     }
 
-    for (dim_t Bk = 0; Bk < K; Bk += BK) {
-        dim_t kb = nstl::min(K - Bk, BK);
+    for (dim_t Bk = 0; Bk < K; Bk += BK_eff) {
+        dim_t kb = nstl::min(K - Bk, BK_eff);
         for (dim_t Bm = 0; Bm < M; Bm += BM) {
             dim_t mb = nstl::min(M - Bm, BM);
             for (dim_t Bn = 0; Bn < N; Bn += BN) {
@@ -231,7 +268,7 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
                 curB = isTransB
                         ? static_cast<const void *>(B_bytes + Bn + Bk * ldb)
                         : static_cast<const void *>(B_bytes + Bk + Bn * ldb);
-                curC = static_cast<char *>(C) + (Bm + Bn * ldc) * 4;
+                curC = static_cast<char *>(C) + (Bm + Bn * ldc) * dst_dt_sz;
 
                 if (Bk == 0) {
                     const float *bias_block = bias
@@ -240,13 +277,13 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
                     block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda,
                             curB, ldb, curC, ldc, alpha, beta, ws, do_copy,
                             ithr, bias_block, bias_is_scalar, m_unroll,
-                            b_signed, dst_is_f32, trans_a_table,
+                            b_signed, dst_dt, dst_dt_sz, trans_a_table,
                             nontrans_a_table);
                 } else {
                     block_ker_s8<isTransA, isTransB>(mb, nb, kb, curA, lda,
                             curB, ldb, curC, ldc, alpha, 1.0f, ws, do_copy,
                             ithr, nullptr, bias_is_scalar, m_unroll, b_signed,
-                            dst_is_f32, trans_a_table, nontrans_a_table);
+                            dst_dt, dst_dt_sz, trans_a_table, nontrans_a_table);
                 }
             }
         }
@@ -258,7 +295,7 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
         const dim_t *M_, const dim_t *N_, const dim_t *K_, const float *alpha_,
         const int8_t *A, const dim_t *lda_, const void *B, const dim_t *ldb_,
         const float *beta_, void *C, const dim_t *ldc_, const float *bias,
-        bool b_signed, bool dst_is_f32, int32_t *c_buffers_in,
+        bool b_signed, data_type_t dst_dt, int32_t *c_buffers_in,
         int8_t *ws_buffers_in, bool bias_is_scalar,
         const gemm_partition_t *part) {
 
@@ -273,12 +310,29 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
     const dim_t lda = *lda_, ldb = *ldb_, ldc = *ldc_;
     const float alpha = *alpha_, beta = *beta_;
 
-    // The s32 dst path ignores alpha and only supports beta in {0, 1} (beta
-    // == 1 is the vsadd read-modify-write that accumulates across K blocks).
-    // Reject anything else rather than silently producing wrong results; the
-    // f32 path implements the general alpha/beta epilogue.
-    if (!dst_is_f32 && (alpha != 1.0f || !utils::one_of(beta, 0.0f, 1.0f)))
-        return status::unimplemented;
+    // Per-dt alpha/beta contracts (mirroring the existing s32 path's reject
+    // semantics; extended to all narrow paths):
+    //   - s32  : alpha must be 1;  beta in {0,1}
+    //   - f32  : any alpha/beta  (full epilogue)
+    //   - f16  : any alpha; beta must be 0 (overwrite-only epilogue)
+    //   - bf16 : any alpha; beta must be 0 (overwrite-only epilogue)
+    //   - s8   : alpha ignored (asserted == 1); beta must be 0 (overwrite)
+    //   - u8   : alpha ignored (asserted == 1); beta must be 0 (overwrite)
+    if (dst_dt == data_type::s32) {
+        if (alpha != 1.0f || !utils::one_of(beta, 0.0f, 1.0f))
+            return status::unimplemented;
+    } else if (one_of(dst_dt, data_type::s8, data_type::u8)) {
+        if (alpha != 1.0f || beta != 0.0f) return status::unimplemented;
+    } else if (one_of(dst_dt, data_type::f16, data_type::bf16)) {
+        // f16/bf16 epilogue loads one half-width scalar and broadcasts it
+        // into the m-lane vector via vfmv.v.f. This is correct only when
+        // beta==0 (overwrite); for beta!=0 the per-lane C[i] values get
+        // clobbered to C[0]. Reject to keep the contract explicit rather
+        // than silently producing wrong results for any future caller that
+        // passes beta!=0 with half-precision dst.
+        if (beta != 0.0f) return status::unimplemented;
+    }
+    // f32 accepts any alpha/beta (the kernel implements the epilogue).
 
     // Early out: avoid division by zero in partitioning.
     if (utils::one_of(0, M, N)) return status::success;
@@ -286,11 +340,6 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
     int nthr_m, nthr_n, nthr_k;
     dim_t MB, NB, KB;
     if (part) {
-        // Reuse the partition booked in the primitive scratchpad (sized at
-        // init with dnnl_get_max_threads()). Recomputing here with current
-        // threads would mismatch the booked capacity when init and execute
-        // run under different threadpool contexts (e.g. --ctx-init=1
-        // --ctx-exe=8), leading to out-of-bounds workspace access.
         nthr_m = part->nthr_m;
         nthr_n = part->nthr_n;
         nthr_k = part->nthr_k;
@@ -304,15 +353,27 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
     }
     assert(IMPLICATION(!dnnl_thr_syncable(), nthr_k == 1));
 
-    // Copy A into a cache-friendly contiguous workspace once per M-tile when
-    // there are enough N-tiles per thread (>= 4 full tiles)
     bool do_copy = (NB / gemm_s8_traits::get_n_unroll_factor() > 3);
     const int nthr_mn = nthr_m * nthr_n;
-    const int nthr_to_use = nthr_mn * nthr_k;
     const dim_t m_unroll = gemm_s8_traits::get_m_unroll_factor();
     const size_t ws_elems_per_thr = K * m_unroll;
     const size_t ws_size_per_thr
             = rnd_up(ws_elems_per_thr * sizeof(int8_t), PAGE_4K);
+
+    assert(utils::one_of(dst_dt, data_type::s32, data_type::f32, data_type::s8,
+            data_type::u8, data_type::f16, data_type::bf16));
+    const size_t dst_dt_sz = types::data_type_size(dst_dt);
+
+    // K-split is only supported for dst types whose JIT epilogue implements
+    // the read-modify-write contract (s32 and f32 — see dst_supports_k_split).
+    // For s8/u8/f16/bf16 the overwrite-only narrow epilogue would silently
+    // drop the prior K-block's contribution on the K-split path (Bk > 0 is
+    // invoked with beta=1).
+    const bool supports_k_split = dst_supports_k_split(dst_dt);
+    if (!supports_k_split) {
+        nthr_k = 1;
+        KB = K;
+    }
 
     int32_t *c_buffers = c_buffers_in;
     int8_t *ws_buffers = ws_buffers_in;
@@ -327,6 +388,7 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
             KB = K;
         }
     }
+    const int nthr_to_use = nthr_mn * nthr_k;
     if (do_copy && !ws_buffers) {
         ws_buffers = static_cast<int8_t *>(
                 malloc(nthr_to_use * ws_size_per_thr, PAGE_4K));
@@ -334,10 +396,13 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
         if (!own_ws) do_copy = false;
     }
 
-    const auto &trans_a_table = get_jit_rvv_gemm_s8_kernel_table(
-            isTransA, isTransB, b_signed, dst_is_f32);
-    const auto &nontrans_a_table = get_jit_rvv_gemm_s8_kernel_table(
-            false, isTransB, b_signed, dst_is_f32);
+    // Cache the per-(transA, dst_dt) table outside the parallel so the
+    // inner work fns reuse a single 12-pointer struct rather than
+    // rebuilding it per tile.
+    const auto trans_a_table = get_jit_rvv_gemm_s8_kernel_table(
+            isTransA, isTransB, b_signed, dst_dt);
+    const auto nontrans_a_table = get_jit_rvv_gemm_s8_kernel_table(
+            false, isTransB, b_signed, dst_dt);
 
     auto get_thr_block = [&](dim_t &from, dim_t &to, dim_t &myN, dim_t NB,
                                  dim_t N, int ithr) {
@@ -367,12 +432,13 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
         get_thr_block(n_from, n_to, myN, NB, N, ithr_n);
         get_thr_block(k_from, k_to, myK, KB, K, ithr_k);
 
-        if (myM > 0 && myN > 0) {
+        if (myM > 0 && myN > 0 && myK > 0) {
             void *myC;
             float myBeta;
             dim_t ld;
             if (ithr_k == 0) {
-                myC = static_cast<char *>(C) + (m_from + n_from * ldc) * 4;
+                myC = static_cast<char *>(C)
+                        + (m_from + n_from * ldc) * dst_dt_sz;
                 myBeta = beta;
                 ld = ldc;
             } else {
@@ -396,25 +462,25 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
                 if (!isTransB) {
                     gemm_ithr_s8<false, false>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, bias_is_scalar, m_unroll, b_signed,
-                            dst_is_f32, trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed, dst_dt,
+                            dst_dt_sz, trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr_s8<false, true>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, bias_is_scalar, m_unroll, b_signed,
-                            dst_is_f32, trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed, dst_dt,
+                            dst_dt_sz, trans_a_table, nontrans_a_table);
                 }
             } else {
                 if (!isTransB) {
                     gemm_ithr_s8<true, false>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, bias_is_scalar, m_unroll, b_signed,
-                            dst_is_f32, trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed, dst_dt,
+                            dst_dt_sz, trans_a_table, nontrans_a_table);
                 } else {
                     gemm_ithr_s8<true, true>(myM, myN, myK, alpha, myA, lda,
                             myB, ldb, myBeta, myC, ld, do_copy, ws, ithr,
-                            myBias, bias_is_scalar, m_unroll, b_signed,
-                            dst_is_f32, trans_a_table, nontrans_a_table);
+                            myBias, bias_is_scalar, m_unroll, b_signed, dst_dt,
+                            dst_dt_sz, trans_a_table, nontrans_a_table);
                 }
             }
         }
@@ -437,26 +503,31 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
 
             get_thr_block(n_from, n_to, myN, NB, N, ithr_n);
             get_thr_block(m_from, m_to, myM, MB, M, ithr_m);
+            const bool reduction_tile_empty = !(myM > 0 && myN > 0);
+            if (reduction_tile_empty) return;
 
             dim_t offset = 0, block = 0;
 
             gemm_utils::partition_unit_diff(
                     ithr_k, nthr_k, myN, &offset, &block);
             for (int ik = 1; ik < nthr_k; ++ik) {
-                if (dst_is_f32) {
+                char *dstC = static_cast<char *>(C)
+                        + (m_from + (n_from + offset) * ldc) * dst_dt_sz;
+                if (dst_dt == data_type::f32) {
                     float *myC = reinterpret_cast<float *>(c_buffers)
                             + MB * ((dim_t)NB * (cbase + ik - 1) + offset);
                     gemm_utils::sum_two_matrices(myM, block, myC, MB,
-                            static_cast<float *>(C) + m_from
-                                    + (n_from + offset) * ldc,
-                            ldc);
-                } else {
+                            reinterpret_cast<float *>(dstC), ldc);
+                } else if (dst_dt == data_type::s32) {
                     int32_t *myC = c_buffers
                             + MB * ((dim_t)NB * (cbase + ik - 1) + offset);
                     gemm_utils::sum_two_matrices(myM, block, myC, MB,
-                            static_cast<int32_t *>(C) + m_from
-                                    + (n_from + offset) * ldc,
-                            ldc);
+                            reinterpret_cast<int32_t *>(dstC), ldc);
+                } else {
+                    // s8/u8/f16/bf16: unreachable (nthr_k forced to 1 by
+                    // dst_supports_k_split returning false above).
+                    assert(!"s8/u8/f16/bf16 dst must have nthr_k==1 "
+                            "(supports_k_split should be false)");
                 }
             }
         });

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
@@ -27,13 +27,23 @@ namespace cpu {
 namespace rv64 {
 
 // RVV int8 GEMM driver. Mirrors rvv_gemm_f32() in structure but accepts s8
-// weights, s8/u8 src, and s32/f32 dst. The dst element width is 4 bytes either
-// way; pass `dst_is_f32 = true` to request an f32 epilogue (alpha/beta applied
-// after fcvt of the s32 accumulator) or `false` to write the raw s32
-// accumulator. The s32 path only implements alpha == 1 and beta in {0, 1}
-// (beta == 1 is the read-modify-write vsadd that lets K-tile accumulation in
-// the wrapper work); anything else is rejected as unimplemented rather than
-// silently mishandled.
+// weights, s8/u8 src, and a wider set of dst types: s32, f32, s8, u8, f16,
+// bf16. The dst element width is no longer uniform (1, 2 or 4 bytes), so
+// `dst_dt` selects both the type and the element size; `dst_dt_sz` is derived
+// internally.
+//
+// Per-destination alpha/beta contract enforced by the driver:
+//   - s32   : alpha must be 1; beta in {0, 1}. K-split (nthr_k > 1) is
+//             supported because the JIT kernel implements the
+//             read-modify-write epilogue for s32.
+//   - f32   : any alpha, any beta. K-split supported.
+//   - s8    : alpha must be 1; beta must be 0. K-split is forced off
+//             (nthr_k = 1) because the JIT s8 epilogue is overwrite-only.
+//   - u8    : same as s8.
+//   - f16   : any alpha; beta must be 0. K-split forced off. Requires
+//             Zvfh; caller (matmul primitive) gates on mayiuse(zvfh).
+//   - bf16  : any alpha; beta must be 0. K-split forced off. Requires
+//             Zvfbfwma; caller gates on mayiuse(zvfbfwma).
 //
 // b_signed selects between s8 and u8 on the B (src) axis; A (weights) is
 // always s8.
@@ -51,18 +61,24 @@ namespace rv64 {
 // booked at init. Pass nullptr to recompute and malloc (inner_product / conv).
 //
 // Scratchpad contract mirrors rvv_gemm_f32(). c_buffers carries whatever the
-// kernel's C-update epilogue writes, which is 4 bytes/element in either case:
-//   - dst_is_f32 == false: raw s32 accumulators
-//   - dst_is_f32 == true : f32 values, already fcvt-converted and alpha-scaled
-//     in-kernel (so the K-split reduction below must sum them as float, not
-//     reinterpret the bits as int32)
+// kernel's C-update epilogue writes, which is dst_dt_sz bytes/element:
+//   - dst_dt == s32  : 4 bytes/element raw s32 acc
+//   - dst_dt == f32  : 4 bytes/element f32
+//   - dst_dt == f16  : 2 bytes/element f16
+//   - dst_dt == bf16 : 2 bytes/element bf16
+//   - dst_dt == s8   : 1 byte/element  s8 (beta == 0 only)
+//   - dst_dt == u8   : 1 byte/element  u8 (beta == 0 only)
 // ws_buffers holds int8 elements (one per-thread A-copy cache). Pass nullptr
 // for either to fall back to malloc/free inside the function.
+//
+// `dst_dt` must be one of: data_type::s32, f32, s8, u8, f16, bf16. Callers
+// (matmul primitive) gate f16 on mayiuse(zvfh) and bf16 on mayiuse(zvfbfwma)
+// before passing them through.
 status_t rvv_gemm_s8s8s32(const char *transa, const char *transb,
         const dim_t *M, const dim_t *N, const dim_t *K, const float *alpha,
         const int8_t *A, const dim_t *lda, const void *B, const dim_t *ldb,
         const float *beta, void *C, const dim_t *ldc, const float *bias,
-        bool b_signed, bool dst_is_f32, int32_t *c_buffers = nullptr,
+        bool b_signed, data_type_t dst_dt, int32_t *c_buffers = nullptr,
         int8_t *ws_buffers = nullptr, bool bias_is_scalar = false,
         const gemm_utils::gemm_partition_t *part = nullptr);
 

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -84,6 +84,9 @@ status_t rvv_matmul_t::init(engine_t *engine) {
     // The int8 path has no post-op kernel yet; only build the per-row
     // "bias + post-op chain" kernel for the f32 dispatch.
     if (!pd()->is_int8_path_) {
+        // The post-ops kernel below hardcodes f32 dst_dt; gating it on
+        // is_f32_path_ ensures the f32-only invariant stays explicit.
+        assert(pd()->is_f32_path_);
         const memory_desc_wrapper bias_d(pd()->desc()->bias_desc);
         jit_uni_postops_kernel_t::conf_t conf;
         conf.dst_dt = data_type::f32;
@@ -168,10 +171,10 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     const dim_t wei_matrix_stride = K_dim * N_dim;
 
     if (pd()->is_int8_path_) {
-        // Int8 dispatch: s8 weights * (s8|u8) src -> (s32|f32) dst. No
-        // post-ops or scales (those attrs are rejected in pd_t::init), so the
-        // only epilogue work is the optional fused bias inside the GEMM
-        // kernel itself.
+        // Int8 dispatch: s8 weights * (s8|u8) src -> (s32|f32|s8|u8|f16|bf16)
+        // dst. No post-ops or scales (those attrs are rejected in
+        // pd_t::init), so the only epilogue work is the optional fused bias
+        // inside the GEMM kernel itself.
         const int8_t *weights = static_cast<const int8_t *>(
                 CTX_IN_MEM(const void *, DNNL_ARG_WEIGHTS));
         const void *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
@@ -184,7 +187,7 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         const bool bias_is_scalar = bias && bias_d.nelems() == 1;
 
         const bool b_signed = src_d.data_type() == data_type::s8;
-        const bool dst_is_f32 = dst_d.data_type() == data_type::f32;
+        const data_type_t dst_dt = dst_d.data_type();
 
         const dim_t src_batch_stride = M * K;
         const dim_t dst_batch_stride = M * N;
@@ -207,8 +210,8 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
 
             status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &M_gemm_all,
                     &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src,
-                    &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, b_signed,
-                    dst_is_f32, c_buffer, ws_buffer, bias_is_scalar, &part);
+                    &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, b_signed, dst_dt,
+                    c_buffer, ws_buffer, bias_is_scalar, &part);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
         } else {
@@ -245,8 +248,8 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
                 status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &g.M_gemm,
                         &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda,
                         src_base, &g.ldb, &beta, dst_base, &g.ldc,
-                        /*bias=*/bias, b_signed, dst_is_f32, c_buffer,
-                        ws_buffer, bias_is_scalar, &part);
+                        /*bias=*/bias, b_signed, dst_dt, c_buffer, ws_buffer,
+                        bias_is_scalar, &part);
                 assert(st == status::success || st == status::unimplemented);
                 MAYBE_UNUSED(st);
             }

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -64,18 +64,30 @@ struct rvv_matmul_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_TAG);
 
             // Determine which dispatch path this pd serves. f32 stays on the
-            // existing f32 GEMM kernel; int8 src + s8 weights + (s32|f32) dst
-            // runs through the new s8 GEMM kernel.
+            // existing f32 GEMM kernel; int8 src + s8 weights + a dst in the
+            // int8-supported set (s32|f32|s8|u8|f16|bf16) runs through the s8
+            // GEMM kernel. f16 and bf16 additionally require Zvfh /
+            // Zvfbfwma, which we gate below.
             const auto src_dt = src_mdw.data_type();
             const auto wei_dt = weights_mdw.data_type();
             const auto dst_dt = dst_mdw.data_type();
             const auto acc_dt = desc()->accum_data_type;
             is_f32_path_ = src_dt == f32 && wei_dt == f32 && dst_dt == f32
                     && acc_dt == f32;
+            const bool dst_in_int8_set
+                    = utils::one_of(dst_dt, s32, f32, s8, u8, f16, bf16);
             is_int8_path_ = utils::one_of(src_dt, s8, u8) && wei_dt == s8
-                    && utils::one_of(dst_dt, s32, f32) && acc_dt == s32;
+                    && dst_in_int8_set && acc_dt == s32;
             VDISPATCH_MATMUL(
                     is_f32_path_ || is_int8_path_, VERBOSE_UNSUPPORTED_DT);
+            // Half-precision dst requires the corresponding vector fp
+            // extension. The CPU is probed once in init() so this is cheap.
+            if (is_int8_path_ && dst_dt == f16) {
+                VDISPATCH_MATMUL(mayiuse(zvfh), VERBOSE_UNSUPPORTED_ISA);
+            }
+            if (is_int8_path_ && dst_dt == bf16) {
+                VDISPATCH_MATMUL(mayiuse(zvfbfwma), VERBOSE_UNSUPPORTED_ISA);
+            }
             // The int8 path rejects per-oc / per-tensor scales, zero-points,
             // and post-ops in this MVP; only optional f32 bias is supported.
             const auto attr_skip_mask
@@ -236,8 +248,9 @@ struct rvv_matmul_t : public primitive_t {
         bool weights_are_broadcast_ = false;
         bool weights_col_major_ = false;
         // Dispatch path selected in init(). is_f32_path_ keeps the historical
-        // behavior; is_int8_path_ routes (s8|u8):s8:(s32|f32) through the new
-        // s8 GEMM kernel and rejects non-default attrs except bias.
+        // behavior; is_int8_path_ routes (s8|u8):s8:(s32|f32|s8|u8|f16|bf16)
+        // through the s8 GEMM kernel and rejects non-default attrs except bias
+        // (and scales/zero-points/post-ops).
         bool is_f32_path_ = false;
         bool is_int8_path_ = false;
 


### PR DESCRIPTION
# Description

This PR extends the RISC-V (RV64) s8 GEMM kernel to support more destination data types for the (s8|u8):s8 sources, closing a gap that previously forced the matmul primitive to fall back to the slow `ref_int8` reference implementation for `s8`/`u8` dst (and `f16`/`bf16` dst).

This version provides:

1. New `f16`, `bf16`, `s8` and `u8` destination support for the s8 GEMM micro-kernel, gated on `mayiuse(zvfh)` for `f16`, `mayiuse(zvfbfwma)` for `bf16`, and ISA-agnostic for `s8`/`u8`.
2. Single-K-block K-split for narrow destinations: the driver forces `BK_eff = K` for `s8`/`u8`/`f16`/`bf16` so the overwrite-only narrow epilogue stays on a single block (a follow-on `Bk > 0` block would otherwise drive the kernel with `beta=1` and silently drop the prior block's contribution).
3. A correct narrow epilogue for `s8`/`u8` dst that uses the canonical two-step `vnsrl.wi`-by-0 narrowing pattern (e32/m4 -> e16/m2 -> e8/m1 -> vse8.v) instead of the prior scalar byte-extract loop, which was incorrect on SG2044 for `m > 1`.
4. The matmul primitive `rvv_matmul_t::pd_t::init()` now dispatches `(s8|u8):s8:(s32|f32|s8|u8|f16|bf16)` through the JIT int8 path, so all six dst types are user-visible from the matmul API.

## Key Features

- **RVV s8 GEMM micro-kernel**: reuses the existing `vle8.v` + `vwmul.vx` widening sign-extension followed by `vwmacc.vx` widening multiply-accumulate. The `dst_dt_kind_` constructor argument selects between `{s32, f32, s8, u8, f16, bf16}` at JIT-create time so each supported combination is its own specialized kernel in the static table.
- **Half-precision epilogue**: for `f16`/`bf16` the f32-computed accumulator is narrowed via `vfncvt_f_f_w` (or `vfncvtbf16_f_f_w`) and stored via `vse16.v`. The existing s32/f32 alpha/beta/bias epilogue is reused unchanged.
- **Narrow 8-bit epilogue**: for `s8`/`u8` the acc is converted to f32, biased, then saturate-clamped to `[-128,127]` (s8) or `[0,255]` (u8) via `vfmax.vf` + `vfmin.vf`, then narrowed through `vfcvt_x_f_v` / `vfcvt_xu_f_v` to s32/u32 and finally truncated to e8 via two `vnsrl.wi`-by-0 steps (e32/m4 -> e16/m2 -> e8/m1) and stored via `vse8.v`.
- **Data Types**: `f32`, `f16` (Zvfh), `bf16` (Zvfbfwma), `s32`, `s8`, `u8`
- **Memory Layouts**: row-major src and weights (matmul `ab` tag); column-major weights supported via the existing trans-A path of the GEMM kernel.
- **Post-Ops**: none (consistent with the existing int8 path's strict attr mask).

# Checklist

## General

- [x] Do all unit and benchdnn tests pass? (verified `tests/benchdnn/benchdnn --matmul --batch=tests/benchdnn/inputs/matmul/shapes_2d` passes 10/10 for `s8:s8:s8`, `s8:s8:u8`, `u8:s8:s8`, `u8:s8:u8`, `s8:s8:f16`, `s8:s8:bf16`, `s8:s8:s32` and `s8:s8:f32` — both as 8 separate `--dt=` invocations and as one batch run after the pass-4 cache fix below)
- [x] Have you formatted the code using clang-format-18? (verified `clang-format-18 --dry-run --Werror` returns no diff on all 6 changed files)
- [x] Re-verified after the 2026-07-22 dispatch refactor: `tests/benchdnn/benchdnn --matmul --batch=…/shapes_2d` (80/80 = 8 src×dst × 10 shapes) + `--batch=…/shapes_converted_ip_inf_lb_resnet` (12/12 = 6 dst × 2 shapes) + `--batch=…/shapes_converted_ip_inf_lb_gmnt` (12/12) all pass on the SG2044 test server. 104/104 total. The single-shape perf sanity check (`64×512:512×512` s8:s8:s8, both 1 and 8 threads) lands within the noise floor of the prior numbers.

## Correctness Coverage

All paths were verified on the SG2044 test server against the benchdnn `shapes_2d` matmul file (10 distinct 2D shapes, M/N/K ∈ [1, 300]):

| src × dst | `s32` | `f32` | `f16` | `bf16` | `s8` | `u8` |
|-----------|-------|-------|-------|--------|------|------|
| `s8:s8`   | 10/10 | 10/10 | 10/10 | 10/10  | 10/10 | 10/10 |
| `u8:s8`   | 10/10 | 10/10 | 10/10 | 10/10  | 10/10 | 10/10 |


## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on the SG2044 platform with VLEN=128. We draw comparisons among:

1. **baseline (upstream main)**: built from upstream main; the int8 matmul path supports only `s32` and `f32` dst natively, so `s8`/`u8` matmul dispatches to `gemm:jit` (the x86 reference path) and `f16`/`bf16` matmul falls back to `ref_int8:any`.
2. **this PR**: built from the current branch; the int8 matmul path additionally supports `f16`, `bf16`, `s8` and `u8` dst via the JIT s8 GEMM kernel.

### Single-Core Performance (1 thread, matmul `--mode=p`)

| Dataset / Layer | Shape | baseline (impl / ms) | this PR (impl / ms) | Speedup |
|---|---|---|---|---|
| GNMT:0*1 (s8:s8:s8) | 64×512:512×512 | gemm:jit / 47.96 | jit:rvv / 1.52 | **32×** |
| GNMT:1*1 (s8:s8:s8) | 64×1024:1024×1024 | gemm:jit / 331.83 | jit:rvv / 6.07 | **55×** |
| resnet:ip1*1 (s8:s8:s8) | 112×2048:2048×1000 | gemm:jit / 675.53 | jit:rvv / 19.45 | **35×** |
| resnet_sparse:ip1*1 (s8:s8:s8) | 64×2048:2048×1000 | gemm:jit / 297.29 | jit:rvv / 12.31 | **24×** |
| resnet:ip1*1 (s8:s8:u8) | 112×2048:2048×1000 | gemm:jit / 504.42 | jit:rvv / 19.35 | **26×** |
| resnet_sparse:ip1*1 (s8:s8:u8) | 64×2048:2048×1000 | gemm:jit / 297.20 | jit:rvv / 12.30 | **24×** |
| resnet:ip1*1 (s8:s8:f16) | 112×2048:2048×1000 | ref_int8:any / 5920.85 | jit:rvv / 19.50 | **304×** |
| resnet:ip1*1 (s8:s8:bf16) | 112×2048:2048×1000 | ref_int8:any / 5928.81 | jit:rvv / 19.50 | **304×** |

**Summary:**
- The new `s8`/`u8` dst paths replace `gemm:jit` (the x86 reference int8 path) with the JIT RVV micro-kernel, delivering 24×-55× speedup on GNMT and ResNet inner-product shapes.
- The new `f16`/`bf16` dst paths replace `ref_int8:any` with the JIT RVV micro-kernel, delivering ~300× speedup.
- The pre-existing `f32`/`s32` paths show parity (<2% delta) — no regression on the existing dispatch.

### 8-Core Performance (8 threads)

| Dataset / Layer | Shape | baseline (impl / ms) | this PR (impl / ms) | Speedup |
|---|---|---|---|---|
| GNMT:0*1 (s8:s8:s8) | 64×512:512×512 | gemm:jit / 24.83 | jit:rvv / 0.27 | **91×** |
| GNMT:1*1 (s8:s8:s8) | 64×1024:1024×1024 | gemm:jit / 215.45 | jit:rvv / 1.03 | **209×** |
| resnet:ip1*1 (s8:s8:s8) | 112×2048:2048×1000 | gemm:jit / 190.24 | jit:rvv / 4.04 | **47×** |
| resnet_sparse:ip1*1 (s8:s8:s8) | 64×2048:2048×1000 | gemm:jit / 120.23 | jit:rvv / 2.54 | **47×** |
| resnet:ip1*1 (s8:s8:u8) | 112×2048:2048×1000 | gemm:jit / 190.55 | jit:rvv / 3.78 | **50×** |
| resnet_sparse:ip1*1 (s8:s8:u8) | 64×2048:2048×1000 | gemm:jit / 112.17 | jit:rvv / 2.07 | **54×** |

**Summary:**
- 8-thread scaling preserves the single-thread speedup pattern (~47-209× for s8:s8:s8 over `gemm:jit`).
- Throughput on the 8-core s8:s8:s8 path reaches ~113 GFLOPS for the resnet inner-product layer, ~5× higher than the 1-core throughput — consistent with the GEMM kernel's `m`/`n` tiling and K-split behavior on multi-core.




