### PR TITLE
common: concat: bound concat_dim by source ndims

### DIFF
--- a/src/common/concat.cpp
+++ b/src/common/concat.cpp
@@ -80,6 +80,8 @@ status_t concat_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
             !memory_desc_wrapper(src_mds[0]).has_runtime_dims_or_strides(),
             VERBOSE_RUNTIMEDIM_UNSUPPORTED);
 
+    VCHECK_CONCAT(concat_dim >= 0 && concat_dim < ndims, VERBOSE_BAD_AXIS);
+
     dim_t concat_dim_sz = dims[concat_dim];
     VCHECK_CONCAT(!memory_desc_wrapper(src_mds[0]).format_any(),
             VERBOSE_UNSUPPORTED_TAG_S, "src");

--- a/tests/gtests/test_concat.cpp
+++ b/tests/gtests/test_concat.cpp
@@ -299,6 +299,31 @@ CPU_INSTANTIATE_TEST_SUITE_P(TestConcat_EF_bf16, concat_test_bf16, cases_EF());
 CPU_INSTANTIATE_TEST_SUITE_P(
         TestConcat_EF_f16, concat_test_float16, cases_EF());
 
+TEST(concat_test_axis_t, TestConcatOutOfRangeAxis) {
+    SKIP_IF_HIP(true, "Concat operator is not supported");
+    auto eng = get_test_engine();
+    SKIP_IF(is_amd_gpu(eng), "Concat operator is not supported");
+
+    dnnl_dims_t dims = {2, 4, 5, 5};
+    dnnl_memory_desc_t mds[2];
+    for (auto &md : mds)
+        ASSERT_EQ(dnnl_memory_desc_create_with_tag(
+                          &md, 4, dims, dnnl_f32, dnnl_nchw),
+                dnnl_success);
+
+    // The destination is derived by the library, so the axis indexes the
+    // source dims directly.
+    for (int axis : {-1, 4, 100}) {
+        dnnl_primitive_desc_t concat_pd = nullptr;
+        ASSERT_EQ(dnnl_concat_primitive_desc_create(&concat_pd, eng.get(),
+                          nullptr, 2, axis, mds, nullptr),
+                dnnl_invalid_arguments);
+    }
+
+    for (auto &md : mds)
+        ASSERT_EQ(dnnl_memory_desc_destroy(md), dnnl_success);
+}
+
 static auto cases_padded = []() {
     return ::testing::Values(
             concat_test_params_t {1, {fmt::nChw16c, fmt::nChw16c}, fmt::nChw16c,


### PR DESCRIPTION
# Description

concat_primitive_desc_create indexes src_mds[0]->dims with the caller's concat_dim before anything bounds it, so a value outside [0, ndims) reads past the dims_t in the source descriptor and, on the dst_md == nullptr path that dnnl::concat::primitive_desc(engine, concat_dimension, srcs) takes, writes concat_dim_sz past the stack-local dummy_dst_md. the same unchecked value is stored in concat_pd_t::concat_dim_ and then indexes the dims and offsets stack arrays in concat_pd_t::init and set_default_params. shuffle_desc_init and softmax_desc_init already reject an axis outside [0, ndims) with VERBOSE_BAD_AXIS, so concat does the same before the first use of the value.

reproduce with two 4D f32 nchw source descriptors and dnnl_concat_primitive_desc_create(&pd, eng, NULL, 2, -1, mds, NULL). before the change asan reports a stack-buffer-overflow write of size 8 at concat_pd.hpp:171 underflowing the 96-byte `dims` array in concat_pd_t::init; a concat_dimension of 4 or 100 walks off the other end instead. after the change the call returns invalid_arguments, and valid axes are unaffected. test_concat, test_sum, test_iface_pd_iter and the graph concat suites pass locally under asan.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
