### PR TITLE
xe: fix strided destination handling

### DIFF
--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -314,6 +314,37 @@ struct memory_desc_wrapper {
         return buff_size;
     }
 
+    /** returns the number of elements spanned by the descriptor, i.e. one past
+     * the largest linear offset `off_v()` may return. Exceeds `nelems(true)`
+     * for strided descriptors. */
+    size_t span() const {
+        if (utils::one_of(format_kind(), format_kind::undef, format_kind::any)
+                || is_zero() || has_zero_dim())
+            return 0;
+
+        if (has_runtime_dims_or_strides()) return runtime_value_for<size_t>();
+
+        if (is_blocking_desc()) {
+            dims_t blocks = {0};
+            compute_blocks(blocks);
+
+            const auto &bd = blocking_desc();
+
+            dim_t max_size = 0;
+            for (int d = 0; d < ndims(); ++d) {
+                dim_t strided_pdim = padded_dims()[d] / blocks[d];
+                dim_t effective_stride = strided_pdim == 1 ? 1 : bd.strides[d];
+                max_size = nstl::max(max_size, strided_pdim * effective_stride);
+            }
+
+            if (max_size == 1 && bd.inner_nblks != 0) max_size = blk_size();
+            return static_cast<size_t>(max_size);
+        } else {
+            assert(!"unsupported format kind");
+            return 0;
+        }
+    }
+
     /** returns the size required to store described memory note: does not
         include offset0 by default */
     size_t size(int index = 0, bool include_additional_size = true,
@@ -340,22 +371,7 @@ struct memory_desc_wrapper {
         } else if (is_zen_packed_desc()) {
             return zen_packed_desc().size;
         } else if (is_blocking_desc()) {
-            dims_t blocks = {0};
-            compute_blocks(blocks);
-
-            const auto &bd = blocking_desc();
-
-            size_t max_size = 0;
-            for (int d = 0; d < ndims(); ++d) {
-                dim_t strided_pdim = padded_dims()[d] / blocks[d];
-                dim_t effective_stride = strided_pdim == 1 ? 1 : bd.strides[d];
-                max_size = nstl::max<size_t>(
-                        max_size, strided_pdim * effective_stride);
-            }
-
-            if (max_size == 1 && bd.inner_nblks != 0) {
-                max_size = static_cast<size_t>(blk_size());
-            }
+            const size_t max_size = span();
 
             // `div_up` guarantees a spot in memory for odd number of half-byte
             // elements. Crucial case is `1` when simple division returns 0.

--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -79,6 +79,10 @@ public:
 
     void register_buffer_size(const memory_desc_wrapper &mdw);
     void register_buffer_size(const memory_desc_info_t &mdi);
+    void register_buffer_size(dim_t size_elems, size_t size_bytes) {
+        if (size_elems > INT32_MAX) use_int32_offset(false);
+        if (size_bytes > UINT32_MAX) require_stateless_addressing(true);
+    }
 
     // Enable various optimizations when all buffers are < 2GB in size. In this
     // case, int32_t types can be used for data offsets and avoid int64_t
@@ -167,11 +171,6 @@ public:
     bool has_custom_headers() const { return !custom_headers_.empty(); }
 
 private:
-    void register_buffer_size(dim_t nelems, size_t size) {
-        if (nelems > INT32_MAX) use_int32_offset(false);
-        if (size > UINT32_MAX) require_stateless_addressing(true);
-    }
-
     void set_default_options(const primitive_attr_t *attr) {
         // By default fp32 division and sqrt are not IEEE-compliant
         add_option("-cl-fp32-correctly-rounded-divide-sqrt");

--- a/src/gpu/intel/conv/ref.cpp
+++ b/src/gpu/intel/conv/ref.cpp
@@ -199,8 +199,6 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     auto &dst_sround = CTX_IN_STORAGE(DNNL_ARG_ATTR_ROUNDING_SEED);
 
     auto &conf = pd()->conf;
-    const bool subbyte_pack = pd()->subbyte_pack_;
-    const auto c_d = ctx.memory_mdw(DNNL_ARG_DST, pd()->dst_md());
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
             memory_tracking::names::key_conv_pack_space);
 
@@ -208,7 +206,7 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     arg_list.set(0, src);
     arg_list.set(1, weights);
     arg_list.set(2, bias);
-    arg_list.set(3, subbyte_pack ? *tmp : dst);
+    arg_list.set(3, pack_ ? *tmp : dst);
 
     unsigned arg_idx = append_post_ops_to_arg_list(
             ctx, arg_list, 4, pd()->attr()->post_ops_, *pd()->dst_md());
@@ -236,22 +234,9 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
     auto nd_range = pd()->conf.dispatch.nd_range();
 
-    CHECK(parallel_for(ctx, nd_range, kernels_[0], arg_list));
-
-    if (!subbyte_pack) return status::success;
-
-    // The unpacked buffer is indexed with dst_md() offsets, so packing covers
-    // its whole element span, not just its element count.
-    const dim_t dst_span = c_d.span();
-    compute::kernel_arg_list_t repack_arg_list;
-    repack_arg_list.set(0, *tmp);
-    repack_arg_list.set(1, dst);
-    repack_arg_list.set(2, dst_span);
-    repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((dst_span * 4 + 7) / 8);
-    compute::nd_range_t repack_nd_range(repack_gws);
-    return large_parallel_for(
-            ctx, repack_nd_range, kernels_[1], repack_arg_list, 4);
+    CHECK(parallel_for(ctx, nd_range, kernel_, arg_list));
+    if (!pack_) return status::success;
+    return pack_(ctx, *tmp, dst);
 }
 
 status_t ref_bwd_data_t::pd_t::init_conf(const impl::engine_t *engine) {
@@ -285,14 +270,11 @@ status_t ref_bwd_data_t::execute_backward_data(const exec_ctx_t &ctx) const {
 
     auto &conf = pd()->conf;
 
-    const bool subbyte_pack = pd()->subbyte_pack_;
-    const auto c_d = ctx.memory_mdw(DNNL_ARG_DIFF_DST, pd()->diff_dst_md());
-    const dim_t nelems = c_d.nelems();
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
             memory_tracking::names::key_conv_pack_space);
 
     compute::kernel_arg_list_t arg_list;
-    arg_list.set(0, subbyte_pack ? *tmp : diff_src);
+    arg_list.set(0, pack_ ? *tmp : diff_src);
     arg_list.set(1, weights);
     arg_list.set(2, diff_dst);
     arg_list.set(3, bias);
@@ -321,18 +303,9 @@ status_t ref_bwd_data_t::execute_backward_data(const exec_ctx_t &ctx) const {
 
     auto nd_range = pd()->conf.dispatch.nd_range();
 
-    CHECK(parallel_for(ctx, nd_range, kernels_[0], arg_list));
-
-    if (!subbyte_pack) return status::success;
-    compute::kernel_arg_list_t repack_arg_list;
-    repack_arg_list.set(0, *tmp);
-    repack_arg_list.set(1, diff_src);
-    repack_arg_list.set(2, into<dim_t>(nelems));
-    repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((nelems * 4 + 7) / 8);
-    compute::nd_range_t repack_nd_range(repack_gws);
-    return large_parallel_for(
-            ctx, repack_nd_range, kernels_[1], repack_arg_list, 4);
+    CHECK(parallel_for(ctx, nd_range, kernel_, arg_list));
+    if (!pack_) return status::success;
+    return pack_(ctx, *tmp, diff_src);
 }
 
 status_t ref_bwd_weights_t::pd_t::init_conf(const impl::engine_t *engine) {
@@ -356,33 +329,20 @@ status_t ref_bwd_weights_t::execute_backward_weights(
     auto &diff_bias = CTX_OUT_CLEAN_STORAGE(DNNL_ARG_DIFF_BIAS, status);
     CHECK(status);
 
-    const bool subbyte_pack = pd()->subbyte_pack_;
-    const auto c_d
-            = ctx.memory_mdw(DNNL_ARG_DIFF_WEIGHTS, pd()->diff_weights_md());
-    const dim_t nelems = c_d.nelems();
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
             memory_tracking::names::key_conv_pack_space);
 
     compute::kernel_arg_list_t arg_list;
     arg_list.set(0, src);
-    arg_list.set(1, subbyte_pack ? *tmp : diff_weights);
+    arg_list.set(1, pack_ ? *tmp : diff_weights);
     arg_list.set(2, diff_bias);
     arg_list.set(3, diff_dst);
 
     auto nd_range = pd()->conf.dispatch.nd_range();
 
-    CHECK(parallel_for(ctx, nd_range, kernels_[0], arg_list));
-
-    if (!subbyte_pack) return status::success;
-    compute::kernel_arg_list_t repack_arg_list;
-    repack_arg_list.set(0, *tmp);
-    repack_arg_list.set(1, diff_weights);
-    repack_arg_list.set(2, into<dim_t>(nelems));
-    repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((nelems * 4 + 7) / 8);
-    compute::nd_range_t repack_nd_range(repack_gws);
-    return large_parallel_for(
-            ctx, repack_nd_range, kernels_[1], repack_arg_list, 4);
+    CHECK(parallel_for(ctx, nd_range, kernel_, arg_list));
+    if (!pack_) return status::success;
+    return pack_(ctx, *tmp, diff_weights);
 }
 
 } // namespace conv

--- a/src/gpu/intel/conv/ref.cpp
+++ b/src/gpu/intel/conv/ref.cpp
@@ -89,8 +89,8 @@ static status_t init_conf_common(
 }
 
 static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
-        const conf_t &conf, const post_ops_t &post_ops,
-        const memory_desc_t *dst_md) {
+        const conf_t &conf, const subbyte_pack_desc_t &pack_desc,
+        const post_ops_t &post_ops, const memory_desc_t *dst_md) {
     kernel_ctx.require_stateless_addressing(conf.require_stateless_addressing);
     kernel_ctx.define_int("NDIMS", conf.ndims);
     kernel_ctx.define_int("G", conf.ngroups);
@@ -165,18 +165,18 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
             "SUM");
 
     CHECK(def_attr_info(kernel_ctx, conf.attr_info, post_ops, *dst_md));
