### PR TITLE
cpu: x64: fix double kernel generation in jit_uni_cvt_xf16_to_ps_t

### DIFF
--- a/src/cpu/x64/jit_uni_convert_xf16.hpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.hpp
@@ -166,9 +166,7 @@ struct jit_uni_cvt_xf16_to_ps_t : public jit_generator_t {
         : jit_generator_t(jit_name())
         , input_dt_(dt)
         , with_add_(with_add)
-        , row_stride_(row_stride) {
-        create_kernel();
-    }
+        , row_stride_(row_stride) {}
 
     void generate() override;
 


### PR DESCRIPTION
Fixes a segfault noticed in GPU testing.

`jit_uni_cvt_xf16_to_ps_t` called `create_kernel()` from its own constructor, while its owner `jit_cvt_xf16_to_ps_t` called `kernel_->create_kernel()` again right after construction. As a result `generate()` was executed twice on the same `Xbyak::CodeGenerator`.

Commit 0101412fc331a192a20c7e0c65b0856ee08f2bd4 removed write permission after kernel creation, resulting in a segfault on the redundant call. This patch removes a call to create_kernel() to avoid the segfault.