### PR TITLE
graph: backend: dnnl: guard `<optional>` header

### DIFF
--- a/src/graph/backend/dnnl/executables/base.hpp
+++ b/src/graph/backend/dnnl/executables/base.hpp
@@ -17,7 +17,9 @@
 #define GRAPH_BACKEND_DNNL_EXECUTABLES_BASE_HPP
 
 #include <memory>
+#ifdef DNNL_WITH_SYCL
 #include <optional>
+#endif
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
The `<optional>` header is only used by SYCL builds. This change fixes an MSVC warning observed in other builds:
```
...\include\optional(11): warning STL4038: The contents of <optional> are available only with C++17 or later.
```
This warning is not promoted to an error with `/WX`, so CI is already passing.