### PR TITLE
Introduce sum injector

### DIFF
--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -125,8 +125,9 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
                     rhs_sp, f8_e5m2_cvt_.get(), f8_e4m3_cvt_.get()};
 
             auto st = safe_ptr_assign(postops_injector_,
-                    po_injector_t::create(
-                            this, brg.isa_impl, brg.attr()->post_ops_, bsp));
+                    po_injector_t::create(this, brg.isa_impl,
+                            brg.attr()->post_ops_, bsp,
+                            /* enable_native_sum = */ brg.with_sum));
             if (st != status::success) {
                 assert(!"postops_injector creation failed");
             }
@@ -163,7 +164,6 @@ private:
     std::unique_ptr<fp8_conversion_e4m3_t> f8_e4m3_cvt_;
 
     Xbyak::Label avx_tail_mask_;
-    Xbyak::Label sum_zp_scale_data_;
     Xbyak::Label f16_perm_even_table_;
     Xbyak::Label f16_perm_odd_table_;
     using reg64_t = const Xbyak::Reg64;
@@ -233,8 +233,6 @@ private:
     const reg64_savable_t reg_do_comp {regscratchpad_, rbx};
     const reg64_savable_t reg_skip_accm {regscratchpad_, rbx};
     const reg64_t reg_tmp_gpr = rbx;
-    const reg64_savable_t reg_ptr_sum_scale {regscratchpad_, rbx};
-    const reg64_savable_t reg_ptr_sum_zp {regscratchpad_, rbx};
     const reg64_savable_t reg_zp_a_val {regscratchpad_, rbx};
     const reg64_savable_t reg_buf {regscratchpad_, rbx, r26};
     const reg64_savable_t reg_dynamic_C_offset {regscratchpad_, rbx};
@@ -1640,7 +1638,10 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
         dim_t bd_end = bd_start + bd_block_shift;
 
         const auto set_binary_injecotr_params = [&] {
-            if (!brg.with_binary || !with_binary_non_scalar_bcast_) return;
+            // Sum post-op requires binary parameters to be set.
+            const bool set_for_binary
+                    = brg.with_binary && with_binary_non_scalar_bcast_;
+            if (!set_for_binary && !brg.with_sum) return;
             for_(dim_t bd = bd_start; bd < bd_end; bd++)
             for (dim_t ld = 0; ld < ld_block2; ld++) {
                 const auto vmm_idx = accm(ld_block2, bd, ld).getIdx();
@@ -1661,93 +1662,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
             }
         };
 
