### PR TITLE
fixup: tests: gtests: test_concurrency: enable profiling flags

### DIFF
--- a/tests/gtests/test_concurrency.cpp
+++ b/tests/gtests/test_concurrency.cpp
@@ -130,7 +130,8 @@ public:
         return create_object<stream>(reuse_stream_, key, stream_mgr_, [&] {
             stream::flags stream_flags = stream::flags::default_flags;
 #ifdef DNNL_EXPERIMENTAL_PROFILING
-            stream_flags |= stream::flags::profiling;
+            const bool is_gpu = get_test_engine_kind() == engine::kind::gpu;
+            if (is_gpu) stream_flags |= stream::flags::profiling;
 #endif
             return stream(eng, stream_flags);
         });


### PR DESCRIPTION
Profiling flag is not applicable for CPU engine.

Fixes [MFDNN-15420](https://jira.devtools.intel.com/browse/MFDNN-15420)