### PR TITLE
cpu: aarch64: fix prim create in post ops fallback

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -120,7 +120,8 @@ template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,
         typename bia_data_t = src_data_t>
 status_t execute_forward_conv_acl(const exec_ctx_t &ctx,
         conv_obj_t *acl_conv_obj, const conv_pd_t *pd,
-        const std::map<int, conv_key_t> &conv_keys) {
+        const std::map<int, conv_key_t> &conv_keys,
+        const post_ops_fallback_t &post_ops) {
 
     auto src_base = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
     auto wei_base = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
@@ -187,7 +188,7 @@ status_t execute_forward_conv_acl(const exec_ctx_t &ctx,
     acl_conv_obj->conv.run(pack);
 
     void *dst = dst_tensor.buffer();
-    CHECK(pd->post_ops.execute(ctx, dst));
+    CHECK(post_ops.execute(ctx, dst));
 
     return status::success;
 }
@@ -195,8 +196,9 @@ status_t execute_forward_conv_acl(const exec_ctx_t &ctx,
 template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,
         typename wei_data_t = src_data_t, typename dst_data_t = src_data_t,
         typename bia_data_t = src_data_t>
-status_t execute_forward_conv_acl(
-        const exec_ctx_t &ctx, conv_obj_t &acl_conv_obj, const conv_pd_t *pd) {
+status_t execute_forward_conv_acl(const exec_ctx_t &ctx,
+        conv_obj_t &acl_conv_obj, const conv_pd_t *pd,
+        const post_ops_fallback_t &post_ops) {
     bool with_bias = pd->acp_.with_bias;
     bool use_dst_acc_for_sum = pd->acp_.use_dst_acc_for_sum;
 
@@ -232,7 +234,7 @@ status_t execute_forward_conv_acl(
     if (with_bias) { acl_conv_obj.bia_tensor.allocator()->free(); }
 
     void *dst = acl_conv_obj.dst_tensor.buffer();
-    status_t status = pd->post_ops.execute(ctx, dst);
+    status_t status = post_ops.execute(ctx, dst);
 
     acl_conv_obj.dst_tensor.allocator()->free();
 

--- a/src/cpu/aarch64/acl_deconvolution.cpp
+++ b/src/cpu/aarch64/acl_deconvolution.cpp
@@ -54,7 +54,7 @@ status_t acl_deconvolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     acl_obj.deconv.run();
 
     void *dst = acl_obj.dst_tensor.buffer();
-    status_t status = pd()->post_ops.execute(ctx, dst);
+    status_t status = post_ops_.execute(ctx, dst);
 
     acl_obj.src_tensor.allocator()->free();
     acl_obj.dst_tensor.allocator()->free();

--- a/src/cpu/aarch64/acl_deconvolution.hpp
+++ b/src/cpu/aarch64/acl_deconvolution.hpp
@@ -326,6 +326,11 @@ struct acl_deconvolution_fwd_t : public primitive_t {
 
     acl_deconvolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
+    status_t init(engine_t *engine) override {
+        post_ops_ = pd()->post_ops;
+        return post_ops_.init_primitives(engine);
+    }
+
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
     }
@@ -349,6 +354,7 @@ private:
     mutable std::mutex mtx;
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    post_ops_fallback_t post_ops_;
 }; // acl_deconvolution_fwd_t
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_depthwise_convolution.cpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.cpp
@@ -37,7 +37,7 @@ const std::map<int, conv_key_t> depthwise_conv_keys
 status_t acl_depthwise_convolution_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
     return execute_forward_conv_acl<acl_obj_t<Op>, pd_t, data_t>(
-            ctx, acl_obj_.get(), pd(), depthwise_conv_keys);
+            ctx, acl_obj_.get(), pd(), depthwise_conv_keys, post_ops_);
 }
 
 status_t acl_depthwise_convolution_fwd_t::pd_t::init(const engine_t *engine) {
@@ -87,6 +87,8 @@ status_t acl_depthwise_convolution_fwd_t::init(engine_t *engine) {
             1, // depth multiplier default value
             acp_.act_info, acp_.dilation_info);
     acl_obj_->aux_mem_req = acl_obj_->conv.workspace();
+    post_ops_ = pd()->post_ops;
+    CHECK(post_ops_.init_primitives(engine));
     return status::success;
 }
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_depthwise_convolution.hpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
@@ -56,6 +56,7 @@ private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     std::unique_ptr<acl_obj_t<Op>> acl_obj_;
+    post_ops_fallback_t post_ops_;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -101,6 +101,8 @@ status_t acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::init(
             &acp_.dst_tensor_info, acp_.padstride_info, acp_.weights_info,
             acp_.dilation_info, acp_.act_info, acp_.fast_math);
     acl_obj_->aux_mem_req = acl_obj_->conv.workspace();
+    post_ops_ = pd()->post_ops;
+    CHECK(post_ops_.init_primitives(engine));
     return status::success;
 }
 
@@ -110,7 +112,8 @@ status_t
 acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::execute_forward(
         const exec_ctx_t &ctx) const {
     return execute_forward_conv_acl<acl_obj_t<Op>, pd_t, src_data_t, wei_data_t,
-            dst_data_t, bia_data_t>(ctx, acl_obj_.get(), pd(), gemm_conv_keys);
+            dst_data_t, bia_data_t>(
+            ctx, acl_obj_.get(), pd(), gemm_conv_keys, post_ops_);
 }
 
 using namespace data_type;

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -66,6 +66,7 @@ private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     std::unique_ptr<acl_obj_t<Op>> acl_obj_;
+    post_ops_fallback_t post_ops_;
 }; // acl_gemm_convolution_fwd_t
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -48,13 +48,15 @@ status_t acl_indirect_gemm_convolution_fwd_t::init(engine_t *engine) {
                     acp_.act_info, acp_.fast_math, 1, acp_.weights_info,
                     acp_.use_fp32_acc));
     acl_obj_->aux_mem_req = acl_obj_->conv.workspace();