-        const auto sum_injector = [&] {
-            const float *p_sum_scale = &brg.sum_scale;
-            const int32_t *p_sum_zp = &brg.sum_zp;
-            const bool p_sum_scale_reg_set = *p_sum_scale != 1.f;
-            const bool p_sum_zp_reg_set = *p_sum_zp != 0;
-            const bool reset_avx_tail_mask = p_sum_zp_reg_set;
-
-            {
-                const reg64_savable_guard_t register_sum_fp8_guard(
-                        {{{&reg_ptr_sum_scale},
-                                 with_binary_non_scalar_bcast_
-                                         && p_sum_scale_reg_set},
-                                {{&reg_ptr_sum_zp}, p_sum_zp_reg_set},
-                                {{&reg64_fp8_aux}, brg.is_fp8_via_convert()}});
-
-                const auto &vmm_sum_zp = vmm_tmp(1);
-
-                if (p_sum_zp_reg_set) {
-                    assert(!brg.is_gemv && "feature is not supported for gemv");
-                    mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-                    if (is_superset(brg.isa_impl, avx512_core)) {
-                        vcvtdq2ps(vmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
-                    } else {
-                        uni_vpbroadcastd(vmm_sum_zp, ptr[reg_ptr_sum_zp]);
-                        uni_vcvtdq2ps(vmm_sum_zp, vmm_sum_zp);
-                    }
-                }
-
-                if (p_sum_scale_reg_set) {
-                    if (is_superset(brg.isa_impl, avx512_core)) {
-                        // embd bcast fma
-                        mov(reg_ptr_sum_scale,
-                                reinterpret_cast<size_t>(p_sum_scale));
-                    } else {
-                        lea(reg_ptr_sum_scale, ptr[rip + sum_zp_scale_data_]);
-                    }
-                }
-
-                for_(dim_t bd = bd_start; bd < bd_end; bd++)
-                for (dim_t ld = 0; ld < ld_block2; ld++) {
-                    const auto vmm = accm(ld_block2, bd, ld);
-                    const auto addr = ptr[reg_aux_D + D_offset(bd, ld)];
-                    const auto vmm_prev_dst = vmm_tmp(0);
-                    if (!brg.is_gemv) {
-                        const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-                        const auto k_mask
-                                = is_tail ? ld_tail_mask : ld_full_mask;
-                        const dim_t ld_size
-                                = is_tail ? brg.ldb_tail : brg.ld_block;
-                        cvt2ps(brg.sum_dt, vmm_prev_dst, addr, is_tail, false,
-                                k_mask, ld_size);
-                    } else {
-                        const bool use_partial_mask = !brg.gemv_acc_is_vector()
-                                || gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
-                        const auto k_mask = use_partial_mask ? gemv_partial_mask
-                                                             : gemv_full_mask;
-
-                        const dim_t elements_to_load = use_partial_mask
-                                ? brg.gemv_acc_is_vector() ? brg.gemv_tail : 1
-                                : brg.bd_block / brg.gemv_bd_block();
-                        cvt2ps(brg.sum_dt, vmm_prev_dst, addr, use_partial_mask,
-                                false, k_mask, elements_to_load);
-                    }
-
-                    if (p_sum_zp_reg_set)
-                        uni_vsubps(vmm_prev_dst, vmm_prev_dst, vmm_sum_zp);
-                    if (p_sum_scale_reg_set) {
-                        if (is_superset(brg.isa_impl, avx512_core))
-                            uni_vfmadd231ps(vmm, vmm_prev_dst,
-                                    ptr_b[reg_ptr_sum_scale]);
-                        else
-                            uni_vfmadd231ps(
-                                    vmm, vmm_prev_dst, ptr[reg_ptr_sum_scale]);
-                    } else
-                        uni_vaddps(vmm, vmm, vmm_prev_dst);
-                }
-            }
-
-            if (reset_avx_tail_mask) maybe_set_avx_mask(is_ld_tail);
-        };
-
         set_binary_injecotr_params();
-
-        if (brg.with_sum) {
-            postops_injector_->set_lambda_injector(
-                    primitive_kind::sum, sum_injector);
-        }
 
         postops_injector_->compute_vector_range(
                 max_effective_vregs - bd_end * ld_block2,
@@ -3935,20 +3850,12 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
             dd(0);
     }
 
-    if (!is_superset(brg.isa_impl, avx512_core) && brg.with_sum
-            && brg.sum_scale != 1.f) {
-        L(sum_zp_scale_data_);
-        const dim_t scale_int = float2int(brg.sum_scale);
-        for (dim_t i = 0; i < simd; ++i)
-            dd(scale_int);
-    }
-
     if (brg.is_fp8_via_convert()) {
         if (f8_e5m2_cvt_) f8_e5m2_cvt_->prepare_table();
         if (f8_e4m3_cvt_) f8_e4m3_cvt_->prepare_table();
     }
 
-    if (brg.with_eltwise)
+    if (brg.with_eltwise || brg.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 
     if (brg.is_f16_b_non_amx_vnni()) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -1637,7 +1637,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
         dim_t bd_start = bd_block_idx;
         dim_t bd_end = bd_start + bd_block_shift;
 
-        const auto set_binary_injecotr_params = [&] {
+        const auto set_binary_injector_params = [&] {
             // Sum post-op requires binary parameters to be set.
             const bool set_for_binary
                     = brg.with_binary && with_binary_non_scalar_bcast_;
@@ -1662,7 +1662,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
             }
         };
 
-        set_binary_injecotr_params();
+        set_binary_injector_params();
 
         postops_injector_->compute_vector_range(
                 max_effective_vregs - bd_end * ld_block2,

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 #include <numeric>
+#include <utility>
 #include "common/broadcast_strategy.hpp"
 #include "cpu/x64/injectors/injector_utils.hpp"
 
@@ -67,6 +68,19 @@ register_preserve_guard_t::register_preserve_guard_t(jit_generator_t *host,
                         host_->ptr[host_->rsp + stack_offset], Xbyak::Zmm(idx));
         }
     }
+}
+
+register_preserve_guard_t::register_preserve_guard_t(
+        register_preserve_guard_t &&other)
+    : host_(other.host_)
+    , reg64_stack_(std::move(other.reg64_stack_))
+    , vmm_stack_(std::move(other.vmm_stack_))
+    , vmm_to_preserve_size_bytes_(other.vmm_to_preserve_size_bytes_) {
+
+    other.host_ = nullptr;
+    other.reg64_stack_ = std::stack<Xbyak::Reg64>();
+    other.vmm_stack_ = std::stack<Xbyak::Xmm>();
+    other.vmm_to_preserve_size_bytes_ = 0;
 }
 
 register_preserve_guard_t::~register_preserve_guard_t() {

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -56,9 +56,7 @@ public:
     register_preserve_guard_t(jit_generator_t *host,
             std::initializer_list<Xbyak::Reg64> reg64_to_preserve,
             std::initializer_list<Xbyak::Xmm> vmm_to_preserve = {});
-    register_preserve_guard_t(register_preserve_guard_t &&other) = default;
-    register_preserve_guard_t &operator=(register_preserve_guard_t &&other)
-            = default;
+    register_preserve_guard_t(register_preserve_guard_t &&other);
     DNNL_DISALLOW_COPY_AND_ASSIGN(register_preserve_guard_t);
     ~register_preserve_guard_t();
     size_t stack_space_occupied() const;

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "common/math_utils.hpp"
 #include "common/primitive.hpp"
@@ -3061,6 +3062,53 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs(const data_type_t &data_type,
 }
 
 template <cpu_isa_t isa, typename Vmm>
+void jit_uni_binary_injector_t<isa, Vmm>::load_acc_as_f32(const Vmm &dst,
+        const Xbyak::Reg64 &base, size_t byte_off, data_type_t data_type,
+        bool with_tail, const tail_lode_mode_t tail_load_mode) const {
+
+    // The RHS address register, reused here to point at accumulator memory
+    // (see the declaration on reusing the RHS load path).
+    const auto addr_reg = rhs_arg_static_params_.rhs_addr_reg;
+    const bool byte_off_fits
+            = byte_off <= (size_t)std::numeric_limits<int>::max();
+
+    // The address needs its own register (`addr_reg`) when it cannot be
+    // represented as a `[base + disp]` operand. Two cases force that:
+    //   1. AVX2 tail loads: the helper reads the pointer from `addr_reg` and
+    //      ignores the operand.
+    //   2. A byte offset that doesn't fit int range.
+    // No-tail and AVX-512 opmask tail loads take the operand directly.
+    const bool need_scratch_reg = (with_tail && !is_avx512_) || !byte_off_fits;
+
+    // This is a direct entry point so the register-preserve guard is not in
+    // effect here. Since we need to follow the defined ABI we preserve the
+    // helper GPRs when the caller requested it.
+    const bool preserve_gpr = rhs_arg_static_params_.preserve_gpr_helpers;
+    if (need_scratch_reg) {
+        if (preserve_gpr) host_->push(addr_reg);
+
+        if (byte_off_fits) {
+            host_->lea(addr_reg, host_->ptr[base + (int)byte_off]);
+        } else {
+            // Use a scratch register to handle large offsets.
+            const auto tmp_reg = rhs_arg_static_params_.rhs_helper_reg;
+            if (preserve_gpr) host_->push(tmp_reg);
+
+            host_->mov(tmp_reg, byte_off);
+            host_->lea(addr_reg, host_->ptr[base + tmp_reg]);
+
+            if (preserve_gpr) host_->pop(tmp_reg);
+        }
+    }
+    const auto addr = need_scratch_reg ? host_->ptr[addr_reg]
+                                       : host_->ptr[base + (int)byte_off];
+    load_rhs(data_type, dst, addr, tail_load_mode, with_tail);
+
+    if (types::is_integral_dt(data_type)) cvt_to_f32(dst);
+    if (need_scratch_reg && preserve_gpr) host_->pop(addr_reg);
+}
+
+template <cpu_isa_t isa, typename Vmm>
 Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::remove_bcast_bit(
         const Xbyak::Address &rhs_addr) const {
     return Xbyak::Address(rhs_addr.getBit(), false, rhs_addr.getRegExp());
@@ -3591,7 +3639,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
         case data_type::f16:
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, rhs_addr);
-            else if (isa == avx2_vnni_2)
+            else if (is_avx512_ || isa == avx2_vnni_2)
+                // `is_avx512_` is allowed here to enable `load_acc_as_f32`.
                 host_->vcvtph2ps(tmp_vmm, rhs_addr);
             else
                 assert(!"unsupported ISA for given data type");
@@ -3676,7 +3725,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_dynamically_with_opmask(
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm | tail_opmask | host_->T_z, rhs_addr);
             else
-                assert(!"unsupported masked tail processing");
+                // This branch exists to enable `load_acc_as_f32` on avx512_core
+                host_->vcvtph2ps(tmp_vmm | tail_opmask | host_->T_z, rhs_addr);
             break;
         case data_type::f8_e5m2:
             assert(f8_e5m2_cvt_);

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -3639,8 +3639,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
         case data_type::f16:
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, rhs_addr);
-            else if (is_avx512_ || isa == avx2_vnni_2)
-                // `is_avx512_` is allowed here to enable `load_acc_as_f32`.
+            else if (isa == avx2_vnni_2)
                 host_->vcvtph2ps(tmp_vmm, rhs_addr);
             else
                 assert(!"unsupported ISA for given data type");
