### PR TITLE
common: memory_desc: validate descriptor deserialized from blob

### DIFF
--- a/src/common/memory_desc.cpp
+++ b/src/common/memory_desc.cpp
@@ -1132,8 +1132,26 @@ status_t dnnl_memory_desc_create_with_blob(
         memory_desc_t **md, const uint8_t *blob) {
     if (one_of(nullptr, md, blob)) return invalid_arguments;
 
-    *md = new memory_desc_t();
-    memcpy(*md, blob, sizeof(memory_desc_t));
+    auto md_ptr = utils::make_unique<memory_desc_t>();
+    if (!md_ptr) return out_of_memory;
+    memcpy(md_ptr.get(), blob, sizeof(memory_desc_t));
+
+    // The blob carries a raw memory_desc_t, so every field is caller-supplied.
+    // Validate it before it reaches consumers that index fixed-size dims_t
+    // arrays by these values (e.g. memory_desc_wrapper::size ->
+    // compute_blocks writes blocks[inner_idxs[i]]).
+    CHECK(memory_desc_sanity_check(*md_ptr));
+    if (md_ptr->format_kind == format_kind::blocked) {
+        const auto &blk = md_ptr->format_desc.blocking;
+        VCHECK_MEMORY(blk.inner_nblks >= 0 && blk.inner_nblks <= DNNL_MAX_NDIMS,
+                invalid_arguments, VERBOSE_BAD_PARAM, "inner_nblks");
+        for (int i = 0; i < blk.inner_nblks; ++i)
+            VCHECK_MEMORY(
+                    blk.inner_idxs[i] >= 0 && blk.inner_idxs[i] < md_ptr->ndims,
+                    invalid_arguments, VERBOSE_BAD_PARAM, "inner_idxs");
+    }
+
+    *md = md_ptr.release();
     return success;
 }
 

--- a/tests/gtests/internals/test_memory_desc_blob.cpp
+++ b/tests/gtests/internals/test_memory_desc_blob.cpp
@@ -1,0 +1,103 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstdint>
+#include <vector>
+
+#include "tests/gtests/dnnl_test_common.hpp"
+#include "gtest/gtest.h"
+
+#include "dnnl.hpp"
+
+#include "common/memory_desc.hpp"
+
+namespace dnnl {
+
+// dnnl_memory_desc_create_with_blob copies a raw memory_desc_t out of the
+// caller-supplied blob, so every field is attacker-controlled. Consumers such
+// as dnnl_memory_desc_get_size index fixed-size dims_t arrays by these fields
+// (compute_blocks does `blocks[inner_idxs[i]] *= ...`). A blob whose ndims or
+// blocking.inner_idxs are out of range must be rejected rather than driving an
+// out-of-bounds access.
+
+namespace {
+std::vector<uint8_t> blob_of(dnnl_memory_desc_t md) {
+    size_t blob_sz = 0;
+    EXPECT_EQ(dnnl_memory_desc_get_blob(nullptr, &blob_sz, md), dnnl_success);
+    std::vector<uint8_t> blob(blob_sz);
+    EXPECT_EQ(
+            dnnl_memory_desc_get_blob(blob.data(), &blob_sz, md), dnnl_success);
+    return blob;
+}
+} // namespace
+
+TEST(test_memory_desc_blob, ValidBlobRoundTrips) {
+    dnnl_memory_desc_t md {};
+    dnnl_dims_t dims = {2, 16, 4, 4};
+    ASSERT_EQ(dnnl_memory_desc_create_with_tag(
+                      &md, 4, dims, dnnl_f32, dnnl_aBcd16b),
+            dnnl_success);
+
+    const std::vector<uint8_t> blob = blob_of(md);
+
+    dnnl_memory_desc_t rt {};
+    ASSERT_EQ(
+            dnnl_memory_desc_create_with_blob(&rt, blob.data()), dnnl_success);
+    EXPECT_EQ(dnnl_memory_desc_get_size(rt), dnnl_memory_desc_get_size(md));
+
+    dnnl_memory_desc_destroy(rt);
+    dnnl_memory_desc_destroy(md);
+}
+
+TEST(test_memory_desc_blob, RejectsOutOfBoundsInnerIdx) {
+    dnnl_memory_desc_t md {};
+    dnnl_dims_t dims = {2, 16, 4, 4};
+    ASSERT_EQ(dnnl_memory_desc_create_with_tag(
+                      &md, 4, dims, dnnl_f32, dnnl_aBcd16b),
+            dnnl_success);
+
+    std::vector<uint8_t> blob = blob_of(md);
+    reinterpret_cast<impl::memory_desc_t *>(blob.data())
+            ->format_desc.blocking.inner_idxs[0]
+            = 100000;
+
+    dnnl_memory_desc_t bad = nullptr;
+    EXPECT_EQ(dnnl_memory_desc_create_with_blob(&bad, blob.data()),
+            dnnl_invalid_arguments);
+    EXPECT_EQ(bad, nullptr);
+
+    dnnl_memory_desc_destroy(md);
+}
+
+TEST(test_memory_desc_blob, RejectsOutOfBoundsNdims) {
+    dnnl_memory_desc_t md {};
+    dnnl_dims_t dims = {2, 16, 4, 4};
+    ASSERT_EQ(dnnl_memory_desc_create_with_tag(
+                      &md, 4, dims, dnnl_f32, dnnl_aBcd16b),
+            dnnl_success);
+
+    std::vector<uint8_t> blob = blob_of(md);
+    reinterpret_cast<impl::memory_desc_t *>(blob.data())->ndims = 1000;
+
+    dnnl_memory_desc_t bad = nullptr;
+    EXPECT_EQ(dnnl_memory_desc_create_with_blob(&bad, blob.data()),
+            dnnl_invalid_arguments);
+    EXPECT_EQ(bad, nullptr);
+
+    dnnl_memory_desc_destroy(md);
+}
+
+} // namespace dnnl


### PR DESCRIPTION
# Description

dnnl_memory_desc_create_with_blob copies the blob straight into a memory_desc_t and returns it unchecked, so every field including ndims and the blocking descriptor is caller-supplied. a later query runs memory_desc_wrapper::size -> compute_blocks, which does blocks[inner_idxs[i]] *= inner_blks[i] into a fixed dims_t sized DNNL_MAX_NDIMS; an inner_idxs value outside [0, ndims) writes past that stack array, and an out-of-range ndims overflows the same buffer through array_set. validate the reconstructed descriptor before returning it, reusing memory_desc_sanity_check for ndims/dims/dtype and bounding inner_nblks and inner_idxs for blocked formats, which is the same validation the normal creation paths already run. blobs produced by dnnl_memory_desc_get_blob round-trip unchanged.

reproduce with a valid f32 nChw16c descriptor: take its blob from dnnl_memory_desc_get_blob, set blocking.inner_idxs[0] to 100000, then dnnl_memory_desc_create_with_blob followed by dnnl_memory_desc_get_size. before the change asan reports a write past the 96-byte `blocks` stack array in compute_blocks (memory_desc_wrapper.hpp); after it the blob is rejected with invalid_arguments and the destination is untouched. the new gtest in tests/gtests/internals covers the oversized inner_idxs and ndims rejections plus a valid round-trip.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
