### PR TITLE
cpu: rv64: route 64-channel plain-blocked reorder to the general kernel

### DIFF
--- a/src/cpu/rv64/reorder/jit_uni_reorder_utils.cpp
+++ b/src/cpu/rv64/reorder/jit_uni_reorder_utils.cpp
@@ -87,9 +87,8 @@ bool prb_is_f32_default_plain_blocked_reorder(
             || !prb_has_small_strides(p))
         return false;
 
-    auto is_supported_block = [](size_t n) {
-        return utils::one_of(n, 4ul, 8ul, 16ul, 32ul, 64ul);
-    };
+    auto is_supported_block
+            = [](size_t n) { return utils::one_of(n, 4ul, 8ul, 16ul, 32ul); };
 
     plain_blocked_reorder_desc_t candidates[2];
     int ncandidates = 0;


### PR DESCRIPTION

# Description

Extends #5363. Routes 64-channel plain↔blocked reorders (e.g. `nchw`↔`nhwc`) to the general `jit_uni_reorder` RVV kernel instead of letting them fall back to the scalar reference reorder.

In `prb_is_f32_default_plain_blocked_reorder`, `is_supported_block` accepts block sizes `{4, 8, 16, 32, 64}`, but the specialized `jit_blk` transpose kernel (`jit_single_blk_kernel_t::applicable`) only implements `{4, 8, 16, 32}`.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

### Results

Measured on Spacemit K3, `VLEN=256`, 8 threads.

| Metric | Before | After |
|---|---|---|
| 64-ch `nchw`↔`nhwc` reorder impl | `simple:any` (scalar) | `jit:uni` (RVV) |
| Per-reorder time | ~19-36 ms | ~2.3 ms |
| ResNet-18 step reorder total | ~95 ms | ~27 ms |

### Testing

Numerically verified against the reference implementation on a 64-channel convolution (forward, `grad_input`, `grad_weight` all match, max abs diff ~1e-6). No new reorder cases are enabled that lack a validated path.