### PR TITLE
Redesign injectors

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -71,12 +71,9 @@ jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
         const binary_injector::static_params_t bsp {
                 this->param1, enabled_bcast_strategy, rhs_sp};
 
-        auto st = safe_ptr_assign(postops_injector_,
-                injector::jit_uni_postops_injector_base_t<Vmm>::create(
-                        this, brg.isa_impl, brg.attr()->post_ops_, bsp));
-        if (st != status::success) {
-            assert(!"postops_injector creation failed");
-        }
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                        this, brg.attr()->post_ops_, bsp);
 
         with_binary_non_scalar_bcast_
                 = binary_injector::any_binary_postop_rhs_non_scalar_broadcast(

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -169,7 +169,7 @@ private:
             typename utils::conditional<std::is_same<Wmm, Xbyak::Tmm>::value,
                     Xbyak::Zmm, Wmm>::type;
     using Vmm_low_t = typename vreg_traits_t<Vmm>::Vmm_lower_t;
-    using po_injector_t = injector::jit_uni_postops_injector_base_t<Vmm>;
+    using po_injector_t = injector::jit_uni_postops_injector_t<Vmm>;
     std::unique_ptr<po_injector_t> postops_injector_;
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -99,12 +99,8 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
             esp.preserve_vmm = preserve_vmm;
             esp.preserve_p_table = false;
 
-            auto st = safe_ptr_assign(postops_injector_,
-                    po_injector_t::create(this, brg.isa_impl,
-                            brg.attr()->post_ops_, bsp, esp));
-            if (st != status::success) {
-                assert(!"postops_injector creation failed");
-            }
+            postops_injector_ = utils::make_unique<po_injector_t>(
+                    this, brg.attr()->post_ops_, bsp, esp);
 
             using namespace dnnl::impl::cpu::binary_injector_utils;
             std::tie(with_binary_per_oc_bcast_, with_binary_per_oc_sp_bcast_,
@@ -143,7 +139,7 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
     const brgemm_desc_t &get_brg() const override { return brg; }
 
 private:
-    using po_injector_t = injector::jit_uni_postops_injector_base_t<Zmm>;
+    using po_injector_t = injector::jit_uni_postops_injector_t<Zmm>;
     std::unique_ptr<po_injector_t> postops_injector_;
 
     std::unique_ptr<fp8_conversion_e5m2_t> f8_e5m2_cvt_;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -124,13 +124,9 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
                     binary_injector::get_all_strategies_supported_by_injector(),
                     rhs_sp, f8_e5m2_cvt_.get(), f8_e4m3_cvt_.get()};
 
-            auto st = safe_ptr_assign(postops_injector_,
-                    po_injector_t::create(this, brg.isa_impl,
-                            brg.attr()->post_ops_, bsp,
-                            /* enable_native_sum = */ brg.with_sum));
-            if (st != status::success) {
-                assert(!"postops_injector creation failed");
-            }
+            postops_injector_ = utils::make_unique<po_injector_t>(this,
+                    brg.attr()->post_ops_, bsp,
+                    /* enable_native_sum = */ brg.with_sum);
 
             with_binary_non_scalar_bcast_ = binary_injector::
                     any_binary_postop_rhs_non_scalar_broadcast(
@@ -157,7 +153,7 @@ private:
             typename utils::conditional<std::is_same<Wmm, Xbyak::Tmm>::value,
                     Xbyak::Zmm, Wmm>::type;
     using Vmm_lower_t = typename vreg_traits_t<Vmm>::Vmm_lower_t;
-    using po_injector_t = injector::jit_uni_postops_injector_base_t<Vmm>;
+    using po_injector_t = injector::jit_uni_postops_injector_t<Vmm>;
     std::unique_ptr<po_injector_t> postops_injector_;
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
     std::unique_ptr<fp8_conversion_e5m2_t> f8_e5m2_cvt_;

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -107,7 +107,7 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
                 save_state, reserved_eltwise_gpr, reserved_eltwise_maskr};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, post_ops, binary_static_params, eltwise_static_params);
 #undef PARAM_OFF
     }

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -71,7 +71,9 @@ void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, size_t g_start, size_t g_end,
 
 template <data_type_t dst_data_type>
 gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
-    : jit_generator_t(jit_name())
+    : jit_generator_t(jit_name(),
+              mayiuse(avx512_core_bf16) ? avx512_core_bf16
+                                        : bf16_emulation_t::get_isa())
     , jcp_(pd->jcp_)
     , do_sum_(dst_data_type != data_type::f32 && jcp_.with_sum)
     , max_data_reg_idx_(31)
@@ -119,8 +121,7 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
 
     vlen_ = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
 
