### PR TITLE
[GPU] Fix various Xe3p/CRI performance edge cases

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
@@ -37,9 +37,9 @@ Package::Status Package::finalize(const ClobberSet &knownClobbers) {
     }
 
     Decoder decoder(hw, binary);
-    DependencyRegion dstRegion;
 
     auto clobbered = knownClobbers;
+    int maxAccIdx = -1;
 
     for (; !decoder.done(); decoder.advance()) {
         // Check for systolic usage.
@@ -49,13 +49,35 @@ Package::Status Package::finalize(const ClobberSet &knownClobbers) {
         // Get destination region and add to clobbers. This indeterminate for
         // indirect or variable sized destinations. In this case, rely on
         // knownClobbers.
-        if (decoder.getOperandRegion(dstRegion, -1)) {
+        DependencyRegion dstRegion;
+        if (!decoder.getOperandRegion(dstRegion, -1)) continue;
+
+        if (dstRegion.rf == RegFileGRF) {
             if (dstRegion.unspecified
                 && !(dstRegion.isValid() && knownClobbers[dstRegion.base])) {
                     status = Status::UncertainClobbers;
             } else
                 for (int j = 0; j < dstRegion.size; j++)
                     clobbered[dstRegion.base + j] = true;
+        }
+
+        // There is no vISA-supported mechanism for passing clobber data for ARF registers.
+        // We can either disallow overwriting ARF, or blindly expect the kernel to save/restore them.
+        // Allow the use of acc/flag registers only, for now.
+        if (dstRegion.rf == RegFileARF) {
+            ARFType dstType = static_cast<ARFType>(dstRegion.base >> 4);
+            if (dstType == ARFType::acc) {
+                // Expectation: kernel saves/restores accumulator registers if needed.
+                // Track the higest acc index, to use a GRF mode that supports the number of accumulators used
+                int accBase = dstRegion.base & 0xF;
+                int accLast = accBase + std::max(int(dstRegion.size), 1) - 1;
+                maxAccIdx = std::max(maxAccIdx, accLast);
+            } else if (dstType == ARFType::f) {
+                // Expectation: kernel saves/restores flag registers if needed.
+            } else {
+                // Other ARF registers are not expected to be overwritten
+                status = Status::UncertainClobbers;
+            }
         }
     }
 
@@ -90,6 +112,12 @@ Package::Status Package::finalize(const ClobberSet &knownClobbers) {
             last = std::max(last, range.boffset + range.blen);
 
     grfMin = (last + regBytes - 1) / regBytes;
+
+    int nacc = AccumulatorRegister::count(hw, grfMin);
+    if (nacc <= maxAccIdx) {
+        // Upgrade to 8 accumulators
+        grfMin = 256;
+    }
 
     // Generate LUID from hash of kernel. Later, the cataloguer can update it in case of collisions.
     uint32_t luid = 0;

--- a/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/package.cpp
@@ -61,23 +61,24 @@ Package::Status Package::finalize(const ClobberSet &knownClobbers) {
                     clobbered[dstRegion.base + j] = true;
         }
 
-        // There is no vISA-supported mechanism for passing clobber data for ARF registers.
-        // We can either disallow overwriting ARF, or blindly expect the kernel to save/restore them.
-        // Allow the use of acc/flag registers only, for now.
+        // Allow acc/flag ARF destinations only if declared in knownClobbers.
         if (dstRegion.rf == RegFileARF) {
             ARFType dstType = static_cast<ARFType>(dstRegion.base >> 4);
+            int arfIdx = dstRegion.base & 0xF;
+            int arfLen = dstRegion.size;
+            bool known = false;
             if (dstType == ARFType::acc) {
-                // Expectation: kernel saves/restores accumulator registers if needed.
-                // Track the higest acc index, to use a GRF mode that supports the number of accumulators used
-                int accBase = dstRegion.base & 0xF;
-                int accLast = accBase + std::max(int(dstRegion.size), 1) - 1;
-                maxAccIdx = std::max(maxAccIdx, accLast);
+                known = true;
+                for (int j = arfIdx; j < arfIdx + arfLen; j++)
+                    known &= knownClobbers.acc(j);
+                maxAccIdx = std::max(maxAccIdx, arfIdx + arfLen - 1);
             } else if (dstType == ARFType::f) {
-                // Expectation: kernel saves/restores flag registers if needed.
-            } else {
-                // Other ARF registers are not expected to be overwritten
-                status = Status::UncertainClobbers;
+                known = true;
+                for (int j = arfIdx; j < arfIdx + arfLen; j++)
+                    known &= knownClobbers.flag(j);
             }
+            if (!known)
+                status = Status::UncertainClobbers;
         }
     }
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -109,6 +109,9 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
     for (int i = 0; i < accSave.getLen(); i++)
         mov<uint32_t>(accElts, accSave[i], AccumulatorRegister(i));
 
+    knownClobbers.addFlag(0, FlagRegister::count(hw));
+    knownClobbers.addAcc(0, accSaveCount);
+
     // Beginning of microkernel:
     //   - check32
     //   - fused ID calculation

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -100,6 +100,15 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
         mov(1, flagSave[i], FlagRegister(i));
     }
 
+    // Save accumulator registers used by the host kernel, if we'll use them here
+    // TODO: Only done in the case of FMA kChain currently. Generalize to other accumulator uses.
+    const int accSaveCount = (strategy.kChain > 1 && !strategy.systolic)
+        ? AccumulatorRegister::count(hw, strategy.GRFs, problem.Tc.real().ngen()) : 0;
+    const int accElts = GRF::bytes(hw) >> 2;  // dwords per accumulator register
+    GRFRange accSave = state.ra.alloc_range(accSaveCount);
+    for (int i = 0; i < accSave.getLen(); i++)
+        mov<uint32_t>(accElts, accSave[i], AccumulatorRegister(i));
+
     // Beginning of microkernel:
     //   - check32
     //   - fused ID calculation
@@ -186,6 +195,11 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
     if (strategy.prefetchB && state.effBp.isInvalid()) state.effBp = state.effB;
 
     gemmSubkernel(problem, strategy, state);
+
+    // Restore accumulator registers if saved above.
+    for (int i = 0; i < accSave.getLen(); i++)
+        mov<uint32_t>(accElts, AccumulatorRegister(i), accSave[i]);
+    state.ra.safeRelease(accSave);
 
     // Restore flag registers and dispatch mask and return to host kernel.
     for (int i = 0; i < FlagRegister::count(hw); i++)

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -101,9 +101,9 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
     }
 
     // Save accumulator registers used by the host kernel, if we'll use them here
