### PR TITLE
[GPU] Reduce JIT conv/deconv primitive creation time

### DIFF
--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -1940,7 +1940,8 @@ status_t init_cfg(config_t &cfg, const primitive_t *prim) {
             cfg = std::move(try_cfg);
             return status::success;
         }
-        cfg.tiler().move_next(cfg);
+        // Pass the tried config: the GRF mode is set on it, not on cfg.
+        cfg.tiler().move_next(try_cfg);
     }
     return status::runtime_error;
 }

--- a/src/gpu/intel/conv/jit/tiler.cpp
+++ b/src/gpu/intel/conv/jit/tiler.cpp
@@ -634,7 +634,7 @@ private:
             return false;
         }
 
-        blocking_t blk;
+        const blocking_t &blk;
         dim_t b_iter;
         dim_t m_iter;
         dim_t n_iter;
@@ -1207,26 +1207,27 @@ dim_t grf_usage_bytes(const config_t &cfg, const blocking_params_t &params) {
 
 void sort_by_model_scores(params_generator_t &params_gen, const config_t &cfg,
         tiler_mode_t mode) {
-    std::unordered_map<int, float> eff_scores;
+    std::vector<float> eff_scores(params_gen.configs());
+    auto shape = cfg.shape(/*pad=*/true);
     for (int i = 0; i < params_gen.configs(); i++) {
         auto &p = params_gen.at(i);
         float score = model::get_score(cfg, p);
-        float eff = p.blocking().get_efficiency(cfg.shape(/*pad=*/true));
-        eff_scores.emplace(p.id(), score * eff);
+        float eff = p.blocking().get_efficiency(shape);
+        eff_scores[p.id()] = score * eff;
     }
     if (mode == tiler_mode_t::lookup) {
         // Give the lookup entry the highest score.
         eff_scores[params_gen.at(0).id()] = 1.0f;
     }
     params_gen.sort(0, params_gen.configs(),
-            [&](const blocking_params_t &p) { return -eff_scores.at(p.id()); });
+            [&](const blocking_params_t &p) { return -eff_scores[p.id()]; });
 
     // Heuristics when model tie is detected
     auto &params_vec = params_gen.params_vec();
     auto &p_best = params_vec[0];
     for (auto &p_next : params_gen.params_vec()) {
         if (&p_best == &p_next) continue;
-        if (eff_scores.at(p_best.id()) != eff_scores.at(p_next.id())) break;
+        if (eff_scores[p_best.id()] != eff_scores[p_next.id()]) break;
 
         if (cfg.prb().is_bwd_w && cfg.allow_global_reduction()) {
             // As the model estimate is the same, prefer fewer atomic reductions
@@ -1246,6 +1247,7 @@ void sort_by_model_scores(params_generator_t &params_gen, const config_t &cfg,
     }
 
 #ifdef DNNL_DEV_MODE
+    if (!logger_t<log_level_t::trace>::is_enabled()) return;
     using namespace ir_utils;
     std::vector<std::string> headers
             = {"Config", "Score", "Eff", "Regs", "SLM size"};

--- a/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
@@ -364,7 +364,7 @@ public:
                                 && a.is_equal(other.b)));
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         if (is_commutative_op(op_kind)) {
             size_t a_hash = hash(a);
             size_t b_hash = hash(b);
@@ -400,7 +400,7 @@ public:
         return value == other.value;
     }
 
-    size_t get_hash() const override { return hash(value); }
+    size_t compute_hash() const override { return hash(value); }
 
     bool value;
 
@@ -434,7 +434,7 @@ public:
                 && (saturate == other.saturate);
     }
 
-    size_t get_hash() const override { return hash(type, expr, saturate); }
+    size_t compute_hash() const override { return hash(type, expr, saturate); }
 
     bool is_bool_vec_u16() const {
         if (is_bool_vec(expr.type()) && is_u16_or_u32_scalar(type)) return true;
@@ -472,7 +472,7 @@ public:
 
     bool operator==(const const_var_t &other) const { return this == &other; }
 
-    size_t get_hash() const override { return hash(name); }
+    size_t compute_hash() const override { return hash(name); }
 
     std::string name;
 
@@ -494,7 +494,7 @@ public:
         return type == other.type && (value == other.value);
     }
 
-    size_t get_hash() const override { return hash(value); }
+    size_t compute_hash() const override { return hash(value); }
 
     double value;
 
@@ -517,7 +517,7 @@ public:
         return type == other.type && (value == other.value);
     }
 