+    post_ops_ = pd()->post_ops;
+    CHECK(post_ops_.init_primitives(engine));
     return status::success;
 }
 
 status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
     return execute_forward_conv_acl<acl_obj_t<Op>, pd_t, data_t>(
-            ctx, acl_obj_.get(), pd(), indirect_conv_keys);
+            ctx, acl_obj_.get(), pd(), indirect_conv_keys, post_ops_);
 }
 
 status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init_conf() {

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -60,6 +60,7 @@ private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     std::unique_ptr<acl_obj_t<Op>> acl_obj_;
+    post_ops_fallback_t post_ops_;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_inner_product.cpp
+++ b/src/cpu/aarch64/acl_inner_product.cpp
@@ -32,6 +32,9 @@ status_t acl_inner_product_fwd_t::init(engine_t *engine) {
             aip.with_bias ? &aip.bia_tensor_info : nullptr,
             &aip.dst_tensor_info, aip.fc_info, aip.weights_info);
 
+    post_ops_ = pd()->post_ops;
+    CHECK(post_ops_.init_primitives(engine));
+
     return status::success;
 }
 
@@ -87,7 +90,7 @@ status_t acl_inner_product_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     inner_product_op_->run(run_pack);
 
     void *dst = dst_tensor.buffer();
-    CHECK(pd()->post_ops.execute(ctx, dst));
+    CHECK(post_ops_.execute(ctx, dst));
 
     return status::success;
 }

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -74,6 +74,7 @@ private:
     }
     std::unique_ptr<arm_compute::experimental::op::CpuFullyConnected>
             inner_product_op_;
+    post_ops_fallback_t post_ops_;
 }; // acl_inner_product_fwd_t
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -35,7 +35,7 @@ status_t acl_wino_convolution_fwd_t::execute_forward(
 
     return execute_forward_conv_acl<
             acl_obj_t<arm_compute::NEWinogradConvolutionLayer>, pd_t, data_t>(
-            ctx, acl_wino_obj, pd());
+            ctx, acl_wino_obj, pd(), post_ops_);
 }
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -121,6 +121,11 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
 
     acl_wino_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
