### PR TITLE
gpu: intel: gemm: with_post_ops: fix the order of dropout and post-ops

### DIFF
--- a/src/gpu/intel/gemm/with_post_ops.cl
+++ b/src/gpu/intel/gemm/with_post_ops.cl
@@ -56,8 +56,8 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
 #if DROPOUT_USE_HOST_SCALARS
         long dropout_seed, long dropout_offset, float dropout_p
 #else
-        __global long *dropout_seed_buf, __global long *dropout_offset_buf,
-        __global float *dropout_p_buf
+        __global SEED_DATA_T *dropout_seed_buf,
+        __global long *dropout_offset_buf, __global float *dropout_p_buf
 #endif
 #endif
 ) {
@@ -72,6 +72,15 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
 #endif
 #if WITH_HOST_DST_ZP
     int *dst_zp = &dst_zp_value;
+#endif
+#if WITH_DROPOUT
+#if !DROPOUT_USE_HOST_SCALARS
+    SEED_DATA_T dropout_seed = dropout_seed_buf[0];
+    long dropout_offset = DROPOUT_USE_OFFSET ? dropout_offset_buf[0] : 0;
+    float dropout_p = dropout_p_buf[0];
+#endif
+    uint dropout_threshold = get_dropout_threshold(dropout_p);
+    float dropout_inv_q = (dropout_p != 1.f) ? 1.f / (1.f - dropout_p) : 0.f;
 #endif
 
     const uint d0 = GWS_GET_D0();
@@ -102,10 +111,23 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
             acc += b;
         }
 
+        accumulator = AS_POST_OP_DATA_T(acc);
+#if WITH_DROPOUT
+#if WITH_SEED_S64 && DROPOUT_USE_OFFSET
+        uint res = philox_4x32_w_offset(data_idx, dropout_seed, dropout_offset);
+#else
+        uint res = philox_4x32(data_idx, dropout_seed);
+#endif
+        uchar dropout = res > dropout_threshold;
+        accumulator = (dropout) ? accumulator * dropout_inv_q : 0;
+#if DROPOUT_HAS_OUTPUT_MASK
+        dropout_mask_buf[data_idx] = dropout;
+#endif
+#endif
+
         // Apply postops
         POST_OP_DATA_T sum_src = WITH_SUM ? load(sum_src, dst, data_idx) : 0.0f;
 
-        accumulator = AS_POST_OP_DATA_T(acc);
         APPLY_POST_OPS_SERIAL(accumulator, sum_src, d0, d1, d2, d3, d4, d5);
 #if WITH_DYN_DST_SCALE == 0
         if (C_SCALES) {
@@ -115,24 +137,5 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
 #endif
         if (DST_ZERO_POINT) accumulator += dst_zp[0];
     }
-#if WITH_DROPOUT
-#if !DROPOUT_USE_HOST_SCALARS
-    long dropout_seed = dropout_seed_buf[0];
-    long dropout_offset = DROPOUT_USE_OFFSET ? dropout_offset_buf[0] : 0;
-    float dropout_p = dropout_p_buf[0];
-#endif
-    uint dropout_threshold = get_dropout_threshold(dropout_p);
-    float dropout_inv_q = (dropout_p != 1.f) ? 1.f / (1.f - dropout_p) : 0.f;
-#if DROPOUT_USE_OFFSET
-    uint res = philox_4x32_w_offset(data_idx, dropout_seed, dropout_offset);
-#else
-    uint res = philox_4x32(data_idx, dropout_seed);
-#endif
-    uchar dropout = res > dropout_threshold;
-    accumulator = (dropout) ? accumulator * dropout_inv_q : 0;
-#if DROPOUT_HAS_OUTPUT_MASK
-    dropout_mask_buf[data_idx] = dropout;
-#endif
-#endif
     write(dst + data_idx, accumulator);
 }

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -248,7 +248,11 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
             acc_type = data_type::f32;
         }
     }