+    kernel_ctx.register_buffer_size(pack_desc.span(), pack_desc.span());
     return status::success;
 }
 
 status_t ref_fwd_t::pd_t::init_conf(const impl::engine_t *engine) {
-    CHECK(init_conf_common(conf, this, engine));
-    return status::success;
+    return init_conf_common(conf, this, engine);
 }
 
 status_t ref_fwd_t::pd_t::init_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
-    return init_kernel_ctx_common(
-            kernel_ctx, conf, attr()->post_ops_, invariant_dst_md());
+    return init_kernel_ctx_common(kernel_ctx, conf, pack_desc_,
+            attr()->post_ops_, invariant_dst_md());
 }
 
 status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
@@ -240,14 +240,13 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 }
 
 status_t ref_bwd_data_t::pd_t::init_conf(const impl::engine_t *engine) {
-    CHECK(init_conf_common(conf, this, engine));
-    return status::success;
+    return init_conf_common(conf, this, engine);
 }
 
 status_t ref_bwd_data_t::pd_t::init_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
-    return init_kernel_ctx_common(
-            kernel_ctx, conf, attr()->post_ops_, invariant_src_md());
+    return init_kernel_ctx_common(kernel_ctx, conf, pack_desc_,
+            attr()->post_ops_, invariant_src_md());
 }
 
 status_t ref_bwd_data_t::execute_backward_data(const exec_ctx_t &ctx) const {
@@ -314,8 +313,8 @@ status_t ref_bwd_weights_t::pd_t::init_conf(const impl::engine_t *engine) {
 
 status_t ref_bwd_weights_t::pd_t::init_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
-    return init_kernel_ctx_common(
-            kernel_ctx, conf, attr()->post_ops_, invariant_wei_md());
+    return init_kernel_ctx_common(kernel_ctx, conf, pack_desc_,
+            attr()->post_ops_, invariant_wei_md());
 }
 
 status_t ref_bwd_weights_t::execute_backward_weights(

--- a/src/gpu/intel/conv/ref.cpp
+++ b/src/gpu/intel/conv/ref.cpp
@@ -201,7 +201,6 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     auto &conf = pd()->conf;
     const bool subbyte_pack = pd()->subbyte_pack_;
     const auto c_d = ctx.memory_mdw(DNNL_ARG_DST, pd()->dst_md());
-    const dim_t nelems = c_d.nelems();
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
             memory_tracking::names::key_conv_pack_space);
 
@@ -240,12 +239,16 @@ status_t ref_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     CHECK(parallel_for(ctx, nd_range, kernels_[0], arg_list));
 
     if (!subbyte_pack) return status::success;
+
+    // The unpacked buffer is indexed with dst_md() offsets, so packing covers
+    // its whole element span, not just its element count.
+    const dim_t dst_span = c_d.span();
     compute::kernel_arg_list_t repack_arg_list;
     repack_arg_list.set(0, *tmp);
     repack_arg_list.set(1, dst);
-    repack_arg_list.set(2, into<dim_t>(nelems));
+    repack_arg_list.set(2, dst_span);
     repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((nelems * 4 + 7) / 8);
+    compute::range_t repack_gws((dst_span * 4 + 7) / 8);
     compute::nd_range_t repack_nd_range(repack_gws);
     return large_parallel_for(
             ctx, repack_nd_range, kernels_[1], repack_arg_list, 4);

--- a/src/gpu/intel/conv/ref.hpp
+++ b/src/gpu/intel/conv/ref.hpp
@@ -22,6 +22,7 @@
 #include "common/primitive.hpp"
 #include "gpu/intel/conv/config.hpp"
 #include "gpu/intel/primitive.hpp"
+#include "gpu/intel/subbyte_pack.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -102,12 +103,11 @@ struct ref_fwd_t : public primitive_t {
             CHECK(attr_zero_points_ok({{DNNL_ARG_SRC, {0, 2}},
                     {DNNL_ARG_WEIGHTS, {0}}, {DNNL_ARG_DST, {0, 2}}}));
 
-            subbyte_pack_ = utils::one_of(
-                    dst_md_.data_type, data_type::f4_e2m1, data_type::f4_e3m0);
-            if (subbyte_pack_) {
+            CHECK(pack_desc_.init(*dst_md(0)));
+            if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
-                        memory_desc_wrapper(dst_md(0)).span(), sizeof(char),
+                        pack_desc_.span(), sizeof(char),
                         OCL_BUFFER_ALIGNMENT);
             }
 
@@ -116,7 +116,7 @@ struct ref_fwd_t : public primitive_t {
 
         status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
-        bool subbyte_pack_ = false;
+        subbyte_pack_desc_t pack_desc_;
 
         conf_t conf;
 
@@ -136,15 +136,12 @@ struct ref_fwd_t : public primitive_t {
 
         auto status = pd()->init_kernel_ctx(kernel_ctx);
         if (status != status::success) return status;
-        kernels_.resize(2);
 
         CHECK(create_kernel(
-                engine, &kernels_[0], "ref_convolution_fwd", kernel_ctx));
-        if (pd()->subbyte_pack_)
-            CHECK(create_kernel(
-                    engine, &kernels_[1], "subbyte_pack", kernel_ctx));
-        if (!kernels_[0]) return status::runtime_error;
-        if (pd()->subbyte_pack_ && !kernels_[1]) return status::runtime_error;
+                engine, &kernel_, "ref_convolution_fwd", kernel_ctx));
+        if (pd()->pack_desc_)
+            CHECK(pack_.create(pd()->pack_desc_, *this, engine));
+        if (!kernel_) return status::runtime_error;
 
         return status::success;
     }
