### PR TITLE
cpu: x64: matmul: guard extendable_k in small-dims heuristic

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -179,8 +179,10 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         best_blocking.need_buf_c_ = false;
         best_blocking.need_buf_a_ = best_blocking.use_buffer_a;
 
+        // extendable_k requires A to be contiguous along K (LDA == K).
         best_blocking.extendable_k_ = bgmmc.K % best_blocking.wei_k_blk != 0
-                && !best_blocking.skip_extendable_k();
+                && !best_blocking.skip_extendable_k()
+                && best_blocking.get_actual_lda() == bgmmc.K;
 
         best_blocking.is_a_nt_ = true;
         best_blocking.is_b_nt = true;


### PR DESCRIPTION
Another quard for extendable_k path. It was identified by code review of #5620

maybe_small_dims_heuristics' set_common reads A directly from user memory with the user's LDA, but enabled extendable_k without checking that A is contiguous along K (LDA == K). A padded src LDA corrupts the result, same as the set_blocking_parameters paths. Add the get_actual_lda() == K guard here too.