@@ -3725,8 +3724,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_dynamically_with_opmask(
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm | tail_opmask | host_->T_z, rhs_addr);
             else
-                // This branch exists to enable `load_acc_as_f32` on avx512_core
-                host_->vcvtph2ps(tmp_vmm | tail_opmask | host_->T_z, rhs_addr);
+                assert(!"unsupported masked tail processing");
             break;
         case data_type::f8_e5m2:
             assert(f8_e5m2_cvt_);

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -305,6 +305,18 @@ public:
             const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
+    /*
+     * Reads a value from `base + byte_off` into vmm `dst` as f32, reusing the
+     * RHS load path (`load_rhs` and its helpers). The sum post-op uses it to
+     * read the accumulator's previous value, so the RHS infrastructure
+     * (`rhs_addr_reg`, tail mask, integer-to-f32 conversion) operates on
+     * accumulator memory. `byte_off` values past `int` range go through a
+     * scratch register.
+     */
+    void load_acc_as_f32(const Vmm &dst, const Xbyak::Reg64 &base,
+            size_t byte_off, data_type_t data_type, bool with_tail,
+            tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT) const;
+
 private:
     /*
      * Determines if hint passed by user is valid (is inside range

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 #include <cassert>
+#include <vector>
 #include "common/verbose.hpp"
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 
@@ -56,15 +57,18 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params,
-        const lambda_jit_injectors_t &lambda_jit_injectors)
+        const lambda_jit_injectors_t &lambda_jit_injectors,
+        bool enable_native_sum)
     : post_ops_(post_ops)
     , host_(host)
     , binary_injector_(nullptr)
-    , lambda_jit_injectors_(lambda_jit_injectors) {
+    , lambda_jit_injectors_(lambda_jit_injectors)
+    , sum_is_native_(enable_native_sum) {
 
     const auto &esp = eltwise_static_params;
     bool is_like_binary = false;
     bool is_eltwise = false;
+    bool is_sum = false;
 
     for (int i = 0; i < post_ops.len(); i++) {
         const auto &post_op = post_ops.entry_[i];
@@ -81,6 +85,8 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
                             esp.preserve_vmm, esp.preserve_p_table));
         } else if (post_op.is_like_binary()) {
             is_like_binary = true;
+        } else if (post_op.is_sum(false, false)) {
+            is_sum = true;
         }
     }
 
@@ -92,10 +98,28 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
                 injector opmask. Otherwise eltwise injector will overwrite \
                 binary tail opmask.");
 
-    if (is_like_binary)
+    // Native sum reads the previous value through the binary injector's load
+    // path so the binary injector is created for a sum-only chain as well.
+    if (is_like_binary || is_sum)
         binary_injector_ = utils::make_unique<
                 binary_injector::jit_uni_binary_injector_t<isa, Vmm>>(
                 host, binary_static_params);
+
+    // Build one sum injector per sum post-op when the caller opted in to
+    // native sum.
+    if (is_sum && sum_is_native_) {
+        const auto &rhs = binary_static_params.rhs_arg_static_params;
+        const auto dst_dt = rhs.dst_d.data_type();
+        for (int i = 0; i < post_ops.len(); i++) {
+            const auto &post_op = post_ops.entry_[i];
+            if (!post_op.is_sum(false, false)) continue;
+
+            idx_to_sum_injector_.emplace(i,
+                    jit_uni_sum_injector_t<isa, Vmm>(host_, post_op.sum, dst_dt,
+                            binary_injector_.get(), rhs.rhs_dt_helper_vmm_idx,
+                            rhs.preserve_vmm_helper));
+        }
+    }
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -128,13 +152,15 @@ jit_uni_postops_injector_base_t<Xbyak::Zmm> *
 jit_uni_postops_injector_base_t<Xbyak::Zmm>::create(jit_generator_t *host,
         cpu_isa_t isa, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params) {
+        const eltwise_injector::static_params_t &eltwise_static_params,
+        bool enable_native_sum) {
 
 // Exact match case goes first and required to force `isa` passed by user.
 #define CASE_EXACT_MATCH(_isa) \
     if (isa == (_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Zmm>( \
-                host, post_ops, binary_static_params, eltwise_static_params);
+        return new jit_uni_postops_injector_t<_isa, Xbyak::Zmm>(host, \
+                post_ops, binary_static_params, eltwise_static_params, \
+                lambda_jit_injectors_t(), enable_native_sum);
 
     CASE_EXACT_MATCH(avx512_core_fp16);
     CASE_EXACT_MATCH(avx512_core_bf16);
@@ -146,8 +172,9 @@ jit_uni_postops_injector_base_t<Xbyak::Zmm>::create(jit_generator_t *host,
 // not every ISA has instances in post-ops injector.
 #define CASE_MAYIUSE(_isa) \
     if (mayiuse(_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Zmm>( \
-                host, post_ops, binary_static_params, eltwise_static_params);
+        return new jit_uni_postops_injector_t<_isa, Xbyak::Zmm>(host, \
+                post_ops, binary_static_params, eltwise_static_params, \
+                lambda_jit_injectors_t(), enable_native_sum);
 
     CASE_MAYIUSE(avx512_core_fp16);
     CASE_MAYIUSE(avx512_core_bf16);
@@ -164,13 +191,15 @@ jit_uni_postops_injector_base_t<Xbyak::Ymm> *
 jit_uni_postops_injector_base_t<Xbyak::Ymm>::create(jit_generator_t *host,
         cpu_isa_t isa, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params) {
+        const eltwise_injector::static_params_t &eltwise_static_params,
+        bool enable_native_sum) {
 
 // Exact match case goes first and required to force `isa` passed by user.
 #define CASE_EXACT_MATCH(_isa) \
     if (isa == (_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Ymm>( \
-                host, post_ops, binary_static_params, eltwise_static_params);
+        return new jit_uni_postops_injector_t<_isa, Xbyak::Ymm>(host, \
+                post_ops, binary_static_params, eltwise_static_params, \
+                lambda_jit_injectors_t(), enable_native_sum);
 
     CASE_EXACT_MATCH(avx512_core_fp16);
     CASE_EXACT_MATCH(avx512_core);
@@ -184,8 +213,9 @@ jit_uni_postops_injector_base_t<Xbyak::Ymm>::create(jit_generator_t *host,
 // not every ISA has instances in post-ops injector.
 #define CASE_MAYIUSE(_isa) \
     if (mayiuse(_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Ymm>( \
-                host, post_ops, binary_static_params, eltwise_static_params);
+        return new jit_uni_postops_injector_t<_isa, Xbyak::Ymm>(host, \
+                post_ops, binary_static_params, eltwise_static_params, \
+                lambda_jit_injectors_t(), enable_native_sum);
 
     CASE_MAYIUSE(avx512_core_fp16);
     CASE_MAYIUSE(avx512_core);
@@ -204,13 +234,15 @@ jit_uni_postops_injector_base_t<Xbyak::Xmm> *
 jit_uni_postops_injector_base_t<Xbyak::Xmm>::create(jit_generator_t *host,
         cpu_isa_t isa, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params) {
+        const eltwise_injector::static_params_t &eltwise_static_params,
+        bool enable_native_sum) {
 
 // Exact match case goes first and required to force `isa` passed by user.
 #define CASE_EXACT_MATCH(_isa) \
     if (isa == (_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Xmm>( \
-                host, post_ops, binary_static_params, eltwise_static_params);
+        return new jit_uni_postops_injector_t<_isa, Xbyak::Xmm>(host, \
+                post_ops, binary_static_params, eltwise_static_params, \
+                lambda_jit_injectors_t(), enable_native_sum);
 
     CASE_EXACT_MATCH(avx512_core_fp16);
     CASE_EXACT_MATCH(avx512_core);
@@ -225,8 +257,9 @@ jit_uni_postops_injector_base_t<Xbyak::Xmm>::create(jit_generator_t *host,
 // not every ISA has instances in post-ops injector.
 #define CASE_MAYIUSE(_isa) \
     if (mayiuse(_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Xmm>( \
-                host, post_ops, binary_static_params, eltwise_static_params);
+        return new jit_uni_postops_injector_t<_isa, Xbyak::Xmm>(host, \
+                post_ops, binary_static_params, eltwise_static_params, \
+                lambda_jit_injectors_t(), enable_native_sum);
 
     CASE_MAYIUSE(avx512_core_fp16);
     CASE_MAYIUSE(avx512_core);
@@ -245,10 +278,11 @@ template <typename Vmm>
 jit_uni_postops_injector_base_t<Vmm> *
 jit_uni_postops_injector_base_t<Vmm>::create(jit_generator_t *host,
         cpu_isa_t isa, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params) {
+        const binary_injector::static_params_t &binary_static_params,
+        bool enable_native_sum) {
     const eltwise_injector::static_params_t eltwise_static_params;
-    return create(
-            host, isa, post_ops, binary_static_params, eltwise_static_params);
+    return create(host, isa, post_ops, binary_static_params,
+            eltwise_static_params, enable_native_sum);
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -286,6 +320,9 @@ void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
             // Ternary op handles two arguments at the same time, thus,
             // skipping one more.
             if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
+        } else if (sum_is_native_ && post_op.is_sum(false, false)) {
+            idx_to_sum_injector_.at(i).compute_vector_range(
+                    vmm_idxs, rhs_arg_params);
         } else {
             const auto lam = lambda_jit_injectors_.find(post_op.kind);
             if (lam != lambda_jit_injectors_.end()) lam->second();
@@ -302,6 +339,12 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_postops_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
     for (auto &alg_elt_inject : alg_to_eltwise_injector_)
         alg_elt_inject.second.prepare_table(gen_table);
+
+    // Sum injectors emit their scale/zero-point constants here, similar to the
+    // eltwise loop above.
+    if (sum_is_native_)
+        for (auto &kv : idx_to_sum_injector_)
+            kv.second.prepare_table(gen_table);
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -27,6 +27,7 @@
 #include "cpu/x64/injectors/injector_utils.hpp"
 #include "cpu/x64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
+#include "cpu/x64/injectors/jit_uni_sum_injector.hpp"
 #include "cpu/x64/jit_generator.hpp"
 #include <initializer_list>
 
@@ -65,14 +66,22 @@ public:
     // cases it's aligned with the former kernel ISA if such enum value is
     // instantiated for injectors. If not, uses the next available isa enum
     // value in compliance with same vector length.
+    //
+    // `enable_native_sum` opts in to handling the sum post-op inside the
+    // injector instead of through a caller-provided lambda. Native sum reads
+    // the previous value from the address supplied per accumulator in
+    // `rhs_arg_dynamic_params_t`, so the caller must provide it (as it does for
+    // binary post-ops).
     static jit_uni_postops_injector_base_t *create(jit_generator_t *host,
             cpu_isa_t isa, const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
-            const eltwise_injector::static_params_t &eltwise_static_params);
+            const eltwise_injector::static_params_t &eltwise_static_params,
+            bool enable_native_sum = false);
 
     static jit_uni_postops_injector_base_t *create(jit_generator_t *host,
             cpu_isa_t isa, const post_ops_t &post_ops,
-            const binary_injector::static_params_t &binary_static_params);
+            const binary_injector::static_params_t &binary_static_params,
+            bool enable_native_sum = false);
 
     virtual ~jit_uni_postops_injector_base_t() = default;
 
@@ -125,6 +134,9 @@ public:
      * params for eltwise_injector
      * @param lambda_jit_injectors <optional> - allows user specify custom injector
      * function for given post-op type
+     * @param enable_native_sum <optional> - handle the sum post-op inside the
+     * injector instead of through a caller-provided lambda (see the `create`
+     * documentation for the caller's obligations)
      */
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
@@ -137,11 +149,14 @@ public:
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
             const eltwise_injector::static_params_t &eltwise_static_params);