@@ -156,7 +153,8 @@ struct ref_fwd_t : public primitive_t {
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::vector<compute::kernel_t> kernels_;
+    compute::kernel_t kernel_;
+    subbyte_pack_t pack_;
 };
 
 struct ref_bwd_data_t : public primitive_t {
@@ -212,17 +210,12 @@ struct ref_bwd_data_t : public primitive_t {
             VDISPATCH_CONV_SC(attr_.set_default_formats(diff_src_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
-            subbyte_pack_
-                    = utils::one_of(dst_md()->data_type, f4_e2m1, f4_e3m0);
-            if (subbyte_pack_) {
-                using namespace dnnl::impl::memory_tracking::names;
-                const memory_desc_wrapper dst_mdw(dst_md(0));
-                const auto &padded_dims = dst_mdw.padded_dims();
-                const dim_t ndims = dst_mdw.ndims();
-                const dim_t nelems = utils::array_product(padded_dims, ndims);
+            CHECK(pack_desc_.init(*diff_src_md(0)));
+            if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
-                        nelems, sizeof(char), OCL_BUFFER_ALIGNMENT);
+                        pack_desc_.span(), sizeof(char),
+                        OCL_BUFFER_ALIGNMENT);
             }
 
             return init_conf(engine);
@@ -230,7 +223,7 @@ struct ref_bwd_data_t : public primitive_t {
 
         status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
-        bool subbyte_pack_ = false;
+        subbyte_pack_desc_t pack_desc_;
 
         conf_t conf;
 
@@ -251,14 +244,11 @@ struct ref_bwd_data_t : public primitive_t {
         auto status = pd()->init_kernel_ctx(kernel_ctx);
         if (status != status::success) return status;
 
-        kernels_.resize(2);
         CHECK(create_kernel(
-                engine, &kernels_[0], "ref_convolution_bwd_data", kernel_ctx));
-        if (pd()->subbyte_pack_)
-            CHECK(create_kernel(
-                    engine, &kernels_[1], "subbyte_pack", kernel_ctx));
-        if (!kernels_[0]) return status::runtime_error;
-        if (pd()->subbyte_pack_ && !kernels_[1]) return status::runtime_error;
+                engine, &kernel_, "ref_convolution_bwd_data", kernel_ctx));
+        if (pd()->pack_desc_)
+            CHECK(pack_.create(pd()->pack_desc_, *this, engine));
+        if (!kernel_) return status::runtime_error;
 
         return status::success;
     }
@@ -270,7 +260,8 @@ struct ref_bwd_data_t : public primitive_t {
 private:
     status_t execute_backward_data(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::vector<compute::kernel_t> kernels_;
+    compute::kernel_t kernel_;
+    subbyte_pack_t pack_;
 };
 
 struct ref_bwd_weights_t : public primitive_t {
@@ -328,17 +319,12 @@ struct ref_bwd_weights_t : public primitive_t {
             VDISPATCH_CONV(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
 
-            subbyte_pack_ = utils::one_of(dst_md()->data_type,
-                    data_type::f4_e2m1, data_type::f4_e3m0);
-            if (subbyte_pack_) {
-                using namespace dnnl::impl::memory_tracking::names;
-                const memory_desc_wrapper dst_mdw(dst_md(0));
-                const auto &padded_dims = dst_mdw.padded_dims();
-                const dim_t ndims = dst_mdw.ndims();
-                const dim_t nelems = utils::array_product(padded_dims, ndims);
+            CHECK(pack_desc_.init(*diff_weights_md(0)));
+            if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
-                        nelems, sizeof(char), OCL_BUFFER_ALIGNMENT);
+                        pack_desc_.span(), sizeof(char),
+                        OCL_BUFFER_ALIGNMENT);
             }
 
             return init_conf(engine);
@@ -346,7 +332,7 @@ struct ref_bwd_weights_t : public primitive_t {
 
         status_t init_conf(const impl::engine_t *engine);
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
-        bool subbyte_pack_ = false;
+        subbyte_pack_desc_t pack_desc_;
 
         conf_t conf;
 
@@ -367,14 +353,11 @@ struct ref_bwd_weights_t : public primitive_t {
         auto status = pd()->init_kernel_ctx(kernel_ctx);
         if (status != status::success) return status;
 
-        kernels_.resize(2);
-        CHECK(create_kernel(engine, &kernels_[0], "ref_convolution_bwd_weights",
-                kernel_ctx));
-        if (pd()->subbyte_pack_)
-            CHECK(create_kernel(
-                    engine, &kernels_[1], "subbyte_pack", kernel_ctx));
-        if (!kernels_[0]) return status::runtime_error;
-        if (pd()->subbyte_pack_ && !kernels_[1]) return status::runtime_error;
+        CHECK(create_kernel(
+                engine, &kernel_, "ref_convolution_bwd_weights", kernel_ctx));
+        if (pd()->pack_desc_)
+            CHECK(pack_.create(pd()->pack_desc_, *this, engine));
+        if (!kernel_) return status::runtime_error;
 
         return status::success;
     }
@@ -386,7 +369,8 @@ struct ref_bwd_weights_t : public primitive_t {
 private:
     status_t execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::vector<compute::kernel_t> kernels_;
+    compute::kernel_t kernel_;
+    subbyte_pack_t pack_;
 };
 
 } // namespace conv

--- a/src/gpu/intel/conv/ref.hpp
+++ b/src/gpu/intel/conv/ref.hpp
@@ -105,14 +105,10 @@ struct ref_fwd_t : public primitive_t {
             subbyte_pack_ = utils::one_of(
                     dst_md_.data_type, data_type::f4_e2m1, data_type::f4_e3m0);
             if (subbyte_pack_) {
-                using namespace dnnl::impl::memory_tracking::names;
-                const memory_desc_wrapper dst_mdw(dst_md(0));
-                const auto &padded_dims = dst_mdw.padded_dims();
-                const dim_t ndims = dst_mdw.ndims();
-                const dim_t nelems = utils::array_product(padded_dims, ndims);
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
-                        nelems, sizeof(char), OCL_BUFFER_ALIGNMENT);
+                        memory_desc_wrapper(dst_md(0)).span(), sizeof(char),
+                        OCL_BUFFER_ALIGNMENT);
             }
 
             return init_conf(engine);

--- a/src/gpu/intel/conv/ref.hpp
+++ b/src/gpu/intel/conv/ref.hpp
@@ -104,6 +104,10 @@ struct ref_fwd_t : public primitive_t {
                     {DNNL_ARG_WEIGHTS, {0}}, {DNNL_ARG_DST, {0, 2}}}));
 
             CHECK(pack_desc_.init(*dst_md(0)));
+            VDISPATCH_CONV(
+                    IMPLICATION(bool(pack_desc_),
+                            attr()->post_ops_.find(primitive_kind::sum) == -1),
+                    VERBOSE_UNSUPPORTED_POSTOP);
             if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
@@ -211,6 +215,10 @@ struct ref_bwd_data_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             CHECK(pack_desc_.init(*diff_src_md(0)));
+            VDISPATCH_CONV(
+                    IMPLICATION(bool(pack_desc_),
+                            attr()->post_ops_.find(primitive_kind::sum) == -1),
+                    VERBOSE_UNSUPPORTED_POSTOP);
             if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,

--- a/src/gpu/intel/conv/ref.hpp
+++ b/src/gpu/intel/conv/ref.hpp
@@ -111,8 +111,7 @@ struct ref_fwd_t : public primitive_t {
             if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
-                        pack_desc_.span(), sizeof(char),
-                        OCL_BUFFER_ALIGNMENT);
+                        pack_desc_.span(), sizeof(char), OCL_BUFFER_ALIGNMENT);
             }
 
             return init_conf(engine);
@@ -222,8 +221,7 @@ struct ref_bwd_data_t : public primitive_t {
             if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
-                        pack_desc_.span(), sizeof(char),
-                        OCL_BUFFER_ALIGNMENT);
+                        pack_desc_.span(), sizeof(char), OCL_BUFFER_ALIGNMENT);
             }
 
             return init_conf(engine);