+    data_type_t seed_type = attr()->dropout_.seed_dt_;
+    bool with_seed_s64 = attr()->dropout_.seed_dt_ == data_type::s64;
+
     def_data_type(kernel_ctx, acc_type, "ACC");
+    def_data_type(kernel_ctx, seed_type, "SEED");
 
     kernel_ctx.define_int("NDIMS", ndims);
     CHECK(def_attr_info(
@@ -259,6 +263,7 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
     kernel_ctx.define_int("DST_ZERO_POINT",
             !attr()->zero_points_.has_default_values(DNNL_ARG_DST));
     kernel_ctx.define_int("WITH_DROPOUT", with_dropout);
+    kernel_ctx.define_int("WITH_SEED_S64", with_seed_s64);
     kernel_ctx.define_int("DROPOUT_USE_HOST_SCALARS", dropout_use_host_scalars);
     kernel_ctx.define_int("DROPOUT_USE_OFFSET", dropout_use_offset);
     kernel_ctx.define_int("DROPOUT_HAS_OUTPUT_MASK", dropout_has_output_mask);

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -103,14 +103,14 @@ struct ref_t : public primitive_t {
                     || utils::one_of(wei_dt_, f4_e2m1, f4_e3m0);
             const bool is_int8 = utils::one_of(src_dt_, u8, s8)
                     && utils::one_of(wei_dt_, u8, s8, u4, s4);
+            // Note: fp4 bias will require sub-byte reads in the kernel.
             VDISPATCH_MATMUL(
                     (is_int8
                             || ((is_f32 || is_f64 || is_f16 || is_f8 || is_f4
                                         || is_bf16)
                                     && IMPLICATION(with_bias(),
                                             utils::one_of(bia_dt_, f32, f16,
-                                                    bf16, f8_e5m2, f8_e4m3,
-                                                    f4_e2m1, dst_dt_)))),
+                                                    bf16, f8_e5m2, f8_e4m3)))),
                     VERBOSE_UNSUPPORTED_DT_CFG);
             VDISPATCH_MATMUL_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);


### PR DESCRIPTION
Exposed with new coverage:
```
[   0][DST][0:0] exp_f32:        0.25 exp:        0.25 got:    0.277778 diff:0.0277778 rdiff:0.111111
[   1][DST][0:1] exp_f32:           1 exp:           1 got:     1.11111 diff:0.111111 rdiff:0.111111
[   2][DST][0:2] exp_f32:        0.25 exp:        0.25 got:    0.277778 diff:0.0277778 rdiff:0.111111
[   3][DST][0:3] exp_f32:        0.25 exp:        0.25 got:    0.277778 diff:0.0277778 rdiff:0.111111
[   4][DST][0:4] exp_f32:        0.25 exp:        0.25 got:    0.277778 diff:0.0277778 rdiff:0.111111
[   5][DST][0:5] exp_f32:        0.25 exp:        0.25 got:    0.277778 diff:0.0277778 rdiff:0.111111
[   6][DST][0:6] exp_f32:        0.25 exp:        0.25 got:    0.277778 diff:0.0277778 rdiff:0.111111
[   7][DST][0:7] exp_f32:           1 exp:           1 got:     1.11111 diff:0.111111 rdiff:0.111111
[   8][DST][0:8] exp_f32:           1 exp:           1 got:     1.11111 diff:0.111111 rdiff:0.111111
[   9][DST][0:9] exp_f32:        0.25 exp:        0.25 got:    0.277778 diff:0.0277778 rdiff:0.111111
[COMPARE_STATS][DST]: trh=0 err_max_diff:    0.25 err_max_rdiff:       1 all_max_diff:    0.25 all_max_rdiff:       1
1109:FAILED (errors:1104 total:2208) (1878 ms) __REPRO: --mode-modifier=P --matmul --engine=gpu --stag=abx --wtag=abx --dtag=abx --attr-scales=src:host_scalar:2 --attr-post-ops=clip_v2:0.25:1 --attr-fpmath=tf32 --attr-dropout=0.1:976278:abx:0:1 1x1504:1504x1104
```
Fixed by swapping the order of post-ops and dropout.