-    // TODO: Only done in the case of FMA kChain currently. Generalize to other accumulator uses.
-    const int accSaveCount = (strategy.kChain > 1 && !strategy.systolic)
-        ? AccumulatorRegister::count(hw, strategy.GRFs, problem.Tc.real().ngen()) : 0;
+    // TODO: Only save the accumulators used by the kernel. Potentially move into the package,
+    // which already decodes/scans the microkernel binary for register usage.
+    const int accSaveCount = AccumulatorRegister::count(hw, strategy.GRFs, problem.Tc.real().ngen());
     const int accElts = GRF::bytes(hw) >> 2;  // dwords per accumulator register
     GRFRange accSave = state.ra.alloc_range(accSaveCount);
     for (int i = 0; i < accSave.getLen(); i++)

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -95,7 +95,7 @@ void Generator<hw>::outerProductFMA(int h, int ha_period, int hb_period, int opC
 
     // Emit an FMA instruction.
     auto outputFMA = [&](InstructionModifier mod, const Subregister &A, const Subregister &B, const Subregister &C, const RegData &bcastSrc, bool colMajor, int hh, bool ivfirst, bool ivlast) {
-        auto Cacc = AccumulatorRegister(accNum).sub(0, Tc.real().ngen());
+        auto Cacc = AccumulatorRegister(accNum).sub(C.getOffset(), Tc.real().ngen());
         auto Csrc = (hh == 0                    && ivfirst) ? C : Cacc;
         auto Cdst = (hh == opCount - minOPCount && ivlast)  ? C : Cacc;
         if (startRepackC && hh == 0)

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -165,13 +165,18 @@ void Generator<hw>::outerProductFMA(int h, int ha_period, int hb_period, int opC
     accPerFMA = std::max(accPerFMA, minAccPerFMA);
     int independentAccs = div_up(accCount, accPerFMA);
 
+    // Mirror canColMajor/canRowMajor logic below. If neither, downgrade simd to 1.
+    bool fmaVectorized = (isRegisterColMajor(problem.Ta, problem.A, strategy.A) && globalCM)
+                      || (!isRegisterColMajor(problem.Tb, problem.B, strategy.B) && !globalCM);
+    int fmaExpected = fmaVectorized ? fmaSIMD : 1;
+
     int nx1i = 1, ny1 = 1;
     if (kChain > 1) {
         if (independentAccs < icompCount) hw_unsupported();
         int indepAccComp = div_up(independentAccs, icompCount);
 
-        nx1i = std::min(nx1, indepAccComp * fmaSIMD);
-        ny1 = div_up(indepAccComp, div_up(nx1i, fmaSIMD));
+        nx1i = std::min(nx1, indepAccComp * fmaExpected);
+        ny1 = div_up(indepAccComp, div_up(nx1i, fmaExpected));
 
         noAccSBSet &= Tc.isFP()
                    && (div_up(nx1i, necAcc) * ny1 * icompCount >= 8)

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_multiply.cxx
@@ -459,7 +459,12 @@ void Generator<hw>::outerProductSystolic(int h, int ha_period, int hb_period, in
                 if (rc != 8 && strategy.extendedAtomicFMA) hw_unsupported();
             }
 
-            if (hhbase + ksys < opCount && rc == 8) mod |= Fwd;
+            bool canFwd = (hw == ngen::HW::Xe3p)
+                && (getProductFamily() >= ngen::ProductFamily::CRI)
+                && (rc == 8)
+                && mod.isAtomic()
+                && (Tc != Type::f16);
+            if (hhbase + ksys < opCount && canFwd) mod |= Fwd;
 
             if (startRepackC && hhbase == 0)
                 srcC0 = null.retype(C0.getType());

--- a/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_allocation.cxx
@@ -559,14 +559,17 @@ void Generator<hw>::gemmAllocRegs(GEMMProblem &problem, GEMMStrategy &strategy, 
     if (state.Bp_layout.valid() && needsPFRegs(state.Bp_layout.addressingStrategy()))
         state.Bp_regs = state.ra.alloc_range(state.Bp_layout.regs());
 
+    // bdpas has additional GRF conflict requirements: A scales must be in the same bank as A.
+    auto Ascale_hint = state.useBDPAS ? getHint(HintType::A0, strategy) : Bundle();
+
     // Allocate registers for A/B quantization parameters.
     state.A_offsetRegs = state.ra.alloc_range(state.A_offsetLayout.regs());
     state.B_offsetRegs = state.ra.alloc_range(state.B_offsetLayout.regs());
     state.Ar_offsetRegs = state.ra.alloc_range(state.Ar_offsetLayout.regs());
     state.Br_offsetRegs = state.ra.alloc_range(state.Br_offsetLayout.regs());
-    state.A_scaleRegs = state.ra.alloc_range(state.A_scaleLayout.regs());
+    state.A_scaleRegs = state.ra.alloc_range(state.A_scaleLayout.regs(), state.Ar_scaleLayout.empty() ? Ascale_hint : Bundle());
     state.B_scaleRegs = state.ra.alloc_range(state.B_scaleLayout.regs());
-    state.Ar_scaleRegs = state.ra.alloc_range(state.Ar_scaleLayout.regs());
+    state.Ar_scaleRegs = state.ra.alloc_range(state.Ar_scaleLayout.regs(), Ascale_hint);
     state.Br_scaleRegs = state.ra.alloc_range(state.Br_scaleLayout.regs());
     state.Ag_regs = state.ra.alloc_range(state.Ag_layout.regs());
     state.Bg_regs = state.ra.alloc_range(state.Bg_layout.regs());

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -243,9 +243,6 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     //                         64-bit emulation > r0 header storage.
     if (AccumulatorRegister::count(hw, GRFs, problem.Tc.real().ngen()) == 0)
         kChain = 1;
-    // Fwd modifier not supported in below case
-    if (hw == HW::Xe3p && systolic && problem.product.family < ProductFamily::CRI)
-        kChain = 1;
     cAccumulators &= (kChain == 1);
 
     bool emulateNeedsAcc = emulate.emulate64 || emulate.emulateDWxDW;

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -238,13 +238,25 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
 
     dpasw &= systolic && fused;
 
-    // Accumulator usage: 64-bit emulation, or k chaining, or extra C registers, or storage for r0 header.
-    // Priority: k chaining > extra C registers > r0 header storage.
-    //                         64-bit emulation > r0 header storage.
-    if (AccumulatorRegister::count(hw, GRFs, problem.Tc.real().ngen()) == 0)
+    if (kChain == 0) {
+        kChain = 1;
+        if (!cAccumulators) {
+            if (!systolic && !dotVL && Ta.isFP() && Tb.isFP() && hw >= HW::XeHP)
+                kChain = gcd(ka_load, kb_load);
+            if (systolic && problem.product.family == ProductFamily::CRI) {
+                int minOPCount = minOuterProductCount(problem, *this);
+                kChain = std::max(1, gcd(ka_load, kb_load) / minOPCount);
+            }
+        }
+    }
+
+    if (!systolic && AccumulatorRegister::count(hw, GRFs, problem.Tc.real().ngen()) == 0)
         kChain = 1;
     cAccumulators &= (kChain == 1);
 
+    // Accumulator usage: 64-bit emulation, or k chaining, or extra C registers, or storage for r0 header.
+    // Priority: k chaining > extra C registers > r0 header storage.
+    //                         64-bit emulation > r0 header storage.
     bool emulateNeedsAcc = emulate.emulate64 || emulate.emulateDWxDW;
     if (moveR0 == MoveR0::Acc)
         if (cAccumulators || emulateNeedsAcc || xParallel || (kChain > 1) || barrierFreq || fuseBeta)

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -1085,6 +1085,7 @@ void unparseAddressBase(std::ostream &s, ngen::AddressBase base)
     switch (base.getModel()) {
         case ngen::AddressModel::ModelA64:     s << 'a'; break;
         case ngen::AddressModel::ModelCC:      s << 'c'; break;
+        case ngen::AddressModel::ModelSLM:     s << 'l'; break;
         case ngen::AddressModel::ModelSC:      s << 'm'; break;
         case ngen::AddressModel::ModelBTS:     s << 's'; break;
         case ngen::AddressModel::ModelInvalid: s << 'r'; break;

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -915,7 +915,7 @@ std::string unparseStrategy(HW hw, const GEMMProblem &problem, const GEMMStrateg
         if (strategy.dotVL > 1) s << strategy.dotVL;
     }
 
-    if (strategy.kChain > 1)                s << " kc" << strategy.kChain;
+    if (strategy.kChain > 0)                s << " kc" << strategy.kChain;
 
     if (strategy.atomicFMA)                 s << (strategy.extendedAtomicFMA ? " xaf" : " af");
     if (strategy.stallAfterLoad)            s << " st";

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
@@ -32,13 +32,29 @@ struct Setting;
 
 struct ClobberSet {
     static constexpr int maxRegs = 512;
+    static constexpr int maxAcc = 16;
+    static constexpr int maxFlag = 16;
     std::array<bool, maxRegs> clobbered = {};
+    std::array<bool, maxAcc> accClobbered = {};
+    std::array<bool, maxFlag> flagClobbered = {};
 
-    void clear() { clobbered.fill(false); }
+    void clear() { clobbered.fill(false); accClobbered.fill(false); flagClobbered.fill(false); }
     bool empty() const { return std::none_of(clobbered.begin(), clobbered.end(), [](bool b) { return b; }); }
     size_t size() const { return clobbered.size(); }
     bool operator[](uint32_t reg) const { return clobbered[reg]; }
     bool &operator[](uint32_t reg) { return clobbered[reg]; }
+
+    bool acc(uint32_t idx) const { return idx < maxAcc && accClobbered[idx]; }
+    bool flag(uint32_t idx) const { return idx < maxFlag && flagClobbered[idx]; }
+
+    void addAcc(uint32_t start, uint32_t len) {
+        for (uint32_t i = start; i < start + len && i < maxAcc; i++)
+            accClobbered[i] = true;
+    }
+    void addFlag(uint32_t start, uint32_t len) {
+        for (uint32_t i = start; i < start + len && i < maxFlag; i++)
+            flagClobbered[i] = true;
+    }
 
     std::string str() const {
         std::string out = "{";
@@ -112,6 +128,9 @@ struct Package {
     Status status = Status::Pending;
 
     // Analyzes the package and deduces information from the raw microkernel binary.
+    // Note: if any ARF registers are used, they must be declared in knownClobbers, which
+    // indicates that the microkernel has save/restore code for those registers. Only supports
+    // acc/flag ARF registers so far
     Status finalize(const ClobberSet &knownClobbers = {});
 };
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/strategy.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/strategy.hpp
@@ -195,7 +195,7 @@ struct GEMMStrategyPOD : public CommonStrategy {
     bool fmaBoustrophedon = false;               // Use boustrophedon ordering inside FMA/DPAS blocks?
                                     ZPAD(A, 1)
     int fmaSIMD = 0;                             // Vector length for FMA (0 = default = 2 GRFs).
-    int kChain = 1;                              // # of FMAs to chain in k dimension.
+    int kChain = 0;                              // # of FMAs to chain in k dimension.
     int dotVL = 0;                               // If > 0, use dot products of the given length, instead of outer products.
     int wg[3] = {0,0,0};                         // m/n/k workgroup sizes, 0 if unconstrained. Indexed by LoopType.
     WGType forceWGUpdate = WGDynamic;            // Force work group update type.

--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -1421,7 +1421,7 @@ public:
         return 2;
     }
     static constexpr14 int count(HW hw, int grfCount, DataType dt = DataType::invalid) {
-        return count(hw, dt) * (grfCount == 256 ? 2 : 1);
+        return count(hw, dt) * (grfCount >= 256 ? 2 : 1);
     }
 };
 


### PR DESCRIPTION
Fixes several small bugs/edge cases found while working on CRI:
- bdpas has GRF conflicts unless A and A_scale are in the same bank. Update register allocation to enforce this.
- systolic fwd usage was brittle and implemented strangely, changed to match spec.
- Accumulator counting is incorrect for Xe3p+, since `grf512` was not accounted for.
- Enable k-chaining by default. Very important for performance on CRI. Backported from the gemmstone repo. This leads to moderate performance improvements on all platforms, will include some details below when CI finishes.
- Fixed a bug with FMA k-chaining, related to incorrect counting of required/used accumulation registers.
- Fixed another bug in FMA k-chaining, related to invalid register regioning

CI revealed several bugs in microkernels after kChain is enabled by default, which are also fixed now:
- Accumulator registers are not tracked, allowing microkernels to clobber existing data in them. They're now saved/restored like flag registers.
- Related issue: ARF were being tracked with GRF clobbers, leading to incorrect clobber regions - these are now tracked completely separately as expected.
- Logic is added to increase `grfMin` according to required number of accumulators.