### PR TITLE
xe: sdpa: Add 32, and 64 head size configs for Xe3p

### DIFF
--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -607,24 +607,30 @@ static std::vector<fwd_config_record_t> sorted_configs = []() {
         {{compute::gpu_arch_t::xe2, 128, f32 | fma | second_token | integrated }, { 16, 16, 32, 16, 4, 2, 4, 2 }},
         {{compute::gpu_arch_t::xe2, 256, fma | second_token | integrated }, { 16, 16, 32, 16, 8, 2, 8, 2 }},
 
-        {{compute::gpu_arch_t::xe3p,  32, fma },                            { 16, 16, 16, 16,  2, 2,  2, 2}},
-        {{compute::gpu_arch_t::xe3p,  64, fma | second_token },             { 16, 16, 16, 16,  8, 4,  8, 4}},
-        {{compute::gpu_arch_t::xe3p,  32, fma | second_token | quantized }, { 16, 16, 16, 16,  2, 2,  2, 2}},
-        {{compute::gpu_arch_t::xe3p,  64, fma | second_token | quantized }, { 16, 16, 16, 16,  8, 4,  8, 4}},
-        {{compute::gpu_arch_t::xe3p, 128 },                         {32, 32, 32, 32, 4, 4, 4, 4}},
-        {{compute::gpu_arch_t::xe3p, 128, second_token },           {32, 32, 32, 32, 4, 1, 4, 1}},
-        {{compute::gpu_arch_t::xe3p, 128, quantized},               {32, 32, 32, 32, 4, 4, 4, 4}},
-        {{compute::gpu_arch_t::xe3p, 128, second_token | quantized },           {32, 32, 32, 32, 4, 1, 4, 1}},
+        {{compute::gpu_arch_t::xe3p,  32 },                                       { 32, 32, 32, 16, 4, 1, 1, 4}},
+        {{compute::gpu_arch_t::xe3p,  32, quantized },                            { 32, 32, 32, 16, 4, 1, 1, 4}},
+        {{compute::gpu_arch_t::xe3p,  32, fma },                                  { 16, 16, 16, 16, 2, 2, 2, 2}},
+        {{compute::gpu_arch_t::xe3p,  32, fma | second_token | quantized },       { 16, 16, 16, 16, 2, 2, 2, 2}},
 
-        {{compute::gpu_arch_t::xe3p, 256, second_token },           {32, 32, 32, 32, 8, 1, 8, 1}},
-        {{compute::gpu_arch_t::xe3p, 256, quantized},               {32, 32, 32, 32, 8, 2, 8, 2}},
-        {{compute::gpu_arch_t::xe3p, 256, second_token | quantized },           {32, 32, 32, 32, 8, 1, 8, 1}},
+        {{compute::gpu_arch_t::xe3p,  64 },                                       { 32, 32, 32, 16, 4, 2, 2, 4}},
+        {{compute::gpu_arch_t::xe3p,  64, quantized },                            { 32, 32, 32, 16, 4, 2, 2, 4}},
+        {{compute::gpu_arch_t::xe3p,  64, fma | second_token },                   { 16, 16, 16, 16, 8, 4, 8, 4}},
+        {{compute::gpu_arch_t::xe3p,  64, fma | second_token | quantized },       { 16, 16, 16, 16, 8, 4, 8, 4}},
 
-        {{compute::gpu_arch_t::xe3p, 512},                                        {32, 16, 32, 16, 16, 2, 16, 2}},
-        {{compute::gpu_arch_t::xe3p, 512, second_token },                         {32, 16, 32, 16, 16, 1, 16, 1}},
-        {{compute::gpu_arch_t::xe3p, 512, second_token | quantized },             {32, 16, 32, 16, 16, 1, 16, 1}},
-        {{compute::gpu_arch_t::xe3p, 512, fma | quantized },                      {16, 16, 32, 16, 16, 1, 16, 1}},
-        {{compute::gpu_arch_t::xe3p, 512, fma | f32 | second_token | quantized }, {16, 16, 32, 16, 16, 1, 16, 1}},
+        {{compute::gpu_arch_t::xe3p, 128 },                                       { 32, 32, 32, 32, 4, 4, 4, 4}},
+        {{compute::gpu_arch_t::xe3p, 128, second_token },                         { 32, 32, 32, 32, 4, 1, 4, 1}},
+        {{compute::gpu_arch_t::xe3p, 128, quantized},                             { 32, 32, 32, 32, 4, 4, 4, 4}},
+        {{compute::gpu_arch_t::xe3p, 128, second_token | quantized },             { 32, 32, 32, 32, 4, 1, 4, 1}},
+
+        {{compute::gpu_arch_t::xe3p, 256, second_token },                         { 32, 32, 32, 32, 8, 1, 8, 1}},
+        {{compute::gpu_arch_t::xe3p, 256, quantized},                             { 32, 32, 32, 32, 8, 2, 8, 2}},
+        {{compute::gpu_arch_t::xe3p, 256, second_token | quantized },             { 32, 32, 32, 32, 8, 1, 8, 1}},
+
+        {{compute::gpu_arch_t::xe3p, 512},                                        { 32, 16, 32, 16, 16, 2, 16, 2}},
+        {{compute::gpu_arch_t::xe3p, 512, second_token },                         { 32, 16, 32, 16, 16, 1, 16, 1}},
+        {{compute::gpu_arch_t::xe3p, 512, second_token | quantized },             { 32, 16, 32, 16, 16, 1, 16, 1}},
+        {{compute::gpu_arch_t::xe3p, 512, fma | quantized },                      { 16, 16, 32, 16, 16, 1, 16, 1}},
+        {{compute::gpu_arch_t::xe3p, 512, fma | f32 | second_token | quantized }, { 16, 16, 32, 16, 16, 1, 16, 1}},
     };
     // clang-format on
 


### PR DESCRIPTION
# Description

Add new configs for SDPA that target Xe3p for head size 32 and 64. Previously these head sizes were targeting by the 128 head size config which was failing with incorrect values. 

Fixes: [MFDNN-15370](https://jira.devtools.intel.com/browse/MFDNN-15370)