-    size_t get_hash() const override { return hash(value); }
+    size_t compute_hash() const override { return hash(value); }
 
     static expr_t shrink_type(const expr_t &e) {
         auto &imm = e.as<int_imm_t>();
@@ -563,7 +563,7 @@ public:
                 && false_expr.is_equal(other.false_expr);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(cond, true_expr, false_expr);
     }
 
@@ -609,7 +609,7 @@ public:
                 && utils::is_equal(v_vec, other.v_vec);
     }
 
-    size_t get_hash() const override { return hash(c, u_vec, v_vec); }
+    size_t compute_hash() const override { return hash(c, u_vec, v_vec); }
 
     expr_t c;
     std::vector<expr_t> u_vec;
@@ -648,7 +648,9 @@ public:
                 && off.is_equal(other.off) && (stride == other.stride);
     }
 
-    size_t get_hash() const override { return hash(type, buf, off, stride); }
+    size_t compute_hash() const override {
+        return hash(type, buf, off, stride);
+    }
 
     bool has_default_stride() const { return stride == default_stride; }
 
@@ -680,7 +682,7 @@ public:
         return base.is_equal(other.base) && off.is_equal(other.off);
     }
 
-    size_t get_hash() const override { return hash(base, off); }
+    size_t compute_hash() const override { return hash(base, off); }
 
     // Normalizes (base op off) pointer so that the new base is a variable and
     // off is an offset expression.
@@ -777,7 +779,7 @@ public:
                 && utils::is_equal(idx, other.idx);
     }
 
-    size_t get_hash() const override { return hash(vec, idx); }
+    size_t compute_hash() const override { return hash(vec, idx); }
 
     int elems() const { return int(idx.size()); }
 
@@ -846,7 +848,7 @@ public:
                 && b.is_equal(other.b) && c.is_equal(other.c);
     }
 
-    size_t get_hash() const override { return hash(op_kind, a, b, c); }
+    size_t compute_hash() const override { return hash(op_kind, a, b, c); }
 
     op_kind_t op_kind;
     expr_t a;
@@ -887,7 +889,7 @@ public:
         return (op_kind == other.op_kind) && a.is_equal(other.a);
     }
 
-    size_t get_hash() const override { return hash(op_kind, a); }
+    size_t compute_hash() const override { return hash(op_kind, a); }
 
     op_kind_t op_kind;
     expr_t a;
@@ -909,7 +911,9 @@ public:
         return this == &other;
     }
 
-    size_t get_hash() const override { return std::hash<std::string> {}(name); }
+    size_t compute_hash() const override {
+        return std::hash<std::string> {}(name);
+    }
 
     std::string name;
     bool is_mutable = false;
@@ -948,7 +952,7 @@ public:
         return oss.str();
     }
 
-    size_t get_hash() const override { return hash(var, off, elems); }
+    size_t compute_hash() const override { return hash(var, off, elems); }
 
     expr_t var;
     int off;
@@ -1135,7 +1139,7 @@ public:
         return this == &obj;
     }
 
-    size_t get_hash() const override { return hash(buf_sizes); }
+    size_t compute_hash() const override { return hash(buf_sizes); }
 
     // List of buffers accessed from instructions.
     std::vector<expr_t> bufs;
@@ -1195,7 +1199,7 @@ public:
                 && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(buf, size, kind, attrs, body);
     }
 
@@ -1257,7 +1261,7 @@ public:
         return var.is_equal(other.var) && value.is_equal(other.value);
     }
 
-    size_t get_hash() const override { return hash(var, value); }
+    size_t compute_hash() const override { return hash(var, value); }
 
     std::string str() const override {
         std::ostringstream oss;
@@ -1314,7 +1318,7 @@ public:
                 && (stride == other.stride) && (fill_mask0 == other.fill_mask0);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(buf, off, value, stride, mask, fill_mask0);
     }
 
@@ -1377,7 +1381,7 @@ public:
                 && step.is_equal(other.step) && (unroll == other.unroll);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(var, init, bound, body, step, unroll);
     }
 
@@ -1426,7 +1430,7 @@ public:
                 && else_body.is_equal(other.else_body);
     }
 
