### PR TITLE
cpu: x64: binary injector: fix per_w index calculation

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -2125,82 +2125,72 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
     const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
     const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
 
-    if (is_out_addr || is_out_reg) {
-        Xbyak::Address out_addr = is_out_addr ? it_out_addr->second
-                                              : host_->ptr[it_out_reg->second];
-        const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
-        const auto &addr_cache_reg = rhs_arg_static_params_.rhs_addr_cache_reg;
+    if (!is_out_addr && !is_out_reg) return;
 
-        const auto dst_d = rhs_arg_static_params_.dst_d;
-        const auto strides = dst_d.blocking_desc().strides;
-        const auto layout = injector_utils::get_layout_type(dst_d);
+    Xbyak::Address out_addr = is_out_addr ? it_out_addr->second
+                                          : host_->ptr[it_out_reg->second];
+    const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+    const auto &addr_cache_reg = rhs_arg_static_params_.rhs_addr_cache_reg;
 
-        if (is_first) {
-            calculate_no_broadcast_base(out_addr, tmp_reg);
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto strides = dst_d.blocking_desc().strides;
+    const auto layout = injector_utils::get_layout_type(dst_d);
 
-            const auto rax = host_->rax;
-            const auto rdx = host_->rdx;
-            const auto r8 = host_->r8;
+    const auto rax = host_->rax;
+    const auto rdx = host_->rdx;
+    const auto r8 = host_->r8;
 
-            const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg
-                                    ? utils::one_of(
-                                              it_out_reg->second, rax, rdx, r8)
-                                    : false,
-                            host_,
-                            {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
+    // The width index of a position is that position reduced modulo the row
+    // length, so it does not distribute over addition. Deriving it separately
+    // for the base and for the per-vmm displacement yields
+    // `w(base) + w(off)`, which diverges from the required `w(base + off)` once
+    // a displacement reaches a full row. The displacement therefore joins the
+    // linear position before the reduction. Only the rhs base pointer stays
+    // loop-invariant, so that is what the cache register holds.
+    assert(!utils::one_of(addr_cache_reg, rax, rdx, r8)
+            && "the rhs address cache register must survive the division");
+    if (is_first)
+        host_->mov(addr_cache_reg, addr_reg);
+    else
+        host_->mov(addr_reg, addr_cache_reg);
 
-            switch (layout) {
-                case injector_utils::layout_t::ncsp:
-                    calculate_w_ncsp_base(strides, tmp_reg);
-                    break;
-                case injector_utils::layout_t::c_blocked:
-                    calculate_w_blocked_base(strides, tmp_reg);
-                    break;
-                case injector_utils::layout_t::nspc:
-                    calculate_w_nspc_base(strides, tmp_reg);
-                    break;
-                case injector_utils::layout_t::cspn:
-                    calculate_w_cspn_base(strides, tmp_reg);
-                    break;
-                default: assert(!"Unknown layout");
-            }
+    calculate_no_broadcast_base(out_addr, tmp_reg);
+    if (it_off_val != vmm_idx_to_out_elem_off_val.end()) {
+        const auto off_elems = it_off_val->second
+                >> math::ilog2q(types::data_type_size(dst_d.data_type()));
+        assert(off_elems <= (size_t)std::numeric_limits<int>::max()
+                && "destination element offset does not fit a displacement");
+        if (off_elems) host_->add(tmp_reg, (int)off_elems);
+    }
 
-            if (elem_size_bytes == 1) {
-                host_->add(addr_reg, rax);
-            } else {
-                const int shift_val = std::log2(elem_size_bytes);
-                host_->mov(tmp_reg, rax);
-                host_->sal(tmp_reg, shift_val);
-                host_->add(addr_reg, tmp_reg);
-            }
-            host_->mov(addr_cache_reg, addr_reg);
-        } else {
-            host_->mov(addr_reg, addr_cache_reg);
-        }
+    const injector_utils::conditional_register_preserve_guard_t register_guard {
+            is_out_reg ? utils::one_of(it_out_reg->second, rax, rdx, r8)
+                       : false,
+            host_, {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
 
-        if (it_off_val != vmm_idx_to_out_elem_off_val.end()) {
-            switch (layout) {
-                case injector_utils::layout_t::ncsp:
-                    calculate_w_ncsp_partial(strides, it_off_val->second,
-                            tmp_reg, elem_size_bytes);
-                    break;
-                case injector_utils::layout_t::c_blocked:
-                    calculate_w_blocked_partial(strides, it_off_val->second,
-                            tmp_reg, elem_size_bytes);
-                    break;
-                case injector_utils::layout_t::nspc:
-                    calculate_w_nspc_partial(strides, it_off_val->second,
-                            tmp_reg, elem_size_bytes);
-                    break;
-                case injector_utils::layout_t::cspn:
-                    calculate_w_cspn_partial(strides, it_off_val->second,
-                            tmp_reg, elem_size_bytes);
-                    break;
-                default: assert(!"Unknown layout");
-            }
-            host_->add(addr_reg, tmp_reg);
-        }
+    switch (layout) {
+        case injector_utils::layout_t::ncsp:
+            calculate_w_ncsp_base(strides, tmp_reg);
+            break;
+        case injector_utils::layout_t::c_blocked:
+            calculate_w_blocked_base(strides, tmp_reg);
+            break;
+        case injector_utils::layout_t::nspc:
+            calculate_w_nspc_base(strides, tmp_reg);
+            break;
+        case injector_utils::layout_t::cspn:
+            calculate_w_cspn_base(strides, tmp_reg);
+            break;
+        default: assert(!"Unknown layout");
+    }
+
+    if (elem_size_bytes == 1) {
+        host_->add(addr_reg, rax);
+    } else {
+        const int shift_val = std::log2(elem_size_bytes);
+        host_->mov(tmp_reg, rax);
+        host_->sal(tmp_reg, shift_val);
+        host_->add(addr_reg, tmp_reg);
     }
 }
 
@@ -2233,32 +2223,9 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_base(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
-    // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
-    // w_off = w * stride_w
-    const auto ndims = rhs_arg_static_params_.dst_d.ndims();
-    const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
-                                    rhs_arg_static_params_.dst_d.data_type()));
-    const auto w = (offset_shr % strides[ndims - 2]) / strides[ndims - 1];
-    const auto offset_adj = w * strides[ndims - 1];
-    host_->mov(tmp_reg,
-            elem_size_bytes > 1 ? offset_adj << math::ilog2q(elem_size_bytes)
-                                : offset_adj);
-}
-
-template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_blocked_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     calculate_w_ncsp_base(strides, tmp_reg);
-}
-
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
-    calculate_w_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -2289,36 +2256,11 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_base(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
-    // offset = nDHWC + dHWC + hWC + wC + c
-    // w_off = w
-    const auto ndims = rhs_arg_static_params_.dst_d.ndims();
-    const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
-                                    rhs_arg_static_params_.dst_d.data_type()));
-    const auto offset_adj
-            = (offset_shr % strides[ndims - 2]) / strides[ndims - 1];
-    host_->mov(tmp_reg,
-            elem_size_bytes > 1 ? offset_adj << math::ilog2q(elem_size_bytes)
-                                : offset_adj);
-}
-
-template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_cspn_base(
         const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // w_off = w
     calculate_w_nspc_base(strides, tmp_reg);
-}
-
-template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
-    // offset = cDHWN + dHWN + hWN + wN + n
-    // w_off = w
-    calculate_w_nspc_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -478,24 +478,12 @@ private:
             bool is_first) const;
     void calculate_w_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
     void calculate_w_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
     void calculate_w_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
     void calculate_w_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
 
     void append_mb_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -225,18 +225,12 @@ void jit_uni_binary_kernel_t<isa, Vmm>::apply_postops(int unroll, bool tail) {
         if (!conf_.is_i8) shl(reg_tmp_, is_xf16(conf_.dst_type) ? 1 : 2);
         add(reg_tmp1_, reg_tmp_);
 
-        const auto postops_per_w_broadcast_exists
-                = conf_.postops_per_w_broadcast_exists;
         for (int vmm_idx = 1; vmm_idx < unroll + vmm_start_idx_; vmm_idx++) {
             const auto vmm_l_off = (vmm_idx - vmm_start_idx_) * simd_w_;
             const auto dst_dt_size = types::data_type_size(conf_.dst_type);
             rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_tmp1_);
-            if (postops_per_w_broadcast_exists)
-                rhs_arg_params.vmm_idx_to_out_addr.emplace(
-                        vmm_idx, dst_ptr(vmm_l_off * dst_dt_size));
-            else
-                rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
-                        vmm_idx, vmm_l_off * dst_dt_size);
+            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
+                    vmm_idx, vmm_l_off * dst_dt_size);
             if (tail) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
         }
         postops_injector_->compute_vector_range(


### PR DESCRIPTION
A `per_w` post-op holds one value per width position so the injector has to know the width index of every accumulator it applies the post-op to. Nothing tells it that index. The caller only passes a destination address and the injector works backwards from it: subtract the start of the tensor to get a position then undo the stride arithmetic to recover the width index.

The address arrives in two parts: a pointer known only at run time and a byte offset for that particular accumulator that is known while the kernel is being built. `append_w_offset()` calculated a width index from each part on its own and added the two results. That was a bug. A width index has a fixed range. When it reaches the end, it starts again from the beginning. However, adding two values can produce a number outside that range. Since the result is not adjusted back into the valid range, the injector creates an invalid index.

The split existed because the compile-time part was cheap to calculate. It became a constant when the kernel was built while the runtime part required actual division. Handling the cheap part separately seemed like a performance improvement.
The result is a read beyond the post-op data. For a `per_w` post-op, values are stored in a buffer with one entry for each width position. The calculated index tells where to read from. If the index is too large the read starts past the end of the buffer.

It stayed hidden for two reasons. The buffer is padded and repeats its data so an index that is too large often still reads the correct values. The only caller that could hit the bad case already had a workaround in commit 9eb361e34c: it passes a complete address for each accumulator so the injector never has to combine two parts. All other callers still pass two parts but their offsets either stay within one width range or cross it by full width amounts making the wrapped part have no effect.

This PR fixes the issue by adding the offset to the position first then calculating the index. This makes the wrap happen once on the final position. The separate offset path is removed.

This is not slower. The injector flags every address request as the first so the division already ran per accumulator and the cache was never read for `per_w`. It now holds the base pointer instead of a per-accumulator address.

With the two parts handled correctly, the binary kernel no longer needs the workaround. The four `calculate_w_*_partial()` helpers that calculated the index from only the offset are removed.