### PR TITLE
ze: add support for parallel execution

### DIFF
--- a/src/gpu/intel/ocl/kernel.cpp
+++ b/src/gpu/intel/ocl/kernel.cpp
@@ -39,72 +39,18 @@ namespace gpu {
 namespace intel {
 namespace ocl {
 
-// Kernel wrapper storing a per-thread copy of cl_kernel.
-class kernel_wrapper_t {
-public:
-    kernel_wrapper_t(cl_kernel kernel = nullptr) : kernel_(kernel) {}
-
-    operator cl_kernel() const { return kernel_; }
-
-    status_t set_arg(int arg_index, size_t arg_size, const void *arg_value) {
-        cl_int err = xpu::ocl::clSetKernelArg(
-                kernel_, arg_index, arg_size, arg_value);
-        return xpu::ocl::convert_to_dnnl(err);
-    }
-
-    status_t set_usm_arg(
-            impl::engine_t *engine, int arg_index, const void *arg_value) {
-        return xpu::ocl::usm::set_kernel_arg(
-                engine, kernel_, arg_index, arg_value);
-    }
-
-private:
-    cl_kernel kernel_;
-};
-
-class kernel_cache_t {
-public:
-    kernel_cache_t(cl_kernel main_kernel) : main_kernel_(main_kernel) {}
-
-    ~kernel_cache_t() {
-        for (auto &kv : kernels_) {
-            // See the comment in 'src/xpu/ocl/utils.hpp' next to
-            // `xpu::ocl::clReleaseKernel(t)` call. It explains the logic behind
-            // such handling.
-            auto cl_st = xpu::ocl::clReleaseKernel(kv.second);
-            if (cl_st != CL_SUCCESS && cl_st != CL_INVALID_OPERATION) {
-                OCL_CHECK_V(cl_st);
-            }
-        }
-    }
-
-    status_t get(kernel_wrapper_t **kernel) {
-        auto id = std::this_thread::get_id();
-        {
-            utils::lock_read_t lock_read(mutex_);
-            auto it = kernels_.find(id);
-            if (it != kernels_.end()) {
-                *kernel = &it->second;
-                return status::success;
-            }
-        }
-
-        // No copy for this thread, clone the original kernel and save the
-        // copy.
+cl_kernel kernel_t::thread_local_kernel() {
+    if (!kernel_tls_.is_set()) {
+        // No copy for this thread, clone the original kernel and save the copy.
         cl_kernel cloned_kernel;
-        CHECK(xpu::ocl::clone_kernel(main_kernel_, &cloned_kernel));
+        auto st = xpu::ocl::clone_kernel(ocl_kernel(), &cloned_kernel);
+        assert(st == status::success);
+        if (st != status::success) return nullptr;
 
-        utils::lock_write_t lock_write(mutex_);
-        auto ret = kernels_.emplace(id, cloned_kernel);
-        *kernel = &ret.first->second;
-        return status::success;
+        kernel_tls_.set(cloned_kernel);
     }
-
-private:
-    cl_kernel main_kernel_;
-    std::unordered_map<std::thread::id, kernel_wrapper_t> kernels_;
-    utils::rw_mutex_t mutex_;
-};
+    return kernel_tls_.get();
+}
 
 status_t kernel_t::get_binary(
         const impl::engine_t *engine, xpu::binary_t &binary) const {
@@ -123,6 +69,17 @@ status_t kernel_t::get_binary_size(
             ocl_kernel(), ocl_engine->device(), binary_size);
 }
 
+status_t kernel_t::set_arg(cl_kernel kernel, int arg_index, size_t arg_size,
+        const void *arg_value) {
+    OCL_CHECK(xpu::ocl::clSetKernelArg(kernel, arg_index, arg_size, arg_value));
+    return status::success;
+}
+
+status_t kernel_t::set_usm_arg(impl::engine_t *engine, cl_kernel kernel,
+        int arg_index, const void *arg_value) {
+    return xpu::ocl::usm::set_kernel_arg(engine, kernel, arg_index, arg_value);
+}
+
 status_t kernel_t::parallel_for(impl::stream_t &stream,
         const compute::nd_range_t &range,
         const compute::kernel_arg_list_t &arg_list, const xpu::event_t &deps,
@@ -131,8 +88,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
     auto *ocl_stream = utils::downcast<stream_t *>(&stream);
     cl_command_queue queue = ocl_stream->queue();
 
-    kernel_wrapper_t *kernel = nullptr;
-    CHECK(cache_->get(&kernel));
+    const auto &kernel = thread_local_kernel();
     CHECK(check_scalar_arguments(arg_list));
     CHECK(check_alignment(arg_list));
 
@@ -170,7 +126,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
                                 const xpu::ocl::buffer_memory_storage_t *>(
                                 ocl_mem_storage);
                         auto ocl_mem = m->mem_object();
-                        CHECK(kernel->set_arg(i, sizeof(cl_mem), &ocl_mem));
+                        CHECK(set_arg(kernel, i, sizeof(cl_mem), &ocl_mem));
                         param_bytes += pointer_size;
                         break;
                     }
@@ -179,7 +135,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
                                 const xpu::ocl::usm_memory_storage_t *>(
                                 ocl_mem_storage);
                         auto *usm_ptr = m->usm_ptr();
-                        CHECK(kernel->set_usm_arg(stream.engine(), i, usm_ptr));
+                        CHECK(set_usm_arg(stream.engine(), kernel, i, usm_ptr));
                         param_bytes += pointer_size;
                         break;
                     }
@@ -187,21 +143,21 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
                 }
             } else {
                 if (xpu::ocl::usm::is_usm_supported(stream.engine())) {
-                    CHECK(kernel->set_usm_arg(stream.engine(), i, nullptr));
+                    CHECK(set_usm_arg(stream.engine(), kernel, i, nullptr));
                     param_bytes += pointer_size;
                 } else {
                     cl_mem null_mem = nullptr;
-                    CHECK(kernel->set_arg(i, sizeof(cl_mem), &null_mem));
+                    CHECK(set_arg(kernel, i, sizeof(cl_mem), &null_mem));
                     param_bytes += pointer_size;
                 }
             }
         } else if (arg.is_local()) {
-            CHECK(kernel->set_arg(i, arg.size(), arg.value()));
+            CHECK(set_arg(kernel, i, arg.size(), arg.value()));
             // Assuming local memory arguments contribute to
             // the CL_DEVICE_MAX_PARAMETER_SIZE limit as a pointer type
             param_bytes += pointer_size;
         } else {
-            CHECK(kernel->set_arg(i, arg.size(), arg.value()));
+            CHECK(set_arg(kernel, i, arg.size(), arg.value()));
             param_bytes += arg.size();
         }
     }