-    isa_ = mayiuse(avx512_core_bf16) ? avx512_core_bf16
-                                     : bf16_emulation_t::get_isa();
+    isa_ = max_cpu_isa();
 
     if (isa_ != avx512_core_bf16) {
         max_data_reg_idx_ = 26;

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -202,7 +202,7 @@ private:
         size_t vlen_;
         cpu_isa_t isa_;
         std::unique_ptr<bf16_emulation_t> bf16_emu_;
-        std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+        std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
                 postops_injector_;
 
         void apply_postops(const bool apply_mask, const size_t out_offset,

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -3671,48 +3671,49 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_statically(
         assert(!"unsupported data type");
 }
 
-// Support compare with Address param only when isa is avx512.
-// AVX512 implementation
 template <cpu_isa_t isa, typename Vmm>
 template <typename T>
-typename std::enable_if<std::is_same<T, Xbyak::Zmm>::value
-        || std::is_same<T, Xbyak::Address>::value>::type
-jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
+void jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
         const Vmm &lhs, const T &rhs, const unsigned int cmp_predicate) const {
-    // For GreaterEqual op, replace 0xFFFFFFFF by 1
-    // which was returned by vcmpps.
-    const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;
-    const Xbyak::Xmm xreg_one
-            = Xbyak::Xmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
-    const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
+    // The rhs operand shape selects the sequence, and it also pins the ISA. A
+    // memory operand needs the opmask form because it only arrives from the
+    // `inject_binary` path that fuses the tail mask into the binary op, which
+    // exists on AVX-512 alone. A `Zmm` operand needs it because VEX `vcmpps`
+    // has no 512-bit encoding. Every other case is a `Ymm` or `Xmm` register,
+    // which keeps the VEX sequence even on an AVX-512 host. A host without
+    // opmasks never reaches the first branch: `inject_binary` routes each of
+    // its compares through a temporary vector register.
+    const bool rhs_requires_opmask = std::is_same<T, Xbyak::Zmm>::value
+            || std::is_same<T, Xbyak::Address>::value;
+    if (rhs_requires_opmask) {
+        assert(is_avx512_ && "compare with an opmask requires AVX-512");
+        // For GreaterEqual op, replace 0xFFFFFFFF by 1
+        // which was returned by vcmpps.
+        const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;
+        const Xbyak::Xmm xreg_one
+                = Xbyak::Xmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+        const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
 
-    push_opmask(host_, cmp_mask);
-    host_->vcmpps(cmp_mask, lhs, rhs, cmp_predicate);
-    host_->mov(reg_tmp, float2int(1));
-    host_->uni_vmovq(xreg_one, reg_tmp);
-    // broadcast 1.0f with mask
-    host_->vbroadcastss(dst | cmp_mask | host_->T_z, xreg_one);
-    // pop tail mask from stack
-    pop_opmask(host_, cmp_mask);
-}
+        push_opmask(host_, cmp_mask);
+        host_->vcmpps(cmp_mask, lhs, rhs, cmp_predicate);
+        host_->mov(reg_tmp, float2int(1));
+        host_->uni_vmovq(xreg_one, reg_tmp);
+        // broadcast 1.0f with mask
+        host_->vbroadcastss(dst | cmp_mask | host_->T_z, xreg_one);
+        // pop tail mask from stack
+        pop_opmask(host_, cmp_mask);
+    } else {
+        const int vmm_idx = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
+        const Vmm vreg_one = Vmm(vmm_idx);
+        const Xbyak::Xmm xreg_one = Xbyak::Xmm(vmm_idx);
+        const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
 
-// SSE4.1., AVX and AVX2 implementation
-template <cpu_isa_t isa, typename Vmm>
-template <typename T>
-typename std::enable_if<!(std::is_same<T, Xbyak::Zmm>::value
-        || std::is_same<T, Xbyak::Address>::value)>::type
-jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
-        const Vmm &lhs, const T &rhs, const unsigned int cmp_predicate) const {
-    const int vmm_idx = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
-    const Vmm vreg_one = Vmm(vmm_idx);
-    const Xbyak::Xmm xreg_one = Xbyak::Xmm(vmm_idx);
-    const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
-
-    host_->uni_vcmpps(dst, lhs, rhs, cmp_predicate);
-    host_->mov(reg_tmp, float2int(1));
-    host_->uni_vmovq(xreg_one, reg_tmp);
-    host_->uni_vbroadcastss(vreg_one, xreg_one);
-    host_->uni_vminps(dst, dst, vreg_one);
+        host_->uni_vcmpps(dst, lhs, rhs, cmp_predicate);
+        host_->mov(reg_tmp, float2int(1));
+        host_->uni_vmovq(xreg_one, reg_tmp);
+        host_->uni_vbroadcastss(vreg_one, xreg_one);
+        host_->uni_vminps(dst, dst, vreg_one);
+    }
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -3746,75 +3747,6 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_binary(alg_kind_t binary_alg,
             break;
         default: assert(!"unsupported algorithm");
     }
-}
-
-template <cpu_isa_t isa, typename Vmm>
-struct helper_binary_t {};
-
-template <typename Vmm>
-struct helper_binary_t<avx, Vmm> {
-    template <typename T, typename F>
-    static void execute_binary(jit_generator_t *host, F execute_cmp_binary,
-            alg_kind_t binary_alg, const Vmm &dst, const Vmm &lhs,
-            const T &rhs) {
-        switch (binary_alg) {
-            case alg_kind::binary_add: host->uni_vaddps(dst, lhs, rhs); break;
-            case alg_kind::binary_mul: host->uni_vmulps(dst, lhs, rhs); break;
-            case alg_kind::binary_max: host->uni_vmaxps(dst, lhs, rhs); break;
-            case alg_kind::binary_min: host->uni_vminps(dst, lhs, rhs); break;
-            case alg_kind::binary_div: host->uni_vdivps(dst, lhs, rhs); break;
-            case alg_kind::binary_sub: host->uni_vsubps(dst, lhs, rhs); break;
-            case alg_kind::binary_ge:
-                execute_cmp_binary(dst, lhs, rhs, jit_generator_t::_cmp_nlt_us);
-                break;
-            case alg_kind::binary_gt:
-                execute_cmp_binary(dst, lhs, rhs, jit_generator_t::_cmp_nle_us);
-                break;
-            case alg_kind::binary_le:
-                execute_cmp_binary(dst, lhs, rhs, jit_generator_t::_cmp_le_os);
-                break;
-            case alg_kind::binary_lt:
-                execute_cmp_binary(dst, lhs, rhs, jit_generator_t::_cmp_lt_os);
-                break;
-            case alg_kind::binary_eq:
-                execute_cmp_binary(dst, lhs, rhs, jit_generator_t::_cmp_eq_oq);
-                break;
-            case alg_kind::binary_ne:
-                execute_cmp_binary(dst, lhs, rhs, jit_generator_t::_cmp_neq_uq);
-                break;
-            default: assert(!"unsupported algorithm");
-        }
-    }
-};
-
-template <>
-template <typename T>
-void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::execute_binary(
-        alg_kind_t binary_alg, const Xbyak::Ymm &dst, const Xbyak::Ymm &lhs,
-        const T &rhs) const {
-
-    const auto execute_cmp_binary_lam
-            = [this](const Xbyak::Ymm &dst, const Xbyak::Ymm &lhs, const T &rhs,
-                      const unsigned int cmp_predicate) {
-        this->execute_cmp_binary<T>(dst, lhs, rhs, cmp_predicate);
-    };
-    helper_binary_t<avx, Xbyak::Ymm>::execute_binary<T>(
-            host_, execute_cmp_binary_lam, binary_alg, dst, lhs, rhs);
-}
-
-template <>
-template <typename T>
-void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::execute_binary(
-        alg_kind_t binary_alg, const Xbyak::Xmm &dst, const Xbyak::Xmm &lhs,
-        const T &rhs) const {
-
-    const auto execute_cmp_binary_lam
-            = [this](const Xbyak::Xmm &dst, const Xbyak::Xmm &lhs, const T &rhs,
-                      const unsigned int cmp_predicate) {
-        this->execute_cmp_binary<T>(dst, lhs, rhs, cmp_predicate);
-    };
-    helper_binary_t<avx, Xbyak::Xmm>::execute_binary<T>(
-            host_, execute_cmp_binary_lam, binary_alg, dst, lhs, rhs);
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -3458,37 +3458,38 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_i8_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
+    if (is_avx_ && std::is_same<Vmm, Xbyak::Ymm>::value) {
+        // AVX has no 256-bit integer operations, so each 128-bit half is
+        // extended to dwords on its own and the two are joined in the float
+        // domain.
+        static constexpr int one_load_size = xmm_size_elem * sizeof(uint8_t);
+        const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
+        const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
+        const auto tmp_ymm = Xbyak::Ymm(tmp_vmm.getIdx());
+
+        auto load_i8_fn = [&](const Xbyak::Address &addr) {
+            if (data_type == data_type::s8)
+                host_->uni_vpmovsxbd(tmp_xmm, addr);
+            else if (data_type == data_type::u8)
+                host_->uni_vpmovzxbd(tmp_xmm, addr);
+            else
+                assert(!"unsupported data type");
+        };
+
+        load_i8_fn(host_->ptr[rhs_addr_reg + one_load_size]);
+        push_vmm(host_, tmp_xmm);
+        load_i8_fn(rhs_addr);
+        host_->vinsertf128(tmp_ymm, tmp_ymm, host_->ptr[host_->rsp], 1);
+        restore_stack(host_, tmp_xmm);
+        return;
+    }
+
     if (data_type == data_type::s8)
         host_->uni_vpmovsxbd(tmp_vmm, rhs_addr);
     else if (data_type == data_type::u8)
         host_->uni_vpmovzxbd(tmp_vmm, rhs_addr);
     else
         assert(!"unsupported data type");
-}
-
-template <>
-void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_i8_no_tail(
-        const data_type_t &data_type, const Xbyak::Ymm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-    static constexpr int xmm_size_elem = 4;
-    static constexpr int one_load_size = xmm_size_elem * sizeof(uint8_t);
-    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-    const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
-
-    auto load_i8_fn = [&](const Xbyak::Address &addr) {
-        if (data_type == data_type::s8)
-            host_->uni_vpmovsxbd(tmp_xmm, addr);
-        else if (data_type == data_type::u8)
-            host_->uni_vpmovzxbd(tmp_xmm, addr);
-        else
-            assert(!"unsupported data type");
-    };
-
-    load_i8_fn(host_->ptr[rhs_addr_reg + one_load_size]);
-    push_vmm(host_, tmp_xmm);
-    load_i8_fn(rhs_addr);
-    host_->vinsertf128(tmp_vmm, tmp_vmm, host_->ptr[host_->rsp], 1);
-    restore_stack(host_, tmp_xmm);
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -3561,120 +3562,80 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_statically(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
-    assert(!"unsupported tail load mode");
-}
-template <cpu_isa_t isa, typename Vmm>
-struct helper_load_tail_t {};
+    // An opmask-capable ISA has no static tail path. `load_rhs` sends its tails
+    // to `load_rhs_tail_dynamically_with_opmask`, so arriving here means the
+    // caller asked for a tail mode this ISA does not implement.
+    if (is_avx512_) {
+        assert(!"unsupported tail load mode");
+        return;
+    }
 
-template <typename Vmm>
-struct helper_load_tail_t<avx2, Vmm> {
-    static void load_rhs_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
-            const data_type_t &data_type, const Vmm &tmp_vmm,
-            const Xbyak::Address &rhs_addr) {
+    const auto &tail_size = rhs_arg_static_params_.tail_size;
+    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
 
+    // Sub-dword floating point is widened in place from a packed tail, so it
+    // shares neither the zeroing nor the element assembly the dword paths
+    // below need.
+    if (is_superset(isa, avx2_vnni_2)
+            && utils::one_of(data_type, data_type::bf16, data_type::f16)) {
+        const auto tmp_lower_vmm =
+                typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
+        host_->load_bytes(
+                tmp_lower_vmm, rhs_addr_reg, 0, tail_size * sizeof(bfloat16_t));
+        if (data_type == data_type::bf16) {
+            host_->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
+            host_->vpslld(tmp_vmm, tmp_vmm, 16);
+        } else // f16
+            host_->vcvtph2ps(tmp_vmm, tmp_lower_vmm);
+        return;
+    }
+
+    if (!is_avx_) {
+        // SSE4.1 and AVX2 both load the whole tail with one `load_data` call,
+        // which picks the widening sequence from the data type.
         if (!utils::one_of(data_type, data_type::f32, data_type::s32,
                     data_type::s8, data_type::u8))
             assert(!"unsupported data type");
 
-        host->load_data(data_type, tmp_vmm, rhs_addr_reg, 0, tail_size);
+        host_->load_data(data_type, tmp_vmm, rhs_addr_reg, 0, tail_size);
+        return;
     }
-};
 
-template <typename Vmm>
-struct helper_load_tail_t<avx2_vnni_2, Vmm> {
-    static void load_rhs_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
-            const data_type_t &data_type, const Vmm &tmp_vmm,
-            const Xbyak::Address &rhs_addr) {
-        if (utils::one_of(data_type, data_type::bf16, data_type::f16)) {
-            const auto tmp_lower_vmm =
-                    typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
-            host->load_bytes(tmp_lower_vmm, rhs_addr_reg, 0,
-                    tail_size * sizeof(bfloat16_t));
-            if (data_type == data_type::bf16) {
-                host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
-                host->vpslld(tmp_vmm, tmp_vmm, 16);
-            } else //f16
-                host->vcvtph2ps(tmp_vmm, tmp_lower_vmm);
-        } else
-            helper_load_tail_t<avx2, Vmm>::load_rhs_tail_statically(host,
-                    tail_size, rhs_addr_reg, data_type, tmp_vmm, rhs_addr);
-    }
-};
-
-template <>
-void jit_uni_binary_injector_t<avx2, Xbyak::Ymm>::load_rhs_tail_statically(
-        const data_type_t &data_type, const Xbyak::Ymm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-
-    const auto &tail_size = rhs_arg_static_params_.tail_size;
-    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-    helper_load_tail_t<avx2, Xbyak::Ymm>::load_rhs_tail_statically(
-            host_, tail_size, rhs_addr_reg, data_type, tmp_vmm, rhs_addr);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx2, Xbyak::Xmm>::load_rhs_tail_statically(
-        const data_type_t &data_type, const Xbyak::Xmm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-
-    const auto &tail_size = rhs_arg_static_params_.tail_size;
-    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-    helper_load_tail_t<avx2, Xbyak::Xmm>::load_rhs_tail_statically(
-            host_, tail_size, rhs_addr_reg, data_type, tmp_vmm, rhs_addr);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx2_vnni_2,
-        Xbyak::Ymm>::load_rhs_tail_statically(const data_type_t &data_type,
-        const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr) const {
-    const auto &tail_size = rhs_arg_static_params_.tail_size;
-    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-    helper_load_tail_t<avx2_vnni_2, Xbyak::Ymm>::load_rhs_tail_statically(
-            host_, tail_size, rhs_addr_reg, data_type, tmp_vmm, rhs_addr);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx2_vnni_2,
-        Xbyak::Xmm>::load_rhs_tail_statically(const data_type_t &data_type,
-        const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr) const {
-    const auto &tail_size = rhs_arg_static_params_.tail_size;
-    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-    helper_load_tail_t<avx2_vnni_2, Xbyak::Xmm>::load_rhs_tail_statically(
-            host_, tail_size, rhs_addr_reg, data_type, tmp_vmm, rhs_addr);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
-        const data_type_t &data_type, const Xbyak::Ymm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-    const auto &tail_size = rhs_arg_static_params_.tail_size;
-    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-
-    host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
-    static constexpr int xmm_size_elem = 4;
-    const auto res = std::div(tail_size, xmm_size_elem);
+    // AVX from here on. The tail is assembled in the lower half, and a Ymm
+    // destination has its upper half joined in the float domain by
+    // `load_tail_avx` because AVX has no 256-bit integer operations.
+    const bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
     const auto vmm_idx = tmp_vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
 
+    host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
+
     if (data_type == data_type::f32 || data_type == data_type::s32) {
-        const auto upper_half_op
-                = [&](int upper_half_data_size, bool should_load_lower_half) {
-            const int offset = should_load_lower_half
-                    ? xmm_size_elem * sizeof(float)
-                    : 0;
-            for (int i = 0; i < res.rem; i++)
+        if (is_ymm) {
+            const auto res = std::div(tail_size, xmm_size_elem);
+            const auto upper_half_op = [&](int upper_half_data_size,
+                                               bool should_load_lower_half) {
+                const int offset = should_load_lower_half
+                        ? xmm_size_elem * sizeof(float)
+                        : 0;
+                for (int i = 0; i < res.rem; i++)
+                    host_->vpinsrd(tmp_xmm, tmp_xmm,
+                            host_->ptr[rhs_addr_reg + offset
+                                    + i * sizeof(float)],
+                            i);
+            };
+
+            const auto lower_half_op = [&](int upper_half_data_size) {
+                host_->vmovups(tmp_xmm, rhs_addr);
+            };
+
+            load_tail_avx(
+                    host_, vmm_idx, tail_size, upper_half_op, lower_half_op);
+        } else {
+            for (size_t i = 0; i < tail_size; i++)
                 host_->vpinsrd(tmp_xmm, tmp_xmm,
-                        host_->ptr[rhs_addr_reg + offset + i * sizeof(float)],
-                        i);
-        };
-
-        const auto lower_half_op = [&](int upper_half_data_size) {
-            host_->vmovups(tmp_xmm, rhs_addr);
-        };
-        load_tail_avx(host_, vmm_idx, tail_size, upper_half_op, lower_half_op);
-
+                        host_->ptr[rhs_addr_reg + i * sizeof(float)], i);
+        }
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
         const auto cvt_to_dword = [&](const Xbyak::Operand &operand) {
             if (data_type == data_type::s8)
@@ -3683,59 +3644,31 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
                 host_->vpmovzxbd(tmp_xmm, operand);
         };
 
-        const auto upper_half_op
-                = [&](int upper_half_data_size, bool should_load_lower_half) {
-            const int offset = should_load_lower_half ? xmm_size_elem : 0;
-            for (int i = 0; i < upper_half_data_size; i++)
+        if (is_ymm) {
+            const auto upper_half_op = [&](int upper_half_data_size,
+                                               bool should_load_lower_half) {
+                const int offset = should_load_lower_half ? xmm_size_elem : 0;
+                for (int i = 0; i < upper_half_data_size; i++)
+                    host_->vpinsrb(tmp_xmm, tmp_xmm,
+                            host_->ptr[rhs_addr_reg + offset
+                                    + i * sizeof(int8_t)],
+                            i);
+                cvt_to_dword(tmp_xmm);
+            };
+
+            const auto lower_half_op
+                    = [&](int upper_half_data_size) { cvt_to_dword(rhs_addr); };
+
+            load_tail_avx(
+                    host_, vmm_idx, tail_size, upper_half_op, lower_half_op);
+        } else {
+            for (size_t i = 0; i < tail_size; i++)
                 host_->vpinsrb(tmp_xmm, tmp_xmm,
-                        host_->ptr[rhs_addr_reg + offset + i * sizeof(int8_t)],
-                        i);
+                        host_->ptr[rhs_addr_reg + i * sizeof(int8_t)], i);
             cvt_to_dword(tmp_xmm);
-        };
-
-        const auto lower_half_op
-                = [&](int upper_half_data_size) { cvt_to_dword(rhs_addr); };
-
-        load_tail_avx(host_, vmm_idx, tail_size, upper_half_op, lower_half_op);
+        }
     } else
         assert(!"unsupported data type");
-}
-
-template <>
-void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::load_rhs_tail_statically(
-        const data_type_t &data_type, const Xbyak::Xmm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-    const auto &tail_size = rhs_arg_static_params_.tail_size;
-    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-    host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
-
-    if (data_type == data_type::f32 || data_type == data_type::s32) {
-        for (size_t i = 0; i < tail_size; i++)
-            host_->vpinsrd(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(float)], i);
-    } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        for (size_t i = 0; i < tail_size; i++)
-            host_->vpinsrb(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(int8_t)], i);
-        if (data_type == data_type::s8)
-            host_->vpmovsxbd(tmp_vmm, tmp_vmm);
-        else
-            host_->vpmovzxbd(tmp_vmm, tmp_vmm);
-    } else
-        assert(!"unsupported data type");
-}
-
-template <>
-void jit_uni_binary_injector_t<sse41, Xbyak::Xmm>::load_rhs_tail_statically(
-        const data_type_t &data_type, const Xbyak::Xmm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-    if (!utils::one_of(data_type, data_type::f32, data_type::s32, data_type::s8,
-                data_type::u8))
-        assert(!"unsupported data type");
-
-    const auto &tail_size = rhs_arg_static_params_.tail_size;
-    host_->load_data(data_type, tmp_vmm, rhs_arg_static_params_.rhs_addr_reg, 0,
-            tail_size);
 }
 
 // Support compare with Address param only when isa is avx512.

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -389,8 +389,8 @@ rhs_arg_static_params_t::rhs_arg_static_params_t(
     , is_tail(tail_size)
     , is_opmask_set_(is_opmask_set) {}
 
-template <cpu_isa_t isa, typename Vmm>
-jit_uni_binary_injector_t<isa, Vmm>::jit_uni_binary_injector_t(
+template <typename Vmm>
+jit_uni_binary_injector_t<Vmm>::jit_uni_binary_injector_t(
         jit_generator_t *host, const static_params_t &static_params)
     : host_(host)
     , f8_e5m2_cvt_(static_params.f8_e5m2_cvt_)
@@ -425,8 +425,8 @@ static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
     return false;
 }
 
-template <cpu_isa_t isa, typename Vmm>
-int jit_uni_binary_injector_t<isa, Vmm>::adjust_temp_vmm_hint(
+template <typename Vmm>
+int jit_uni_binary_injector_t<Vmm>::adjust_temp_vmm_hint(
         int user_hint, int start_idx, int end_idx, int max_vmm_idx) const {
     const bool user_hint_in_vector_range
             = user_hint >= start_idx && user_hint <= end_idx;
@@ -483,8 +483,8 @@ static void restore_stack(jit_generator_t *host, const Vmm &vmm) {
     host->add(host->rsp, vreg_traits_t<Vmm>::vlen);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-std::pair<bool, int> jit_uni_binary_injector_t<isa, Vmm>::should_preserve_vmm(
+template <typename Vmm>
+std::pair<bool, int> jit_uni_binary_injector_t<Vmm>::should_preserve_vmm(
         int curr_idx, int vmm_hint, int max_vmm_idx,
         bool dt_helper_vmm_needed) const {
     if (dt_helper_vmm_needed && vmm_hint == curr_idx) {
@@ -496,8 +496,8 @@ std::pair<bool, int> jit_uni_binary_injector_t<isa, Vmm>::should_preserve_vmm(
     return std::make_pair(false, vmm_hint);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(size_t start_idx,
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::compute_vector_range(size_t start_idx,
         size_t end_idx, std::size_t rhs_arg_idx,
         const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
@@ -507,8 +507,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(size_t start_idx,
     compute_vector_range(vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs,
         std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
@@ -518,7 +518,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const auto end_idx = *(vmm_idxs.rbegin());
 
     // Phase 1 Validate temporary vmm user hint
-    const int max_vmm_idx = isa_num_vregs(isa) - 1;
+    const int max_vmm_idx = isa_num_vregs(isa_) - 1;
     auto &vmm_hint = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
     vmm_hint = adjust_temp_vmm_hint(vmm_hint, start_idx, end_idx, max_vmm_idx);
 
@@ -547,7 +547,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
             || should_preserve_vmm_tail || post_op.is_prelu();
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
     const int simd_w
-            = isa_max_vlen(isa) / types::data_type_size(dst_d.data_type());
+            = isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type());
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
@@ -719,8 +719,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     if (post_op.is_prelu() && is_avx512_) pop_opmask(host_, get_aux_kmask());
 }
 
-template <cpu_isa_t isa, typename Vmm>
-Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::prepare_rhs_arg_addr(
+template <typename Vmm>
+Xbyak::Address jit_uni_binary_injector_t<Vmm>::prepare_rhs_arg_addr(
         std::size_t vmm_idx, std::size_t rhs_arg_idx,
         const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
@@ -849,8 +849,8 @@ Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::prepare_rhs_arg_addr(
     return host_->ptr[rhs_addr_reg];
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_no_broadcast_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -888,8 +888,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_no_broadcast_base(
         Xbyak::Address addr, const Xbyak::Reg64 &out_reg) const {
     // addr may carry a zword[] (512-bit) size annotation because it was built
     // for a Zmm vmm access. LEA only needs the address computation, not the
@@ -903,8 +903,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_base(
                     rhs_arg_static_params_.dst_d.data_type())));
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_no_broadcast_partial(
         const std::size_t offset, const Xbyak::Reg64 &out_reg,
         std::size_t elem_size_bytes) const {
     const auto offset_adj = offset >> math::ilog2q(types::data_type_size(
@@ -914,8 +914,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -1007,8 +1007,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // c = (offset % strides[0]) / strides[1]
     // output = rax
@@ -1025,8 +1025,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_base(
     host_->div(tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // c = (offset % strides[0]) / strides[1]
@@ -1040,14 +1040,14 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_blocked_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     // output = rax
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w
-            = isa_max_vlen(isa) / types::data_type_size(dst_d.data_type());
+            = isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type());
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1071,8 +1071,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
     if (blk_size > simd_w) host_->add(rax, r8);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_blocked_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
@@ -1087,8 +1087,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_nspc_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // c = offset % C
     // output = rax
@@ -1103,8 +1103,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_base(
     host_->mov(rax, rdx);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_nspc_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // c = offset % C
@@ -1117,8 +1117,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // c = offset / strides[1]
     // output = rax
@@ -1131,8 +1131,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_base(
     host_->div(tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_cspn_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // c = offset / strides[1]
@@ -1144,8 +1144,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_oc_d_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -1214,8 +1214,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_d_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
 
     /* 
@@ -1249,8 +1249,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_base(
     host_->div(tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_d_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // dst_offset % dstride[0] / dstride[2] = b*C + c
@@ -1264,8 +1264,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_mb_sp_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -1371,8 +1371,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
         const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
         const dim_t *dst_strides, const Xbyak::Reg64 &addr_reg,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
@@ -1456,13 +1456,11 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa,
-        Vmm>::calculate_mb_sp_ncsp_partial_rhs_strided(const memory_desc_wrapper
-                                                               &dst_d,
-        const memory_desc_wrapper &rhs_d, std::size_t dst_offset_bytes,
-        const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes) const {
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_partial_rhs_strided(
+        const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
+        std::size_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
+        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     const dim_t rhs_offset
             = rhs_offset_per_mb_spatial(dst_d, rhs_d, dst_offset_bytes);
     if (rhs_offset == 0) return;
@@ -1478,8 +1476,8 @@ void jit_uni_binary_injector_t<isa,
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_sp_off = (n * (stride_n/C)) + (d * stride_d) + (h * stride_h) + (w * stride_w)
@@ -1522,8 +1520,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base(
     // rax = offset - (c * stride_c) - (n * (C - 1)DHW)
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
@@ -1548,14 +1546,14 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_blocked_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
     // output = rax
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w
-            = isa_max_vlen(isa) / types::data_type_size(dst_d.data_type());
+            = isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type());
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
 
     const auto rax = host_->rax;
@@ -1576,8 +1574,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
     calculate_mb_sp_ncsp_base(strides, tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_blocked_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
@@ -1601,8 +1599,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_nspc_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_sp_off = nDHW + dHW + hW + w
@@ -1618,8 +1616,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_base(
     host_->div(tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_nspc_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
@@ -1634,8 +1632,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_sp_off = dHWN + hWN + wN + n
@@ -1651,8 +1649,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_base(
     host_->mov(rax, rdx);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_cspn_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
@@ -1666,8 +1664,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_mb_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -1760,8 +1758,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
@@ -1820,8 +1818,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_base(
     // rax = (n * (stride_n/(C*D*H))) + (w * stride_w)
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
@@ -1843,24 +1841,24 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_blocked_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_blocked_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     // output = rax
     calculate_mb_sp_ncsp_base(strides, tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_blocked_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_blocked_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     calculate_mb_w_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_nspc_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_w_off = nW + w
@@ -1911,8 +1909,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_base(
     if (ndims >= 3) host_->add(rax, tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_nspc_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
@@ -1932,8 +1930,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_w_off = wN + n
@@ -1961,8 +1959,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_base(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_cspn_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
@@ -1977,8 +1975,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_hw_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -2066,8 +2064,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
         }
     }
 }
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_hw_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_hw_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = nCHW + cHW + hW + w (for 4D)
@@ -2088,8 +2086,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_hw_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_hw_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_hw_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nCHW + cHW + hW + w (for 4D)
     // per_spatial_off = hW + w
@@ -2111,8 +2109,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_hw_ncsp_base(
     host_->mov(rax, rdx);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -2194,8 +2192,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_w_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // w_off = w * stride_w
@@ -2222,14 +2220,14 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_base(
     // rax = w * stride_w
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_blocked_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_w_blocked_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     calculate_w_ncsp_base(strides, tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_w_nspc_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // w_off = w
@@ -2255,16 +2253,16 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_base(
     // rax = w
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_cspn_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_w_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // w_off = w
     calculate_w_nspc_base(strides, tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_mb_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -2355,8 +2353,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_off = offset / stride_n
@@ -2372,8 +2370,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_base(
     // rax = n
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
@@ -2387,16 +2385,16 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_nspc_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_nspc_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_off = n;
     calculate_mb_ncsp_base(strides, tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_nspc_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_nspc_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
@@ -2404,8 +2402,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_nspc_partial(
     calculate_mb_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_off = offset % N = offset % strides[ndims-1]
@@ -2424,8 +2422,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_base(
     // rax = n
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_cspn_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
@@ -2440,8 +2438,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_oc_spatial_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -2532,8 +2530,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // oc_spatial_off = offset % stride_n
@@ -2547,8 +2545,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_base(
     host_->mov(rax, rdx);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
@@ -2561,16 +2559,16 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_nspc_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_nspc_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // oc_spatial_off = offset % stride_n
     calculate_oc_spatial_ncsp_base(strides, tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_nspc_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_nspc_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
@@ -2579,8 +2577,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_nspc_partial(
             strides, offset, tmp_reg, elem_size_bytes);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // oc_spatial_off = offset / strides[ndims - 1]
@@ -2596,8 +2594,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_base(
     host_->div(tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_cspn_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
@@ -2611,8 +2609,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::append_mb_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
         const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
@@ -2703,8 +2701,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_ncsp_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nCDHW + cDHW + dHW + hW + w
     // mb_oc_off = nC + c
@@ -2718,8 +2716,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_base(
     host_->div(tmp_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_ncsp_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = nCDHW + cDHW + dHW + hW + w
@@ -2732,8 +2730,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_nspc_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_oc_off = nC + c
@@ -2761,8 +2759,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_base(
     host_->add(rax, tmp_reg); // rax = nC + c
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_nspc_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
@@ -2781,8 +2779,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_base(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_oc_off = cN + n
@@ -2810,8 +2808,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_base(
     host_->add(rax, tmp_reg); // rax = cN + n
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_partial(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_cspn_partial(
         const dim_t *strides, const std::size_t offset,
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
@@ -2830,8 +2828,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_partial(
                                 : offset_adj);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::inject_binary(
         const dnnl_post_ops::entry_t &post_op, Vmm dst,
         const Xbyak::Address &rhs_addr, bool with_tail,
         const tail_lode_mode_t tail_load_mode) const {
@@ -2846,7 +2844,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
     const bool scalar_f32
             = rhs_addr.isBroadcast() && rhs_arg_data_type == data_type::f32;
     const bool with_tail_not_fusable_to_binary_op
-            = with_tail && !isa_has_masks(isa);
+            = with_tail && !isa_has_masks(isa_);
     const bool cmp_op_with_tail_vector_mem_operand
             = cmp_op && with_tail && !rhs_addr.isBroadcast();
     const bool process_rhs_arg_using_tmp_vmm
@@ -2875,7 +2873,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
     } else {
         const auto lhs = dst;
         if (with_tail) {
-            assert(isa_has_masks(isa));
+            assert(isa_has_masks(isa_));
             assert(rhs_arg_static_params_.is_opmask_set()
                     && "Opmask is not set for tail loading avx512");
             const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
@@ -2889,8 +2887,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::inject_binary_with_ternary_op(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::inject_binary_with_ternary_op(
         const dnnl_post_ops::entry_t &post_op, Vmm dst,
         const Xbyak::Address &rhs_addr, Vmm tmp_vmm, bool with_tail,
         const tail_lode_mode_t tail_load_mode) const {
@@ -2905,7 +2903,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary_with_ternary_op(
         // While a more direct implementation can be obtained by
         // blending the tensors, the current approach reserves
         // fewer registers for operation.
-        if (is_superset(isa, avx512_core)) {
+        if (is_superset(isa_, avx512_core)) {
             const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;
             push_opmask(host_, cmp_mask);
             push_vmm(host_, dst);
@@ -2963,8 +2961,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary_with_ternary_op(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::execute_broadcast(
         const data_type_t &data_type, const Vmm &tmp_reg,
         const Xbyak::Address &rhs_addr, const tail_lode_mode_t tail_load_mode,
         bool with_tail) const {
@@ -2984,8 +2982,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast(
         execute_broadcast_no_tail(data_type, tmp_reg, rhs_addr);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::load_rhs(const data_type_t &data_type,
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::load_rhs(const data_type_t &data_type,
         const Vmm &tmp_reg, const Xbyak::Address &rhs_addr,
         const tail_lode_mode_t tail_load_mode, bool with_tail) const {
     if (with_tail) {
@@ -3003,8 +3001,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs(const data_type_t &data_type,
         load_rhs_no_tail(data_type, tmp_reg, rhs_addr);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::load_acc_as_f32(const Vmm &dst,
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::load_acc_as_f32(const Vmm &dst,
         const Xbyak::Reg64 &base, size_t byte_off, data_type_t data_type,
         bool with_tail, const tail_lode_mode_t tail_load_mode) const {
 
@@ -3050,20 +3048,20 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_acc_as_f32(const Vmm &dst,
     if (need_scratch_reg && preserve_gpr) host_->pop(addr_reg);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::remove_bcast_bit(
+template <typename Vmm>
+Xbyak::Address jit_uni_binary_injector_t<Vmm>::remove_bcast_bit(
         const Xbyak::Address &rhs_addr) const {
     return Xbyak::Address(rhs_addr.getBit(), false, rhs_addr.getRegExp());
 }
 
-template <cpu_isa_t isa, typename Vmm>
-Xbyak::Opmask jit_uni_binary_injector_t<isa, Vmm>::get_aux_kmask() const {
+template <typename Vmm>
+Xbyak::Opmask jit_uni_binary_injector_t<Vmm>::get_aux_kmask() const {
     auto tail_mask_idx = rhs_arg_static_params_.tail_opmask.getIdx();
     return Xbyak::Opmask(tail_mask_idx < 7 ? tail_mask_idx + 1 : 1);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::cvt_to_f32(const Vmm &tmp_vmm) const {
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::cvt_to_f32(const Vmm &tmp_vmm) const {
     if (is_sse41_) {
         const Xbyak::Xmm tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
         host_->cvtdq2ps(tmp_xmm, tmp_xmm);
@@ -3071,11 +3069,11 @@ void jit_uni_binary_injector_t<isa, Vmm>::cvt_to_f32(const Vmm &tmp_vmm) const {
         host_->uni_vcvtdq2ps(tmp_vmm, tmp_vmm);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_no_tail(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::execute_broadcast_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
-    assert(is_data_supported(isa, data_type) && "unsupported data type");
+    assert(is_data_supported(isa_, data_type) && "unsupported data type");
     switch (data_type) {
         case data_type::f32: host_->uni_vbroadcastss(tmp_vmm, rhs_addr); break;
         case data_type::s32: host_->uni_vpbroadcastd(tmp_vmm, rhs_addr); break;
@@ -3086,7 +3084,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_no_tail(
         case data_type::f16:
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, host_->ptr_b[rhs_addr.getRegExp()]);
-            else if (is_superset(isa, avx2_vnni_2))
+            else if (is_superset(isa_, avx2_vnni_2))
                 host_->vbcstnesh2ps(tmp_vmm, rhs_addr);
             else
                 assert(!"unsupported ISA for given data type");
@@ -3103,7 +3101,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_no_tail(
             if (is_avx512_) {
                 host_->vpbroadcastw(tmp_vmm, rhs_addr);
                 host_->vpslld(tmp_vmm, tmp_vmm, 0x10);
-            } else if (is_superset(isa, avx2_vnni_2)) {
+            } else if (is_superset(isa_, avx2_vnni_2)) {
                 host_->vbcstnebf162ps(tmp_vmm, rhs_addr);
             } else
                 assert(!"unsupported ISA for given data type");
@@ -3112,8 +3110,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_no_tail(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_s8u8_no_tail(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::execute_broadcast_s8u8_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
     assert(utils::one_of(data_type, data_type::s8, data_type::u8)
@@ -3163,12 +3161,12 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_s8u8_no_tail(
         assert(!"unsupported ISA");
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_with_opmask(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_with_opmask(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
 
-    assert(is_data_supported(isa, data_type) && "unsupported data type");
+    assert(is_data_supported(isa_, data_type) && "unsupported data type");
     assert(rhs_arg_static_params_.is_opmask_set()
             && "Opmask is not set for tail loading avx512");
     const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
@@ -3301,8 +3299,8 @@ static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
         host->vshufps(tmp_xmm, tmp_xmm, tmp_xmm, imms.at(tail_size - 2));
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_statically(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_statically(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr, const std::size_t tail_size) const {
     // An opmask-capable ISA has no static tail path. `execute_broadcast` sends
@@ -3321,7 +3319,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_statically(
     // Sub-dword floating point is widened in place from a packed tail, so it
     // shares neither the zeroing nor the element assembly the integer and f32
     // paths below need.
-    if (is_superset(isa, avx2_vnni_2)
+    if (is_superset(isa_, avx2_vnni_2)
             && utils::one_of(data_type, data_type::bf16, data_type::f16,
                     data_type::f8_e5m2, data_type::f8_e4m3)) {
         const auto tmp_lower_vmm =
@@ -3401,8 +3399,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_statically(
         assert(!"unsupported data type");
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_with_gpr(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_with_gpr(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
 
@@ -3416,11 +3414,11 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_with_gpr(
     host_->runtime_tail_process<Vmm>(reg_tail_size, reg_tmp, runtime_tail_load);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::load_rhs_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
-    assert(is_data_supported(isa, data_type) && "unsupported data type");
+    assert(is_data_supported(isa_, data_type) && "unsupported data type");
     switch (data_type) {
         case data_type::f32:
         case data_type::s32: host_->uni_vmovups(tmp_vmm, rhs_addr); break;
@@ -3431,7 +3429,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
         case data_type::f16:
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, rhs_addr);
-            else if (is_superset(isa, avx2_vnni_2))
+            else if (is_superset(isa_, avx2_vnni_2))
                 host_->vcvtph2ps(tmp_vmm, rhs_addr);
             else
                 assert(!"unsupported ISA for given data type");
@@ -3445,7 +3443,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
             f8_e4m3_cvt_->vcvt_f8_to_f32(tmp_vmm, rhs_addr);
             break;
         case data_type::bf16:
-            if (is_avx512_ || is_superset(isa, avx2_vnni_2)) {
+            if (is_avx512_ || is_superset(isa_, avx2_vnni_2)) {
                 host_->vpmovzxwd(tmp_vmm, rhs_addr);
                 host_->vpslld(tmp_vmm, tmp_vmm, 0x10);
                 break;
@@ -3454,8 +3452,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_i8_no_tail(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::load_rhs_i8_no_tail(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
     if (is_avx_ && std::is_same<Vmm, Xbyak::Ymm>::value) {
@@ -3492,11 +3490,11 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_i8_no_tail(
         assert(!"unsupported data type");
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_dynamically_with_opmask(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_dynamically_with_opmask(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
-    assert(is_data_supported(isa, data_type) && "unsupported data type");
+    assert(is_data_supported(isa_, data_type) && "unsupported data type");
     assert(rhs_arg_static_params_.is_opmask_set()
             && "Opmask is not set for tail loading avx512");
 
@@ -3537,8 +3535,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_dynamically_with_opmask(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_dynamically_with_gpr(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_dynamically_with_gpr(
         const data_type_t &data_type, const Vmm &tmp_vmm) const {
 
     const bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -3558,8 +3556,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_dynamically_with_gpr(
     host_->runtime_tail_process<Vmm>(reg_tail_size, reg_tmp, runtime_tail_load);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_statically(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_statically(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr) const {
     // An opmask-capable ISA has no static tail path. `load_rhs` sends its tails
@@ -3576,7 +3574,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_statically(
     // Sub-dword floating point is widened in place from a packed tail, so it
     // shares neither the zeroing nor the element assembly the dword paths
     // below need.
-    if (is_superset(isa, avx2_vnni_2)
+    if (is_superset(isa_, avx2_vnni_2)
             && utils::one_of(data_type, data_type::bf16, data_type::f16)) {
         const auto tmp_lower_vmm =
                 typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
@@ -3671,9 +3669,9 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_tail_statically(
         assert(!"unsupported data type");
 }
 
-template <cpu_isa_t isa, typename Vmm>
+template <typename Vmm>
 template <typename T>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
+void jit_uni_binary_injector_t<Vmm>::execute_cmp_binary(const Vmm &dst,
         const Vmm &lhs, const T &rhs, const unsigned int cmp_predicate) const {
     // The rhs operand shape selects the sequence, and it also pins the ISA. A
     // memory operand needs the opmask form because it only arrives from the
@@ -3716,9 +3714,9 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
+template <typename Vmm>
 template <typename T>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_binary(alg_kind_t binary_alg,
+void jit_uni_binary_injector_t<Vmm>::execute_binary(alg_kind_t binary_alg,
         const Vmm &dst, const Vmm &lhs, const T &rhs) const {
     switch (binary_alg) {
         case alg_kind::binary_add: host_->uni_vaddps(dst, lhs, rhs); break;
@@ -3749,11 +3747,11 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_binary(alg_kind_t binary_alg,
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::execute_prelu(
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::execute_prelu(
         const Vmm &dst, const Xbyak::Operand &rhs) const {
     Vmm tmp_vmm = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
-    if (is_superset(isa, avx512_core)) {
+    if (is_superset(isa_, avx512_core)) {
         assert(rhs.isMEM());
         Vmm dst_vmm = Vmm(dst.getIdx());
         Xbyak::Opmask maybe_tail_kmask = Xbyak::Opmask(dst.getOpmaskIdx());
@@ -3762,7 +3760,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_prelu(
         host_->vcmpps(aux_kmask | maybe_tail_kmask, dst_vmm, tmp_vmm,
                 jit_generator_t::_cmp_le_os);
         host_->vmulps(dst_vmm | aux_kmask, dst_vmm, rhs);
-    } else if (is_superset(isa, avx)) {
+    } else if (is_superset(isa_, avx)) {
         // Three operand version
         host_->uni_vmulps(tmp_vmm, dst, rhs);
         host_->uni_vblendvps(dst, dst, tmp_vmm, dst);
@@ -3787,27 +3785,16 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_prelu(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::compute_vector(size_t idx,
+template <typename Vmm>
+void jit_uni_binary_injector_t<Vmm>::compute_vector(size_t idx,
         std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
     compute_vector_range({idx}, rhs_arg_idx, post_op, rhs_arg_params);
 }
 
-template class jit_uni_binary_injector_t<avx512_core_fp16>;
-template class jit_uni_binary_injector_t<avx512_core_fp16, Xbyak::Ymm>;
-template class jit_uni_binary_injector_t<avx512_core_fp16, Xbyak::Xmm>;
-template class jit_uni_binary_injector_t<avx512_core_bf16>;
-template class jit_uni_binary_injector_t<avx512_core>;
-template class jit_uni_binary_injector_t<avx512_core, Xbyak::Ymm>;
-template class jit_uni_binary_injector_t<avx512_core, Xbyak::Xmm>;
-template class jit_uni_binary_injector_t<avx2_vnni_2>;
-template class jit_uni_binary_injector_t<avx2_vnni_2, Xbyak::Xmm>;
-template class jit_uni_binary_injector_t<avx2, Xbyak::Ymm>;
-template class jit_uni_binary_injector_t<avx2, Xbyak::Xmm>;
-template class jit_uni_binary_injector_t<avx, Xbyak::Ymm>;
-template class jit_uni_binary_injector_t<avx, Xbyak::Xmm>;
-template class jit_uni_binary_injector_t<sse41>;
+template class jit_uni_binary_injector_t<Xbyak::Zmm>;
+template class jit_uni_binary_injector_t<Xbyak::Ymm>;
+template class jit_uni_binary_injector_t<Xbyak::Xmm>;
 
 #undef VCHECK_BIN_INJ_BOOL
 

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -518,7 +518,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const auto end_idx = *(vmm_idxs.rbegin());
 
     // Phase 1 Validate temporary vmm user hint
-    static constexpr int max_vmm_idx = cpu_isa_traits_t<isa>::n_vregs - 1;
+    const int max_vmm_idx = isa_num_vregs(isa) - 1;
     auto &vmm_hint = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
     vmm_hint = adjust_temp_vmm_hint(vmm_hint, start_idx, end_idx, max_vmm_idx);
 
@@ -546,8 +546,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
             || rhs_arg_data_type != data_type::f32 || bcast_f32_non_avx512
             || should_preserve_vmm_tail || post_op.is_prelu();
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
-    const int simd_w = cpu_isa_traits_t<isa>::vlen
-            / types::data_type_size(dst_d.data_type());
+    const int simd_w
+            = isa_max_vlen(isa) / types::data_type_size(dst_d.data_type());
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
@@ -1046,8 +1046,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     // output = rax
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int simd_w = cpu_isa_traits_t<isa>::vlen
-            / types::data_type_size(dst_d.data_type());
+    const int simd_w
+            = isa_max_vlen(isa) / types::data_type_size(dst_d.data_type());
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1554,8 +1554,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
     // output = rax
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int simd_w = cpu_isa_traits_t<isa>::vlen
-            / types::data_type_size(dst_d.data_type());
+    const int simd_w
+            = isa_max_vlen(isa) / types::data_type_size(dst_d.data_type());
     const int blk_size = dst_d.blocking_desc().inner_blks[0];
 
     const auto rax = host_->rax;
@@ -3088,7 +3088,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_no_tail(
         case data_type::f16:
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, host_->ptr_b[rhs_addr.getRegExp()]);
-            else if (isa == avx2_vnni_2)
+            else if (is_superset(isa, avx2_vnni_2))
                 host_->vbcstnesh2ps(tmp_vmm, rhs_addr);
             else
                 assert(!"unsupported ISA for given data type");
@@ -3105,7 +3105,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_no_tail(
             if (is_avx512_) {
                 host_->vpbroadcastw(tmp_vmm, rhs_addr);
                 host_->vpslld(tmp_vmm, tmp_vmm, 0x10);
-            } else if (isa == avx2_vnni_2) {
+            } else if (is_superset(isa, avx2_vnni_2)) {
                 host_->vbcstnebf162ps(tmp_vmm, rhs_addr);
             } else
                 assert(!"unsupported ISA for given data type");
@@ -3581,7 +3581,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
         case data_type::f16:
             if (is_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, rhs_addr);
-            else if (isa == avx2_vnni_2)
+            else if (is_superset(isa, avx2_vnni_2))
                 host_->vcvtph2ps(tmp_vmm, rhs_addr);
             else
                 assert(!"unsupported ISA for given data type");
@@ -3595,7 +3595,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::load_rhs_no_tail(
             f8_e4m3_cvt_->vcvt_f8_to_f32(tmp_vmm, rhs_addr);
             break;
         case data_type::bf16:
-            if (is_avx512_ || isa == avx2_vnni_2) {
+            if (is_avx512_ || is_superset(isa, avx2_vnni_2)) {
                 host_->vpmovzxwd(tmp_vmm, rhs_addr);
                 host_->vpslld(tmp_vmm, tmp_vmm, 0x10);
                 break;

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -3064,13 +3064,11 @@ Xbyak::Opmask jit_uni_binary_injector_t<isa, Vmm>::get_aux_kmask() const {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::cvt_to_f32(const Vmm &tmp_vmm) const {
-    host_->uni_vcvtdq2ps(tmp_vmm, tmp_vmm);
-}
-
-template <>
-void jit_uni_binary_injector_t<sse41, Xbyak::Xmm>::cvt_to_f32(
-        const Xbyak::Xmm &tmp_vmm) const {
-    host_->cvtdq2ps(tmp_vmm, tmp_vmm);
+    if (is_sse41_) {
+        const Xbyak::Xmm tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
+        host_->cvtdq2ps(tmp_xmm, tmp_xmm);
+    } else
+        host_->uni_vcvtdq2ps(tmp_vmm, tmp_vmm);
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -3121,94 +3119,48 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_s8u8_no_tail(
     assert(utils::one_of(data_type, data_type::s8, data_type::u8)
             && "unsupported data type");
 
-    const Xbyak::Xmm xmm(tmp_vmm.getIdx());
+    const auto rhs_helper_reg_idx
+            = rhs_arg_static_params_.rhs_helper_reg.getIdx();
+    const Xbyak::Reg8 tmp_reg8 = Xbyak::Reg8(rhs_helper_reg_idx);
+    const Xbyak::Reg32 tmp_reg32 = Xbyak::Reg32(rhs_helper_reg_idx);
+    const Xbyak::Xmm tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
 
-    host_->uni_vpinsrb(xmm, xmm, rhs_addr, 0);
-    if (data_type == data_type::s8)
-        host_->uni_vpmovsxbd(xmm, xmm);
-    else if (data_type == data_type::u8)
-        host_->uni_vpmovzxbd(tmp_vmm, xmm);
-    host_->uni_vpbroadcastd(tmp_vmm, xmm);
-}
-
-template <cpu_isa_t isa, typename Vmm>
-struct helper_broadcast_s8u8_t {};
-
-template <typename Vmm>
-struct helper_broadcast_s8u8_t<avx, Vmm> {
-    static void execute_broadcast_s8u8_no_tail(jit_generator_t *host,
-            const int rhs_helper_reg_idx, const data_type_t &data_type,
-            const Vmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-            const std::function<void()> &post_process) {
-
-        if (data_type != data_type::s8 && data_type != data_type::u8)
-            assert(!"unsupported data type");
-
-        const Xbyak::Reg8 tmp_reg8 = Xbyak::Reg8(rhs_helper_reg_idx);
-        const Xbyak::Reg32 tmp_reg32 = Xbyak::Reg32(rhs_helper_reg_idx);
-        const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
-        host->mov(tmp_reg8, rhs_addr);
-        host->vmovd(tmp_xmm, tmp_reg32);
-        host->vpunpcklbw(tmp_xmm, tmp_xmm, tmp_xmm);
-        host->vpshuflw(tmp_xmm, tmp_xmm, 0);
+    if (has_avx2_) {
+        host_->uni_vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, 0);
         if (data_type == data_type::s8)
-            host->vpmovsxbd(tmp_xmm, tmp_xmm);
-        else
-            host->vpmovzxbd(tmp_xmm, tmp_xmm);
-
-        if (post_process) post_process();
-    }
-};
-
-template <>
-void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::execute_broadcast_s8u8_no_tail(
-        const data_type_t &data_type, const Xbyak::Ymm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-
-    const auto rhs_helper_reg_idx
-            = rhs_arg_static_params_.rhs_helper_reg.getIdx();
-    const auto expand_xmm_to_ymm = [&] {
-        const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
-        host_->vinsertf128(tmp_vmm, tmp_vmm, tmp_xmm, 1);
-    };
-
-    helper_broadcast_s8u8_t<avx, Xbyak::Ymm>::execute_broadcast_s8u8_no_tail(
-            host_, rhs_helper_reg_idx, data_type, tmp_vmm, rhs_addr,
-            expand_xmm_to_ymm);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::execute_broadcast_s8u8_no_tail(
-        const data_type_t &data_type, const Xbyak::Xmm &tmp_vmm,
-        const Xbyak::Address &rhs_addr) const {
-
-    const auto rhs_helper_reg_idx
-            = rhs_arg_static_params_.rhs_helper_reg.getIdx();
-    helper_broadcast_s8u8_t<avx, Xbyak::Xmm>::execute_broadcast_s8u8_no_tail(
-            host_, rhs_helper_reg_idx, data_type, tmp_vmm, rhs_addr, nullptr);
-}
-
-template <>
-void jit_uni_binary_injector_t<sse41,
-        Xbyak::Xmm>::execute_broadcast_s8u8_no_tail(const data_type_t
-                                                            &data_type,
-        const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr) const {
-
-    if (data_type == data_type::s8 || data_type == data_type::u8) {
-        const auto tmp_reg64_idx
-                = rhs_arg_static_params_.rhs_helper_reg.getIdx();
-        const Xbyak::Reg8 tmp_reg8 = Xbyak::Reg8(tmp_reg64_idx);
+            host_->uni_vpmovsxbd(tmp_xmm, tmp_xmm);
+        else if (data_type == data_type::u8)
+            host_->uni_vpmovzxbd(tmp_vmm, tmp_xmm);
+        host_->uni_vpbroadcastd(tmp_vmm, tmp_xmm);
+    } else if (is_avx_) {
+        // AVX has no register-source dword broadcast, so the byte is
+        // duplicated across the low half by an unpack and a shuffle before the
+        // extension spreads it over the four dwords.
         host_->mov(tmp_reg8, rhs_addr);
-        const Xbyak::Reg32 tmp_reg32 = Xbyak::Reg32(tmp_reg64_idx);
-        host_->movd(tmp_vmm, tmp_reg32);
-        host_->punpcklbw(tmp_vmm, tmp_vmm);
-        host_->pshuflw(tmp_vmm, tmp_vmm, 0);
+        host_->vmovd(tmp_xmm, tmp_reg32);
+        host_->vpunpcklbw(tmp_xmm, tmp_xmm, tmp_xmm);
+        host_->vpshuflw(tmp_xmm, tmp_xmm, 0);
         if (data_type == data_type::s8)
-            host_->pmovsxbd(tmp_vmm, tmp_vmm);
+            host_->vpmovsxbd(tmp_xmm, tmp_xmm);
         else
-            host_->pmovzxbd(tmp_vmm, tmp_vmm);
+            host_->vpmovzxbd(tmp_xmm, tmp_xmm);
+        // AVX has no 256-bit integer operations either, so a Ymm destination
+        // gets its upper half from a float-domain copy of the lower one.
+        if (std::is_same<Vmm, Xbyak::Ymm>::value) {
+            const Xbyak::Ymm tmp_ymm = Xbyak::Ymm(tmp_vmm.getIdx());
+            host_->vinsertf128(tmp_ymm, tmp_ymm, tmp_xmm, 1);
+        }
+    } else if (is_sse41_) {
+        host_->mov(tmp_reg8, rhs_addr);
+        host_->movd(tmp_xmm, tmp_reg32);
+        host_->punpcklbw(tmp_xmm, tmp_xmm);
+        host_->pshuflw(tmp_xmm, tmp_xmm, 0);
+        if (data_type == data_type::s8)
+            host_->pmovsxbd(tmp_xmm, tmp_xmm);
+        else
+            host_->pmovzxbd(tmp_xmm, tmp_xmm);
     } else
-        assert(!"unsupported data type");
+        assert(!"unsupported ISA");
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -3302,203 +3302,101 @@ static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-struct helper_bcast_tail_t {};
-
-template <typename Vmm>
-struct helper_bcast_tail_t<avx2, Vmm> {
-    static void execute_broadcast_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const data_type_t &data_type,
-            const Vmm &tmp_vmm, const Xbyak::Address &rhs_addr) {
-        host->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
-
-        if (data_type == data_type::f32 || data_type == data_type::s32) {
-            execute_broadcast_f32_tail_avx(host, tmp_vmm, rhs_addr, tail_size);
-        } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-            const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
-            for (std::size_t i = 0; i < tail_size; i++)
-                host->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
-
-            if (data_type == data_type::s8)
-                host->vpmovsxbd(tmp_vmm, tmp_xmm);
-            else
-                host->vpmovzxbd(tmp_vmm, tmp_xmm);
-        } else
-            assert(!"unsupported data type");
-    }
-};
-
-template <typename Vmm>
-struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
-    static void execute_broadcast_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const data_type_t &data_type,
-            const Vmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-            fp8_conversion_e5m2_t *f8_e5m2_cvt,
-            fp8_conversion_e4m3_t *f8_e4m3_cvt) {
-        if (utils::one_of(data_type, data_type::bf16, data_type::f16,
-                    data_type::f8_e5m2, data_type::f8_e4m3)) {
-            const auto tmp_lower_vmm =
-                    typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
-            host->load_bytes(tmp_lower_vmm, rhs_addr,
-                    tail_size * types::data_type_size(data_type));
-            if (data_type == data_type::bf16) {
-                host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
-                host->vpslld(tmp_vmm, tmp_vmm, 16);
-            } else if (data_type == data_type::f16) {
-                host->vcvtph2ps(tmp_vmm, tmp_lower_vmm);
-            } else
-                assert(!"Unsupported data type");
-
-        } else {
-            helper_bcast_tail_t<avx2, Vmm>::execute_broadcast_tail_statically(
-                    host, tail_size, data_type, tmp_vmm, rhs_addr);
-        }
-    }
-};
-
-template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_statically(
         const data_type_t &data_type, const Vmm &tmp_vmm,
         const Xbyak::Address &rhs_addr, const std::size_t tail_size) const {
-    assert(!"unsupported tail load mode");
-}
+    // An opmask-capable ISA has no static tail path. `execute_broadcast` sends
+    // its tails to `execute_broadcast_tail_with_opmask`, so arriving here means
+    // the caller asked for a tail mode this ISA does not implement.
+    if (is_avx512_) {
+        assert(!"unsupported tail load mode");
+        return;
+    }
 
-template <>
-void jit_uni_binary_injector_t<avx2_vnni_2,
-        Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
-                                                               &data_type,
-        const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
-    helper_bcast_tail_t<avx2_vnni_2,
-            Xbyak::Ymm>::execute_broadcast_tail_statically(host_, tail_size,
-            data_type, tmp_vmm, rhs_addr, f8_e5m2_cvt_, f8_e4m3_cvt_);
-}
+    const auto vmm_idx = tmp_vmm.getIdx();
+    const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
+    static const std::array<Xbyak::uint8, 2> imms {
+            {MM_SHUFFLE(3, 2, 0, 0), MM_SHUFFLE(3, 0, 0, 0)}};
 
-template <>
-void jit_uni_binary_injector_t<avx2_vnni_2,
-        Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
-                                                               &data_type,
-        const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
-    helper_bcast_tail_t<avx2_vnni_2,
-            Xbyak::Xmm>::execute_broadcast_tail_statically(host_, tail_size,
-            data_type, tmp_vmm, rhs_addr, f8_e5m2_cvt_, f8_e4m3_cvt_);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx2,
-        Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
-                                                               &data_type,
-        const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
-    helper_bcast_tail_t<avx2, Xbyak::Ymm>::execute_broadcast_tail_statically(
-            host_, tail_size, data_type, tmp_vmm, rhs_addr);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx2,
-        Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
-                                                               &data_type,
-        const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
-    helper_bcast_tail_t<avx2, Xbyak::Xmm>::execute_broadcast_tail_statically(
-            host_, tail_size, data_type, tmp_vmm, rhs_addr);
-}
-
-template <>
-void jit_uni_binary_injector_t<avx,
-        Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
-                                                               &data_type,
-        const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+    // Sub-dword floating point is widened in place from a packed tail, so it
+    // shares neither the zeroing nor the element assembly the integer and f32
+    // paths below need.
+    if (is_superset(isa, avx2_vnni_2)
+            && utils::one_of(data_type, data_type::bf16, data_type::f16,
+                    data_type::f8_e5m2, data_type::f8_e4m3)) {
+        const auto tmp_lower_vmm =
+                typename vreg_traits_t<Vmm>::Vmm_lower_t(vmm_idx);
+        host_->load_bytes(tmp_lower_vmm, rhs_addr,
+                tail_size * types::data_type_size(data_type));
+        if (data_type == data_type::bf16) {
+            host_->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
+            host_->vpslld(tmp_vmm, tmp_vmm, 16);
+        } else if (data_type == data_type::f16)
+            host_->vcvtph2ps(tmp_vmm, tmp_lower_vmm);
+        else
+            assert(!"unsupported data type");
+        return;
+    }
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
     if (data_type == data_type::f32 || data_type == data_type::s32) {
-        execute_broadcast_f32_tail_avx(host_, tmp_vmm, rhs_addr, tail_size);
+        if (is_sse41_) {
+            host_->movss(tmp_xmm, rhs_addr);
+            if (tail_size > 1)
+                host_->shufps(tmp_xmm, tmp_xmm, imms[tail_size - 2]);
+        } else
+            execute_broadcast_f32_tail_avx(host_, tmp_vmm, rhs_addr, tail_size);
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        const auto vmm_idx = tmp_vmm.getIdx();
-        const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
-        static const std::array<Xbyak::uint8, 2> imms {
-                {MM_SHUFFLE(3, 2, 0, 0), MM_SHUFFLE(3, 0, 0, 0)}};
+        if (is_sse41_) {
+            for (std::size_t i = 0; i < tail_size; i++)
+                host_->pinsrb(tmp_xmm, rhs_addr, i);
 
-        const auto cvt_to_dword = [&] {
             if (data_type == data_type::s8)
-                host_->vpmovsxbd(tmp_xmm, tmp_xmm);
+                host_->pmovsxbd(tmp_xmm, tmp_xmm);
             else
-                host_->vpmovzxbd(tmp_xmm, tmp_xmm);
-        };
+                host_->pmovzxbd(tmp_xmm, tmp_xmm);
+        } else if (is_avx_ && std::is_same<Vmm, Xbyak::Ymm>::value) {
+            // AVX has no 256-bit integer operations, so the value is extended
+            // to dwords in the lower half and the halves are then joined in
+            // the float domain by `load_tail_avx`.
+            const auto cvt_to_dword = [&] {
+                if (data_type == data_type::s8)
+                    host_->vpmovsxbd(tmp_xmm, tmp_xmm);
+                else
+                    host_->vpmovzxbd(tmp_xmm, tmp_xmm);
+            };
 
-        const auto init_op = [&] {
-            host_->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, 0);
-            cvt_to_dword();
-        };
+            const auto init_op = [&] {
+                host_->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, 0);
+                cvt_to_dword();
+            };
 
-        const auto upper_half_op
-                = [&](int upper_half_data_size, bool should_load_lower_half) {
-            if (upper_half_data_size > 1)
-                host_->vshufps(tmp_xmm, tmp_xmm, tmp_xmm,
-                        imms.at(upper_half_data_size - 2));
-        };
+            const auto upper_half_op = [&](int upper_half_data_size,
+                                               bool should_load_lower_half) {
+                if (upper_half_data_size > 1)
+                    host_->vshufps(tmp_xmm, tmp_xmm, tmp_xmm,
+                            imms.at(upper_half_data_size - 2));
+            };
 
-        const auto lower_half_op = [&](int upper_half_data_size) {
-            host_->vshufps(tmp_xmm, tmp_xmm, tmp_xmm, 0);
-        };
+            const auto lower_half_op = [&](int upper_half_data_size) {
+                host_->vshufps(tmp_xmm, tmp_xmm, tmp_xmm, 0);
+            };
 
-        load_tail_avx(host_, vmm_idx, tail_size, init_op, upper_half_op,
-                lower_half_op);
-    } else
-        assert(!"unsupported data type");
-}
+            load_tail_avx(host_, vmm_idx, tail_size, init_op, upper_half_op,
+                    lower_half_op);
+        } else {
+            // The destination is at most 128 bits wide, or the ISA extends
+            // bytes straight to a wider destination, so the tail is inserted
+            // element by element and extended in one step.
+            for (std::size_t i = 0; i < tail_size; i++)
+                host_->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
 
-template <>
-void jit_uni_binary_injector_t<avx,
-        Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
-                                                               &data_type,
-        const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
-
-    host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
-
-    const auto load_tail_avx_xmm = [&]() {
-        for (size_t i = 0; i < tail_size; i++)
-            host_->vpinsrb(tmp_vmm, tmp_vmm, rhs_addr, i);
-    };
-
-    if (data_type == data_type::f32 || data_type == data_type::s32) {
-        execute_broadcast_f32_tail_avx(host_, tmp_vmm, rhs_addr, tail_size);
-    } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        load_tail_avx_xmm();
-        if (data_type == data_type::s8)
-            host_->vpmovsxbd(tmp_vmm, tmp_vmm);
-        else
-            host_->vpmovzxbd(tmp_vmm, tmp_vmm);
-    } else
-        assert(!"unsupported data type");
-}
-
-template <>
-void jit_uni_binary_injector_t<sse41,
-        Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
-                                                               &data_type,
-        const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
-
-    host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
-    if (data_type == data_type::f32 || data_type == data_type::s32) {
-        static const std::array<Xbyak::uint8, 2> imms {
-                {MM_SHUFFLE(3, 2, 0, 0), MM_SHUFFLE(3, 0, 0, 0)}};
-
-        host_->movss(tmp_vmm, rhs_addr);
-        if (tail_size > 1) host_->shufps(tmp_vmm, tmp_vmm, imms[tail_size - 2]);
-
-    } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        for (std::size_t i = 0; i < tail_size; i++)
-            host_->pinsrb(tmp_vmm, rhs_addr, i);
-
-        if (data_type == data_type::s8)
-            host_->pmovsxbd(tmp_vmm, tmp_vmm);
-        else
-            host_->pmovzxbd(tmp_vmm, tmp_vmm);
+            if (data_type == data_type::s8)
+                host_->vpmovsxbd(tmp_vmm, tmp_xmm);
+            else
+                host_->vpmovzxbd(tmp_vmm, tmp_xmm);
+        }
     } else
         assert(!"unsupported data type");
 }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -530,13 +530,13 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
     const auto needs_ternary_input = post_op.is_binary_with_ternary_op();
     const auto &vmm_tail_idx = rhs_arg_params.vmm_tail_idx_;
     const bool tail_exists_in_range = !vmm_tail_idx.empty();
-    const bool bcast_f32_non_avx512 = !is_avx512_
+    const bool bcast_f32_non_avx512 = !has_avx512_core_
             && utils::one_of(rhs_broadcasting_strategy,
                     broadcasting_strategy_t::scalar,
                     broadcasting_strategy_t::per_oc_spatial)
             && rhs_arg_data_type == data_type::f32;
     const bool should_preserve_vmm_tail = tail_exists_in_range
-            && (!is_avx512_
+            && (!has_avx512_core_
                     || !utils::one_of(rhs_broadcasting_strategy,
                             broadcasting_strategy_t::scalar,
                             broadcasting_strategy_t::per_oc_spatial)
@@ -636,7 +636,8 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
 
     bool vmm0_was_preserved = false;
     static const Vmm zero_vmm(0);
-    if (post_op.is_prelu() && is_avx512_) push_opmask(host_, get_aux_kmask());
+    if (post_op.is_prelu() && has_avx512_core_)
+        push_opmask(host_, get_aux_kmask());
 
     Xbyak::Address rhs1_arg_addr {};
     Xbyak::Address rhs2_arg_addr {};
@@ -716,7 +717,8 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
     }
     // ...and restored afterwards
     if (vmm0_was_preserved) pop_vmm(host_, zero_vmm);
-    if (post_op.is_prelu() && is_avx512_) pop_opmask(host_, get_aux_kmask());
+    if (post_op.is_prelu() && has_avx512_core_)
+        pop_opmask(host_, get_aux_kmask());
 }
 
 template <typename Vmm>
@@ -2848,10 +2850,12 @@ void jit_uni_binary_injector_t<Vmm>::inject_binary(
     const bool cmp_op_with_tail_vector_mem_operand
             = cmp_op && with_tail && !rhs_addr.isBroadcast();
     const bool process_rhs_arg_using_tmp_vmm
-            = rhs_arg_data_type != data_type::f32 || (scalar_f32 && !is_avx512_)
+            = rhs_arg_data_type != data_type::f32
+            || (scalar_f32 && !has_avx512_core_)
             || with_tail_not_fusable_to_binary_op
             || !binary_op_with_unaligned_mem_operand_allowed_
-            || (cmp_op && !is_avx512_) || cmp_op_with_tail_vector_mem_operand;
+            || (cmp_op && !has_avx512_core_)
+            || cmp_op_with_tail_vector_mem_operand;
 
     if (process_rhs_arg_using_tmp_vmm) {
 
@@ -2969,8 +2973,8 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast(
     if (with_tail) {
         if (tail_load_mode == tail_lode_mode_t::DYNAMIC
                 || (tail_load_mode == tail_lode_mode_t::DEFAULT
-                        && is_avx512_)) {
-            if (is_avx512_)
+                        && has_avx512_core_)) {
+            if (has_avx512_core_)
                 execute_broadcast_tail_with_opmask(
                         data_type, tmp_reg, rhs_addr);
             else
@@ -2989,8 +2993,8 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs(const data_type_t &data_type,
     if (with_tail) {
         if (tail_load_mode == tail_lode_mode_t::DYNAMIC
                 || (tail_load_mode == tail_lode_mode_t::DEFAULT
-                        && is_avx512_)) {
-            if (is_avx512_)
+                        && has_avx512_core_)) {
+            if (has_avx512_core_)
                 load_rhs_tail_dynamically_with_opmask(
                         data_type, tmp_reg, rhs_addr);
             else
@@ -3018,7 +3022,8 @@ void jit_uni_binary_injector_t<Vmm>::load_acc_as_f32(const Vmm &dst,
     //      ignores the operand.
     //   2. A byte offset that doesn't fit int range.
     // No-tail and AVX-512 opmask tail loads take the operand directly.
-    const bool need_scratch_reg = (with_tail && !is_avx512_) || !byte_off_fits;
+    const bool need_scratch_reg
+            = (with_tail && !has_avx512_core_) || !byte_off_fits;
 
     // This is a direct entry point so the register-preserve guard is not in
     // effect here. Since we need to follow the defined ABI we preserve the
@@ -3082,7 +3087,7 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_no_tail(
             execute_broadcast_s8u8_no_tail(data_type, tmp_vmm, rhs_addr);
             break;
         case data_type::f16:
-            if (is_avx512_core_fp16_)
+            if (has_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, host_->ptr_b[rhs_addr.getRegExp()]);
             else if (is_superset(isa_, avx2_vnni_2))
                 host_->vbcstnesh2ps(tmp_vmm, rhs_addr);
@@ -3098,7 +3103,7 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_no_tail(
             f8_e4m3_cvt_->bcst_f8_to_f32(tmp_vmm, rhs_addr);
             break;
         case data_type::bf16:
-            if (is_avx512_) {
+            if (has_avx512_core_) {
                 host_->vpbroadcastw(tmp_vmm, rhs_addr);
                 host_->vpslld(tmp_vmm, tmp_vmm, 0x10);
             } else if (is_superset(isa_, avx2_vnni_2)) {
@@ -3191,7 +3196,7 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_with_opmask(
             break;
         }
         case data_type::f16:
-            if (is_avx512_core_fp16_)
+            if (has_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm | tail_opmask | host_->T_z,
                         host_->ptr_b[rhs_addr.getRegExp()]);
             else
@@ -3306,7 +3311,7 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_statically(
     // An opmask-capable ISA has no static tail path. `execute_broadcast` sends
     // its tails to `execute_broadcast_tail_with_opmask`, so arriving here means
     // the caller asked for a tail mode this ISA does not implement.
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         assert(!"unsupported tail load mode");
         return;
     }
@@ -3427,7 +3432,7 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_no_tail(
             load_rhs_i8_no_tail(data_type, tmp_vmm, rhs_addr);
             break;
         case data_type::f16:
-            if (is_avx512_core_fp16_)
+            if (has_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm, rhs_addr);
             else if (is_superset(isa_, avx2_vnni_2))
                 host_->vcvtph2ps(tmp_vmm, rhs_addr);
@@ -3443,7 +3448,7 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_no_tail(
             f8_e4m3_cvt_->vcvt_f8_to_f32(tmp_vmm, rhs_addr);
             break;
         case data_type::bf16:
-            if (is_avx512_ || is_superset(isa_, avx2_vnni_2)) {
+            if (has_avx512_core_ || is_superset(isa_, avx2_vnni_2)) {
                 host_->vpmovzxwd(tmp_vmm, rhs_addr);
                 host_->vpslld(tmp_vmm, tmp_vmm, 0x10);
                 break;
@@ -3512,7 +3517,7 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_dynamically_with_opmask(
             host_->vpmovzxbd(tmp_vmm | tail_opmask | host_->T_z, rhs_addr);
             break;
         case data_type::f16:
-            if (is_avx512_core_fp16_)
+            if (has_avx512_core_fp16_)
                 host_->vcvtph2psx(tmp_vmm | tail_opmask | host_->T_z, rhs_addr);
             else
                 assert(!"unsupported masked tail processing");
@@ -3563,7 +3568,7 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_statically(
     // An opmask-capable ISA has no static tail path. `load_rhs` sends its tails
     // to `load_rhs_tail_dynamically_with_opmask`, so arriving here means the
     // caller asked for a tail mode this ISA does not implement.
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         assert(!"unsupported tail load mode");
         return;
     }
@@ -3684,7 +3689,7 @@ void jit_uni_binary_injector_t<Vmm>::execute_cmp_binary(const Vmm &dst,
     const bool rhs_requires_opmask = std::is_same<T, Xbyak::Zmm>::value
             || std::is_same<T, Xbyak::Address>::value;
     if (rhs_requires_opmask) {
-        assert(is_avx512_ && "compare with an opmask requires AVX-512");
+        assert(has_avx512_core_ && "compare with an opmask requires AVX-512");
         // For GreaterEqual op, replace 0xFFFFFFFF by 1
         // which was returned by vcmpps.
         const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -655,8 +655,8 @@ private:
      * When using benchdnn zmalloc_protect doesn't guarantee that tensor memory
      * address is 64 byte aligned, which can cause segmentation fault.
      */
-    static constexpr bool binary_op_with_unaligned_mem_operand_allowed_
-            = !utils::one_of(isa, avx, sse41);
+    const bool binary_op_with_unaligned_mem_operand_allowed_
+            = is_superset(isa, avx2);
 };
 
 } // namespace binary_injector

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -645,6 +645,9 @@ private:
     const bcast_set_t supported_strategy_set_;
     const bool is_avx512_ = is_superset(isa, avx512_core);
     const bool is_avx512_core_fp16_ = is_superset(isa, avx512_core_fp16);
+    const bool has_avx2_ = is_superset(isa, avx2);
+    const bool is_avx_ = is_superset(isa, avx) && !has_avx2_;
+    const bool is_sse41_ = !is_superset(isa, avx);
 
     static constexpr int sizeof_reg64 = 8;
     /*

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -568,14 +568,7 @@ private:
             std::size_t elem_size_bytes) const;
 
     template <typename T>
-    typename std::enable_if<std::is_same<T, Xbyak::Zmm>::value
-            || std::is_same<T, Xbyak::Address>::value>::type
-    execute_cmp_binary(const Vmm &dst, const Vmm &lhs, const T &rhs,
-            const unsigned int cmp_predicate) const;
-    template <typename T>
-    typename std::enable_if<!(std::is_same<T, Xbyak::Zmm>::value
-            || std::is_same<T, Xbyak::Address>::value)>::type
-    execute_cmp_binary(const Vmm &dst, const Vmm &lhs, const T &rhs,
+    void execute_cmp_binary(const Vmm &dst, const Vmm &lhs, const T &rhs,
             const unsigned int cmp_predicate) const;
     template <typename T>
     void execute_binary(alg_kind_t binary_alg, const Vmm &dst, const Vmm &lhs,

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -641,8 +641,8 @@ private:
     const Xbyak::Reg64 param1_;
     const bcast_set_t supported_strategy_set_;
     const cpu_isa_t isa_ = host_->max_cpu_isa();
-    const bool is_avx512_ = is_superset(isa_, avx512_core);
-    const bool is_avx512_core_fp16_ = is_superset(isa_, avx512_core_fp16);
+    const bool has_avx512_core_ = is_superset(isa_, avx512_core);
+    const bool has_avx512_core_fp16_ = is_superset(isa_, avx512_core_fp16);
     const bool has_avx2_ = is_superset(isa_, avx2);
     const bool is_avx_ = is_superset(isa_, avx) && !has_avx2_;
     const bool is_sse41_ = !is_superset(isa_, avx);

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -266,8 +266,12 @@ bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
  * Main mechanism responsible for injecting binary postops supporting various
  * isa: sse41, avx, avx2, avx512 with core, bf16 extensions as well as data
  * types: f32, bf16, s32, u8, s8.
+ *
+ * The ISA to generate for is taken from the host generator, which already
+ * carries it as its `max_cpu_isa()` ceiling. `Vmm` stays a template parameter
+ * to keep the vector width statically typed.
  */
-template <cpu_isa_t isa, typename Vmm = typename cpu_isa_traits_t<isa>::Vmm>
+template <typename Vmm>
 class jit_uni_binary_injector_t {
 public:
     jit_uni_binary_injector_t(
@@ -636,11 +640,12 @@ private:
     const rhs_arg_static_params_t rhs_arg_static_params_;
     const Xbyak::Reg64 param1_;
     const bcast_set_t supported_strategy_set_;
-    const bool is_avx512_ = is_superset(isa, avx512_core);
-    const bool is_avx512_core_fp16_ = is_superset(isa, avx512_core_fp16);
-    const bool has_avx2_ = is_superset(isa, avx2);
-    const bool is_avx_ = is_superset(isa, avx) && !has_avx2_;
-    const bool is_sse41_ = !is_superset(isa, avx);
+    const cpu_isa_t isa_ = host_->max_cpu_isa();
+    const bool is_avx512_ = is_superset(isa_, avx512_core);
+    const bool is_avx512_core_fp16_ = is_superset(isa_, avx512_core_fp16);
+    const bool has_avx2_ = is_superset(isa_, avx2);
+    const bool is_avx_ = is_superset(isa_, avx) && !has_avx2_;
+    const bool is_sse41_ = !is_superset(isa_, avx);
 
     static constexpr int sizeof_reg64 = 8;
     /*
@@ -652,7 +657,7 @@ private:
      * address is 64 byte aligned, which can cause segmentation fault.
      */
     const bool binary_op_with_unaligned_mem_operand_allowed_
-            = is_superset(isa, avx2);
+            = is_superset(isa_, avx2);
 };
 
 } // namespace binary_injector

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -495,7 +495,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
     assert(mayiuse(isa));
 
     using namespace Xbyak::util;
-    const int XMM_float_lanes_count = 4;
+    const int XMM_float_elems_count = 4;
     const int tanh_n_polynomials = 32;
 
     // register mapping
@@ -509,11 +509,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
                              : vmm_mask_; // TODO: why `vmm_mask_` directly?
     Vmm vmm_src_original = vmm_aux(3);
     Vmm vmm_sign = vmm_aux(3);
-    Reg64 gpr_idx[XMM_float_lanes_count];
+    Reg64 gpr_idx[XMM_float_elems_count];
 
     if (!has_avx2_) {
-        assert(aux_gprs_count(alg_, is_fwd_, alpha_) >= XMM_float_lanes_count);
-        for (int i = 0; i < XMM_float_lanes_count; i++)
+        assert(aux_gprs_count(alg_, is_fwd_, alpha_) >= XMM_float_elems_count);
+        for (int i = 0; i < XMM_float_elems_count; i++)
             gpr_idx[i] = Reg64(preserved_gpr_indices_[i
                     + need_vmm_stack_ptr(alg_, is_fwd_, alpha_)]);
     }
@@ -548,76 +548,51 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
         return table_val(tanh_pol_table, coeff_off * tanh_n_polynomials + off);
     };
     auto gather_coefficient_init = [&](Vmm vmm_pol_idx, int nelems) {
-        switch (isa) {
-            case sse41:
-                for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx, i);
-                break;
-            case avx: {
-                Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
-                for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
-            } break;
-            case avx2_vnni_2:
-            case avx2:
-                // needed for gather instruction
-                h->uni_vxorps(vmm_mask_, vmm_mask_, vmm_mask_);
-                break;
-            case avx512_core_fp16:
-            case avx512_core_bf16:
-            case avx512_core:
-            case avx10_2: break;
-            default: assert(!"unimplemented");
+        if (is_sse41_) {
+            for (int i = 0; i < XMM_float_elems_count; ++i)
+                h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx, i);
+        } else if (is_avx_) {
+            Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
+            for (int i = 0; i < XMM_float_elems_count; ++i)
+                h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
+        } else if (has_avx2_ && !is_avx512_) {
+            // Zero the mask so that the `_cmp_eq_oq` compare in
+            // `gather_coefficient` yields all ones. A NaN left over in the
+            // register would compare unequal to itself.
+            h->uni_vxorps(vmm_mask_, vmm_mask_, vmm_mask_);
         }
+        // AVX-512 gathers with `vpermt2ps`, which takes no mask register.
     };
     auto gather_coefficient
             = [&](Vmm vmm_coeff, int coeff_idx, Vmm vmm_pol_idx) {
-        switch (isa) {
-            case sse41:
-                for (int idx = 0; idx < 4; ++idx) {
-                    Xbyak::Address coeff_addr
-                            = ptr[p_table_ + coeffs_off(coeff_idx)
-                                    + gpr_idx[idx] * sizeof(float)];
-                    h->pinsrd(vmm_coeff, coeff_addr, idx);
-                }
-                break;
-            case avx: {
-                Xmm xmm_coeff = Xmm(vmm_coeff.getIdx());
-                for (int idx = 0; idx < 4; ++idx) {
-                    Xbyak::Address coeff_addr
-                            = ptr[p_table_ + coeffs_off(coeff_idx)
-                                    + gpr_idx[idx] * sizeof(float)];
-                    h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
-                }
-            } break;
-            case avx2_vnni_2:
-            case avx2: {
-                Xbyak::Address idx_addr = ptr[p_table_ + coeffs_off(coeff_idx)
-                        + vmm_pol_idx * sizeof(float)];
-                // we set the mask to all ones to gather full
-                // register.  needs to be done after each gather since
-                // since the gather instructions zeros the mask if
-                // successful
-                h->uni_vcmpps(vmm_mask_, vmm_mask_, vmm_mask_, _cmp_eq_oq);
-                h->vgatherdps(vmm_coeff, idx_addr, vmm_mask_);
-                break;
+        if (is_sse41_) {
+            for (int idx = 0; idx < 4; ++idx) {
+                Xbyak::Address coeff_addr = ptr[p_table_ + coeffs_off(coeff_idx)
+                        + gpr_idx[idx] * sizeof(float)];
+                h->pinsrd(vmm_coeff, coeff_addr, idx);
             }
-                // use gather instruction
-            case avx512_core_fp16:
-            case avx512_core_bf16:
-            case avx512_core:
-            case avx10_2:
-                // we use vpermt2ps to not override the indices
-                // this also enables to save a register for table loading
-                {
-                    Zmm zmm_coeff(vmm_coeff.getIdx());
-                    Zmm zmm_pol_idx(vmm_pol_idx.getIdx());
-                    h->uni_vmovups(zmm_coeff, coeffs_address(coeff_idx, 0));
-                    h->vpermt2ps(zmm_coeff, zmm_pol_idx,
-                            coeffs_address(coeff_idx, 16));
-                    break;
-                }
-            default: assert(!"unimplemented");
+        } else if (is_avx_) {
+            Xmm xmm_coeff = Xmm(vmm_coeff.getIdx());
+            for (int idx = 0; idx < 4; ++idx) {
+                Xbyak::Address coeff_addr = ptr[p_table_ + coeffs_off(coeff_idx)
+                        + gpr_idx[idx] * sizeof(float)];
+                h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
+            }
+        } else if (has_avx2_ && !is_avx512_) {
+            Xbyak::Address idx_addr = ptr[p_table_ + coeffs_off(coeff_idx)
+                    + vmm_pol_idx * sizeof(float)];
+            // Set the mask to all ones to gather a full register. A
+            // successful `vgatherdps` zeroes its mask, so the mask has to be
+            // rebuilt before every gather.
+            h->uni_vcmpps(vmm_mask_, vmm_mask_, vmm_mask_, _cmp_eq_oq);
+            h->vgatherdps(vmm_coeff, idx_addr, vmm_mask_);
+        } else {
+            // AVX-512 uses `vpermt2ps` so that the indices are not
+            // overwritten. That also saves a register for table loading.
+            Zmm zmm_coeff(vmm_coeff.getIdx());
+            Zmm zmm_pol_idx(vmm_pol_idx.getIdx());
+            h->uni_vmovups(zmm_coeff, coeffs_address(coeff_idx, 0));
+            h->vpermt2ps(zmm_coeff, zmm_pol_idx, coeffs_address(coeff_idx, 16));
         }
     };
 

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -360,7 +360,7 @@ void jit_uni_eltwise_injector_t<Wmm>::vec_shift(const Vmm &vmm_dst,
 template <typename Wmm>
 void jit_uni_eltwise_injector_t<Wmm>::compute_cmp_mask(const Vmm &vmm_src,
         const Xbyak::Operand &compare_operand, int cmp_predicate) {
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         h->vcmpps(k_mask_, vmm_src, compare_operand, cmp_predicate);
     } else {
         h->uni_vcmpps(vmm_mask_, vmm_src, compare_operand, cmp_predicate);
@@ -372,7 +372,7 @@ void jit_uni_eltwise_injector_t<Wmm>::compute_cmp_mask(const Vmm &vmm_src,
 template <typename Wmm>
 void jit_uni_eltwise_injector_t<Wmm>::blend_with_mask(
         const Vmm &vmm_dst, const Xbyak::Operand &src) {
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         h->vblendmps(vmm_dst | k_mask_, vmm_dst, src);
     } else {
         h->uni_vblendvps(vmm_dst, vmm_dst, src, vmm_mask_);
@@ -384,7 +384,7 @@ void jit_uni_eltwise_injector_t<Wmm>::blend_with_mask(
 // Nicely combines with jump_if_zero (jz).
 template <typename Wmm>
 void jit_uni_eltwise_injector_t<Wmm>::test_mask() {
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         h->kortestw(k_mask_, k_mask_);
     } else {
         h->uni_vtestps(vmm_mask_, vmm_mask_);
@@ -506,8 +506,9 @@ void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
     Vmm vmm_coeff = vmm_aux(0);
     Vmm vmm_pol = vmm_aux(1);
     Vmm vmm_indices = vmm_aux(2);
-    Vmm vmm_tmp = is_avx512_ ? vmm_aux(2) // index `2` works for AVX512_CORE
-                             : vmm_mask_; // TODO: why `vmm_mask_` directly?
+    Vmm vmm_tmp = has_avx512_core_
+            ? vmm_aux(2) // index `2` works for AVX512_CORE
+            : vmm_mask_; // TODO: why `vmm_mask_` directly?
     Vmm vmm_src_original = vmm_aux(3);
     Vmm vmm_sign = vmm_aux(3);
     Reg64 gpr_idx[XMM_float_elems_count];
@@ -557,7 +558,7 @@ void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
             Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
             for (int i = 0; i < XMM_float_elems_count; ++i)
                 h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
-        } else if (has_avx2_ && !is_avx512_) {
+        } else if (has_avx2_ && !has_avx512_core_) {
             // Zero the mask so that the `_cmp_eq_oq` compare in
             // `gather_coefficient` yields all ones. A NaN left over in the
             // register would compare unequal to itself.
@@ -580,7 +581,7 @@ void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
                         + gpr_idx[idx] * sizeof(float)];
                 h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
             }
-        } else if (has_avx2_ && !is_avx512_) {
+        } else if (has_avx2_ && !has_avx512_core_) {
             Xbyak::Address idx_addr = ptr[p_table_ + coeffs_off(coeff_idx)
                     + vmm_pol_idx * sizeof(float)];
             // Set the mask to all ones to gather a full register. A
@@ -836,7 +837,7 @@ void jit_uni_eltwise_injector_t<Wmm>::soft_relu_compute_vector_fwd(
     // compute 2^-(n-1)
     // vmm_src now represents n-1
     h->uni_vsubps(vmm_src, vmm_src, table_val(one));
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         h->vmulps(vmm_aux(1), vmm_src, table_val(minus_one));
         h->vcvtps2dq(vmm_aux(1), vmm_aux(1));
     } else if (is_avx_) {
@@ -931,7 +932,7 @@ void jit_uni_eltwise_injector_t<Wmm>::logistic_compute_vector_fwd(
     // Now we have to apply the "symmetry" based on original sign
     h->uni_vmovups(vmm_aux(1), table_val(one));
     h->uni_vsubps(vmm_aux(1), vmm_aux(1), vmm_src);
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         h->vptestmd(k_mask_, vmm_aux(2), vmm_aux(2));
     } else {
         h->uni_vmovups(vmm_mask_, vmm_aux(2));
@@ -1032,7 +1033,7 @@ void jit_uni_eltwise_injector_t<Wmm>::log_compute_vector_fwd(
             = [&](const Vmm &vmm_dst, const Vmm &vmm_idxs, size_t offt = 0) {
         Xbyak::Address table_idx = h->ptr[p_table_ + table_start_idx + offt
                 + vmm_idxs * sizeof(float)];
-        if (is_avx512_) {
+        if (has_avx512_core_) {
             h->kmovw(k_mask_, table_val(log_full_k_reg_mask));
             h->vgatherdps(vmm_dst | k_mask_, table_idx);
         } else if (has_avx2_) {
@@ -1180,7 +1181,7 @@ void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_fwd(
         // caller obligation to save k-regs as callee may use them
         static constexpr int k_mask_size = 8;
         size_t n_k_regs_to_save = 8;
-        if (is_avx512_) {
+        if (has_avx512_core_) {
             h->sub(h->rsp, n_k_regs_to_save * k_mask_size);
             for (size_t i = 0; i < n_k_regs_to_save; ++i) {
                 if (mayiuse(avx512_core))
@@ -1241,7 +1242,7 @@ void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_fwd(
         h->uni_vmovups(vmm_src, h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_]);
 
         // restore k registers
-        if (is_avx512_) {
+        if (has_avx512_core_) {
             for (int i = n_k_regs_to_save - 1; i >= 0; --i) {
                 if (mayiuse(avx512_core))
                     h->kmovq(Opmask(i), h->ptr[h->rsp + i * k_mask_size]);
@@ -1266,7 +1267,7 @@ void jit_uni_eltwise_injector_t<
     using namespace Xbyak::util;
 
     // TODO: consider enabling for lower ISA
-    if (!is_avx512_) return;
+    if (!has_avx512_core_) return;
 
     // register mapping
     Vmm vmm_pol = vmm_aux(0);
@@ -1331,7 +1332,7 @@ void jit_uni_eltwise_injector_t<
 template <typename Wmm>
 void jit_uni_eltwise_injector_t<Wmm>::gelu_erf_compute_vector_fwd(
         const Vmm &vmm_src) {
-    if (is_avx512_) {
+    if (has_avx512_core_) {
         gelu_erf_minimax_approx_compute_vector_fwd(vmm_src);
         return;
     }
@@ -2883,8 +2884,9 @@ void jit_uni_eltwise_injector_t<Wmm>::register_table_entries() {
     if (need.gelu_tanh()) push_entries_of(gelu_tanh_consts);
     if (need.gelu_erf()) push_entries_of(gelu_erf_Abramowitz_Stegun_consts);
     if (need.gelu_erf()) push_entries_of(gelu_erf_Abramowitz_Stegun_polynomial);
-    if (need.gelu_erf() && is_avx512_) push_entries_of(gelu_erf_minimax_consts);
-    if (need.gelu_erf() && is_avx512_)
+    if (need.gelu_erf() && has_avx512_core_)
+        push_entries_of(gelu_erf_minimax_consts);
+    if (need.gelu_erf() && has_avx512_core_)
         push_entries_of(gelu_erf_minimax_polynomial);
 
     if (need.log()) push_entries_of(log_consts);

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -88,7 +88,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     const auto start_idx = *(vmm_compute_idxs.begin());
     const auto end_idx = *(vmm_compute_idxs.rbegin()) + 1;
     // For sse41 mask register must be Xmm(0), reserve it unconditionally.
-    if (isa == sse41 && need_vmm_mask_register_) {
+    if (is_sse41_ && need_vmm_mask_register_) {
         static constexpr int mask_idx = 0;
         assert(start_idx > mask_idx);
         // When external indices come, they must secure first index is 0.
@@ -302,7 +302,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
     // For avx we need a register to save the upper part of Ymm
     // Note: the number in `aux_vecs_count` is accounted for here.
     using namespace alg_kind;
-    const bool preserve_vec_for_avx = isa == avx
+    const bool preserve_vec_for_avx = is_avx_
             && utils::one_of(alg_, eltwise_tanh, eltwise_elu, eltwise_abs,
                     eltwise_soft_relu, eltwise_mish, eltwise_logistic,
                     eltwise_exp, eltwise_gelu_tanh, eltwise_swish,
@@ -331,7 +331,7 @@ Wmm jit_uni_eltwise_injector_t<isa, Wmm>::vmm_aux(size_t idx) {
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::vec_shift(const Vmm &vmm_dst,
         const Vmm &vmm_src, bool shift_left, const int imm) {
-    if (isa != avx) {
+    if (!is_avx_) {
         if (shift_left)
             h->uni_vpslld(vmm_dst, vmm_src, imm);
         else
@@ -428,7 +428,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::exp_compute_vector_fwd(
     // compute 2^(n-1)
     h->uni_vsubps(vmm_src, vmm_src, table_val(one));
     h->uni_vcvtps2dq(vmm_aux(1), vmm_src);
-    if (isa != avx)
+    if (!is_avx_)
         h->uni_vpaddd(vmm_aux(1), vmm_aux(1), table_val(exponent_bias));
     else {
         Ymm ymm_aux2 = Ymm(vmm_aux(1).getIdx());
@@ -492,7 +492,7 @@ template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
         const Vmm &vmm_src) {
     // we add a check as the avx2 code cannot be used for avx
-    assert(IMPLICATION(isa == avx2, mayiuse(avx2)));
+    assert(mayiuse(isa));
 
     using namespace Xbyak::util;
     const int XMM_float_lanes_count = 4;
@@ -511,7 +511,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
     Vmm vmm_sign = vmm_aux(3);
     Reg64 gpr_idx[XMM_float_lanes_count];
 
-    if (isa == sse41 || isa == avx) {
+    if (!has_avx2_) {
         assert(aux_gprs_count(alg_, is_fwd_, alpha_) >= XMM_float_lanes_count);
         for (int i = 0; i < XMM_float_lanes_count; i++)
             gpr_idx[i] = Reg64(preserved_gpr_indices_[i
@@ -628,7 +628,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
 
     // We compute the indices for the table lookup
     h->uni_vmovups(vmm_indices, vmm_src);
-    if (isa != avx)
+    if (!is_avx_)
         h->uni_vpsubd(vmm_indices, vmm_indices, table_val(tanh_idx_bias));
     else {
         Ymm ymm_indices = Ymm(vmm_indices.getIdx());
@@ -654,7 +654,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
         h->uni_vfmadd213ps(vmm_pol, vmm_src, vmm_coeff);
     }
 
-    if (isa == avx) {
+    if (is_avx_) {
         Ymm ymm_indices = Ymm(vmm_indices.getIdx());
         Ymm ymm_pol = Ymm(vmm_pol.getIdx());
         Ymm ymm_src = Ymm(vmm_src.getIdx());
@@ -862,7 +862,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::soft_relu_compute_vector_fwd(
     if (is_avx512_) {
         h->vmulps(vmm_aux(1), vmm_src, table_val(minus_one));
         h->vcvtps2dq(vmm_aux(1), vmm_aux(1));
-    } else if (isa == avx) {
+    } else if (is_avx_) {
         h->uni_vxorps(vmm_aux(1), vmm_src, table_val(sign_mask));
         h->uni_vcvtps2dq(vmm_aux(1), vmm_aux(1));
     } else {
@@ -872,7 +872,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::soft_relu_compute_vector_fwd(
     // restore vmm_src to n
     h->uni_vaddps(vmm_src, vmm_src, table_val(one));
 
-    if (isa != avx)
+    if (!is_avx_)
         h->uni_vpaddd(vmm_aux(1), vmm_aux(1), table_val(exponent_bias));
     else {
         Ymm ymm_aux1 = Ymm(vmm_aux(1).getIdx());
@@ -997,7 +997,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
     // If (x == 1) result = 0;
 
     // set unused register as tmp for avx
-    if (isa == avx) {
+    if (is_avx_) {
         ymm_tmp_ = Ymm(vmm_aux(0).getIdx());
         xmm_tmp_ = Xmm(vmm_aux(0).getIdx());
     }
@@ -1016,7 +1016,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
 
     // get E, don't care about sign as only positive numbers are considered
     vec_shift(vmm_aux(3), vmm_src, false, n_mantissa_bits_);
-    if (isa != avx)
+    if (!is_avx_)
         h->uni_vpaddd(vmm_aux(3), vmm_aux(3), vmm_aux(2));
     else {
         Ymm ymm_aux2 = Ymm(vmm_aux(2).getIdx());
@@ -1058,10 +1058,10 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
         if (is_avx512_) {
             h->kmovw(k_mask_, table_val(log_full_k_reg_mask));
             h->vgatherdps(vmm_dst | k_mask_, table_idx);
-        } else if (utils::one_of(isa, avx2, avx2_vnni_2)) {
+        } else if (has_avx2_) {
             h->uni_vmovups(vmm_mask_, table_val(sign_mask));
             h->vgatherdps(vmm_dst, table_idx, vmm_mask_);
-        } else if (isa == avx || isa == sse41) {
+        } else {
             Xbyak::Reg64 reg_tmp
                     = p_table_.getIdx() != h->r9.getIdx() ? h->r9 : h->r10;
 
@@ -1254,7 +1254,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
             h->uni_vzeroupper(); // eliminate performance penalties on avx
             h->call(h->r12);
             // eliminate performance penalties on sse isa
-            if (isa == sse41) h->uni_vzeroupper();
+            if (is_sse41_) h->uni_vzeroupper();
             h->uni_vmovss(source, xmm0);
         }
 
@@ -1497,7 +1497,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_tanh_compute_vector_bwd(
     h->uni_vmovups(vmm_aux(2), vmm_aux(4));
 
     // compute 0.5 * (1 + T) * (1 + G2 * (1 - T))
-    if (isa == sse41 || isa == avx) {
+    if (!has_avx2_) {
         h->uni_vmovups(vmm_aux(3), table_val(one));
         h->uni_vsubps(vmm_aux(3), vmm_aux(3), vmm_src);
         h->uni_vmulps(vmm_aux(2), vmm_aux(2), vmm_aux(3));
@@ -1625,7 +1625,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::swish_compute_vector_bwd(
     // Q = sigmoid(alpha * s)
     logistic_compute_vector_fwd(vmm_src);
     // compute Q * (1 + R * (1 - Q))
-    if (utils::one_of(isa, sse41, avx)) {
+    if (!has_avx2_) {
         h->uni_vmovups(vmm_aux(1), table_val(one));
         h->uni_vsubps(vmm_aux(1), vmm_aux(1), vmm_src);
         h->uni_vmulps(vmm_aux(1), vmm_aux(1), vmm_aux(3));
@@ -1808,7 +1808,7 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_gprs_count(
     switch (alg) {
         case eltwise_tanh_use_dst_for_bwd:
         case eltwise_tanh:
-        case eltwise_gelu_tanh: ret = isa == sse41 || isa == avx ? 4 : 0; break;
+        case eltwise_gelu_tanh: ret = !is_superset(isa, avx2) ? 4 : 0; break;
         default: ret = 0;
     }
     return ret + need_vmm_stack_ptr(alg, is_fwd, alpha);
@@ -1828,7 +1828,7 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
     if (is_fwd) {
         switch (alg) {
             case eltwise_gelu_tanh: ret = 1; break;
-            case eltwise_log: ret = 1 + utils::one_of(isa, sse41, avx); break;
+            case eltwise_log: ret = 1 + !is_superset(isa, avx2); break;
             case eltwise_pow: ret = n_vregs_ + 2; break;
             default: ret = 0;
         }
@@ -1846,7 +1846,7 @@ template <cpu_isa_t isa, typename Wmm>
 size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
         alg_kind_t alg, bool is_fwd, float alpha) {
     // For avx we need a register to save the upper part of Ymm
-    const bool extra_avx_vmm = isa == avx;
+    const bool extra_avx_vmm = is_superset(isa, avx) && !is_superset(isa, avx2);
     size_t n_vmms = 0;
 
     using namespace alg_kind;

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -63,15 +63,15 @@ bool is_supported(cpu_isa_t isa, alg_kind_t alg, data_type_t dt) {
 
 using namespace Xbyak;
 
-template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::get_stack_vmm_space() {
+template <typename Wmm>
+size_t jit_uni_eltwise_injector_t<Wmm>::get_stack_vmm_space() {
     return (save_state_ * preserve_vmm_ * n_vregs_to_preserve_
-                   + op_vecs_count(alg_, is_fwd_))
+                   + op_vecs_count(isa_, alg_, is_fwd_))
             * vlen_;
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
         const injector_utils::vmm_index_set_t &vmm_compute_idxs,
         injector_utils::vmm_index_set_iterator_t &start_idx_tail_it,
         const injector_utils::vmm_index_set_t &vmm_aux_indices) {
@@ -79,7 +79,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
     // Mask register is a Vmm register on AVX2 and below. It qualifies as an
     // additional register to preserve.
-    need_vmm_mask_register_ = need_mask_register(alg_, is_fwd_, alpha_);
+    need_vmm_mask_register_ = need_mask_register(isa_, alg_, is_fwd_, alpha_);
 
     n_vregs_preserved_ = 0;
     assert(IMPLICATION(!vmm_aux_indices.empty(),
@@ -156,7 +156,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
     // Preserve GPRs.
     size_t preserved_gprs_count = 0;
-    size_t n_gprs_to_preserve = aux_gprs_count(alg_, is_fwd_, alpha_);
+    size_t n_gprs_to_preserve = aux_gprs_count(isa_, alg_, is_fwd_, alpha_);
     if (n_gprs_to_preserve > 0) {
         // Allocate GPRs from the end not to mess with ABI compatibility.
         for (int gpr_idx = Operand::R15; gpr_idx >= 0; gpr_idx--) {
@@ -168,7 +168,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
         assert(preserved_gprs_count == n_gprs_to_preserve);
     }
 
-    if (need_vmm_stack_ptr(alg_, is_fwd_, alpha_)) {
+    if (need_vmm_stack_ptr(isa_, alg_, is_fwd_, alpha_)) {
         reg_vmm_stack_ptr_ = Reg64(preserved_gpr_indices_[0]);
     }
 
@@ -222,8 +222,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     assign_regs();
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::injector_preamble_tail(
         size_t n_vregs_not_preserved) {
     // There was enough vmm registers to compute everything in one round.
     if (n_vregs_not_preserved == 0) return;
@@ -261,8 +261,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
     assign_regs();
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::injector_postamble() {
     using namespace Xbyak::util;
     const int stack_vmm_space = get_stack_vmm_space();
 
@@ -282,21 +282,22 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
         if (n_vregs_preserved_)
             h->mov(h->rsp,
                     ptr[reg_vmm_stack_ptr_
-                            + op_vecs_count(alg_, is_fwd_) * vlen_]);
+                            + op_vecs_count(isa_, alg_, is_fwd_) * vlen_]);
     } else if (stack_vmm_space) {
         h->mov(h->rsp, ptr[reg_vmm_stack_ptr_ + stack_vmm_space]);
     }
 
     if (!save_state_) return;
-    for (int i = static_cast<int>(aux_gprs_count(alg_, is_fwd_, alpha_)) - 1;
+    for (int i
+            = static_cast<int>(aux_gprs_count(isa_, alg_, is_fwd_, alpha_)) - 1;
             i >= 0; --i)
         h->pop(Reg64(preserved_gpr_indices_[i]));
 
     if (preserve_p_table_) h->pop(p_table_);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::assign_regs() {
     vmm_mask_ = Vmm(preserved_vmm_tail_indices_[0]);
 
     // For avx we need a register to save the upper part of Ymm
@@ -322,14 +323,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
 // `preserved_vmm_indices_`. This is an internal container which can be
 // initialized with stock values from the injector, or with external values
 // provided by the user.
-template <cpu_isa_t isa, typename Wmm>
-Wmm jit_uni_eltwise_injector_t<isa, Wmm>::vmm_aux(size_t idx) {
+template <typename Wmm>
+Wmm jit_uni_eltwise_injector_t<Wmm>::vmm_aux(size_t idx) {
     assert(idx < (n_vregs_preserved_ - need_vmm_mask_register_));
     return Vmm(preserved_vmm_indices_[idx]);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::vec_shift(const Vmm &vmm_dst,
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::vec_shift(const Vmm &vmm_dst,
         const Vmm &vmm_src, bool shift_left, const int imm) {
     if (!is_avx_) {
         if (shift_left)
@@ -356,8 +357,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::vec_shift(const Vmm &vmm_dst,
 
 // Uses injector masks objects: k_mask_ (>= avx512_core) or vmm_mask_ (<= avx2).
 // Stores a mask by applying cmpps on two inputs w/ a given predicate.
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::compute_cmp_mask(const Vmm &vmm_src,
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::compute_cmp_mask(const Vmm &vmm_src,
         const Xbyak::Operand &compare_operand, int cmp_predicate) {
     if (is_avx512_) {
         h->vcmpps(k_mask_, vmm_src, compare_operand, cmp_predicate);
@@ -368,8 +369,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_cmp_mask(const Vmm &vmm_src,
 
 // Uses injector masks objects: k_mask_ (>= avx512_core) or vmm_mask_ (<= avx2).
 // Blends a result of second input into a first input w/ a stored mask.
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::blend_with_mask(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::blend_with_mask(
         const Vmm &vmm_dst, const Xbyak::Operand &src) {
     if (is_avx512_) {
         h->vblendmps(vmm_dst | k_mask_, vmm_dst, src);
@@ -381,8 +382,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::blend_with_mask(
 // Uses injector masks objects: k_mask_ (>= avx512_core) or vmm_mask_ (<= avx2).
 // Tests a mask for all zeros. If all zeroes occur, set ZF = 1.
 // Nicely combines with jump_if_zero (jz).
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::test_mask() {
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::test_mask() {
     if (is_avx512_) {
         h->kortestw(k_mask_, k_mask_);
     } else {
@@ -390,8 +391,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::test_mask() {
     }
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::exp_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::exp_compute_vector_fwd(
         const Vmm &vmm_src) {
     // exp(x) =
     // = exp(n * ln(2) + r) // divide x by ln(2) and get quot and rem
@@ -456,8 +457,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::exp_compute_vector_fwd(
     h->uni_vmulps(vmm_src, vmm_src, table_val(two));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::relu_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::relu_compute_vector_fwd(
         const Vmm &vmm_src) {
     h->uni_vmovups(vmm_aux(0), vmm_src);
     compute_cmp_mask(vmm_src, table_val(zero), _cmp_gt_os);
@@ -465,14 +466,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::relu_compute_vector_fwd(
     blend_with_mask(vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::relu_zero_ns_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::relu_zero_ns_compute_vector_fwd(
         const Vmm &vmm_src) {
     h->uni_vmaxps(vmm_src, vmm_src, table_val(zero));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::elu_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::elu_compute_vector_fwd(
         const Vmm &vmm_src) {
     // IMPORTANT: we use vmm_aux(2) for the mask as exp_compute does not use it.
     h->uni_vmovups(vmm_aux(2), vmm_src);
@@ -488,11 +489,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::elu_compute_vector_fwd(
     blend_with_mask(vmm_src, vmm_aux(2));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
         const Vmm &vmm_src) {
     // we add a check as the avx2 code cannot be used for avx
-    assert(mayiuse(isa));
+    assert(mayiuse(isa_));
 
     using namespace Xbyak::util;
     const int XMM_float_elems_count = 4;
@@ -512,10 +513,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
     Reg64 gpr_idx[XMM_float_elems_count];
 
     if (!has_avx2_) {
-        assert(aux_gprs_count(alg_, is_fwd_, alpha_) >= XMM_float_elems_count);
+        assert(aux_gprs_count(isa_, alg_, is_fwd_, alpha_)
+                >= XMM_float_elems_count);
         for (int i = 0; i < XMM_float_elems_count; i++)
             gpr_idx[i] = Reg64(preserved_gpr_indices_[i
-                    + need_vmm_stack_ptr(alg_, is_fwd_, alpha_)]);
+                    + need_vmm_stack_ptr(isa_, alg_, is_fwd_, alpha_)]);
     }
 
     // We split the positive domain in 33 intervals:
@@ -671,8 +673,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
     h->uni_vmovups(vmm_src, vmm_dst);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_tanh_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::gelu_tanh_compute_vector_fwd(
         const Vmm &vmm_src) {
     h->uni_vmovups(vmm_aux(0), vmm_src);
 
@@ -697,42 +699,42 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_tanh_compute_vector_fwd(
     h->uni_vmulps(vmm_src, vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::square_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::square_compute_vector_fwd(
         const Vmm &vmm_src) {
     h->uni_vmulps(vmm_src, vmm_src, vmm_src);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::abs_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::abs_compute_vector_fwd(
         const Vmm &vmm_src) {
     // compute abs(x) = _mm_and_ps(x, 01111..111));
     h->uni_vandps(vmm_src, vmm_src, table_val(positive_mask));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::sqrt_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::sqrt_compute_vector_fwd(
         const Vmm &vmm_src) {
     h->uni_vsqrtps(vmm_src, vmm_src);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::linear_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::linear_compute_vector_fwd(
         const Vmm &vmm_src) {
     // compute x = alpha * x + beta;
     h->uni_vmovups(vmm_aux(0), table_val(alpha));
     h->uni_vfmadd213ps(vmm_src, vmm_aux(0), table_val(beta));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::clip_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::clip_compute_vector_fwd(
         const Vmm &vmm_src) {
     h->uni_vmaxps(vmm_src, vmm_src, table_val(alpha));
     h->uni_vminps(vmm_src, vmm_src, table_val(beta));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::mish_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::mish_compute_vector_fwd(
         const Vmm &vmm_src) {
     // An equation other than mish(x) = x*tanh(srelu(x)) was used
     // to calculate mish, but it should be remembered that it is equivalent
@@ -764,8 +766,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::mish_compute_vector_fwd(
     h->uni_vmulps(vmm_src, vmm_src, vmm_aux(2));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::hardswish_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::hardswish_compute_vector_fwd(
         const Vmm &vmm_src) {
     // result = x * hardsigmoid(x)
     h->uni_vmovups(vmm_aux(0), vmm_src);
@@ -773,8 +775,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::hardswish_compute_vector_fwd(
     h->uni_vmulps(vmm_src, vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::hardsigmoid_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::hardsigmoid_compute_vector_fwd(
         const Vmm &vmm_src) {
     // result = max(0, min(1, alpha * x + beta))
     h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
@@ -783,8 +785,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::hardsigmoid_compute_vector_fwd(
     h->uni_vmaxps(vmm_src, vmm_src, table_val(zero));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::soft_relu_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::soft_relu_compute_vector_fwd(
         const Vmm &vmm_src) {
     // alpha scaling
     h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
@@ -905,8 +907,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::soft_relu_compute_vector_fwd(
     }
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::logistic_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::logistic_compute_vector_fwd(
         const Vmm &vmm_src) {
     // To avoid exp(x) overflow happened at x > logf(FLT_MAX), negate positive,
     // compute exp(x), where x <= 0 to get 0 <= exp(x) <= 1 and restore value
@@ -938,8 +940,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::logistic_compute_vector_fwd(
     h->uni_vmovups(vmm_src, vmm_aux(1));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::swish_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::swish_compute_vector_fwd(
         const Vmm &vmm_src) {
     // Save src data for later usage
     h->uni_vmovups(vmm_aux(3), vmm_src);
@@ -952,8 +954,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::swish_compute_vector_fwd(
     h->uni_vmulps(vmm_src, vmm_src, vmm_aux(3));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::log_compute_vector_fwd(
         const Vmm &vmm_src) {
     // From J.-M. Muller and others, Handbook of Floating-Point Arithmetic, 2010
     // Here is a brief mathematics to approximate log(x):
@@ -1147,8 +1149,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
     h->L(end_log_one_label);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_fwd(
         const Vmm &vmm_src) {
     // dispatch between special cases.
     if (beta_ == -1) { // alpha / x
@@ -1191,10 +1193,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         // 1. Caller obligation to save vector registers as callee may use them.
         // 2. Additionally save space for vmm_src, to put the answer in-place on
         // this space and space for beta.
-        // 3. There is an implicit assumption that the host code uses the same
-        // `isa` as the injector. Once the assumption is wrong, `n_vregs_` and
-        // `vlen_` should be replaced with `host_isa::vlen_` and
-        // `host_isa::n_vregs_`.
+        // 3. The injector takes its `isa` from the host code, thus, `n_vregs_`
+        // and `vlen_` always match the host.
         for (size_t i = 2; i < n_vregs_ + 2; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_], Vmm(i - 2));
         h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_], vmm_src); // src
@@ -1260,8 +1260,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
     }
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa,
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<
         Wmm>::gelu_erf_minimax_approx_compute_vector_fwd(const Vmm &vmm_src) {
     using namespace Xbyak::util;
 
@@ -1328,8 +1328,8 @@ void jit_uni_eltwise_injector_t<isa,
     h->uni_vmulps(vmm_src, vmm_src, table_val(half));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_erf_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::gelu_erf_compute_vector_fwd(
         const Vmm &vmm_src) {
     if (is_avx512_) {
         gelu_erf_minimax_approx_compute_vector_fwd(vmm_src);
@@ -1397,8 +1397,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_erf_compute_vector_fwd(
     h->uni_vfmadd213ps(vmm_src, vmm_aux(3), vmm_aux(3));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::relu_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::relu_compute_vector_bwd(
         const Vmm &vmm_src) {
     // invariant to whether `s` or `d` is passed.
     // get mask of `s` > 0
@@ -1408,8 +1408,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::relu_compute_vector_bwd(
     blend_with_mask(vmm_src, table_val(one));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::elu_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::elu_compute_vector_bwd(
         const Vmm &vmm_src) {
     if (use_dst_) {
         // get mask of `d` > 0
@@ -1433,8 +1433,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::elu_compute_vector_bwd(
     }
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_bwd(
         const Vmm &vmm_src) {
     // res = 1 - d^2 = 1 - tanh^2(s)
     if (!use_dst_) tanh_compute_vector_fwd(vmm_src);
@@ -1443,8 +1443,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_bwd(
     h->uni_vmovups(vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_tanh_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::gelu_tanh_compute_vector_bwd(
         const Vmm &vmm_src) {
     h->uni_vmovups(vmm_aux(0), vmm_src);
 
@@ -1490,15 +1490,15 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_tanh_compute_vector_bwd(
     h->uni_vmulps(vmm_src, vmm_src, table_val(half));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::square_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::square_compute_vector_bwd(
         const Vmm &vmm_src) {
     // res = 2 * s
     h->uni_vmulps(vmm_src, vmm_src, table_val(two));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::abs_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::abs_compute_vector_bwd(
         const Vmm &vmm_src) {
     // replace positive values with 1.f
     compute_cmp_mask(vmm_src, table_val(zero), _cmp_gt_os);
@@ -1508,8 +1508,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::abs_compute_vector_bwd(
     blend_with_mask(vmm_src, table_val(minus_one));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::sqrt_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::sqrt_compute_vector_bwd(
         const Vmm &vmm_src) {
     // res = 0.5 / d = 0.5 / sqrt(s)
     if (!use_dst_) sqrt_compute_vector_fwd(vmm_src);
@@ -1519,21 +1519,21 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::sqrt_compute_vector_bwd(
     h->uni_vmovups(vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::linear_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::linear_compute_vector_bwd(
         const Vmm &vmm_src) {
     h->uni_vmovups(vmm_src, table_val(alpha));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::soft_relu_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::soft_relu_compute_vector_bwd(
         const Vmm &vmm_src) {
     h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
     logistic_compute_vector_fwd(vmm_src);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::mish_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::mish_compute_vector_bwd(
         const Vmm &vmm_src) {
     // IMPORTANT: we use vmm_aux(2) to save src as exp does not use it.
     h->uni_vmovups(vmm_aux(2), vmm_src); // vmm_aux(2) = x
@@ -1573,8 +1573,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::mish_compute_vector_bwd(
     h->uni_vdivps(vmm_src, vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::logistic_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::logistic_compute_vector_bwd(
         const Vmm &vmm_src) {
     // res = d * (1 - d) = d - d * d; d = logistic(s)
     if (!use_dst_) logistic_compute_vector_fwd(vmm_src);
@@ -1584,14 +1584,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::logistic_compute_vector_bwd(
     h->uni_vmulps(vmm_src, vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::exp_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::exp_compute_vector_bwd(
         const Vmm &vmm_src) {
     if (!use_dst_) exp_compute_vector_fwd(vmm_src);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::swish_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::swish_compute_vector_bwd(
         const Vmm &vmm_src) {
     // R = alpha * s
     h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
@@ -1614,8 +1614,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::swish_compute_vector_bwd(
     }
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::log_compute_vector_bwd(
         const Vmm &vmm_src) {
     // res = 1 / s
     h->uni_vmovups(vmm_aux(0), table_val(one));
@@ -1624,8 +1624,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_bwd(
     h->uni_vmovups(vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::clip_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::clip_compute_vector_bwd(
         const Vmm &vmm_src) {
     // set result with 1.f
     h->uni_vmovups(vmm_aux(0), table_val(one));
@@ -1640,8 +1640,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::clip_compute_vector_bwd(
     h->uni_vmovups(vmm_src, vmm_aux(0));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_bwd(
         const Vmm &vmm_src) {
     // dispatch some special cases.
     if (beta_ == 0) { // zero
@@ -1671,8 +1671,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_bwd(
     }
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_erf_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::gelu_erf_compute_vector_bwd(
         const Vmm &vmm_src) {
     // R = s / sqrt(2)
     h->uni_vmulps(vmm_src, vmm_src,
@@ -1735,8 +1735,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::gelu_erf_compute_vector_bwd(
     h->uni_vmovups(vmm_src, vmm_aux(2));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::hardswish_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::hardswish_compute_vector_bwd(
         const Vmm &vmm_src) {
     // Get mask for 0 < alpha * x + beta < 1
     h->uni_vmovups(vmm_aux(0), vmm_src);
@@ -1752,8 +1752,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::hardswish_compute_vector_bwd(
     blend_with_mask(vmm_src, table_val(one));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::hardsigmoid_compute_vector_bwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::hardsigmoid_compute_vector_bwd(
         const Vmm &vmm_src) {
     // Get mask for 0 < alpha * x + beta < 1
     // Zero rest values.
@@ -1769,15 +1769,15 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::hardsigmoid_compute_vector_bwd(
     h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::round_compute_vector_fwd(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::round_compute_vector_fwd(
         const Vmm &vmm_src) {
     h->uni_vroundps(vmm_src, vmm_src, _op_mxcsr);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_gprs_count(
-        alg_kind_t alg, bool is_fwd, float alpha) {
+template <typename Wmm>
+size_t jit_uni_eltwise_injector_t<Wmm>::aux_gprs_count(
+        cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha) {
     using namespace alg_kind;
     int ret = 0;
     switch (alg) {
@@ -1786,30 +1786,33 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_gprs_count(
         case eltwise_gelu_tanh: ret = !is_superset(isa, avx2) ? 4 : 0; break;
         default: ret = 0;
     }
-    return ret + need_vmm_stack_ptr(alg, is_fwd, alpha);
+    return ret + need_vmm_stack_ptr(isa, alg, is_fwd, alpha);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-bool jit_uni_eltwise_injector_t<isa, Wmm>::need_vmm_stack_ptr(
-        alg_kind_t alg, bool is_fwd, float alpha) {
-    return op_vecs_count(alg, is_fwd) + aux_vecs_count(alg, is_fwd, alpha);
+template <typename Wmm>
+bool jit_uni_eltwise_injector_t<Wmm>::need_vmm_stack_ptr(
+        cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha) {
+    return op_vecs_count(isa, alg, is_fwd)
+            + aux_vecs_count(isa, alg, is_fwd, alpha);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
-        alg_kind_t alg, bool is_fwd) {
+template <typename Wmm>
+size_t jit_uni_eltwise_injector_t<Wmm>::op_vecs_count(
+        cpu_isa_t isa, alg_kind_t alg, bool is_fwd) {
     using namespace alg_kind;
     int ret = 0;
     if (is_fwd) {
         switch (alg) {
             case eltwise_gelu_tanh: ret = 1; break;
             case eltwise_log: ret = 1 + !is_superset(isa, avx2); break;
-            case eltwise_pow: ret = n_vregs_ + 2; break;
+            case eltwise_pow: ret = isa_num_vregs(isa) + 2; break;
             default: ret = 0;
         }
     } else {
         switch (alg) {
-            case eltwise_pow: ret = 1 + (n_vregs_ + 2 /*calls fwd*/); break;
+            case eltwise_pow:
+                ret = 1 + (isa_num_vregs(isa) + 2 /*calls fwd*/);
+                break;
             default: ret = 0;
         }
     }
@@ -1817,9 +1820,9 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
     return ret;
 }
 
-template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
-        alg_kind_t alg, bool is_fwd, float alpha) {
+template <typename Wmm>
+size_t jit_uni_eltwise_injector_t<Wmm>::aux_vecs_count(
+        cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha) {
     // For avx we need a register to save the upper part of Ymm
     const bool extra_avx_vmm = is_superset(isa, avx) && !is_superset(isa, avx2);
     size_t n_vmms = 0;
@@ -1896,12 +1899,12 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
         }
     }
 
-    return n_vmms + need_mask_register(alg, is_fwd, alpha);
+    return n_vmms + need_mask_register(isa, alg, is_fwd, alpha);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-bool jit_uni_eltwise_injector_t<isa, Wmm>::need_mask_register(
-        alg_kind_t alg, bool is_fwd, float alpha) {
+template <typename Wmm>
+bool jit_uni_eltwise_injector_t<Wmm>::need_mask_register(
+        cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha) {
     if (is_superset(isa, avx512_core)) return false;
 
     using namespace alg_kind;
@@ -1973,8 +1976,8 @@ bool jit_uni_eltwise_injector_t<isa, Wmm>::need_mask_register(
     return false;
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::compute_body(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::compute_body(
         const injector_utils::vmm_index_set_iterator_t &start_idx_it,
         const injector_utils::vmm_index_set_iterator_t &end_idx_it) {
     using namespace alg_kind;
@@ -2078,8 +2081,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_body(
     });
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::compute_vector_range(
         size_t start_compute_idx, size_t end_compute_idx,
         const injector_utils::vmm_index_set_t &vmm_aux_indices) {
     injector_utils::vmm_index_set_t vmm_compute_idxs;
@@ -2088,8 +2091,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
     compute_vector_range(vmm_compute_idxs, vmm_aux_indices);
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_compute_idxs,
         const injector_utils::vmm_index_set_t &vmm_aux_indices) {
     if (vmm_compute_idxs.empty()) return;
@@ -2111,8 +2114,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
     injector_postamble();
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::prepare_table(bool gen_table) {
     if (!gen_table) return;
 
     h->align(64);
@@ -2153,8 +2156,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
     }
 }
 
-template <cpu_isa_t isa, typename Wmm>
-void jit_uni_eltwise_injector_t<isa, Wmm>::register_table_entries() {
+template <typename Wmm>
+void jit_uni_eltwise_injector_t<Wmm>::register_table_entries() {
     // This function is responsible to pick all necessary constants
     // for a given algorithm, compute right offset for them to be used
     // in table_val() and save the hexadecimal value of them, which
@@ -2900,23 +2903,9 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::register_table_entries() {
     }
 }
 
-template struct jit_uni_eltwise_injector_t<avx10_2>;
-template struct jit_uni_eltwise_injector_t<avx10_2, Xbyak::Ymm>;
-template struct jit_uni_eltwise_injector_t<avx10_2, Xbyak::Xmm>;
-template struct jit_uni_eltwise_injector_t<avx512_core_fp16>;
-template struct jit_uni_eltwise_injector_t<avx512_core_fp16, Xbyak::Ymm>;
-template struct jit_uni_eltwise_injector_t<avx512_core_fp16, Xbyak::Xmm>;
-template struct jit_uni_eltwise_injector_t<avx512_core_bf16>;
-template struct jit_uni_eltwise_injector_t<avx512_core>;
-template struct jit_uni_eltwise_injector_t<avx512_core, Ymm>;
-template struct jit_uni_eltwise_injector_t<avx512_core, Xmm>;
-template struct jit_uni_eltwise_injector_t<avx2_vnni_2>;
-template struct jit_uni_eltwise_injector_t<avx2_vnni_2, Xmm>;
-template struct jit_uni_eltwise_injector_t<avx2>;
-template struct jit_uni_eltwise_injector_t<avx2, Xmm>;
-template struct jit_uni_eltwise_injector_t<avx>;
-template struct jit_uni_eltwise_injector_t<avx, Xmm>;
-template struct jit_uni_eltwise_injector_t<sse41>;
+template struct jit_uni_eltwise_injector_t<Zmm>;
+template struct jit_uni_eltwise_injector_t<Ymm>;
+template struct jit_uni_eltwise_injector_t<Xmm>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -75,7 +75,14 @@ bool is_supported(cpu_isa_t isa, alg_kind_t alg, data_type_t dt);
 
 } // namespace eltwise_injector
 
-template <cpu_isa_t isa, typename Wmm = typename cpu_isa_traits_t<isa>::Vmm>
+/*
+ * Main mechanism responsible for injecting eltwise postops.
+ *
+ * The ISA to generate for is taken from the host generator, which already
+ * carries it as its `max_cpu_isa()` ceiling. `Wmm` stays a template parameter
+ * to keep the vector width statically typed.
+ */
+template <typename Wmm>
 struct jit_uni_eltwise_injector_t {
     using Vmm = Wmm;
 
@@ -111,8 +118,8 @@ struct jit_uni_eltwise_injector_t {
         , use_dst_(use_dst)
         , preserve_vmm_(preserve_vmm)
         , preserve_p_table_(preserve_p_table)
-        , n_vregs_to_preserve_(aux_vecs_count(alg_, is_fwd_, alpha_)) {
-        assert(eltwise_injector::is_supported(isa, alg_, dt_));
+        , n_vregs_to_preserve_(aux_vecs_count(isa_, alg_, is_fwd_, alpha_)) {
+        assert(eltwise_injector::is_supported(isa_, alg_, dt_));
 
         register_table_entries();
     }
@@ -142,8 +149,10 @@ struct jit_uni_eltwise_injector_t {
 
     // This call is `static` and `public` to make a decision on the injector's
     // saving state if the caller can supply the necessary number of vmms. The
-    // decision must be made BEFORE constructing the injector, thus, `static`.
-    static size_t aux_vecs_count(alg_kind_t alg, bool is_fwd, float alpha);
+    // decision must be made BEFORE constructing the injector, thus, `static`,
+    // and `isa` comes as an argument since there's no host to query yet.
+    static size_t aux_vecs_count(
+            cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
 
 private:
     const alg_kind_t alg_;
@@ -177,15 +186,16 @@ private:
         _op_mxcsr = jit_generator_t::_op_mxcsr
     };
 
-    const bool is_avx512_ = is_superset(isa, avx512_core);
-    const bool has_avx2_ = is_superset(isa, avx2);
-    const bool is_avx_ = is_superset(isa, avx) && !has_avx2_;
-    const bool is_sse41_ = !is_superset(isa, avx);
+    const cpu_isa_t isa_ = h->max_cpu_isa();
+    const bool is_avx512_ = is_superset(isa_, avx512_core);
+    const bool has_avx2_ = is_superset(isa_, avx2);
+    const bool is_avx_ = is_superset(isa_, avx) && !has_avx2_;
+    const bool is_sse41_ = !is_superset(isa_, avx);
 
     static constexpr size_t vlen_ = vreg_traits_t<Vmm>::vlen;
     static constexpr size_t preserved_vecs_max_ = 6;
     static constexpr size_t preserved_gprs_max_ = 5;
-    static constexpr size_t n_vregs_ = cpu_isa_traits_t<isa>::n_vregs;
+    const size_t n_vregs_ = isa_num_vregs(isa_);
     static constexpr int n_mantissa_bits_ = 23;
 
     const size_t n_vregs_to_preserve_;
@@ -203,10 +213,13 @@ private:
     Xbyak::Ymm ymm_tmp_;
     Xbyak::Xmm xmm_tmp_;
 
-    static bool need_mask_register(alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t aux_gprs_count(alg_kind_t alg, bool is_fwd, float alpha);
-    static bool need_vmm_stack_ptr(alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t op_vecs_count(alg_kind_t alg, bool is_fwd);
+    static bool need_mask_register(
+            cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
+    static size_t aux_gprs_count(
+            cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
+    static bool need_vmm_stack_ptr(
+            cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
+    static size_t op_vecs_count(cpu_isa_t isa, alg_kind_t alg, bool is_fwd);
     size_t get_stack_vmm_space();
 
     void compute_body(

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -187,7 +187,7 @@ private:
     };
 
     const cpu_isa_t isa_ = h->max_cpu_isa();
-    const bool is_avx512_ = is_superset(isa_, avx512_core);
+    const bool has_avx512_core_ = is_superset(isa_, avx512_core);
     const bool has_avx2_ = is_superset(isa_, avx2);
     const bool is_avx_ = is_superset(isa_, avx) && !has_avx2_;
     const bool is_sse41_ = !is_superset(isa_, avx);

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -178,6 +178,9 @@ private:
     };
 
     const bool is_avx512_ = is_superset(isa, avx512_core);
+    const bool has_avx2_ = is_superset(isa, avx2);
+    const bool is_avx_ = is_superset(isa, avx) && !has_avx2_;
+    const bool is_sse41_ = !is_superset(isa, avx);
 
     static constexpr size_t vlen_ = vreg_traits_t<Vmm>::vlen;
     static constexpr size_t preserved_vecs_max_ = 6;

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -108,7 +108,7 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
             if (!post_op.is_sum(false, false)) continue;
 
             idx_to_sum_injector_.emplace(i,
-                    jit_uni_sum_injector_t<isa, Vmm>(host_, post_op.sum, dst_dt,
+                    jit_uni_sum_injector_t<Vmm>(host_, post_op.sum, dst_dt,
                             binary_injector_.get(), rhs.rhs_dt_helper_vmm_idx,
                             rhs.preserve_vmm_helper));
         }

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -29,26 +29,19 @@ namespace injector {
 
 size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
     size_t res = 0;
-#define CASE_ELTWISE_SUPERSET(_isa) \
-    if (is_superset(isa, _isa)) { \
-        res = nstl::max(res, \
-                jit_uni_eltwise_injector_t<_isa>::aux_vecs_count( \
-                        post_op.eltwise.alg, is_fwd, post_op.eltwise.alpha)); \
-        continue; \
-    }
-
     for (int i = 0; i < post_ops.len(); i++) {
         const auto &post_op = post_ops.entry_[i];
         if (post_op.is_eltwise()) {
-            CASE_ELTWISE_SUPERSET(avx512_core);
-            CASE_ELTWISE_SUPERSET(avx2);
-            CASE_ELTWISE_SUPERSET(sse41);
+            // The count doesn't depend on the vector width, thus, the `Vmm`
+            // argument is arbitrary.
+            res = nstl::max(res,
+                    jit_uni_eltwise_injector_t<Xbyak::Zmm>::aux_vecs_count(isa,
+                            post_op.eltwise.alg, is_fwd,
+                            post_op.eltwise.alpha));
         }
         // TODO: add support for other post-ops types. For now we assume that
         // other post operations do not use vectors implicitly.
     }
-#undef CASE_ELTWISE_SUPERSET
-
     return res;
 }
 
@@ -79,7 +72,7 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
             // moment. Once the use case show up, add the argument to the
             // top-level ctor and propagate its value.
             alg_to_eltwise_injector_.emplace(i,
-                    jit_uni_eltwise_injector_t<isa, Vmm>(host_, post_op.eltwise,
+                    jit_uni_eltwise_injector_t<Vmm>(host_, post_op.eltwise,
                             data_type::f32, esp.save_state, esp.p_table_,
                             esp.k_mask_, esp.is_fwd, esp.use_dst,
                             esp.preserve_vmm, esp.preserve_p_table));

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -102,7 +102,7 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
     // path so the binary injector is created for a sum-only chain as well.
     if (is_like_binary || is_sum)
         binary_injector_ = utils::make_unique<
-                binary_injector::jit_uni_binary_injector_t<isa, Vmm>>(
+                binary_injector::jit_uni_binary_injector_t<Vmm>>(
                 host, binary_static_params);
 
     // Build one sum injector per sum post-op when the caller opted in to

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -45,8 +45,8 @@ size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
     return res;
 }
 
-template <cpu_isa_t isa, typename Vmm>
-jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
+template <typename Vmm>
+jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params,
@@ -83,7 +83,8 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
         }
     }
 
-    if (is_superset(isa, avx512_core) && is_eltwise && is_like_binary
+    if (is_superset(host->max_cpu_isa(), avx512_core) && is_eltwise
+            && is_like_binary
             && binary_static_params.rhs_arg_static_params.tail_size)
         assert(eltwise_static_params.k_mask_
                 != binary_static_params.rhs_arg_static_params.tail_opmask &&
@@ -115,172 +116,34 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
+template <typename Vmm>
+jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params)
+        const binary_injector::static_params_t &binary_static_params,
+        bool enable_native_sum)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-              eltwise_injector::static_params_t(), lambda_jit_injectors_t()) {}
+              eltwise_injector::static_params_t(), lambda_jit_injectors_t(),
+              enable_native_sum) {}
 
-template <cpu_isa_t isa, typename Vmm>
-jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
+template <typename Vmm>
+jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const lambda_jit_injectors_t &lambda_jit_injectors)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
               eltwise_injector::static_params_t(), lambda_jit_injectors) {}
 
-template <cpu_isa_t isa, typename Vmm>
-jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
+template <typename Vmm>
+jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
               eltwise_static_params, lambda_jit_injectors_t()) {}
 
-// Specialization instantiations are needed to avoid instantiating ISA with
-// Vmm that don't make any sense like sse41 + Zmm.
-template <>
-jit_uni_postops_injector_base_t<Xbyak::Zmm> *
-jit_uni_postops_injector_base_t<Xbyak::Zmm>::create(jit_generator_t *host,
-        cpu_isa_t isa, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params,
-        bool enable_native_sum) {
-
-// Exact match case goes first and required to force `isa` passed by user.
-#define CASE_EXACT_MATCH(_isa) \
-    if (isa == (_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Zmm>(host, \
-                post_ops, binary_static_params, eltwise_static_params, \
-                lambda_jit_injectors_t(), enable_native_sum);
-
-    CASE_EXACT_MATCH(avx512_core_fp16);
-    CASE_EXACT_MATCH(avx512_core_bf16);
-    CASE_EXACT_MATCH(avx512_core);
-
-#undef CASE_EXACT_MATCH
-
-// When there's no exact match, pick up what's allowed through mayiuse since
-// not every ISA has instances in post-ops injector.
-#define CASE_MAYIUSE(_isa) \
-    if (mayiuse(_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Zmm>(host, \
-                post_ops, binary_static_params, eltwise_static_params, \
-                lambda_jit_injectors_t(), enable_native_sum);
-
-    CASE_MAYIUSE(avx512_core_fp16);
-    CASE_MAYIUSE(avx512_core_bf16);
-    CASE_MAYIUSE(avx512_core);
-
-#undef CASE_MAYIUSE
-
-    assert(!"Kernel is empty!");
-    return nullptr;
-}
-
-template <>
-jit_uni_postops_injector_base_t<Xbyak::Ymm> *
-jit_uni_postops_injector_base_t<Xbyak::Ymm>::create(jit_generator_t *host,
-        cpu_isa_t isa, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params,
-        bool enable_native_sum) {
-
-// Exact match case goes first and required to force `isa` passed by user.
-#define CASE_EXACT_MATCH(_isa) \
-    if (isa == (_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Ymm>(host, \
-                post_ops, binary_static_params, eltwise_static_params, \
-                lambda_jit_injectors_t(), enable_native_sum);
-
-    CASE_EXACT_MATCH(avx512_core_fp16);
-    CASE_EXACT_MATCH(avx512_core);
-    CASE_EXACT_MATCH(avx2_vnni_2);
-    CASE_EXACT_MATCH(avx2);
-    CASE_EXACT_MATCH(avx);
-
-#undef CASE_EXACT_MATCH
-
-// When there's no exact match, pick up what's allowed through mayiuse since
-// not every ISA has instances in post-ops injector.
-#define CASE_MAYIUSE(_isa) \
-    if (mayiuse(_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Ymm>(host, \
-                post_ops, binary_static_params, eltwise_static_params, \
-                lambda_jit_injectors_t(), enable_native_sum);
-
-    CASE_MAYIUSE(avx512_core_fp16);
-    CASE_MAYIUSE(avx512_core);
-    CASE_MAYIUSE(avx2_vnni_2);
-    CASE_MAYIUSE(avx2);
-    CASE_MAYIUSE(avx);
-
-#undef CASE_MAYIUSE
-
-    assert(!"Kernel is empty!");
-    return nullptr;
-}
-
-template <>
-jit_uni_postops_injector_base_t<Xbyak::Xmm> *
-jit_uni_postops_injector_base_t<Xbyak::Xmm>::create(jit_generator_t *host,
-        cpu_isa_t isa, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params,
-        bool enable_native_sum) {
-
-// Exact match case goes first and required to force `isa` passed by user.
-#define CASE_EXACT_MATCH(_isa) \
-    if (isa == (_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Xmm>(host, \
-                post_ops, binary_static_params, eltwise_static_params, \
-                lambda_jit_injectors_t(), enable_native_sum);
-
-    CASE_EXACT_MATCH(avx512_core_fp16);
-    CASE_EXACT_MATCH(avx512_core);
-    CASE_EXACT_MATCH(avx2_vnni_2);
-    CASE_EXACT_MATCH(avx2);
-    CASE_EXACT_MATCH(avx);
-    CASE_EXACT_MATCH(sse41);
-
-#undef CASE_EXACT_MATCH
-
-// When there's no exact match, pick up what's allowed through mayiuse since
-// not every ISA has instances in post-ops injector.
-#define CASE_MAYIUSE(_isa) \
-    if (mayiuse(_isa)) \
-        return new jit_uni_postops_injector_t<_isa, Xbyak::Xmm>(host, \
-                post_ops, binary_static_params, eltwise_static_params, \
-                lambda_jit_injectors_t(), enable_native_sum);
-
-    CASE_MAYIUSE(avx512_core_fp16);
-    CASE_MAYIUSE(avx512_core);
-    CASE_MAYIUSE(avx2_vnni_2);
-    CASE_MAYIUSE(avx2);
-    CASE_MAYIUSE(avx);
-    CASE_MAYIUSE(sse41);
-
-#undef CASE_MAYIUSE
-
-    assert(!"Kernel is empty!");
-    return nullptr;
-}
-
 template <typename Vmm>
-jit_uni_postops_injector_base_t<Vmm> *
-jit_uni_postops_injector_base_t<Vmm>::create(jit_generator_t *host,
-        cpu_isa_t isa, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params,
-        bool enable_native_sum) {
-    const eltwise_injector::static_params_t eltwise_static_params;
-    return create(host, isa, post_ops, binary_static_params,
-            eltwise_static_params, enable_native_sum);
-}
-
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
-        size_t start_idx, size_t end_idx,
+void jit_uni_postops_injector_t<Vmm>::compute_vector_range(size_t start_idx,
+        size_t end_idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
     injector_utils::vmm_index_set_t vmm_idxs;
@@ -289,15 +152,15 @@ void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
     compute_vector_range(vmm_idxs, rhs_arg_params);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
+template <typename Vmm>
+void jit_uni_postops_injector_t<Vmm>::compute_vector_range(
         size_t start_idx, size_t end_idx) {
     compute_vector_range(
             start_idx, end_idx, binary_injector::rhs_arg_dynamic_params_t());
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
+template <typename Vmm>
+void jit_uni_postops_injector_t<Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
@@ -322,14 +185,14 @@ void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
         }
     }
 }
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
+template <typename Vmm>
+void jit_uni_postops_injector_t<Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs) {
     compute_vector_range(vmm_idxs, binary_injector::rhs_arg_dynamic_params_t());
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
+template <typename Vmm>
+void jit_uni_postops_injector_t<Vmm>::prepare_table(bool gen_table) {
     for (auto &alg_elt_inject : alg_to_eltwise_injector_)
         alg_elt_inject.second.prepare_table(gen_table);
 
@@ -340,19 +203,19 @@ void jit_uni_postops_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
             kv.second.prepare_table(gen_table);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(size_t idx,
+template <typename Vmm>
+void jit_uni_postops_injector_t<Vmm>::compute_vector(size_t idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
     compute_vector_range({idx}, rhs_arg_params);
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(size_t idx) {
+template <typename Vmm>
+void jit_uni_postops_injector_t<Vmm>::compute_vector(size_t idx) {
     compute_vector_range({idx});
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::set_lambda_injector(
+template <typename Vmm>
+void jit_uni_postops_injector_t<Vmm>::set_lambda_injector(
         dnnl_primitive_kind_t kind, const std::function<void()> &jit_injector) {
     lambda_jit_injectors_[kind] = jit_injector;
 }
@@ -465,24 +328,9 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
     return true;
 }
 
-template class jit_uni_postops_injector_t<avx512_core_fp16, Xbyak::Zmm>;
-template class jit_uni_postops_injector_t<avx512_core_fp16, Xbyak::Ymm>;
-template class jit_uni_postops_injector_t<avx512_core_fp16, Xbyak::Xmm>;
-template class jit_uni_postops_injector_t<avx512_core_bf16, Xbyak::Zmm>;
-template class jit_uni_postops_injector_t<avx512_core, Xbyak::Zmm>;
-template class jit_uni_postops_injector_t<avx512_core, Xbyak::Ymm>;
-template class jit_uni_postops_injector_t<avx512_core, Xbyak::Xmm>;
-template class jit_uni_postops_injector_t<avx2_vnni_2, Xbyak::Ymm>;
-template class jit_uni_postops_injector_t<avx2_vnni_2, Xbyak::Xmm>;
-template class jit_uni_postops_injector_t<avx2, Xbyak::Ymm>;
-template class jit_uni_postops_injector_t<avx2, Xbyak::Xmm>;
-template class jit_uni_postops_injector_t<avx, Xbyak::Ymm>;
-template class jit_uni_postops_injector_t<avx, Xbyak::Xmm>;
-template class jit_uni_postops_injector_t<sse41, Xbyak::Xmm>;
-
-template class jit_uni_postops_injector_base_t<Xbyak::Zmm>;
-template class jit_uni_postops_injector_base_t<Xbyak::Ymm>;
-template class jit_uni_postops_injector_base_t<Xbyak::Xmm>;
+template class jit_uni_postops_injector_t<Xbyak::Zmm>;
+template class jit_uni_postops_injector_t<Xbyak::Ymm>;
+template class jit_uni_postops_injector_t<Xbyak::Xmm>;
 
 #undef VCHECK_PO_INJ_BOOL
 

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -192,8 +192,7 @@ private:
     post_ops_t post_ops_;
     jit_generator_t *host_;
     // Key is a numerical order of a post-op in attributes.
-    std::map<int, jit_uni_eltwise_injector_t<isa, Vmm>>
-            alg_to_eltwise_injector_;
+    std::map<int, jit_uni_eltwise_injector_t<Vmm>> alg_to_eltwise_injector_;
     std::unique_ptr<binary_injector::jit_uni_binary_injector_t<Vmm>>
             binary_injector_;
     // Native sum injectors, one per sum post-op, keyed by post-op index same as

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -194,7 +194,7 @@ private:
     // Key is a numerical order of a post-op in attributes.
     std::map<int, jit_uni_eltwise_injector_t<isa, Vmm>>
             alg_to_eltwise_injector_;
-    std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa, Vmm>>
+    std::unique_ptr<binary_injector::jit_uni_binary_injector_t<Vmm>>
             binary_injector_;
     // Native sum injectors, one per sum post-op, keyed by post-op index same as
     // `alg_to_eltwise_injector_`. They contain a `binary_injector_` pointer but

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -199,7 +199,7 @@ private:
     // `alg_to_eltwise_injector_`. They contain a `binary_injector_` pointer but
     // do not own it. Keep `idx_to_sum_injector_` after the `binary_injector_`
     // field, just in case.
-    std::map<int, jit_uni_sum_injector_t<isa, Vmm>> idx_to_sum_injector_;
+    std::map<int, jit_uni_sum_injector_t<Vmm>> idx_to_sum_injector_;
     lambda_jit_injectors_t lambda_jit_injectors_;
     // When set, a sum entry is handled by the sum injector instead of a lambda.
     const bool sum_is_native_;

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -49,80 +49,15 @@ using lambda_jit_injectors_t
 
 size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
 
-// A base isa-agnostic post-ops injector abstract class.
-//
 // The main mechanism of handling various post-ops types. It utilizes internally
 // specialized injectors to generate post-ops code to host primitive. Random
 // order of post-ops is supported.
 //
-// Note: to move back from `create` to constructor and merge base into a parent
-// class, both binary and eltwise injector top-level objects should become
-// isa-agnostic, which allows to call their constructors or methods passing isa
-// at runtime.
+// The ISA the code is generated for is taken from the host generator, see
+// `jit_generator_t::max_cpu_isa()`. `Vmm` remains a template parameter to keep
+// the vector width the injector operates on statically typed.
 template <typename Vmm>
-class jit_uni_postops_injector_base_t {
-public:
-    // `isa` argument specifies the ISA the kernel to be generated for. In most
-    // cases it's aligned with the former kernel ISA if such enum value is
-    // instantiated for injectors. If not, uses the next available isa enum
-    // value in compliance with same vector length.
-    //
-    // `enable_native_sum` opts in to handling the sum post-op inside the
-    // injector instead of through a caller-provided lambda. Native sum reads
-    // the previous value from the address supplied per accumulator in
-    // `rhs_arg_dynamic_params_t`, so the caller must provide it (as it does for
-    // binary post-ops).
-    static jit_uni_postops_injector_base_t *create(jit_generator_t *host,
-            cpu_isa_t isa, const post_ops_t &post_ops,
-            const binary_injector::static_params_t &binary_static_params,
-            const eltwise_injector::static_params_t &eltwise_static_params,
-            bool enable_native_sum = false);
-
-    static jit_uni_postops_injector_base_t *create(jit_generator_t *host,
-            cpu_isa_t isa, const post_ops_t &post_ops,
-            const binary_injector::static_params_t &binary_static_params,
-            bool enable_native_sum = false);
-
-    virtual ~jit_uni_postops_injector_base_t() = default;
-
-    // Generates code of post_ops chain injected to host primitive. Applied to
-    // ordered set of vector registers' indexes.
-    // @rhs_arg_params: see jit_uni_binary_injector description
-    virtual void compute_vector_range(
-            const injector_utils::vmm_index_set_t &vmm_idxs,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
-            = 0;
-    virtual void compute_vector_range(
-            const injector_utils::vmm_index_set_t &vmm_idxs)
-            = 0;
-
-    // Generates code of post_ops chain injected to host primitive. Applied to
-    // range <start_idx, end_idx) of vector registers' indexes.
-    // @rhs_arg_params: see jit_uni_binary_injector description
-    virtual void compute_vector_range(size_t start_idx, size_t end_idx,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
-            = 0;
-    virtual void compute_vector_range(size_t start_idx, size_t end_idx) = 0;
-
-    // Generates code of post_ops chain injected to host primitive. Applied to
-    // a single vector register index.
-    // @rhs_arg_params: see jit_uni_binary_injector description
-    virtual void compute_vector(size_t idx,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
-            = 0;
-    virtual void compute_vector(size_t idx) = 0;
-
-    // Thin wrapper for eltwise injector specific function
-    virtual void prepare_table(bool gen_table) = 0;
-    virtual void set_lambda_injector(lambda_jit_injectors_t::key_type,
-            const lambda_jit_injectors_t::mapped_type &jit_injector)
-            = 0;
-};
-
-// A parent isa-specific post-ops injector class. A specific instance is
-// assigned based on `cpu_isa_t isa` argument in the base class.
-template <cpu_isa_t isa, typename Vmm = typename cpu_isa_traits_t<isa>::Vmm>
-class jit_uni_postops_injector_t : public jit_uni_postops_injector_base_t<Vmm> {
+class jit_uni_postops_injector_t {
 public:
     /*
      * @param host <required> - user primitive where post-ops generated code is
@@ -135,12 +70,15 @@ public:
      * @param lambda_jit_injectors <optional> - allows user specify custom injector
      * function for given post-op type
      * @param enable_native_sum <optional> - handle the sum post-op inside the
-     * injector instead of through a caller-provided lambda (see the `create`
-     * documentation for the caller's obligations)
+     * injector instead of through a caller-provided lambda. Native sum reads
+     * the previous value from the address supplied per accumulator in
+     * `rhs_arg_dynamic_params_t`, so the caller must provide it (as it does for
+     * binary post-ops).
      */
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
-            const binary_injector::static_params_t &binary_static_params);
+            const binary_injector::static_params_t &binary_static_params,
+            bool enable_native_sum = false);
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
@@ -149,8 +87,8 @@ public:
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
             const eltwise_injector::static_params_t &eltwise_static_params);
-    // This is the delegation target for the other constructors and the only one
-    // that carries `enable_native_sum`, since it owns all construction state.
+    // This is the delegation target for the other constructors, since it owns
+    // all construction state.
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
@@ -158,35 +96,31 @@ public:
             const lambda_jit_injectors_t &lambda_jit_injectors,
             bool enable_native_sum = false);
 
-    ~jit_uni_postops_injector_t() override = default;
-
-    // See `jit_uni_postops_injector_base_t::compute_vector_range(...)`
+    // Generates code of post_ops chain injected to host primitive. Applied to
+    // ordered set of vector registers' indexes.
+    // @rhs_arg_params: see jit_uni_binary_injector description
     void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
-            override;
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs);
 
-    void compute_vector_range(
-            const injector_utils::vmm_index_set_t &vmm_idxs) override;
-
-    // See `jit_uni_postops_injector_base_t::compute_vector_range(...)`
+    // Generates code of post_ops chain injected to host primitive. Applied to
+    // range <start_idx, end_idx) of vector registers' indexes.
+    // @rhs_arg_params: see jit_uni_binary_injector description
     void compute_vector_range(size_t start_idx, size_t end_idx,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
-            override;
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+    void compute_vector_range(size_t start_idx, size_t end_idx);
 
-    void compute_vector_range(size_t start_idx, size_t end_idx) override;
-
-    // See `jit_uni_postops_injector_base_t::compute_vector(...)`
+    // Generates code of post_ops chain injected to host primitive. Applied to
+    // a single vector register index.
+    // @rhs_arg_params: see jit_uni_binary_injector description
     void compute_vector(size_t idx,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
-            override;
-    void compute_vector(size_t idx) override;
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+    void compute_vector(size_t idx);
 
-    /*
-     * Thin wrapper for eltwise injector specific function
-     */
-    void prepare_table(bool gen_table) override;
+    // Thin wrapper for eltwise injector specific function
+    void prepare_table(bool gen_table);
     void set_lambda_injector(lambda_jit_injectors_t::key_type,
-            const lambda_jit_injectors_t::mapped_type &jit_injector) override;
+            const lambda_jit_injectors_t::mapped_type &jit_injector);
 
 private:
     post_ops_t post_ops_;

--- a/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
@@ -27,7 +27,7 @@ namespace x64 {
 template <cpu_isa_t isa, typename Vmm>
 jit_uni_sum_injector_t<isa, Vmm>::jit_uni_sum_injector_t(jit_generator_t *host,
         const post_ops_t::entry_t::sum_t &sum, data_type_t dst_dt,
-        binary_injector::jit_uni_binary_injector_t<isa, Vmm> *binary_injector,
+        binary_injector::jit_uni_binary_injector_t<Vmm> *binary_injector,
         size_t scratch_vmm_idx, bool preserve_scratch_vmm)
     : host_(host)
     , binary_injector_(binary_injector)

--- a/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
@@ -24,8 +24,8 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-template <cpu_isa_t isa, typename Vmm>
-jit_uni_sum_injector_t<isa, Vmm>::jit_uni_sum_injector_t(jit_generator_t *host,
+template <typename Vmm>
+jit_uni_sum_injector_t<Vmm>::jit_uni_sum_injector_t(jit_generator_t *host,
         const post_ops_t::entry_t::sum_t &sum, data_type_t dst_dt,
         binary_injector::jit_uni_binary_injector_t<Vmm> *binary_injector,
         size_t scratch_vmm_idx, bool preserve_scratch_vmm)
@@ -47,8 +47,8 @@ jit_uni_sum_injector_t<isa, Vmm>::jit_uni_sum_injector_t(jit_generator_t *host,
             && "native sum read type is undef: binary static params unset");
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_sum_injector_t<isa, Vmm>::compute_vector_range(
+template <typename Vmm>
+void jit_uni_sum_injector_t<Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
@@ -57,7 +57,7 @@ void jit_uni_sum_injector_t<isa, Vmm>::compute_vector_range(
 
     // If a user-provided scratch register happens to be one of the
     // accumulators, pick a new free register.
-    const int max_idx = cpu_isa_traits_t<isa>::n_vregs - 1;
+    const int max_idx = isa_num_vregs(isa_) - 1;
     const int scratch = (int)scratch_vmm_idx_;
 
     int tmp_idx = scratch;
@@ -118,11 +118,11 @@ void jit_uni_sum_injector_t<isa, Vmm>::compute_vector_range(
     }
 }
 
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_sum_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
+template <typename Vmm>
+void jit_uni_sum_injector_t<Vmm>::prepare_table(bool gen_table) {
     if (!gen_table || (!has_scale_ && !has_zp_)) return;
 
-    const int simd = cpu_isa_traits_t<isa>::vlen / (int)sizeof(float);
+    const int simd = isa_max_vlen(isa_) / (int)sizeof(float);
     const auto store_value = [&](float val) {
         for (int i = 0; i < simd; i++)
             host_->dd(float2int(val));
@@ -138,20 +138,9 @@ void jit_uni_sum_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
     }
 }
 
-template class jit_uni_sum_injector_t<avx512_core_fp16, Xbyak::Zmm>;
-template class jit_uni_sum_injector_t<avx512_core_fp16, Xbyak::Ymm>;
-template class jit_uni_sum_injector_t<avx512_core_fp16, Xbyak::Xmm>;
-template class jit_uni_sum_injector_t<avx512_core_bf16, Xbyak::Zmm>;
-template class jit_uni_sum_injector_t<avx512_core, Xbyak::Zmm>;
-template class jit_uni_sum_injector_t<avx512_core, Xbyak::Ymm>;
-template class jit_uni_sum_injector_t<avx512_core, Xbyak::Xmm>;
-template class jit_uni_sum_injector_t<avx2_vnni_2, Xbyak::Ymm>;
-template class jit_uni_sum_injector_t<avx2_vnni_2, Xbyak::Xmm>;
-template class jit_uni_sum_injector_t<avx2, Xbyak::Ymm>;
-template class jit_uni_sum_injector_t<avx2, Xbyak::Xmm>;
-template class jit_uni_sum_injector_t<avx, Xbyak::Ymm>;
-template class jit_uni_sum_injector_t<avx, Xbyak::Xmm>;
-template class jit_uni_sum_injector_t<sse41, Xbyak::Xmm>;
+template class jit_uni_sum_injector_t<Xbyak::Zmm>;
+template class jit_uni_sum_injector_t<Xbyak::Ymm>;
+template class jit_uni_sum_injector_t<Xbyak::Xmm>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/injectors/jit_uni_sum_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_sum_injector.hpp
@@ -36,7 +36,11 @@ namespace x64 {
 // The typed, tail-aware read is delegated to the binary injector
 // (`load_acc_as_f32`), so this injector only owns the sum arithmetic, the
 // scale/zero-point constants and the single scratch vector register.
-template <cpu_isa_t isa, typename Vmm = typename cpu_isa_traits_t<isa>::Vmm>
+//
+// The ISA to generate for is taken from the host generator, which already
+// carries it as its `max_cpu_isa()` ceiling. `Vmm` stays a template parameter
+// to keep the vector width statically typed.
+template <typename Vmm>
 class jit_uni_sum_injector_t {
 public:
     // `sum` supplies the scale, zero-point and read data type. When
@@ -64,6 +68,8 @@ public:
 private:
     jit_generator_t *host_;
     binary_injector::jit_uni_binary_injector_t<Vmm> *binary_injector_;
+
+    const cpu_isa_t isa_ = host_->max_cpu_isa();
 
     // Read type for the previous value (`sum.dt` or `dst_dt` when undefined).
     const data_type_t sum_dt_;

--- a/src/cpu/x64/injectors/jit_uni_sum_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_sum_injector.hpp
@@ -47,8 +47,7 @@ public:
     // preserved when `preserve_scratch_vmm` is set.
     jit_uni_sum_injector_t(jit_generator_t *host,
             const post_ops_t::entry_t::sum_t &sum, data_type_t dst_dt,
-            binary_injector::jit_uni_binary_injector_t<isa, Vmm>
-                    *binary_injector,
+            binary_injector::jit_uni_binary_injector_t<Vmm> *binary_injector,
             size_t scratch_vmm_idx, bool preserve_scratch_vmm);
 
     // Computes `acc += scale * (prev - zp)` for each accumulator in `vmm_idxs`.
@@ -64,7 +63,7 @@ public:
 
 private:
     jit_generator_t *host_;
-    binary_injector::jit_uni_binary_injector_t<isa, Vmm> *binary_injector_;
+    binary_injector::jit_uni_binary_injector_t<Vmm> *binary_injector_;
 
     // Read type for the previous value (`sum.dt` or `dst_dt` when undefined).
     const data_type_t sum_dt_;

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -28,22 +28,22 @@ namespace x64 {
 namespace ir {
 
 template <typename Vmm>
-using injector_base_t = injector::jit_uni_postops_injector_base_t<Vmm>;
+using injector_t = injector::jit_uni_postops_injector_t<Vmm>;
 
 namespace {
 
-// Create an injector for the target ISA and return it type-erased.
+// Create an injector and return it type-erased. The ISA it generates for comes
+// from the host generator.
 template <typename Vmm>
-std::shared_ptr<void> create_injector(jit_generator_t &gen, cpu_isa_t isa,
+std::shared_ptr<void> create_injector(jit_generator_t &gen,
         const post_ops_t &post_ops,
         const binary_injector::static_params_t &bsp) {
-    return std::shared_ptr<injector_base_t<Vmm>>(
-            injector_base_t<Vmm>::create(&gen, isa, post_ops, bsp));
+    return std::make_shared<injector_t<Vmm>>(&gen, post_ops, bsp);
 }
 
 template <typename Vmm>
-injector_base_t<Vmm> *cast2tgt(void *injector) {
-    return static_cast<injector_base_t<Vmm> *>(injector);
+injector_t<Vmm> *cast2tgt(void *injector) {
+    return static_cast<injector_t<Vmm> *>(injector);
 }
 
 } // namespace
@@ -77,8 +77,8 @@ postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
             binary_injector::get_all_strategies_supported_by_injector(),
             rhs_sp};
 
-    injector_ = is_zmm_ ? create_injector<Xbyak::Zmm>(gen, isa, post_ops, bsp)
-                        : create_injector<Xbyak::Ymm>(gen, isa, post_ops, bsp);
+    injector_ = is_zmm_ ? create_injector<Xbyak::Zmm>(gen, post_ops, bsp)
+                        : create_injector<Xbyak::Ymm>(gen, post_ops, bsp);
     assert(injector_ && "ir post-ops injector creation failed");
 
     with_eltwise_ = post_ops.find(primitive_kind::eltwise) != -1;

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -87,7 +87,7 @@ struct postops_injector_t {
     void DNNL_API maybe_prepare_table();
 
 private:
-    // Type-erased `jit_uni_postops_injector_base_t<Vmm>`. Cast to the target
+    // Type-erased `jit_uni_postops_injector_t<Vmm>`. Cast to the target
     // type when used, based on `is_zmm_`.
     std::shared_ptr<void> injector_;
     bool is_zmm_ = false;

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -65,7 +65,7 @@ jit_avx2_1x1_conv_kernel_f32_t::jit_avx2_1x1_conv_kernel_f32_t(
         static_params_t static_params {this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx2>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Ymm>>(
                 this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
@@ -48,7 +48,7 @@ struct jit_avx2_1x1_conv_kernel_f32_t : public jit_generator_t {
     const primitive_attr_t &attr_;
 
 private:
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx2>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Ymm>>
             postops_injector_;
 
     constexpr static int isa_simd_width_

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -70,7 +70,7 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
         static_params_t static_params {this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx2>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Ymm>>(
                 this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
@@ -47,7 +47,7 @@ struct jit_avx2_conv_fwd_kernel_f32_t : public jit_generator_t {
     const primitive_attr_t &attr_;
 
 private:
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx2>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Ymm>>
             postops_injector_;
 
     constexpr static int isa_simd_width_

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -68,7 +68,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -50,7 +50,7 @@ using namespace Xbyak;
 jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name()), jcp(ajcp), attr_(attr) {
+    : jit_generator_t(jit_name(), avx512_core), jcp(ajcp), attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
@@ -48,7 +48,7 @@ struct jit_avx512_common_1x1_conv_kernel_t : public jit_generator_t {
     const primitive_attr_t &attr_;
 
 private:
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
 
     constexpr static int isa_simd_width_

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -114,7 +114,7 @@ jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::
                 this->param1, rhs_args_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -96,7 +96,7 @@ template <typename Vmm>
 jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::
         jit_avx512_common_conv_fwd_kernel_vmm_t(const jit_conv_conf_t &ajcp,
                 const primitive_attr_t &attr, const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name()), jcp(ajcp), attr_(attr) {
+    : jit_generator_t(jit_name(), avx512_core), jcp(ajcp), attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -110,7 +110,7 @@ private:
     Xbyak::Reg64 imm_addr64 = r15;
     Vmm vmm_wei = Vmm(31);
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
 
     inline void prepare_output(int ur_w);

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -62,7 +62,7 @@ jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
@@ -53,7 +53,7 @@ struct jit_avx512_core_amx_1x1_fwd_kernel_t : public jit_generator_t {
 private:
     constexpr static int isa_simd_width_
             = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
 
     enum {

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1095,7 +1095,7 @@ jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp.post_ops, static_params);
     }
     copy_to_pbuffer_

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -274,7 +274,7 @@ struct jit_avx512_core_amx_fwd_kernel_t : public jit_generator_t {
 private:
     constexpr static int isa_simd_width_
             = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
     std::unique_ptr<jit_avx512_core_amx_copy_to_pbuffer_t> copy_to_pbuffer_;
     std::unique_ptr<jit_avx512_core_amx_copy_to_wbuffer_t> copy_to_wbuffer_;

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -481,7 +481,7 @@ struct jit_avx512_core_amx_bwd_data_kernel_t : public jit_generator_t {
         , bwd_data_copy_kernel_(nullptr) {
         if (jcp.with_eltwise)
             eltwise_injector_ = utils::make_unique<
-                    jit_uni_eltwise_injector_t<avx512_core>>(this, jcp.eltwise);
+                    jit_uni_eltwise_injector_t<Xbyak::Zmm>>(this, jcp.eltwise);
         bwd_data_copy_kernel_ = utils::make_unique<
                 jit_avx512_core_amx_bwd_data_copy_kernel_t>(jcp);
     }
@@ -513,7 +513,7 @@ struct jit_avx512_core_amx_bwd_data_kernel_t : public jit_generator_t {
     }
 
 private:
-    std::unique_ptr<jit_uni_eltwise_injector_t<avx512_core>> eltwise_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_t<Xbyak::Zmm>> eltwise_injector_;
     std::unique_ptr<jit_avx512_core_amx_bwd_data_copy_kernel_t>
             bwd_data_copy_kernel_;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -63,7 +63,7 @@ jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp.post_ops, static_params);
     }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -45,7 +45,7 @@ using namespace Xbyak;
 jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name(), avx512_core_bf16), jcp(ajcp), attr_(attr) {
+    : jit_generator_t(jit_name(), ajcp.isa), jcp(ajcp), attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
@@ -50,7 +50,7 @@ struct jit_avx512_core_bf16_1x1_conv_kernel_t : public jit_generator_t {
 private:
     constexpr static int isa_simd_width_
             = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
 
     using reg64_t = const Xbyak::Reg64;

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -100,7 +100,7 @@ template <typename Vmm>
 jit_avx512_core_bf16_fwd_kernel_vmm_t<
         Vmm>::jit_avx512_core_bf16_fwd_kernel_vmm_t(const jit_conv_conf_t &ajcp,
         const primitive_attr_t &attr, const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name(), avx512_core_bf16), jcp(ajcp), attr_(attr) {
+    : jit_generator_t(jit_name(), ajcp.isa), jcp(ajcp), attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -120,9 +120,9 @@ jit_avx512_core_bf16_fwd_kernel_vmm_t<
         const static_params_t static_params {
                 this->param1, rhs_arg_static_params};
 
-        postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core, Vmm>>(
-                this, jcp.post_ops, static_params);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                        this, jcp.post_ops, static_params);
     }
     if (!isa_has_bf16(jcp.isa))
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -263,9 +263,7 @@ template <typename Vmm>
 struct jit_avx512_core_bf16_bwd_data_kernel_vmm_t : public jit_generator_t {
 
     jit_avx512_core_bf16_bwd_data_kernel_vmm_t(const jit_conv_conf_t &ajcp)
-        : jit_generator_t(jit_name(), avx512_core_bf16)
-        , jcp(ajcp)
-        , bf16_emu_(nullptr) {
+        : jit_generator_t(jit_name(), ajcp.isa), jcp(ajcp), bf16_emu_(nullptr) {
         if (!isa_has_bf16(jcp.isa))
             bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,
                     bf16_emu_reserv_1, bf16_emu_reserv_2, bf16_emu_reserv_3,
@@ -477,9 +475,7 @@ struct jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t
 
     jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t(
             const jit_conv_conf_t &ajcp)
-        : jit_generator_t(jit_name(), avx512_core_bf16)
-        , jcp(ajcp)
-        , bf16_emu_(nullptr) {
+        : jit_generator_t(jit_name(), ajcp.isa), jcp(ajcp), bf16_emu_(nullptr) {
         if (!isa_has_bf16(jcp.isa)) {
             bf16_emu_ = utils::make_unique<bf16_emulation_t>(
                     this, one, even, selector, scratch, tmp0, tmp1);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -127,7 +127,7 @@ private:
     constexpr static int off_reg_ker_ = 8;
     constexpr static int stack_space_needed_ = 16;
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -54,7 +54,7 @@ jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp.post_ops, static_params);
     }
     if (!isa_has_bf16(jcp.isa))

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -35,7 +35,7 @@ using namespace dnnl::impl::utils;
 
 jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name()), jcp(ajcp) {
+    : jit_generator_t(jit_name(), ajcp.isa), jcp(ajcp) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -119,7 +119,7 @@ private:
             int ur_ch_blocks, int ur_w, bool last_ch_block_flag);
     inline void store_dst(int ur_ch_blocks, int ur_w, bool last_ch_block_flag);
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
 
     std::unique_ptr<bf16_emulation_t> bf16_emu_;

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -54,7 +54,7 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
         static_params_t static_params {this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp.post_ops, static_params);
     }
 

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -37,7 +37,7 @@ using namespace Xbyak;
 
 jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name()), jcp(ajcp) {
+    : jit_generator_t(jit_name(), ajcp.isa), jcp(ajcp) {
     const auto simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
     const auto tail_size = jcp.oc_without_padding % simd_w;
     if (jcp.with_eltwise || jcp.with_binary) {

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
@@ -106,7 +106,7 @@ private:
                 format_tag::nwc);
     }
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
     std::unique_ptr<io::jit_io_multi_dt_helper_t<Xbyak::Zmm>> io_;
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -72,9 +72,9 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
         const static_params_t static_params {
                 this->param1, rhs_arg_static_params};
 
-        postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core, Vmm>>(
-                this, jcp.post_ops, static_params);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                        this, jcp.post_ops, static_params);
     }
     if (jcp.dst_dt == data_type::bf16 && !isa_has_bf16(jcp.isa))
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -49,7 +49,7 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
         jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t(
                 const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
                 const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name())
+    : jit_generator_t(jit_name(), ajcp.isa)
     , jcp(ajcp)
     , attr_(attr)
     , postops_injector_(nullptr) {
@@ -875,6 +875,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     // used for bf16 output
     jcp.isa = mayiuse(avx512_core_bf16) ? avx512_core_bf16
+            : mayiuse(avx512_core_vnni) ? avx512_core_vnni
                                         : bf16_emulation_t::get_isa();
 
     const memory_desc_wrapper src_d(src_md);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -47,7 +47,7 @@ private:
     using Vmm_down_t =
             typename utils::conditional<std::is_same<Vmm, Xbyak::Zmm>::value,
                     Xbyak::Ymm, Xbyak::Xmm>::type;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     /* register mapping */

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -83,9 +83,9 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
         const static_params_t static_params {
                 this->param1, rhs_arg_static_params};
 
-        postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core, Vmm>>(
-                this, jcp.post_ops, static_params);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                        this, jcp.post_ops, static_params);
     }
     if (!isa_has_bf16(jcp.isa) && jcp.dst_dt == data_type::bf16)
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -50,7 +50,7 @@ private:
             typename utils::conditional<std::is_same<Vmm, Xbyak::Zmm>::value,
                     Xbyak::Ymm, Xbyak::Xmm>::type;
     const int ic_sub_step = 4;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     enum {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -44,7 +44,7 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
         jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t(
                 const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
                 const memory_desc_t &dst_md)
-    : jit_generator_t(jit_name())
+    : jit_generator_t(jit_name(), ajcp.isa)
     , jcp(ajcp)
     , attr_(attr)
     , postops_injector_(nullptr) {
@@ -292,6 +292,7 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     jcp.post_ops = p;
 
     jcp.has_vnni = mayiuse(avx512_core_vnni);
+    jcp.isa = jcp.has_vnni ? avx512_core_vnni : avx512_core;
 
     jcp.is_oc_scale = attr.scales_.get_mask(DNNL_ARG_WEIGHTS) > 0;
     jcp.with_src_scales = !attr.scales_.get(DNNL_ARG_SRC).has_default_values();

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -66,9 +66,9 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
                 use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp {this->param1, rhs_sp};
 
-        postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core, Vmm>>(
-                this, jcp.post_ops, bsp);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                        this, jcp.post_ops, bsp);
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -84,7 +84,7 @@ struct jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t : public jit_generator_t {
     const primitive_attr_t &attr_;
 
 private:
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     const int ic_sub_step = 4;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -978,6 +978,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     if (is_relo_with_relo_weights) {
         jit_brgemm_relo_copy_to_wbuffer_t::cfg_t wjcp;
+        wjcp.isa = jcp.isa;
         wjcp.wei_dt = jcp.wei_dt;
         wjcp.out_oc_block = jcp.oc_block;
         wjcp.inp_oc_block = 16;

--- a/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
@@ -27,6 +27,7 @@ namespace x64 {
 
 struct jit_brgemm_relo_copy_to_wbuffer_t : public jit_generator_t {
     struct cfg_t {
+        cpu_isa_t isa {isa_undef};
         data_type_t wei_dt {data_type_t::dnnl_data_type_undef};
         int out_oc_block {0};
         int inp_oc_block {0};
@@ -47,7 +48,7 @@ struct jit_brgemm_relo_copy_to_wbuffer_t : public jit_generator_t {
     using reg64_t = Xbyak::Reg64;
 
     jit_brgemm_relo_copy_to_wbuffer_t(const cfg_t &ajcp)
-        : jit_generator_t(jit_name(), avx512_core_amx), wjcp(ajcp) {}
+        : jit_generator_t(jit_name(), ajcp.isa), wjcp(ajcp) {}
 
 private:
     cfg_t wjcp;

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -99,12 +99,8 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         const eltwise_injector::static_params_t esp {
                 save_state, reserved_eltwise_gpr, reserved_eltwise_maskr};
 
-        auto st = safe_ptr_assign(postops_injector_,
-                po_injector_t::create(
-                        this, brg_.isa_impl, attr_.post_ops_, bsp, esp));
-        if (st != status::success) {
-            assert(!"postops_injector creation failed");
-        }
+        postops_injector_ = utils::make_unique<po_injector_t>(
+                this, attr_.post_ops_, bsp, esp);
     }
 
     inp_dt_ = brg_.dt_c;

--- a/src/cpu/x64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.hpp
@@ -114,7 +114,7 @@ private:
 
     using Vmm_lower_t = typename vreg_traits_t<Vmm>::Vmm_lower_t;
     using Vmm_lower2_t = typename vreg_traits_t<Vmm_lower_t>::Vmm_lower_t;
-    using po_injector_t = injector::jit_uni_postops_injector_base_t<Vmm>;
+    using po_injector_t = injector::jit_uni_postops_injector_t<Vmm>;
     std::unique_ptr<po_injector_t> postops_injector_;
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
     std::unique_ptr<fp8_conversion_e5m2_t> f8_e5m2_cvt_;

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -124,9 +124,8 @@ private:
     };
 
     const bool is_avx512_ = utils::one_of(isa, avx512_core, avx512_core_bf16);
-    static constexpr cpu_isa_t inject_isa_
-            = isa == avx512_core_bf16 ? avx512_core : isa;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<inject_isa_>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<
+            typename cpu_isa_traits_t<isa>::Vmm>>
             postops_injector_;
 
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
@@ -351,9 +350,11 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
         const eltwise_injector::static_params_t eltwise_static_params {
                 save_state, reg_tmp_comp, eltwise_reserved_opmask_};
 
-        postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<inject_isa_>>(this,
-                this->post_ops_, binary_static_params, eltwise_static_params);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<
+                        typename cpu_isa_traits_t<isa>::Vmm>>(this,
+                        this->post_ops_, binary_static_params,
+                        eltwise_static_params);
 
         using namespace dnnl::impl::cpu::binary_injector_utils;
         std::tie(any_binary_postop_is_no_bcast_type_,

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -92,7 +92,7 @@ private:
         bool should_apply_zp_src_pad_comp_d;
     };
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
 
     size_t number_of_reserved_zmm_regs_;
@@ -197,7 +197,7 @@ jit_pp_ker_t::jit_pp_ker_t(
         const static_params_t static_params {reg_param_, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<avx512_core>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
                 this, jcp_.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -142,7 +142,7 @@ private:
 jit_pp_ker_t::jit_pp_ker_t(
         const convolution_pd_t *pd, const conv_gemm_conf_t &jcp)
     : pp_ker_t(pd, jcp)
-    , jit_generator_t(jit_name())
+    , jit_generator_t(jit_name(), avx512_core)
     , number_of_reserved_zmm_regs_(0)
     , bias_data_type_size_(jcp.bias_data_type != data_type::undef
                       ? types::data_type_size(jcp.bias_data_type)

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -58,7 +58,7 @@ jit_sse41_1x1_conv_kernel_f32_t::jit_sse41_1x1_conv_kernel_f32_t(
         const binary_injector::static_params_t static_params {
                 this->param1, rhs_arg_static_params};
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<sse41>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Xmm>>(
                 this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.hpp
@@ -77,7 +77,7 @@ private:
 
     xmm_t reg_bcast = xmm_t(15);
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<sse41>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Xmm>>
             postops_injector_;
 
     void generate_bcast_loop(int load_loop_blk);

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -58,7 +58,7 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<sse41>>(
+                injector::jit_uni_postops_injector_t<Xbyak::Xmm>>(
                 this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
@@ -64,7 +64,7 @@ private:
 
     Xbyak::Reg32 reg_ci_flag = r13d;
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<sse41>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Xmm>>
             postops_injector_;
 
     inline void oh_step_unroll_kw(

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -148,9 +148,9 @@ void jit_uni_binary_kernel_t<isa, Vmm>::init_post_ops_injector() {
     const binary_injector::static_params_t bsp(this->param1,
             get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 
-    postops_injector_ = utils::make_unique<
-            injector::jit_uni_postops_injector_t<inject_isa, Vmm>>(
-            this, po, bsp, esp);
+    postops_injector_
+            = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                    this, po, bsp, esp);
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -137,10 +137,8 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     const size_t offt_src1_;
     const size_t offt_src2_;
 
-    static constexpr cpu_isa_t inject_isa
-            = isa == avx512_core_bf16 ? avx512_core : isa;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<inject_isa, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
     const Opmask elt_inj_opmask_ = k1;
 

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -55,7 +55,8 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
         static_params_t static_params {this->param1, rhs_arg_static_params};
 
         postops_injector_
-                = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
+                = utils::make_unique<injector::jit_uni_postops_injector_t<
+                        typename cpu_isa_traits_t<isa>::Vmm>>(
                         this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
@@ -119,7 +119,8 @@ private:
                 format_tag::nwc);
     }
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<
+            typename cpu_isa_traits_t<isa>::Vmm>>
             postops_injector_;
 
     void generate() override;

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -93,8 +93,8 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
         // using the first 7 vregs can be considered volatile during the call
         // to eltwise injector
         const bool save_state = is_fwd_ ? false : true;
-        eltwise_injector_.reset(new jit_uni_eltwise_injector_t<injector_isa>(
-                this, desc.alg_kind, desc.alpha, desc.beta, 1.f, data_type::f32,
+        eltwise_injector_.reset(new jit_uni_eltwise_injector_t<Vmm>(this,
+                desc.alg_kind, desc.alpha, desc.beta, 1.f, data_type::f32,
                 save_state, reg_injector_table, injector_mask, is_fwd_,
                 pd_->use_dst()));
         io::io_conf_t io_conf;
@@ -233,8 +233,6 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
 
 private:
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr cpu_isa_t injector_isa
-            = isa == avx512_core_amx ? avx512_core : isa;
 
     const int vlen_;
     const int simd_w_;
@@ -262,7 +260,7 @@ private:
     Vmm vmm_src_odd = Vmm(8);
     Vmm vmm_diff_dst_even = vmm_diff_dst;
     Vmm vmm_diff_dst_odd = Vmm(9);
-    std::unique_ptr<jit_uni_eltwise_injector_t<injector_isa>> eltwise_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> eltwise_injector_;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
 
     /* bf16 and fp8 support */
@@ -287,9 +285,6 @@ status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     // disabling verbose dispatch messages for unsupported isa for better readability
     if (!mayiuse(isa)) return status::unimplemented;
 
-    static constexpr cpu_isa_t injector_isa
-            = isa == avx512_core_amx ? avx512_core : isa;
-
     VDISPATCH_ELTWISE(is_fwd(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_ELTWISE(utils::one_of(src_md()->data_type, f32, bf16, f16,
                               f8_e5m2, f8_e4m3),
@@ -309,8 +304,7 @@ status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(const engine_t *engine) {
             VERBOSE_ISA_DT_MISMATCH);
     VDISPATCH_ELTWISE(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "data");
     VDISPATCH_ELTWISE(src_d.is_dense(true), VERBOSE_UNSUPPORTED_SPARSE_CFG);
-    VDISPATCH_ELTWISE(
-            eltwise_injector::is_supported(injector_isa, desc_.alg_kind, f32),
+    VDISPATCH_ELTWISE(eltwise_injector::is_supported(isa, desc_.alg_kind, f32),
             VERBOSE_BAD_ALGORITHM);
     // refer to a comment in jit_uni_kernel why this is needed
     VDISPATCH_ELTWISE(IMPLICATION(!src_d.is_dense(), is_zero_preserved()),
@@ -378,9 +372,6 @@ status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     // readability
     if (!mayiuse(isa)) return status::unimplemented;
 
-    static constexpr cpu_isa_t injector_isa
-            = isa == avx512_core_amx ? avx512_core : isa;
-
     VDISPATCH_ELTWISE(!is_fwd(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_ELTWISE(utils::one_of(data_md()->data_type, f32, bf16, f16,
                               f8_e5m2, f8_e4m3),
@@ -402,8 +393,8 @@ status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     VDISPATCH_ELTWISE(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "data");
     VDISPATCH_ELTWISE(set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
     VDISPATCH_ELTWISE(data_d.is_dense(true), VERBOSE_UNSUPPORTED_SPARSE_CFG);
-    VDISPATCH_ELTWISE(eltwise_injector::is_isa_supported(injector_isa),
-            VERBOSE_UNSUPPORTED_ISA);
+    VDISPATCH_ELTWISE(
+            eltwise_injector::is_isa_supported(isa), VERBOSE_UNSUPPORTED_ISA);
     VDISPATCH_ELTWISE(eltwise_injector::is_alg_supported(desc_.alg_kind),
             VERBOSE_BAD_ALGORITHM);
     // refer to a comment in jit_uni_kernel why this is needed

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -144,7 +144,7 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<isa>>(
+                    injector::jit_uni_postops_injector_t<Vmm>>(
                     this, pd_->attr()->post_ops_, bsp, esp);
         }
         preamble();
@@ -259,7 +259,7 @@ protected:
     bool with_src_scales_ = false;
     bool with_dst_scales_ = false;
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     void compute_dst_body(size_t offt_elems, bool tail = false) {

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -136,7 +136,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     Mmx mmx_tmp = Mmx(2);
     int post_op_tail_opmask_idx_ = -1;
     jit_pool_conf_t jpp;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     enum : int { max_vidx_base = utils::one_of(isa, sse41, avx2) ? 7 : 2 };
@@ -265,7 +265,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<isa>>(
+                    injector::jit_uni_postops_injector_t<Vmm>>(
                     this, jpp.post_ops, bsp);
         }
     }

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -134,7 +134,7 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<isa>>(
+                    injector::jit_uni_postops_injector_t<Vmm>>(
                     this, pd_->attr()->post_ops_, bsp, esp);
         }
         preamble();
@@ -248,7 +248,7 @@ protected:
     bool with_src_scales_ = false;
     bool with_dst_scales_ = false;
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     void compute_dst_body(size_t offt_elems, bool tail = false) {

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -192,7 +192,7 @@ protected:
     bool with_src_scales_ = false;
     bool with_dst_scales_ = false;
 
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     const Reg64 reg_param = abi_param1;
@@ -566,7 +566,7 @@ protected:
                     get_supported_bcast_strategies(dst_d_.ndims()), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<isa>>(
+                    injector::jit_uni_postops_injector_t<Vmm>>(
                     this, pd_->attr()->post_ops_, bsp, esp);
         }
         preamble();

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -103,7 +103,7 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
                 f8_e4m3_cvt_.get()};
 
         postops_injector_
-                = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
                         this, jpp.post_ops, bsp);
     }
 

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -259,7 +259,7 @@ private:
 
     std::unique_ptr<fp8_conversion_e5m2_t> f8_e5m2_cvt_;
     std::unique_ptr<fp8_conversion_e4m3_t> f8_e4m3_cvt_;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
 };

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -163,9 +163,9 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::init_post_ops_injector(
     const binary_injector::static_params_t bsp(
             reg_param_, get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 
-    postops_injector_ = utils::make_unique<
-            injector::jit_uni_postops_injector_t<inject_isa_, Vmm>>(
-            this, conf_.post_ops, bsp, esp);
+    postops_injector_
+            = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                    this, conf_.post_ops, bsp, esp);
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/jit_uni_reduction_kernel.hpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.hpp
@@ -138,10 +138,7 @@ private:
     const Xbyak::Reg64 reg_po_injector_helper_2_ = r15;
     const Xbyak::Reg64 reg_po_injector_helper_3_ = r12;
 
-    // post-ops injector does not use avx512_core_bf16 instructions
-    static constexpr cpu_isa_t inject_isa_
-            = isa == avx512_core_bf16 ? avx512_core : isa;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<inject_isa_, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 };
 

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -68,9 +68,9 @@ jit_uni_resampling_kernel_t<isa, Vmm>::jit_uni_resampling_kernel_t(
         const binary_injector::static_params_t bsp {
                 reg_param, accepted_broadcasts, rhs_sp};
 
-        postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<isa, Vmm>>(
-                this, conf_.post_ops, bsp);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                        this, conf_.post_ops, bsp);
 
         std::tie(any_binary_postop_is_per_oc_bcast_type_,
                 any_binary_postop_is_per_oc_sp_bcast_type_)

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -207,7 +207,7 @@ private:
     bool any_binary_postop_is_per_oc_sp_bcast_type_ = false;
 
     io::jit_io_multi_dt_helper_t<Vmm> io_;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 };
 } // namespace x64

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -67,7 +67,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
 
     std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> exp_injector_;
     std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> log_injector_;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     Reg64 reg_param = abi_param1;
@@ -966,7 +966,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<isa>>(
+                    injector::jit_uni_postops_injector_t<Vmm>>(
                     this, pd_->attr()->post_ops_, bsp);
         }
 #undef PARAM_OFF
@@ -1059,7 +1059,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
 
     std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> exp_injector_;
     std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> log_injector_;
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
 
     Reg64 reg_param = abi_param1;
@@ -1551,7 +1551,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<isa>>(
+                    injector::jit_uni_postops_injector_t<Vmm>>(
                     this, pd_->attr()->post_ops_, bsp);
         }
 #undef PARAM_OFF

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -65,8 +65,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     const memory_desc_wrapper src_d_, dst_d_, diff_dst_d_;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
 
-    std::unique_ptr<jit_uni_eltwise_injector_t<isa>> exp_injector_;
-    std::unique_ptr<jit_uni_eltwise_injector_t<isa>> log_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> exp_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> log_injector_;
     std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
             postops_injector_;
 
@@ -635,8 +635,9 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                     // Prepare indices for exp aux vmms.
                     injector_utils::vmm_index_set_t exp_aux_indices;
                     const auto exp_vmm_aux_count
-                            = jit_uni_eltwise_injector_t<isa>::aux_vecs_count(
-                                    alg_kind::eltwise_exp, pd_->is_fwd(), 0.f);
+                            = jit_uni_eltwise_injector_t<Vmm>::aux_vecs_count(
+                                    isa, alg_kind::eltwise_exp, pd_->is_fwd(),
+                                    0.f);
                     for (size_t j = 0; j < exp_vmm_aux_count; j++) {
                         // Insert the next idx starting after `vreg_tmp_sum`.
                         exp_aux_indices.insert(static_cast<size_t>(
@@ -940,11 +941,11 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     // initialization.
     void generate() override {
         if (pd_->is_fwd() || is_logsoftmax_)
-            exp_injector_.reset(new jit_uni_eltwise_injector_t<isa>(this,
+            exp_injector_.reset(new jit_uni_eltwise_injector_t<Vmm>(this,
                     alg_kind::eltwise_exp, 0.0f, 0.0f, 1.0f, data_type::f32,
                     !use_ext_aux_vmms_, reg_exp_injector_table, injector_mask));
         if (pd_->is_fwd() && is_logsoftmax_) {
-            log_injector_.reset(new jit_uni_eltwise_injector_t<isa>(this,
+            log_injector_.reset(new jit_uni_eltwise_injector_t<Vmm>(this,
                     alg_kind::eltwise_log, 0.0f, 0.0f, 1.0f, data_type::f32,
                     true, reg_log_injector_table, injector_mask));
         }
@@ -1056,8 +1057,8 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     const memory_desc_wrapper src_d_, dst_d_;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
 
-    std::unique_ptr<jit_uni_eltwise_injector_t<isa>> exp_injector_;
-    std::unique_ptr<jit_uni_eltwise_injector_t<isa>> log_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> exp_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_t<Vmm>> log_injector_;
     std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
             postops_injector_;
 
@@ -1525,11 +1526,11 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
 
     void generate() override {
         if (pd_->is_fwd() || is_logsoftmax_)
-            exp_injector_.reset(new jit_uni_eltwise_injector_t<isa>(this,
+            exp_injector_.reset(new jit_uni_eltwise_injector_t<Vmm>(this,
                     alg_kind::eltwise_exp, 0.0f, 0.0f, 1.0f, data_type::f32,
                     true, reg_exp_injector_table, injector_mask));
         if (pd_->is_fwd() && is_logsoftmax_) {
-            log_injector_.reset(new jit_uni_eltwise_injector_t<isa>(this,
+            log_injector_.reset(new jit_uni_eltwise_injector_t<Vmm>(this,
                     alg_kind::eltwise_log, 0.0f, 0.0f, 1.0f, data_type::f32,
                     true, reg_log_injector_table, injector_mask));
         }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -64,7 +64,8 @@ jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa,
         static_params_t static_params {this->param1, rhs_arg_static_params};
 
         postops_injector_
-                = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
+                = utils::make_unique<injector::jit_uni_postops_injector_t<
+                        typename cpu_isa_traits_t<isa>::Vmm>>(
                         this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -42,7 +42,8 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t : public jit_generator_t {
     const primitive_attr_t &attr_;
 
 private:
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<
+            typename cpu_isa_traits_t<isa>::Vmm>>
             postops_injector_;
 
     enum {

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -79,7 +79,8 @@ jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_
-                = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
+                = utils::make_unique<injector::jit_uni_postops_injector_t<
+                        typename cpu_isa_traits_t<isa>::Vmm>>(
                         this, jcp.post_ops, static_params);
     }
 }

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -43,7 +43,8 @@ struct jit_uni_x8s8s32x_fwd_kernel_vmm_t : public jit_generator_t {
 private:
     constexpr static int isa_simd_width_
             = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<
+            typename cpu_isa_traits_t<isa>::Vmm>>
             postops_injector_;
     enum {
         typesize = sizeof(float),

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -442,9 +442,9 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
                 tail_size, Xbyak::Opmask(2), use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp {this->param1_, rhs_sp};
 
-        postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<isa, Vmm>>(
-                this, jcp_.post_ops, bsp);
+        postops_injector_
+                = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                        this, jcp_.post_ops, bsp);
     }
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -38,7 +38,7 @@ class jit_uni_deconv_zp_pad_str_kernel_base_t;
 } // namespace zp
 
 namespace injector {
-template <cpu_isa_t isa, typename Vmm>
+template <typename Vmm>
 class jit_uni_postops_injector_t;
 } // namespace injector
 
@@ -56,7 +56,7 @@ struct jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t : public jit_generator_t {
     const jit_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
 private:
-    std::unique_ptr<injector::jit_uni_postops_injector_t<isa, Vmm>>
+    std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>
             postops_injector_;
     using reg64_t = const Xbyak::Reg64;
 

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn.hpp
@@ -24,6 +24,7 @@
 #include "cpu/cpu_lrn_pd.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu/x64/jit_avx512_core_bf16cvt.hpp"
+#include "cpu/x64/lrn/jit_avx512_common_lrn_utils.hpp"
 #include "cpu/x64/lrn/lrn_executor.hpp"
 
 namespace dnnl {
@@ -36,16 +37,7 @@ struct jit_avx512_common_lrn_fwd_t : public primitive_t {
         using cpu_lrn_fwd_pd_t::cpu_lrn_fwd_pd_t;
 
         DECLARE_COMMON_PD_T(
-                JIT_IMPL_NAME_HELPER("lrn_jit:",
-                        utils::map(true, avx512_core,
-                                d_type == data_type::bf16
-                                        && mayiuse(avx512_core_bf16),
-                                avx512_core_bf16,
-                                d_type == data_type::bf16
-                                        && !mayiuse(avx512_core_bf16),
-                                bf16_emulation_t::get_isa(),
-                                d_type == data_type::f16, avx512_core_fp16),
-                        ""),
+                JIT_IMPL_NAME_HELPER("lrn_jit:", lrn::get_isa<d_type>(), ""),
                 jit_avx512_common_lrn_fwd_t);
 
         status_t init(const engine_t *engine);
@@ -76,16 +68,7 @@ struct jit_avx512_common_lrn_bwd_t : public primitive_t {
         using cpu_lrn_bwd_pd_t::cpu_lrn_bwd_pd_t;
 
         DECLARE_COMMON_PD_T(
-                JIT_IMPL_NAME_HELPER("lrn_jit:",
-                        utils::map(true, avx512_core,
-                                d_type == data_type::bf16
-                                        && mayiuse(avx512_core_bf16),
-                                avx512_core_bf16,
-                                d_type == data_type::bf16
-                                        && !mayiuse(avx512_core_bf16),
-                                bf16_emulation_t::get_isa(),
-                                d_type == data_type::f16, avx512_core_fp16),
-                        ""),
+                JIT_IMPL_NAME_HELPER("lrn_jit:", lrn::get_isa<d_type>(), ""),
                 jit_avx512_common_lrn_bwd_t);
 
         status_t init(const engine_t *engine);

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.cpp
@@ -16,6 +16,7 @@
 
 #include <numeric>
 #include "cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.hpp"
+#include "cpu/x64/lrn/jit_avx512_common_lrn_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -217,7 +218,7 @@ void jit_avx512_common_lrn_kernel_bwd_t<f16>::store_tail(int tail_value,
 template <data_type_t d_type>
 jit_avx512_common_lrn_kernel_bwd_t<d_type>::jit_avx512_common_lrn_kernel_bwd_t(
         float alpha, float beta, int local_size, const char *name)
-    : jit_generator_t(name, avx512_core_bf16)
+    : jit_generator_t(name, get_isa<d_type>())
     , local_size_ {local_size - !(local_size % 2)}
     , z_prev_ {[this]() {
         std::vector<int> v(this->local_size_ / 2);

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
@@ -16,6 +16,7 @@
 
 #include <numeric>
 #include "cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.hpp"
+#include "cpu/x64/lrn/jit_avx512_common_lrn_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -215,7 +216,7 @@ template <data_type_t d_type>
 jit_avx512_common_lrn_kernel_fwd_t<d_type>::jit_avx512_common_lrn_kernel_fwd_t(
         prop_kind_t prop_kind, float alpha, float beta, float k, int local_size,
         const char *name)
-    : jit_generator_t(name, avx512_core_bf16)
+    : jit_generator_t(name, get_isa<d_type>())
     , pk_(prop_kind)
     , alpha_(alpha)
     , beta_(beta)

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_utils.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_utils.hpp
@@ -17,6 +17,12 @@
 #ifndef CPU_X64_LRN_JIT_AVX512_COMMON_LRN_UTILS_HPP
 #define CPU_X64_LRN_JIT_AVX512_COMMON_LRN_UTILS_HPP
 
+#include "common/c_types_map.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/jit_avx512_core_bf16cvt.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -42,6 +48,16 @@ struct nChw16c_across_t {
 // NOLINTEND(readability-identifier-naming)
 
 enum class tail_mode { NoTail, NextTail, CurrentTail };
+
+template <data_type_t d_type>
+cpu_isa_t get_isa() {
+    return utils::map(true, avx512_core,
+            d_type == data_type::bf16 && mayiuse(avx512_core_bf16),
+            avx512_core_bf16,
+            d_type == data_type::bf16 && !mayiuse(avx512_core_bf16),
+            bf16_emulation_t::get_isa(), d_type == data_type::f16,
+            avx512_core_fp16);
+}
 
 } // namespace lrn
 } // namespace x64

--- a/src/cpu/x64/matmul/postops_estimator.hpp
+++ b/src/cpu/x64/matmul/postops_estimator.hpp
@@ -51,7 +51,7 @@ public:
     }
 
 private:
-    using po_injector_t = injector::jit_uni_postops_injector_base_t<Xbyak::Zmm>;
+    using po_injector_t = injector::jit_uni_postops_injector_t<Xbyak::Zmm>;
     std::unique_ptr<po_injector_t> postops_injector_;
     static constexpr size_t mean_none_vec_code_bytes = 8;
     static constexpr size_t mean_vec_inst_bytes = 7;
@@ -76,13 +76,8 @@ private:
         esp.preserve_vmm = false;
         esp.preserve_p_table = false;
 
-        auto st = safe_ptr_assign(postops_injector_,
-                po_injector_t::create(this,
-                        impl::cpu::x64::cpu_isa_t::avx512_core_amx,
-                        attr.post_ops_, bsp, esp));
-        if (st != status::success) {
-            assert(!"postops_injector creation failed");
-        }
+        postops_injector_ = utils::make_unique<po_injector_t>(
+                this, attr.post_ops_, bsp, esp);
     }
 
     const char *name() const final {

--- a/src/cpu/x64/matmul/postops_estimator.hpp
+++ b/src/cpu/x64/matmul/postops_estimator.hpp
@@ -57,7 +57,8 @@ private:
     static constexpr size_t mean_vec_inst_bytes = 7;
 
     postops_estimator_t(memory_desc_t &dst_md, primitive_attr_t &attr)
-        : jit_generator_t("dummy_generator") {
+        : jit_generator_t("dummy_generator",
+                  impl::cpu::x64::cpu_isa_t::avx512_core_amx) {
         auto dsc = memory_desc_wrapper(dst_md);
         const dnnl::impl::cpu::x64::binary_injector::rhs_arg_static_params_t
                 rhs_sp(static_cast<size_t>(Xbyak::Zmm(1).getIdx()), this->r14,

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
@@ -30,9 +30,7 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_gru_cell_postgemm_part1_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part1_fwd)
 
-    using injector_t = typename utils::conditional<isa == avx512_core,
-            jit_uni_eltwise_injector_t<avx512_core>,
-            jit_uni_eltwise_injector_t<isa>>::type;
+    using injector_t = jit_uni_eltwise_injector_t<isa>;
 
     jit_uni_gru_cell_postgemm_part1_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
@@ -30,7 +30,8 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_gru_cell_postgemm_part1_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part1_fwd)
 
-    using injector_t = jit_uni_eltwise_injector_t<isa>;
+    using injector_t
+            = jit_uni_eltwise_injector_t<typename cpu_isa_traits_t<isa>::Vmm>;
 
     jit_uni_gru_cell_postgemm_part1_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
@@ -53,7 +54,7 @@ protected:
     std::unique_ptr<injector_t> sigmoid_injector_;
 
     // register size in bytes
-    using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
+    using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr size_t qscale_dt_size = sizeof(float);
     const size_t vlen_dst

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
@@ -29,9 +29,7 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_gru_cell_postgemm_part2_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part2_fwd)
 
-    using injector_t = typename utils::conditional<isa == avx512_core,
-            jit_uni_eltwise_injector_t<avx512_core>,
-            jit_uni_eltwise_injector_t<isa>>::type;
+    using injector_t = jit_uni_eltwise_injector_t<isa>;
 
     jit_uni_gru_cell_postgemm_part2_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
@@ -29,7 +29,8 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_gru_cell_postgemm_part2_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part2_fwd)
 
-    using injector_t = jit_uni_eltwise_injector_t<isa>;
+    using injector_t
+            = jit_uni_eltwise_injector_t<typename cpu_isa_traits_t<isa>::Vmm>;
 
     jit_uni_gru_cell_postgemm_part2_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
@@ -53,7 +54,7 @@ protected:
     std::unique_ptr<injector_t> tanh_injector_;
 
     // register size in bytes
-    using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
+    using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr size_t qscale_dt_size = sizeof(float);
     const size_t vlen_dst

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
@@ -30,7 +30,8 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_gru_lbr_cell_postgemm_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_lbr_cell_postgemm_fwd)
 
-    using injector_t = jit_uni_eltwise_injector_t<isa>;
+    using injector_t
+            = jit_uni_eltwise_injector_t<typename cpu_isa_traits_t<isa>::Vmm>;
 
     jit_uni_gru_lbr_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
@@ -54,7 +55,7 @@ protected:
     std::unique_ptr<injector_t> tanh_injector_;
 
     // register size in bytes
-    using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
+    using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
 
     const size_t vlen_dst

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
@@ -30,9 +30,7 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_gru_lbr_cell_postgemm_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_lbr_cell_postgemm_fwd)
 
-    using injector_t = typename utils::conditional<isa == avx512_core,
-            jit_uni_eltwise_injector_t<avx512_core>,
-            jit_uni_eltwise_injector_t<isa>>::type;
+    using injector_t = jit_uni_eltwise_injector_t<isa>;
 
     jit_uni_gru_lbr_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm.hpp
@@ -37,8 +37,8 @@ struct jit_uni_lstm_cell_postgemm_t {
     }
 
 protected:
-    using injector_t = jit_uni_eltwise_injector_t<isa>;
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
+    using injector_t = jit_uni_eltwise_injector_t<Vmm>;
     const size_t vlen_ = cpu_isa_traits_t<isa>::vlen;
 
     Vmm get_next_tmp_vmm() {

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_projection_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_projection_postgemm_fwd.hpp
@@ -44,7 +44,7 @@ struct jit_uni_lstm_cell_projection_postgemm_fwd_t
 
 protected:
     // register size in bytes
-    using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
+    using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr size_t qscale_dt_size = sizeof(float);
     const size_t vlen_dst

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
@@ -30,9 +30,7 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_rnn_cell_postgemm_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_rnn_cell_postgemm_fwd)
 
-    using injector_t = typename utils::conditional<isa == avx512_core,
-            jit_uni_eltwise_injector_t<avx512_core>,
-            jit_uni_eltwise_injector_t<isa>>::type;
+    using injector_t = jit_uni_eltwise_injector_t<isa>;
 
     jit_uni_rnn_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
@@ -30,7 +30,8 @@ template <cpu_isa_t isa, impl::data_type_t src_data_t,
 struct jit_uni_rnn_cell_postgemm_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_rnn_cell_postgemm_fwd)
 
-    using injector_t = jit_uni_eltwise_injector_t<isa>;
+    using injector_t
+            = jit_uni_eltwise_injector_t<typename cpu_isa_traits_t<isa>::Vmm>;
 
     jit_uni_rnn_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
@@ -49,7 +50,7 @@ protected:
     std::unique_ptr<injector_t> injector_;
 
     // register size in bytes
-    using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
+    using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr size_t cstate_dt_size = sizeof(float);
     static constexpr size_t qscale_dt_size = sizeof(float);


### PR DESCRIPTION
While working on introducing a sum injector (#5706), I learned enough about the binary injector to identify its design flaws and how they could be addressed. As a result, I decided to redesign the injectors.

The current design has a few flaws that come from one fundamental design decision.

  **Problems**

1. The injectors are instantiated per ISA and per `Vmm`. Conceptually an injector emits code into a host JIT generator's buffer so the injector's ISA is expected to be consistent with the host's ISA. The current design forces us to either create the injector in the kernel with a compile-time ISA parameter or do a runtime dispatch between explicitly instantiated injectors. Our kernels use both approaches inconsistently. That makes it easy to accidentally mismatch the host ISA and the injector ISA. I found such a bug while implementing the new design. It also forces developers to work out which ISA the injector should be built for even though the JIT generator already knows this. On top of that, we only instantiate an injector for the ISAs its own functionality needs and that set can differ between the different kinds of injectors.

2. Because of the first point, the binary injector became heavily overengineered. It had to dispatch between compile-time instantiations for every combination of ISA and `Vmm`, which needed dozens of template specializations, template helpers and a base class.

3. Silently wrong dispatches were there by design. The existing comment says: `// When there's no exact match, pick up what's allowed through mayiuse since not every ISA has instances in post-ops injector.` In other words, we picked the injector based on what the machine supports rather than on the host ISA.

4. It increases the library size.

  **What the new design does**

1. Makes the ISA a runtime-only parameter in all injectors queried from the host JIT generator so consistency is enforced by the design itself.

2. Removes dozens of helpers, specializations, dispatch code and a redundant base class.

3. Decreases the library size by ~2.3 MB.

Below is what the explicit instantiations of the injectors look like now. Once we remove SSE4.1 and AVX support there will only be YMM and ZMM versions left.

<img width="1317" height="367" alt="Screenshot 2026-08-03 100935" src="https://github.com/user-attachments/assets/6332dfa2-620f-46f1-891c-dc44d38015a8" />
<img width="1288" height="291" alt="Screenshot 2026-08-03 101001" src="https://github.com/user-attachments/assets/bb6155de-b75b-4631-9ff2-78a007167619" />
<img width="1289" height="281" alt="Screenshot 2026-08-03 101152" src="https://github.com/user-attachments/assets/21f6e66e-6e17-4819-9cb1-932522ebc50b" />
<img width="1277" height="336" alt="Screenshot 2026-08-03 101222" src="https://github.com/user-attachments/assets/71ddc546-8b51-48fe-bd00-295b2d4f19bb" />
