### PR TITLE
cpu: x64: zen64: apply pd_t::init 'const engine_t *' changes

### DIFF
--- a/src/cpu/x64/zen64/matmul/zen_matmul.cpp
+++ b/src/cpu/x64/zen64/matmul/zen_matmul.cpp
@@ -97,7 +97,7 @@ inline zen_bmm_params_t compute_zen_bmm_params(const memory_desc_wrapper &src_d,
 } // namespace
 #endif
 
-status_t zen_matmul_t::pd_t::init(engine_t *engine) {
+status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
     using smask_t = primitive_attr_t::skip_mask_t;
 
 #if !DNNL_X64_USE_ZEN

--- a/src/cpu/x64/zen64/matmul/zen_matmul.hpp
+++ b/src/cpu/x64/zen64/matmul/zen_matmul.hpp
@@ -46,7 +46,7 @@ struct zen_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("zen:matmul:f32|bf16:amd", zen_matmul_t);
 
-        status_t init(engine_t *engine);
+        status_t init(const engine_t *engine);
     };
 
     zen_matmul_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/cpu/x64/zen64/reorder/zen_reorder.cpp
+++ b/src/cpu/x64/zen64/reorder/zen_reorder.cpp
@@ -100,8 +100,8 @@ status_t f32_to_bf16_plain(const void *src, void *dst, int64_t K, int64_t N,
 } // namespace
 #endif
 
-status_t zen_reorder_t::pd_t::init(
-        engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+status_t zen_reorder_t::pd_t::init(const engine_t *engine,
+        const engine_t *src_engine, const engine_t *dst_engine) {
 #if !DNNL_X64_USE_ZEN
     return status::unimplemented;
 #else
@@ -250,9 +250,9 @@ status_t zen_reorder_t::pd_t::init(
 }
 
 status_t zen_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
-        const memory_desc_t *src_md, engine_t *dst_engine,
-        const memory_desc_t *dst_md) {
+        const engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *src_engine, const memory_desc_t *src_md,
+        const engine_t *dst_engine, const memory_desc_t *dst_md) {
     using namespace status;
 
     VDISPATCH_REORDER_IC(impl::is_dense_format_kind({src_md, dst_md}),

--- a/src/cpu/x64/zen64/reorder/zen_reorder.hpp
+++ b/src/cpu/x64/zen64/reorder/zen_reorder.hpp
@@ -56,14 +56,14 @@ struct zen_reorder_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("zen:reorder", zen_reorder_t);
 
-        status_t init(
-                engine_t *engine, engine_t *src_engine, engine_t *dst_engine);
+        status_t init(const engine_t *engine, const engine_t *src_engine,
+                const engine_t *dst_engine);
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, engine_t *src_engine,
-                const memory_desc_t *src_md, engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         friend dnnl::impl::impl_list_item_t;
     };


### PR DESCRIPTION
# Description

Follow-up to 95277a7a ("src: update pd_t::init to use 'const engine_t *'"),
which changed `primitive_desc_t::init()` and `reorder_pd_t::create()` to accept
`const engine_t *`. The `src/cpu/x64/zen64` sources were not updated at that
time, so their overrides no longer match the base class signatures and fail to
compile.

This was not caught by CI because `src/cpu/x64/CMakeLists.txt` removes the
entire `zen64/` directory from `SOURCES` unless `DNNL_X64_USE_ZEN=ON`, which is
off by default. Default builds are unaffected; the mismatch only surfaces when
configuring with `-DDNNL_X64_USE_ZEN=ON`.

This mirrors what 47e64d76 did for the nvidia and amd GPU backends.

Changed signatures, `engine_t *` -> `const engine_t *`:

- `zen_matmul_t::pd_t::init(engine)`
- `zen_reorder_t::pd_t::init(engine, src_engine, dst_engine)`
- `zen_reorder_t::pd_t::create(..., engine, ..., src_engine, ..., dst_engine, ...)`

This is a signature-only change. No dispatch conditions, kernel logic, or
runtime behavior are modified; the remaining hunks are clang-format reflow
caused by the longer parameter types.

## Reproducer

Before this change, configuring and building with the ZenDNN backend enabled
fails with a signature mismatch on the `init`/`create` overrides:

    cmake -DDNNL_X64_USE_ZEN=ON ..
    make

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?