@@ -331,8 +329,7 @@ struct ref_bwd_weights_t : public primitive_t {
             if (pack_desc_) {
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_conv_pack_space,
-                        pack_desc_.span(), sizeof(char),
-                        OCL_BUFFER_ALIGNMENT);
+                        pack_desc_.span(), sizeof(char), OCL_BUFFER_ALIGNMENT);
             }
 
             return init_conf(engine);

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -84,28 +84,7 @@ status_t with_post_ops_t::pd_t::init(const impl::engine_t *engine) {
             "bias reduction");
 
     subbyte_pack_ = utils::one_of(d->c_type(), f4_e2m1, f4_e3m0);
-    if (subbyte_pack_) {
-        using namespace dnnl::impl::memory_tracking::names;
-        const memory_desc_wrapper dst_mdw(dst_md(0));
-        const auto &padded_dims = dst_mdw.padded_dims();
-        const dim_t ndims = dst_mdw.ndims();
-        const dim_t nelems = utils::array_product(padded_dims, ndims);
-        auto scratchpad = scratchpad_registry().registrar();
-        scratchpad.book(memory_tracking::names::key_matmul_pack_space, nelems,
-                sizeof(char), OCL_BUFFER_ALIGNMENT);
-    }
-
     dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
-    if (dynamic_scales_) {
-        using namespace dnnl::impl::memory_tracking::names;
-        const memory_desc_wrapper dst_mdw(dst_md(0));
-        const auto &padded_dims = dst_mdw.padded_dims();
-        const dim_t ndims = dst_mdw.ndims();
-        const dim_t nelems = utils::array_product(padded_dims, ndims);
-        auto scratchpad = scratchpad_registry().registrar();
-        scratchpad.book(memory_tracking::names::key_matmul_dyn_scale_space,
-                nelems, sizeof(float), OCL_BUFFER_ALIGNMENT);
-    }
 
     const auto impl_list = engine->get_implementation_list(op_desc());
     int current_impl_idx
@@ -273,10 +252,18 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
 
 void with_post_ops_t::pd_t::init_scratchpad() {
     auto scratchpad = scratchpad_registry().registrar();
+    const dim_t dst_span = memory_desc_wrapper(dst_md(0)).span();
+    if (subbyte_pack_) {
+        scratchpad.book(memory_tracking::names::key_matmul_pack_space, dst_span,
+                sizeof(char), OCL_BUFFER_ALIGNMENT);
+    }
+    if (dynamic_scales_) {
+        scratchpad.book(memory_tracking::names::key_matmul_dyn_scale_space,
+                dst_span, sizeof(float), OCL_BUFFER_ALIGNMENT);
+    }
     if (use_scratchpad_with_post_op_worker) {
-        memory_desc_wrapper dst_mdw(dst_md());
-        scratchpad.book(memory_tracking::names::key_gemm_tmp_buffer,
-                dst_mdw.size(), types::data_type_size(desc_.acc_type));
+        scratchpad.book(memory_tracking::names::key_gemm_tmp_buffer, dst_span,
+                types::data_type_size(desc_.acc_type), OCL_BUFFER_ALIGNMENT);
     }
     scratchpad.book(memory_tracking::names::key_nested_multiple,
             pd_->scratchpad_registry());
@@ -401,14 +388,16 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
         CHECK(parallel_for(ctx, nd_range, kernels_[1], arg_list));
     }
     if (!subbyte_pack) return status_t::dnnl_success;
-    memory_desc_wrapper dst_mdw(pd()->dst_md(0));
-    const dim_t nelems = dst_mdw.nelems();
+
+    // The unpacked buffer is indexed with dst_md() offsets, so packing covers
+    // its whole element span, not just its element count.
+    const dim_t dst_span = memory_desc_wrapper(pd()->dst_md(0)).span();
     compute::kernel_arg_list_t repack_arg_list;
     repack_arg_list.set(0, *tmp);
     repack_arg_list.set(1, GEMM_CTX_ARG_STORAGE(c));
-    repack_arg_list.set(2, into<dim_t>(nelems));
+    repack_arg_list.set(2, dst_span);
     repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((nelems * 4 + 7) / 8);
