### PR TITLE
[GPU] Fix unimplemented SDPA cases on CRI

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -1659,6 +1659,13 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
     if (state.repackB) {
 	    state.Br_layout = RegisterLayout(hw, Tb, strategy.kb_load, unrollN, state.B_layout.colMajor(), crosspackB, tileK_B, tileN_B, true, splitB);
     }
+
+    int opCountAB = outerProductCount(problem, strategy);
+    if ((state.repackA ? state.Ar_layout.cols() : state.A_layout.cols()) < opCountAB)
+        stub("A k-granularity too small for outer product count");
+    if ((state.repackB ? state.Br_layout.rows() : state.B_layout.rows()) < opCountAB)
+        stub("B k-granularity too small for outer product count");
+
     // Prepare to repack C if needed, and choose repack tile size.
     if (Tc != Tc_compute || problem.forceLateQuant(minOuterProductCount(problem, strategy))) {
         auto &period = state.cRepackPeriod;

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -290,14 +290,10 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
         // On CRI, dpas fwd modifier is required for optimal compute throughput
         maskedOPCount *= 2;
 
-    if (!slmA) {
-        ka_load = align_up(ka_load, opCount);
-        ka_load_masked = align_up(ka_load_masked, maskedOPCount);
-    }
-    if (!slmB) {
-        kb_load = align_up(kb_load, opCount);
-        kb_load_masked = align_up(kb_load_masked, maskedOPCount);
-    }
+    ka_load = align_up(ka_load, opCount);
+    kb_load = align_up(kb_load, opCount);
+    ka_load_masked = align_up(ka_load_masked, maskedOPCount);
+    kb_load_masked = align_up(kb_load_masked, maskedOPCount);
 
     if (ka_load == 0 || kb_load == 0)
         stub("Zero k-load granularity is invalid");
@@ -364,6 +360,20 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     A.address2D &= !isPacked(problem.A.layout);
     B.address2D &= !isPacked(problem.B.layout);
 
+    // SLM staging must cover the k-loads, on the main and the masked path.
+    int minUnrollKSLM = 1, minUnrollKSLMMasked = 1;
+    if (slmA) {
+        minUnrollKSLM = lcm(minUnrollKSLM, ka_load);
+        minUnrollKSLMMasked = lcm(minUnrollKSLMMasked, lcm(ka_load, ka_load_masked));
+    }
+    if (slmB) {
+        minUnrollKSLM = lcm(minUnrollKSLM, kb_load);
+        minUnrollKSLMMasked = lcm(minUnrollKSLMMasked, lcm(kb_load, kb_load_masked));
+    }
+
+    if (unrollKSLM > 0) minUnrollKSLM = unrollKSLM = lcm(unrollKSLM, minUnrollKSLM);
+    if (unrollKSLMMasked > 0) unrollKSLMMasked = lcm(unrollKSLMMasked, minUnrollKSLMMasked);
+
     // k interleaving chunk size.
     if (kInterleave) {
         int kchunk0 = lcm(ka_inc(), kb_inc());
@@ -390,14 +400,6 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     }
     if (ka_pfStride) ukAlign = lcm(ukAlign, ka_pfStride);
     if (kb_pfStride) ukAlign = lcm(ukAlign, kb_pfStride);
-
-    int minUnrollKSLM = 1;
-    if (unrollKSLM > 0)
-        minUnrollKSLM = unrollKSLM;
-    else {
-        if (slmA) minUnrollKSLM = lcm(minUnrollKSLM, ka_load);
-        if (slmB) minUnrollKSLM = lcm(minUnrollKSLM, kb_load);
-    }
 
     ukAlign = lcm(ukAlign, minUnrollKSLM * slmVersions);
 


### PR DESCRIPTION
PR fixes [MFDNN-15403](https://jira.devtools.intel.com/browse/MFDNN-15403).

The issue is caused by incompatibility between `kb_load = 16` and `kChain = 2`. `GEMMStrategy::preflight()` has a fixup in case of non-SLM loads but skips SLM loads: https://github.com/uxlfoundation/oneDNN/blob/b7bfe8bf3c252d31bcbf93d30b617897a1e447be/src/gpu/intel/gemm/jit/generator/strategy.cpp#L297-L300

The PR extends it to SLM also adjusting `unrollKSLM` accordingly. PR also introduces a diagnostic to catch similar issues in the future with a more clear message.