### PR TITLE
cpu: x64: restrict gemv f16 to avx512_core_f16

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -365,13 +365,13 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
                             || is_superset(brg->isa_impl, avx2_vnni_2)))
             return status::unimplemented;
     } else {
-        // The GEMV code path requires avx512_core_bf16 for bf16 and avx512_core
-        // for f16.
+        // The GEMV code path requires avx512_core_bf16 for bf16 and
+        // avx512_core_fp16 for f16.
         if (!IMPLICATION(one_of(data_type::bf16, dt_bias, dt_d),
                     is_superset(brg->isa_impl, avx512_core_bf16)))
             return status::unimplemented;
         if (!IMPLICATION(one_of(data_type::f16, dt_bias, dt_d),
-                    is_superset(brg->isa_impl, avx512_core)))
+                    is_superset(brg->isa_impl, avx512_core_fp16)))
             return status::unimplemented;
     }
 

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -132,7 +132,8 @@ void set_isa_impl(brgemm_desc_t *brg) {
             brg->isa_impl = is_isa_ok(avx512_core_bf16) ? avx512_core_bf16
                                                         : isa_undef;
         } else if (everyone_is(data_type::f16, brg->dt_a, brg->dt_b)) {
-            brg->isa_impl = is_isa_ok(avx512_core) ? avx512_core : isa_undef;
+            brg->isa_impl = is_isa_ok(avx512_core_fp16) ? avx512_core_fp16
+                                                        : isa_undef;
         }
         return;
     }
@@ -789,7 +790,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
  *
  */
 status_t brgemm_blocking_vmm_gemv(brgemm_desc_t *brg) {
-    assert(utils::one_of(brg->isa_impl, avx2, avx512_core, avx512_core_bf16));
+    assert(utils::one_of(
+            brg->isa_impl, avx2, avx512_core_bf16, avx512_core_fp16));
     assert(brg->load_dim == 1);
 
     const int simd_w = is_superset(brg->isa_impl, avx512_core) ? 16 : 8;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -302,11 +302,11 @@ status_t gemv_check_isa_with_datatype(
     // Valid GEMV (dt, isa) combinations:
     // - f32  -> avx2
     // - bf16 -> avx512_core_bf16
-    // - f16  -> avx512_core
+    // - f16  -> avx512_core_fp16
     // Any other data type or isa is unsupported.
     const bool ok = (bm_conf_utils.is_f32() && isa == avx2)
             || (bm_conf_utils.is_bf16() && isa == avx512_core_bf16)
-            || (bm_conf_utils.is_f16() && isa == avx512_core);
+            || (bm_conf_utils.is_f16() && isa == avx512_core_fp16);
 
     return ok ? status::success : status::unimplemented;
 }
@@ -579,11 +579,11 @@ bool is_gemv_applicable(const brgemm_matmul_conf_t &bgmmc,
     // instantiation can execute the case because GEMM/GEMV dispatching logic
     // relies on it. Here we require the platform to support the exact isa that
     // `gemv_check_isa_with_datatype` mandates for the data type:
-    // f32 -> avx2, bf16 -> avx512_core_bf16, f16 -> avx512_core.
+    // f32 -> avx2, bf16 -> avx512_core_bf16, f16 -> avx512_core_fp16.
     // This also rejects any data type not supported by the GEMV path.
     const bool gemv_isa_dt_supported = (bm_conf_utils.is_f32() && mayiuse(avx2))
             || (bm_conf_utils.is_bf16() && mayiuse(avx512_core_bf16))
-            || (bm_conf_utils.is_f16() && mayiuse(avx512_core));
+            || (bm_conf_utils.is_f16() && mayiuse(avx512_core_fp16));
     if (!gemv_isa_dt_supported) return false;
 
     const format_tag_t gemv_A_tag = bm_conf_utils.get_gemv_A_tag(A_md);
@@ -2042,6 +2042,14 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             VERBOSE_ISA_DT_MISMATCH);
 
     if (bgmmc.is_gemv) {
+        // The GEMV code path requires the compute data types to remain the
+        // same as the memory data types because brgemv performs upconversion on
+        // the fly when necessary.
+        bgmmc.src_dt = bgmmc.orig_src_dt;
+        bgmmc.wei_dt = bgmmc.orig_wei_dt;
+        bgmmc.tr_a_dt_sz = types::data_type_size(bgmmc.src_dt);
+        bgmmc.tr_b_dt_sz = types::data_type_size(bgmmc.wei_dt);
+
         bgmmc.gemv_strategy = bm_conf_utils.get_gemv_strategy(
                 bm_conf_utils.get_gemv_A_tag(src_md),
                 bm_conf_utils.get_gemv_B_tag(weights_md));


### PR DESCRIPTION
Since matmul requires avx512_core_f16 for f16 it does not make sense to support gemv code path for lower isa. On top of that, the building blocks like binary injector require avx512_core_f16 for f16 causing gemv f16 + binary to fall back to the reference.

Before fix:
```
0:PASSED (350 ms) __REPRO: --matmul --dt=f16:f16:f16 --attr-post-ops=mul:f16 256x256:256x1
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| ref:any : 1 (100%)                                       |
============================================================
```

After fix:
```
0:PASSED (355 ms) __REPRO: --matmul --dt=f16:f16:f16 --attr-post-ops=mul:f16 256x256:256x1
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| brg_matmul:avx10_1_512 : 1 (100%)                        |
============================================================
```

Backport is here: https://github.com/uxlfoundation/oneDNN/pull/5720