### PR TITLE
cpu: rv64: resampling: add RVV JIT forward (f32/f16, nearest/linear)

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -343,6 +343,7 @@ enum {
     key_wino_V,
     key_wino_M,
     key_binary_post_ops_expanded_rhs,
+    key_binary_post_ops_rhs_ptrs,
     // These two keys should always be the last ones,
     // even though they are not in alphabetical order
     key_nested,

--- a/src/cpu/cpu_resampling_list.cpp
+++ b/src/cpu/cpu_resampling_list.cpp
@@ -25,6 +25,11 @@
 using namespace dnnl::impl::cpu::x64;
 #endif
 
+#if DNNL_RV64
+#include "cpu/rv64/jit_uni_resampling.hpp"
+using namespace dnnl::impl::cpu::rv64;
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -38,6 +43,8 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
     static std::map<pk_impl_key_t, std::vector<impl_list_item_t>> the_map = REG_RESAMPLING_P({
         {{forward}, {
             CPU_INSTANCE_X64(jit_uni_resampling_fwd_t)
+            CPU_INSTANCE_RV64(jit_uni_resampling_fwd_t<zvfh>)
+            CPU_INSTANCE_RV64(jit_uni_resampling_fwd_t<v>)
             CPU_INSTANCE(simple_resampling_fwd_t)
             CPU_INSTANCE(ref_resampling_fwd_t)
             nullptr,

--- a/src/cpu/rv64/jit_primitive_conf.hpp
+++ b/src/cpu/rv64/jit_primitive_conf.hpp
@@ -228,17 +228,8 @@ struct jit_uni_pool_bwd_args_t {
     dim_t ws_vec_byte_stride; // ws channel stride (max; ncsp: OD*OH*OW*ind_sz)
 };
 
-// Memory layout family handled by the resampling kernel. The vector always runs
-// along the channel dimension: nspc has channels innermost (unit-stride vector
-// over C); ncsp has channels outermost (vector over C strided by the spatial
-// size); blocked (nCxc) vectorizes over the inner channel block (unit stride),
-// with the driver iterating the outer C-blocks.
-enum class jit_resampling_tag_kind_t { undef, nspc, ncsp, blocked };
-
-// Resampling configuration, populated by jit_uni_resampling_kernel_t::init_conf
-// and consumed by the driver and the kernel. Forward; f32 (isa v) or f16
-// (isa zvfh); nearest and linear (bi/trilinear) interpolation on nspc/ncsp/
-// blocked layouts, with an optional fused post-op chain.
+// Resampling forward configuration, filled by init_conf, read by the driver
+// and the kernel.
 struct jit_resampling_conf_t {
     int ndims;
     int mb, c;
@@ -246,51 +237,50 @@ struct jit_resampling_conf_t {
     alg_kind_t alg; // resampling_nearest or resampling_linear
     data_type_t data_type; // f32 or f16
     int dt_size;
-    jit_resampling_tag_kind_t tag_kind;
-    int block; // inner channel block for the blocked layout (16 or 8); else 0
+    // Layout, in elements, taken from the blocking descriptors (not tags). The
+    // vector runs along C; the kernel tests c_stride at run time to pick
+    // unit-stride or strided access. block is the channel inner block, 1 when
+    // plain: channels are contiguous inside a block (c_stride 1, cb_stride
+    // steps between blocks), while a plain layout is one group (cb_stride 0).
+    int block;
+    dim_t src_c_stride, dst_c_stride;
+    dim_t src_cb_stride, dst_cb_stride;
+    dim_t src_mb_stride, dst_mb_stride;
+    dim_t src_d_stride, src_h_stride, src_w_stride;
+    dim_t dst_d_stride, dst_h_stride, dst_w_stride;
     cpu_isa_t isa;
     // Source points combined per output point: 1 for nearest; for linear
     // 1 << (spatial dims) = 2 (1D) / 4 (2D) / 8 (3D).
     int num_corners;
-    // Post-ops fused in-kernel via the injector (mirrors rv64 pooling): an
-    // eltwise chain (f32 and f16, computed at f32), plus at most one binary
-    // (f32 only, positioned host-side per output point).
+    // Injector-fused post-ops: an eltwise chain (f32/f16, computed at f32) plus
+    // at most one binary (f32 only).
     bool with_postops;
     bool fuse_eltwise;
     bool fuse_binary;
-    // A sum post-op (dst = sum_scale * dst + result) applied in-kernel at its
-    // position in the chain: the injector skips sum entries, so the kernel
-    // reads dst back, scales it in, and applies the surrounding entries as two
-    // sub-ranges. sum_idx is that position; -1 when there is no sum.
+    // sum (dst = sum_scale * dst + result). The injector skips sum entries, so
+    // the kernel applies it itself at sum_idx; -1 when there is no sum.
     bool fuse_sum;
     int sum_idx;
     float sum_scale;
     post_ops_t post_ops;
 };
 
-// Per-output-point kernel arguments. The driver computes the (up to 8) source
-// corner pointers and their interpolation weights on the host (via
-// resampling_utils, the same math as ref_resampling); the kernel combines the
-// corners' channel vectors. The vector runs along C: unit-stride for nspc and
-// blocked, strided by the spatial size for ncsp (one routine serves all three).
+// Per-output-point kernel arguments. The driver resolves the corner pointers
+// and weights on the host via resampling_utils (the same math as ref); the
+// kernel combines their channel vectors.
 struct jit_resampling_args_t {
-    // Channel-0 pointers of each source corner. Nearest uses src[0] only; linear
-    // uses conf.num_corners of them.
+    // Channel-0 of each source corner; conf.num_corners of them are live.
     const void *src[8];
     void *dst;
-    // Per-corner interpolation weight (product of the 1D linear weights). Unused
-    // for nearest (num_corners == 1: the single corner is copied verbatim).
+    // Product of the 1D linear weights per corner; unused for nearest.
     float weights[8];
     dim_t channels; // channels to combine (the vector work)
     dim_t src_vec_byte_stride; // byte stride between consecutive channels in src
     dim_t dst_vec_byte_stride; // byte stride between consecutive channels in dst
-    // Binary post-op rhs for the injector's indirect mode (same contract as
-    // pooling): post_op_rhs is the base of the per-binary src1 ORIGIN pointer
-    // array (one f32 pointer per binary, in attribute order); post_op_off0 is
-    // the shared byte offset of the first active lane -- 0 for scalar, the
-    // channel-group offset for per-oc, and this output position's channel-0
-    // element offset (* sizeof(f32)) for full-dst. The kernel advances the
-    // offset per channel chunk. Unused when no binary is fused.
+    // Binary rhs for the injector's indirect mode, as in pooling: post_op_rhs
+    // is the per-binary src1 origin pointer array, post_op_off0 the shared byte
+    // offset of the first active lane (0 scalar, channel-group per-oc, this
+    // point's channel-0 element offset full-dst). The kernel advances it.
     const void *post_op_rhs = nullptr;
     dim_t post_op_off0 = 0;
 };

--- a/src/cpu/rv64/jit_primitive_conf.hpp
+++ b/src/cpu/rv64/jit_primitive_conf.hpp
@@ -228,6 +228,66 @@ struct jit_uni_pool_bwd_args_t {
     dim_t ws_vec_byte_stride; // ws channel stride (max; ncsp: OD*OH*OW*ind_sz)
 };
 
+// Memory layout family handled by the resampling kernel. The vector always runs
+// along the channel dimension: nspc has channels innermost (unit-stride vector
+// over C); ncsp has channels outermost (vector over C strided by the spatial
+// size); blocked (nCxc) vectorizes over the inner channel block (unit stride),
+// with the driver iterating the outer C-blocks.
+enum class jit_resampling_tag_kind_t { undef, nspc, ncsp, blocked };
+
+// Resampling configuration, populated by jit_uni_resampling_kernel_t::init_conf
+// and consumed by the driver and the kernel. Forward; f32 (isa v) or f16
+// (isa zvfh); nearest and linear (bi/trilinear) interpolation on nspc/ncsp/
+// blocked layouts, with an optional fused post-op chain.
+struct jit_resampling_conf_t {
+    int ndims;
+    int mb, c;
+    int id, ih, iw, od, oh, ow;
+    alg_kind_t alg; // resampling_nearest or resampling_linear
+    data_type_t data_type; // f32 or f16
+    int dt_size;
+    jit_resampling_tag_kind_t tag_kind;
+    int block; // inner channel block for the blocked layout (16 or 8); else 0
+    cpu_isa_t isa;
+    // Source points combined per output point: 1 for nearest; for linear
+    // 1 << (spatial dims) = 2 (1D) / 4 (2D) / 8 (3D).
+    int num_corners;
+    // Post-ops fused in-kernel via the injector (mirrors rv64 pooling): an
+    // eltwise chain (f32 and f16, computed at f32), plus at most one binary
+    // (f32 only, positioned host-side per output point).
+    bool with_postops;
+    bool fuse_eltwise;
+    bool fuse_binary;
+    post_ops_t post_ops;
+};
+
+// Per-output-point kernel arguments. The driver computes the (up to 8) source
+// corner pointers and their interpolation weights on the host (via
+// resampling_utils, the same math as ref_resampling); the kernel combines the
+// corners' channel vectors. The vector runs along C: unit-stride for nspc and
+// blocked, strided by the spatial size for ncsp (one routine serves all three).
+struct jit_resampling_args_t {
+    // Channel-0 pointers of each source corner. Nearest uses src[0] only; linear
+    // uses conf.num_corners of them.
+    const void *src[8];
+    void *dst;
+    // Per-corner interpolation weight (product of the 1D linear weights). Unused
+    // for nearest (num_corners == 1: the single corner is copied verbatim).
+    float weights[8];
+    dim_t channels; // channels to combine (the vector work)
+    dim_t src_vec_byte_stride; // byte stride between consecutive channels in src
+    dim_t dst_vec_byte_stride; // byte stride between consecutive channels in dst
+    // Binary post-op rhs for the injector's indirect mode (same contract as
+    // pooling): post_op_rhs is the base of the per-binary src1 ORIGIN pointer
+    // array (one f32 pointer per binary, in attribute order); post_op_off0 is
+    // the shared byte offset of the first active lane -- 0 for scalar, the
+    // channel-group offset for per-oc, and this output position's channel-0
+    // element offset (* sizeof(f32)) for full-dst. The kernel advances the
+    // offset per channel chunk. Unused when no binary is fused.
+    const void *post_op_rhs = nullptr;
+    dim_t post_op_off0 = 0;
+};
+
 struct jit_1x1_conv_conf_t {
     prop_kind_t prop_kind;
     int mb;

--- a/src/cpu/rv64/jit_primitive_conf.hpp
+++ b/src/cpu/rv64/jit_primitive_conf.hpp
@@ -258,6 +258,13 @@ struct jit_resampling_conf_t {
     bool with_postops;
     bool fuse_eltwise;
     bool fuse_binary;
+    // A sum post-op (dst = sum_scale * dst + result) applied in-kernel at its
+    // position in the chain: the injector skips sum entries, so the kernel
+    // reads dst back, scales it in, and applies the surrounding entries as two
+    // sub-ranges. sum_idx is that position; -1 when there is no sum.
+    bool fuse_sum;
+    int sum_idx;
+    float sum_scale;
     post_ops_t post_ops;
 };
 

--- a/src/cpu/rv64/jit_uni_resampling.cpp
+++ b/src/cpu/rv64/jit_uni_resampling.cpp
@@ -1,0 +1,216 @@
+/*******************************************************************************
+* Copyright 2026 openKylin community
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <vector>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/resampling_utils.hpp"
+#include "cpu/rv64/jit_uni_resampling.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace resampling_utils;
+
+template <cpu_isa_t isa>
+jit_uni_resampling_fwd_t<isa>::jit_uni_resampling_fwd_t(const pd_t *apd)
+    : primitive_t(apd) {}
+
+template <cpu_isa_t isa>
+jit_uni_resampling_fwd_t<isa>::~jit_uni_resampling_fwd_t() = default;
+
+template <cpu_isa_t isa>
+status_t jit_uni_resampling_fwd_t<isa>::init(engine_t *engine) {
+    UNUSED(engine);
+    CHECK(safe_ptr_assign(kernel_,
+            new jit_uni_resampling_kernel_t<isa, d_type>(pd()->conf_)));
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
+        const exec_ctx_t &ctx) const {
+    const auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const data_t *src0 = src + src_d.off_l(0);
+    data_t *dst0 = dst + dst_d.off_l(0);
+
+    const auto &conf = pd()->conf_;
+    const dim_t MB = conf.mb, C = conf.c;
+    const dim_t ID = conf.id, IH = conf.ih, IW = conf.iw;
+    const dim_t OD = conf.od, OH = conf.oh, OW = conf.ow;
+    const dim_t ndims = conf.ndims;
+    const alg_kind_t alg = conf.alg;
+    const bool is_ncsp = conf.tag_kind == jit_resampling_tag_kind_t::ncsp;
+
+    const dim_t in_sp = ID * IH * IW;
+    const dim_t out_sp = OD * OH * OW;
+
+    // Channel grouping. ncsp: one strided group over all C. nspc/blocked:
+    // channel-contiguous groups of B (= C for nspc, = the inner block for
+    // blocked), iterated over Cb outer blocks. sp_scale is the element step
+    // between adjacent spatial points (x64's inner_stride).
+    const dim_t B = is_ncsp ? C : (conf.block ? conf.block : C);
+    const dim_t Cb = is_ncsp ? 1 : utils::div_up(C, B);
+    const dim_t src_sp_scale = is_ncsp ? 1 : B;
+    const dim_t dst_sp_scale = is_ncsp ? 1 : B;
+    const dim_t src_vec_byte_stride
+            = (is_ncsp ? in_sp : (dim_t)1) * conf.dt_size;
+    const dim_t dst_vec_byte_stride
+            = (is_ncsp ? out_sp : (dim_t)1) * conf.dt_size;
+    const dim_t src_mb_stride = is_ncsp ? C * in_sp : Cb * in_sp * B;
+    const dim_t dst_mb_stride = is_ncsp ? C * out_sp : Cb * out_sp * B;
+    const dim_t src_cb_stride = is_ncsp ? 0 : in_sp * B;
+    const dim_t dst_cb_stride = is_ncsp ? 0 : out_sp * B;
+
+    // Fused binary (f32 only). The injector runs in indirect mode: it reads the
+    // rhs base from a per-binary ORIGIN pointer array and adds the shared byte
+    // offset the driver hands it per output point (see jit_resampling_args_t).
+    enum { BC_NONE, BC_SCALAR, BC_PER_OC, BC_FULL } bcast = BC_NONE;
+    std::vector<const void *> po_rhs;
+    if (conf.fuse_binary) {
+        int bin_idx = 0;
+        for (int i = 0; i < conf.post_ops.len(); i++) {
+            if (!conf.post_ops.entry_[i].is_binary()) continue;
+            bin_idx = i;
+            const memory_desc_wrapper s1_d(
+                    conf.post_ops.entry_[i].binary.src1_desc);
+            const auto *base = static_cast<const char *>(ctx.host_ptr(
+                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
+            po_rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
+        }
+        const memory_desc_wrapper s1(
+                conf.post_ops.entry_[bin_idx].binary.src1_desc);
+        if (s1.nelems(true) == 1)
+            bcast = BC_SCALAR;
+        else if (s1.nelems() == C)
+            bcast = BC_PER_OC;
+        else
+            bcast = BC_FULL;
+    }
+    const void *const po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
+
+    auto sp_index = [=](dim_t id, dim_t ih, dim_t iw) {
+        return (id * IH + ih) * IW + iw;
+    };
+
+    parallel_nd(MB, Cb, OD, OH, OW,
+            [&](dim_t mb, dim_t cb, dim_t od, dim_t oh, dim_t ow) {
+        jit_resampling_args_t args = {};
+        // Valid channels in this group (last blocked group may be partial).
+        args.channels = is_ncsp ? C : ((C - cb * B) < B ? (C - cb * B) : B);
+        args.src_vec_byte_stride = src_vec_byte_stride;
+        args.dst_vec_byte_stride = dst_vec_byte_stride;
+
+        const dim_t out_sp_off = (od * OH + oh) * OW + ow;
+        data_t *p_dst = dst0 + mb * dst_mb_stride + cb * dst_cb_stride
+                + out_sp_off * dst_sp_scale;
+        args.dst = p_dst;
+
+        const data_t *src_base = src0 + mb * src_mb_stride + cb * src_cb_stride;
+
+        if (alg == alg_kind::resampling_nearest) {
+            const dim_t id = ndims >= 5 ? nearest_idx(od, OD, ID) : 0;
+            const dim_t ih = ndims >= 4 ? nearest_idx(oh, OH, IH) : 0;
+            const dim_t iw = nearest_idx(ow, OW, IW);
+            args.src[0] = src_base + sp_index(id, ih, iw) * src_sp_scale;
+        } else {
+            dim_t d_idx[2] = {0, 0}, h_idx[2] = {0, 0}, w_idx[2] = {0, 0};
+            float d_w[2] = {1.f, 0.f}, h_w[2] = {1.f, 0.f}, w_w[2] = {1.f, 0.f};
+            int dn = 1, hn = 1, wn = 2;
+
+            const linear_coeffs_t wc(ow, OW, IW);
+            w_idx[0] = wc.idx[0];
+            w_idx[1] = wc.idx[1];
+            w_w[0] = wc.wei[0];
+            w_w[1] = wc.wei[1];
+            if (ndims >= 4) {
+                const linear_coeffs_t hc(oh, OH, IH);
+                h_idx[0] = hc.idx[0];
+                h_idx[1] = hc.idx[1];
+                h_w[0] = hc.wei[0];
+                h_w[1] = hc.wei[1];
+                hn = 2;
+            }
+            if (ndims >= 5) {
+                const linear_coeffs_t dc(od, OD, ID);
+                d_idx[0] = dc.idx[0];
+                d_idx[1] = dc.idx[1];
+                d_w[0] = dc.wei[0];
+                d_w[1] = dc.wei[1];
+                dn = 2;
+            }
+
+            int c = 0;
+            for (int i = 0; i < dn; i++)
+                for (int j = 0; j < hn; j++)
+                    for (int k = 0; k < wn; k++) {
+                        args.src[c] = src_base
+                                + sp_index(d_idx[i], h_idx[j], w_idx[k])
+                                        * src_sp_scale;
+                        args.weights[c] = d_w[i] * h_w[j] * w_w[k];
+                        c++;
+                    }
+        }
+
+        if (conf.fuse_binary) {
+            args.post_op_rhs = po_rhs_arr;
+            switch (bcast) {
+                case BC_SCALAR: args.post_op_off0 = 0; break;
+                case BC_PER_OC:
+                    args.post_op_off0 = cb * B * (dim_t)sizeof(float);
+                    break;
+                case BC_FULL:
+                    args.post_op_off0 = (p_dst - dst0) * (dim_t)sizeof(float);
+                    break;
+                default: break;
+            }
+        }
+
+        (*kernel_)(&args);
+
+        // Blocked layout zero-pads the channel dimension: when C is not a
+        // multiple of the block, the last block's padded channels
+        // [valid, block) must be zero in the output. The kernel wrote only the
+        // valid channels (contiguous from p_dst), so zero the padding tail here.
+        // nspc/ncsp have no channel padding (block == 0). Padding must stay zero
+        // regardless of post-ops (they apply to logical elements only).
+        if (conf.block && cb == Cb - 1 && args.channels < B) {
+            data_t *pd = static_cast<data_t *>(args.dst);
+            for (dim_t c = args.channels; c < B; c++)
+                pd[c] = data_t(0.f);
+        }
+    });
+
+    return status::success;
+}
+
+template struct jit_uni_resampling_fwd_t<v>;
+template struct jit_uni_resampling_fwd_t<zvfh>;
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_uni_resampling.cpp
+++ b/src/cpu/rv64/jit_uni_resampling.cpp
@@ -14,10 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <vector>
-
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
 #include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
@@ -75,20 +74,18 @@ status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
     // Fused binary (f32 only); the injector reads the rhs origin array and adds
     // the per-point byte offset set below (see jit_resampling_args_t).
     enum { BC_NONE, BC_SCALAR, BC_PER_OC, BC_FULL } bcast = BC_NONE;
-    std::vector<const void *> po_rhs;
+    // The rhs origin array comes from the scratchpad booked by the pd, so this
+    // path never allocates. post_ops_ok() caps binaries at one.
+    const void **po_rhs = nullptr;
     if (conf.fuse_binary) {
-        int bin_idx = 0;
-        for (int i = 0; i < conf.post_ops.len(); i++) {
-            if (!conf.post_ops.entry_[i].is_binary()) continue;
-            bin_idx = i;
-            const memory_desc_wrapper s1_d(
-                    conf.post_ops.entry_[i].binary.src1_desc);
-            const auto *base = static_cast<const char *>(ctx.host_ptr(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-            po_rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
-        }
+        po_rhs = ctx.get_scratchpad_grantor().template get<const void *>(
+                memory_tracking::names::key_binary_post_ops_rhs_ptrs);
+        const int bin_idx = conf.post_ops.find(primitive_kind::binary);
         const memory_desc_wrapper s1(
                 conf.post_ops.entry_[bin_idx].binary.src1_desc);
+        const auto *base = static_cast<const char *>(ctx.host_ptr(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(bin_idx) | DNNL_ARG_SRC_1));
+        po_rhs[0] = base + s1.off_l(0) * sizeof(float);
         if (s1.nelems(true) == 1)
             bcast = BC_SCALAR;
         else if (s1.nelems() == C)
@@ -96,7 +93,6 @@ status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
         else
             bcast = BC_FULL;
     }
-    const void *const po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     // Element offset of a spatial point.
     auto src_sp_off = [=](dim_t id, dim_t ih, dim_t iw) {
@@ -164,7 +160,7 @@ status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
         }
 
         if (conf.fuse_binary) {
-            args.post_op_rhs = po_rhs_arr;
+            args.post_op_rhs = po_rhs;
             switch (bcast) {
                 case BC_SCALAR: args.post_op_off0 = 0; break;
                 case BC_PER_OC:

--- a/src/cpu/rv64/jit_uni_resampling.cpp
+++ b/src/cpu/rv64/jit_uni_resampling.cpp
@@ -18,6 +18,7 @@
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
@@ -63,31 +64,16 @@ status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
     const dim_t OD = conf.od, OH = conf.oh, OW = conf.ow;
     const dim_t ndims = conf.ndims;
     const alg_kind_t alg = conf.alg;
-    const bool is_ncsp = conf.tag_kind == jit_resampling_tag_kind_t::ncsp;
 
-    const dim_t in_sp = ID * IH * IW;
-    const dim_t out_sp = OD * OH * OW;
+    // A blocked layout is walked one block at a time; a plain one is a single
+    // group over all of C. Strides come from conf, so no tag is named here.
+    const dim_t B = conf.block > 1 ? conf.block : C;
+    const dim_t Cb = utils::div_up(C, B);
+    const dim_t src_vec_byte_stride = conf.src_c_stride * conf.dt_size;
+    const dim_t dst_vec_byte_stride = conf.dst_c_stride * conf.dt_size;
 
-    // Channel grouping. ncsp: one strided group over all C. nspc/blocked:
-    // channel-contiguous groups of B (= C for nspc, = the inner block for
-    // blocked), iterated over Cb outer blocks. sp_scale is the element step
-    // between adjacent spatial points (x64's inner_stride).
-    const dim_t B = is_ncsp ? C : (conf.block ? conf.block : C);
-    const dim_t Cb = is_ncsp ? 1 : utils::div_up(C, B);
-    const dim_t src_sp_scale = is_ncsp ? 1 : B;
-    const dim_t dst_sp_scale = is_ncsp ? 1 : B;
-    const dim_t src_vec_byte_stride
-            = (is_ncsp ? in_sp : (dim_t)1) * conf.dt_size;
-    const dim_t dst_vec_byte_stride
-            = (is_ncsp ? out_sp : (dim_t)1) * conf.dt_size;
-    const dim_t src_mb_stride = is_ncsp ? C * in_sp : Cb * in_sp * B;
-    const dim_t dst_mb_stride = is_ncsp ? C * out_sp : Cb * out_sp * B;
-    const dim_t src_cb_stride = is_ncsp ? 0 : in_sp * B;
-    const dim_t dst_cb_stride = is_ncsp ? 0 : out_sp * B;
-
-    // Fused binary (f32 only). The injector runs in indirect mode: it reads the
-    // rhs base from a per-binary ORIGIN pointer array and adds the shared byte
-    // offset the driver hands it per output point (see jit_resampling_args_t).
+    // Fused binary (f32 only); the injector reads the rhs origin array and adds
+    // the per-point byte offset set below (see jit_resampling_args_t).
     enum { BC_NONE, BC_SCALAR, BC_PER_OC, BC_FULL } bcast = BC_NONE;
     std::vector<const void *> po_rhs;
     if (conf.fuse_binary) {
@@ -112,30 +98,33 @@ status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
     }
     const void *const po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
-    auto sp_index = [=](dim_t id, dim_t ih, dim_t iw) {
-        return (id * IH + ih) * IW + iw;
+    // Element offset of a spatial point.
+    auto src_sp_off = [=](dim_t id, dim_t ih, dim_t iw) {
+        return id * conf.src_d_stride + ih * conf.src_h_stride
+                + iw * conf.src_w_stride;
     };
 
     parallel_nd(MB, Cb, OD, OH, OW,
             [&](dim_t mb, dim_t cb, dim_t od, dim_t oh, dim_t ow) {
         jit_resampling_args_t args = {};
         // Valid channels in this group (last blocked group may be partial).
-        args.channels = is_ncsp ? C : ((C - cb * B) < B ? (C - cb * B) : B);
+        args.channels = nstl::min(B, C - cb * B);
         args.src_vec_byte_stride = src_vec_byte_stride;
         args.dst_vec_byte_stride = dst_vec_byte_stride;
 
-        const dim_t out_sp_off = (od * OH + oh) * OW + ow;
-        data_t *p_dst = dst0 + mb * dst_mb_stride + cb * dst_cb_stride
-                + out_sp_off * dst_sp_scale;
+        data_t *p_dst = dst0 + mb * conf.dst_mb_stride + cb * conf.dst_cb_stride
+                + od * conf.dst_d_stride + oh * conf.dst_h_stride
+                + ow * conf.dst_w_stride;
         args.dst = p_dst;
 
-        const data_t *src_base = src0 + mb * src_mb_stride + cb * src_cb_stride;
+        const data_t *src_base
+                = src0 + mb * conf.src_mb_stride + cb * conf.src_cb_stride;
 
         if (alg == alg_kind::resampling_nearest) {
             const dim_t id = ndims >= 5 ? nearest_idx(od, OD, ID) : 0;
             const dim_t ih = ndims >= 4 ? nearest_idx(oh, OH, IH) : 0;
             const dim_t iw = nearest_idx(ow, OW, IW);
-            args.src[0] = src_base + sp_index(id, ih, iw) * src_sp_scale;
+            args.src[0] = src_base + src_sp_off(id, ih, iw);
         } else {
             dim_t d_idx[2] = {0, 0}, h_idx[2] = {0, 0}, w_idx[2] = {0, 0};
             float d_w[2] = {1.f, 0.f}, h_w[2] = {1.f, 0.f}, w_w[2] = {1.f, 0.f};
@@ -168,8 +157,7 @@ status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
                 for (int j = 0; j < hn; j++)
                     for (int k = 0; k < wn; k++) {
                         args.src[c] = src_base
-                                + sp_index(d_idx[i], h_idx[j], w_idx[k])
-                                        * src_sp_scale;
+                                + src_sp_off(d_idx[i], h_idx[j], w_idx[k]);
                         args.weights[c] = d_w[i] * h_w[j] * w_w[k];
                         c++;
                     }
@@ -191,13 +179,11 @@ status_t jit_uni_resampling_fwd_t<isa>::execute_forward(
 
         (*kernel_)(&args);
 
-        // Blocked layout zero-pads the channel dimension: when C is not a
-        // multiple of the block, the last block's padded channels
-        // [valid, block) must be zero in the output. The kernel wrote only the
-        // valid channels (contiguous from p_dst), so zero the padding tail here.
-        // nspc/ncsp have no channel padding (block == 0). Padding must stay zero
-        // regardless of post-ops (they apply to logical elements only).
-        if (conf.block && cb == Cb - 1 && args.channels < B) {
+        // A blocked layout zero-pads C: the last block's [valid, block) lanes
+        // must read 0, and stay 0 regardless of post-ops (which apply to
+        // logical elements only). The kernel wrote only the valid channels,
+        // contiguous from p_dst, so zero the tail here.
+        if (conf.block > 1 && cb == Cb - 1 && args.channels < B) {
             data_t *pd = static_cast<data_t *>(args.dst);
             for (dim_t c = args.channels; c < B; c++)
                 pd[c] = data_t(0.f);

--- a/src/cpu/rv64/jit_uni_resampling.hpp
+++ b/src/cpu/rv64/jit_uni_resampling.hpp
@@ -60,15 +60,15 @@ struct jit_uni_resampling_fwd_t : public primitive_t {
             VDISPATCH_RESAMPLING(attr()->has_default_values(
                                          sm::post_ops, dst_md()->data_type),
                     VERBOSE_UNSUPPORTED_ATTR);
-            // Resolve binary post-op src1 formats (may be format_any) against the
-            // concrete dst before post_ops_ok() inspects their layout.
+            // Resolve format_any src1 against dst before post_ops_ok() reads
+            // their layout.
             VDISPATCH_RESAMPLING(
                     attr_.set_default_formats(dst_md(0)) == status::success,
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_RESAMPLING(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
 
-            // init_conf fills conf_ and selects the layout (nspc/ncsp/blocked);
-            // it returns unimplemented for any other tag / alg / dtype.
+            // init_conf fills conf_ and rejects any layout/alg/dtype it cannot
+            // serve.
             const status_t conf_status
                     = jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
                             conf_, this);
@@ -80,22 +80,14 @@ struct jit_uni_resampling_fwd_t : public primitive_t {
         jit_resampling_conf_t conf_ = {};
 
     private:
-        // Accept an injector-supported post-op chain: any number of forward
-        // eltwise ops, at most one binary, and at most one sum. The binary is
-        // fused for f32 only (the kernel accumulates f16 at f32 but has no f16
-        // binary path) and only for the broadcasts the kernel positions
-        // host-side: per-tensor (scalar), per-oc ([1,C,1,..], read as a dense
-        // [C] vector), and full-dst (read 1:1 with the output). The sum is
-        // applied by the kernel at its position in the chain (the injector
-        // skips it), reading dst back with the same access form as the store;
-        // it requires a zero zero-point and a dst-typed accumulation. Anything
-        // else (prelu, >1 binary, >1 sum, f16+binary, exotic broadcast) falls
-        // back to simple/ref_resampling.
+        // Any number of eltwise ops, at most one binary and one sum. The
+        // binary is f32-only (there is no f16 binary path) and limited to the
+        // broadcasts the driver positions host-side: scalar, per-oc and
+        // full-dst. Anything else falls back to simple/ref_resampling.
         bool post_ops_ok() const {
             const auto &po = attr()->post_ops_;
             if (po.has_default_values()) return true;
-            // The injector rejects sum outright, so gate the chain on a copy
-            // with the sum entries removed and validate those separately.
+            // The injector rejects sum, so validate it separately.
             int n_sum = 0;
             post_ops_t po_no_sum;
             for (int i = 0; i < po.len(); i++) {
@@ -105,9 +97,8 @@ struct jit_uni_resampling_fwd_t : public primitive_t {
                     continue;
                 }
                 if (++n_sum > 1) return false;
-                // A non-zero zero-point would need an extra subtract the kernel
-                // does not emit; sum.dt must match dst (no reinterpreting the
-                // destination as another type on read-back).
+                // A non-zero zero-point needs a subtract the kernel does not
+                // emit; sum.dt must match dst on read-back.
                 if (e.sum.zero_point != 0) return false;
                 if (!utils::one_of(e.sum.dt, data_type::undef, d_type))
                     return false;

--- a/src/cpu/rv64/jit_uni_resampling.hpp
+++ b/src/cpu/rv64/jit_uni_resampling.hpp
@@ -1,0 +1,137 @@
+/*******************************************************************************
+* Copyright 2026 openKylin community
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_UNI_RESAMPLING_HPP
+#define CPU_RV64_JIT_UNI_RESAMPLING_HPP
+
+#include <memory>
+
+#include "common/memory_desc_wrapper.hpp"
+#include "common/primitive.hpp"
+
+#include "cpu/cpu_resampling_pd.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
+#include "cpu/rv64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/rv64/jit_uni_resampling_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+template <cpu_isa_t isa>
+struct jit_uni_resampling_fwd_t : public primitive_t {
+    static constexpr data_type_t d_type
+            = (isa == zvfh) ? data_type::f16 : data_type::f32;
+    using data_t = typename prec_traits_t<d_type>::type;
+
+    struct pd_t : public cpu_resampling_fwd_pd_t {
+        using cpu_resampling_fwd_pd_t::cpu_resampling_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", conf_.isa, ""),
+                jit_uni_resampling_fwd_t);
+
+        status_t init(const engine_t *engine) {
+            using namespace data_type;
+            using sm = primitive_attr_t::skip_mask_t;
+
+            VDISPATCH_RESAMPLING(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_RESAMPLING(is_fwd(), VERBOSE_BAD_PROPKIND);
+            VDISPATCH_RESAMPLING(utils::everyone_is(d_type, src_md()->data_type,
+                                         dst_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_RESAMPLING(
+                    !has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+            VDISPATCH_RESAMPLING(set_default_params() == status::success,
+                    VERBOSE_UNSUPPORTED_TAG);
+            VDISPATCH_RESAMPLING(attr()->has_default_values(
+                                         sm::post_ops, dst_md()->data_type),
+                    VERBOSE_UNSUPPORTED_ATTR);
+            // Resolve binary post-op src1 formats (may be format_any) against the
+            // concrete dst before post_ops_ok() inspects their layout.
+            VDISPATCH_RESAMPLING(
+                    attr_.set_default_formats(dst_md(0)) == status::success,
+                    VERBOSE_UNSUPPORTED_POSTOP);
+            VDISPATCH_RESAMPLING(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
+
+            // init_conf fills conf_ and selects the layout (nspc/ncsp/blocked);
+            // it returns unimplemented for any other tag / alg / dtype.
+            const status_t conf_status
+                    = jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
+                            conf_, this);
+            VDISPATCH_RESAMPLING(
+                    conf_status == status::success, VERBOSE_UNSUPPORTED_TAG);
+            return status::success;
+        }
+
+        jit_resampling_conf_t conf_ = {};
+
+    private:
+        // Accept an injector-supported post-op chain: any number of forward
+        // eltwise ops, plus at most one binary. The binary is fused for f32 only
+        // (the kernel accumulates f16 at f32 but has no f16 binary path) and only
+        // for the broadcasts the kernel positions host-side: per-tensor (scalar),
+        // per-oc ([1,C,1,..], read as a dense [C] vector), and full-dst (read 1:1
+        // with the output). Anything else (sum, prelu, >1 binary, f16+binary,
+        // exotic broadcast) falls back to simple/ref_resampling.
+        bool post_ops_ok() const {
+            const auto &po = attr()->post_ops_;
+            if (po.has_default_values()) return true;
+            if (!injector::jit_uni_postops_injector_t<isa>::post_ops_ok(po))
+                return false;
+            const memory_desc_wrapper dst_d(dst_md());
+            int n_binary = 0;
+            for (int i = 0; i < po.len(); i++) {
+                if (!po.entry_[i].is_binary()) continue;
+                if (++n_binary > 1) return false;
+                if (d_type != data_type::f32) return false;
+                const auto &b = po.entry_[i].binary;
+                if (b.src1_desc.data_type != data_type::f32) return false;
+                const memory_desc_wrapper s1(b.src1_desc);
+                const bool scalar = s1.nelems(true) == 1;
+                bool per_oc = dst_d.ndims() >= 2 && s1.ndims() == dst_d.ndims()
+                        && s1.dims()[1] == dst_d.dims()[1] && s1.is_dense(true);
+                for (int k = 0; per_oc && k < dst_d.ndims(); k++)
+                    if (k != 1 && s1.dims()[k] != 1) per_oc = false;
+                const bool full = s1.similar_to(dst_d, true, false);
+                if (!scalar && !per_oc && !full) return false;
+            }
+            return true;
+        }
+    };
+
+    jit_uni_resampling_fwd_t(const pd_t *apd);
+    ~jit_uni_resampling_fwd_t() override;
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_uni_resampling_kernel_t<isa, d_type>> kernel_;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/jit_uni_resampling.hpp
+++ b/src/cpu/rv64/jit_uni_resampling.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "common/memory_desc_wrapper.hpp"
+#include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
 
 #include "cpu/cpu_resampling_pd.hpp"
@@ -74,12 +75,23 @@ struct jit_uni_resampling_fwd_t : public primitive_t {
                             conf_, this);
             VDISPATCH_RESAMPLING(
                     conf_status == status::success, VERBOSE_UNSUPPORTED_TAG);
+            init_scratchpad();
             return status::success;
         }
 
         jit_resampling_conf_t conf_ = {};
 
     private:
+        // The kernel reads the binary rhs origins through a pointer array; book
+        // it here so execute() never allocates. post_ops_ok() caps binaries at
+        // one, so the array holds a single entry.
+        void init_scratchpad() {
+            if (!conf_.fuse_binary) return;
+            auto scratchpad = scratchpad_registry().registrar();
+            scratchpad.template book<const void *>(
+                    memory_tracking::names::key_binary_post_ops_rhs_ptrs, 1);
+        }
+
         // Any number of eltwise ops, at most one binary and one sum. The
         // binary is f32-only (there is no f16 binary path) and limited to the
         // broadcasts the driver positions host-side: scalar, per-oc and

--- a/src/cpu/rv64/jit_uni_resampling.hpp
+++ b/src/cpu/rv64/jit_uni_resampling.hpp
@@ -81,16 +81,39 @@ struct jit_uni_resampling_fwd_t : public primitive_t {
 
     private:
         // Accept an injector-supported post-op chain: any number of forward
-        // eltwise ops, plus at most one binary. The binary is fused for f32 only
-        // (the kernel accumulates f16 at f32 but has no f16 binary path) and only
-        // for the broadcasts the kernel positions host-side: per-tensor (scalar),
-        // per-oc ([1,C,1,..], read as a dense [C] vector), and full-dst (read 1:1
-        // with the output). Anything else (sum, prelu, >1 binary, f16+binary,
-        // exotic broadcast) falls back to simple/ref_resampling.
+        // eltwise ops, at most one binary, and at most one sum. The binary is
+        // fused for f32 only (the kernel accumulates f16 at f32 but has no f16
+        // binary path) and only for the broadcasts the kernel positions
+        // host-side: per-tensor (scalar), per-oc ([1,C,1,..], read as a dense
+        // [C] vector), and full-dst (read 1:1 with the output). The sum is
+        // applied by the kernel at its position in the chain (the injector
+        // skips it), reading dst back with the same access form as the store;
+        // it requires a zero zero-point and a dst-typed accumulation. Anything
+        // else (prelu, >1 binary, >1 sum, f16+binary, exotic broadcast) falls
+        // back to simple/ref_resampling.
         bool post_ops_ok() const {
             const auto &po = attr()->post_ops_;
             if (po.has_default_values()) return true;
-            if (!injector::jit_uni_postops_injector_t<isa>::post_ops_ok(po))
+            // The injector rejects sum outright, so gate the chain on a copy
+            // with the sum entries removed and validate those separately.
+            int n_sum = 0;
+            post_ops_t po_no_sum;
+            for (int i = 0; i < po.len(); i++) {
+                const auto &e = po.entry_[i];
+                if (e.kind != primitive_kind::sum) {
+                    po_no_sum.entry_.push_back(e);
+                    continue;
+                }
+                if (++n_sum > 1) return false;
+                // A non-zero zero-point would need an extra subtract the kernel
+                // does not emit; sum.dt must match dst (no reinterpreting the
+                // destination as another type on read-back).
+                if (e.sum.zero_point != 0) return false;
+                if (!utils::one_of(e.sum.dt, data_type::undef, d_type))
+                    return false;
+            }
+            if (!injector::jit_uni_postops_injector_t<isa>::post_ops_ok(
+                        po_no_sum))
                 return false;
             const memory_desc_wrapper dst_d(dst_md());
             int n_binary = 0;

--- a/src/cpu/rv64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_resampling_kernel.cpp
@@ -44,8 +44,6 @@ jit_uni_resampling_kernel_t<isa, d_type>::jit_uni_resampling_kernel_t(
 template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
         jit_resampling_conf_t &conf, const resampling_pd_t *pd) {
-    using namespace format_tag;
-
     const memory_desc_wrapper src_d(pd->src_md());
     const memory_desc_wrapper dst_d(pd->dst_md());
     const int ndims = pd->ndims();
@@ -58,25 +56,40 @@ status_t jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
                 alg, alg_kind::resampling_nearest, alg_kind::resampling_linear))
         return status::unimplemented;
 
-    // Layout: nspc (channels innermost), ncsp (channels outermost), or blocked
-    // (nCxc, inner channel block). The vector runs along C in all three.
-    const auto nspc_tag = utils::pick(ndims - 3, nwc, nhwc, ndhwc);
-    const auto ncsp_tag = utils::pick(ndims - 3, ncw, nchw, ncdhw);
-    const auto blk16_tag = utils::pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
-    const auto blk8_tag = utils::pick(ndims - 3, nCw8c, nChw8c, nCdhw8c);
-    conf.block = 0;
-    if (src_d.matches_tag(nspc_tag) && dst_d.matches_tag(nspc_tag))
-        conf.tag_kind = jit_resampling_tag_kind_t::nspc;
-    else if (src_d.matches_tag(ncsp_tag) && dst_d.matches_tag(ncsp_tag))
-        conf.tag_kind = jit_resampling_tag_kind_t::ncsp;
-    else if (src_d.matches_tag(blk16_tag) && dst_d.matches_tag(blk16_tag)) {
-        conf.tag_kind = jit_resampling_tag_kind_t::blocked;
-        conf.block = 16;
-    } else if (src_d.matches_tag(blk8_tag) && dst_d.matches_tag(blk8_tag)) {
-        conf.tag_kind = jit_resampling_tag_kind_t::blocked;
-        conf.block = 8;
-    } else
+    // Layout comes from the blocking descriptors, not from format tags: tags
+    // are a user-facing label and can share a name across differing strides.
+    if (!src_d.is_blocking_desc() || !dst_d.is_blocking_desc())
         return status::unimplemented;
+
+    // The vector runs along C, so only a single innermost block on the channel
+    // dimension keeps channels contiguous. Returns 0 to reject.
+    auto channel_block = [](const memory_desc_wrapper &md) -> int {
+        const auto &bd = md.blocking_desc();
+        if (bd.inner_nblks == 0) return 1;
+        if (bd.inner_nblks != 1 || bd.inner_idxs[0] != 1) return 0; // reject
+        return (int)bd.inner_blks[0];
+    };
+    const int src_blk = channel_block(src_d), dst_blk = channel_block(dst_d);
+    if (src_blk == 0 || dst_blk == 0) return status::unimplemented;
+    // One grouping drives both tensors, so the blocks must agree.
+    if (src_blk != dst_blk) return status::unimplemented;
+    conf.block = src_blk;
+
+    const auto &sbd = src_d.blocking_desc();
+    const auto &dbd = dst_d.blocking_desc();
+    // Blocked: strides[1] steps between blocks. Plain: it is the channel step.
+    conf.src_c_stride = conf.block > 1 ? 1 : sbd.strides[1];
+    conf.dst_c_stride = conf.block > 1 ? 1 : dbd.strides[1];
+    conf.src_cb_stride = conf.block > 1 ? sbd.strides[1] : 0;
+    conf.dst_cb_stride = conf.block > 1 ? dbd.strides[1] : 0;
+    conf.src_mb_stride = sbd.strides[0];
+    conf.dst_mb_stride = dbd.strides[0];
+    conf.src_w_stride = sbd.strides[ndims - 1];
+    conf.dst_w_stride = dbd.strides[ndims - 1];
+    conf.src_h_stride = ndims >= 4 ? sbd.strides[ndims - 2] : 0;
+    conf.dst_h_stride = ndims >= 4 ? dbd.strides[ndims - 2] : 0;
+    conf.src_d_stride = ndims >= 5 ? sbd.strides[ndims - 3] : 0;
+    conf.dst_d_stride = ndims >= 5 ? dbd.strides[ndims - 3] : 0;
 
     conf.ndims = ndims;
     conf.mb = pd->MB();
@@ -94,11 +107,8 @@ status_t jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
     conf.num_corners
             = (alg == alg_kind::resampling_nearest) ? 1 : (1 << (ndims - 2));
 
-    // Post-ops fused in-kernel (mirrors rv64 pooling): eltwise chain for f32 and
-    // f16 (computed at f32); at most one binary for f32 only. The pd's
-    // post_ops_ok() has already restricted the chain shape; here we only set the
-    // fusion flags. An accepted chain that this kernel cannot fuse is a bug in
-    // the gate, so bail to ref if that ever happens.
+    // The pd's post_ops_ok() already restricted the chain; set the fusion flags
+    // here, and bail to ref if the gate ever lets through something unfusable.
     const auto &po = pd->attr()->post_ops_;
     conf.post_ops = po;
     conf.with_postops = !po.has_default_values();
@@ -106,8 +116,7 @@ status_t jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
     conf.sum_idx = -1;
     conf.sum_scale = 1.f;
     if (conf.with_postops) {
-        // The injector cannot carry sum, so it is validated (and later applied)
-        // separately; gate the injectable part on a sum-free copy.
+        // The injector cannot carry sum; gate the rest on a sum-free copy.
         post_ops_t po_no_sum;
         for (int i = 0; i < po.len(); i++) {
             const auto &e = po.entry_[i];
@@ -151,9 +160,9 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f32() {
     const int n = conf_.num_corners;
     const bool po = conf_.fuse_eltwise || conf_.fuse_binary;
 
-    // Classify the fused binary (if any) to pick the rhs load form. Lanes are
-    // channels: per-tensor -> scalar; per-oc / full-dst on nspc/blocked ->
-    // contiguous; full-dst on ncsp -> strided by the dst channel stride.
+    // Pick the rhs load form. Lanes are channels: per-tensor -> scalar; per-oc
+    // and contiguous full-dst -> unit stride; full-dst over a channel-strided
+    // dst -> strided (a full-dst rhs matches the dst layout).
     bool bin_scalar = false, bin_strided = false;
     if (conf_.fuse_binary)
         for (int i = 0; i < conf_.post_ops.len(); i++) {
@@ -163,8 +172,7 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f32() {
             bin_scalar = s1.nelems() == 1;
             const bool per_oc = !bin_scalar && s1.nelems() == (dim_t)conf_.c;
             const bool full = !bin_scalar && !per_oc;
-            bin_strided
-                    = full && conf_.tag_kind == jit_resampling_tag_kind_t::ncsp;
+            bin_strided = full && conf_.dst_c_stride != 1;
         }
 
     const Reg corner_reg[8] = {s1, s2, s3, s4, s5, s6, s7, s8};
@@ -255,14 +263,12 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f32() {
         rhs_dyn.vmm_idx_to_out_off[v_acc.getIdx()] = a5;
         const int n_po = conf_.post_ops.len();
         const int s_idx = conf_.fuse_sum ? conf_.sum_idx : -1;
-        // Entries before the sum, then the sum itself, then the rest. The
-        // injector skips sum entries, so a single full-range call would drop it.
+        // The injector skips sum, so apply the chain around it in two ranges.
         if (po)
             po_inj->compute_vector(
                     v_acc.getIdx(), rhs_dyn, 0, s_idx < 0 ? n_po : s_idx);
         if (conf_.fuse_sum) {
-            // dst is read back with the same access form as the store: unit
-            // stride for nspc/blocked, dst channel stride (a1) for ncsp.
+            // dst is read back with the same access form as the store.
             Label sum_strided, sum_done;
             bne(a1, t2, sum_strided);
             vle32_v(v_tmp, s9);
@@ -416,10 +422,8 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f16() {
         L(done);
     };
 
-    // Apply the post-op chain to the f32 accumulator. Entered and left with the
-    // e32/m2 vtype. The injector skips sum entries, so the chain is applied as
-    // [0, sum) then the sum then (sum, len); the sum reads dst back as f16 and
-    // widens it, using the same access form as the store (a1 vs t2).
+    // Apply the chain to the f32 accumulator; entered and left at e32/m2. The
+    // sum reads dst back as f16 and widens it (same access form as the store).
     const bool need_f32 = po || conf_.fuse_sum;
     auto apply_chain = [&]() {
         const int n_po = conf_.post_ops.len();

--- a/src/cpu/rv64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_resampling_kernel.cpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 
+#include "common/bit_cast.hpp"
 #include "common/c_types_map.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
@@ -101,16 +102,34 @@ status_t jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
     const auto &po = pd->attr()->post_ops_;
     conf.post_ops = po;
     conf.with_postops = !po.has_default_values();
-    conf.fuse_eltwise = conf.fuse_binary = false;
+    conf.fuse_eltwise = conf.fuse_binary = conf.fuse_sum = false;
+    conf.sum_idx = -1;
+    conf.sum_scale = 1.f;
     if (conf.with_postops) {
+        // The injector cannot carry sum, so it is validated (and later applied)
+        // separately; gate the injectable part on a sum-free copy.
+        post_ops_t po_no_sum;
+        for (int i = 0; i < po.len(); i++) {
+            const auto &e = po.entry_[i];
+            if (e.kind == primitive_kind::sum) {
+                conf.fuse_sum = true;
+                conf.sum_idx = i;
+                conf.sum_scale = e.sum.scale;
+            } else
+                po_no_sum.entry_.push_back(e);
+        }
         const bool inj_ok
-                = injector::jit_uni_postops_injector_t<isa>::post_ops_ok(po);
-        bool has_binary = false;
-        for (int i = 0; i < po.len(); i++)
-            if (po.entry_[i].is_binary()) has_binary = true;
-        conf.fuse_eltwise = inj_ok && !has_binary;
+                = injector::jit_uni_postops_injector_t<isa>::post_ops_ok(
+                        po_no_sum);
+        bool has_binary = false, has_eltwise = false;
+        for (int i = 0; i < po_no_sum.len(); i++) {
+            if (po_no_sum.entry_[i].is_binary()) has_binary = true;
+            if (po_no_sum.entry_[i].is_eltwise()) has_eltwise = true;
+        }
+        conf.fuse_eltwise = inj_ok && has_eltwise && !has_binary;
         conf.fuse_binary = inj_ok && has_binary && (d_type == data_type::f32);
-        if (!conf.fuse_eltwise && !conf.fuse_binary)
+        if (!inj_ok) return status::unimplemented;
+        if (!conf.fuse_eltwise && !conf.fuse_binary && !conf.fuse_sum)
             return status::unimplemented;
     }
     return status::success;
@@ -229,12 +248,38 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f32() {
         }
     }
 
-    if (po) {
+    if (po || conf_.fuse_sum) {
         // a5 is the per-chunk byte offset of the first active lane
         // (off_is_bytes); the injector derives each rhs address from it.
         binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
         rhs_dyn.vmm_idx_to_out_off[v_acc.getIdx()] = a5;
-        po_inj->compute_vector(v_acc.getIdx(), rhs_dyn);
+        const int n_po = conf_.post_ops.len();
+        const int s_idx = conf_.fuse_sum ? conf_.sum_idx : -1;
+        // Entries before the sum, then the sum itself, then the rest. The
+        // injector skips sum entries, so a single full-range call would drop it.
+        if (po)
+            po_inj->compute_vector(
+                    v_acc.getIdx(), rhs_dyn, 0, s_idx < 0 ? n_po : s_idx);
+        if (conf_.fuse_sum) {
+            // dst is read back with the same access form as the store: unit
+            // stride for nspc/blocked, dst channel stride (a1) for ncsp.
+            Label sum_strided, sum_done;
+            bne(a1, t2, sum_strided);
+            vle32_v(v_tmp, s9);
+            j_(sum_done);
+            L(sum_strided);
+            vlse32_v(v_tmp, s9, a1);
+            L(sum_done);
+            if (conf_.sum_scale == 1.f)
+                vfadd_vv(v_acc, v_acc, v_tmp);
+            else {
+                li(t4, (int32_t)utils::bit_cast<uint32_t>(conf_.sum_scale));
+                fmv_w_x(ft3, t4);
+                vfmacc_vf(v_acc, ft3, v_tmp);
+            }
+        }
+        if (po && s_idx >= 0)
+            po_inj->compute_vector(v_acc.getIdx(), rhs_dyn, s_idx + 1, n_po);
     }
 
     {
@@ -371,6 +416,40 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f16() {
         L(done);
     };
 
+    // Apply the post-op chain to the f32 accumulator. Entered and left with the
+    // e32/m2 vtype. The injector skips sum entries, so the chain is applied as
+    // [0, sum) then the sum then (sum, len); the sum reads dst back as f16 and
+    // widens it, using the same access form as the store (a1 vs t2).
+    const bool need_f32 = po || conf_.fuse_sum;
+    auto apply_chain = [&]() {
+        const int n_po = conf_.post_ops.len();
+        const int s_idx = conf_.fuse_sum ? conf_.sum_idx : -1;
+        if (po)
+            po_inj->compute_vector(
+                    v_acc.getIdx(), rhs_dyn, 0, s_idx < 0 ? n_po : s_idx);
+        if (conf_.fuse_sum) {
+            vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+            Label sum_strided, sum_done;
+            bne(a1, t2, sum_strided);
+            vle16_v(v_f16, s9);
+            j_(sum_done);
+            L(sum_strided);
+            vlse16_v(v_f16, s9, a1);
+            L(sum_done);
+            vfwcvt_f_f_v(v_wide, v_f16); // f16 m1 -> f32 m2
+            vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+            if (conf_.sum_scale == 1.f)
+                vfadd_vv(v_acc, v_acc, v_wide);
+            else {
+                li(t4, (int32_t)utils::bit_cast<uint32_t>(conf_.sum_scale));
+                fmv_w_x(ft3, t4);
+                vfmacc_vf(v_acc, ft3, v_wide);
+            }
+        }
+        if (po && s_idx >= 0)
+            po_inj->compute_vector(v_acc.getIdx(), rhs_dyn, s_idx + 1, n_po);
+    };
+
     Label ch_loop, ch_done;
     L(ch_loop);
     beqz(s10, ch_done);
@@ -380,10 +459,10 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f16() {
         // widen to f32, apply the chain, narrow back.
         vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         load_f16(corner_reg[0]);
-        if (po) {
+        if (need_f32) {
             vfwcvt_f_f_v(v_acc, v_f16); // f16 m1 -> f32 m2
             vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
-            po_inj->compute_vector(v_acc.getIdx(), rhs_dyn);
+            apply_chain();
             vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
             vfncvt_f_f_w(v_f16, v_acc); // f32 m2 -> f16 m1
         }
@@ -401,7 +480,7 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f16() {
             vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
             vfmacc_vf(v_acc, wei_reg[i], v_wide);
         }
-        if (po) po_inj->compute_vector(v_acc.getIdx(), rhs_dyn);
+        if (need_f32) apply_chain();
         vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vfncvt_f_f_w(v_f16, v_acc); // narrow result to f16
     }

--- a/src/cpu/rv64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_resampling_kernel.cpp
@@ -1,0 +1,471 @@
+/*******************************************************************************
+* Copyright 2026 openKylin community
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstddef>
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/rv64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/rv64/jit_uni_resampling_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+template <cpu_isa_t isa, data_type_t d_type>
+jit_uni_resampling_kernel_t<isa, d_type>::jit_uni_resampling_kernel_t(
+        const jit_resampling_conf_t &conf)
+    : jit_generator_t(conf.alg == alg_kind::resampling_nearest
+                      ? "jit_rvv_resampling_nearest"
+                      : "jit_rvv_resampling_linear")
+    , conf_(conf) {
+    create_kernel();
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+status_t jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
+        jit_resampling_conf_t &conf, const resampling_pd_t *pd) {
+    using namespace format_tag;
+
+    const memory_desc_wrapper src_d(pd->src_md());
+    const memory_desc_wrapper dst_d(pd->dst_md());
+    const int ndims = pd->ndims();
+
+    // The template dtype (f32 for isa v, f16 for isa zvfh) must match src/dst.
+    if (src_d.data_type() != d_type || dst_d.data_type() != d_type)
+        return status::unimplemented;
+    const alg_kind_t alg = pd->desc()->alg_kind;
+    if (!utils::one_of(
+                alg, alg_kind::resampling_nearest, alg_kind::resampling_linear))
+        return status::unimplemented;
+
+    // Layout: nspc (channels innermost), ncsp (channels outermost), or blocked
+    // (nCxc, inner channel block). The vector runs along C in all three.
+    const auto nspc_tag = utils::pick(ndims - 3, nwc, nhwc, ndhwc);
+    const auto ncsp_tag = utils::pick(ndims - 3, ncw, nchw, ncdhw);
+    const auto blk16_tag = utils::pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
+    const auto blk8_tag = utils::pick(ndims - 3, nCw8c, nChw8c, nCdhw8c);
+    conf.block = 0;
+    if (src_d.matches_tag(nspc_tag) && dst_d.matches_tag(nspc_tag))
+        conf.tag_kind = jit_resampling_tag_kind_t::nspc;
+    else if (src_d.matches_tag(ncsp_tag) && dst_d.matches_tag(ncsp_tag))
+        conf.tag_kind = jit_resampling_tag_kind_t::ncsp;
+    else if (src_d.matches_tag(blk16_tag) && dst_d.matches_tag(blk16_tag)) {
+        conf.tag_kind = jit_resampling_tag_kind_t::blocked;
+        conf.block = 16;
+    } else if (src_d.matches_tag(blk8_tag) && dst_d.matches_tag(blk8_tag)) {
+        conf.tag_kind = jit_resampling_tag_kind_t::blocked;
+        conf.block = 8;
+    } else
+        return status::unimplemented;
+
+    conf.ndims = ndims;
+    conf.mb = pd->MB();
+    conf.c = pd->C();
+    conf.id = pd->ID();
+    conf.ih = pd->IH();
+    conf.iw = pd->IW();
+    conf.od = pd->OD();
+    conf.oh = pd->OH();
+    conf.ow = pd->OW();
+    conf.alg = alg;
+    conf.data_type = d_type;
+    conf.dt_size = (int)types::data_type_size(d_type);
+    conf.isa = isa;
+    conf.num_corners
+            = (alg == alg_kind::resampling_nearest) ? 1 : (1 << (ndims - 2));
+
+    // Post-ops fused in-kernel (mirrors rv64 pooling): eltwise chain for f32 and
+    // f16 (computed at f32); at most one binary for f32 only. The pd's
+    // post_ops_ok() has already restricted the chain shape; here we only set the
+    // fusion flags. An accepted chain that this kernel cannot fuse is a bug in
+    // the gate, so bail to ref if that ever happens.
+    const auto &po = pd->attr()->post_ops_;
+    conf.post_ops = po;
+    conf.with_postops = !po.has_default_values();
+    conf.fuse_eltwise = conf.fuse_binary = false;
+    if (conf.with_postops) {
+        const bool inj_ok
+                = injector::jit_uni_postops_injector_t<isa>::post_ops_ok(po);
+        bool has_binary = false;
+        for (int i = 0; i < po.len(); i++)
+            if (po.entry_[i].is_binary()) has_binary = true;
+        conf.fuse_eltwise = inj_ok && !has_binary;
+        conf.fuse_binary = inj_ok && has_binary && (d_type == data_type::f32);
+        if (!conf.fuse_eltwise && !conf.fuse_binary)
+            return status::unimplemented;
+    }
+    return status::success;
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_resampling_kernel_t<isa, d_type>::generate() {
+    if (d_type == data_type::f16)
+        generate_f16();
+    else
+        generate_f32();
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_resampling_kernel_t<isa, d_type>::generate_f32() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const VReg v_acc(4), v_tmp(8);
+    const int n = conf_.num_corners;
+    const bool po = conf_.fuse_eltwise || conf_.fuse_binary;
+
+    // Classify the fused binary (if any) to pick the rhs load form. Lanes are
+    // channels: per-tensor -> scalar; per-oc / full-dst on nspc/blocked ->
+    // contiguous; full-dst on ncsp -> strided by the dst channel stride.
+    bool bin_scalar = false, bin_strided = false;
+    if (conf_.fuse_binary)
+        for (int i = 0; i < conf_.post_ops.len(); i++) {
+            const auto &e = conf_.post_ops.entry_[i];
+            if (!e.is_binary()) continue;
+            const memory_desc_wrapper s1(e.binary.src1_desc);
+            bin_scalar = s1.nelems() == 1;
+            const bool per_oc = !bin_scalar && s1.nelems() == (dim_t)conf_.c;
+            const bool full = !bin_scalar && !per_oc;
+            bin_strided
+                    = full && conf_.tag_kind == jit_resampling_tag_kind_t::ncsp;
+        }
+
+    const Reg corner_reg[8] = {s1, s2, s3, s4, s5, s6, s7, s8};
+    const FReg wei_reg[8] = {fa0, fa1, fa2, fa3, fa4, fa5, fa6, fa7};
+
+    const int stack_size = 96;
+    addi(sp, sp, -stack_size);
+    sd(s1, sp, 0);
+    sd(s2, sp, 8);
+    sd(s3, sp, 16);
+    sd(s4, sp, 24);
+    sd(s5, sp, 32);
+    sd(s6, sp, 40);
+    sd(s7, sp, 48);
+    sd(s8, sp, 56);
+    sd(s9, sp, 64);
+    sd(s10, sp, 72);
+    sd(s11, sp, 80);
+
+    using p_t = jit_resampling_args_t;
+    for (int i = 0; i < n; i++) {
+        ld(corner_reg[i], reg_param,
+                static_cast<int>(offsetof(p_t, src) + i * sizeof(void *)));
+        if (n > 1)
+            flw(wei_reg[i], reg_param,
+                    static_cast<int>(
+                            offsetof(p_t, weights) + i * sizeof(float)));
+    }
+    ld(s9, reg_param, static_cast<int>(offsetof(p_t, dst)));
+    ld(s10, reg_param, static_cast<int>(offsetof(p_t, channels)));
+    ld(s11, reg_param, static_cast<int>(offsetof(p_t, src_vec_byte_stride)));
+    ld(a1, reg_param, static_cast<int>(offsetof(p_t, dst_vec_byte_stride)));
+    if (conf_.fuse_binary) {
+        // a4 = rhs ORIGIN pointer array; a5 = shared byte offset (advanced per
+        // channel chunk). The injector runs in indirect mode.
+        ld(a4, reg_param, static_cast<int>(offsetof(p_t, post_op_rhs)));
+        ld(a5, reg_param, static_cast<int>(offsetof(p_t, post_op_off0)));
+    }
+
+    addi(t2, x0, 4); // element size, for the unit-stride fast path
+
+    // Post-op injector (built once; the binary rhs base is read from the
+    // pointer array in a4 at the offset in a5, advanced per chunk).
+    injector::jit_uni_postops_injector_t<isa> *po_inj = nullptr;
+    // v24 doubles as the binary rhs scratch; entries execute serially, and
+    // post_ops_ok(n_vaux = 3) rejects the algs that would read v_aux3/v_aux4.
+    eltwise_injector::static_params_t esp(VReg(12), VReg(16), VReg(20),
+            VReg(24), VReg(24), ft0, ft1, t3, /*is_fwd=*/true);
+    binary_injector::static_params_t bsp_contig(VReg(24), ft2, a4, a5, a3);
+    binary_injector::static_params_t bsp_strided(VReg(24), ft2, a4, a5, a3, a1);
+    bsp_contig.off_is_bytes = bsp_strided.off_is_bytes = true;
+    injector::jit_uni_postops_injector_t<isa> po_inj_obj(this, conf_.post_ops,
+            esp,
+            conf_.fuse_binary ? (bin_strided ? &bsp_strided : &bsp_contig)
+                              : nullptr);
+    if (po) po_inj = &po_inj_obj;
+
+    auto load_vec = [&](const VReg &vd, const Reg &ptr) {
+        Label strided, done;
+        bne(s11, t2, strided);
+        vle32_v(vd, ptr);
+        j_(done);
+        L(strided);
+        vlse32_v(vd, ptr, s11);
+        L(done);
+    };
+
+    Label ch_loop, ch_done;
+    L(ch_loop);
+    beqz(s10, ch_done);
+    vsetvli(t0, s10, SEW::e32, LMUL::m1, VTA::ta, VMA::ma);
+
+    if (n == 1) {
+        load_vec(v_acc, corner_reg[0]);
+    } else {
+        load_vec(v_tmp, corner_reg[0]);
+        vfmul_vf(v_acc, v_tmp, wei_reg[0]);
+        for (int i = 1; i < n; i++) {
+            load_vec(v_tmp, corner_reg[i]);
+            vfmacc_vf(v_acc, wei_reg[i], v_tmp);
+        }
+    }
+
+    if (po) {
+        // a5 is the per-chunk byte offset of the first active lane
+        // (off_is_bytes); the injector derives each rhs address from it.
+        binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
+        rhs_dyn.vmm_idx_to_out_off[v_acc.getIdx()] = a5;
+        po_inj->compute_vector(v_acc.getIdx(), rhs_dyn);
+    }
+
+    {
+        Label strided_dst, dst_done;
+        bne(a1, t2, strided_dst);
+        vse32_v(v_acc, s9);
+        j_(dst_done);
+        L(strided_dst);
+        vsse32_v(v_acc, s9, a1);
+        L(dst_done);
+    }
+
+    // Advance corner pointers by vl * src_vec_byte_stride (shared stride).
+    {
+        Label strided_adv, adv_done;
+        bne(s11, t2, strided_adv);
+        slli(t1, t0, 2);
+        j_(adv_done);
+        L(strided_adv);
+        mul(t1, t0, s11);
+        L(adv_done);
+    }
+    for (int i = 0; i < n; i++)
+        add(corner_reg[i], corner_reg[i], t1);
+    // Advance dst by vl * dst_vec_byte_stride.
+    {
+        Label strided_adv, adv_done;
+        bne(a1, t2, strided_adv);
+        slli(t1, t0, 2);
+        j_(adv_done);
+        L(strided_adv);
+        mul(t1, t0, a1);
+        L(adv_done);
+    }
+    add(s9, s9, t1);
+    // Advance the shared rhs offset by vl * per-channel byte stride (full-dst on
+    // ncsp: the dst channel stride a1; per-oc: contiguous element size). The
+    // origin array (a4) is fixed; the injector reads array[arg_idx] + a5. Scalar
+    // rhs is broadcast, so it does not advance.
+    if (conf_.fuse_binary && !bin_scalar) {
+        if (bin_strided)
+            mul(t1, t0, a1);
+        else
+            slli(t1, t0, 2);
+        add(a5, a5, t1);
+    }
+    sub(s10, s10, t0); // channels -= vl
+
+    j_(ch_loop);
+    L(ch_done);
+
+    ld(s1, sp, 0);
+    ld(s2, sp, 8);
+    ld(s3, sp, 16);
+    ld(s4, sp, 24);
+    ld(s5, sp, 32);
+    ld(s6, sp, 40);
+    ld(s7, sp, 48);
+    ld(s8, sp, 56);
+    ld(s9, sp, 64);
+    ld(s10, sp, 72);
+    ld(s11, sp, 80);
+    addi(sp, sp, stack_size);
+    ret();
+#else
+    ret();
+#endif
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_resampling_kernel_t<isa, d_type>::generate_f16() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    // f16 loads (m1) widened to an f32 accumulator (m2); the weighted sum and
+    // any eltwise post-op run at f32; the result is narrowed back to f16.
+    const VReg v_f16(2); // f16 load buffer (m1)
+    const VReg v_acc(4); // f32 accumulator (m2: v4-v5)
+    const VReg v_wide(8); // f32 widened corner (m2: v8-v9)
+    const int n = conf_.num_corners;
+    const bool po = conf_.fuse_eltwise; // binary is f32-only (rejected for f16)
+
+    const Reg corner_reg[8] = {s1, s2, s3, s4, s5, s6, s7, s8};
+    const FReg wei_reg[8] = {fa0, fa1, fa2, fa3, fa4, fa5, fa6, fa7};
+
+    const int stack_size = 96;
+    addi(sp, sp, -stack_size);
+    sd(s1, sp, 0);
+    sd(s2, sp, 8);
+    sd(s3, sp, 16);
+    sd(s4, sp, 24);
+    sd(s5, sp, 32);
+    sd(s6, sp, 40);
+    sd(s7, sp, 48);
+    sd(s8, sp, 56);
+    sd(s9, sp, 64);
+    sd(s10, sp, 72);
+    sd(s11, sp, 80);
+
+    using p_t = jit_resampling_args_t;
+    for (int i = 0; i < n; i++) {
+        ld(corner_reg[i], reg_param,
+                static_cast<int>(offsetof(p_t, src) + i * sizeof(void *)));
+        if (n > 1)
+            flw(wei_reg[i], reg_param,
+                    static_cast<int>(
+                            offsetof(p_t, weights) + i * sizeof(float)));
+    }
+    ld(s9, reg_param, static_cast<int>(offsetof(p_t, dst)));
+    ld(s10, reg_param, static_cast<int>(offsetof(p_t, channels)));
+    ld(s11, reg_param, static_cast<int>(offsetof(p_t, src_vec_byte_stride)));
+    ld(a1, reg_param, static_cast<int>(offsetof(p_t, dst_vec_byte_stride)));
+
+    addi(t2, x0, 2); // f16 element size (2 bytes) for the unit-stride fast path
+
+    // Eltwise-only injector for f16 (computed at f32 on the m2 accumulator).
+    injector::jit_uni_postops_injector_t<isa> *po_inj = nullptr;
+    eltwise_injector::static_params_t esp(VReg(12), VReg(16), VReg(20),
+            VReg(24), VReg(24), ft0, ft1, t3, /*is_fwd=*/true);
+    injector::jit_uni_postops_injector_t<isa> po_inj_obj(
+            this, conf_.post_ops, esp);
+    if (po) po_inj = &po_inj_obj;
+    // Eltwise-only here: no binary rhs to address.
+    binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
+
+    // Load an f16 channel vector (unit-stride vle16 for nspc/blocked, strided
+    // vlse16 for ncsp) into v_f16 under the current e16 vtype.
+    auto load_f16 = [&](const Reg &ptr) {
+        Label strided, done;
+        bne(s11, t2, strided);
+        vle16_v(v_f16, ptr);
+        j_(done);
+        L(strided);
+        vlse16_v(v_f16, ptr, s11);
+        L(done);
+    };
+
+    Label ch_loop, ch_done;
+    L(ch_loop);
+    beqz(s10, ch_done);
+
+    if (n == 1) {
+        // Nearest: copy the single f16 corner. With a fused eltwise post-op,
+        // widen to f32, apply the chain, narrow back.
+        vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        load_f16(corner_reg[0]);
+        if (po) {
+            vfwcvt_f_f_v(v_acc, v_f16); // f16 m1 -> f32 m2
+            vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+            po_inj->compute_vector(v_acc.getIdx(), rhs_dyn);
+            vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+            vfncvt_f_f_w(v_f16, v_acc); // f32 m2 -> f16 m1
+        }
+    } else {
+        // Linear: widen each f16 corner to f32, weighted-accumulate at f32.
+        vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        load_f16(corner_reg[0]);
+        vfwcvt_f_f_v(v_acc, v_f16);
+        vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+        vfmul_vf(v_acc, v_acc, wei_reg[0]);
+        for (int i = 1; i < n; i++) {
+            vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+            load_f16(corner_reg[i]);
+            vfwcvt_f_f_v(v_wide, v_f16);
+            vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+            vfmacc_vf(v_acc, wei_reg[i], v_wide);
+        }
+        if (po) po_inj->compute_vector(v_acc.getIdx(), rhs_dyn);
+        vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vfncvt_f_f_w(v_f16, v_acc); // narrow result to f16
+    }
+
+    // Store the f16 result (unit-stride for nspc/blocked, strided for ncsp).
+    {
+        Label strided_dst, dst_done;
+        bne(a1, t2, strided_dst);
+        vse16_v(v_f16, s9);
+        j_(dst_done);
+        L(strided_dst);
+        vsse16_v(v_f16, s9, a1);
+        L(dst_done);
+    }
+
+    // Advance corner pointers by vl * src_vec_byte_stride.
+    {
+        Label strided_adv, adv_done;
+        bne(s11, t2, strided_adv);
+        slli(t1, t0, 1); // vl * 2 (f16)
+        j_(adv_done);
+        L(strided_adv);
+        mul(t1, t0, s11);
+        L(adv_done);
+    }
+    for (int i = 0; i < n; i++)
+        add(corner_reg[i], corner_reg[i], t1);
+    {
+        Label strided_adv, adv_done;
+        bne(a1, t2, strided_adv);
+        slli(t1, t0, 1);
+        j_(adv_done);
+        L(strided_adv);
+        mul(t1, t0, a1);
+        L(adv_done);
+    }
+    add(s9, s9, t1);
+    sub(s10, s10, t0);
+
+    j_(ch_loop);
+    L(ch_done);
+
+    ld(s1, sp, 0);
+    ld(s2, sp, 8);
+    ld(s3, sp, 16);
+    ld(s4, sp, 24);
+    ld(s5, sp, 32);
+    ld(s6, sp, 40);
+    ld(s7, sp, 48);
+    ld(s8, sp, 56);
+    ld(s9, sp, 64);
+    ld(s10, sp, 72);
+    ld(s11, sp, 80);
+    addi(sp, sp, stack_size);
+    ret();
+#else
+    ret();
+#endif
+}
+
+template struct jit_uni_resampling_kernel_t<v, data_type::f32>;
+template struct jit_uni_resampling_kernel_t<zvfh, data_type::f16>;
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/rv64/jit_uni_resampling_kernel.hpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright 2026 openKylin community
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_UNI_RESAMPLING_KERNEL_HPP
+#define CPU_RV64_JIT_UNI_RESAMPLING_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+
+#include "cpu/cpu_resampling_pd.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+#include "cpu/rv64/jit_primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+template <cpu_isa_t isa, data_type_t d_type>
+struct jit_uni_resampling_kernel_t : public jit_generator_t {
+
+    jit_uni_resampling_kernel_t(const jit_resampling_conf_t &conf);
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_resampling_kernel_t)
+
+    // Populate conf and select the memory layout (nspc/ncsp); returns
+    // status::unimplemented for any layout/dtype/alg this kernel does not handle.
+    static status_t init_conf(
+            jit_resampling_conf_t &conf, const resampling_pd_t *pd);
+
+    void operator()(const jit_resampling_args_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    void generate_f32();
+    void generate_f16();
+
+    jit_resampling_conf_t conf_;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
# Description

Adds a JIT resampling forward primitive for RV64, replacing the `simple`/`ref` fallback for the common cases. One unified kernel vectorizes along the channel dimension and combines the interpolation corners of each output point.

## Coverage

- **Data types:** f32 and f16. f16 widens to f32 at the load boundary (`vfwcvt`), accumulates and applies post-ops at f32, and narrows at the store (`vfncvt`).
- **Algorithms:** `nearest` and `linear` (bi/trilinear), for 1D/2D/3D spatial.
- **Layouts:** NSPC (`nwc`/`nhwc`/`ndhwc`), NCSP (`ncw`/`nchw`/`ncdhw`), and channel-blocked (`nCw/hw/dhw{8,16}c`, including a partial last block). The vector always runs along C — unit-stride `vle32`/`vle16` for NSPC and the blocked inner block, strided `vlse` for NCSP — so a single routine serves all three.
- **Fused post-ops:** an eltwise chain (f32 and f16, computed at f32); at most one binary (f32 only) with per-tensor, per-oc or full-dst broadcast; and at most one `sum`. Eltwise and binary go through the standard rv64 post-op injector in indirect mode. The injector skips `sum` entries by design, so the kernel applies the chain as `[0, sum)`, then the sum, then `(sum, len)` — reading dst back with the same access form as the store. 

The driver computes the (up to 8) source corner pointers and their interpolation weights host-side via `cpu/resampling_utils.hpp` — the same math as `ref_resampling` — so the kernel stays a flat strip-mined loop: `v_acc = wei0 * c0` (`vfmul_vf`) followed by `+= wei_i * c_i` (`vfmacc_vf`); `nearest` is a plain copy.


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

All measurements on a Spacemit X100 (RV64GCV + Zvfh), 8 threads, at each commit.

- **`test_resampling` gtest:** 20/20 pass.
- **Correctness sweep, no post-ops:** 62/62 benchdnn `--mode=C` cases pass with zero ref fallbacks — f32/f16 x nearest/linear x 1D/2D/3D x `nwc`/`ncw`/`nhwc`/`nchw`/`nChw16c`/`nChw8c`/`ndhwc`/`ncdhw` with `ic=17` (partial channel block), plus post-ops `relu`, `add:f32`, `add:f32:per_oc` and `relu+add:f32:per_oc` on `nhwc`, `nchw` and `nChw16c`. All dispatch to `jit:rvv` / `jit:rvv_zvfh`.
- **Correctness sweep, sum:** 60/60 pass across `sum`, `sum:2` (non-unit scale), `sum+relu`, `relu+sum` and `sum+add:f32:per_oc` x f32/f16 x `nhwc`/`nchw`/`nChw16c` x nearest/linear. 54 dispatch to `jit:rvv*`; the 6 that fall back are f16 combined with a binary, as documented above.
- **Performance** (`mb1ic256_ih64iw64_oh128ow128`, a 2x 2D upsample), speedup over the `simple_resampling` and `ref_resampling` fallbacks:

| dtype | tag | alg | jit (ms) | vs `simple` | vs `ref` |
|-------|-----|-----|---------:|------------:|---------:|
| f32 | nhwc    | nearest | 0.590 | 10.5x | 159x |
| f32 | nhwc    | linear  | 0.703 | 27.5x | 256x |
| f32 | nChw16c | nearest | 2.69  |  2.8x | 22.2x |
| f32 | nChw16c | linear  | 3.36  |  6.1x | 44.8x |
| f32 | nchw    | nearest | 16.2  |  1.9x | 2.9x |
| f32 | nchw    | linear  | 22.1  |  1.5x | 5.9x |
| f16 | nhwc    | nearest | 0.292 | 30.4x | 301x |
| f16 | nhwc    | linear  | 0.665 | 39.3x | 270x |
| f16 | nChw16c | nearest | 2.63  |  4.2x | 22.6x |
| f16 | nChw16c | linear  | 3.14  |  8.7x | 51.1x |
| f16 | nchw    | nearest | 16.6  |  1.9x | 3.1x |
| f16 | nchw    | linear  | 25.1  |  1.5x | 5.6x |

- **Same shape with a fused `sum`** (the U-Net / FPN upsample-plus-skip pattern), vs `simple`, which pays a scalar `ref_post_ops_t` call per element:

| dtype | tag | alg | jit (ms) | vs `simple` |
|-------|-----|-----|---------:|------------:|
| f32 | nhwc    | nearest | 1.78  | 13.1x |
| f32 | nhwc    | linear  | 1.86  | 20.9x |
| f32 | nChw16c | nearest | 2.96  |  8.7x |
| f32 | nChw16c | linear  | 3.50  | 11.4x |
| f32 | nchw    | nearest | 19.6  |  2.9x |
| f32 | nchw    | linear  | 26.2  |  2.1x |
| f16 | nhwc    | nearest | 0.681 | 49.6x |
| f16 | nhwc    | linear  | 0.865 | 53.2x |
| f16 | nChw16c | nearest | 2.72  | 13.2x |
| f16 | nChw16c | linear  | 3.20  | 14.9x |
| f16 | nchw    | nearest | 22.1  |  2.8x |
| f16 | nchw    | linear  | 28.3  |  2.1x |
