### PR TITLE
tests: benchdnn: add bia_dt to perf report

### DIFF
--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -104,7 +104,7 @@ struct settings_t : public base_settings_t {
 
     const char *perf_template_csv() const {
         static const std::string args
-                = "%dir%,%sdt%,%stag%,%wtag%,%dtag%,%alg%";
+                = "%dir%,%sdt%,%bia_dt%,%stag%,%wtag%,%dtag%,%alg%";
         return perf_template_csv_base(args);
     }
 
@@ -207,6 +207,7 @@ struct perf_report_t : public base_perf_report_t {
     const std::vector<dnnl_data_type_t> *sdt() const override {
         return &p_->dt;
     }
+    const dnnl_data_type_t *bia_dt() const override { return &p_->bia_dt_; }
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/deconv/deconv.hpp
+++ b/tests/benchdnn/deconv/deconv.hpp
@@ -106,7 +106,7 @@ struct settings_t : public base_settings_t {
 
     const char *perf_template_csv() const {
         static const std::string args
-                = "%dir%,%sdt%,%stag%,%wtag%,%dtag%,%alg%";
+                = "%dir%,%sdt%,%bia_dt%,%stag%,%wtag%,%dtag%,%alg%";
         return perf_template_csv_base(args);
     }
 
@@ -205,6 +205,7 @@ struct perf_report_t : public base_perf_report_t {
     const std::vector<dnnl_data_type_t> *sdt() const override {
         return &p_->dt;
     }
+    const dnnl_data_type_t *bia_dt() const override { return &p_->bia_dt_; }
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/doc/knobs_perf_report.md
+++ b/tests/benchdnn/doc/knobs_perf_report.md
@@ -31,6 +31,7 @@ Data types options supported:
 | Syntax | Primitives                                     | Description
 | :--    | :--                                            | :--
 | %cfg%  | Conv, IP, Matmul, Pool, RNN                    | Config which describes data types and filling rules
+| %bia_dt% | BRGEMM, Conv, Deconv, IP, Matmul             | Bias data type (precision)
 | %dt%   | Data md based, Resampling, Zeropad             | Source and Destination Data type (precision)
 | %ddt%  | Binary, Concat, Reduction, Reorder, Sum        | Destination data types (precision)
 | %sdt%  | Binary, Concat, Prelu, Reduction, Reorder, Sum | Source data types (precision)
@@ -137,9 +138,9 @@ CSV-style:
                --batch=inputs/ip/test_ip_all
 ```
 ```
-Template entries: perf,%engine%,%impl%,%name%,%dir%,%sdt%,%stag%,%wtag%,%dtag%,%attr%,%desc%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
-perf,engine,impl,name,dir,sdt,stag,wtag,dtag,attr,desc,Gops,max_ctime,min_time,min_Gflops,avg_time,avg_Gflops
-perf,cpu,brg_matmul:avx512_core,"resnet:ip1",FWD_B,f32:f32:f32,any,any,any,,ic2048oc1000n"resnet:ip1",0.008192,0.9375,0.0234375,349.525,0.027302,300.051
+Template entries: perf,%engine%,%impl%,%name%,%dir%,%sdt%,%bia_dt%,%stag%,%wtag%,%dtag%,%attr%,%desc%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
+perf,engine,impl,name,dir,sdt,bia_dt,stag,wtag,dtag,attr,desc,Gops,max_ctime,min_time,min_Gflops,avg_time,avg_Gflops
+perf,cpu,brg_matmul:avx512_core,"resnet:ip1",FWD_B,f32:f32:f32,f32,any,any,any,,ic2048oc1000n"resnet:ip1",0.008192,0.9375,0.0234375,349.525,0.027302,300.051
 ...
 ```
 

--- a/tests/benchdnn/ip/ip.hpp
+++ b/tests/benchdnn/ip/ip.hpp
@@ -56,7 +56,8 @@ struct settings_t : public base_settings_t {
     std::vector<std::string> stag {tag::any}, wtag {tag::any}, dtag {tag::any};
 
     const char *perf_template_csv() const {
-        static const std::string args = "%dir%,%sdt%,%stag%,%wtag%,%dtag%";
+        static const std::string args
+                = "%dir%,%sdt%,%bia_dt%,%stag%,%wtag%,%dtag%";
         return perf_template_csv_base(args);
     }
 
@@ -152,6 +153,7 @@ struct perf_report_t : public base_perf_report_t {
     const std::vector<dnnl_data_type_t> *sdt() const override {
         return &p_->dt;
     }
+    const dnnl_data_type_t *bia_dt() const override { return &p_->bia_dt_; }
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -52,7 +52,7 @@ struct settings_t : public base_settings_t {
     std::vector<std::vector<dims_mask_t>> rt_dims_masks {{}};
 
     const char *perf_template_csv() const {
-        static const std::string args = "%sdt%,%stag%,%wtag%,%dtag%";
+        static const std::string args = "%sdt%,%bia_dt%,%stag%,%wtag%,%dtag%";
         return perf_template_csv_base(args);
     }
 
@@ -232,6 +232,7 @@ struct perf_report_t : public base_perf_report_t {
     const std::vector<dnnl_data_type_t> *sdt() const override {
         return &p_->dt;
     }
+    const dnnl_data_type_t *bia_dt() const override { return &p_->bia_dt; }
     const attr_t *attr() const override { return &p_->attr; }
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }

--- a/tests/benchdnn/utils/perf_report.cpp
+++ b/tests/benchdnn/utils/perf_report.cpp
@@ -118,6 +118,7 @@ void base_perf_report_t::handle_option(std::ostream &s, const char *&option,
     HANDLE("dt", if (dt()) s << *dt());
     HANDLE("group", if (group()) s << *group());
     HANDLE("sdt", if (sdt()) s << *sdt());
+    HANDLE("bia_dt", if (bia_dt()) s << *bia_dt());
     HANDLE("stag", if (stag()) s << *stag());
     HANDLE("mb", if (user_mb()) s << *user_mb());
     HANDLE("name", if (name()) s << *name());

--- a/tests/benchdnn/utils/perf_report.hpp
+++ b/tests/benchdnn/utils/perf_report.hpp
@@ -49,6 +49,7 @@ struct base_perf_report_t {
     virtual const dir_t *dir() const { return nullptr; }
     virtual const dnnl_data_type_t *dt() const { return nullptr; }
     virtual const std::vector<dnnl_data_type_t> *sdt() const { return nullptr; }
+    virtual const dnnl_data_type_t *bia_dt() const { return nullptr; }
     virtual const dnnl_data_type_t *ddt() const { return nullptr; }
     virtual const std::string *tag() const { return nullptr; }
     virtual const std::string *stat_tag() const { return nullptr; }


### PR DESCRIPTION
# Description

Bias datatype was previously not a parameter of perf template, so you could have two distinct `benchdnn` invocations with the same parameters in the perf report. Now they are distinguishable (see below)

```
benchdnn --mode=f --matmul --perf-template=csv --dt=bf16 --bia-dt=bf16,f32 1x1:1x1
perf,engine,impl,name,sdt,bia_dt,stag,wtag,dtag,attr,desc,Gops,max_ctime,min_time,min_Gflops,avg_time,avg_Gflops
perf,cpu,brg:sve_128,,bf16:bf16:bf16,bf16,any,any,any,,1x1:1x1,2e-09,0.467529,0.000488281,0.004096,0.000646998,0.0030912
perf,cpu,brg:sve_128,,bf16:bf16:bf16,f32,any,any,any,,1x1:1x1,2e-09,0.465576,0.000488281,0.004096,0.000650422,0.00307492
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