+    compute::range_t repack_gws((dst_span * 4 + 7) / 8);
     compute::nd_range_t repack_nd_range(repack_gws);
     return large_parallel_for(impl::exec_ctx_t(ctx.stream()), repack_nd_range,
             kernels_[2], repack_arg_list, 4);

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -143,6 +143,13 @@ status_t with_post_ops_t::pd_t::init(const impl::engine_t *engine) {
 
     CHECK(pack_desc_.init(*dst_md(0)));
     dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
+    VDISPATCH_GEMM(IMPLICATION(bool(pack_desc_) || dynamic_scales_,
+                           attr()->post_ops_.find(primitive_kind::sum) == -1),
+            VERBOSE_UNSUPPORTED_POSTOP);
+    VDISPATCH_GEMM(IMPLICATION(dynamic_scales_,
+                           !memory_desc_wrapper(dst_md(0))
+                                    .has_runtime_dims_or_strides()),
+            VERBOSE_RUNTIMEDIM_UNSUPPORTED);
 
     use_scratchpad_with_post_op_worker = use_reorder
             || attributes_with_po->post_ops_.find(primitive_kind_t::dnnl_sum)

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -83,9 +83,6 @@ status_t with_post_ops_t::pd_t::init(const impl::engine_t *engine) {
     VDISPATCH_GEMM(d->sum_ab == sum_ab::sum_none, VERBOSE_UNSUPPORTED_FEATURE,
             "bias reduction");
 
-    subbyte_pack_ = utils::one_of(d->c_type(), f4_e2m1, f4_e3m0);
-    dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
-
     const auto impl_list = engine->get_implementation_list(op_desc());
     int current_impl_idx
             = impl_list_item_t::find<with_post_ops_t::pd_t>(impl_list);
@@ -143,6 +140,9 @@ status_t with_post_ops_t::pd_t::init(const impl::engine_t *engine) {
     desc_.acc_type = desc.c_desc.data_type;
     CHECK(attr_.set_default_formats(dst_md(0)));
     VDISPATCH_GEMM(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
+
+    CHECK(pack_desc_.init(*dst_md(0)));
+    dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
 
     use_scratchpad_with_post_op_worker = use_reorder
             || attributes_with_po->post_ops_.find(primitive_kind_t::dnnl_sum)
@@ -252,10 +252,10 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
 
 void with_post_ops_t::pd_t::init_scratchpad() {
     auto scratchpad = scratchpad_registry().registrar();
-    const dim_t dst_span = memory_desc_wrapper(dst_md(0)).span();
-    if (subbyte_pack_) {
-        scratchpad.book(memory_tracking::names::key_matmul_pack_space, dst_span,
-                sizeof(char), OCL_BUFFER_ALIGNMENT);
+    const size_t dst_span = memory_desc_wrapper(dst_md(0)).span();
+    if (pack_desc_) {
+        scratchpad.book(memory_tracking::names::key_matmul_pack_space,
+                pack_desc_.span(), sizeof(char), OCL_BUFFER_ALIGNMENT);
     }
     if (dynamic_scales_) {
         scratchpad.book(memory_tracking::names::key_matmul_dyn_scale_space,
@@ -293,7 +293,6 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
 
     CHECK(gemm(prim_)->execute(nested_ctx));
 
-    const bool subbyte_pack = pd()->subbyte_pack_;
     const bool dyn_scales = pd()->dynamic_scales_;
 
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
@@ -308,9 +307,9 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
                                    : GEMM_CTX_ARG_STORAGE(c));
     arg_list.set(1, GEMM_CTX_ARG_STORAGE(bias));
     arg_list.set(2,
-            dyn_scales             ? *tmp_ds
-                    : subbyte_pack ? *tmp
-                                   : GEMM_CTX_ARG_STORAGE(c));
+            dyn_scales      ? *tmp_ds
+                    : pack_ ? *tmp
+                            : GEMM_CTX_ARG_STORAGE(c));
     const auto &args = ctx.args();
     int idx = append_post_ops_to_arg_list(args.exec_args, arg_list, 3,
             pd()->attr()->post_ops_, *pd()->dst_md());
@@ -370,7 +369,7 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
         compute::kernel_arg_list_t arg_list;
         int arg_idx = 0;
         arg_list.set(arg_idx++, *tmp_ds);
-        arg_list.set(arg_idx++, subbyte_pack ? *tmp : GEMM_CTX_ARG_STORAGE(c));
+        arg_list.set(arg_idx++, pack_ ? *tmp : GEMM_CTX_ARG_STORAGE(c));
         arg_list.set(arg_idx++, GEMM_CTX_ARG_STORAGE(c_scales));
         arg_list.set(arg_idx++, group_size);
         arg_list.set(arg_idx++, D0);
@@ -387,20 +386,8 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
         compute::nd_range_t nd_range(gws);
         CHECK(parallel_for(ctx, nd_range, kernels_[1], arg_list));
     }
-    if (!subbyte_pack) return status_t::dnnl_success;
-
-    // The unpacked buffer is indexed with dst_md() offsets, so packing covers
-    // its whole element span, not just its element count.
-    const dim_t dst_span = memory_desc_wrapper(pd()->dst_md(0)).span();
-    compute::kernel_arg_list_t repack_arg_list;
-    repack_arg_list.set(0, *tmp);
-    repack_arg_list.set(1, GEMM_CTX_ARG_STORAGE(c));
-    repack_arg_list.set(2, dst_span);
-    repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((dst_span * 4 + 7) / 8);
-    compute::nd_range_t repack_nd_range(repack_gws);
-    return large_parallel_for(impl::exec_ctx_t(ctx.stream()), repack_nd_range,
-            kernels_[2], repack_arg_list, 4);
+    if (!pack_) return status::success;
+    return pack_(impl::exec_ctx_t(ctx.stream()), *tmp, GEMM_CTX_ARG_STORAGE(c));
 }
 
 } // namespace gemm

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -217,6 +217,7 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
     int ndims = src_info.ndims;
     kernel_ctx.set_data_type(dynamic_scales_ ? acc_type_ : c_type);
     kernel_ctx.require_stateless_addressing(has_large_buffers());
+    kernel_ctx.register_buffer_size(pack_desc_.span(), pack_desc_.span());
 
     const auto &attr_scales = attr()->scales_;
     const bool with_src_scales = !attr_scales.has_default_values(DNNL_ARG_SRC);

--- a/src/gpu/intel/gemm/with_post_ops.hpp
+++ b/src/gpu/intel/gemm/with_post_ops.hpp
@@ -20,6 +20,7 @@
 #include "gpu/intel/gemm/config.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
 #include "gpu/intel/primitive_conf.hpp"
+#include "gpu/intel/subbyte_pack.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -52,7 +53,7 @@ struct with_post_ops_t : public primitive_t {
         bool use_reorder = false;
         compute::dispatch_t dispatch_;
         attr_info_t attr_info_;
-        bool subbyte_pack_ = false;
+        subbyte_pack_desc_t pack_desc_;
         bool dynamic_scales_ = false;
         bool with_dropout = false;
         bool dropout_use_host_scalars = false;
@@ -100,9 +101,8 @@ struct with_post_ops_t : public primitive_t {
             CHECK(create_kernel(
                     engine, &kernels_[1], "dynamic_scale_dst", alt_ctx));
         }
-        if (pd()->subbyte_pack_)
-            CHECK(create_kernel(
-                    engine, &kernels_[2], "subbyte_pack", kernel_ctx));
+        if (pd()->pack_desc_)
+            CHECK(pack_.create(pd()->pack_desc_, *this, engine));
         return status::success;
     }
 
@@ -111,7 +111,8 @@ struct with_post_ops_t : public primitive_t {
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     std::shared_ptr<impl::primitive_t> prim_;
-    std::array<compute::kernel_t, 3> kernels_ = {};
+    std::array<compute::kernel_t, 2> kernels_ = {};
+    subbyte_pack_t pack_;
 };
 
 } // namespace gemm

--- a/src/gpu/intel/matmul/ref.cpp
+++ b/src/gpu/intel/matmul/ref.cpp
@@ -264,8 +264,6 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
             = std::max(std::max(zp_ngroups_k, scale_ngroups_k), gs_ngroups_k);
     const auto group_K = K / ngroups_k;
 
-    const bool subbyte_pack
-            = pd()->subbyte_pack_; //(c_d.data_type() == data_type::f4_e2m1);
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
             memory_tracking::names::key_matmul_pack_space);
     auto tmp_ds = ctx.get_scratchpad_grantor().get_memory_storage(
@@ -275,7 +273,7 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
     int arg_idx = 0;
     arg_list.set(arg_idx++, a);
     arg_list.set(arg_idx++, b);
-    arg_list.set(arg_idx++, dyn_scales ? *tmp_ds : (subbyte_pack ? *tmp : c));
+    arg_list.set(arg_idx++, dyn_scales ? *tmp_ds : (pack_ ? *tmp : c));
     arg_list.set(arg_idx++, bias);
     arg_list.set(arg_idx++, a0);
     arg_list.set(arg_idx++, src_zp_stride_k);
@@ -413,7 +411,7 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
         compute::kernel_arg_list_t arg_list;
         int arg_idx = 0;
         arg_list.set(arg_idx++, *tmp_ds);
-        arg_list.set(arg_idx++, subbyte_pack ? *tmp : c);
+        arg_list.set(arg_idx++, pack_ ? *tmp : c);
         arg_list.set(arg_idx++, dst_scales);
         arg_list.set(arg_idx++, group_size);
         arg_list.set(arg_idx++, D0);
@@ -430,21 +428,8 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
         compute::nd_range_t nd_range(gws);
         CHECK(parallel_for(ctx, nd_range, kernels_[1], arg_list));
     }
-
-    if (!subbyte_pack) return status_t::dnnl_success;
-
-    // The unpacked buffer is indexed with dst_md() offsets, so packing covers
-    // its whole element span, not just its element count.
-    const dim_t c_span = c_d.span();
-    compute::kernel_arg_list_t repack_arg_list;
-    repack_arg_list.set(0, *tmp);
-    repack_arg_list.set(1, c);
-    repack_arg_list.set(2, c_span);
-    repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((c_span * 4 + 7) / 8);
-    compute::nd_range_t repack_nd_range(repack_gws);
-    return large_parallel_for(
-            ctx, repack_nd_range, kernels_[2], repack_arg_list, 4);
+    if (!pack_) return status::success;
+    return pack_(ctx, *tmp, c);
 }
 
 } // namespace matmul

--- a/src/gpu/intel/matmul/ref.cpp
+++ b/src/gpu/intel/matmul/ref.cpp
@@ -266,7 +266,6 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
 
     const bool subbyte_pack
             = pd()->subbyte_pack_; //(c_d.data_type() == data_type::f4_e2m1);
-    const dim_t nelems = c_d.nelems();
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
             memory_tracking::names::key_matmul_pack_space);
     auto tmp_ds = ctx.get_scratchpad_grantor().get_memory_storage(
@@ -433,12 +432,16 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
     }
 
     if (!subbyte_pack) return status_t::dnnl_success;
+
+    // The unpacked buffer is indexed with dst_md() offsets, so packing covers
+    // its whole element span, not just its element count.
+    const dim_t c_span = c_d.span();
     compute::kernel_arg_list_t repack_arg_list;
     repack_arg_list.set(0, *tmp);
     repack_arg_list.set(1, c);
-    repack_arg_list.set(2, into<dim_t>(nelems));
+    repack_arg_list.set(2, c_span);
     repack_arg_list.set(3, 4);
-    compute::range_t repack_gws((nelems * 4 + 7) / 8);
+    compute::range_t repack_gws((c_span * 4 + 7) / 8);
     compute::nd_range_t repack_nd_range(repack_gws);
     return large_parallel_for(
             ctx, repack_nd_range, kernels_[2], repack_arg_list, 4);

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -28,6 +28,7 @@
 #include "gpu/intel/matmul/config.hpp"
 #include "gpu/intel/primitive.hpp"
 #include "gpu/intel/primitive_conf.hpp"