@@ -224,7 +180,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
 
         cl_uint num_events = (cl_uint)events.size();
         const cl_event *events_data = num_events ? events.data() : nullptr;
-        cl_int err = xpu::ocl::clEnqueueNDRangeKernel(queue, *kernel, ndims,
+        cl_int err = xpu::ocl::clEnqueueNDRangeKernel(queue, kernel, ndims,
                 nullptr, range.global_range().data(),
                 range.local_range() ? range.local_range().data() : nullptr,
                 num_events, events_data, &event.unwrap());
@@ -233,7 +189,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
     } else {
         bool save_event = save_events_ || stream.is_profiling_enabled()
                 || stream.is_verbose_profiler_enabled();
-        cl_int err = xpu::ocl::clEnqueueNDRangeKernel(queue, *kernel, ndims,
+        cl_int err = xpu::ocl::clEnqueueNDRangeKernel(queue, kernel, ndims,
                 nullptr, range.global_range().data(),
                 range.local_range() ? range.local_range().data() : nullptr, 0,
                 nullptr, save_event ? &event.unwrap() : nullptr);
@@ -314,9 +270,7 @@ kernel_t::kernel_t(xpu::ocl::wrapper_t<cl_kernel> &&ocl_kernel,
     : ocl_kernel_(std::move(ocl_kernel))
     , arg_types_(arg_types)
     , src_(src)
-    , save_events_(false) {
-    cache_ = std::make_shared<kernel_cache_t>(ocl_kernel_);
-}
+    , save_events_(false) {}
 
 } // namespace ocl
 } // namespace intel

--- a/src/gpu/intel/ocl/kernel.hpp
+++ b/src/gpu/intel/ocl/kernel.hpp
@@ -21,8 +21,11 @@
 #include <CL/cl.h>
 
 #include "gpu/intel/compute/kernel.hpp"
+
 #include "xpu/ocl/utils.hpp"
 #include "xpu/utils.hpp"
+
+#include "common/thread_local_storage.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -30,13 +33,16 @@ namespace gpu {
 namespace intel {
 namespace ocl {
 
-class kernel_cache_t;
-
 class kernel_t : public compute::kernel_impl_t {
 public:
     ~kernel_t() override = default;
 
+    // Returns the main cl_kernel. The interface is `const` as the kernel is
+    // unmodifiable.
     cl_kernel ocl_kernel() const { return ocl_kernel_; }
+    // Returns a copy of the main kernel from the tls. The interface is not
+    // `const` as it modifies `kernel_tls_` state.
+    cl_kernel thread_local_kernel();
 
     status_t get_binary(
             const impl::engine_t *engine, xpu::binary_t &binary) const override;
@@ -44,6 +50,10 @@ public:
     status_t get_binary_size(
             const impl::engine_t *engine, size_t *binary_size) const override;
 
+    status_t set_arg(cl_kernel kernel, int arg_index, size_t arg_size,
+            const void *arg_value);
+    status_t set_usm_arg(impl::engine_t *engine, cl_kernel kernel,
+            int arg_index, const void *arg_value);
     status_t parallel_for(impl::stream_t &stream,
             const compute::nd_range_t &range,
             const compute::kernel_arg_list_t &arg_list,
@@ -76,7 +86,7 @@ private:
 
     xpu::ocl::wrapper_t<cl_kernel> ocl_kernel_;
     std::vector<gpu::intel::compute::scalar_type_t> arg_types_;
-    std::shared_ptr<kernel_cache_t> cache_;
+    utils::thread_local_storage_t<xpu::ocl::wrapper_t<cl_kernel>> kernel_tls_;
     compute::program_src_t src_;
     bool save_events_;
 };

--- a/src/gpu/intel/ze/kernel.cpp
+++ b/src/gpu/intel/ze/kernel.cpp
@@ -48,7 +48,20 @@ status_t kernel_t::make(compute::kernel_t &compute_kernel,
 kernel_t::kernel_t(
         const std::shared_ptr<xpu::ze::wrapper_t<ze_module_handle_t>> &amodule,
         ze_kernel_handle_t akernel, const std::string &kernel_name)
-    : module_(amodule), kernel_(akernel), kernel_name_(kernel_name) {}
+    : module_(amodule), ze_kernel_(akernel), kernel_name_(kernel_name) {}
+
+ze_kernel_handle_t kernel_t::thread_local_kernel() {
+    if (!kernel_tls_.is_set()) {
+        // No copy for this thread, clone the original kernel and save the copy.
+        ze_kernel_handle_t cloned_kernel;
+        auto st = xpu::ze::create_kernel(cloned_kernel, *module_, kernel_name_);
+        assert(st == status::success);
+        if (st != status::success) return nullptr;
+
+        kernel_tls_.set(cloned_kernel);
+    }
+    return kernel_tls_.get();
+}
 
 status_t kernel_t::check_alignment(
         const compute::kernel_arg_list_t &arg_list) const {
@@ -66,10 +79,10 @@ status_t kernel_t::check_alignment(
     return status::success;
 }
 
-status_t kernel_t::set_arg(
-        int arg_index, size_t arg_size, const void *arg_value) const {
+status_t kernel_t::set_arg(ze_kernel_handle_t kernel, int arg_index,
+        size_t arg_size, const void *arg_value) {
     ZE_CHECK(xpu::ze::zeKernelSetArgumentValue(
-            kernel_, arg_index, arg_size, arg_value));
+            kernel, arg_index, arg_size, arg_value));
     return status::success;
 }
 
@@ -77,6 +90,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
         const compute::nd_range_t &range,
         const compute::kernel_arg_list_t &arg_list, const xpu::event_t &deps,
         xpu::event_t &out_dep) {
+    const auto &kernel = thread_local_kernel();
     CHECK(check_scalar_arguments(arg_list));
     CHECK(check_alignment(arg_list));
 
@@ -107,17 +121,17 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
                 }
 
                 void *ptr = ze_mem_storage->ptr();
-                CHECK(set_arg(i, pointer_size, &ptr));
+                CHECK(set_arg(kernel, i, pointer_size, &ptr));
                 param_bytes += pointer_size;
             } else {
-                CHECK(set_arg(i, pointer_size, nullptr));
+                CHECK(set_arg(kernel, i, pointer_size, nullptr));
                 param_bytes += pointer_size;
             }
         } else if (arg.is_local()) {
-            CHECK(set_arg(i, arg.size(), arg.value()));
+            CHECK(set_arg(kernel, i, arg.size(), arg.value()));
             param_bytes += pointer_size;
         } else {
-            CHECK(set_arg(i, arg.size(), arg.value()));
+            CHECK(set_arg(kernel, i, arg.size(), arg.value()));
             param_bytes += arg.size();
         }
     }
@@ -158,7 +172,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
                 return status::invalid_arguments;
         }
     } else {
-        ZE_CHECK(xpu::ze::zeKernelSuggestGroupSize(kernel_, global_size[0],
+        ZE_CHECK(xpu::ze::zeKernelSuggestGroupSize(kernel, global_size[0],
                 global_size[1], global_size[2], &group_size[0], &group_size[1],
                 &group_size[2]));
     }
@@ -171,15 +185,21 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
     }
 
     ZE_CHECK(xpu::ze::zeKernelSetGroupSize(
-            kernel_, group_size[0], group_size[1], group_size[2]));
+            kernel, group_size[0], group_size[1], group_size[2]));
     ze_group_count_t group_count = {global_size[0] / group_size[0],
             global_size[1] / group_size[1], global_size[2] / group_size[2]};
 
     const auto &ze_deps = xpu::ze::event_t::from(deps);
