### PR TITLE
cpu: x64: drop write permissions after JIT complete

### DIFF
--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -2798,7 +2798,7 @@ public:
 private:
     const cpu_isa_t max_cpu_isa_;
     const Xbyak::uint8 *getCode() {
-        this->ready();
+        this->readyRE();
         if (!is_initialized()) return nullptr;
         const Xbyak::uint8 *code = CodeGenerator::getCode();
         register_jit_code(code, getSize());


### PR DESCRIPTION
`Xbyak::CodeGenerator` allocates RW pages for us when used in AutoGrow mode (good). Since we don't need to write to the JIT'ted content after we've finished our initial pass, we can drop the `PROT_WRITE` permissions and retain only Read-Execute. This is required in some locked down systems that forbid RWX for security reasons.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

There are no **new** failures. Before and after:
```
29% tests passed, 68 tests failed out of 96
```

- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

This is not easy to unit-test. I caught this when intercepting `mmap()` and `mprotect()` when the protection arguments had `PROT_WRITE|PROT_EXEC`.