### PR TITLE
benchdnn: introduce concise mode

### DIFF
--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -58,6 +58,7 @@
 int verbose {0};
 bool canonical {false};
 bool mem_check {true};
+bool concise {false};
 std::string skip_impl;
 stat_t benchdnn_stat {0};
 std::string driver_name;
@@ -161,12 +162,14 @@ int main(int argc, char **argv) {
 
     total_time.stamp();
 
+    maybe_clear_heartbeat();
+
     print_impl_names_summary();
     print_impl_names_csv_summary();
 
     // Failed cases summary.
-    if (!has_bench_mode_bit(mode_bit_t::perf) && summary.failed_cases
-            && !benchdnn_stat.failed_cases.empty()) {
+    if (!concise && !has_bench_mode_bit(mode_bit_t::perf)
+            && summary.failed_cases && !benchdnn_stat.failed_cases.empty()) {
         printf("===========================================================\n");
         printf("= Failed cases summary (--summary=no-failures to disable) =\n");
         printf("===========================================================\n");

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include <algorithm>
 #include <cctype>
@@ -25,6 +26,12 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "oneapi/dnnl/dnnl.h"
 
@@ -88,6 +95,52 @@ dir_t str2dir(const char *str) {
     return DIR_UNDEF;
 }
 
+bool stdout_is_tty() {
+    static const int is_tty = [] {
+#ifdef _WIN32
+        return _isatty(_fileno(stdout));
+#else
+        return isatty(fileno(stdout));
+#endif
+    }();
+    return is_tty != 0;
+}
+
+bool interactive_heartbeat_enabled() {
+    if (!stdout_is_tty()) return false;
+    if (verbose > 0) return false;
+
+    for (const char *prefix : {"ONEDNN_", "DNNL_"}) {
+        const std::string dnnl_verbose = benchdnn_getenv_string(
+                (std::string(prefix) + "VERBOSE").c_str());
+        if (!dnnl_verbose.empty() && dnnl_verbose != "0"
+                && dnnl_verbose != "none")
+            return false;
+    }
+    return true;
+}
+
+int heartbeat_len = 0;
+void print_heartbeat(int64_t tests_done) {
+    if (tests_done <= 0) return;
+
+    if (interactive_heartbeat_enabled()) {
+        heartbeat_len = printf("\rcompleted tests: %" PRId64, tests_done) - 1;
+        fflush(stdout);
+    } else if (tests_done % 1000 == 0) {
+        printf("completed tests: %" PRId64 "\n", tests_done);
+        fflush(stdout);
+    }
+}
+
+void maybe_clear_heartbeat() {
+    if (!heartbeat_len) return;
+
+    printf("\r%*s\r", heartbeat_len, "");
+    fflush(stdout);
+    heartbeat_len = 0;
+}
+
 void parse_result(res_t &res, const char *pstr) {
     auto &bs = benchdnn_stat;
 
@@ -131,6 +184,8 @@ void parse_result(res_t &res, const char *pstr) {
             SAFE_V(FAIL);
     }
 
+    if (concise && !is_failed) print_me = false;
+
     std::string reason;
     if (res.reason != reason_t::none) {
         reason = " (" + reason2str(res.reason) + ")";
@@ -169,12 +224,17 @@ void parse_result(res_t &res, const char *pstr) {
                     "salt, and proceed with extra caution.");
         }
     }
-    if (print_me) { BENCHDNN_PRINT(0, "%s\n", full_repro.c_str()); }
+    if (print_me) {
+        maybe_clear_heartbeat();
+        BENCHDNN_PRINT(0, "%s\n", full_repro.c_str());
+    }
 
     // Update this after collecting stats.
     bs.tests++;
     assert(bs.tests
             == bs.passed + bs.skipped + bs.mistrusted + bs.failed + bs.listed);
+
+    if (concise) print_heartbeat(bs.tests);
 
     if (has_bench_mode_bit(mode_bit_t::perf)) {
         const auto &t = res.timer_map.perf_timer();

--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -98,6 +98,7 @@ extern bool attr_same_pd_check;
 extern bool check_ref_impl;
 extern std::string skip_impl; /* empty or "" means skip nothing */
 extern std::string driver_name;
+extern bool concise;
 
 // This is a safeguard for BENCHDNN_PRINTF macro against mismatches between
 // format specifiers and passed arguments that could lead to runtime failures.
@@ -202,6 +203,8 @@ const char *state2str(res_state_t state);
 
 dir_t str2dir(const char *str);
 void parse_result(res_t &res, const char *pstr);
+
+void maybe_clear_heartbeat();
 
 /* misc */
 void init_fp_mode();

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -210,6 +210,11 @@ Refer to [implementation filtering](knob_impl_filter.md) for details.
 `--start=N` specifies the test index `N` to start testing from. All tests
 before the index `N` will be skipped.
 
+### --concise
+`--concise`, or a short form `-c`, instructs the driver to suppress the full
+reproducer line for non-failing cases. A lightweight progress counter is
+occasionally printed to demonstrate forward progress.
+
 ### --summary
 `--summary=VALUE` provides additional specific statistics output. Refer to
 [summary documentation](knob_summary.md) for details.

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1362,6 +1362,27 @@ static bool parse_canonical(
             canonical, false, parsers::str2bool, str, option_name, help);
 }
 
+static bool parse_concise(
+        const char *str, const std::string &option_name = "concise") {
+    static const std::string help
+            = ", -c    (Default: not set)\n    Instructs the driver to "
+              "suppress the full repro line for non-failing cases.\n";
+    utils::add_option_to_help(option_name, help, /* with_args = */ false);
+
+    const std::string pattern = utils::get_pattern(option_name, false);
+    if (utils::option_matched(pattern, str)) {
+        concise = true;
+        return true;
+    }
+
+    // Short form, exact match only (no suffix/value expected).
+    if (!strcmp(str, "-c")) {
+        concise = true;
+        return true;
+    }
+    return false;
+}
+
 static bool parse_check_ref_impl(
         const char *str, const std::string &option_name = "check-ref-impl") {
     static const std::string help
@@ -1899,13 +1920,13 @@ bool parse_bench_settings(const char *str) {
 
     bool parsed = parse_allow_enum_tags_only(str)
             || parse_attr_same_pd_check(str) || parse_canonical(str)
-            || parse_check_ref_impl(str) || parse_cold_cache(str)
-            || parse_cpu_isa_hints(str) || parse_engine(str)
-            || parse_fast_ref(str) || parse_fix_times_per_prb(str)
-            || parse_global_impl(str) || parse_global_skip_impl(str)
-            || parse_max_ms_per_prb(str) || parse_num_streams(str)
-            || parse_repeats_per_prb(str) || parse_mem_check(str)
-            || parse_memory_kind(str) || parse_mode(str)
+            || parse_check_ref_impl(str) || parse_concise(str)
+            || parse_cold_cache(str) || parse_cpu_isa_hints(str)
+            || parse_engine(str) || parse_fast_ref(str)
+            || parse_fix_times_per_prb(str) || parse_global_impl(str)
+            || parse_global_skip_impl(str) || parse_max_ms_per_prb(str)
+            || parse_num_streams(str) || parse_repeats_per_prb(str)
+            || parse_mem_check(str) || parse_memory_kind(str) || parse_mode(str)
             || parse_mode_modifier(str) || parse_start(str)
             || parse_stream_kind(str) || parse_summary(str)
             || parse_verbose(str) || parse_execution_mode(str)


### PR DESCRIPTION
Introduces a concise printing mode to benchdnn that skips printing for passing tests. To demonstrate forward progress, an occasional heartbeat is printed in this mode.

The motivation for this change is to enable better interaction of benchdnn with generative AI tooling. The prints associated with passing workloads provide little value in this case and end up wasting significant context space.