+#include "gpu/intel/subbyte_pack.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -121,8 +122,7 @@ struct ref_t : public primitive_t {
                             dev_info_->has_native(f64)),
                     VERBOSE_UNSUPPORTED_DT);
             CHECK(dropout_ok());
-            subbyte_pack_ = utils::one_of(
-                    dst_dt_, data_type::f4_e2m1, data_type::f4_e3m0);
+            CHECK(pack_desc_.init(*dst_md(0)));
             dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
             const dim_t dst_span = memory_desc_wrapper(dst_md(0)).span();
             auto scratchpad = scratchpad_registry().registrar();
@@ -131,9 +131,10 @@ struct ref_t : public primitive_t {
                         memory_tracking::names::key_matmul_dyn_scale_space,
                         dst_span, sizeof(float), OCL_BUFFER_ALIGNMENT);
             }
-            if (subbyte_pack_) {
+            if (pack_desc_) {
                 scratchpad.book(memory_tracking::names::key_matmul_pack_space,
-                        dst_span, sizeof(char), OCL_BUFFER_ALIGNMENT);
+                        pack_desc_.span(), sizeof(char),
+                        OCL_BUFFER_ALIGNMENT);
             }
 
             non_default_attrs_ = !attr()->has_default_values();
@@ -143,7 +144,7 @@ struct ref_t : public primitive_t {
         }
 
         bool non_default_attrs_ = false;
-        bool subbyte_pack_ = false;
+        subbyte_pack_desc_t pack_desc_;
         bool dynamic_scales_ = false;
         data_type_t bia_dt_ = data_type::undef;
         data_type_t src_dt_ = data_type::undef;
@@ -296,12 +297,10 @@ struct ref_t : public primitive_t {
         if (pd()->dynamic_scales_)
             CHECK(create_kernel(
                     engine, &kernels_[1], "dynamic_scale_dst", kernel_ctx));
-        if (pd()->subbyte_pack_)
-            CHECK(create_kernel(
-                    engine, &kernels_[2], "subbyte_pack", kernel_ctx));
+        if (pd()->pack_desc_)
+            CHECK(pack_.create(pd()->pack_desc_, *this, engine));
         if (!kernels_[0]) return status::runtime_error;
         if (pd()->dynamic_scales_ && !kernels_[1]) return status::runtime_error;
-        if (pd()->subbyte_pack_ && !kernels_[2]) return status::runtime_error;
         return status::success;
     }
 