-    size_t get_hash() const override { return hash(cond, body, else_body); }
+    size_t compute_hash() const override { return hash(cond, body, else_body); }
 
     std::string line_str() const {
         ostringstream_t oss;
@@ -1461,7 +1465,7 @@ public:
                 && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override { return hash(var, value, body); }
+    size_t compute_hash() const override { return hash(var, value, body); }
 
     std::string line_str() const {
         ostringstream_t out;
@@ -1587,7 +1591,7 @@ public:
         return (label == other.label) && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override { return hash(label, body); }
+    size_t compute_hash() const override { return hash(label, body); }
 
     stmt_label_t label;
     stmt_t body;
@@ -1616,7 +1620,7 @@ public:
         return utils::is_equal(vec, other.vec);
     }
 
-    size_t get_hash() const override { return hash(vec); }
+    size_t compute_hash() const override { return hash(vec); }
 
     std::vector<stmt_t> vec;
 
@@ -1639,7 +1643,7 @@ public:
         return cond.is_equal(other.cond) && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override { return hash(cond, body); }
+    size_t compute_hash() const override { return hash(cond, body); }
 
     std::string line_str() const {
         ostringstream_t out;
@@ -1701,7 +1705,7 @@ public:
         return mod.getAll() == other.mod.getAll();
     }
 
-    size_t get_hash() const override { return hash(mod.getAll()); }
+    size_t compute_hash() const override { return hash(mod.getAll()); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -1748,8 +1752,8 @@ class func_impl_t : public object::impl_t {
 public:
     func_impl_t(object::impl_t::info_t type_info) : object::impl_t(type_info) {}
 
-    size_t get_hash() const override {
-        dsl_error() << "get_hash() is not implemented.";
+    size_t compute_hash() const override {
+        dsl_error() << "compute_hash() is not implemented.";
         return 0;
     }
 
@@ -1813,7 +1817,7 @@ public:
                 && attr.is_equal(other.attr);
     }
 
-    size_t get_hash() const override { return hash(args, attr); }
+    size_t compute_hash() const override { return hash(args, attr); }
 
     std::string line_str() const {
         ostringstream_t out;

--- a/src/gpu/intel/gemm/jit/dsl/ir/grf_permutation.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/grf_permutation.hpp
@@ -80,7 +80,7 @@ public:
         return this == &obj;
     }
 
-    size_t get_hash() const override { return 0; }
+    size_t compute_hash() const override { return 0; }
 
     std::shared_ptr<grf_permutation_t> grf_perm;
 

--- a/src/gpu/intel/gemm/jit/dsl/ir/ir.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/ir.hpp
@@ -823,7 +823,7 @@ public:
     }
 
 private:
-    object_map_t<expr_t, std::vector<relation_t>> relations_;
+    const object_map_t<expr_t, std::vector<relation_t>> &relations_;
 };
 
 // TODO: Add integers check (only integers can be constrained).
@@ -834,6 +834,10 @@ public:
     }
 
     void add_constraint(const expr_t &e);
+
+    bool is_empty() const {
+        return relations_.empty() && modulus_infos_.empty();
+    }
 
     bool can_prove(const expr_t &e, bool try_simplify = true) const {
         auto ret = can_prove_impl(e, /*do_simplify=*/false);

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
@@ -1823,7 +1823,22 @@ private:
     constraint_set_t cset_;
 };
 
