### PR TITLE
xe, common: default-initialize values used in hashing

### DIFF
--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -292,7 +292,8 @@ struct fpmath_t : public c_compatible {
 
 struct dnnl_post_ops : public dnnl::impl::c_compatible {
     struct entry_t {
-        entry_t() : kind(dnnl::impl::primitive_kind::undefined) {}
+        // Initialize binary to avoid uninitialized memory in the union.
+        entry_t() : kind(dnnl::impl::primitive_kind::undefined), binary {} {}
 
         entry_t(const entry_t &other) = default;
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -3127,7 +3127,7 @@ CopyOperand CopyPlan::zipImmediates(const CopyOperand &o1, const CopyOperand &o2
             pattern |= pattern << bits;
         if (v1 <= 0xF && v2 <= 0xF)
             return ngen::Immediate::uv(pattern);
-        else if (o1.type == DataType::w && v1 + 8 <= 0xF && v2 + 8 <= 0xF)
+        else if (o1.type == DataType::w && (uint16_t)(v1 + 8) <= 0xF && (uint16_t)(v2 + 8) <= 0xF)
             return ngen::Immediate::v(pattern);
     }
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -3765,7 +3765,7 @@ int CopyPlan::cycleCount() const
 
 void CopyPlan::dump(std::ostream &os, int n, bool sortInfo) const
 {
-    for (int i = 0; i < std::min<int>(n, insns.size()); ++i) {
+    for (int i = 0; i < std::min(n, (int)insns.size()); ++i) {
         insns[i].dump(os, *this, sortInfo);
         os << std::endl;
     }

--- a/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/problem.hpp
@@ -69,13 +69,13 @@ inline MatrixLayout charLayout(char c) {
 }
 
 struct MatrixAddressing {
-    MatrixLayout layout;            // Layout type (N/T/Pr/Pc)
+    MatrixLayout layout = MatrixLayout::N; // Layout type (N/T/Pr/Pc)
     uint8_t pad[3] = {};
-    uint32_t packSize = 0;           // # of elements in a packed row/column for packed layouts.
+    uint32_t packSize = 0;          // # of elements in a packed row/column for packed layouts.
     uint16_t tileR = 0, tileC = 0;  // Tiling (0 if none) for packed layouts.
     uint8_t panelLength = 0;        // Length of the panel for packed layouts = #cols/rows for Pc/Pr respectively.
     uint8_t crosspack = 1;          // Crosspack for packed layouts.
-    uint8_t alignment;              // Alignment for all addresses, offsets, and leading dimensions.
+    uint8_t alignment = 1;          // Alignment for all addresses, offsets, and leading dimensions.
     bool needA64 = false;
 
     void setAlignment(int align) { alignment = static_cast<uint8_t>(sanitizeAlign(align)); }


### PR DESCRIPTION
While investigating [MFDNN-15374](https://jira.devtools.intel.com/browse/MFDNN-15374), valgrind reported uninitialized values being used in kernel cache hashing. These changes add default initializers to the offending values.

Also addresses a Coverity hit.