+    status_t init(engine_t *engine) override {
+        post_ops_ = pd()->post_ops;
+        return post_ops_.init_primitives(engine);
+    }
+
     status_t create_resource(
             engine_t *engine, resource_mapper_t &mapper) const override {
         if (mapper.has_resource(this)) return status::success;
@@ -148,6 +153,7 @@ private:
     mutable std::mutex mtx;
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    post_ops_fallback_t post_ops_;
 }; // acl_wino_convolution_fwd_t
 
 } // namespace aarch64

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -294,6 +294,9 @@ status_t acl_lowp_matmul_t::init(engine_t *engine) {
         }
     }
 
+    fallback_post_ops_ = pd()->fallback_post_ops;
+    CHECK(fallback_post_ops_.init_primitives(engine));
+
     return status::success;
 }
 
@@ -407,7 +410,7 @@ status_t acl_lowp_matmul_t::execute(const exec_ctx_t &ctx) const {
     // these are in-place so that dst=src. However, when there is a non-fused
     // sum, we set dst to be the tensor where data to be summed is stored.
     void *dst_post_ops;
-    if (pd()->fallback_post_ops.has_sum() && !pd()->almc_.sum_is_fused) {
+    if (fallback_post_ops_.has_sum() && !pd()->almc_.sum_is_fused) {
         if (pd()->almc_.dst_is_s8) {
             dst_post_ops = dst_cast_tensor.buffer();
         } else {
@@ -417,7 +420,7 @@ status_t acl_lowp_matmul_t::execute(const exec_ctx_t &ctx) const {
         dst_post_ops = src_post_ops;
     }
     status_t post_ops_status
-            = pd()->fallback_post_ops.execute(ctx, src_post_ops, dst_post_ops);
+            = fallback_post_ops_.execute(ctx, src_post_ops, dst_post_ops);
 
     // free() here tells ACL it can no longer use it, it does not deallocate
     src_tensor.allocator()->free();

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.hpp
@@ -77,6 +77,7 @@ private:
     std::unique_ptr<arm_compute::experimental::op::CpuQuantize> quant_;
     std::unique_ptr<arm_compute::experimental::op::CpuDequantize> dequant_;
     std::unique_ptr<arm_compute::experimental::op::CpuGEMMLowp> gemm_;
+    post_ops_fallback_t fallback_post_ops_;
 
     mutable std::mutex mtx_;
 };

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -57,6 +57,9 @@ status_t acl_lowp_matmul_sq_t::init(engine_t *engine) {
             almc.with_bias ? &almc.bia_tensor_info : nullptr,
             &almc.dst_tensor_info, almc.gemm_info);
 
+    post_ops_ = pd()->post_ops;
+    CHECK(post_ops_.init_primitives(engine));
+
     return status::success;
 }
 

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.hpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.hpp
@@ -84,6 +84,7 @@ private:
         return (const pd_t *)primitive_t::pd().get();
     }
     std::unique_ptr<arm_compute::experimental::op::CpuGEMMLowp> gemm_;
+    post_ops_fallback_t post_ops_;
 };
 
 } // namespace matmul

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -62,6 +62,9 @@ status_t acl_matmul_t::init(engine_t *engine) {
                 amp_.gemm_info.activation_info());
     }
 
+    post_ops_ = pd()->post_ops;
+    CHECK(post_ops_.init_primitives(engine));
+
     return status::success;
 }
 
@@ -386,7 +389,7 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
     }
 
     void *dst = dst_tensor.buffer();
-    status = pd()->post_ops.execute(ctx, dst);
+    status = post_ops_.execute(ctx, dst);
 
     return status;
 }

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -63,6 +63,7 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
     std::unique_ptr<acl_matmul_obj_t> acl_obj_;
+    post_ops_fallback_t post_ops_;
     mutable std::mutex mtx_;
 }; // acl_matmul_t
 