-    ze_event_handle_t out_event = ze_stream->create_event();
-
-    ZE_CHECK(xpu::ze::zeCommandListAppendLaunchKernel(ze_stream->list(),
-            kernel_, &group_count, out_event, ze_deps.size(), ze_deps.data()));
+    ze_event_handle_t out_event = nullptr;
+    {
+        // `zeEventCreate` and `zeCommandListAppendLaunchKernel` are not thread
+        // safe. Rely on impl's underlying mutex to serialize access to them.
+        std::lock_guard<std::mutex> guard(ze_stream->list_mutex());
+        out_event = ze_stream->create_event();
+        ZE_CHECK(xpu::ze::zeCommandListAppendLaunchKernel(ze_stream->list(),
+                kernel, &group_count, out_event, ze_deps.size(),
+                ze_deps.data()));
+    }
 
     if (out_event) xpu::ze::event_t::from(out_dep).append(out_event);
     if (stream.is_profiling_enabled()) {
@@ -196,7 +216,7 @@ status_t kernel_t::get_binary(
 }
 
 status_t kernel_t::get_kernel_binary(xpu::binary_t &binary) const {
-    return ze::get_kernel_binary(kernel_, binary);
+    return ze::get_kernel_binary(ze_kernel(), binary);
 }
 
 status_t kernel_t::get_binary_size(

--- a/src/gpu/intel/ze/kernel.hpp
+++ b/src/gpu/intel/ze/kernel.hpp
@@ -21,6 +21,8 @@
 
 #include "xpu/ze/utils.hpp"
 
+#include "common/thread_local_storage.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace gpu {
@@ -35,11 +37,18 @@ public:
             ze_kernel_handle_t akernel, const std::string &kernel_name);
     ~kernel_t() override = default;
 
+    // Returns the main ze_kernel. The interface is `const` as the kernel is
+    // unmodifiable.
+    ze_kernel_handle_t ze_kernel() const { return ze_kernel_; }
+    // Returns a copy of the main kernel from the tls. The interface is not
+    // `const` as it modifies `kernel_tls_` state.
+    ze_kernel_handle_t thread_local_kernel();
+
     status_t check_alignment(
             const compute::kernel_arg_list_t &arg_list) const override;
 
-    status_t set_arg(
-            int arg_index, size_t arg_size, const void *arg_value) const;
+    status_t set_arg(ze_kernel_handle_t kernel, int arg_index, size_t arg_size,
+            const void *arg_value);
 
     status_t parallel_for(impl::stream_t &stream,
             const compute::nd_range_t &range,
@@ -71,9 +80,11 @@ private:
     // the last one through ref_counting.
     //
     // Additionally, it's important to initialize `module` first to ensure the
-    // order of destruction is `kernel_` first and then `module_`.
+    // order of destruction is `ze_kernel_` first and then `module_`.
     std::shared_ptr<xpu::ze::wrapper_t<ze_module_handle_t>> module_;
-    xpu::ze::wrapper_t<ze_kernel_handle_t> kernel_;
+    xpu::ze::wrapper_t<ze_kernel_handle_t> ze_kernel_;
+    utils::thread_local_storage_t<xpu::ze::wrapper_t<ze_kernel_handle_t>>
+            kernel_tls_;
     std::string kernel_name_;
 
     DNNL_DISALLOW_COPY_AND_ASSIGN(kernel_t);

--- a/src/gpu/intel/ze/stream.hpp
+++ b/src/gpu/intel/ze/stream.hpp
@@ -43,6 +43,7 @@ public:
     ze_event_handle_t create_event() const { return impl()->create_event(); }
 
     ze_command_list_handle_t list() const { return impl()->list(); }
+    std::mutex &list_mutex() { return impl()->list_mutex(); }
 
     status_t wait() override { return impl()->wait(); }
     status_t barrier() override { return impl()->barrier(); }

--- a/src/gpu/intel/ze/utils.cpp
+++ b/src/gpu/intel/ze/utils.cpp
@@ -263,31 +263,19 @@ status_t create_kernels(ze_device_handle_t device, ze_context_handle_t context,
     for (size_t i = 0; i < kernel_names.size(); i++) {
         if (kernel_names[i] == nullptr) continue;
 
+        // If the kernel_name is empty, it likely means it's coming from ngen.
+        // In this case it's expected that an ngen-based program contains only
+        // 1 kernel.
+        //
+        // `xpu::ze::create_kernel` would query a name from a module.
         std::string kernel_name(kernel_names[i]);
         if (kernel_name.empty()) {
-            // (copied from OCL backend).
-            // Handle the ngen cases when kernel name is not available.
-            // Query the kernel name from the program. It's expected that
-            // an ngen based program contains only 1 kernel.
             if (kernel_names.size() != 1 || kernels.size() != 1)
                 return status::invalid_arguments;
-
-            uint32_t count = 1;
-            const char *name = nullptr;
-            ZE_CHECK(xpu::ze::zeModuleGetKernelNames(
-                    *module_ptr, &count, &name));
-
-            kernel_name = std::string(name);
-            assert(!kernel_name.empty());
-            if (kernel_name.empty()) return status::runtime_error;
         }
-        ze_kernel_desc_t kernel_desc {};
-        kernel_desc.stype = ZE_STRUCTURE_TYPE_KERNEL_DESC;
-        kernel_desc.pKernelName = kernel_name.c_str();
 
         ze_kernel_handle_t kernel;
-        ZE_CHECK(xpu::ze::zeKernelCreate(*module_ptr, &kernel_desc, &kernel));
-
+        CHECK(xpu::ze::create_kernel(kernel, *module_ptr, kernel_name));
         kernels[i] = kernel;
     }
 

--- a/src/xpu/ze/utils.cpp
+++ b/src/xpu/ze/utils.cpp
@@ -119,6 +119,31 @@ ze_memory_type_t get_pointer_type(
     return memory_allocation_properties.type;
 }
 
+status_t create_kernel(ze_kernel_handle_t &kernel,
+        ze_module_handle_t module_handle, const std::string &akernel_name) {
+    std::string kernel_name(akernel_name);
+    if (kernel_name.empty()) {
+        // Re-used the approach from OCL backend.
+        // Handle cases when kernel name is not available (they mostly come from
+        // ngen) by querying the kernel name from the module.
+        uint32_t count = 1;
+        const char *name = nullptr;
+        ZE_CHECK(xpu::ze::zeModuleGetKernelNames(module_handle, &count, &name));
+
+        kernel_name = std::string(name);
+        assert(!kernel_name.empty());
+        if (kernel_name.empty()) return status::runtime_error;
+    }
+
+    ze_kernel_desc_t kernel_desc {};
+    kernel_desc.stype = ZE_STRUCTURE_TYPE_KERNEL_DESC;
+    kernel_desc.pKernelName = kernel_name.c_str();
+
+    ZE_CHECK(xpu::ze::zeKernelCreate(module_handle, &kernel_desc, &kernel));
+
+    return status::success;
+}
+
 status_t append_memory_copy(ze_command_list_handle_t list,
         std::mutex &list_mutex, void *dst, const void *src, size_t size,
         ze_event_handle_t out_event, uint32_t num_deps_events,

--- a/src/xpu/ze/utils.hpp
+++ b/src/xpu/ze/utils.hpp
@@ -291,6 +291,8 @@ xpu::device_uuid_t get_device_uuid(ze_device_handle_t device);
 status_t get_device_index(size_t *index, ze_device_handle_t device);
 std::string get_kernel_name(ze_kernel_handle_t kernel);
 ze_memory_type_t get_pointer_type(ze_context_handle_t, const void *ptr);
+status_t create_kernel(ze_kernel_handle_t &kernel,
+        ze_module_handle_t module_handle, const std::string &kernel_name);
 status_t append_memory_copy(ze_command_list_handle_t list,
         std::mutex &list_mutex, void *dst, const void *src, size_t size,
         ze_event_handle_t out_event, uint32_t num_deps_events,

--- a/tests/gtests/test_concurrency.cpp
+++ b/tests/gtests/test_concurrency.cpp
@@ -127,8 +127,13 @@ public:
 
     stream create_stream(const engine &eng) const {
         key_t key(reinterpret_cast<uint64_t>(eng.get()));
-        return create_object<stream>(
-                reuse_stream_, key, stream_mgr_, [&] { return stream(eng); });
+        return create_object<stream>(reuse_stream_, key, stream_mgr_, [&] {
+            stream::flags stream_flags = stream::flags::default_flags;
+#ifdef DNNL_EXPERIMENTAL_PROFILING
+            stream_flags |= stream::flags::profiling;
+#endif
+            return stream(eng, stream_flags);
+        });
     }
 
     template <typename T>

--- a/tests/gtests/test_concurrency.cpp
+++ b/tests/gtests/test_concurrency.cpp
@@ -287,12 +287,6 @@ protected:
         if (get_test_engine_kind() == engine::kind::gpu)
             set_primitive_cache_capacity(0);
 #endif
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_ZE
-        // Note: necessary abstractions to support concurrent kernel generation
-        // are not introduced for Level Zero backend.
-        SKIP_IF(true,
-                "Concurrent execution is not supported by Level Zero backend.");
-#endif
         // This test doesn't work properly under SDE.
         const int len = 1024;
         char value_str[len];


### PR DESCRIPTION
[MFDNN-15356](https://jira.devtools.intel.com/browse/MFDNN-15356)

OpenCL backend had a pair of `kernel_cache_t` and `kernel_wrapper_t` abstractions to handle parallel execution through cloning a kernel into a thread-local storage. That infrastructure was replaced with existing `thread_local_storage_t` abstraction for OpenCL and introduced for Level Zero backend.

The only addition required is a serialized access to `KernelLaunch` call since it is not thread-safe by design.

Feel free to propose a better names for interfaces if you feel current ones are not good enough.