@@ -312,7 +311,8 @@ struct ref_t : public primitive_t {
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     status_t execute_ref(const exec_ctx_t &ctx) const;
-    std::array<compute::kernel_t, 3> kernels_ = {};
+    std::array<compute::kernel_t, 2> kernels_ = {};
+    subbyte_pack_t pack_;
 };
 
 } // namespace matmul

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -124,7 +124,15 @@ struct ref_t : public primitive_t {
             CHECK(dropout_ok());
             CHECK(pack_desc_.init(*dst_md(0)));
             dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
-            const dim_t dst_span = memory_desc_wrapper(dst_md(0)).span();
+            VDISPATCH_MATMUL(
+                    IMPLICATION(bool(pack_desc_) || dynamic_scales_,
+                            attr()->post_ops_.find(primitive_kind::sum) == -1),
+                    VERBOSE_UNSUPPORTED_POSTOP);
+            VDISPATCH_MATMUL(IMPLICATION(dynamic_scales_,
+                                     !memory_desc_wrapper(dst_md(0))
+                                              .has_runtime_dims_or_strides()),
+                    VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+            const size_t dst_span = memory_desc_wrapper(dst_md(0)).span();
             auto scratchpad = scratchpad_registry().registrar();
             if (dynamic_scales_) {
                 scratchpad.book(

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -124,26 +124,16 @@ struct ref_t : public primitive_t {
             subbyte_pack_ = utils::one_of(
                     dst_dt_, data_type::f4_e2m1, data_type::f4_e3m0);
             dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
+            const dim_t dst_span = memory_desc_wrapper(dst_md(0)).span();
+            auto scratchpad = scratchpad_registry().registrar();
             if (dynamic_scales_) {
-                using namespace dnnl::impl::memory_tracking::names;
-                const memory_desc_wrapper dst_mdw(dst_md(0));
-                const auto &padded_dims = dst_mdw.padded_dims();
-                const dim_t ndims = dst_mdw.ndims();
-                const dim_t nelems = utils::array_product(padded_dims, ndims);
-                auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(
                         memory_tracking::names::key_matmul_dyn_scale_space,
-                        nelems, sizeof(float), OCL_BUFFER_ALIGNMENT);
+                        dst_span, sizeof(float), OCL_BUFFER_ALIGNMENT);
             }
             if (subbyte_pack_) {
-                using namespace dnnl::impl::memory_tracking::names;
-                const memory_desc_wrapper dst_mdw(dst_md(0));
-                const auto &padded_dims = dst_mdw.padded_dims();
-                const dim_t ndims = dst_mdw.ndims();
-                const dim_t nelems = utils::array_product(padded_dims, ndims);
-                auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(memory_tracking::names::key_matmul_pack_space,
-                        nelems, sizeof(char), OCL_BUFFER_ALIGNMENT);
+                        dst_span, sizeof(char), OCL_BUFFER_ALIGNMENT);
             }
 
             non_default_attrs_ = !attr()->has_default_values();

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -141,8 +141,7 @@ struct ref_t : public primitive_t {
             }
             if (pack_desc_) {
                 scratchpad.book(memory_tracking::names::key_matmul_pack_space,
-                        pack_desc_.span(), sizeof(char),
-                        OCL_BUFFER_ALIGNMENT);
+                        pack_desc_.span(), sizeof(char), OCL_BUFFER_ALIGNMENT);
             }
 
             non_default_attrs_ = !attr()->has_default_values();
@@ -231,6 +230,8 @@ struct ref_t : public primitive_t {
         CHECK(def_attr_info(kernel_ctx, pd()->attr_info_,
                 pd()->attr()->post_ops_, *pd()->dst_md()));
         kernel_ctx.require_stateless_addressing(pd()->has_large_buffers());
+        kernel_ctx.register_buffer_size(
+                pd()->pack_desc_.span(), pd()->pack_desc_.span());
 
         if (!pd()->attr()->precomputed_reductions_.has_default_values(
                     DNNL_ARG_SRC))

--- a/src/gpu/intel/reorder/config.hpp
+++ b/src/gpu/intel/reorder/config.hpp
@@ -16,6 +16,7 @@
 
 #include "gpu/gpu_reorder_pd.hpp"
 #include "gpu/intel/primitive_conf.hpp"
+#include "gpu/intel/subbyte_pack.hpp"
 #include "gpu/intel/utils.hpp"
 
 #ifndef GPU_INTEL_REORDER_CONFIG_HPP
@@ -104,7 +105,7 @@ struct conf_t {
     custom_kernel_t implementation;
     int ndims;
     size_t nelems;
-    bool subbyte_pack = false;
+    subbyte_pack_desc_t pack_desc;
     bool require_stateless_addressing;
 
     compute::dispatch_t dispatch;

--- a/src/gpu/intel/reorder/ref.cpp
+++ b/src/gpu/intel/reorder/ref.cpp
@@ -56,8 +56,7 @@ status_t ref_t::pd_t::init_conf(const impl::engine_t *engine) {
     if (conf.nelems == 0) return status::success;
 
     conf.dispatch = intel_engine->create_dispatch(dst_mdw.md_);
-    conf.subbyte_pack
-            = utils::one_of(dst_mdw.data_type(), u4, s4, f4_e2m1, f4_e3m0);
+    CHECK(conf.pack_desc.init(*dst_md()));
 
     dim_t blocks[MAX_NDIMS] = {1, 1, 0, 0, 0, 0};
     for (int i = 0; i < MAX_NDIMS; ++i) {
@@ -112,9 +111,9 @@ status_t ref_t::pd_t::init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const {
 
 void ref_t::pd_t::init_scratchpad() {
     auto scratchpad = scratchpad_registry().registrar();
-    if (conf.subbyte_pack) {
+    if (conf.pack_desc) {
         scratchpad.book(memory_tracking::names::key_reorder_space,
-                memory_desc_wrapper(dst_md(0)).span(), sizeof(char),
+                conf.pack_desc.span(), sizeof(char),
                 OCL_BUFFER_ALIGNMENT);
     }
     if (conf.src_quant.with_scale()) {
@@ -137,14 +136,14 @@ status_t ref_t::execute(const exec_ctx_t &ctx) const {
     if (conf.nelems == 0) return status::success;
 
     std::unique_ptr<memory_storage_t> tmp;
-    if (conf.subbyte_pack) {
+    if (pack_) {
         tmp = ctx.get_scratchpad_grantor().get_memory_storage(
                 memory_tracking::names::key_reorder_space);
     }
 
     compute::kernel_arg_list_t arg_list;
     arg_list.append(src);
-    arg_list.append(conf.subbyte_pack ? *tmp : dst);
+    arg_list.append(pack_ ? *tmp : dst);
 
     arg_list.append(conf.src_quant.scales(ctx));
     arg_list.append(conf.src_quant.zero_points(ctx));
@@ -159,22 +158,8 @@ status_t ref_t::execute(const exec_ctx_t &ctx) const {
 
     auto nd_range = conf.dispatch.nd_range();
     CHECK(large_parallel_for(
-            ctx, nd_range, kernels_[0], arg_list, arg_list.nargs()));
-
-    if (conf.subbyte_pack) {
-        // The unpacked buffer is indexed with dst_md() offsets, so packing
-        // covers its whole element span, not just its element count.
-        const dim_t dst_span = memory_desc_wrapper(pd()->dst_md(0)).span();
-        compute::kernel_arg_list_t repack_arg_list;
-        repack_arg_list.set(0, *tmp);
-        repack_arg_list.set(1, dst);
-        repack_arg_list.set(2, dst_span);
-        repack_arg_list.set(3, 4);
-        compute::range_t repack_gws((dst_span * 4 + 7) / 8);
-        compute::nd_range_t repack_nd_range(repack_gws);
-        CHECK(large_parallel_for(
-                ctx, repack_nd_range, kernels_[1], repack_arg_list, 4));
-    }
+            ctx, nd_range, kernel_, arg_list, arg_list.nargs()));
+    if (pack_) CHECK(pack_(ctx, *tmp, dst));
     CHECK(pd()->maybe_exec_zp_precompute_conv(ctx, zp_precomp_conv_));
     return status::success;
 }

--- a/src/gpu/intel/reorder/ref.cpp
+++ b/src/gpu/intel/reorder/ref.cpp
@@ -113,8 +113,9 @@ status_t ref_t::pd_t::init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const {
 void ref_t::pd_t::init_scratchpad() {
     auto scratchpad = scratchpad_registry().registrar();
     if (conf.subbyte_pack) {
-        scratchpad.book(memory_tracking::names::key_reorder_space, conf.nelems,
-                sizeof(char), OCL_BUFFER_ALIGNMENT);
+        scratchpad.book(memory_tracking::names::key_reorder_space,
+                memory_desc_wrapper(dst_md(0)).span(), sizeof(char),
+                OCL_BUFFER_ALIGNMENT);
     }
     if (conf.src_quant.with_scale()) {
         scratchpad.book(memory_tracking::names::key_reorder_src_scales,
@@ -161,12 +162,15 @@ status_t ref_t::execute(const exec_ctx_t &ctx) const {
             ctx, nd_range, kernels_[0], arg_list, arg_list.nargs()));
 
     if (conf.subbyte_pack) {
+        // The unpacked buffer is indexed with dst_md() offsets, so packing
+        // covers its whole element span, not just its element count.
+        const dim_t dst_span = memory_desc_wrapper(pd()->dst_md(0)).span();
         compute::kernel_arg_list_t repack_arg_list;
         repack_arg_list.set(0, *tmp);
         repack_arg_list.set(1, dst);
-        repack_arg_list.set(2, into<dim_t>(conf.nelems));
+        repack_arg_list.set(2, dst_span);
         repack_arg_list.set(3, 4);
-        compute::range_t repack_gws((conf.nelems * 4 + 7) / 8);
+        compute::range_t repack_gws((dst_span * 4 + 7) / 8);
         compute::nd_range_t repack_nd_range(repack_gws);
         CHECK(large_parallel_for(
                 ctx, repack_nd_range, kernels_[1], repack_arg_list, 4));

--- a/src/gpu/intel/reorder/ref.cpp
+++ b/src/gpu/intel/reorder/ref.cpp
@@ -57,6 +57,8 @@ status_t ref_t::pd_t::init_conf(const impl::engine_t *engine) {
 
     conf.dispatch = intel_engine->create_dispatch(dst_mdw.md_);
     CHECK(conf.pack_desc.init(*dst_md()));
+    if (conf.pack_desc && attr()->post_ops_.find(primitive_kind::sum) != -1)
+        return status::unimplemented;
 
     dim_t blocks[MAX_NDIMS] = {1, 1, 0, 0, 0, 0};
     for (int i = 0; i < MAX_NDIMS; ++i) {

--- a/src/gpu/intel/reorder/ref.cpp
+++ b/src/gpu/intel/reorder/ref.cpp
@@ -107,6 +107,8 @@ status_t ref_t::pd_t::init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const {
 
     def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC");
     def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");
+    kernel_ctx.register_buffer_size(
+            conf.pack_desc.span(), conf.pack_desc.span());
 
     return status::success;
 }
@@ -115,8 +117,7 @@ void ref_t::pd_t::init_scratchpad() {
     auto scratchpad = scratchpad_registry().registrar();
     if (conf.pack_desc) {
         scratchpad.book(memory_tracking::names::key_reorder_space,
-                conf.pack_desc.span(), sizeof(char),
-                OCL_BUFFER_ALIGNMENT);
+                conf.pack_desc.span(), sizeof(char), OCL_BUFFER_ALIGNMENT);
     }
     if (conf.src_quant.with_scale()) {
         scratchpad.book(memory_tracking::names::key_reorder_src_scales,

--- a/src/gpu/intel/reorder/ref.hpp
+++ b/src/gpu/intel/reorder/ref.hpp
@@ -136,15 +136,11 @@ struct ref_t : public primitive_t {
 
         const auto &conf = pd()->conf;
         if (conf.nelems == 0) return status::success;
-        kernels_.resize(2);
 
-        CHECK(create_kernel(engine, &kernels_[0], "ref_reorder", kernel_ctx));
-        if (conf.subbyte_pack)
-            CHECK(create_kernel(
-                    engine, &kernels_[1], "subbyte_pack", kernel_ctx));
+        CHECK(create_kernel(engine, &kernel_, "ref_reorder", kernel_ctx));
+        if (conf.pack_desc) CHECK(pack_.create(conf.pack_desc, *this, engine));
 
-        if (!kernels_[0]) return status::runtime_error;
-        if (conf.subbyte_pack && !kernels_[1]) return status::runtime_error;
+        if (!kernel_) return status::runtime_error;
         return status::success;
     }
 
@@ -152,7 +148,8 @@ struct ref_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::vector<compute::kernel_t> kernels_;
+    compute::kernel_t kernel_;
+    subbyte_pack_t pack_;
     std::shared_ptr<impl::primitive_t> zp_precomp_conv_;
 };
 

--- a/src/gpu/intel/subbyte_pack.cl
+++ b/src/gpu/intel/subbyte_pack.cl
@@ -19,16 +19,26 @@
 #include "gpu/intel/include/types_interop.h"
 
 __kernel void subbyte_pack(__global uchar *restrict src,
-        __global uchar *restrict dst, off_t n, int bits, int64x3_t offset) {
-    const uchar mask = (1 << bits) - 1;
+        __global uchar *restrict dst, int64x6_t dims, int64x6_t strides,
+        int64x3_t offset) {
+    const int elems_per_byte = 8 / SUBBYTE_PACK_BITS;
 
-    const off_t dst_off = get_global_id(0) + offset.array[0];
-    const off_t src_off = (8 / bits) * dst_off;
+    const off_t i0 = (get_global_id(0) + offset.array[0]) * elems_per_byte;
+    off_t off = i0;
+    if (SUBBYTE_PACK_NDIMS > 1)
+        off += (get_global_id(1) + offset.array[1]) * strides.array[1];
+
+    if (SUBBYTE_PACK_NDIMS > 2) {
+        off_t rem = get_global_id(2) + offset.array[2];
+        for (int d = 2; d < SUBBYTE_PACK_NDIMS; ++d) {
+            off += (rem % dims.array[d]) * strides.array[d];
+            rem /= dims.array[d];
+        }
+    }
 
     uchar packed = 0;
-    for (int i = 0, j = 0; i < 8; i += bits, ++j) {
-        uchar byte = src_off + j < n ? src[src_off + j] : 0;
-        packed |= (byte & mask) << i;
-    }
-    dst[dst_off] = packed;
+    for (int k = 0; k < elems_per_byte; ++k)
+        if (i0 + k < dims.array[0])
+            packed |= (uchar)(src[off + k] << (k * SUBBYTE_PACK_BITS));
+    dst[off / elems_per_byte] = packed;
 }

--- a/src/gpu/intel/subbyte_pack.cpp
+++ b/src/gpu/intel/subbyte_pack.cpp
@@ -1,0 +1,110 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/subbyte_pack.hpp"
+
+#include "common/memory_desc_wrapper.hpp"
+#include "gpu/intel/block_structure.hpp"
+#include "gpu/intel/primitive.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+
+status_t subbyte_pack_desc_t::init(const memory_desc_t &dst_md) {
+    const memory_desc_wrapper mdw(dst_md);
+    const dim_t elems_per_byte
+            = into<dim_t>(mdw.sub_byte_data_type_multiplier());
+    if (elems_per_byte == 1) return status::success;
+    if (dst_md.format_kind != format_kind::blocked || dst_md.offset0 != 0)
+        return status::unimplemented;
+    if (mdw.has_runtime_dims_or_strides()) return status::unimplemented;
+
+    auto layout = block_layout_t(mdw);
+    for (auto &block : layout)
+        block.dim_idx = 0;
+    layout = layout.normalized();
+
+    if (layout.empty()) return status::success;
+
+    conf_.bits = into<int>(8 / elems_per_byte);
+    span_ = mdw.span();
+    conf_.use_int32_offset = span_ <= INT32_MAX;
+    conf_.require_stateless_addressing = span_ > UINT32_MAX;
+
+    if (layout.size() > max_ndims) return status::unimplemented;
+    for (const auto &block : layout) {
+        dims_.array[conf_.ndims] = block.block;
+        strides_.array[conf_.ndims] = static_cast<dim_t>(block.stride);
+        conf_.ndims++;
+    }
+
+    if (strides_.array[0] != 1) return status::unimplemented;
+    for (int d = 1; d < conf_.ndims; d++)
+        if (strides_.array[d] % elems_per_byte) return status::unimplemented;
+
+    gws_[0] = utils::div_up(dims_.array[0], elems_per_byte);
+    for (int d = 1; d < conf_.ndims; d++)
+        gws_[d == 1 ? 1 : 2] *= dims_.array[d];
+
+    return status::success;
+}
+
+const std::vector<const char *> &
+subbyte_pack_desc_t::conf_t::get_kernel_names() const {
+    static const std::vector<const char *> names {"subbyte_pack"};
+    return names;
+}
+
+status_t subbyte_pack_desc_t::conf_t::create_generator(
+        const engine_t &engine, compute::kernel_bundle_t &bundle) const {
+    compute::kernel_ctx_t kernel_ctx;
+    kernel_ctx.define_int("SUBBYTE_PACK_BITS", bits);
+    kernel_ctx.define_int("SUBBYTE_PACK_NDIMS", ndims);
+    kernel_ctx.use_int32_offset(use_int32_offset);
+    kernel_ctx.require_stateless_addressing(require_stateless_addressing);
+    return engine.create_kernel_bundle(bundle, get_kernel_names(), kernel_ctx);
+}
+
+status_t subbyte_pack_t::create(const subbyte_pack_desc_t &desc,
+        primitive_t &primitive, impl::engine_t *engine) {
+    CHECK(primitive.create_kernel(
+            engine, kernel_, "subbyte_pack", desc.conf()));
+    if (!kernel_) return status::runtime_error;
+
+    nd_range_ = desc.nd_range();
+    dims_ = desc.dims();
+    strides_ = desc.strides();
+    return status::success;
+}
+
+status_t subbyte_pack_t::operator()(const exec_ctx_t &ctx,
+        const memory_storage_t &src, const memory_storage_t &dst) const {
+    compute::kernel_arg_list_t arg_list;
+    arg_list.set(0, src);
+    arg_list.set(1, dst);
+    arg_list.set(2, dims_);
+    arg_list.set(3, strides_);
+
+    return primitive_t::large_parallel_for(
+            ctx, nd_range_, kernel_, arg_list, 4);
+}
+
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/subbyte_pack.hpp
+++ b/src/gpu/intel/subbyte_pack.hpp
@@ -1,0 +1,95 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_SUBBYTE_PACK_HPP
+#define GPU_INTEL_SUBBYTE_PACK_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/primitive_exec_types.hpp"
+#include "common/serialization.hpp"
+#include "gpu/intel/compute/kernel.hpp"
+#include "gpu/intel/compute/kernel_ctx.hpp"
+#include "gpu/intel/compute/types_interop.hpp"
+#include "gpu/intel/compute/utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+
+struct primitive_t;
+class engine_t;
+
+// The subbyte_pack kernel takes a temporary buffer holding one sub-byte element
+// per byte and packs into the destination.
+struct subbyte_pack_desc_t {
+    status_t init(const memory_desc_t &dst_md);
+    explicit operator bool() const { return bool(conf_); }
+    size_t span() const { return span_; }
+
+    struct conf_t : public trivially_serializable_t<conf_t> {
+        status_t create_generator(
+                const engine_t &engine, compute::kernel_bundle_t &bundle) const;
+        const std::vector<const char *> &get_kernel_names() const;
+        explicit operator bool() const { return bits != 0; }
+
+        int bits = 0;
+        int ndims = 0;
+        bool use_int32_offset = false;
+        bool require_stateless_addressing = false;
+        uint8_t pad[2] = {};
+    };
+    const conf_t &conf() const { return conf_; }
+
+    compute::int64x6_t dims() const { return dims_; }
+    compute::int64x6_t strides() const { return strides_; }
+    compute::nd_range_t nd_range() const {
+        return compute::nd_range_t(compute::range_t(into<size_t>(gws_[0]),
+                into<size_t>(gws_[1]), into<size_t>(gws_[2])));
+    }
+
+private:
+    static constexpr int max_ndims = 6;
+
+    conf_t conf_;
+
+    // Destination layout, ordered from inner-most to outer-most axis.
+    compute::int64x6_t dims_ = {};
+    compute::int64x6_t strides_ = {};
+    size_t span_ = 0;
+    dim_t gws_[3] = {1, 1, 1};
+};
+
+struct subbyte_pack_t {
+    status_t create(const subbyte_pack_desc_t &desc, primitive_t &primitive,
+            impl::engine_t *engine);
+    status_t operator()(const exec_ctx_t &ctx, const memory_storage_t &src,
+            const memory_storage_t &dst) const;
+    explicit operator bool() const { return bool(kernel_); }
+
+private:
+    compute::kernel_t kernel_;
+    compute::nd_range_t nd_range_;
+    compute::int64x6_t dims_ = {};
+    compute::int64x6_t strides_ = {};
+};
+
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
Fixes [MFDNN-15352](https://jira.devtools.intel.com/browse/MFDNN-15352).

Several GPU implementations operate on temporary buffers with the same layout as
the destination. These implementations relied on destination element count for
memory size calculations resulting in a GPU segfaults for strided destinations.

For testing, the matmul implementation will be covered by the upcoming generated
suite. This patch does not add any regression tests for the reference version as
the optimized implementations already pass.