--- a/src/cpu/aarch64/post_ops_fallback.cpp
+++ b/src/cpu/aarch64/post_ops_fallback.cpp
@@ -39,6 +39,7 @@ status_t post_ops_fallback_t::init(const engine_t *engine, post_ops_t &post_ops,
 
     // Reset properties derived from post_ops
     sum_index = -1;
+    post_op_pds = {};
     post_op_primitives = {};
 
     for (int i = post_op_start_index; i < post_ops.len(); i++) {
@@ -65,9 +66,9 @@ status_t post_ops_fallback_t::init(const engine_t *engine, post_ops_t &post_ops,
             po_desc.src_desc[1] = dst_md;
             po_desc.dst_desc = dst_md;
 
-            std::shared_ptr<primitive_t> binary_prim;
-            CHECK(create_binary_primitive(engine, po_desc, binary_prim));
-            post_op_primitives.push_back(std::move(binary_prim));
+            std::shared_ptr<primitive_desc_t> binary_pd;
+            CHECK(create_binary_pd(engine, po_desc, binary_pd));
+            post_op_pds.push_back(std::move(binary_pd));
 
         } else if (po.is_binary()) {
             binary_desc_t po_desc;
@@ -80,9 +81,9 @@ status_t post_ops_fallback_t::init(const engine_t *engine, post_ops_t &post_ops,
             }
             po_desc.dst_desc = dst_md;
 
-            std::shared_ptr<primitive_t> binary_prim;
-            CHECK(create_binary_primitive(engine, po_desc, binary_prim));
-            post_op_primitives.push_back(std::move(binary_prim));
+            std::shared_ptr<primitive_desc_t> binary_pd;
+            CHECK(create_binary_pd(engine, po_desc, binary_pd));
+            post_op_pds.push_back(std::move(binary_pd));
 
         } else if (po.is_eltwise()) {
             VDISPATCH_FALLBACK_POST_OPS(po.eltwise.scale == 1.0f,
@@ -95,9 +96,9 @@ status_t post_ops_fallback_t::init(const engine_t *engine, post_ops_t &post_ops,
                     po.eltwise.alg, &dst_md, &dst_md, nullptr, nullptr,
                     po.eltwise.alpha, po.eltwise.beta));
 
-            std::shared_ptr<primitive_t> eltwise_prim;
-            CHECK(create_eltwise_primitive(engine, ed, eltwise_prim));
-            post_op_primitives.push_back(std::move(eltwise_prim));
+            std::shared_ptr<primitive_desc_t> eltwise_pd;
+            CHECK(create_eltwise_pd(engine, ed, eltwise_pd));
+            post_op_pds.push_back(std::move(eltwise_pd));
 
         } else {
             // Unsupported catchall
@@ -107,13 +108,26 @@ status_t post_ops_fallback_t::init(const engine_t *engine, post_ops_t &post_ops,
     return status::success;
 }
 
+status_t post_ops_fallback_t::init_primitives(engine_t *engine) {
+    post_op_primitives = {};
+    post_op_primitives.reserve(post_op_pds.size());
+
+    for (const auto &post_op_pd : post_op_pds) {
+        std::shared_ptr<primitive_t> post_op;
+        CHECK(post_op_pd->create_primitive(post_op, engine));
+        post_op_primitives.push_back(std::move(post_op));
+    }
+
+    return status::success;
+}
+
 void post_ops_fallback_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad) const {
     using namespace memory_tracking::names;
 
-    for (size_t i = 0; i < post_op_primitives.size(); ++i) {
+    for (size_t i = 0; i < post_op_pds.size(); ++i) {
         scratchpad.book(key_nested_multiple + (int)i,
-                post_op_primitives[i]->pd()->scratchpad_registry());
+                post_op_pds[i]->scratchpad_registry());
     }
 }
 
@@ -160,44 +174,36 @@ status_t post_ops_fallback_t::execute_binary(const exec_ctx_t &ctx,
     return post_op->execute(binary_ctx);
 }
 
-status_t post_ops_fallback_t::create_binary_primitive(const engine_t *engine,
+status_t post_ops_fallback_t::create_binary_pd(const engine_t *engine,
         const binary_desc_t &binary_desc,
-        std::shared_ptr<primitive_t> &primitive) const {
+        std::shared_ptr<primitive_desc_t> &primitive_desc) const {
     auto empty_attr = dnnl_primitive_attr();
 
     primitive_desc_iterator_t it(engine,
             reinterpret_cast<const op_desc_t *>(&binary_desc), &empty_attr,
             nullptr);
 
-    std::shared_ptr<primitive_desc_t> binary_pd;
     while (++it != it.end()) {
-        binary_pd = *it;
-        if (binary_pd) break;
+        primitive_desc = *it;
+        if (primitive_desc) return status::success;
     }
-    if (!binary_pd) return status::unimplemented;
-
-    return binary_pd->create_primitive(
-            primitive, const_cast<engine_t *>(engine));
+    return status::unimplemented;
 }
 
-status_t post_ops_fallback_t::create_eltwise_primitive(const engine_t *engine,
+status_t post_ops_fallback_t::create_eltwise_pd(const engine_t *engine,
         const eltwise_desc_t &eltwise_desc,
-        std::shared_ptr<primitive_t> &primitive) const {
+        std::shared_ptr<primitive_desc_t> &primitive_desc) const {
     auto empty_attr = dnnl_primitive_attr();
 
     primitive_desc_iterator_t it(engine,
             reinterpret_cast<const op_desc_t *>(&eltwise_desc), &empty_attr,
             nullptr);
 
-    std::shared_ptr<primitive_desc_t> eltwise_pd;
     while (++it != it.end()) {
-        eltwise_pd = *it;
-        if (eltwise_pd) break;
+        primitive_desc = *it;
+        if (primitive_desc) return status::success;
     }
-    if (!eltwise_pd) return status::unimplemented;
-
-    return eltwise_pd->create_primitive(
-            primitive, const_cast<engine_t *>(engine));
+    return status::unimplemented;
 }
 
 status_t post_ops_fallback_t::execute_eltwise(const exec_ctx_t &ctx,
@@ -226,7 +232,6 @@ status_t post_ops_fallback_t::execute_eltwise(const exec_ctx_t &ctx,
 
 status_t post_ops_fallback_t::execute(
         const exec_ctx_t &ctx, void *src, void *dst) const {
-
     int post_op_index = post_op_start_index_;
     int primitive_index = 0;
 

--- a/src/cpu/aarch64/post_ops_fallback.hpp
+++ b/src/cpu/aarch64/post_ops_fallback.hpp
@@ -37,6 +37,8 @@ struct post_ops_fallback_t {
     status_t init(const engine_t *engine, post_ops_t &post_ops,
             const memory_desc_t &dst_md, int post_op_start_index = 0);
 
+    status_t init_primitives(engine_t *engine);
+
     bool has_sum() const { return sum_index >= 0; }
 
     void init_scratchpad(memory_tracking::registrar_t &scratchpad) const;
@@ -45,13 +47,13 @@ struct post_ops_fallback_t {
             const exec_ctx_t &ctx, void *src, void *dst = nullptr) const;
 
 private:
-    status_t create_binary_primitive(const engine_t *engine,
+    status_t create_binary_pd(const engine_t *engine,
             const binary_desc_t &binary_desc,
-            std::shared_ptr<primitive_t> &primitive) const;
+            std::shared_ptr<primitive_desc_t> &primitive_desc) const;
 
-    status_t create_eltwise_primitive(const engine_t *engine,
+    status_t create_eltwise_pd(const engine_t *engine,
             const eltwise_desc_t &eltwise_desc,
-            std::shared_ptr<primitive_t> &primitive) const;
+            std::shared_ptr<primitive_desc_t> &primitive_desc) const;
 
     status_t execute_binary(const exec_ctx_t &ctx, const primitive_t *post_op,
             const void *src0, const void *src1, const void *src2, void *dst,
@@ -66,6 +68,8 @@ private:
     // number of post ops which were fused.
     int post_op_start_index_ = 0;
     data_type_t dst_data_type;
+    // Vector of primitive descriptors used to create the post op primitives.
+    std::vector<std::shared_ptr<primitive_desc_t>> post_op_pds;
     // Vector of primitives used to execute the post ops.
     std::vector<std::shared_ptr<primitive_t>> post_op_primitives;
 };


### PR DESCRIPTION
# Description

post ops fallback was silently mutating the engine with a `const cast` in the `init` function. To fix this, add another method: `init_primitives` which is called during the wrapper's `primitive::init` function which allows mutation of the engine.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