+expr_t simplify_expr_impl(const expr_t &_e, const constraint_set_t &cset);
+
 expr_t simplify_expr(const expr_t &_e, const constraint_set_t &cset) {
+    if (!cset.is_empty()) return simplify_expr_impl(_e, cset);
+    if (is_const(_e) || is_var(_e)) return _e;
+    static const size_t max_cache_size = 4096;
+    static thread_local object_eq_map_t<expr_t, expr_t> cache;
+    auto it = cache.find(_e);
+    if (it != cache.end()) return it->second;
+    auto ret = simplify_expr_impl(_e, cset);
+    if (cache.size() >= max_cache_size) cache.clear();
+    cache.emplace(_e, ret);
+    return ret;
+}
+
+expr_t simplify_expr_impl(const expr_t &_e, const constraint_set_t &cset) {
     expr_t e = _e;
 
     if (is_const(e) || is_var(e)) return e;
@@ -2421,7 +2436,6 @@ expr_t nary_op_canonicalize(const expr_t &_e) {
     e = mul_nary_op_expander_t().mutate(e);
 
     dsl_assert(is_nary_op_canonical(e)) << e;
-    maybe_unused(is_nary_op_canonical(e));
 
     return e;
 }

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
@@ -1513,7 +1513,8 @@ public:
         auto _b = nary_op_back_transform(b);
 
         // 0 <= a < b => (a / b) == 0
-        bool abs_a_lt_b = cset.can_prove(_a >= 0) && cset.can_prove(_a < _b);
+        bool abs_a_lt_b = cset.can_prove(_a >= 0, /*try_simplify=*/false)
+                && cset.can_prove(_a < _b, /*try_simplify=*/false);
 
         // 0 <= a < b => (a % b) == a
         if (abs_a_lt_b) {

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
@@ -42,7 +42,7 @@ public:
 
     bool operator==(const pexpr_t &other) const { return id == other.id; }
 
-    size_t get_hash() const override { return hash(id); }
+    size_t compute_hash() const override { return hash(id); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -102,7 +102,7 @@ public:
         return (id == other.id) && (value == other.value);
     }
 
-    size_t get_hash() const override { return hash(id, value); }
+    size_t compute_hash() const override { return hash(id, value); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -721,7 +721,7 @@ public:
         return (op_kind == other.op_kind) && utils::is_equal(args, other.args);
     }
 
-    size_t get_hash() const override { return hash(op_kind, args); }
+    size_t compute_hash() const override { return hash(op_kind, args); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -1040,7 +1040,7 @@ public:
         return f_common.factors.size() == factors.size();
     }
 
-    size_t get_hash() const override { return hash(factors); }
+    size_t compute_hash() const override { return hash(factors); }
 
     std::string str() const override {
         ostringstream_t oss;

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/trace.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/trace.cpp
@@ -46,7 +46,7 @@ void trace_stop(const char *pass_name) {
     if (get_trace_profiler()) get_trace_profiler()->stop(pass_name);
 }
 void trace_perf() {
-    dsl_perf() << get_trace_profiler();
+    if (get_trace_profiler()) dsl_perf() << *get_trace_profiler();
 }
 
 void trace_pass(

--- a/src/gpu/intel/gemm/jit/include/gemmstone/dsl/ir/object.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/dsl/ir/object.hpp
@@ -46,7 +46,15 @@ public:
     // Provides equality semantics.
     virtual bool is_equal(const impl_t &obj) const = 0;
 
-    virtual size_t get_hash() const = 0;
+    // Memoized, the hash is computed at most once per object: IR objects are
+    // immutable once created by design.
+    size_t get_hash() const {
+        if (!hash_) {
+            size_t h = compute_hash();
+            hash_ = h ? h : 1; // 0 marks "not computed yet"
+        }
+        return hash_;
+    }
 
     bool is_expr() const { return info().is_expr; }
     bool is_stmt() const { return info().is_stmt; }
@@ -88,6 +96,8 @@ public:
     virtual void _visit(ir_visitor_t &visitor) const;
 
 protected:
+    virtual size_t compute_hash() const = 0;
+
     friend class gemmstone::dsl::ir::object_t;
     template <typename T>
     friend struct info_t;
@@ -140,6 +150,7 @@ private:
 
     ref_count_t ref_count_;
     info_t info_;
+    mutable size_t hash_ = 0;
 };
 
 template <typename T>
@@ -236,6 +247,7 @@ public:
 
     // Comparison with equality semantics.
     bool is_equal(const object_t &other) const {
+        if (impl_ == other.impl()) return true;
         if (is_empty() || other.is_empty())
             return is_empty() == other.is_empty();
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/dsl/tensor.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/dsl/tensor.hpp
@@ -71,8 +71,9 @@ private:
             return !operator==(other);
         }
 
+        // NUL-padded names: byte-swapped compare matches strncmp() ordering.
         bool operator<(const name_t &other) const {
-            return std::strncmp(data_, other.data_, max_len) < 0;
+            return bswap(numeric_value()) < bswap(other.numeric_value());
         }
 
         size_t index() const {
@@ -89,6 +90,17 @@ private:
         std::string str() const { return data_; }
 
     private:
+        static uint64_t bswap(uint64_t v) {
+#if defined(__GNUC__) || defined(__clang__)
+            return __builtin_bswap64(v);
+#else
+            uint64_t ret = 0;
+            for (int i = 0; i < 8; i++)
+                ret |= ((v >> (8 * i)) & 0xFF) << (8 * (7 - i));
+            return ret;
+#endif
+        }
+
         uint64_t numeric_value() const {
             uint64_t ret;
             static_assert(sizeof(*this) == sizeof(ret),
@@ -283,8 +295,9 @@ public:
     }
 
     const ValueT &operator[](const idx_t &key) const {
-        gemm_assert(has(key), "Key not found: " + key.str());
-        return map_.at(key);
+        auto it = map_.find(key);
+        if (it == map_.end()) stub(("Key not found: " + key.str()).c_str());
+        return it->second;
     }
 
     ValueT &operator[](const idx_t &key) {

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -374,6 +374,19 @@ private:
     dim_t block_;
 };
 
+// Some complex expressions need more than one simplify() call.
+inline expr_t simplify_repeat(
+        const expr_t &e, const constraint_set_t &cset, int max_tries = 5) {
+    auto ret = e;
+    auto next = ir::simplify(ret, cset);
+    for (int i = 0; i < max_tries; i++) {
+        ret = next;
+        next = ir::simplify(next, cset);
+        if (next.is_equal(ret)) break;
+    }
+    return ret;
+}
+
 class mask_tensor_t {
 public:
     mask_tensor_t() = default;
@@ -416,16 +429,8 @@ public:
     }
 
     void simplify(const constraint_set_t &cset) {
-        for (auto &mask : id2masks_) {
-            auto new_mask = ir::simplify(mask, cset);
-            // Some complex expressions need more than one simplify() call.
-            int max_tries = 5;
-            for (int i = 0; i < max_tries; i++) {
-                mask = new_mask;
-                new_mask = ir::simplify(new_mask, cset);
-                if (new_mask.is_equal(mask)) break;
-            }
-        }
+        for (auto &mask : id2masks_)
+            mask = simplify_repeat(mask, cset);
         mask2ids_.clear();
         for (int i = 0; i < int(id2masks_.size()); i++) {
             auto ret = mask2ids_.insert({id2masks_[i], i});
@@ -930,8 +935,9 @@ public:
         auto _vlayout = create_dense_vlayout();
         mask_tensor_t mask_tensor(_vlayout);
         icoord_t vargs(nvdims());
-        create_mask_tensor(mask_tensor, _vlayout, 0, vargs, tmask);
-        mask_tensor.simplify(cset);
+        // Distinct per-tdim mask factors are far fewer than elements.
+        std::vector<object_eq_map_t<expr_t, expr_t>> memo(ntdims());
+        create_mask_tensor(mask_tensor, _vlayout, 0, vargs, tmask, cset, memo);
         return mask_tensor;
     }
 
@@ -1045,12 +1051,13 @@ private:
 
     void create_mask_tensor(mask_tensor_t &mask_tensor,
             const layout_t &_vlayout, dim_idx_t vidx, icoord_t &vargs,
-            uint32_t tmask) const {
+            uint32_t tmask, const constraint_set_t &cset,
+            std::vector<object_eq_map_t<expr_t, expr_t>> &memo) const {
         if (vidx == _vlayout.ndims()) {
             bool is_init = false;
             coord_t vvalues;
             coord_t targs;
-            expr_t mask = bool_imm_t::make(true);
+            expr_t mask;
             for (dim_idx_t i = 0; i < ntdims(); i++) {
                 auto &tdim = tdims_[i];
                 if ((tmask & (1 << i)) == 0) continue;
@@ -1063,15 +1070,32 @@ private:
                     targs = cvt_vargs_to_targs(vargs);
                     is_init = true;
                 }
-                mask &= tdim.mask(targs[i], vvars_, vvalues);
+                auto f = tdim.mask(targs[i], vvars_, vvalues);
+                expr_t fs;
+                auto it = memo[i].find(f);
+                if (it != memo[i].end()) {
+                    fs = it->second;
+                } else {
+                    fs = simplify_repeat(f, cset);
+                    memo[i].emplace(f, fs);
+                }
+                // Fold the conjunction as simplify_rewrite_and() would.
+                if (auto *imm = fs.as_ptr<bool_imm_t>()) {
+                    if (imm->value) continue;
+                    mask = fs;
+                    break;
+                }
+                mask = mask.is_empty() ? fs : (mask & fs);
             }
+            if (mask.is_empty()) mask = bool_imm_t::make(true);
             mask_tensor.set_mask(_vlayout.offset<dim_t>(vargs), mask);
             return;
         }
 
         for (dim_idx_t i = 0; i < vdims()[vidx]; i++) {
             vargs[vidx] = i;
-            create_mask_tensor(mask_tensor, _vlayout, vidx + 1, vargs, tmask);
+            create_mask_tensor(
+                    mask_tensor, _vlayout, vidx + 1, vargs, tmask, cset, memo);
         }
     }
 


### PR DESCRIPTION
Jira: [MFDNN-15342](https://jira.devtools.intel.com/browse/MFDNN-15342)

Changes:

1. ~Implemented kernel cache for convolution reorders. This is important for NCHW activations where reorder kernels can be reused~ To be addressed in a separate PR.
    - Impact: ~15% convolution creation time reduction for the cases of interest
2. `simplify()` caching and minor optimizations in the tiler and `idx_map_t`
    - Impact: ~20% deconvolution creation time reduction
3. Mask split for the legacy send plan (used with division/modulus in strided backward-by-data convolution)
    - Current version already has deduplication via `mask2ids`, the new version goes a step further to use per-dimension simplification
    - Impact: ~10% deconvolution creation time reduction

When combining all three, the cases from the Jira show these creation time improvements on average:

- Convolution: ~25% creation time reduction
- Deconvolution: ~65% creation time reduction