### PR TITLE
cpu: x64: drop write permissions after JIT complete

### DIFF
--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -2798,7 +2798,7 @@ public:
 private:
     const cpu_isa_t max_cpu_isa_;
     const Xbyak::uint8 *getCode() {
-        this->ready();
+        this->readyRE();
         if (!is_initialized()) return nullptr;
         const Xbyak::uint8 *code = CodeGenerator::getCode();
         register_jit_code(code, getSize());

--- a/src/cpu/x64/jit_uni_convert_xf16.hpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.hpp
@@ -166,9 +166,7 @@ struct jit_uni_cvt_xf16_to_ps_t : public jit_generator_t {
         : jit_generator_t(jit_name())
         , input_dt_(dt)
         , with_add_(with_add)
-        , row_stride_(row_stride) {
-        create_kernel();
-    }
+        , row_stride_(row_stride) {}
 
     void generate() override;
 


### PR DESCRIPTION
Follow up on #5698 to see what failures remain.

Seems like this one bug in the conversion code caused a lot of issues after we dropped write permissions. After the fix the issues are gone.