### PR TITLE
build: don't pass -fsycl-targets to the static archiver

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,11 +164,9 @@ if(DNNL_WITH_SYCL)
     # Enable linking SYCL kernels.
     if(DNNL_SYCL_CUDA OR (DNNL_SYCL_GENERIC AND NVIDIA_TARGET_SUPPORTED))
         append(CMAKE_SHARED_LINKER_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda")
-        append(CMAKE_STATIC_LINKER_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda")
     endif()
     if(DNNL_AMD_ENABLE_SYCL_KERNELS)
         append(CMAKE_SHARED_LINKER_FLAGS "-fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=${DNNL_AMD_SYCL_KERNELS_TARGET_ARCH}")
-        append(CMAKE_STATIC_LINKER_FLAGS "-fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=${DNNL_AMD_SYCL_KERNELS_TARGET_ARCH}")
     endif()
 endif()
 


### PR DESCRIPTION
This PR fixes a static library build issue that occurs when the GPU vendor is NVIDIA or AMD.

`CMAKE_STATIC_LINKER_FLAGS` is forwarded to the archiver (llvm-ar/ar), not to the linker.
Passing `-fsycl-targets=...` causes llvm-ar to interpret it as an operation string and fail with unknown option f, which breaks static library builds (`ONEDNN_LIBRARY_TYPE=STATIC`) for the NVIDIA and AMD targets.

```
$ CC=/dpcpp/build/bin/clang CXX=/dpcpp/build/bin/clang++ cmake -B ./build_static -S . \
-DONEDNN_CPU_RUNTIME=NONE -DONEDNN_GPU_RUNTIME=SYCL -DONEDNN_LIBRARY_TYPE=STATIC -DONEDNN_GPU_VENDOR=NVIDIA
$ cmake --build ./build_static 

...

[ 30%] Built target dnnl_common
[ 30%] Built target dnnl_graph_backend_dnnl
[ 31%] Linking CXX static library libdnnl.a
/dpcpp/build/bin/llvm-ar: error: unknown option f
OVERVIEW: LLVM Archiver

USAGE: llvm-ar [options] [-]<operation>[modifiers] [relpos] [count] <archive> [files]
       llvm-ar -M [< mri-script]

OPTIONS:
  --format              - archive format to create
    =default            -   default
    =gnu                -   gnu
    =darwin             -   darwin
    =bsd                -   bsd
    =bigarchive         -   big archive (AIX OS)
    =coff               -   coff
  --plugin=<string>     - ignored for compatibility
  -h --help             - display this help and exit
  --output              - the directory to extract archive members to
  --rsp-quoting         - quoting style for response files
    =posix              -   posix
    =windows            -   windows
  --thin                - create a thin archive
  --version             - print the version and exit
  -X{32|64|32_64|any}   - object mode (only for AIX OS)
  @<file>               - read options from <file>

OPERATIONS:
  d - delete [files] from the archive
  m - move [files] in the archive
  p - print contents of [files] found in the archive
  q - quick append [files] to the archive
  r - replace or insert [files] into the archive
  s - act as ranlib
  t - display list of files in archive
  x - extract [files] from the archive

MODIFIERS:
  [a] - put [files] after [relpos]
  [b] - put [files] before [relpos] (same as [i])
  [c] - do not warn if archive had to be created
  [D] - use zero for timestamps and uids/gids (default)
  [h] - display this help and exit
  [i] - put [files] before [relpos] (same as [b])
  [l] - ignored for compatibility
  [L] - add archive's contents
  [N] - use instance [count] of name
  [o] - preserve original dates
  [O] - display member offsets
  [P] - use full names when matching (implied for thin archives)
  [s] - create an archive index (cf. ranlib)
  [S] - do not build a symbol table
  [T] - deprecated, use --thin instead
  [u] - update only [files] newer than archive contents
  [U] - use actual timestamps and uids/gids
  [v] - be verbose about actions taken
  [V] - display the version and exit
gmake[2]: *** [src/CMakeFiles/dnnl.dir/build.make:626: src/libdnnl.a] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:964: src/CMakeFiles/dnnl.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[ 31%] Built target graph_unit_test_dnnl_backend
gmake: *** [Makefile:146: all] Error 2
```