+    // This is the delegation target for the other constructors and the only one
+    // that carries `enable_native_sum`, since it owns all construction state.
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
             const eltwise_injector::static_params_t &eltwise_static_params,
-            const lambda_jit_injectors_t &lambda_jit_injectors);
+            const lambda_jit_injectors_t &lambda_jit_injectors,
+            bool enable_native_sum = false);
 
     ~jit_uni_postops_injector_t() override = default;
 
@@ -181,7 +196,14 @@ private:
             alg_to_eltwise_injector_;
     std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa, Vmm>>
             binary_injector_;
+    // Native sum injectors, one per sum post-op, keyed by post-op index same as
+    // `alg_to_eltwise_injector_`. They contain a `binary_injector_` pointer but
+    // do not own it. Keep `idx_to_sum_injector_` after the `binary_injector_`
+    // field, just in case.
+    std::map<int, jit_uni_sum_injector_t<isa, Vmm>> idx_to_sum_injector_;
     lambda_jit_injectors_t lambda_jit_injectors_;
+    // When set, a sum entry is handled by the sum injector instead of a lambda.
+    const bool sum_is_native_;
 };
 
 enum post_op_type { sum = 0, eltwise, binary, prelu };

--- a/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
@@ -1,0 +1,159 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include <cassert>
+
+#include "common/utils.hpp"
+
+#include "cpu/x64/injectors/jit_uni_sum_injector.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+template <cpu_isa_t isa, typename Vmm>
+jit_uni_sum_injector_t<isa, Vmm>::jit_uni_sum_injector_t(jit_generator_t *host,
+        const post_ops_t::entry_t::sum_t &sum, data_type_t dst_dt,
+        binary_injector::jit_uni_binary_injector_t<isa, Vmm> *binary_injector,
+        size_t scratch_vmm_idx, bool preserve_scratch_vmm)
+    : host_(host)
+    , binary_injector_(binary_injector)
+    , sum_dt_(sum.dt == data_type::undef ? dst_dt : sum.dt)
+    , scale_val_(sum.scale)
+    , zp_val_((float)sum.zero_point)
+    , has_scale_(scale_val_ != 1.f)
+    , has_zp_(sum.zero_point != 0)
+    , scratch_vmm_idx_(scratch_vmm_idx)
+    , preserve_scratch_vmm_(preserve_scratch_vmm) {
+
+    // The inputs are borrowed from the binary injector's static params so
+    // we want to check that the caller populated them for real use. An undef
+    // read type means `dst_d` was left unset.
+    assert(binary_injector_ && "native sum requires the binary injector");
+    assert(sum_dt_ != data_type::undef
+            && "native sum read type is undef: binary static params unset");
+}
+
+template <cpu_isa_t isa, typename Vmm>
+void jit_uni_sum_injector_t<isa, Vmm>::compute_vector_range(
+        const injector_utils::vmm_index_set_t &vmm_idxs,
+        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
+
+    assert(binary_injector_ && "native sum needs the binary injector");
+    if (vmm_idxs.empty()) return;
+
+    // If a user-provided scratch register happens to be one of the
+    // accumulators, pick a new free register.
+    const int max_idx = cpu_isa_traits_t<isa>::n_vregs - 1;
+    const int scratch = (int)scratch_vmm_idx_;
+
+    int tmp_idx = scratch;
+    bool scratch_changed = false;
+
+    if (vmm_idxs.find((size_t)scratch) != vmm_idxs.end()) {
+        for (int idx = max_idx; idx >= 0; idx--) {
+            if (vmm_idxs.find((size_t)idx) == vmm_idxs.end()) {
+                // Found a free register.
+                tmp_idx = idx;
+                scratch_changed = true;
+                break;
+            }
+        }
+    }
+
+    assert(vmm_idxs.find((size_t)tmp_idx) == vmm_idxs.end()
+            && "native sum could not find a free scratch vector register");
+
+    // Preserve when the caller asked to or whenever we picked a new scratch.
+    // The new scratch register is not the caller's designated scratch so its
+    // prior contents must be saved regardless of `preserve_scratch_vmm_`.
+    const bool preserve_tmp = preserve_scratch_vmm_ || scratch_changed;
+    const injector_utils::conditional_register_preserve_guard_t tmp_guard {
+            preserve_tmp, host_, {}, {Vmm(tmp_idx)}};
+
+    const Vmm prev(tmp_idx);
+
+    for (const auto vmm_idx : vmm_idxs) {
+        const int idx = (int)vmm_idx;
+        const Vmm acc(idx);
+
+        const auto reg_it = rhs_arg_params.vmm_idx_to_out_reg.find(idx);
+        assert(reg_it != rhs_arg_params.vmm_idx_to_out_reg.end()
+                && "native sum needs the destination base-address register per "
+                   "accumulator");
+
+        const auto off_it
+                = rhs_arg_params.vmm_idx_to_out_elem_off_val.find(idx);
+        const size_t off
+                = off_it != rhs_arg_params.vmm_idx_to_out_elem_off_val.end()
+                ? off_it->second
+                : 0;
+
+        const bool with_tail = rhs_arg_params.vmm_tail_idx_.count(idx) > 0;
+
+        binary_injector_->load_acc_as_f32(
+                prev, reg_it->second, off, sum_dt_, with_tail);
+
+        if (has_zp_)
+            host_->uni_vsubps(prev, prev, host_->ptr[host_->rip + zp_lbl_]);
+
+        if (has_scale_) {
+            host_->uni_vfmadd231ps(
+                    acc, prev, host_->ptr[host_->rip + scale_lbl_]);
+        } else
+            host_->uni_vaddps(acc, acc, prev);
+    }
+}
+
+template <cpu_isa_t isa, typename Vmm>
+void jit_uni_sum_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
+    if (!gen_table || (!has_scale_ && !has_zp_)) return;
+
+    const int simd = cpu_isa_traits_t<isa>::vlen / (int)sizeof(float);
+    const auto store_value = [&](float val) {
+        for (int i = 0; i < simd; i++)
+            host_->dd(float2int(val));
+    };
+    host_->align(64);
+    if (has_scale_) {
+        host_->L(scale_lbl_);
+        store_value(scale_val_);
+    }
+    if (has_zp_) {
+        host_->L(zp_lbl_);
+        store_value(zp_val_);
+    }
+}
+
+template class jit_uni_sum_injector_t<avx512_core_fp16, Xbyak::Zmm>;
+template class jit_uni_sum_injector_t<avx512_core_fp16, Xbyak::Ymm>;
+template class jit_uni_sum_injector_t<avx512_core_fp16, Xbyak::Xmm>;
+template class jit_uni_sum_injector_t<avx512_core_bf16, Xbyak::Zmm>;
+template class jit_uni_sum_injector_t<avx512_core, Xbyak::Zmm>;
+template class jit_uni_sum_injector_t<avx512_core, Xbyak::Ymm>;
+template class jit_uni_sum_injector_t<avx512_core, Xbyak::Xmm>;
+template class jit_uni_sum_injector_t<avx2_vnni_2, Xbyak::Ymm>;
+template class jit_uni_sum_injector_t<avx2_vnni_2, Xbyak::Xmm>;
+template class jit_uni_sum_injector_t<avx2, Xbyak::Ymm>;
+template class jit_uni_sum_injector_t<avx2, Xbyak::Xmm>;
+template class jit_uni_sum_injector_t<avx, Xbyak::Ymm>;
+template class jit_uni_sum_injector_t<avx, Xbyak::Xmm>;
+template class jit_uni_sum_injector_t<sse41, Xbyak::Xmm>;
+
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/injectors/jit_uni_sum_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_sum_injector.hpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_INJECTORS_JIT_UNI_SUM_INJECTOR_HPP
+#define CPU_X64_INJECTORS_JIT_UNI_SUM_INJECTOR_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/primitive_attr.hpp"
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/injectors/injector_utils.hpp"
+#include "cpu/x64/injectors/jit_uni_binary_injector.hpp"
+#include "cpu/x64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+// Injects the sum post-op: acc += scale * (prev - zp), where `prev` is the
+// accumulator's previous in-memory value read as f32.
+//
+// The typed, tail-aware read is delegated to the binary injector
+// (`load_acc_as_f32`), so this injector only owns the sum arithmetic, the
+// scale/zero-point constants and the single scratch vector register.
+template <cpu_isa_t isa, typename Vmm = typename cpu_isa_traits_t<isa>::Vmm>
+class jit_uni_sum_injector_t {
+public:
+    // `sum` supplies the scale, zero-point and read data type. When
+    // `sum.dt == undef` the read type falls back to `dst_dt`.
+    // `binary_injector` provides the load path and must outlive this injector.
+    // `scratch_vmm_idx` is the binary injector's helper vmm, reused as the only
+    // scratch since the two never use that vmm at once in one chain. It is
+    // preserved when `preserve_scratch_vmm` is set.
+    jit_uni_sum_injector_t(jit_generator_t *host,
+            const post_ops_t::entry_t::sum_t &sum, data_type_t dst_dt,
+            binary_injector::jit_uni_binary_injector_t<isa, Vmm>
+                    *binary_injector,
+            size_t scratch_vmm_idx, bool preserve_scratch_vmm);
+
+    // Computes `acc += scale * (prev - zp)` for each accumulator in `vmm_idxs`.
+    // The per-accumulator destination address (register + element offset) and
+    // tail flag come from `rhs_arg_params`, exactly as for binary post-ops.
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+
+    // Creates a table with the scale and zero-point constants used by
+    // `compute_vector_range()`. Default values (scale == 1, zero-point == 0)
+    // are omitted.
+    void prepare_table(bool gen_table);
+
+private:
+    jit_generator_t *host_;
+    binary_injector::jit_uni_binary_injector_t<isa, Vmm> *binary_injector_;
+
+    // Read type for the previous value (`sum.dt` or `dst_dt` when undefined).
+    const data_type_t sum_dt_;
+    const float scale_val_;
+    // The zero-point is an integer attribute but applied in f32, so it is
+    // stored already converted to f32.
+    const float zp_val_;
+
+    const bool has_scale_;
+    const bool has_zp_;
+
+    const size_t scratch_vmm_idx_;
+    const bool preserve_scratch_vmm_;
+
+    Xbyak::Label scale_lbl_;
+    Xbyak::Label zp_lbl_;
+};
+
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
The current design of the post-op injector driver (the high level layer) requires each kernel to define and set up a `sum_injector` lambda, which is essentially an injector for the injector. The injector driver calls this lambda to generate code for the sum post-op. Based on the comment in the code, it seems that the design was driven by the assumption that a generic sum injector was unreasonable to implement:

> There are post-op types (for example, sum) that don't have a specialized injector. They heavily rely on kernel-specific internals, which makes generalization unreasonable. Therefore, the user can prepare a kernel-specific lambda and pass it explicitly to the injector.

This PR introduces a generic sum injector that becomes part of the existing injector family (eltwise and binary). It reuses the binary injector's capabilities to load the "prev" data, which is the most complex part of the implementation. The rest of the sum injector is fairly straightforward.

As a first step, I enabled it in `jit_brgemm_kernel.cpp`. Enabling it in other kernels is straightforward and I plan to do so in subsequent PRs.

The new sum injector allows us to remove the `sum_requires_same_params` limitation once the migration is complete.

The main motivation for this work was the IR effort, because the existing sum post-op design was not compatible with IR. Now it's compatible and we can remove those lambdas from ~35 kernels.