### PR TITLE
cpu: x64: zen64: add batched matmul (BMM) support

### DIFF
--- a/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp
@@ -49,6 +49,7 @@ const impl_list_map_t &regular_f32_f32_impl_list_map() {
             nullptr,
         }},
         {{f32, f32, 3}, {
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_copy_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))

--- a/src/cpu/x64/zen64/matmul/zen_matmul.cpp
+++ b/src/cpu/x64/zen64/matmul/zen_matmul.cpp
@@ -48,6 +48,53 @@ using namespace dnnl::impl::cpu::matmul;
 
 #if DNNL_X64_USE_ZEN
 using namespace zen_matmul;
+
+namespace {
+
+// Resolved Zen BMM batch parameters. For the non-batched (2D) path the batch
+// counts stay 1 and the strides keep the (size_t)-1 sentinel (the backend then
+// derives dense strides). For 3D the leading dim is the single batch dim and
+// the per-batch strides are expressed in elements (matching the Zen looper,
+// which scales them by the per-tensor element size).
+struct zen_bmm_params_t {
+    int batch_a = 1;
+    int batch_b = 1;
+    size_t stride_src = static_cast<size_t>(-1);
+    size_t stride_wei = static_cast<size_t>(-1);
+    size_t stride_dst = static_cast<size_t>(-1);
+};
+
+// Compute the BMM batch parameters from resolved (post set_default_formats)
+// descriptors. Shared by pd_t::init (for INT_MAX validation) and execute_body
+// (for the values actually handed to the backend) so the two never diverge.
+inline zen_bmm_params_t compute_zen_bmm_params(const memory_desc_wrapper &src_d,
+        const memory_desc_wrapper &weights_d, const matmul_helper_t &helper,
+        bool wei_is_zen_packed) {
+    zen_bmm_params_t p;
+    if (src_d.ndims() != 3) return p; // 2D: defaults (batch 1, derive strides)
+
+    p.batch_a = static_cast<int>(src_d.dims()[0]);
+    p.batch_b = static_cast<int>(weights_d.dims()[0]);
+    // oneDNN strides are already in elements.
+    p.stride_src = static_cast<size_t>(helper.get_a_stride(0));
+    p.stride_dst = static_cast<size_t>(helper.get_c_stride(0));
+    if (wei_is_zen_packed) {
+        // The packed weights md is opaque (no blocking_desc); each batch
+        // occupies one fixed-size packed slot. Convert the per-slice byte size
+        // to elements for the Zen looper. pd_t::init() has already verified that
+        // per_slice_size is an exact multiple of the (non-zero) element size,
+        // so this division is exact.
+        const size_t wei_elem = weights_d.data_type_size();
+        assert(wei_elem > 0
+                && weights_d.zen_packed_desc().per_slice_size % wei_elem == 0);
+        p.stride_wei = weights_d.zen_packed_desc().per_slice_size / wei_elem;
+    } else {
+        p.stride_wei = static_cast<size_t>(helper.get_b_stride(0));
+    }
+    return p;
+}
+
+} // namespace
 #endif
 
 status_t zen_matmul_t::pd_t::init(engine_t *engine) {
@@ -81,11 +128,34 @@ status_t zen_matmul_t::pd_t::init(engine_t *engine) {
     const auto wei_dt = weights_md(0)->data_type;
     const auto dst_dt = dst_md(0)->data_type;
 
-    // 2D only -- batched (3D+) matmul not yet supported.
-    VDISPATCH_MATMUL(ndims() == 2, VERBOSE_BAD_NDIMS, "dst", ndims());
+    // 2D plain matmul and 3D batched matmul (a single leading batch dim) are
+    // supported. Higher-rank batched matmul (ndims > 3, multiple batch dims)
+    // maps to several batch strides which the Zen BMM looper -- a single
+    // (Batch_A, Batch_B) batch index -- cannot express, so reject it here.
+    VDISPATCH_MATMUL(
+            utils::one_of(ndims(), 2, 3), VERBOSE_BAD_NDIMS, "dst", ndims());
+
+    const bool is_batched = ndims() == 3;
 
     // No zero-dim tensors.
     VDISPATCH_MATMUL(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+
+    // ---- Batch (BMM) validation ----
+    // For 3D the leading dim is the single batch dim. The Zen BMM looper
+    // broadcasts an operand whose batch count is 1 (get_batch_index returns
+    // b % batch, i.e. always 0 when batch == 1) and otherwise expects the
+    // batch index to map 1:1. oneDNN only allows a batch dim to broadcast
+    // when its extent is 1, so require the src and weights batch counts to be
+    // equal or for one of them to broadcast (== 1). The output batch count is
+    // max(src_batch, wei_batch), enforced by the framework on the dst desc.
+    dim_t src_batch = 1, wei_batch = 1;
+    if (is_batched) {
+        src_batch = src_md(0)->dims[0];
+        wei_batch = weights_md(0)->dims[0];
+        VDISPATCH_MATMUL(
+                src_batch == wei_batch || src_batch == 1 || wei_batch == 1,
+                VERBOSE_INCONSISTENT_DIM, "src", 0, "weights", 0);
+    }
 
     // ---- Datatype validation (aligned with Zen support) ----
     // Supported configurations:
@@ -163,6 +233,12 @@ status_t zen_matmul_t::pd_t::init(engine_t *engine) {
                     return false;
             } else if (entry.is_binary()) {
                 using namespace alg_kind;
+                // Binary post-ops are supported on both the 2D and 3D (BMM)
+                // paths. On BMM the Zen backend advances the src1 buffer per
+                // batch by a dense M*N stride and per row by N, so the operand
+                // must be a dense row-major tensor that is full in M and N;
+                // the shape/stride contract is enforced in
+                // check_binary_postop_formats() below.
                 if (!utils::one_of(entry.binary.alg, binary_add, binary_mul))
                     return false;
                 const auto src1_dt = entry.binary.src1_desc.data_type;
@@ -209,10 +285,15 @@ status_t zen_matmul_t::pd_t::init(engine_t *engine) {
     // set_default_formats() leaves it untouched.
     VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
 
+    // Advertise the opaque zen_packed weights format whenever the framework
+    // leaves the weights layout open. For BMM (3D) the packed buffer holds one
+    // packed (K, N) slice per weight batch (wei_batch back-to-back slots),
+    // produced by zen_reorder_t and consumed here with mem_format_b='r' plus a
+    // per-slice batch_stride_wei.
     bool wei_zen_packed = wei_already_packed;
     if (wei_format_any && (wei_dt == bf16 || wei_dt == f32)) {
-        VDISPATCH_MATMUL_SC(
-                zen::init_zen_packed_md(weights_md_, src_dt, K(), N()),
+        VDISPATCH_MATMUL_SC(zen::init_zen_packed_md(weights_md_, src_dt, K(),
+                                    N(), is_batched ? wei_batch : 1),
                 VERBOSE_UNSUPPORTED_TAG);
         wei_zen_packed = true;
     }
@@ -225,10 +306,54 @@ status_t zen_matmul_t::pd_t::init(engine_t *engine) {
             wei_zen_packed || gemm_based::check_gemm_compatible_formats(*this),
             VERBOSE_INCOMPATIBLE_GEMM_FMT);
 
-    // Destination must be plain row-major ab layout.
+    // Source / destination layout validation.
+    //
+    // The Zen backend drives the GEMM via explicit leading dims and per-batch
+    // strides, so it accepts a padded leading dim: src plain with one inner
+    // axis contiguous, dst plain with the last (N) axis contiguous.
+    // check_gemm_{input,output}_format() capture exactly this contract, so an
+    // exact matches_one_of_tag() check would needlessly reject supported
+    // padded layouts. Applied unconditionally (including the packed-weights
+    // path) so an unsupported layout declines at creation, not at runtime.
     const memory_desc_wrapper dst_d(dst_md(0));
-    VDISPATCH_MATMUL(
-            dst_d.matches_one_of_tag(format_tag::ab), VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_MATMUL(gemm_based::check_gemm_output_format(*dst_md(0)),
+            VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_MATMUL(gemm_based::check_gemm_input_format(*src_md(0)),
+            VERBOSE_UNSUPPORTED_TAG);
+
+    // check_gemm_output_format() only enforces plain + contiguous N; unlike
+    // check_gemm_input_format() it does not reject zero strides. A zero stride
+    // on dst (an M- or batch-broadcast output) would make the Zen kernel write
+    // repeatedly to the same location and produce wrong results, so reject it
+    // here explicitly (is_plain() is guaranteed by the check above).
+    const auto &dst_strides = dst_d.blocking_desc().strides;
+    bool dst_no_zero_stride = true;
+    for (int i = 0; i < dst_d.ndims(); i++)
+        dst_no_zero_stride = dst_no_zero_stride && dst_strides[i] != 0;
+    VDISPATCH_MATMUL(dst_no_zero_stride, VERBOSE_UNSUPPORTED_TAG);
+
+    // For BMM the Zen looper treats dim 0 as the single batch dimension and
+    // advances each operand by its dim-0 (batch) stride. check_gemm_*_format()
+    // above only constrains the inner M/K axes, so it would also accept a
+    // permuted layout where the batch dim is not outermost. To
+    // keep the accepted layouts matched to the abc/acb (batch-outermost)
+    // contract, require dim 0 to carry the largest stride for every batched
+    // operand that exposes strides (packed weights are opaque and validated via
+    // their per-slice size instead).
+    if (is_batched) {
+        auto batch_is_outermost = [](const memory_desc_t *md) {
+            const memory_desc_wrapper mdw(md);
+            const auto &s = mdw.blocking_desc().strides;
+            return s[0] >= s[1] && s[0] >= s[2];
+        };
+        VDISPATCH_MATMUL(
+                batch_is_outermost(src_md(0)), VERBOSE_UNSUPPORTED_TAG);
+        VDISPATCH_MATMUL(
+                batch_is_outermost(dst_md(0)), VERBOSE_UNSUPPORTED_TAG);
+        if (!wei_zen_packed)
+            VDISPATCH_MATMUL(
+                    batch_is_outermost(weights_md(0)), VERBOSE_UNSUPPORTED_TAG);
+    }
 
     VDISPATCH_MATMUL(!::dnnl::impl::cpu::x64::binary_injector::
                              any_binary_postop_rhs_with_ternary_scalar_bcast(
@@ -240,12 +365,18 @@ status_t zen_matmul_t::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_POSTOP);
 
     // ---- Binary post-op shape/format validation ----
-    // Supported src1 layouts for binary post-ops via Zen (both ab,
-    // row-major dense):
-    //   * per_tensor : src1 dims match dst exactly (no broadcast)
-    //   * per_channel: broadcast over every dim except the last (N/OC)
-    //                  dim, i.e. the broadcast dims have extent 1 while
-    //                  the channel dim is full-size.
+    // The src1 operand must be a plain row-major dense tensor (ab for 2D, abc
+    // for 3D); the Zen backend does not support arbitrary strides. The channel
+    // (last/N) dim must always be full-size. Supported broadcast patterns:
+    //   2D:  * per_tensor  : dims == dst (M, N)
+    //        * per_channel : M broadcast (1, N) -- applied via the non-batched
+    //                        path, which honors a 1-row operand.
+    //   3D:  * per_tensor  : dims == dst (batch, M, N)
+    //        * batch bcast : (1, M, N) -- reused across batches.
+    //        M must be full on the BMM path: the Zen looper applies a fixed
+    //        per-row (m_start*N) and per-batch (M*N) offset, so a row-broadcast
+    //        operand would be read out of bounds. The batch dim may be full or
+    //        broadcast (1).
     auto check_binary_postop_formats = [&]() -> bool {
         const auto &po = attr()->post_ops_;
         for (int i = 0; i < po.len(); i++) {
@@ -255,24 +386,40 @@ status_t zen_matmul_t::pd_t::init(engine_t *engine) {
             const auto &src1_desc = entry.binary.src1_desc;
             const auto *dst = dst_md(0);
 
-            // Each dim must either match dst (full) or be a unit-extent
-            // broadcast (per_tensor => all full, per_channel => only the
-            // channel dim full). The channel dim (last) must be full-size.
             if (src1_desc.ndims != dst->ndims) return false;
-            const int channel_dim = src1_desc.ndims - 1;
-            for (int d = 0; d < src1_desc.ndims; d++) {
+            const int nd = src1_desc.ndims;
+            const int channel_dim = nd - 1; // N
+            for (int d = 0; d < nd; d++) {
                 const bool full = src1_desc.dims[d] == dst->dims[d];
                 const bool bcast = src1_desc.dims[d] == 1;
                 if (!(full || bcast)) return false;
                 if (d == channel_dim && !full) return false;
             }
+            // On the BMM (3D) path the M dim (nd-2) must be full; the Zen looper
+            // offsets the operand by m_start*N rows, so a 1-row (M-broadcast)
+            // operand cannot be supported there.
+            if (nd == 3 && src1_desc.dims[nd - 2] != dst->dims[nd - 2])
+                return false;
 
-            // ab format: plain row-major dense.
+            // Plain row-major dense: last dim contiguous, row stride == N, and
+            // (3D, batch full) batch stride == M*N.
             const memory_desc_wrapper src1_mdw(src1_desc);
             if (!src1_mdw.is_plain()) return false;
             const auto &strides = src1_mdw.blocking_desc().strides;
-            if (strides[1] != 1 || strides[0] != src1_desc.dims[1])
-                return false;
+            if (strides[nd - 1] != 1) return false;
+            if (strides[nd - 2] != src1_desc.dims[nd - 1]) return false;
+            if (nd == 3 && src1_desc.dims[0] != 1) {
+                // Compute M*N in size_t with an overflow guard: an oversized
+                // product would wrap in signed dim_t and invoke UB even though
+                // such a case is rejected later by the INT_MAX guard.
+                const size_t m = static_cast<size_t>(src1_desc.dims[1]);
+                const size_t n = static_cast<size_t>(src1_desc.dims[2]);
+                if (n != 0 && m > std::numeric_limits<size_t>::max() / n)
+                    return false;
+                const size_t batch_stride = m * n;
+                if (static_cast<size_t>(strides[0]) != batch_stride)
+                    return false;
+            }
         }
         return true;
     };
@@ -286,9 +433,43 @@ status_t zen_matmul_t::pd_t::init(engine_t *engine) {
     // For the packed path the weights md is opaque (no blocking_desc), and the
     // backend uses ldb = N; otherwise read ldb from the plain weights strides.
     const dim_t wei_ldb = wei_zen_packed ? N() : helper.ldb();
-    const bool fits_zen_int_api = helper.M() <= int_max && helper.N() <= int_max
+    // The Zen BMM looper takes Batch_A/Batch_B as int; the batch count is
+    // max(src_batch, wei_batch). Guard all three against the int API.
+    const dim_t batch_count = src_batch > wei_batch ? src_batch : wei_batch;
+    bool fits_zen_int_api = helper.M() <= int_max && helper.N() <= int_max
             && helper.K() <= int_max && helper.lda() <= int_max
-            && wei_ldb <= int_max && helper.ldc() <= int_max;
+            && wei_ldb <= int_max && helper.ldc() <= int_max
+            && src_batch <= int_max && wei_batch <= int_max
+            && batch_count <= int_max;
+
+    // For batched pre-packed weights the per-batch weight stride is derived as
+    // per_slice_size / wei_elem (the opaque md has no blocking_desc). Reject a
+    // descriptor whose per-slice byte size is not an exact multiple of the
+    // weight element size: the integer division would otherwise truncate and
+    // point the Zen looper at the wrong packed slot (silently wrong results).
+    if (is_batched && wei_zen_packed) {
+        const memory_desc_wrapper wei_d(weights_md(0));
+        const size_t wei_elem = wei_d.data_type_size();
+        const size_t per_slice = wei_d.zen_packed_desc().per_slice_size;
+        VDISPATCH_MATMUL(wei_elem > 0 && per_slice % wei_elem == 0,
+                VERBOSE_INCONSISTENT_MDS, "weights", "packed-slice-size");
+    }
+
+    // The per-batch strides handed to the Zen looper must also fit the int API
+    // (defense in depth: they are size_t in the backend but derived from dims).
+    // Only meaningful for the batched path; 2D keeps the (size_t)-1 sentinel.
+    // Guard the call behind fits_zen_int_api: compute_zen_bmm_params() casts the
+    // batch dims to int, so it must not run when the batch/dim validation above
+    // has already failed (batch dims > INT_MAX would be an out-of-range,
+    // implementation-defined integral conversion). When fits_zen_int_api is
+    // already false the VDISPATCH below rejects the primitive regardless.
+    if (is_batched && fits_zen_int_api) {
+        const auto bmm = compute_zen_bmm_params(memory_desc_wrapper(src_md(0)),
+                memory_desc_wrapper(weights_md(0)), helper, wei_zen_packed);
+        const size_t int_max_sz = static_cast<size_t>(int_max);
+        fits_zen_int_api = fits_zen_int_api && bmm.stride_src <= int_max_sz
+                && bmm.stride_wei <= int_max_sz && bmm.stride_dst <= int_max_sz;
+    }
     VDISPATCH_MATMUL(fits_zen_int_api, VERBOSE_UNSUPPORTED_FEATURE,
             "dimension/stride > INT_MAX is not supported");
 
@@ -380,17 +561,23 @@ status_t zen_matmul_direct(data_type_t src_dt, data_type_t wei_dt,
         data_type_t dst_dt, data_type_t bia_dt, const void *A, const void *B,
         void *C, const void *bias, dim_t M, dim_t N, dim_t K, dim_t lda,
         dim_t ldb, dim_t ldc, char transA, char transB, char mem_format_b,
+        int Batch_A, int Batch_B, size_t batch_stride_src,
+        size_t batch_stride_wei, size_t batch_stride_dst,
         const std::vector<matmul_post_op> &cached_postops,
         const std::vector<int> &cached_postop_po_indices, float cached_beta,
         const exec_ctx_t &ctx) {
     using zd = zendnnl::common::data_type_t;
 
+    // Batch_A/Batch_B default to 1 (single GEMM) for the non-batched path.
+    // For BMM the strides are expressed in elements (the Zen looper scales
+    // them by the per-tensor type size); a sentinel of (size_t)-1 lets the
+    // backend derive the dense stride from the dimensions.
     matmul_batch_params_t batch {};
-    batch.Batch_A = 1;
-    batch.Batch_B = 1;
-    batch.batch_stride_src = -1;
-    batch.batch_stride_wei = -1;
-    batch.batch_stride_dst = -1;
+    batch.Batch_A = Batch_A;
+    batch.Batch_B = Batch_B;
+    batch.batch_stride_src = batch_stride_src;
+    batch.batch_stride_wei = batch_stride_wei;
+    batch.batch_stride_dst = batch_stride_dst;
 
     matmul_params params {};
     params.dtypes.src = to_zen_dt(src_dt);
@@ -486,14 +673,33 @@ status_t zen_matmul_t::execute_body(const exec_ctx_t &ctx) const {
         ldb = helper.ldb();
     }
 
+    // Batch (BMM) parameters (shared with pd_t::init via compute_zen_bmm_params
+    // so validation and execution agree). The non-batched path keeps Batch == 1
+    // and the (size_t)-1 stride sentinel (the backend derives dense strides).
+    const auto bmm = compute_zen_bmm_params(
+            src_d, weights_d, helper, wei_is_zen_packed);
+    const int Batch_A = bmm.batch_a;
+    const int Batch_B = bmm.batch_b;
+    const size_t batch_stride_src = bmm.stride_src;
+    const size_t batch_stride_wei = bmm.stride_wei;
+    const size_t batch_stride_dst = bmm.stride_dst;
+
     // pd_t::init() rejects dimensions/strides above INT_MAX; assert here as a
-    // defensive invariant before casting to the int-based Zen API.
+    // defensive invariant before casting to the int-based Zen API. The batch
+    // strides keep their (size_t)-1 sentinel on the 2D path, so only assert
+    // them for the batched path.
+    const size_t int_max_sz
+            = static_cast<size_t>(std::numeric_limits<int>::max());
     assert(M <= std::numeric_limits<int>::max()
             && N <= std::numeric_limits<int>::max()
             && K <= std::numeric_limits<int>::max()
             && lda <= std::numeric_limits<int>::max()
             && ldb <= std::numeric_limits<int>::max()
             && ldc <= std::numeric_limits<int>::max());
+    assert(IMPLICATION(pd()->ndims() == 3,
+            batch_stride_src <= int_max_sz && batch_stride_wei <= int_max_sz
+                    && batch_stride_dst <= int_max_sz));
+    MAYBE_UNUSED(int_max_sz);
 
     // Per-tensor data types (may differ for mixed-precision configs).
     const auto src_dt = src_d.data_type();
@@ -504,9 +710,10 @@ status_t zen_matmul_t::execute_body(const exec_ctx_t &ctx) const {
 
     VDEBUGINFO(2, primitive, matmul,
             "zen matmul: M=%ld N=%ld K=%ld transA=%c transB=%c lda=%ld "
-            "ldb=%ld ldc=%ld src_dt=%d wei_dt=%d dst_dt=%d",
+            "ldb=%ld ldc=%ld src_dt=%d wei_dt=%d dst_dt=%d Batch_A=%d "
+            "Batch_B=%d",
             (long)M, (long)N, (long)K, transA, transB, (long)lda, (long)ldb,
-            (long)ldc, (int)src_dt, (int)wei_dt, (int)dst_dt);
+            (long)ldc, (int)src_dt, (int)wei_dt, (int)dst_dt, Batch_A, Batch_B);
 
     // Extract raw pointers.
     const void *A = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
@@ -520,7 +727,8 @@ status_t zen_matmul_t::execute_body(const exec_ctx_t &ctx) const {
     // Post-ops were pre-built at primitive init(); only binary buffer
     // pointers are patched here from the execution context.
     return zen_matmul_direct(src_dt, wei_dt, dst_dt, bia_dt, A, B, C, bias, M,
-            N, K, lda, ldb, ldc, transA, transB, mem_format_b, zen_postop_,
+            N, K, lda, ldb, ldc, transA, transB, mem_format_b, Batch_A, Batch_B,
+            batch_stride_src, batch_stride_wei, batch_stride_dst, zen_postop_,
             postop_indices_, beta_, ctx);
 #endif // DNNL_X64_USE_ZEN
 }

--- a/src/cpu/x64/zen64/reorder/zen_reorder.cpp
+++ b/src/cpu/x64/zen64/reorder/zen_reorder.cpp
@@ -26,6 +26,7 @@
 #include "common/utils.hpp"
 
 #include <cstdint>
+#include <limits>
 
 #include "cpu/x64/cpu_isa_traits.hpp" // cpu().has(tAMD)
 #include "cpu/x64/zen64/common/zen_format_tag.hpp" // is_zen_packed
@@ -74,17 +75,23 @@ status_t zen_weight_prepack(const void *src, void *dst, zd wei_dt, int64_t K,
 // Plain f32 -> bf16 element conversion (standard reorder_direct path).
 // Writes K rows of N elements contiguously into `dst` (row-major).
 //
-// When src is `ba` (col-major), src_strides={1,K} describes the source;
-// the destination is always written contiguous (lowoha reorder ignores
+// `ldb` is the source leading dim (in elements), read from the actual src
+// strides so a padded leading dim is honored:
+//   * ab (row-major): src_strides = {ldb, 1}   (ldb == N for dense, N+pad if padded)
+//   * ba (col-major): src_strides = {1, ldb}    (ldb == K for dense, K+pad if padded)
+// The destination is always written contiguous (lowoha reorder ignores
 // dst_strides), so dst ends up in `ab` (K-major) regardless of src.
-status_t f32_to_bf16_plain(
-        const void *src, void *dst, int64_t K, int64_t N, bool src_is_ab) {
+status_t f32_to_bf16_plain(const void *src, void *dst, int64_t K, int64_t N,
+        int64_t ldb, bool src_is_ab) {
     zendnnl::lowoha::reorder::reorder_params_t rp;
     rp.src_dtype = zd::f32;
     rp.dst_dtype = zd::bf16;
     rp.src_shape = {K, N};
     rp.dst_shape = {K, N};
-    if (!src_is_ab) rp.src_strides = {1, K};
+    if (src_is_ab)
+        rp.src_strides = {ldb, 1};
+    else
+        rp.src_strides = {1, ldb};
 
     return to_dnnl_status(
             zendnnl::lowoha::reorder::reorder_direct(src, dst, rp));
@@ -113,8 +120,13 @@ status_t zen_reorder_t::pd_t::init(
 
     const memory_desc_wrapper id(src_md_), od(dst_md_);
 
-    VDISPATCH_REORDER_IC(id.ndims() == 2 && od.ndims() == 2, VERBOSE_BAD_NDIMS,
-            "src/dst", id.ndims());
+    // 2D weight slice, or 3D batched weights (one (K, N) slice per batch).
+    VDISPATCH_REORDER_IC(
+            utils::one_of(id.ndims(), 2, 3) && id.ndims() == od.ndims(),
+            VERBOSE_BAD_NDIMS, "src/dst", id.ndims());
+
+    const int ndims = id.ndims();
+    const bool batched = ndims == 3;
 
     const auto type_i = id.data_type();
     const auto type_o = od.data_type();
@@ -153,40 +165,81 @@ status_t zen_reorder_t::pd_t::init(
     VDISPATCH_REORDER_IC(!id.has_zero_dim() && !od.has_zero_dim(),
             VERBOSE_BAD_DIM, "src/dst", 0);
 
-    // src must be plain `ab` or `ba` (the only two 2D row/col-major layouts
-    // the packer accepts via the `trans` parameter).
-    const auto src_tag = id.matches_one_of_tag(ab, ba);
-    VDISPATCH_REORDER_IC(
-            src_tag != format_tag::undef, VERBOSE_UNSUPPORTED_TAG_S, "src");
+    // Each (K, N) slice of src must be plain row-major (`ab`/`abc`) or
+    // col-major (`ba`/`acb`). The packer takes an explicit leading dim (derived
+    // from the actual strides in execute()), so a padded leading dim on one
+    // axis is supported -- an exact tag check would reject those layouts. Match
+    // the matmul contract: require a plain layout with one of the inner (K, N)
+    // axes contiguous and no zero strides. For 3D also require the batch dim to
+    // be outermost (largest stride) so the per-batch stride is the true slice
+    // span (execute() advances src by strides[0] per batch).
+    const auto &src_strides = id.blocking_desc().strides;
+    const bool inner_contig
+            = src_strides[ndims - 1] == 1 || src_strides[ndims - 2] == 1;
+    bool no_zero_stride = true;
+    for (int i = 0; i < ndims; i++)
+        no_zero_stride = no_zero_stride && src_strides[i] != 0;
+    VDISPATCH_REORDER_IC(id.is_plain() && inner_contig && no_zero_stride,
+            VERBOSE_UNSUPPORTED_TAG_S, "src");
+    VDISPATCH_REORDER_IC(!batched
+                    || (src_strides[0] >= src_strides[1]
+                            && src_strides[0] >= src_strides[2]),
+            VERBOSE_UNSUPPORTED_TAG_S, "src");
 
-    // src and dst logical (K, N) must agree (oneDNN reorder API contract).
-    VDISPATCH_REORDER_IC(
-            id.dims()[0] == od.dims()[0] && id.dims()[1] == od.dims()[1],
-            VERBOSE_INCONSISTENT_DIM, "src", 0, "dst", 0);
+    // src and dst logical dims must agree (oneDNN reorder API contract).
+    for (int i = 0; i < ndims; i++)
+        VDISPATCH_REORDER_IC(id.dims()[i] == od.dims()[i],
+                VERBOSE_INCONSISTENT_DIM, "src", i, "dst", i);
 
-    // This reorder packs a single 2D (K, N) weight slice only; batched
-    // (batch > 1) packed descriptors are not supported. A batched dst encodes
-    // size = per_slice_size * batch, so require the two to be equal to reject
-    // any batched packed buffer up front.
+    // Logical (K, N) of one slice and the batch count.
+    const dim_t K = od.dims()[ndims - 2];
+    const dim_t N = od.dims()[ndims - 1];
+    const dim_t batch = batched ? od.dims()[0] : 1;
+
+    // execute() collapses a K==1 slice to contiguous row-major (`ab`) since a
+    // dense single row is layout-agnostic. A padded col-major (`acb`/`ba`) row
+    // (N stride != 1) is *not* contiguous, so that assumption would misread it;
+    // decline it here and let the reference reorder serve the (pathological)
+    // case instead.
+    VDISPATCH_REORDER_IC(K != 1 || src_strides[ndims - 1] == 1,
+            VERBOSE_UNSUPPORTED_TAG_S, "src");
+
+    // zen_weight_prepack takes int64_t K/N/ldb but the matmul that consumes the
+    // packed buffer drives them through the int Zen API; reject oversized slices
+    // up front so packing and matmul agree on what is representable.
+    const dim_t int_max = std::numeric_limits<int>::max();
+    VDISPATCH_REORDER_IC(K <= int_max && N <= int_max && batch <= int_max,
+            VERBOSE_UNSUPPORTED_FEATURE,
+            "dimension > INT_MAX is not supported");
+
+    // Cross-check the recorded packed sizes against the backend-reported
+    // per-slice size to turn a silent overrun into a clean dispatch failure.
+    // The opaque dst carries per_slice_size and size == per_slice_size * batch.
     const auto &zpd = od.zen_packed_desc();
-    VDISPATCH_REORDER_IC(zpd.per_slice_size == zpd.size,
-            VERBOSE_UNSUPPORTED_TAG_S, "dst (batched packed)");
+    const dim_t expected_per_slice = zen_packed_bytes(K, N, type_o);
+    VDISPATCH_REORDER_IC(expected_per_slice > 0
+                    && zpd.per_slice_size
+                            == static_cast<size_t>(expected_per_slice),
+            VERBOSE_INCONSISTENT_MDS, "dst", "packed-slice-size");
 
-    // Reject any dst whose buffer size disagrees with the
-    // backend-reported packed size to turn a silent overrun into a clean
-    // dispatch failure. ndims()==2 here, so size() == per-slice size.
-    const dim_t expected_packed_bytes
-            = zen_packed_bytes(od.dims()[0], od.dims()[1], type_o);
-    VDISPATCH_REORDER_IC(expected_packed_bytes > 0
-                    && od.size() == static_cast<size_t>(expected_packed_bytes),
+    // batch is validated >= 1 (no zero dims) and <= INT_MAX above. Guard the
+    // per_slice_size * batch product against size_t overflow before comparing:
+    // a wrap could otherwise make an undersized buffer pass this check and lead
+    // to out-of-bounds writes during packing. Mirrors init_zen_packed_md().
+    const size_t batch_sz = static_cast<size_t>(batch);
+    VDISPATCH_REORDER_IC(zpd.per_slice_size <= SIZE_MAX / batch_sz,
+            VERBOSE_INCONSISTENT_MDS, "dst", "packed-size-overflow");
+    VDISPATCH_REORDER_IC(
+            zpd.size == zpd.per_slice_size * batch_sz && od.size() == zpd.size,
             VERBOSE_INCONSISTENT_MDS, "dst", "packed-size");
 
     // The f32 -> bf16 prepack path needs a K*N bf16 conversion buffer. Book it
     // on the primitive scratchpad (declared here, consumed in execute() via the
     // grantor) so execution stays allocation-free.
     if (type_i == data_type::f32 && type_o == data_type::bf16) {
-        const size_t conv_bytes = static_cast<size_t>(id.dims()[0])
-                * static_cast<size_t>(id.dims()[1]) * sizeof(int16_t);
+        // One (K, N) bf16 slice; reused across batches in execute().
+        const size_t conv_bytes = static_cast<size_t>(K)
+                * static_cast<size_t>(N) * sizeof(int16_t);
         auto scratchpad = scratchpad_registry().registrar();
         scratchpad.book(memory_tracking::names::key_reorder_space, conv_bytes,
                 /*data_size=*/1, /*alignment=*/64);
@@ -219,59 +272,89 @@ status_t zen_reorder_t::execute(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper dst_d(pd()->dst_md());
 
-    // The src has been validated as a 2D plain `ab` or `ba` layout by
-    // pd_t::init. Logical dims are always (K, N).
-    const int64_t K = src_d.dims()[0];
-    const int64_t N = src_d.dims()[1];
+    // src is a plain 2D (K, N) slice or a 3D batched [B, K, N] tensor, each
+    // slice plain `ab`/`ba` (validated by pd_t::init). Logical per-slice dims
+    // are always (K, N); the batch dim (if any) is outermost.
+    const int ndims = src_d.ndims();
+    const bool batched = ndims == 3;
+    const int64_t K = src_d.dims()[ndims - 2];
+    const int64_t N = src_d.dims()[ndims - 1];
+    const int64_t batch = batched ? src_d.dims()[0] : 1;
 
-    // Detect transpose from the src strides:
-    //   ab -> strides = {N, 1}  -> trans='n', ldb=N
-    //   ba -> strides = {1, K}  -> trans='t', ldb=K
-    // When K==1 (degenerate row), both layouts coincide and we treat the
-    // src as `ab` (trans='n') since the byte stream is identical.
+    // Detect transpose from the slice's last-two-dim strides:
+    //   ab -> strides[..]={ldb, 1}  -> trans='n', ldb = row stride
+    //   ba -> strides[..]={1, ldb}  -> trans='t', ldb = col stride
+    // When K==1 (degenerate row) and the row is contiguous (N stride == 1),
+    // both layouts coincide, so treat the src as `ab` (trans='n'); the byte
+    // stream is identical. A padded (non-contiguous) K==1 row is rejected in
+    // pd_t::init(), so it never reaches here.
     const auto &src_strides = src_d.blocking_desc().strides;
-    const bool src_is_ab = (src_strides[1] == 1) || (src_d.dims()[0] == 1);
+    const bool src_is_ab = (src_strides[ndims - 1] == 1) || (K == 1);
     const bool transposed = !src_is_ab;
 
-    const void *src_ptr = CTX_IN_MEM(const void *, DNNL_ARG_FROM);
-    void *dst_ptr = CTX_OUT_MEM(void *, DNNL_ARG_TO);
+    // The leading dim is read from the actual inner stride (not the logical
+    // extent), so a padded leading dim is honored: ab -> row stride
+    // (strides[ndims-2]); ba -> col stride (strides[ndims-1]).
+    // Exception: when K==1 the slice is a single row and both layouts coincide
+    // (src_is_ab is forced true above), but the K-dimension stride is then
+    // degenerate (can be 1 for an `acb` source) rather than the row length, so
+    // fall back to the logical N -- the packer requires ldb >= N.
+    const int64_t ldb = src_is_ab ? (K == 1 ? N : src_strides[ndims - 2])
+                                  : src_strides[ndims - 1];
 
     const auto src_dt = src_d.data_type();
     const auto dst_dt = dst_d.data_type();
 
-    // ab -> ldb=N (trans='n'); ba -> ldb=K (trans='t').
-    const int64_t ldb = src_is_ab ? N : K;
+    // Per-batch advance: src by its leading-dim stride (elements), dst by one
+    // fixed-size packed slot (per_slice_size bytes).
+    const size_t src_elem = src_d.data_type_size();
+    const size_t src_slice_bytes
+            = batched ? static_cast<size_t>(src_strides[0]) * src_elem : 0;
+    const size_t dst_slice_bytes = dst_d.zen_packed_desc().per_slice_size;
 
-    if (src_dt == data_type::bf16 && dst_dt == data_type::bf16)
-        return zen_weight_prepack(
-                src_ptr, dst_ptr, zd::bf16, K, N, ldb, transposed);
+    const auto *src_base = CTX_IN_MEM(const uint8_t *, DNNL_ARG_FROM);
+    auto *dst_base = CTX_OUT_MEM(uint8_t *, DNNL_ARG_TO);
 
-    if (src_dt == data_type::f32 && dst_dt == data_type::f32)
-        return zen_weight_prepack(
-                src_ptr, dst_ptr, zd::f32, K, N, ldb, transposed);
-
+    // f32 -> bf16 prepack needs a per-slice bf16 conversion buffer (booked in
+    // pd_t::init), reused across batches so execute() stays allocation-free.
+    void *conv = nullptr;
     if (src_dt == data_type::f32 && dst_dt == data_type::bf16) {
-        // Mixed-precision prepack: convert f32 -> plain bf16 (contiguous `ab`),
-        // then prepack that bf16 into the Zen blocked layout. The conversion
-        // scratch is required because f32_to_bf16_plain writes a new bf16
-        // buffer; it is taken from the primitive scratchpad (booked in
-        // pd_t::init), so execute() performs no heap allocation.
-        const auto &scratchpad = ctx.get_scratchpad_grantor();
-        void *conv = scratchpad.get<int16_t>(
+        conv = ctx.get_scratchpad_grantor().get<int16_t>(
                 memory_tracking::names::key_reorder_space);
         if (conv == nullptr) return status::out_of_memory;
-
-        status_t st = f32_to_bf16_plain(src_ptr, conv, K, N, src_is_ab);
-        if (st == success) {
-            // conv is in `ab` (K-major) layout regardless of original src.
-            st = zen_weight_prepack(conv, dst_ptr, zd::bf16, K, N,
-                    /*ldb=*/N, /*transposed=*/false);
-        }
-
-        return st;
     }
 
-    return status::unimplemented;
+    // Pack one (K, N) slice from `src` into `dst`.
+    auto prepack_slice = [&](const void *src, void *dst) -> status_t {
+        if (src_dt == data_type::bf16 && dst_dt == data_type::bf16)
+            return zen_weight_prepack(
+                    src, dst, zd::bf16, K, N, ldb, transposed);
+
+        if (src_dt == data_type::f32 && dst_dt == data_type::f32)
+            return zen_weight_prepack(src, dst, zd::f32, K, N, ldb, transposed);
+
+        if (src_dt == data_type::f32 && dst_dt == data_type::bf16) {
+            // Convert f32 -> plain bf16 (contiguous `ab`), then prepack that
+            // bf16 slice into the Zen blocked layout. The conversion avoids the
+            // backend's f32->bf16 fringe-N bug (see header note).
+            status_t st = f32_to_bf16_plain(src, conv, K, N, ldb, src_is_ab);
+            if (st == success)
+                st = zen_weight_prepack(conv, dst, zd::bf16, K, N,
+                        /*ldb=*/N, /*transposed=*/false);
+            return st;
+        }
+
+        return status::unimplemented;
+    };
+
+    for (int64_t b = 0; b < batch; b++) {
+        const void *src_slice
+                = src_base + static_cast<size_t>(b) * src_slice_bytes;
+        void *dst_slice = dst_base + static_cast<size_t>(b) * dst_slice_bytes;
+        CHECK(prepack_slice(src_slice, dst_slice));
+    }
+
+    return status::success;
 #endif
 }
 


### PR DESCRIPTION
# Description

Enable 3D f32 and bf16 matmul through ZenDNN, including batch broadcasting and per-batch packed-weight reorders.
- Validate supported batch dimensions, strides, layouts, and API bounds
- Support padded and transposed operand layouts
- Register 3D Zen weight reorders and add BMM coverage

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
